### PR TITLE
Allow system index warning in OpenSearchRestTestCase.refreshAllIndices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Make the class CommunityIdProcessor final ([#14448](https://github.com/opensearch-project/OpenSearch/pull/14448))
 - Allow @InternalApi annotation on classes not meant to be constructed outside of the OpenSearch core ([#14575](https://github.com/opensearch-project/OpenSearch/pull/14575))
 - Add @InternalApi annotation to japicmp exclusions ([#14597](https://github.com/opensearch-project/OpenSearch/pull/14597))
+- Allow system index warning in OpenSearchRestTestCase.refreshAllIndices ([#14635](https://github.com/opensearch-project/OpenSearch/pull/14635))
 
 ### Deprecated
 

--- a/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
@@ -709,13 +709,14 @@ public abstract class OpenSearchRestTestCase extends OpenSearchTestCase {
             if (warnings.isEmpty()) {
                 return false;
             }
-            boolean allSystemIndexWarning = true;
+            boolean allSystemIndexWarnings = true;
             for (String warning : warnings) {
                 if (!warning.startsWith("this request accesses system indices:")) {
-                    allSystemIndexWarning = false;
+                    allSystemIndexWarnings = false;
+                    break;
                 }
             }
-            return !allSystemIndexWarning;
+            return !allSystemIndexWarnings;
         });
         refreshRequest.setOptions(requestOptions);
         client().performRequest(refreshRequest);

--- a/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
@@ -708,11 +708,14 @@ public abstract class OpenSearchRestTestCase extends OpenSearchTestCase {
         requestOptions.setWarningsHandler(warnings -> {
             if (warnings.isEmpty()) {
                 return false;
-            } else if (warnings.size() > 1) {
-                return true;
-            } else {
-                return warnings.get(0).startsWith("this request accesses system indices:") == false;
             }
+            boolean allSystemIndexWarning = true;
+            for (String warning : warnings) {
+                if (!warning.startsWith("this request accesses system indices:")) {
+                    allSystemIndexWarning = false;
+                }
+            }
+            return !allSystemIndexWarning;
         });
         refreshRequest.setOptions(requestOptions);
         client().performRequest(refreshRequest);


### PR DESCRIPTION
### Description

Fixes an issue seen in alerting's integTests in https://github.com/opensearch-project/alerting/pull/1584. There is a custom warningHandler, but its not working as expected with the implementation. The test is seeing multiple warnings like this:

```
  2> org.opensearch.client.WarningFailureException: method [POST], host [http://127.0.0.1:33063], URI [/_refresh?expand_wildcards=open%2Chidden], status line [HTTP/1.1 200 OK]
    Warnings: [this request accesses system indices: [.opendistro-alerting-alert-history-2024.07.03-1], but in a future major version, direct access to system indices will be prevented by default, this request accesses system indices: [.opendistro-alerting-alerts], but in a future major version, direct access to system indices will be prevented by default, this request accesses system indices: [.opensearch-notifications-config], but in a future major version, direct access to system indices will be prevented by default]
    {"_shards":{"total":13,"successful":7,"failed":0}}
        at __randomizedtesting.SeedInfo.seed([552E33B552C4F8C7:ABCA2D99D0CE9D4F]:0)
        at app//org.opensearch.client.RestClient.convertResponse(RestClient.java:381)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:355)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:330)
        at app//org.opensearch.test.rest.OpenSearchRestTestCase.refreshAllIndices(OpenSearchRestTestCase.java:718)
        at app//org.opensearch.alerting.DocumentMonitorRunnerIT.test execute monitor generates alerts and findings with per alert execution for actions(DocumentMonitorRunnerIT.kt:687)
  2> NOTE: leaving temporary files on disk at: /local/home/cwperx/projects/alerting/alerting/build/testrun/integTest/temp/org.opensearch.alerting.DocumentMonitorRunnerIT_552E33B552C4F8C7-001
  2> NOTE: test params are: codec=Asserting(Lucene99): {}, docValues:{}, maxPointsInLeafNode=675, maxMBSortInHeap=5.801981985147594, sim=Asserting(RandomSimilarity(queryNorm=true): {}), locale=it-CH, timezone=Australia/Lord_Howe
```

And the custom warning handler here is not working as expected to ignore warnings if all warnings are about system index access.

### Related Issues

Related to CI failure seen in https://github.com/opensearch-project/alerting/pull/1584

### Check List
- [X] Functionality includes testing.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
