### PR TITLE
Fix create or update alias API doesn't throw exception for unsupported parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix FuzzyQuery in keyword field will use IndexOrDocValuesQuery when both of index and doc_value are true ([#14378](https://github.com/opensearch-project/OpenSearch/pull/14378))
 - Fix file cache initialization ([#14004](https://github.com/opensearch-project/OpenSearch/pull/14004))
 - Handle NPE in GetResult if "found" field is missing ([#14552](https://github.com/opensearch-project/OpenSearch/pull/14552))
+- Fix create or update alias API doesn't throw exception for unsupported parameters
 - Refactoring FilterPath.parse by using an iterative approach ([#14200](https://github.com/opensearch-project/OpenSearch/pull/14200))
 - Refactoring Grok.validatePatternBank by using an iterative approach ([#14206](https://github.com/opensearch-project/OpenSearch/pull/14206))
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
@@ -40,6 +40,62 @@
               "description":"The name of the alias to be created or updated"
             }
           }
+        },
+        {
+          "path":"/{index}/_alias",
+          "methods":[
+            "PUT"
+          ],
+          "parts":{
+            "index":{
+              "type":"list",
+              "description":"A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices."
+            }
+          }
+        },
+        {
+          "path":"/{index}/_aliases",
+          "methods":[
+            "PUT"
+          ],
+          "parts":{
+            "index":{
+              "type":"list",
+              "description":"A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices."
+            }
+          }
+        },
+        {
+          "path":"/_alias/{name}",
+          "methods":[
+            "PUT",
+            "POST"
+          ],
+          "parts":{
+            "name":{
+              "type":"string",
+              "description":"The name of the alias to be created or updated"
+            }
+          }
+        },
+        {
+          "path":"/_aliases/{name}",
+          "methods":[
+            "PUT",
+            "POST"
+          ],
+          "parts":{
+            "name":{
+              "type":"string",
+              "description":"The name of the alias to be created or updated"
+            }
+          }
+        },
+        {
+          "path":"/_alias",
+          "methods":[
+            "PUT"
+          ]
         }
       ]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_alias/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_alias/10_basic.yml
@@ -28,6 +28,36 @@
 
   - match: {test_index.aliases.test_alias: {}}
 
+  - do:
+      indices.put_alias:
+        index: test_index
+        body: {"alias": "test_alias_1"}
+
+  - do:
+      indices.get_alias:
+        index: test_index
+        name: test_alias_1
+
+  - match: {test_index.aliases.test_alias_1: {}}
+
+  - do:
+      indices.put_alias:
+        name: test_alias_2
+        body: {"index": "test_index"}
+
+  - do:
+      indices.get_alias:
+        index: test_index
+        name: test_alias_2
+
+  - match: {test_index.aliases.test_alias_2: {}}
+
+  - do:
+      catch: bad_request
+      indices.put_alias:
+        index: null
+        name: null
+
 ---
 "Can't create alias with invalid characters":
 
@@ -102,3 +132,179 @@
         index: test_index
         name: test_alias
   - match: {test_index.aliases.test_alias: {"filter": {"range": {"date_nanos_field": {"gt": "now-7d/d"}}}}}
+
+---
+"Can set index_routing":
+  - do:
+      indices.create:
+        index: test_index
+
+  - do:
+      indices.put_alias:
+        index: test_index
+        name: test_alias
+        body:
+          index_routing: "test"
+
+  - do:
+      indices.get_alias:
+        index: test_index
+        name: test_alias
+  - match: {test_index.aliases.test_alias: { 'index_routing': "test" }}
+
+---
+"Can set routing":
+  - do:
+      indices.create:
+        index: test_index
+
+  - do:
+      indices.put_alias:
+        index: test_index
+        name: test_alias
+        body:
+          routing: "test"
+
+  - do:
+      indices.get_alias:
+        index: test_index
+        name: test_alias
+  - match: {test_index.aliases.test_alias: { 'index_routing': "test", 'search_routing': "test" }}
+
+---
+"Can set search_routing":
+  - do:
+      indices.create:
+        index: test_index
+
+  - do:
+      indices.put_alias:
+        index: test_index
+        name: test_alias
+        body:
+          search_routing: "test"
+
+  - do:
+      indices.get_alias:
+        index: test_index
+        name: test_alias
+  - match: {test_index.aliases.test_alias: { 'search_routing': "test" }}
+
+---
+"Index parameter supports multiple values":
+  - do:
+      indices.create:
+        index: test_index
+  - do:
+      indices.create:
+        index: test_index1
+
+  - do:
+      indices.put_alias:
+        index: test_index,test_index1
+        name: test_alias
+
+  - do:
+      indices.get_alias:
+        index: test_index
+        name: test_alias
+  - match: {test_index.aliases.test_alias: { }}
+  - do:
+      indices.get_alias:
+        index: test_index1
+        name: test_alias
+  - match: {test_index1.aliases.test_alias: { }}
+
+  - do:
+      indices.put_alias:
+        body: {"index": "test_index,test_index1", "alias": "test_alias_1"}
+
+  - do:
+      indices.get_alias:
+        index: test_index
+        name: test_alias_1
+  - match: {test_index.aliases.test_alias_1: { }}
+  - do:
+      indices.get_alias:
+        index: test_index1
+        name: test_alias_1
+  - match: {test_index1.aliases.test_alias_1: { }}
+
+---
+"Index and alias in request body can override path parameters":
+  - do:
+      indices.create:
+        index: test_index
+
+  - do:
+      indices.put_alias:
+        index: test_index_unknown
+        name: test_alias
+        body: {"index": "test_index"}
+
+  - do:
+      indices.get_alias:
+        index: test_index
+        name: test_alias
+  - match: {test_index.aliases.test_alias: { }}
+
+  - do:
+      indices.put_alias:
+        index: test_index
+        name: test_alias_unknown
+        body: {"alias": "test_alias_2"}
+
+  - do:
+      indices.get_alias:
+        index: test_index
+        name: test_alias_2
+  - match: {test_index.aliases.test_alias_2: { }}
+
+  - do:
+      indices.put_alias:
+        body: {"index": "test_index", "alias": "test_alias_3"}
+
+  - do:
+      indices.get_alias:
+        index: test_index
+        name: test_alias_3
+  - match: {test_index.aliases.test_alias_3: { }}
+
+---
+"Can set is_hidden":
+  - skip:
+      version: " - 2.15.99"
+      reason: "Fix was introduced in 2.16.0"
+  - do:
+      indices.create:
+        index: test_index
+
+  - do:
+      indices.put_alias:
+        index: test_index
+        name: test_alias
+        body:
+          is_hidden: true
+
+  - do:
+      indices.get_alias:
+        index: test_index
+        name: test_alias
+  - match: {test_index.aliases.test_alias: { 'is_hidden': true }}
+
+---
+"Throws exception with invalid parameters":
+  - skip:
+      version: " - 2.15.99"
+      reason: "Fix was introduced in 2.16.0"
+
+  - do:
+      indices.create:
+        index: test_index
+
+  - do:
+      catch: /unknown field \[abc\]/
+      indices.put_alias:
+        index: test_index
+        name: test_alias
+        body: {"abc": 1}

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndexPutAliasAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndexPutAliasAction.java
@@ -92,6 +92,7 @@ public class RestIndexPutAliasAction extends BaseRestHandler {
         String indexRouting = null;
         String searchRouting = null;
         Boolean writeIndex = null;
+        Boolean isHidden = null;
 
         if (request.hasContent()) {
             try (XContentParser parser = request.contentParser()) {
@@ -120,10 +121,16 @@ public class RestIndexPutAliasAction extends BaseRestHandler {
                                     searchRouting = parser.textOrNull();
                                 } else if ("is_write_index".equals(currentFieldName)) {
                                     writeIndex = parser.booleanValue();
+                                } else if ("is_hidden".equals(currentFieldName)) {
+                                    isHidden = parser.booleanValue();
+                                } else {
+                                    throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
                                 }
                     } else if (token == XContentParser.Token.START_OBJECT) {
                         if ("filter".equals(currentFieldName)) {
                             filter = parser.mapOrdered();
+                        } else {
+                            throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
                         }
                     }
                 }
@@ -152,6 +159,9 @@ public class RestIndexPutAliasAction extends BaseRestHandler {
         }
         if (writeIndex != null) {
             aliasAction.writeIndex(writeIndex);
+        }
+        if (isHidden != null) {
+            aliasAction.isHidden(isHidden);
         }
         indicesAliasesRequest.addAliasAction(aliasAction);
         return channel -> client.admin().indices().aliases(indicesAliasesRequest, new RestToXContentListener<>(channel));


### PR DESCRIPTION
### Description

This PR fixes the bug of create or update alias API doesn't throw exception for unsupported parameters, the reason is that we don't throw any exception when some unknown fields found when parsing the request. In addition, I found that the `is_hidden` parameter was omitted when parsing the request, so I also add some parsing logic for it.

By the way, because there're some ambiguity between the `Aliases API` and `Create or update alias API`, I've created an document [PR](https://github.com/opensearch-project/documentation-website/pull/7641) for the Create or update alias API which is missing in our documentation. Different from the `Aliases API`, `Create or update alias API` supports multiple  URL paths and http methods, so I add more yml tests for it the verify different use cases.

### Related Issues

https://github.com/opensearch-project/OpenSearch/issues/14384

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
