### PR TITLE
[Logging Improvement] Using lambda invocations instead of checking debug/trace isEnabled explicitly

### DIFF
--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/AbstractAsyncBulkByScrollAction.java
@@ -403,14 +403,12 @@ public abstract class AbstractAsyncBulkByScrollAction<
      * Send a bulk request, handling retries.
      */
     void sendBulkRequest(BulkRequest request, Runnable onSuccess) {
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                "[{}]: sending [{}] entry, [{}] bulk request",
-                task.getId(),
-                request.requests().size(),
-                new ByteSizeValue(request.estimatedSizeInBytes())
-            );
-        }
+        logger.debug(
+            "[{}]: sending [{}] entry, [{}] bulk request",
+            () -> task.getId(),
+            () -> request.requests().size(),
+            () -> new ByteSizeValue(request.estimatedSizeInBytes())
+        );
         if (task.isCancelled()) {
             logger.debug("[{}]: finishing early because the task was cancelled", task.getId());
             finishHim(null);

--- a/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/Netty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/Netty4Transport.java
@@ -228,18 +228,16 @@ public class Netty4Transport extends TcpTransport {
 
     private void createServerBootstrap(ProfileSettings profileSettings, SharedGroupFactory.SharedGroup sharedGroup) {
         String name = profileSettings.profileName;
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                "using profile[{}], worker_count[{}], port[{}], bind_host[{}], publish_host[{}], receive_predictor[{}->{}]",
-                name,
-                sharedGroupFactory.getTransportWorkerCount(),
-                profileSettings.portOrRange,
-                profileSettings.bindHosts,
-                profileSettings.publishHosts,
-                receivePredictorMin,
-                receivePredictorMax
-            );
-        }
+        logger.debug(
+            "using profile[{}], worker_count[{}], port[{}], bind_host[{}], publish_host[{}], receive_predictor[{}->{}]",
+            () -> name,
+            () -> sharedGroupFactory.getTransportWorkerCount(),
+            () -> profileSettings.portOrRange,
+            () -> profileSettings.bindHosts,
+            () -> profileSettings.publishHosts,
+            () -> receivePredictorMin,
+            () -> receivePredictorMax
+        );
 
         final ServerBootstrap serverBootstrap = new ServerBootstrap();
 

--- a/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/ssl/SecureNetty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/ssl/SecureNetty4Transport.java
@@ -215,15 +215,13 @@ public class SecureNetty4Transport extends Netty4Transport {
                         ? inetSocketAddress.getHostName()
                         : inetSocketAddress.getHostString();
 
-                    if (log.isDebugEnabled()) {
-                        log.debug(
-                            "Hostname of peer is {} ({}/{}) with hostnameVerificationResolveHostName: {}",
-                            hostname,
-                            inetSocketAddress.getHostName(),
-                            inetSocketAddress.getHostString(),
-                            hostnameVerificationResovleHostName
-                        );
-                    }
+                    log.debug(
+                        "Hostname of peer is {} ({}/{}) with hostnameVerificationResolveHostName: {}",
+                        () -> hostname,
+                        () -> inetSocketAddress.getHostName(),
+                        () -> inetSocketAddress.getHostString(),
+                        () -> hostnameVerificationResovleHostName
+                    );
 
                     sslEngine = secureTransportSettingsProvider.buildSecureClientTransportEngine(
                         settings,

--- a/plugins/discovery-ec2/src/main/java/org/opensearch/discovery/ec2/AwsEc2SeedHostsProvider.java
+++ b/plugins/discovery-ec2/src/main/java/org/opensearch/discovery/ec2/AwsEc2SeedHostsProvider.java
@@ -107,16 +107,14 @@ class AwsEc2SeedHostsProvider implements SeedHostsProvider {
         instanceStates.add("running");
         instanceStates.add("pending");
 
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                "using host_type [{}], tags [{}], groups [{}] with any_group [{}], availability_zones [{}]",
-                hostType,
-                tags,
-                groups,
-                bindAnyGroup,
-                availabilityZones
-            );
-        }
+        logger.debug(
+            "using host_type [{}], tags [{}], groups [{}] with any_group [{}], availability_zones [{}]",
+            () -> hostType,
+            () -> tags,
+            () -> groups,
+            () -> bindAnyGroup,
+            () -> availabilityZones
+        );
     }
 
     @Override

--- a/plugins/discovery-gce/src/main/java/org/opensearch/cloud/gce/GceInstancesServiceImpl.java
+++ b/plugins/discovery-gce/src/main/java/org/opensearch/cloud/gce/GceInstancesServiceImpl.java
@@ -203,7 +203,7 @@ public class GceInstancesServiceImpl implements GceInstancesService {
     public synchronized Compute client() {
         if (refreshInterval != null && refreshInterval.millis() != 0) {
             if (client != null && (refreshInterval.millis() < 0 || (System.currentTimeMillis() - lastRefresh) < refreshInterval.millis())) {
-                if (logger.isTraceEnabled()) logger.trace("using cache to retrieve client");
+                logger.trace(() -> "using cache to retrieve client");
                 return client;
             }
             lastRefresh = System.currentTimeMillis();

--- a/plugins/discovery-gce/src/main/java/org/opensearch/discovery/gce/GceSeedHostsProvider.java
+++ b/plugins/discovery-gce/src/main/java/org/opensearch/discovery/gce/GceSeedHostsProvider.java
@@ -107,9 +107,7 @@ public class GceSeedHostsProvider implements SeedHostsProvider {
         this.zones = gceInstancesService.zones();
 
         this.tags = TAGS_SETTING.get(settings);
-        if (logger.isDebugEnabled()) {
-            logger.debug("using tags {}", this.tags);
-        }
+        logger.debug("using tags {}", () -> this.tags);
     }
 
     /**
@@ -133,7 +131,7 @@ public class GceSeedHostsProvider implements SeedHostsProvider {
         if (refreshInterval.millis() != 0) {
             if (cachedDynamicHosts != null
                 && (refreshInterval.millis() < 0 || (System.currentTimeMillis() - lastRefresh) < refreshInterval.millis())) {
-                if (logger.isTraceEnabled()) logger.trace("using cache to retrieve node list");
+                logger.trace(() -> "using cache to retrieve node list");
                 return cachedDynamicHosts;
             }
             lastRefresh = System.currentTimeMillis();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -210,10 +210,9 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
             logger.info("--> Creating index test{} with primary {} and replica {}", i, shardCount, replicaCount);
             createIndex("test" + i, shardCount, replicaCount, i % 2 == 0);
             ensureGreen(TimeValue.timeValueSeconds(60));
-            if (logger.isTraceEnabled()) {
-                state = client().admin().cluster().prepareState().execute().actionGet().getState();
-                logger.info(ShardAllocations.printShardDistribution(state));
-            }
+            logger.trace(
+                () -> ShardAllocations.printShardDistribution(client().admin().cluster().prepareState().execute().actionGet().getState())
+            );
         }
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         logger.info(ShardAllocations.printShardDistribution(state));
@@ -271,10 +270,9 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
             logger.info("--> Creating index test{} with primary {} and replica {}", i, shardCount, replicaCount);
             createIndex("test" + i, shardCount, replicaCount, i % 2 == 0);
             ensureGreen(TimeValue.timeValueSeconds(60));
-            if (logger.isTraceEnabled()) {
-                state = client().admin().cluster().prepareState().execute().actionGet().getState();
-                logger.info(ShardAllocations.printShardDistribution(state));
-            }
+            logger.trace(
+                () -> ShardAllocations.printShardDistribution(client().admin().cluster().prepareState().execute().actionGet().getState())
+            );
         }
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         logger.info(ShardAllocations.printShardDistribution(state));

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -486,9 +486,7 @@ public class TransportClusterHealthAction extends TransportClusterManagerNodeRea
         int numberOfInFlightFetch,
         TimeValue pendingTaskTimeInQueue
     ) {
-        if (logger.isTraceEnabled()) {
-            logger.trace("Calculating health based on state version [{}]", clusterState.version());
-        }
+        logger.trace("Calculating health based on state version [{}]", () -> clusterState.version());
 
         String[] concreteIndices;
         if (request.level().equals(ClusterHealthRequest.Level.AWARENESS_ATTRIBUTES)) {

--- a/server/src/main/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -232,9 +232,7 @@ public class TransportFieldCapabilitiesIndexAction extends HandledTransportActio
             this.listener = listener;
 
             ClusterState clusterState = clusterService.state();
-            if (logger.isTraceEnabled()) {
-                logger.trace("executing [{}] based on cluster state version [{}]", request, clusterState.version());
-            }
+            logger.trace("executing [{}] based on cluster state version [{}]", () -> request, () -> clusterState.version());
             nodes = clusterState.nodes();
             ClusterBlockException blockException = checkGlobalBlock(clusterState);
             if (blockException != null) {
@@ -306,9 +304,7 @@ public class TransportFieldCapabilitiesIndexAction extends HandledTransportActio
                 onFailure(shardRouting, new NoShardAvailableActionException(shardRouting.shardId()));
             } else {
                 request.shardId(shardRouting.shardId());
-                if (logger.isTraceEnabled()) {
-                    logger.trace("sending request [{}] on node [{}]", request, node);
-                }
+                logger.trace("sending request [{}] on node [{}]", () -> request, () -> node);
                 transportService.sendRequest(
                     node,
                     ACTION_SHARD_NAME,
@@ -354,9 +350,7 @@ public class TransportFieldCapabilitiesIndexAction extends HandledTransportActio
         @Override
         public void messageReceived(final FieldCapabilitiesIndexRequest request, final TransportChannel channel, Task task)
             throws Exception {
-            if (logger.isTraceEnabled()) {
-                logger.trace("executing [{}]", request);
-            }
+            logger.trace("executing [{}]", () -> request);
             ActionListener<FieldCapabilitiesIndexResponse> listener = new ChannelActionListener<>(channel, ACTION_SHARD_NAME, request);
             executor.execute(ActionRunnable.supply(listener, () -> shardOperation(request)));
         }

--- a/server/src/main/java/org/opensearch/action/search/SearchScrollAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchScrollAsyncAction.java
@@ -317,9 +317,7 @@ abstract class SearchScrollAsyncAction<T extends SearchPhaseResult> implements R
         @Nullable SearchShardTarget searchShardTarget,
         Supplier<SearchPhase> nextPhaseSupplier
     ) {
-        if (logger.isDebugEnabled()) {
-            logger.debug(new ParameterizedMessage("[{}] Failed to execute {} phase", searchId, phaseName), failure);
-        }
+        logger.debug(() -> new ParameterizedMessage("[{}] Failed to execute {} phase", searchId, phaseName), failure);
         addShardFailure(new ShardSearchFailure(failure, searchShardTarget));
         int successfulOperations = successfulOps.decrementAndGet();
         assert successfulOperations >= 0 : "successfulOperations must be >= 0 but was: " + successfulOperations;

--- a/server/src/main/java/org/opensearch/action/support/broadcast/TransportBroadcastAction.java
+++ b/server/src/main/java/org/opensearch/action/support/broadcast/TransportBroadcastAction.java
@@ -256,33 +256,29 @@ public abstract class TransportBroadcastAction<
 
             if (nextShard != null) {
                 if (e != null) {
-                    if (logger.isTraceEnabled()) {
-                        if (!TransportActions.isShardNotAvailableException(e)) {
-                            logger.trace(
-                                new ParameterizedMessage(
-                                    "{}: failed to execute [{}]",
-                                    shard != null ? shard.shortSummary() : shardIt.shardId(),
-                                    request
-                                ),
-                                e
-                            );
-                        }
+                    if (!TransportActions.isShardNotAvailableException(e)) {
+                        logger.trace(
+                            () -> new ParameterizedMessage(
+                                "{}: failed to execute [{}]",
+                                shard != null ? shard.shortSummary() : shardIt.shardId(),
+                                request
+                            ),
+                            e
+                        );
                     }
                 }
                 performOperation(shardIt, nextShard, shardIndex);
             } else {
-                if (logger.isDebugEnabled()) {
-                    if (e != null) {
-                        if (!TransportActions.isShardNotAvailableException(e)) {
-                            logger.debug(
-                                new ParameterizedMessage(
-                                    "{}: failed to execute [{}]",
-                                    shard != null ? shard.shortSummary() : shardIt.shardId(),
-                                    request
-                                ),
-                                e
-                            );
-                        }
+                if (e != null) {
+                    if (!TransportActions.isShardNotAvailableException(e)) {
+                        logger.debug(
+                            () -> new ParameterizedMessage(
+                                "{}: failed to execute [{}]",
+                                shard != null ? shard.shortSummary() : shardIt.shardId(),
+                                request
+                            ),
+                            e
+                        );
                     }
                 }
                 if (expectedOps == counterOps.incrementAndGet()) {

--- a/server/src/main/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -308,9 +308,7 @@ public abstract class TransportBroadcastByNodeAction<
                 throw requestBlockException;
             }
 
-            if (logger.isTraceEnabled()) {
-                logger.trace("resolving shards for [{}] based on cluster state version [{}]", actionName, clusterState.version());
-            }
+            logger.trace("resolving shards for [{}] based on cluster state version [{}]", () -> actionName, () -> clusterState.version());
             ShardsIterator shardIt = shards(clusterState, request, concreteIndices);
             nodeIds = new HashMap<>();
 
@@ -400,9 +398,7 @@ public abstract class TransportBroadcastByNodeAction<
         }
 
         protected void onNodeResponse(DiscoveryNode node, int nodeIndex, NodeResponse response) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("received response for [{}] from node [{}]", actionName, node.getId());
-            }
+            logger.trace("received response for [{}] from node [{}]", () -> actionName, () -> node.getId());
 
             // this is defensive to protect against the possibility of double invocation
             // the current implementation of TransportService#sendRequest guards against this
@@ -416,8 +412,8 @@ public abstract class TransportBroadcastByNodeAction<
 
         protected void onNodeFailure(DiscoveryNode node, int nodeIndex, Throwable t) {
             String nodeId = node.getId();
-            if (logger.isDebugEnabled() && !(t instanceof NodeShouldNotConnectException)) {
-                logger.debug(new ParameterizedMessage("failed to execute [{}] on node [{}]", actionName, nodeId), t);
+            if (!(t instanceof NodeShouldNotConnectException)) {
+                logger.debug(() -> new ParameterizedMessage("failed to execute [{}] on node [{}]", actionName, nodeId), t);
             }
 
             // this is defensive to protect against the possibility of double invocation
@@ -458,9 +454,7 @@ public abstract class TransportBroadcastByNodeAction<
         public void messageReceived(final NodeRequest request, TransportChannel channel, Task task) throws Exception {
             List<ShardRouting> shards = request.getShards();
             final int totalShards = shards.size();
-            if (logger.isTraceEnabled()) {
-                logger.trace("[{}] executing operation on [{}] shards", actionName, totalShards);
-            }
+            logger.trace("[{}] executing operation on [{}] shards", () -> actionName, () -> totalShards);
             final Object[] shardResultOrExceptions = new Object[totalShards];
 
             int shardIndex = -1;
@@ -489,14 +483,10 @@ public abstract class TransportBroadcastByNodeAction<
             final ShardRouting shardRouting
         ) {
             try {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("[{}]  executing operation for shard [{}]", actionName, shardRouting.shortSummary());
-                }
+                logger.trace("[{}]  executing operation for shard [{}]", () -> actionName, () -> shardRouting.shortSummary());
                 ShardOperationResult result = shardOperation(request.indicesLevelRequest, shardRouting);
                 shardResults[shardIndex] = result;
-                if (logger.isTraceEnabled()) {
-                    logger.trace("[{}]  completed operation for shard [{}]", actionName, shardRouting.shortSummary());
-                }
+                logger.trace("[{}]  completed operation for shard [{}]", () -> actionName, () -> shardRouting.shortSummary());
             } catch (Exception e) {
                 BroadcastShardOperationFailedException failure = new BroadcastShardOperationFailedException(
                     shardRouting.shardId(),
@@ -517,16 +507,14 @@ public abstract class TransportBroadcastByNodeAction<
                         );
                     }
                 } else {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug(
-                            new ParameterizedMessage(
-                                "[{}] failed to execute operation for shard [{}]",
-                                actionName,
-                                shardRouting.shortSummary()
-                            ),
-                            e
-                        );
-                    }
+                    logger.debug(
+                        () -> new ParameterizedMessage(
+                            "[{}] failed to execute operation for shard [{}]",
+                            actionName,
+                            shardRouting.shortSummary()
+                        ),
+                        e
+                    );
                 }
             }
         }

--- a/server/src/main/java/org/opensearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/opensearch/action/support/nodes/TransportNodesAction.java
@@ -310,8 +310,8 @@ public abstract class TransportNodesAction<
         }
 
         private void onFailure(int idx, String nodeId, Throwable t) {
-            if (logger.isDebugEnabled() && !(t instanceof NodeShouldNotConnectException)) {
-                logger.debug(new ParameterizedMessage("failed to execute on node [{}]", nodeId), t);
+            if (!(t instanceof NodeShouldNotConnectException)) {
+                logger.debug(() -> new ParameterizedMessage("failed to execute on node [{}]", nodeId), t);
             }
             responses.set(idx, new FailedNodeException(nodeId, "Failed node [" + nodeId + "]", t));
             if (counter.incrementAndGet() == responses.length()) {

--- a/server/src/main/java/org/opensearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/ReplicationOperation.java
@@ -162,9 +162,12 @@ public class ReplicationOperation<
         this.primaryResult = primaryResult;
         final ReplicaRequest replicaRequest = primaryResult.replicaRequest();
         if (replicaRequest != null) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("[{}] op [{}] completed on primary for request [{}]", primary.routingEntry().shardId(), opType, request);
-            }
+            logger.trace(
+                "[{}] op [{}] completed on primary for request [{}]",
+                () -> primary.routingEntry().shardId(),
+                () -> opType,
+                () -> request
+            );
             // we have to get the replication group after successfully indexing into the primary in order to honour recovery semantics.
             // we have to make sure that every operation indexed into the primary after recovery start will also be replicated
             // to the recovery target. If we used an old replication group, we may miss a recovery that has started since then.
@@ -253,9 +256,13 @@ public class ReplicationOperation<
         final ReplicaRequest replicaRequest = replicationProxyRequest.getReplicaRequest();
         final PendingReplicationActions pendingReplicationActions = replicationProxyRequest.getPendingReplicationActions();
 
-        if (logger.isTraceEnabled()) {
-            logger.trace("[{}] sending op [{}] to replica {} for request [{}]", shard.shardId(), opType, shard, replicaRequest);
-        }
+        logger.trace(
+            "[{}] sending op [{}] to replica {} for request [{}]",
+            () -> shard.shardId(),
+            () -> opType,
+            () -> shard,
+            () -> replicaRequest
+        );
         totalShards.incrementAndGet();
         pendingActions.incrementAndGet();
         final ActionListener<ReplicaResponse> replicationListener = new ActionListener<ReplicaResponse>() {

--- a/server/src/main/java/org/opensearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/TransportReplicationAction.java
@@ -837,14 +837,12 @@ public abstract class TransportReplicationAction<
                             replica.getLastSyncedGlobalCheckpoint()
                         );
                         releasable.close(); // release shard operation lock before responding to caller
-                        if (logger.isTraceEnabled()) {
-                            logger.trace(
-                                "action [{}] completed on shard [{}] for request [{}]",
-                                transportReplicaAction,
-                                replicaRequest.getRequest().shardId(),
-                                replicaRequest.getRequest()
-                            );
-                        }
+                        logger.trace(
+                            "action [{}] completed on shard [{}] for request [{}]",
+                            () -> transportReplicaAction,
+                            () -> replicaRequest.getRequest().shardId(),
+                            () -> replicaRequest.getRequest()
+                        );
                         setPhase(task, "finished");
                         onCompletionListener.onResponse(response);
                     }, e -> {
@@ -1064,16 +1062,14 @@ public abstract class TransportReplicationAction<
 
         private void performLocalAction(ClusterState state, ShardRouting primary, DiscoveryNode node, IndexMetadata indexMetadata) {
             setPhase(task, "waiting_on_primary");
-            if (logger.isTraceEnabled()) {
-                logger.trace(
-                    "send action [{}] to local primary [{}] for request [{}] with cluster state version [{}] to [{}] ",
-                    transportPrimaryAction,
-                    request.shardId(),
-                    request,
-                    state.version(),
-                    primary.currentNodeId()
-                );
-            }
+            logger.trace(
+                "send action [{}] to local primary [{}] for request [{}] with cluster state version [{}] to [{}] ",
+                () -> transportPrimaryAction,
+                () -> request.shardId(),
+                () -> request,
+                () -> state.version(),
+                () -> primary.currentNodeId()
+            );
             performAction(
                 node,
                 transportPrimaryAction,
@@ -1113,16 +1109,14 @@ public abstract class TransportReplicationAction<
                 // target is not aware that it is the active primary shard already.
                 request.routedBasedOnClusterVersion(state.version());
             }
-            if (logger.isTraceEnabled()) {
-                logger.trace(
-                    "send action [{}] on primary [{}] for request [{}] with cluster state version [{}] to [{}]",
-                    actionName,
-                    request.shardId(),
-                    request,
-                    state.version(),
-                    primary.currentNodeId()
-                );
-            }
+            logger.trace(
+                "send action [{}] on primary [{}] for request [{}] with cluster state version [{}] to [{}]",
+                () -> actionName,
+                () -> request.shardId(),
+                () -> request,
+                () -> state.version(),
+                () -> primary.currentNodeId()
+            );
             setPhase(task, "rerouted");
             performAction(node, actionName, false, request);
         }
@@ -1236,9 +1230,7 @@ public abstract class TransportReplicationAction<
         void finishOnSuccess(Response response) {
             if (finished.compareAndSet(false, true)) {
                 setPhase(task, "finished");
-                if (logger.isTraceEnabled()) {
-                    logger.trace("operation succeeded. action [{}],request [{}]", actionName, request);
-                }
+                logger.trace("operation succeeded. action [{}],request [{}]", () -> actionName, () -> request);
                 listener.onResponse(response);
             } else {
                 assert false : "finishOnSuccess called but operation is already finished";

--- a/server/src/main/java/org/opensearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/opensearch/action/support/single/shard/TransportSingleShardAction.java
@@ -171,9 +171,7 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
             this.listener = listener;
 
             ClusterState clusterState = clusterService.state();
-            if (logger.isTraceEnabled()) {
-                logger.trace("executing [{}] based on cluster state version [{}]", request, clusterState.version());
-            }
+            logger.trace("executing [{}] based on cluster state version [{}]", () -> request, () -> clusterState.version());
             nodes = clusterState.nodes();
             ClusterBlockException blockException = checkGlobalBlock(clusterState);
             if (blockException != null) {
@@ -267,14 +265,12 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
                 onFailure(shardRouting, new NoShardAvailableActionException(shardRouting.shardId()));
             } else {
                 internalRequest.request().internalShardId = shardRouting.shardId();
-                if (logger.isTraceEnabled()) {
-                    logger.trace(
-                        "sending request [{}] to shard [{}] on node [{}]",
-                        internalRequest.request(),
-                        internalRequest.request().internalShardId,
-                        node
-                    );
-                }
+                logger.trace(
+                    "sending request [{}] to shard [{}] on node [{}]",
+                    () -> internalRequest.request(),
+                    () -> internalRequest.request().internalShardId,
+                    () -> node
+                );
                 final Writeable.Reader<Response> reader = getResponseReader();
                 ShardRouting finalShardRouting = shardRouting;
                 transportService.sendRequest(
@@ -331,9 +327,7 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
 
         @Override
         public void messageReceived(final Request request, final TransportChannel channel, Task task) throws Exception {
-            if (logger.isTraceEnabled()) {
-                logger.trace("executing [{}] on shard [{}]", request, request.internalShardId);
-            }
+            logger.trace("executing [{}] on shard [{}]", () -> request, () -> request.internalShardId);
             asyncShardOperation(request, request.internalShardId, new ChannelActionListener<>(channel, transportShardAction, request));
         }
     }

--- a/server/src/main/java/org/opensearch/action/support/tasks/TransportTasksAction.java
+++ b/server/src/main/java/org/opensearch/action/support/tasks/TransportTasksAction.java
@@ -334,8 +334,8 @@ public abstract class TransportTasksAction<
         }
 
         private void onFailure(int idx, String nodeId, Throwable t) {
-            if (logger.isDebugEnabled() && !(t instanceof NodeShouldNotConnectException)) {
-                logger.debug(new ParameterizedMessage("failed to execute on node [{}]", nodeId), t);
+            if (!(t instanceof NodeShouldNotConnectException)) {
+                logger.debug(() -> new ParameterizedMessage("failed to execute on node [{}]", nodeId), t);
             }
 
             responses.set(idx, new FailedNodeException(nodeId, "Failed node [" + nodeId + "]", t));

--- a/server/src/main/java/org/opensearch/bootstrap/JNAKernel32Library.java
+++ b/server/src/main/java/org/opensearch/bootstrap/JNAKernel32Library.java
@@ -131,10 +131,7 @@ final class JNAKernel32Library {
 
         public boolean callback(long dwCtrlType) {
             int event = (int) dwCtrlType;
-            if (logger.isDebugEnabled()) {
-                logger.debug("console control handler receives event [{}@{}]", event, dwCtrlType);
-
-            }
+            logger.debug("console control handler receives event [{}@{}]", () -> event, () -> dwCtrlType);
             return handler.handle(event);
         }
     }

--- a/server/src/main/java/org/opensearch/bootstrap/JNANatives.java
+++ b/server/src/main/java/org/opensearch/bootstrap/JNANatives.java
@@ -286,9 +286,7 @@ class JNANatives {
         } catch (Exception e) {
             // this is likely to happen unless the kernel is newish, its a best effort at the moment
             // so we log stacktrace at debug for now...
-            if (logger.isDebugEnabled()) {
-                logger.debug("unable to install syscall filter", e);
-            }
+            logger.debug(() -> "unable to install syscall filter", e);
             logger.warn("unable to install syscall filter: ", e);
         }
     }

--- a/server/src/main/java/org/opensearch/bootstrap/SystemCallFilter.java
+++ b/server/src/main/java/org/opensearch/bootstrap/SystemCallFilter.java
@@ -433,12 +433,10 @@ final class SystemCallFilter {
         if (linux_syscall(arch.seccomp, SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_TSYNC, new NativeLong(pointer)) != 0) {
             method = 0;
             int errno1 = Native.getLastError();
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                    "seccomp(SECCOMP_SET_MODE_FILTER): {}, falling back to prctl(PR_SET_SECCOMP)...",
-                    JNACLibrary.strerror(errno1)
-                );
-            }
+            logger.debug(
+                "seccomp(SECCOMP_SET_MODE_FILTER): {}, falling back to prctl(PR_SET_SECCOMP)...",
+                () -> JNACLibrary.strerror(errno1)
+            );
             if (linux_prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, pointer, 0, 0) != 0) {
                 int errno2 = Native.getLastError();
                 throw new UnsupportedOperationException(

--- a/server/src/main/java/org/opensearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/opensearch/cluster/InternalClusterInfoService.java
@@ -285,9 +285,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                     logger.error("NodeStatsAction timed out for ClusterInfoUpdateJob", e);
                 } else {
                     if (e instanceof ClusterBlockException) {
-                        if (logger.isTraceEnabled()) {
-                            logger.trace("Failed to execute NodeStatsAction for ClusterInfoUpdateJob", e);
-                        }
+                        logger.trace(() -> "Failed to execute NodeStatsAction for ClusterInfoUpdateJob", e);
                     } else {
                         logger.warn("Failed to execute NodeStatsAction for ClusterInfoUpdateJob", e);
                     }
@@ -319,9 +317,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                     logger.error("IndicesStatsAction timed out for ClusterInfoUpdateJob", e);
                 } else {
                     if (e instanceof ClusterBlockException) {
-                        if (logger.isTraceEnabled()) {
-                            logger.trace("Failed to execute IndicesStatsAction for ClusterInfoUpdateJob", e);
-                        }
+                        logger.trace(() -> "Failed to execute IndicesStatsAction for ClusterInfoUpdateJob", e);
                     } else {
                         logger.warn("Failed to execute IndicesStatsAction for ClusterInfoUpdateJob", e);
                     }
@@ -422,25 +418,23 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                 }
                 String nodeId = nodeStats.getNode().getId();
                 String nodeName = nodeStats.getNode().getName();
-                if (logger.isTraceEnabled()) {
-                    logger.trace(
-                        "node: [{}], most available: total disk: {},"
-                            + " available disk: {} / least available: total disk: {}, available disk: {}",
-                        nodeId,
-                        mostAvailablePath.getTotal(),
-                        mostAvailablePath.getAvailable(),
-                        leastAvailablePath.getTotal(),
-                        leastAvailablePath.getAvailable()
-                    );
-                }
+                final FsInfo.Path finalMostAvailablePath = mostAvailablePath;
+                final FsInfo.Path finalLeastAvailablePath = leastAvailablePath;
+                logger.trace(
+                    "node: [{}], most available: total disk: {},"
+                        + " available disk: {} / least available: total disk: {}, available disk: {}",
+                    () -> nodeId,
+                    () -> finalMostAvailablePath.getTotal(),
+                    () -> finalMostAvailablePath.getAvailable(),
+                    () -> finalLeastAvailablePath.getTotal(),
+                    () -> finalLeastAvailablePath.getAvailable()
+                );
                 if (leastAvailablePath.getTotal().getBytes() < 0) {
-                    if (logger.isTraceEnabled()) {
-                        logger.trace(
-                            "node: [{}] least available path has less than 0 total bytes of disk [{}], skipping",
-                            nodeId,
-                            leastAvailablePath.getTotal().getBytes()
-                        );
-                    }
+                    logger.trace(
+                        "node: [{}] least available path has less than 0 total bytes of disk [{}], skipping",
+                        () -> nodeId,
+                        () -> finalLeastAvailablePath.getTotal().getBytes()
+                    );
                 } else {
                     newLeastAvailableUsages.put(
                         nodeId,
@@ -454,13 +448,11 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                     );
                 }
                 if (mostAvailablePath.getTotal().getBytes() < 0) {
-                    if (logger.isTraceEnabled()) {
-                        logger.trace(
-                            "node: [{}] most available path has less than 0 total bytes of disk [{}], skipping",
-                            nodeId,
-                            mostAvailablePath.getTotal().getBytes()
-                        );
-                    }
+                    logger.trace(
+                        "node: [{}] most available path has less than 0 total bytes of disk [{}], skipping",
+                        () -> nodeId,
+                        () -> finalMostAvailablePath.getTotal().getBytes()
+                    );
                 } else {
                     newMostAvailableUsages.put(
                         nodeId,

--- a/server/src/main/java/org/opensearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/opensearch/cluster/action/shard/ShardStateAction.java
@@ -309,9 +309,11 @@ public class ShardStateAction {
         observer.waitForNextChange(new ClusterStateObserver.Listener() {
             @Override
             public void onNewClusterState(ClusterState state) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("new cluster state [{}] after waiting for cluster-manager election for shard entry [{}]", state, request);
-                }
+                logger.trace(
+                    "new cluster state [{}] after waiting for cluster-manager election for shard entry [{}]",
+                    () -> state,
+                    () -> request
+                );
                 sendShardAction(actionName, state, request, listener);
             }
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataMappingService.java
@@ -331,8 +331,8 @@ public class MetadataMappingService {
                     updatedMapping = true;
                     if (logger.isDebugEnabled()) {
                         logger.debug("{} create_mapping with source [{}]", index, updatedSource);
-                    } else if (logger.isInfoEnabled()) {
-                        logger.info("{} create_mapping", index);
+                    } else {
+                        logger.info("{} create_mapping", () -> index);
                     }
                 }
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -71,6 +71,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
     private final float avgPrimaryShardsPerNode;
     private final BalancedShardsAllocator.NodeSorter sorter;
     private final Set<RoutingNode> inEligibleTargetNode;
+    private int totalShardCount = 0;
 
     public LocalShardsBalancer(
         Logger logger,
@@ -130,8 +131,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
      */
     @Override
     public float avgShardsPerNode() {
-        float totalShards = nodes.values().stream().map(BalancedShardsAllocator.ModelNode::numShards).reduce(0, Integer::sum);
-        return totalShards / nodes.size();
+        return totalShardCount / nodes.size();
     }
 
     /**
@@ -600,6 +600,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
                 final BalancedShardsAllocator.ModelNode sourceNode = nodes.get(shardRouting.currentNodeId());
                 final BalancedShardsAllocator.ModelNode targetNode = nodes.get(moveDecision.getTargetNode().getId());
                 sourceNode.removeShard(shardRouting);
+                --totalShardCount;
                 Tuple<ShardRouting, ShardRouting> relocatingShards = routingNodes.relocateShard(
                     shardRouting,
                     targetNode.getNodeId(),
@@ -607,6 +608,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
                     allocation.changes()
                 );
                 targetNode.addShard(relocatingShards.v2());
+                ++totalShardCount;
                 logger.trace("Moved shard [{}] to node [{}]", () -> shardRouting, () -> targetNode.getRoutingNode());
 
                 // Verifying if this node can be considered ineligible for further iterations
@@ -724,6 +726,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
                 /* we skip relocating shards here since we expect an initializing shard with the same id coming in */
                 if (RoutingPool.LOCAL_ONLY.equals(RoutingPool.getShardPool(shard, allocation)) && shard.state() != RELOCATING) {
                     node.addShard(shard);
+                    ++totalShardCount;
                     logger.trace("Assigned shard [{}] to node [{}]", () -> shard, () -> node.getNodeId());
                 }
             }
@@ -810,6 +813,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
                     );
                     shard = routingNodes.initializeShard(shard, minNode.getNodeId(), null, shardSize, allocation.changes());
                     minNode.addShard(shard);
+                    ++totalShardCount;
                     if (!shard.primary()) {
                         // copy over the same replica shards to the secondary array so they will get allocated
                         // in a subsequent iteration, allowing replicas of other shards to be allocated first
@@ -837,6 +841,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
                             allocation.routingTable()
                         );
                         minNode.addShard(shard.initialize(minNode.getNodeId(), null, shardSize));
+                        ++totalShardCount;
                     } else {
                         logger.trace("No Node found to assign shard [{}]", () -> finalShard);
                     }
@@ -1009,18 +1014,21 @@ public class LocalShardsBalancer extends ShardsBalancer {
                 }
                 final Decision decision = new Decision.Multi().add(allocationDecision).add(rebalanceDecision);
                 maxNode.removeShard(shard);
+                --totalShardCount;
                 long shardSize = allocation.clusterInfo().getShardSize(shard, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE);
 
                 if (decision.type() == Decision.Type.YES) {
                     /* only allocate on the cluster if we are not throttled */
                     logger.debug("Relocate [{}] from [{}] to [{}]", shard, maxNode.getNodeId(), minNode.getNodeId());
                     minNode.addShard(routingNodes.relocateShard(shard, minNode.getNodeId(), shardSize, allocation.changes()).v1());
+                    ++totalShardCount;
                     return true;
                 } else {
                     /* allocate on the model even if throttled */
                     logger.debug("Simulate relocation of [{}] from [{}] to [{}]", shard, maxNode.getNodeId(), minNode.getNodeId());
                     assert decision.type() == Decision.Type.THROTTLE;
                     minNode.addShard(shard.relocate(minNode.getNodeId(), shardSize));
+                    ++totalShardCount;
                     return false;
                 }
             }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -90,14 +90,12 @@ public class AllocationDeciders extends AllocationDecider {
             Decision decision = allocationDecider.canAllocate(shardRouting, node, allocation);
             // short track if a NO is returned.
             if (decision == Decision.NO) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace(
-                        "Can not allocate [{}] on node [{}] due to [{}]",
-                        shardRouting,
-                        node.node(),
-                        allocationDecider.getClass().getSimpleName()
-                    );
-                }
+                logger.trace(
+                    "Can not allocate [{}] on node [{}] due to [{}]",
+                    () -> shardRouting,
+                    () -> node.node(),
+                    () -> allocationDecider.getClass().getSimpleName()
+                );
                 // short circuit only if debugging is not enabled
                 if (allocation.debugDecision() == false) {
                     return decision;
@@ -114,9 +112,7 @@ public class AllocationDeciders extends AllocationDecider {
     @Override
     public Decision canRemain(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
         if (allocation.shouldIgnoreShardForNode(shardRouting.shardId(), node.nodeId())) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("Shard [{}] should be ignored for node [{}]", shardRouting, node.nodeId());
-            }
+            logger.trace("Shard [{}] should be ignored for node [{}]", () -> shardRouting, () -> node.nodeId());
             return Decision.NO;
         }
         Decision.Multi ret = new Decision.Multi();
@@ -124,14 +120,12 @@ public class AllocationDeciders extends AllocationDecider {
             Decision decision = allocationDecider.canRemain(shardRouting, node, allocation);
             // short track if a NO is returned.
             if (decision == Decision.NO) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace(
-                        "Shard [{}] can not remain on node [{}] due to [{}]",
-                        shardRouting,
-                        node.nodeId(),
-                        allocationDecider.getClass().getSimpleName()
-                    );
-                }
+                logger.trace(
+                    "Shard [{}] can not remain on node [{}] due to [{}]",
+                    () -> shardRouting,
+                    () -> node.nodeId(),
+                    () -> allocationDecider.getClass().getSimpleName()
+                );
                 if (allocation.debugDecision() == false) {
                     return decision;
                 } else {
@@ -232,14 +226,12 @@ public class AllocationDeciders extends AllocationDecider {
             Decision decision = decider.canForceAllocatePrimary(shardRouting, node, allocation);
             // short track if a NO is returned.
             if (decision == Decision.NO) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace(
-                        "Shard [{}] can not be forcefully allocated to node [{}] due to [{}].",
-                        shardRouting.shardId(),
-                        node.nodeId(),
-                        decider.getClass().getSimpleName()
-                    );
-                }
+                logger.trace(
+                    "Shard [{}] can not be forcefully allocated to node [{}] due to [{}].",
+                    () -> shardRouting.shardId(),
+                    () -> node.nodeId(),
+                    () -> decider.getClass().getSimpleName()
+                );
                 if (allocation.debugDecision() == false) {
                     return decision;
                 } else {
@@ -258,9 +250,11 @@ public class AllocationDeciders extends AllocationDecider {
         for (AllocationDecider decider : allocations) {
             Decision decision = decider.canAllocateAnyShardToNode(node, allocation);
             if (decision.type().canPreemptivelyReturn()) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Shard can not be allocated on node [{}] due to [{}]", node.nodeId(), decider.getClass().getSimpleName());
-                }
+                logger.trace(
+                    "Shard can not be allocated on node [{}] due to [{}]",
+                    () -> node.nodeId(),
+                    () -> decider.getClass().getSimpleName()
+                );
                 if (allocation.debugDecision() == false) {
                     return decision;
                 } else {
@@ -280,9 +274,7 @@ public class AllocationDeciders extends AllocationDecider {
             Decision decision = decider.canMoveAway(shardRouting, allocation);
             // short track if a NO is returned.
             if (decision.type().canPreemptivelyReturn()) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Shard [{}] can not be moved away due to [{}]", shardRouting, decider.getClass().getSimpleName());
-                }
+                logger.trace("Shard [{}] can not be moved away due to [{}]", () -> shardRouting, () -> decider.getClass().getSimpleName());
                 if (allocation.debugDecision() == false) {
                     return decision;
                 } else {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -270,9 +270,7 @@ public class DiskThresholdDecider extends AllocationDecider {
         }
 
         ByteSizeValue freeBytesValue = new ByteSizeValue(freeBytes);
-        if (logger.isTraceEnabled()) {
-            logger.trace("node [{}] has {}% used disk", node.nodeId(), usedDiskPercentage);
-        }
+        logger.trace("node [{}] has {}% used disk", () -> node.nodeId(), () -> usedDiskPercentage);
 
         // flag that determines whether the low threshold checks below can be skipped. We use this for a primary shard that is freshly
         // allocated and empty.
@@ -283,14 +281,12 @@ public class DiskThresholdDecider extends AllocationDecider {
         // checks for exact byte comparisons
         if (freeBytes < diskThresholdSettings.getFreeBytesThresholdLow().getBytes()) {
             if (skipLowThresholdChecks == false) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug(
-                        "less than the required {} free bytes threshold ({} free) on node {}, preventing allocation",
-                        diskThresholdSettings.getFreeBytesThresholdLow(),
-                        freeBytesValue,
-                        node.nodeId()
-                    );
-                }
+                logger.debug(
+                    "less than the required {} free bytes threshold ({} free) on node {}, preventing allocation",
+                    () -> diskThresholdSettings.getFreeBytesThresholdLow(),
+                    () -> freeBytesValue,
+                    () -> node.nodeId()
+                );
                 return allocation.decision(
                     Decision.NO,
                     NAME,
@@ -304,15 +300,13 @@ public class DiskThresholdDecider extends AllocationDecider {
             } else if (freeBytes > diskThresholdSettings.getFreeBytesThresholdHigh().getBytes()) {
                 // Allow the shard to be allocated because it is primary that
                 // has never been allocated if it's under the high watermark
-                if (logger.isDebugEnabled()) {
-                    logger.debug(
-                        "less than the required {} free bytes threshold ({} free) on node {}, "
-                            + "but allowing allocation because primary has never been allocated",
-                        diskThresholdSettings.getFreeBytesThresholdLow(),
-                        freeBytesValue,
-                        node.nodeId()
-                    );
-                }
+                logger.debug(
+                    "less than the required {} free bytes threshold ({} free) on node {}, "
+                        + "but allowing allocation because primary has never been allocated",
+                    () -> diskThresholdSettings.getFreeBytesThresholdLow(),
+                    () -> freeBytesValue,
+                    () -> node.nodeId()
+                );
                 return allocation.decision(
                     Decision.YES,
                     NAME,
@@ -322,15 +316,13 @@ public class DiskThresholdDecider extends AllocationDecider {
             } else {
                 // Even though the primary has never been allocated, the node is
                 // above the high watermark, so don't allow allocating the shard
-                if (logger.isDebugEnabled()) {
-                    logger.debug(
-                        "less than the required {} free bytes threshold ({} free) on node {}, "
-                            + "preventing allocation even though primary has never been allocated",
-                        diskThresholdSettings.getFreeBytesThresholdHigh(),
-                        freeBytesValue,
-                        node.nodeId()
-                    );
-                }
+                logger.debug(
+                    "less than the required {} free bytes threshold ({} free) on node {}, "
+                        + "preventing allocation even though primary has never been allocated",
+                    () -> diskThresholdSettings.getFreeBytesThresholdHigh(),
+                    () -> freeBytesValue,
+                    () -> node.nodeId()
+                );
                 return allocation.decision(
                     Decision.NO,
                     NAME,
@@ -348,14 +340,12 @@ public class DiskThresholdDecider extends AllocationDecider {
         if (freeDiskPercentage < diskThresholdSettings.getFreeDiskThresholdLow()) {
             // If the shard is a replica or is a non-empty primary, check the low threshold
             if (skipLowThresholdChecks == false) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug(
-                        "more than the allowed {} used disk threshold ({} used) on node [{}], preventing allocation",
-                        Strings.format1Decimals(usedDiskThresholdLow, "%"),
-                        Strings.format1Decimals(usedDiskPercentage, "%"),
-                        node.nodeId()
-                    );
-                }
+                logger.debug(
+                    "more than the allowed {} used disk threshold ({} used) on node [{}], preventing allocation",
+                    () -> Strings.format1Decimals(usedDiskThresholdLow, "%"),
+                    () -> Strings.format1Decimals(usedDiskPercentage, "%"),
+                    () -> node.nodeId()
+                );
                 return allocation.decision(
                     Decision.NO,
                     NAME,
@@ -369,15 +359,13 @@ public class DiskThresholdDecider extends AllocationDecider {
             } else if (freeDiskPercentage > diskThresholdSettings.getFreeDiskThresholdHigh()) {
                 // Allow the shard to be allocated because it is primary that
                 // has never been allocated if it's under the high watermark
-                if (logger.isDebugEnabled()) {
-                    logger.debug(
-                        "more than the allowed {} used disk threshold ({} used) on node [{}], "
-                            + "but allowing allocation because primary has never been allocated",
-                        Strings.format1Decimals(usedDiskThresholdLow, "%"),
-                        Strings.format1Decimals(usedDiskPercentage, "%"),
-                        node.nodeId()
-                    );
-                }
+                logger.debug(
+                    "more than the allowed {} used disk threshold ({} used) on node [{}], "
+                        + "but allowing allocation because primary has never been allocated",
+                    () -> Strings.format1Decimals(usedDiskThresholdLow, "%"),
+                    () -> Strings.format1Decimals(usedDiskPercentage, "%"),
+                    () -> node.nodeId()
+                );
                 return allocation.decision(
                     Decision.YES,
                     NAME,
@@ -387,15 +375,13 @@ public class DiskThresholdDecider extends AllocationDecider {
             } else {
                 // Even though the primary has never been allocated, the node is
                 // above the high watermark, so don't allow allocating the shard
-                if (logger.isDebugEnabled()) {
-                    logger.debug(
-                        "less than the required {} free bytes threshold ({} bytes free) on node {}, "
-                            + "preventing allocation even though primary has never been allocated",
-                        Strings.format1Decimals(diskThresholdSettings.getFreeDiskThresholdHigh(), "%"),
-                        Strings.format1Decimals(freeDiskPercentage, "%"),
-                        node.nodeId()
-                    );
-                }
+                logger.debug(
+                    "less than the required {} free bytes threshold ({} bytes free) on node {}, "
+                        + "preventing allocation even though primary has never been allocated",
+                    () -> Strings.format1Decimals(diskThresholdSettings.getFreeDiskThresholdHigh(), "%"),
+                    () -> Strings.format1Decimals(freeDiskPercentage, "%"),
+                    () -> node.nodeId()
+                );
                 return allocation.decision(
                     Decision.NO,
                     NAME,
@@ -510,9 +496,7 @@ public class DiskThresholdDecider extends AllocationDecider {
         // If this node is already above the high threshold, the shard cannot remain (get it off!)
         final double freeDiskPercentage = usage.getFreeDiskAsPercentage();
         final long freeBytes = usage.getFreeBytes();
-        if (logger.isTraceEnabled()) {
-            logger.trace("node [{}] has {}% free disk ({} bytes)", node.nodeId(), freeDiskPercentage, freeBytes);
-        }
+        logger.trace("node [{}] has {}% free disk ({} bytes)", () -> node.nodeId(), () -> freeDiskPercentage, () -> freeBytes);
         if (dataPath == null || usage.getPath().equals(dataPath) == false) {
             return allocation.decision(Decision.YES, NAME, "this shard is not allocated on the most utilized disk and can remain");
         }
@@ -542,14 +526,12 @@ public class DiskThresholdDecider extends AllocationDecider {
             );
         }
         if (freeBytes < diskThresholdSettings.getFreeBytesThresholdHigh().getBytes()) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                    "less than the required {} free bytes threshold ({} bytes free) on node {}, shard cannot remain",
-                    diskThresholdSettings.getFreeBytesThresholdHigh(),
-                    freeBytes,
-                    node.nodeId()
-                );
-            }
+            logger.debug(
+                "less than the required {} free bytes threshold ({} bytes free) on node {}, shard cannot remain",
+                () -> diskThresholdSettings.getFreeBytesThresholdHigh(),
+                () -> freeBytes,
+                () -> node.nodeId()
+            );
             return allocation.decision(
                 Decision.NO,
                 NAME,
@@ -562,14 +544,12 @@ public class DiskThresholdDecider extends AllocationDecider {
             );
         }
         if (freeDiskPercentage < diskThresholdSettings.getFreeDiskThresholdHigh()) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                    "less than the required {}% free disk threshold ({}% free) on node {}, shard cannot remain",
-                    diskThresholdSettings.getFreeDiskThresholdHigh(),
-                    freeDiskPercentage,
-                    node.nodeId()
-                );
-            }
+            logger.debug(
+                "less than the required {}% free disk threshold ({}% free) on node {}, shard cannot remain",
+                () -> diskThresholdSettings.getFreeDiskThresholdHigh(),
+                () -> freeDiskPercentage,
+                () -> node.nodeId()
+            );
             return allocation.decision(
                 Decision.NO,
                 NAME,
@@ -603,15 +583,14 @@ public class DiskThresholdDecider extends AllocationDecider {
             // If there is no usage, and we have other nodes in the cluster,
             // use the average usage for all nodes as the usage for this node
             usage = new DiskUsage(node.nodeId(), node.node().getName(), "_na_", avgTotalBytes, avgFreeBytes);
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                    "unable to determine disk usage for {}, defaulting to average across nodes [{} total] [{} free] [{}% free]",
-                    node.nodeId(),
-                    usage.getTotalBytes(),
-                    usage.getFreeBytes(),
-                    usage.getFreeDiskAsPercentage()
-                );
-            }
+            final DiskUsage averageUsage = usage;
+            logger.debug(
+                "unable to determine disk usage for {}, defaulting to average across nodes [{} total] [{} free] [{}% free]",
+                () -> node.nodeId(),
+                () -> averageUsage.getTotalBytes(),
+                () -> averageUsage.getFreeBytes(),
+                () -> averageUsage.getFreeDiskAsPercentage()
+            );
         }
 
         final DiskUsageWithRelocations diskUsageWithRelocations = new DiskUsageWithRelocations(
@@ -627,9 +606,7 @@ public class DiskThresholdDecider extends AllocationDecider {
                 )
                 : 0
         );
-        if (logger.isTraceEnabled()) {
-            logger.trace("getDiskUsage(subtractLeavingShards={}) returning {}", subtractLeavingShards, diskUsageWithRelocations);
-        }
+        logger.trace("getDiskUsage(subtractLeavingShards={}) returning {}", () -> subtractLeavingShards, () -> diskUsageWithRelocations);
 
         return diskUsageWithRelocations;
     }
@@ -661,26 +638,20 @@ public class DiskThresholdDecider extends AllocationDecider {
 
         // Allow allocation regardless if only a single data node is available
         if (enableForSingleDataNode == false && allocation.nodes().getDataNodes().size() <= 1) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("only a single data node is present, allowing allocation");
-            }
+            logger.trace(() -> "only a single data node is present, allowing allocation");
             return allocation.decision(Decision.YES, NAME, "there is only a single data node present");
         }
 
         // Fail open there is no info available
         final ClusterInfo clusterInfo = allocation.clusterInfo();
         if (clusterInfo == null) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("cluster info unavailable for disk threshold decider, allowing allocation.");
-            }
+            logger.trace(() -> "cluster info unavailable for disk threshold decider, allowing allocation.");
             return allocation.decision(Decision.YES, NAME, "the cluster info is unavailable");
         }
 
         // Fail open if there are no disk usages available
         if (usages.isEmpty()) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("unable to determine disk usages for disk-aware allocation, allowing allocation");
-            }
+            logger.trace(() -> "unable to determine disk usages for disk-aware allocation, allowing allocation");
             return allocation.decision(Decision.YES, NAME, "disk usages are unavailable");
         }
         return null;

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
@@ -86,13 +86,11 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
                     && !shardSnapshotStatus.state().completed()
                     && shardSnapshotStatus.nodeId() != null
                     && shardSnapshotStatus.nodeId().equals(shardRouting.currentNodeId())) {
-                    if (logger.isTraceEnabled()) {
-                        logger.trace(
-                            "Preventing snapshotted shard [{}] from being moved away from node [{}]",
-                            shardRouting.shardId(),
-                            shardSnapshotStatus.nodeId()
-                        );
-                    }
+                    logger.trace(
+                        "Preventing snapshotted shard [{}] from being moved away from node [{}]",
+                        () -> shardRouting.shardId(),
+                        () -> shardSnapshotStatus.nodeId()
+                    );
                     return allocation.decision(
                         Decision.THROTTLE,
                         NAME,

--- a/server/src/main/java/org/opensearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/opensearch/cluster/service/ClusterApplierService.java
@@ -489,16 +489,8 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
             warnAboutSlowTaskIfNeeded(executionTime, task.source, stopWatch);
             task.listener.onSuccess(task.source);
         } else {
-            if (logger.isTraceEnabled()) {
-                logger.debug(
-                    "cluster state updated, version [{}], source [{}]\n{}",
-                    newClusterState.version(),
-                    task.source,
-                    newClusterState
-                );
-            } else {
-                logger.debug("cluster state updated, version [{}], source [{}]", newClusterState.version(), task.source);
-            }
+            logger.debug("cluster state updated, version [{}], source [{}]", () -> newClusterState.version(), () -> task.source);
+            logger.trace("{}", () -> newClusterState);
             try {
                 applyChanges(task, previousClusterState, newClusterState, stopWatch);
                 TimeValue executionTime = TimeValue.timeValueMillis(Math.max(0, currentTimeInMillis() - startTimeMS));
@@ -513,30 +505,17 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
                 task.listener.onSuccess(task.source);
             } catch (Exception e) {
                 TimeValue executionTime = TimeValue.timeValueMillis(Math.max(0, currentTimeInMillis() - startTimeMS));
-                if (logger.isTraceEnabled()) {
-                    logger.warn(
-                        new ParameterizedMessage(
-                            "failed to apply updated cluster state in [{}]:\nversion [{}], uuid [{}], source [{}]\n{}",
-                            executionTime,
-                            newClusterState.version(),
-                            newClusterState.stateUUID(),
-                            task.source,
-                            newClusterState
-                        ),
-                        e
-                    );
-                } else {
-                    logger.warn(
-                        new ParameterizedMessage(
-                            "failed to apply updated cluster state in [{}]:\nversion [{}], uuid [{}], source [{}]",
-                            executionTime,
-                            newClusterState.version(),
-                            newClusterState.stateUUID(),
-                            task.source
-                        ),
-                        e
-                    );
-                }
+                logger.warn(
+                    () -> new ParameterizedMessage(
+                        "failed to apply updated cluster state in [{}]:\nversion [{}], uuid [{}], source [{}]",
+                        executionTime,
+                        newClusterState.version(),
+                        newClusterState.stateUUID(),
+                        task.source
+                    ),
+                    e
+                );
+                logger.trace("{}", () -> newClusterState);
                 // failing to apply a cluster state with an exception indicates a bug in validation or in one of the appliers; if we
                 // continue we will retry with the same cluster state but that might not help.
                 assert applicationMayFail();

--- a/server/src/main/java/org/opensearch/common/Rounding.java
+++ b/server/src/main/java/org/opensearch/common/Rounding.java
@@ -1234,8 +1234,14 @@ public abstract class Rounding implements Writeable {
                     }
                     assert highEnough && (false == tooHigh);
                     assert roundedRoundedDown == prevRound;
-                    if (iterations > 3 && logger.isDebugEnabled()) {
-                        logger.debug("Iterated {} time for {} using {}", iterations, utcMillis, TimeIntervalRounding.this.toString());
+                    if (iterations > 3) {
+                        final int currentIterations = iterations;
+                        logger.debug(
+                            "Iterated {} time for {} using {}",
+                            () -> currentIterations,
+                            () -> utcMillis,
+                            () -> TimeIntervalRounding.this.toString()
+                        );
                     }
                     return rounded;
                 }

--- a/server/src/main/java/org/opensearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/server/src/main/java/org/opensearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -170,19 +170,18 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
             currentUsed = this.used.get();
             newUsed = currentUsed + bytes;
             long newUsedWithOverhead = (long) (newUsed * overheadConstant);
-            if (logger.isTraceEnabled()) {
-                logger.trace(
-                    "[{}] Adding [{}][{}] to used bytes [new used: [{}], limit: {} [{}], estimate: {} [{}]]",
-                    this.name,
-                    new ByteSizeValue(bytes),
-                    label,
-                    new ByteSizeValue(newUsed),
-                    memoryBytesLimit,
-                    new ByteSizeValue(memoryBytesLimit),
-                    newUsedWithOverhead,
-                    new ByteSizeValue(newUsedWithOverhead)
-                );
-            }
+            final long finalNewUsed = newUsed;
+            logger.trace(
+                "[{}] Adding [{}][{}] to used bytes [new used: [{}], limit: {} [{}], estimate: {} [{}]]",
+                () -> this.name,
+                () -> new ByteSizeValue(bytes),
+                () -> label,
+                () -> new ByteSizeValue(finalNewUsed),
+                () -> memoryBytesLimit,
+                () -> new ByteSizeValue(memoryBytesLimit),
+                () -> newUsedWithOverhead,
+                () -> new ByteSizeValue(newUsedWithOverhead)
+            );
             if (memoryBytesLimit > 0 && newUsedWithOverhead > memoryBytesLimit) {
                 logger.warn(
                     "[{}] New used memory {} [{}] for data of [{}] would be larger than configured breaker: {} [{}], breaking",

--- a/server/src/main/java/org/opensearch/common/settings/Setting.java
+++ b/server/src/main/java/org/opensearch/common/settings/Setting.java
@@ -2435,12 +2435,15 @@ public class Setting<T> implements ToXContentObject {
     }
 
     static void logSettingUpdate(Setting setting, Settings current, Settings previous, Logger logger) {
-        if (logger.isInfoEnabled()) {
-            if (setting.isFiltered()) {
-                logger.info("updating [{}]", setting.key);
-            } else {
-                logger.info("updating [{}] from [{}] to [{}]", setting.key, setting.getRaw(previous), setting.getRaw(current));
-            }
+        if (setting.isFiltered()) {
+            logger.info("updating [{}]", () -> setting.key);
+        } else {
+            logger.info(
+                "updating [{}] from [{}] to [{}]",
+                () -> setting.key,
+                () -> setting.getRaw(previous),
+                () -> setting.getRaw(current)
+            );
         }
     }
 

--- a/server/src/main/java/org/opensearch/common/util/concurrent/AbstractAsyncTask.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/AbstractAsyncTask.java
@@ -103,9 +103,7 @@ public abstract class AbstractAsyncTask implements Runnable, Closeable {
             cancellable.cancel();
         }
         if (interval.millis() > 0 && mustReschedule()) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("scheduling {} every {}", toString(), interval);
-            }
+            logger.trace("scheduling {} every {}", () -> toString(), () -> interval);
             cancellable = threadPool.schedule(this, interval, getThreadPool());
             isScheduledOrRunning = true;
         } else {

--- a/server/src/main/java/org/opensearch/common/util/concurrent/QueueResizingOpenSearchThreadPoolExecutor.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/QueueResizingOpenSearchThreadPoolExecutor.java
@@ -210,33 +210,30 @@ public final class QueueResizingOpenSearchThreadPoolExecutor extends OpenSearchT
                 final int desiredQueueSize = calculateL(lambda, targetedResponseTimeNanos);
                 final int oldCapacity = workQueue.capacity();
 
-                if (logger.isDebugEnabled()) {
-                    final long avgTaskTime = totalNanos / tasksPerFrame;
-                    logger.debug(
-                        "[{}]: there were [{}] tasks in [{}], avg task time [{}], EWMA task execution [{}], "
-                            + "[{} tasks/s], optimal queue is [{}], current capacity [{}]",
-                        getName(),
-                        tasksPerFrame,
-                        TimeValue.timeValueNanos(totalRuntime),
-                        TimeValue.timeValueNanos(avgTaskTime),
-                        TimeValue.timeValueNanos((long) executionEWMA.getAverage()),
-                        String.format(Locale.ROOT, "%.2f", lambda * TimeValue.timeValueSeconds(1).nanos()),
-                        desiredQueueSize,
-                        oldCapacity
-                    );
-                }
+                logger.debug(
+                    "[{}]: there were [{}] tasks in [{}], avg task time [{}], EWMA task execution [{}], "
+                        + "[{} tasks/s], optimal queue is [{}], current capacity [{}]",
+                    () -> getName(),
+                    () -> tasksPerFrame,
+                    () -> TimeValue.timeValueNanos(totalRuntime),
+                    () -> TimeValue.timeValueNanos(totalNanos / tasksPerFrame),
+                    () -> TimeValue.timeValueNanos((long) executionEWMA.getAverage()),
+                    () -> String.format(Locale.ROOT, "%.2f", lambda * TimeValue.timeValueSeconds(1).nanos()),
+                    () -> desiredQueueSize,
+                    () -> oldCapacity
+                );
 
                 // Adjust the queue size towards the desired capacity using an adjust of
                 // QUEUE_ADJUSTMENT_AMOUNT (either up or down), keeping in mind the min and max
                 // values the queue size can have.
                 final int newCapacity = workQueue.adjustCapacity(desiredQueueSize, QUEUE_ADJUSTMENT_AMOUNT, minQueueSize, maxQueueSize);
-                if (oldCapacity != newCapacity && logger.isDebugEnabled()) {
+                if (oldCapacity != newCapacity) {
                     logger.debug(
                         "adjusted [{}] queue size by [{}], old capacity: [{}], new capacity: [{}]",
-                        getName(),
-                        newCapacity > oldCapacity ? QUEUE_ADJUSTMENT_AMOUNT : -QUEUE_ADJUSTMENT_AMOUNT,
-                        oldCapacity,
-                        newCapacity
+                        () -> getName(),
+                        () -> newCapacity > oldCapacity ? QUEUE_ADJUSTMENT_AMOUNT : -QUEUE_ADJUSTMENT_AMOUNT,
+                        () -> oldCapacity,
+                        () -> newCapacity
                     );
                 }
             } catch (ArithmeticException e) {

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -365,9 +365,7 @@ public final class NodeEnvironment implements Closeable {
 
             this.nodeLockId = nodeLock.nodeId;
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("using node location [{}], local_lock_id [{}]", nodePaths, nodeLockId);
-            }
+            logger.debug("using node location [{}], local_lock_id [{}]", () -> nodePaths, () -> nodeLockId);
 
             maybeLogPathDetails();
             maybeLogHeapDetails();

--- a/server/src/main/java/org/opensearch/gateway/PrimaryShardAllocator.java
+++ b/server/src/main/java/org/opensearch/gateway/PrimaryShardAllocator.java
@@ -433,13 +433,11 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
 
         nodeShardStates.sort(createActiveShardComparator(matchAnyShard, inSyncAllocationIds));
 
-        if (logger.isTraceEnabled()) {
-            logger.trace(
-                "{} candidates for allocation: {}",
-                shard,
-                nodeShardStates.stream().map(s -> s.getNode().getName()).collect(Collectors.joining(", "))
-            );
-        }
+        logger.trace(
+            "{} candidates for allocation: {}",
+            () -> shard,
+            () -> nodeShardStates.stream().map(s -> s.getNode().getName()).collect(Collectors.joining(", "))
+        );
         return new NodeShardsResult(nodeShardStates, numberOfAllocationsFound);
     }
 

--- a/server/src/main/java/org/opensearch/gateway/ReplicaShardAllocator.java
+++ b/server/src/main/java/org/opensearch/gateway/ReplicaShardAllocator.java
@@ -450,23 +450,24 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
                 matchingNode = computeMatchingNode(primaryNode, primaryStore, discoNode, storeFilesMetadata);
             }
             matchingNodes.put(discoNode, matchingNode);
-            if (logger.isTraceEnabled()) {
-                if (matchingNode.isNoopRecovery) {
-                    logger.trace("{}: node [{}] can perform a noop recovery", shard, discoNode.getName());
-                } else if (matchingNode.retainingSeqNo >= 0) {
+            if (matchingNode.isNoopRecovery) {
+                logger.trace("{}: node [{}] can perform a noop recovery", () -> shard, () -> discoNode.getName());
+            } else {
+                final MatchingNode finalMatchingNode = matchingNode;
+                if (matchingNode.retainingSeqNo >= 0) {
                     logger.trace(
                         "{}: node [{}] can perform operation-based recovery with retaining sequence number [{}]",
-                        shard,
-                        discoNode.getName(),
-                        matchingNode.retainingSeqNo
+                        () -> shard,
+                        () -> discoNode.getName(),
+                        () -> finalMatchingNode.retainingSeqNo
                     );
                 } else {
                     logger.trace(
                         "{}: node [{}] has [{}/{}] bytes of re-usable data",
-                        shard,
-                        discoNode.getName(),
-                        new ByteSizeValue(matchingNode.matchingBytes),
-                        matchingNode.matchingBytes
+                        () -> shard,
+                        () -> discoNode.getName(),
+                        () -> new ByteSizeValue(finalMatchingNode.matchingBytes),
+                        () -> finalMatchingNode.matchingBytes
                     );
                 }
             }

--- a/server/src/main/java/org/opensearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/opensearch/http/AbstractHttpServerTransport.java
@@ -218,9 +218,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
             throw new BindHttpException("Failed to bind to " + NetworkAddress.format(hostAddress, port), lastException.get());
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Bound http to address {{}}", NetworkAddress.format(boundSocket.get()));
-        }
+        logger.debug("Bound http to address {{}}", () -> NetworkAddress.format(boundSocket.get()));
         return new TransportAddress(boundSocket.get());
     }
 

--- a/server/src/main/java/org/opensearch/http/HttpTracer.java
+++ b/server/src/main/java/org/opensearch/http/HttpTracer.java
@@ -79,9 +79,9 @@ class HttpTracer {
      */
     @Nullable
     HttpTracer maybeTraceRequest(RestRequest restRequest, @Nullable Exception e) {
-        if (logger.isTraceEnabled() && TransportService.shouldTraceAction(restRequest.uri(), tracerLogInclude, tracerLogExclude)) {
+        if (TransportService.shouldTraceAction(restRequest.uri(), tracerLogInclude, tracerLogExclude)) {
             logger.trace(
-                new ParameterizedMessage(
+                () -> new ParameterizedMessage(
                     "[{}][{}][{}][{}] received request from [{}]",
                     restRequest.getRequestId(),
                     restRequest.header(Task.X_OPAQUE_ID),

--- a/server/src/main/java/org/opensearch/identity/tokens/RestTokenExtractor.java
+++ b/server/src/main/java/org/opensearch/identity/tokens/RestTokenExtractor.java
@@ -43,10 +43,10 @@ public class RestTokenExtractor {
             if (authHeaderValueStr.startsWith(BasicAuthToken.TOKEN_IDENTIFIER)) {
                 return new BasicAuthToken(authHeaderValueStr);
             } else {
-                if (logger.isDebugEnabled()) {
-                    String tokenTypeTruncated = Strings.substring(authHeaderValueStr, 0, 5);
-                    logger.debug("An authentication header was detected but the token type was not supported " + tokenTypeTruncated);
-                }
+                logger.debug(
+                    "An authentication header was detected but the token type was not supported {}",
+                    () -> Strings.substring(authHeaderValueStr, 0, 5)
+                );
             }
         }
 

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -1700,9 +1700,8 @@ public final class IndexSettings {
         }
         assert mergePolicyProvider != null : "should not happen as validation for invalid merge policy values "
             + "are part of setting definition";
-        if (logger.isTraceEnabled()) {
-            logger.trace("Index: " + this.index.getName() + ", Merge policy used: " + mergePolicyProvider);
-        }
+        final MergePolicyProvider finalMergePolicyProvider = mergePolicyProvider;
+        logger.trace("Index: {}, Merge policy used: {}", () -> this.index.getName(), () -> finalMergePolicyProvider);
         return mergePolicyProvider.getMergePolicy();
     }
 

--- a/server/src/main/java/org/opensearch/index/IndexWarmer.java
+++ b/server/src/main/java/org/opensearch/index/IndexWarmer.java
@@ -82,9 +82,7 @@ public final class IndexWarmer {
         if (settings.isWarmerEnabled() == false) {
             return;
         }
-        if (logger.isTraceEnabled()) {
-            logger.trace("{} top warming [{}]", shard.shardId(), reader);
-        }
+        logger.trace("{} top warming [{}]", () -> shard.shardId(), () -> reader);
         shard.warmerService().onPreWarm();
         long time = System.nanoTime();
         final List<TerminationHandle> terminationHandles = new ArrayList<>();
@@ -104,9 +102,7 @@ public final class IndexWarmer {
         }
         long took = System.nanoTime() - time;
         shard.warmerService().onPostWarm(took);
-        if (shard.warmerService().logger().isTraceEnabled()) {
-            shard.warmerService().logger().trace("top warming took [{}]", new TimeValue(took, TimeUnit.NANOSECONDS));
-        }
+        shard.warmerService().logger().trace("top warming took [{}]", () -> new TimeValue(took, TimeUnit.NANOSECONDS));
     }
 
     /**
@@ -178,15 +174,13 @@ public final class IndexWarmer {
                             global.load(reader.leaves().get(0));
                         }
 
-                        if (indexShard.warmerService().logger().isTraceEnabled()) {
-                            indexShard.warmerService()
-                                .logger()
-                                .trace(
-                                    "warmed global ordinals for [{}], took [{}]",
-                                    fieldType.name(),
-                                    TimeValue.timeValueNanos(System.nanoTime() - start)
-                                );
-                        }
+                        indexShard.warmerService()
+                            .logger()
+                            .trace(
+                                "warmed global ordinals for [{}], took [{}]",
+                                () -> fieldType.name(),
+                                () -> TimeValue.timeValueNanos(System.nanoTime() - start)
+                            );
                     } catch (Exception e) {
                         indexShard.warmerService()
                             .logger()

--- a/server/src/main/java/org/opensearch/index/cache/bitset/BitsetFilterCache.java
+++ b/server/src/main/java/org/opensearch/index/cache/bitset/BitsetFilterCache.java
@@ -294,15 +294,13 @@ public final class BitsetFilterCache extends AbstractIndexComponent
                         try {
                             final long start = System.nanoTime();
                             getAndLoadIfNotPresent(filterToWarm, ctx);
-                            if (indexShard.warmerService().logger().isTraceEnabled()) {
-                                indexShard.warmerService()
-                                    .logger()
-                                    .trace(
-                                        "warmed bitset for [{}], took [{}]",
-                                        filterToWarm,
-                                        TimeValue.timeValueNanos(System.nanoTime() - start)
-                                    );
-                            }
+                            indexShard.warmerService()
+                                .logger()
+                                .trace(
+                                    "warmed bitset for [{}], took [{}]",
+                                    () -> filterToWarm,
+                                    () -> TimeValue.timeValueNanos(System.nanoTime() - start)
+                                );
                         } catch (Exception e) {
                             indexShard.warmerService()
                                 .logger()

--- a/server/src/main/java/org/opensearch/index/engine/OpenSearchConcurrentMergeScheduler.java
+++ b/server/src/main/java/org/opensearch/index/engine/OpenSearchConcurrentMergeScheduler.java
@@ -105,16 +105,14 @@ class OpenSearchConcurrentMergeScheduler extends ConcurrentMergeScheduler {
         OnGoingMerge onGoingMerge = new OnGoingMerge(merge);
         onGoingMerges.add(onGoingMerge);
 
-        if (logger.isTraceEnabled()) {
-            logger.trace(
-                "merge [{}] starting..., merging [{}] segments, [{}] docs, [{}] size, into [{}] estimated_size",
-                OneMergeHelper.getSegmentName(merge),
-                merge.segments.size(),
-                totalNumDocs,
-                new ByteSizeValue(totalSizeInBytes),
-                new ByteSizeValue(merge.estimatedMergeBytes)
-            );
-        }
+        logger.trace(
+            "merge [{}] starting..., merging [{}] segments, [{}] docs, [{}] size, into [{}] estimated_size",
+            () -> OneMergeHelper.getSegmentName(merge),
+            () -> merge.segments.size(),
+            () -> totalNumDocs,
+            () -> new ByteSizeValue(totalSizeInBytes),
+            () -> new ByteSizeValue(merge.estimatedMergeBytes)
+        );
         try {
             beforeMerge(onGoingMerge);
             super.doMerge(mergeSource, merge);
@@ -159,8 +157,8 @@ class OpenSearchConcurrentMergeScheduler extends ConcurrentMergeScheduler {
 
             if (tookMS > 20000) { // if more than 20 seconds, DEBUG log it
                 logger.debug("{}", message);
-            } else if (logger.isTraceEnabled()) {
-                logger.trace("{}", message);
+            } else {
+                logger.trace("{}", () -> message);
             }
         }
     }

--- a/server/src/main/java/org/opensearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
@@ -84,14 +84,12 @@ public enum GlobalOrdinalsBuilder {
         final long memorySizeInBytes = ordinalMap.ramBytesUsed();
         breakerService.getBreaker(CircuitBreaker.FIELDDATA).addWithoutBreaking(memorySizeInBytes);
 
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                "global-ordinals [{}][{}] took [{}]",
-                indexFieldData.getFieldName(),
-                ordinalMap.getValueCount(),
-                new TimeValue(System.nanoTime() - startTimeNS, TimeUnit.NANOSECONDS)
-            );
-        }
+        logger.debug(
+            "global-ordinals [{}][{}] took [{}]",
+            () -> indexFieldData.getFieldName(),
+            () -> ordinalMap.getValueCount(),
+            () -> new TimeValue(System.nanoTime() - startTimeNS, TimeUnit.NANOSECONDS)
+        );
         return new GlobalOrdinalsIndexFieldData(
             indexFieldData.getFieldName(),
             indexFieldData.getValuesSourceType(),

--- a/server/src/main/java/org/opensearch/index/reindex/ClientScrollableHitSource.java
+++ b/server/src/main/java/org/opensearch/index/reindex/ClientScrollableHitSource.java
@@ -91,12 +91,10 @@ public class ClientScrollableHitSource extends ScrollableHitSource {
 
     @Override
     public void doStart(RejectAwareActionListener<Response> searchListener) {
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                "executing initial scroll against {}",
-                isEmpty(firstSearchRequest.indices()) ? "all indices" : firstSearchRequest.indices()
-            );
-        }
+        logger.debug(
+            "executing initial scroll against {}",
+            () -> isEmpty(firstSearchRequest.indices()) ? "all indices" : firstSearchRequest.indices()
+        );
         client.search(firstSearchRequest, wrapListener(searchListener));
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -500,8 +500,11 @@ final class StoreRecovery {
                         timeValueMillis(recoveryState.getTimer().time()),
                         sb
                     );
-                } else if (logger.isDebugEnabled()) {
-                    logger.debug("recovery completed from [shard_store], took [{}]", timeValueMillis(recoveryState.getTimer().time()));
+                } else {
+                    logger.debug(
+                        "recovery completed from [shard_store], took [{}]",
+                        () -> timeValueMillis(recoveryState.getTimer().time())
+                    );
                 }
             }
             listener.onResponse(res);
@@ -698,9 +701,7 @@ final class StoreRecovery {
             listener.onFailure(new IndexShardRestoreFailedException(shardId, "empty restore source"));
             return;
         }
-        if (logger.isTraceEnabled()) {
-            logger.trace("[{}] restoring shard [{}]", restoreSource.snapshot(), shardId);
-        }
+        logger.trace("[{}] restoring shard [{}]", () -> restoreSource.snapshot(), () -> shardId);
         final ActionListener<Void> restoreListener = ActionListener.wrap(v -> {
             final Store store = indexShard.store();
             if (indexShard.indexSettings.isRemoteTranslogStoreEnabled() == false) {

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -524,13 +524,11 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
         void updateStalenessThreshold(double stalenessThreshold) {
             double oldStalenessThreshold = this.stalenessThreshold;
             this.stalenessThreshold = stalenessThreshold;
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                    "Staleness threshold for indices request cache changed to {} from {}",
-                    this.stalenessThreshold,
-                    oldStalenessThreshold
-                );
-            }
+            logger.debug(
+                "Staleness threshold for indices request cache changed to {} from {}",
+                () -> this.stalenessThreshold,
+                () -> oldStalenessThreshold
+            );
         }
 
         /**
@@ -713,9 +711,7 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
          * @param stalenessThreshold The staleness threshold as a double.
          */
         private synchronized void cleanCache(double stalenessThreshold) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Cleaning Indices Request Cache with threshold : " + stalenessThreshold);
-            }
+            logger.debug("Cleaning Indices Request Cache with threshold : {}", () -> stalenessThreshold);
             if (canSkipCacheCleanup(stalenessThreshold)) {
                 return;
             }
@@ -799,14 +795,11 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
             }
             double staleKeysInCachePercentage = staleKeysInCachePercentage();
             if (staleKeysInCachePercentage < cleanThresholdPercent) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug(
-                        "Skipping Indices Request cache cleanup since the percentage of stale keys : "
-                            + staleKeysInCachePercentage
-                            + " is less than the threshold : "
-                            + stalenessThreshold
-                    );
-                }
+                logger.debug(
+                    "Skipping Indices Request cache cleanup since the percentage of stale keys : {} is less than the threshold : {}",
+                    () -> staleKeysInCachePercentage,
+                    () -> stalenessThreshold
+                );
                 return true;
             }
             return false;

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -1683,20 +1683,16 @@ public class IndicesService extends AbstractLifecycleComponent
         @Override
         public void run() {
             long startTimeNS = System.nanoTime();
-            if (logger.isTraceEnabled()) {
-                logger.trace("running periodic field data cache cleanup");
-            }
+            logger.trace(() -> "running periodic field data cache cleanup");
             try {
                 this.cache.getCache().refresh();
             } catch (Exception e) {
                 logger.warn("Exception during periodic field data cache cleanup:", e);
             }
-            if (logger.isTraceEnabled()) {
-                logger.trace(
-                    "periodic field data cache cleanup finished in {} milliseconds",
-                    TimeValue.nsecToMSec(System.nanoTime() - startTimeNS)
-                );
-            }
+            logger.trace(
+                "periodic field data cache cleanup finished in {} milliseconds",
+                () -> (TimeValue.nsecToMSec(System.nanoTime() - startTimeNS))
+            );
             // Reschedule itself to run again if not closed
             if (closed.get() == false) {
                 threadPool.scheduleUnlessShuttingDown(interval, ThreadPool.Names.SAME, this);
@@ -1794,13 +1790,11 @@ public class IndicesService extends AbstractLifecycleComponent
             // running a search that times out concurrently will likely timeout again if it's run while we have this `stale` result in the
             // cache. One other option is to not cache requests with a timeout at all...
             indicesRequestCache.invalidate(new IndexShardCacheEntity(context.indexShard()), directoryReader, request.cacheKey());
-            if (logger.isTraceEnabled()) {
-                logger.trace(
-                    "Query timed out, invalidating cache entry for request on shard [{}]:\n {}",
-                    request.shardId(),
-                    request.source()
-                );
-            }
+            logger.trace(
+                "Query timed out, invalidating cache entry for request on shard [{}]:\n {}",
+                () -> request.shardId(),
+                () -> request.source()
+            );
         }
     }
 

--- a/server/src/main/java/org/opensearch/indices/analysis/HunspellService.java
+++ b/server/src/main/java/org/opensearch/indices/analysis/HunspellService.java
@@ -188,9 +188,7 @@ public class HunspellService {
      * @throws Exception when loading fails (due to IO errors or malformed dictionary files)
      */
     private Dictionary loadDictionary(String locale, Settings nodeSettings, Environment env) throws Exception {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Loading hunspell dictionary [{}]...", locale);
-        }
+        logger.debug("Loading hunspell dictionary [{}]...", () -> locale);
         Path dicDir = hunspellDir.resolve(locale);
         if (FileSystemUtils.isAccessibleDirectory(dicDir, logger) == false) {
             throw new OpenSearchException(String.format(Locale.ROOT, "Could not find hunspell dictionary [%s]", locale));

--- a/server/src/main/java/org/opensearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/opensearch/indices/cluster/IndicesClusterStateService.java
@@ -342,9 +342,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         assert localNodeId != null;
 
         for (Index index : event.indicesDeleted()) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("[{}] cleaning index, no longer part of the metadata", index);
-            }
+            logger.debug("[{}] cleaning index, no longer part of the metadata", () -> index);
             AllocatedIndex<? extends Shard> indexService = indicesService.indexService(index);
             final IndexSettings indexSettings;
             if (indexService != null) {
@@ -728,14 +726,12 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             // the cluster-manager thinks we are initializing, but we are already started or on POST_RECOVERY and waiting
             // for cluster-manager to confirm a shard started message (either cluster-manager failover, or a cluster event before
             // we managed to tell the cluster-manager we started), mark us as started
-            if (logger.isTraceEnabled()) {
-                logger.trace(
-                    "{} cluster-manager marked shard as initializing, but shard has state [{}], resending shard started to {}",
-                    shardRouting.shardId(),
-                    state,
-                    nodes.getClusterManagerNode()
-                );
-            }
+            logger.trace(
+                "{} cluster-manager marked shard as initializing, but shard has state [{}], resending shard started to {}",
+                () -> shardRouting.shardId(),
+                () -> state,
+                () -> nodes.getClusterManagerNode()
+            );
             if (nodes.getClusterManagerNode() != null) {
                 shardStateAction.shardStarted(
                     shardRouting,

--- a/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/PeerRecoveryTargetService.java
@@ -643,41 +643,24 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             // do this through ongoing recoveries to remove it from the collection
             onGoingRecoveries.markAsDone(recoveryId);
             if (logger.isTraceEnabled()) {
-                StringBuilder sb = new StringBuilder();
-                sb.append('[')
-                    .append(request.shardId().getIndex().getName())
-                    .append(']')
-                    .append('[')
-                    .append(request.shardId().id())
-                    .append("] ");
-                sb.append("recovery completed from ").append(request.sourceNode()).append(", took[").append(recoveryTime).append("]\n");
-                sb.append("   phase1: recovered_files [")
-                    .append(recoveryResponse.phase1FileNames.size())
-                    .append("]")
-                    .append(" with total_size of [")
-                    .append(new ByteSizeValue(recoveryResponse.phase1TotalSize))
-                    .append("]")
-                    .append(", took [")
-                    .append(timeValueMillis(recoveryResponse.phase1Time))
-                    .append("], throttling_wait [")
-                    .append(timeValueMillis(recoveryResponse.phase1ThrottlingWaitTime))
-                    .append(']')
-                    .append("\n");
-                sb.append("         : reusing_files   [")
-                    .append(recoveryResponse.phase1ExistingFileNames.size())
-                    .append("] with total_size of [")
-                    .append(new ByteSizeValue(recoveryResponse.phase1ExistingTotalSize))
-                    .append("]\n");
-                sb.append("   phase2: start took [").append(timeValueMillis(recoveryResponse.startTime)).append("]\n");
-                sb.append("         : recovered [")
-                    .append(recoveryResponse.phase2Operations)
-                    .append("]")
-                    .append(" transaction log operations")
-                    .append(", took [")
-                    .append(timeValueMillis(recoveryResponse.phase2Time))
-                    .append("]")
-                    .append("\n");
-                logger.trace("{}", sb);
+                logger.trace(
+                    "[{}][{}] recovery completed from {}, took[{}]\n   phase1: recovered_files [{}] with total_size of [{}]"
+                        + ", took [{}], throttling_wait [{}]\n         : reusing_files   [{}] with total_size of [{}]\n   phase2: start took [{}]\n"
+                        + "         : recovered [{}] transaction log operations, took [{}]\n",
+                    () -> request.shardId().getIndex().getName(),
+                    () -> request.shardId().id(),
+                    () -> request.sourceNode(),
+                    () -> recoveryTime,
+                    () -> recoveryResponse.phase1FileNames.size(),
+                    () -> new ByteSizeValue(recoveryResponse.phase1TotalSize),
+                    () -> timeValueMillis(recoveryResponse.phase1Time),
+                    () -> timeValueMillis(recoveryResponse.phase1ThrottlingWaitTime),
+                    () -> recoveryResponse.phase1ExistingFileNames.size(),
+                    () -> new ByteSizeValue(recoveryResponse.phase1ExistingTotalSize),
+                    () -> timeValueMillis(recoveryResponse.startTime),
+                    () -> recoveryResponse.phase2Operations,
+                    () -> timeValueMillis(recoveryResponse.phase2Time)
+                );
             } else {
                 logger.debug("{} recovery done from [{}], took [{}]", request.shardId(), request.sourceNode(), recoveryTime);
             }
@@ -689,16 +672,14 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         }
 
         private void onException(Exception e) {
-            if (logger.isTraceEnabled()) {
-                logger.trace(
-                    () -> new ParameterizedMessage(
-                        "[{}][{}] Got exception on recovery",
-                        request.shardId().getIndex().getName(),
-                        request.shardId().id()
-                    ),
-                    e
-                );
-            }
+            logger.trace(
+                () -> new ParameterizedMessage(
+                    "[{}][{}] Got exception on recovery",
+                    request.shardId().getIndex().getName(),
+                    request.shardId().id()
+                ),
+                e
+            );
             Throwable cause = ExceptionsHelper.unwrapCause(e);
             if (cause instanceof CancellableThreads.ExecutionCancelledException) {
                 // this can also come from the source wrapped in a RemoteTransportException

--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySourceHandler.java
@@ -402,14 +402,12 @@ public abstract class RecoverySourceHandler {
                     phase1ExistingFileNames.add(md.name());
                     phase1ExistingFileSizes.add(md.length());
                     existingTotalSizeInBytes += md.length();
-                    if (logger.isTraceEnabled()) {
-                        logger.trace(
-                            "recovery [phase1]: not recovering [{}], exist in local store and has checksum [{}]," + " size [{}]",
-                            md.name(),
-                            md.checksum(),
-                            md.length()
-                        );
-                    }
+                    logger.trace(
+                        "recovery [phase1]: not recovering [{}], exist in local store and has checksum [{}]," + " size [{}]",
+                        () -> md.name(),
+                        () -> md.checksum(),
+                        () -> md.length()
+                    );
                     totalSizeInBytes += md.length();
                 }
                 List<StoreFileMetadata> phase1Files = new ArrayList<>(diff.different.size() + diff.missing.size());

--- a/server/src/main/java/org/opensearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/opensearch/monitor/os/OsProbe.java
@@ -202,9 +202,7 @@ public class OsProbe {
                 final String[] fields = procLoadAvg.split("\\s+");
                 return new double[] { Double.parseDouble(fields[0]), Double.parseDouble(fields[1]), Double.parseDouble(fields[2]) };
             } catch (final IOException e) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("error reading /proc/loadavg", e);
-                }
+                logger.debug(() -> "error reading /proc/loadavg", e);
                 return null;
             }
         } else {
@@ -216,9 +214,7 @@ public class OsProbe {
                 final double oneMinuteLoadAverage = (double) getSystemLoadAverage.invoke(osMxBean);
                 return new double[] { oneMinuteLoadAverage >= 0 ? oneMinuteLoadAverage : -1, -1, -1 };
             } catch (IllegalAccessException | InvocationTargetException e) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("error reading one minute load average from operating system", e);
-                }
+                logger.debug(() -> "error reading one minute load average from operating system", e);
                 return null;
             }
         }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -491,15 +491,13 @@ public class Node implements Closeable {
                 );
             }
 
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                    "using config [{}], data [{}], logs [{}], plugins [{}]",
-                    initialEnvironment.configDir(),
-                    Arrays.toString(initialEnvironment.dataFiles()),
-                    initialEnvironment.logsDir(),
-                    initialEnvironment.pluginsDir()
-                );
-            }
+            logger.debug(
+                "using config [{}], data [{}], logs [{}], plugins [{}]",
+                () -> initialEnvironment.configDir(),
+                () -> Arrays.toString(initialEnvironment.dataFiles()),
+                () -> initialEnvironment.logsDir(),
+                () -> initialEnvironment.pluginsDir()
+            );
 
             this.pluginsService = new PluginsService(
                 tmpSettings,

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -153,9 +153,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
                 Collections.emptyList(),
                 false
             );
-            if (logger.isTraceEnabled()) {
-                logger.trace("plugin loaded from classpath [{}]", pluginInfo);
-            }
+            logger.trace("plugin loaded from classpath [{}]", () -> pluginInfo);
             pluginsLoaded.add(new Tuple<>(pluginInfo, plugin));
             pluginsList.add(pluginInfo);
             pluginsNames.add(pluginInfo.getName());

--- a/server/src/main/java/org/opensearch/repositories/blobstore/FileRestoreContext.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/FileRestoreContext.java
@@ -135,24 +135,26 @@ public abstract class FileRestoreContext {
             for (StoreFileMetadata md : diff.identical) {
                 BlobStoreIndexShardSnapshot.FileInfo fileInfo = fileInfos.get(md.name());
                 recoveryState.getIndex().addFileDetail(fileInfo.physicalName(), fileInfo.length(), true);
-                if (logger.isTraceEnabled()) {
-                    logger.trace(
-                        "[{}] [{}] not_recovering file [{}] from [{}], exists in local store and is same",
-                        shardId,
-                        snapshotId,
-                        fileInfo.physicalName(),
-                        fileInfo.name()
-                    );
-                }
+                logger.trace(
+                    "[{}] [{}] not_recovering file [{}] from [{}], exists in local store and is same",
+                    () -> shardId,
+                    () -> snapshotId,
+                    () -> fileInfo.physicalName(),
+                    () -> fileInfo.name()
+                );
             }
 
             for (StoreFileMetadata md : concat(diff)) {
                 BlobStoreIndexShardSnapshot.FileInfo fileInfo = fileInfos.get(md.name());
                 filesToRecover.add(fileInfo);
                 recoveryState.getIndex().addFileDetail(fileInfo.physicalName(), fileInfo.length(), false);
-                if (logger.isTraceEnabled()) {
-                    logger.trace("[{}] [{}] recovering [{}] from [{}]", shardId, snapshotId, fileInfo.physicalName(), fileInfo.name());
-                }
+                logger.trace(
+                    "[{}] [{}] recovering [{}] from [{}]",
+                    () -> shardId,
+                    () -> snapshotId,
+                    () -> fileInfo.physicalName(),
+                    () -> fileInfo.name()
+                );
             }
 
             recoveryState.getIndex().setFileDetailsComplete();

--- a/server/src/main/java/org/opensearch/script/ScriptCache.java
+++ b/server/src/main/java/org/opensearch/script/ScriptCache.java
@@ -111,15 +111,13 @@ public class ScriptCache {
                 // If the script type is inline the name will be the same as the code for identification in exceptions
                 // but give the script engine the chance to be better, give it separate name + source code
                 // for the inline case, then its anonymous: null.
-                if (logger.isTraceEnabled()) {
-                    logger.trace(
-                        "context [{}]: compiling script, type: [{}], lang: [{}], options: [{}]",
-                        context.name,
-                        type,
-                        lang,
-                        options
-                    );
-                }
+                logger.trace(
+                    "context [{}]: compiling script, type: [{}], lang: [{}], options: [{}]",
+                    () -> context.name,
+                    () -> type,
+                    () -> lang,
+                    () -> options
+                );
                 // Check whether too many compilations have happened
                 checkCompilationLimit();
                 Object compiledScript = scriptEngine.compile(id, idOrCode, context, options);
@@ -211,9 +209,7 @@ public class ScriptCache {
     private class ScriptCacheRemovalListener implements RemovalListener<CacheKey, Object> {
         @Override
         public void onRemoval(RemovalNotification<CacheKey, Object> notification) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("removed [{}] from cache, reason: [{}]", notification.getValue(), notification.getRemovalReason());
-            }
+            logger.debug("removed [{}] from cache, reason: [{}]", () -> notification.getValue(), () -> notification.getRemovalReason());
             scriptMetrics.onCacheEviction();
         }
     }

--- a/server/src/main/java/org/opensearch/script/ScriptService.java
+++ b/server/src/main/java/org/opensearch/script/ScriptService.java
@@ -442,7 +442,7 @@ public class ScriptService implements Closeable, ClusterStateApplier {
         Objects.requireNonNull(context);
 
         ScriptType type = script.getType();
-        String lang = script.getLang();
+        final String lang;
         String idOrCode = script.getIdOrCode();
         Map<String, String> options = script.getOptions();
 
@@ -458,6 +458,8 @@ public class ScriptService implements Closeable, ClusterStateApplier {
             lang = source.getLang();
             idOrCode = source.getSource();
             options = source.getOptions();
+        } else {
+            lang = script.getLang();
         }
 
         ScriptEngine scriptEngine = getEngine(lang);
@@ -489,9 +491,8 @@ public class ScriptService implements Closeable, ClusterStateApplier {
             }
         }
 
-        if (logger.isTraceEnabled()) {
-            logger.trace("compiling lang: [{}] type: [{}] script: {}", lang, type, idOrCode);
-        }
+        final String finalIdOrCode = idOrCode;
+        logger.trace("compiling lang: [{}] type: [{}] script: {}", () -> lang, () -> type, () -> finalIdOrCode);
 
         ScriptCache scriptCache = cacheHolder.get().get(context.name);
         assert scriptCache != null : "script context [" + context.name + "] has no script cache";

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -107,9 +107,7 @@ public class FetchPhase {
     }
 
     public void execute(SearchContext context) {
-        if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("{}", new SearchContextSourcePrinter(context));
-        }
+        LOGGER.trace("{}", () -> new SearchContextSourcePrinter(context));
 
         if (context.isCancelled()) {
             throw new TaskCancelledException("cancelled task with reason: " + context.getTask().getReasonCancelled());

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -143,9 +143,7 @@ public class QueryPhase {
             return;
         }
 
-        if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("{}", new SearchContextSourcePrinter(searchContext));
-        }
+        LOGGER.trace("{}", () -> new SearchContextSourcePrinter(searchContext));
 
         final AggregationProcessor aggregationProcessor = queryPhaseSearcher.aggregationProcessor(searchContext);
         // Pre-process aggregations as late as possible. In the case of a DFS_Q_T_F

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
@@ -289,16 +289,13 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                         public void onResponse(String newGeneration) {
                             assert newGeneration != null;
                             assert newGeneration.equals(snapshotStatus.generation());
-                            if (logger.isDebugEnabled()) {
-                                final IndexShardSnapshotStatus.Copy lastSnapshotStatus = snapshotStatus.asCopy();
-                                logger.debug(
-                                    "snapshot [{}] completed to [{}] with [{}] at generation [{}]",
-                                    snapshot,
-                                    snapshot.getRepository(),
-                                    lastSnapshotStatus,
-                                    snapshotStatus.generation()
-                                );
-                            }
+                            logger.debug(
+                                "snapshot [{}] completed to [{}] with [{}] at generation [{}]",
+                                () -> snapshot,
+                                () -> snapshot.getRepository(),
+                                () -> snapshotStatus.asCopy(),
+                                () -> snapshotStatus.generation()
+                            );
                             notifySuccessfulSnapshotShard(snapshot, shardId, newGeneration);
                         }
 

--- a/server/src/main/java/org/opensearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskManager.java
@@ -206,9 +206,7 @@ public class TaskManager implements ClusterStateApplier {
         Task task = request.createTask(taskIdGenerator.incrementAndGet(), type, action, request.getParentTask(), headers);
         Objects.requireNonNull(task);
         assert task.getParentTaskId().equals(request.getParentTask()) : "Request [ " + request + "] didn't preserve it parentTaskId";
-        if (logger.isTraceEnabled()) {
-            logger.trace("register {} [{}] [{}] [{}]", task.getId(), type, action, task.getDescription());
-        }
+        logger.trace("register {} [{}] [{}] [{}]", () -> task.getId(), () -> type, () -> action, () -> task.getDescription());
 
         if (task.supportsResourceTracking()) {
             boolean success = task.addResourceTrackingCompletionListener(new NotifyOnceListener<>() {

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -503,9 +503,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
     @Override
     public Cancellable scheduleWithFixedDelay(Runnable command, TimeValue interval, String executor) {
         return new ReschedulingRunnable(command, interval, executor, this, (e) -> {
-            if (logger.isDebugEnabled()) {
-                logger.debug(() -> new ParameterizedMessage("scheduled task [{}] was rejected on thread pool [{}]", command, executor), e);
-            }
+            logger.debug(() -> new ParameterizedMessage("scheduled task [{}] was rejected on thread pool [{}]", command, executor), e);
         },
             (e) -> logger.warn(
                 () -> new ParameterizedMessage("failed to run scheduled task [{}] on thread pool [{}]", command, executor),

--- a/server/src/main/java/org/opensearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/opensearch/transport/TcpTransport.java
@@ -436,13 +436,13 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         } catch (IOException e) {
             throw new BindTransportException("Failed to resolve host " + profileBindHosts, e);
         }
-        if (logger.isDebugEnabled()) {
+        logger.debug("binding server bootstrap to: {}", () -> {
             String[] addresses = new String[hostAddresses.length];
             for (int i = 0; i < hostAddresses.length; i++) {
                 addresses[i] = NetworkAddress.format(hostAddresses[i]);
             }
-            logger.debug("binding server bootstrap to: {}", (Object) addresses);
-        }
+            return (Object) addresses;
+        });
 
         assert hostAddresses.length > 0;
 
@@ -490,9 +490,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         } finally {
             closeLock.writeLock().unlock();
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug("Bound profile [{}] to address {{}}", name, NetworkAddress.format(boundSocket.get()));
-        }
+        logger.debug("Bound profile [{}] to address {{}}", () -> name, () -> NetworkAddress.format(boundSocket.get()));
 
         return boundSocket.get();
     }

--- a/server/src/main/java/org/opensearch/transport/TransportLogger.java
+++ b/server/src/main/java/org/opensearch/transport/TransportLogger.java
@@ -55,41 +55,41 @@ public final class TransportLogger {
     private static final int HEADER_SIZE = TcpHeader.MARKER_BYTES_SIZE + TcpHeader.MESSAGE_LENGTH_SIZE;
 
     static void logInboundMessage(TcpChannel channel, BytesReference message) {
-        if (logger.isTraceEnabled()) {
+        logger.trace(() -> {
             try {
-                String logMessage = format(channel, message, "READ");
-                logger.trace(logMessage);
+                return format(channel, message, "READ");
             } catch (IOException e) {
                 logger.warn("an exception occurred formatting a READ trace message", e);
+                return "";
             }
-        }
+        });
     }
 
     static void logInboundMessage(TcpChannel channel, NativeInboundMessage message) {
-        if (logger.isTraceEnabled()) {
+        logger.trace(() -> {
             try {
-                String logMessage = format(channel, message, "READ");
-                logger.trace(logMessage);
+                return format(channel, message, "READ");
             } catch (IOException e) {
                 logger.warn("an exception occurred formatting a READ trace message", e);
+                return "";
             }
-        }
+        });
     }
 
     static void logOutboundMessage(TcpChannel channel, BytesReference message) {
-        if (logger.isTraceEnabled()) {
+        if (message.get(0) != 'E') {
+            // This is not an OpenSearch transport message.
+            return;
+        }
+        logger.trace(() -> {
             try {
-                if (message.get(0) != 'E') {
-                    // This is not an OpenSearch transport message.
-                    return;
-                }
                 BytesReference withoutHeader = message.slice(HEADER_SIZE, message.length() - HEADER_SIZE);
-                String logMessage = format(channel, withoutHeader, "WRITE");
-                logger.trace(logMessage);
+                return format(channel, withoutHeader, "WRITE");
             } catch (IOException e) {
                 logger.warn("an exception occurred formatting a WRITE trace message", e);
+                return "";
             }
-        }
+        });
     }
 
     private static String format(TcpChannel channel, BytesReference message, String event) throws IOException {

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -304,10 +304,10 @@ public class TransportService extends AbstractLifecycleComponent
         transport.setMessageListener(this);
         connectionManager.addListener(this);
         transport.start();
-        if (transport.boundAddress() != null && logger.isInfoEnabled()) {
-            logger.info("{}", transport.boundAddress());
+        if (transport.boundAddress() != null) {
+            logger.info("{}", () -> transport.boundAddress());
             for (Map.Entry<String, BoundTransportAddress> entry : transport.profileBoundAddresses().entrySet()) {
-                logger.info("profile [{}]: {}", entry.getKey(), entry.getValue());
+                logger.info("profile [{}]: {}", () -> entry.getKey(), () -> entry.getValue());
             }
         }
         localNode = localNodeFactory.apply(transport.boundAddress());
@@ -1240,8 +1240,8 @@ public class TransportService extends AbstractLifecycleComponent
         if (handleIncomingRequests.get() == false) {
             throw new IllegalStateException("transport not ready yet to handle incoming requests");
         }
-        if (tracerLog.isTraceEnabled() && shouldTraceAction(action)) {
-            tracerLog.trace("[{}][{}] received request", requestId, action);
+        if (shouldTraceAction(action)) {
+            tracerLog.trace("[{}][{}] received request", () -> requestId, () -> action);
         }
         messageListener.onRequestReceived(requestId, action);
     }
@@ -1255,8 +1255,8 @@ public class TransportService extends AbstractLifecycleComponent
         TransportRequest request,
         TransportRequestOptions options
     ) {
-        if (tracerLog.isTraceEnabled() && shouldTraceAction(action)) {
-            tracerLog.trace("[{}][{}] sent to [{}] (timeout: [{}])", requestId, action, node, options.timeout());
+        if (shouldTraceAction(action)) {
+            tracerLog.trace("[{}][{}] sent to [{}] (timeout: [{}])", () -> requestId, () -> action, () -> node, () -> options.timeout());
         }
         messageListener.onRequestSent(node, requestId, action, request, options);
     }
@@ -1265,8 +1265,13 @@ public class TransportService extends AbstractLifecycleComponent
     public void onResponseReceived(long requestId, Transport.ResponseContext holder) {
         if (holder == null) {
             checkForTimeout(requestId);
-        } else if (tracerLog.isTraceEnabled() && shouldTraceAction(holder.action())) {
-            tracerLog.trace("[{}][{}] received response from [{}]", requestId, holder.action(), holder.connection().getNode());
+        } else if (shouldTraceAction(holder.action())) {
+            tracerLog.trace(
+                "[{}][{}] received response from [{}]",
+                () -> requestId,
+                () -> holder.action(),
+                () -> holder.connection().getNode()
+            );
         }
         messageListener.onResponseReceived(requestId, holder);
     }
@@ -1274,8 +1279,8 @@ public class TransportService extends AbstractLifecycleComponent
     /** called by the {@link Transport} implementation once a response was sent to calling node */
     @Override
     public void onResponseSent(long requestId, String action, TransportResponse response) {
-        if (tracerLog.isTraceEnabled() && shouldTraceAction(action)) {
-            tracerLog.trace("[{}][{}] sent response", requestId, action);
+        if (shouldTraceAction(action)) {
+            tracerLog.trace("[{}][{}] sent response", () -> requestId, () -> action);
         }
         messageListener.onResponseSent(requestId, action, response);
     }
@@ -1283,7 +1288,7 @@ public class TransportService extends AbstractLifecycleComponent
     /** called by the {@link Transport} implementation after an exception was sent as a response to an incoming request */
     @Override
     public void onResponseSent(long requestId, String action, Exception e) {
-        if (tracerLog.isTraceEnabled() && shouldTraceAction(action)) {
+        if (shouldTraceAction(action)) {
             tracerLog.trace(() -> new ParameterizedMessage("[{}][{}] sent error response", requestId, action), e);
         }
         messageListener.onResponseSent(requestId, action, e);
@@ -1323,9 +1328,9 @@ public class TransportService extends AbstractLifecycleComponent
         }
         if (action == null) {
             assert sourceNode == null;
-            tracerLog.trace("[{}] received response but can't resolve it to a request", requestId);
+            tracerLog.trace("[{}] received response but can't resolve it to a request", () -> requestId);
         } else if (shouldTraceAction(action)) {
-            tracerLog.trace("[{}][{}] received response from [{}]", requestId, action, sourceNode);
+            tracerLog.trace("[{}][{}] received response from [{}]", () -> requestId, () -> action, () -> sourceNode);
         }
     }
 

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -1030,12 +1030,11 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
                 }
             }
 
-            if (logger.isDebugEnabled()) {
-                if (lastKnownCount < numDocs) {
-                    logger.debug("[{}] docs indexed. waiting for [{}]", lastKnownCount, numDocs);
-                } else {
-                    logger.debug("[{}] docs visible for search (needed [{}])", lastKnownCount, numDocs);
-                }
+            final long finalLastKnownCount = lastKnownCount;
+            if (lastKnownCount < numDocs) {
+                logger.debug("[{}] docs indexed. waiting for [{}]", () -> finalLastKnownCount, () -> numDocs);
+            } else {
+                logger.debug("[{}] docs visible for search (needed [{}])", () -> finalLastKnownCount, () -> numDocs);
             }
 
             assertThat(lastKnownCount, greaterThanOrEqualTo(numDocs));

--- a/test/framework/src/main/java/org/opensearch/test/engine/MockEngineSupport.java
+++ b/test/framework/src/main/java/org/opensearch/test/engine/MockEngineSupport.java
@@ -113,9 +113,13 @@ public final class MockEngineSupport {
         Random random = new Random(seed);
         final double ratio = WRAP_READER_RATIO.get(settings);
         boolean wrapReader = random.nextDouble() < ratio;
-        if (logger.isTraceEnabled()) {
-            logger.trace("Using [{}] for shard [{}] seed: [{}] wrapReader: [{}]", this.getClass().getName(), shardId, seed, wrapReader);
-        }
+        logger.trace(
+            "Using [{}] for shard [{}] seed: [{}] wrapReader: [{}]",
+            () -> this.getClass().getName(),
+            () -> shardId,
+            () -> seed,
+            () -> wrapReader
+        );
         mockContext = new MockContext(random, wrapReader, wrapper, settings);
         this.inFlightSearchers = new InFlightSearchers();
         LuceneTestCase.closeAfterSuite(inFlightSearchers); // only one suite closeable per Engine

--- a/test/framework/src/main/java/org/opensearch/test/store/MockFSDirectoryFactory.java
+++ b/test/framework/src/main/java/org/opensearch/test/store/MockFSDirectoryFactory.java
@@ -128,9 +128,7 @@ public class MockFSDirectoryFactory implements IndexStorePlugin.DirectoryFactory
                         OpenSearchTestCase.checkIndexFailures.add(failure);
                         throw failure;
                     } else {
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("check index [success]\n{}", os.bytes().utf8ToString());
-                        }
+                        logger.debug("check index [success]\n{}", () -> os.bytes().utf8ToString());
                     }
                 } catch (LockObtainFailedException e) {
                     IllegalStateException failure = new IllegalStateException("IndexWriter is still open on shard " + shardId, e);


### PR DESCRIPTION
Converted debug/trace/warn/info checks to lambda based logging APIs.

Present scenario:
if (logger.isTraceEnabled()) {
    logger.trace("Some long-running operation returned {}", expensiveOperation());
}
Replace the existing checking of trace/debug logging before actual logging with lambda invocations within the debug/trace loggers:
logger.trace("Some long-running operation returned {}", () -> expensiveOperation());

This achieves the same lazy logging without having to check for logger levels. 

Javadoc of "void debug(String message, Supplier<?>... paramSuppliers)" -> "Logs a message with parameters which are only to be constructed if the logging level is the DEBUG level."

Resolves #8646


### Check List
- [] ~New functionality includes testing.~
- [x] All tests pass
- [ ] ~New functionality has been documented.~
- [] ~New functionality has javadoc added~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [] ~Commit changes are listed out in CHANGELOG.md file (See: [Changelog]~(../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
