### PR TITLE
Add versioning for UploadedIndexMetadata

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataManifest.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataManifest.java
@@ -1121,7 +1121,7 @@ public class ClusterMetadataManifest implements Writeable, ToXContentFragment {
             PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_NAME_FIELD);
             PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_UUID_FIELD);
             PARSER.declareString(ConstructingObjectParser.constructorArg(), UPLOADED_FILENAME_FIELD);
-            PARSER.declareString(ConstructingObjectParser.constructorArg(), COMPONENT_PREFIX_FIELD);
+            PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), COMPONENT_PREFIX_FIELD);
         }
 
         static final String COMPONENT_PREFIX = "index--";

--- a/server/src/test/java/org/opensearch/gateway/remote/ClusterMetadataManifestTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/ClusterMetadataManifestTests.java
@@ -48,7 +48,7 @@ import static org.opensearch.gateway.remote.model.RemoteTransientSettingsMetadat
 public class ClusterMetadataManifestTests extends OpenSearchTestCase {
 
     public void testClusterMetadataManifestXContentV0() throws IOException {
-        UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata("test-index", "test-uuid", "/test/upload/path");
+        UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata("test-index", "test-uuid", "/test/upload/path", CODEC_V0);
         ClusterMetadataManifest originalManifest = ClusterMetadataManifest.builder()
             .clusterTerm(1L)
             .stateVersion(1L)
@@ -74,7 +74,7 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
     }
 
     public void testClusterMetadataManifestXContentV1() throws IOException {
-        UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata("test-index", "test-uuid", "/test/upload/path");
+        UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata("test-index", "test-uuid", "/test/upload/path", CODEC_V1);
         ClusterMetadataManifest originalManifest = ClusterMetadataManifest.builder()
             .clusterTerm(1L)
             .stateVersion(1L)
@@ -620,10 +620,11 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
     }
 
     public void testUploadedIndexMetadataWithoutComponentPrefix() throws IOException {
-        final UploadedIndexMetadata originalUploadedIndexMetadata = new UploadedIndexMetadataV1(
+        final UploadedIndexMetadata originalUploadedIndexMetadata = new UploadedIndexMetadata(
             "test-index",
             "test-index-uuid",
-            "test_file_name"
+            "test_file_name",
+            CODEC_V1
         );
         final XContentBuilder builder = JsonXContent.contentBuilder();
         builder.startObject();
@@ -631,10 +632,8 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
         builder.endObject();
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
-            final UploadedIndexMetadata fromXContentUploadedIndexMetadata = UploadedIndexMetadata.fromXContent(parser);
-            assertEquals(originalUploadedIndexMetadata.getIndexName(), fromXContentUploadedIndexMetadata.getIndexName());
-            assertEquals(originalUploadedIndexMetadata.getIndexUUID(), fromXContentUploadedIndexMetadata.getIndexUUID());
-            assertEquals(originalUploadedIndexMetadata.getUploadedFilename(), fromXContentUploadedIndexMetadata.getUploadedFilename());
+            final UploadedIndexMetadata fromXContentUploadedIndexMetadata = UploadedIndexMetadata.fromXContent(parser, 1L);
+            assertEquals(originalUploadedIndexMetadata, fromXContentUploadedIndexMetadata);
         }
     }
 
@@ -662,17 +661,4 @@ public class ClusterMetadataManifestTests extends OpenSearchTestCase {
         return uploadedIndexMetadata;
     }
 
-    private static class UploadedIndexMetadataV1 extends UploadedIndexMetadata {
-
-        public UploadedIndexMetadataV1(String indexName, String indexUUID, String uploadedFileName) {
-            super(indexName, indexUUID, uploadedFileName);
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            return builder.field("index_name", getIndexName())
-                .field("index_uuid", getIndexUUID())
-                .field("uploaded_filename", getUploadedFilePath());
-        }
-    }
 }

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -2254,13 +2254,14 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             .stateVersion(1L)
             .stateUUID("state-uuid")
             .clusterUUID("cluster-uuid")
+            .codecVersion(CODEC_V2)
             .nodeId("nodeA")
             .opensearchVersion(VersionUtils.randomOpenSearchVersion(random()))
             .previousClusterUUID("prev-cluster-uuid")
             .build();
 
         BlobContainer blobContainer = mockBlobStoreObjects();
-        mockBlobContainer(blobContainer, expectedManifest, Map.of());
+        mockBlobContainer(blobContainer, expectedManifest, Map.of(), CODEC_V2);
         when(blobContainer.readBlob(uploadedIndexMetadata.getUploadedFilename())).thenThrow(FileNotFoundException.class);
 
         remoteClusterStateService.start();
@@ -2288,11 +2289,11 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             .clusterUUID("cluster-uuid")
             .nodeId("nodeA")
             .opensearchVersion(VersionUtils.randomOpenSearchVersion(random()))
-            .codecVersion(ClusterMetadataManifest.CODEC_V0)
+            .codecVersion(CODEC_V2)
             .previousClusterUUID("prev-cluster-uuid")
             .build();
 
-        mockBlobContainer(mockBlobStoreObjects(), expectedManifest, new HashMap<>());
+        mockBlobContainer(mockBlobStoreObjects(), expectedManifest, new HashMap<>(), CODEC_V2);
         remoteClusterStateService.start();
         final ClusterMetadataManifest manifest = remoteClusterStateService.getLatestClusterMetadataManifest(
             clusterState.getClusterName().value(),
@@ -2416,10 +2417,10 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             .nodeId("nodeA")
             .opensearchVersion(VersionUtils.randomOpenSearchVersion(random()))
             .previousClusterUUID("prev-cluster-uuid")
-            .codecVersion(ClusterMetadataManifest.CODEC_V0)
+            .codecVersion(CODEC_V2)
             .build();
 
-        mockBlobContainer(mockBlobStoreObjects(), expectedManifest, Map.of(index.getUUID(), indexMetadata));
+        mockBlobContainer(mockBlobStoreObjects(), expectedManifest, Map.of(index.getUUID(), indexMetadata), CODEC_V2);
 
         Map<String, IndexMetadata> indexMetadataMap = remoteClusterStateService.getLatestClusterState(
             clusterState.getClusterName().value(),
@@ -2664,6 +2665,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             .clusterUUID("cluster-uuid")
             .previousClusterUUID("prev-cluster-uuid")
             .routingTableVersion(1)
+            .codecVersion(CODEC_V2)
             .indicesRouting(List.of(uploadedIndiceRoutingMetadata))
             .build();
 
@@ -3081,7 +3083,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             FORMAT_PARAMS
         );
         when(blobContainer.readBlob(mockManifestFileName)).thenReturn(new ByteArrayInputStream(bytes.streamInput().readAllBytes()));
-        if (codecVersion >= ClusterMetadataManifest.CODEC_V2) {
+        if (codecVersion >= CODEC_V2) {
             String coordinationFileName = getFileNameFromPath(clusterMetadataManifest.getCoordinationMetadata().getUploadedFilename());
             when(blobContainer.readBlob(COORDINATION_METADATA_FORMAT.blobName(coordinationFileName))).thenAnswer((invocationOnMock) -> {
                 BytesReference bytesReference = COORDINATION_METADATA_FORMAT.serialize(


### PR DESCRIPTION
### Description
ComponentPrefix argument is added in UploadedIndexMetadata class in version 2.15. When upgrading from 2.14, this would break as ComponentPrefix is treated as a mandatory argument which will not be remote state serialized using 2.14 version.
So making this argument as optional

### Related Issues
NA

### Check List
- [x] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
