### PR TITLE
[BugFix] Ingest processor cannot read index name from ingestDocument

### DIFF
--- a/server/src/main/java/org/opensearch/action/bulk/BulkRequestParser.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BulkRequestParser.java
@@ -366,6 +366,7 @@ public final class BulkRequestParser {
                         ) {
                             updateRequest.fromXContent(sliceParser);
                         }
+                        updateRequest.doc().index(index);
                         if (fetchSourceContext != null) {
                             updateRequest.fetchSource(fetchSourceContext);
                         }


### PR DESCRIPTION
### Description
This PR is focused on fixing an [issue](https://github.com/opensearch-project/neural-search/issues/798) from **neural search** repo. The reason for the bug is that [text chunking processor](https://github.com/opensearch-project/neural-search/blob/main/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java) cannot read the index name from the `ingestDocument`. 

When `doc_as_upsert` is true, the `getIndexWriteRequest()` function will read the `doc` field from the update request. This PR is a small fix on BulkRequestParser.java to add index field for the doc in updateRequest.

### Related Issues
Resolves https://github.com/opensearch-project/neural-search/issues/798

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
