### PR TITLE
Update version check for the bug fix of match_phrase_prefix_query not working on multiple values and index_prefixes

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/190_index_prefix_search.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/190_index_prefix_search.yml
@@ -138,8 +138,8 @@ setup:
 ---
 "search index prefixes with multiple values":
   - skip:
-      version: " - 2.99.99"
-      reason: "the bug was fixed in 3.0.0"
+      version: " - 2.15.99"
+      reason: "the bug was fixed since 2.16.0"
   - do:
       search:
         rest_total_hits_as_int: true
@@ -154,8 +154,8 @@ setup:
 ---
 "search index prefixes with multiple values and custom position_increment_gap":
   - skip:
-      version: " - 2.99.99"
-      reason: "the bug was fixed in 3.0.0"
+      version: " - 2.15.99"
+      reason: "the bug was fixed since 2.16.0"
   - do:
       search:
         rest_total_hits_as_int: true


### PR DESCRIPTION
### Description

This is a follow-up PR for https://github.com/opensearch-project/OpenSearch/pull/10959, we need to update the version check in the yml test file after the original PR is backported to 2.x.

Changelog is not needed, backport to 2.x is needed for this PR.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/9203
### Check List
<del>- [ ] Functionality includes testing.</del>
<del>- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.</del>
<del>- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.</del>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
