### PR TITLE
fix constant_keyword field type not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Refactoring Grok.validatePatternBank by using an iterative approach ([#14206](https://github.com/opensearch-project/OpenSearch/pull/14206))
 - Update help output for _cat ([#14722](https://github.com/opensearch-project/OpenSearch/pull/14722))
 - Fix bulk upsert ignores the default_pipeline and final_pipeline when auto-created index matches the index template ([#12891](https://github.com/opensearch-project/OpenSearch/pull/12891))
+- Fix constant_keyword field type ([#14651](https://github.com/opensearch-project/OpenSearch/pull/14651))
 
 ### Security
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/110_constant_keyword.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/110_constant_keyword.yml
@@ -1,0 +1,70 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              genre:
+                type : "constant_keyword"
+                "value" : "1"
+
+  - do:
+      index:
+        index: test
+        id: 1
+        body: {
+          "genre": "1"
+        }
+
+  - do:
+      index:
+        index: test
+        id: 2
+        body: {
+          "genre": 1
+        }
+
+  - do:
+      indices.refresh:
+        index: test
+
+---
+# Delete Index when connection is teardown
+teardown:
+  - do:
+      indices.delete:
+        index: test
+
+---
+"Mappings":
+  - skip:
+      version: " - 2.13.99"
+      reason: "constant_keyword is introduced in 2.14.0"
+
+  - do:
+      indices.get_mapping:
+        index: test
+  - is_true: test.mappings
+  - match: { test.mappings.properties.genre.type: constant_keyword }
+  - length: { test.mappings.properties.genre: 2 }
+
+---
+"Supported queries":
+  - skip:
+      version: " - 2.13.99"
+      reason: "constant_keyword is introduced in 2.14.0 in main branch"
+
+  # Verify Document Count
+  - do:
+      search:
+        body: {
+          query: {
+            match_all: {}
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.genre: "1" }
+  - match: { hits.hits.1._source.genre: 1 }

--- a/server/src/main/java/org/opensearch/index/mapper/ConstantKeywordFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ConstantKeywordFieldMapper.java
@@ -68,11 +68,11 @@ public class ConstantKeywordFieldMapper extends ParametrizedFieldMapper {
      */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
-        private final Parameter<String> value;
+        private final Parameter<String> value = Parameter.stringParam(valuePropertyName, false, m -> toType(m).value, null);
 
         public Builder(String name, String value) {
             super(name);
-            this.value = Parameter.stringParam(valuePropertyName, false, m -> toType(m).value, value);
+            this.value.setValue(value);
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/index/mapper/ConstantKeywordFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ConstantKeywordFieldMapperTests.java
@@ -105,6 +105,14 @@ public class ConstantKeywordFieldMapperTests extends OpenSearchSingleNodeTestCas
         assertThat(e.getMessage(), containsString("Field [field] is missing required parameter [value]"));
     }
 
+    public void testBuilderToXContent() throws IOException {
+        ConstantKeywordFieldMapper.Builder builder = new ConstantKeywordFieldMapper.Builder("name", "value1");
+        XContentBuilder xContentBuilder = JsonXContent.contentBuilder().startObject();
+        builder.toXContent(xContentBuilder, false);
+        xContentBuilder.endObject();
+        assertEquals("{\"value\":\"value1\"}", xContentBuilder.toString());
+    }
+
     private final SourceToParse source(CheckedConsumer<XContentBuilder, IOException> build) throws IOException {
         XContentBuilder builder = JsonXContent.contentBuilder().startObject();
         build.accept(builder);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix constant_keyword field type not working

### Related Issues
Resolves #14638
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
