### PR TITLE
[Metadata Immutability] Change different indices lookup objects from array type to lists

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Breaking change: Do not request "search_pipelines" metrics by default in NodesInfoRequest ([#12497](https://github.com/opensearch-project/OpenSearch/pull/12497))
 - Refactor `:libs` module `bootstrap` package to eliminate top level split packages for JPMS support [#17117](https://github.com/opensearch-project/OpenSearch/pull/17117))
 - Refactor the codebase to eliminate top level split packages for JPMS support. [#17153](https://github.com/opensearch-project/OpenSearch/pull/17153))
+- Breaking change: Modify the utility APIs in the Metadata to get different indices ([#14723](https://github.com/opensearch-project/OpenSearch/pull/14723))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -60,6 +60,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static java.util.Collections.emptyMap;
 import static org.opensearch.core.xcontent.ConstructingObjectParser.constructorArg;
@@ -215,13 +216,13 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
     }
 
     /** needed for plugins BWC */
-    public ClusterHealthResponse(String clusterName, String[] concreteIndices, ClusterState clusterState) {
+    public ClusterHealthResponse(String clusterName, Set<String> concreteIndices, ClusterState clusterState) {
         this(clusterName, concreteIndices, clusterState, -1, -1, -1, TimeValue.timeValueHours(0));
     }
 
     public ClusterHealthResponse(
         String clusterName,
-        String[] concreteIndices,
+        Set<String> concreteIndices,
         ClusterState clusterState,
         int numberOfPendingTasks,
         int numberOfInFlightFetch,
@@ -239,7 +240,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
 
     public ClusterHealthResponse(
         String clusterName,
-        String[] concreteIndices,
+        Set<String> concreteIndices,
         ClusterHealthRequest clusterHealthRequest,
         ClusterState clusterState,
         int numberOfPendingTasks,
@@ -262,7 +263,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
         String clusterName,
         ClusterState clusterState,
         ClusterSettings clusterSettings,
-        String[] concreteIndices,
+        Set<String> concreteIndices,
         String awarenessAttributeName,
         int numberOfPendingTasks,
         int numberOfInFlightFetch,
@@ -286,7 +287,7 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
         ClusterHealthRequest clusterHealthRequest,
         ClusterState clusterState,
         ClusterSettings clusterSettings,
-        String[] concreteIndices,
+        Set<String> concreteIndices,
         String awarenessAttributeName,
         int numberOfPendingTasks,
         int numberOfInFlightFetch,

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -58,7 +58,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.discovery.ClusterManagerNotDiscoveredException;
@@ -70,6 +69,8 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -494,7 +495,7 @@ public class TransportClusterHealthAction extends TransportClusterManagerNodeRea
             );
         }
 
-        String[] concreteIndices;
+        Set<String> concreteIndices;
         if (request.level().equals(ClusterHealthRequest.Level.AWARENESS_ATTRIBUTES)) {
             String awarenessAttribute = request.getAwarenessAttribute();
             concreteIndices = clusterState.getMetadata().getConcreteAllIndices();
@@ -512,12 +513,12 @@ public class TransportClusterHealthAction extends TransportClusterManagerNodeRea
         }
 
         try {
-            concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, request);
+            concreteIndices = Set.of(indexNameExpressionResolver.concreteIndexNames(clusterState, request));
         } catch (IndexNotFoundException e) {
             // one of the specified indices is not there - treat it as RED.
             ClusterHealthResponse response = new ClusterHealthResponse(
                 clusterState.getClusterName().value(),
-                Strings.EMPTY_ARRAY,
+                Collections.emptySet(),
                 request,
                 clusterState,
                 numberOfPendingTasks,

--- a/server/src/main/java/org/opensearch/action/admin/indices/datastream/GetDataStreamAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/datastream/GetDataStreamAction.java
@@ -336,7 +336,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
                 }
                 ClusterStateHealth streamHealth = new ClusterStateHealth(
                     state,
-                    dataStream.getIndices().stream().map(Index::getName).toArray(String[]::new)
+                    dataStream.getIndices().stream().map(Index::getName).collect(Collectors.toSet())
                 );
                 dataStreamInfos.add(new Response.DataStreamInfo(dataStream, streamHealth.getStatus(), indexTemplate));
             }

--- a/server/src/main/java/org/opensearch/cluster/health/ClusterStateHealth.java
+++ b/server/src/main/java/org/opensearch/cluster/health/ClusterStateHealth.java
@@ -48,6 +48,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Cluster state health information
@@ -86,9 +87,9 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
      * Creates a new <code>ClusterStateHealth</code> instance considering the current cluster state and the provided index names.
      *
      * @param clusterState    The current cluster state. Must not be null.
-     * @param concreteIndices An array of index names to consider. Must not be null but may be empty.
+     * @param concreteIndices A set of index names to consider. Must not be null but may be empty.
      */
-    public ClusterStateHealth(final ClusterState clusterState, final String[] concreteIndices) {
+    public ClusterStateHealth(final ClusterState clusterState, final Set<String> concreteIndices) {
         numberOfNodes = clusterState.nodes().getSize();
         numberOfDataNodes = clusterState.nodes().getDataNodes().size();
         hasDiscoveredClusterManager = clusterState.nodes().getClusterManagerNodeId() != null;
@@ -152,7 +153,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
 
     public ClusterStateHealth(
         final ClusterState clusterState,
-        final String[] concreteIndices,
+        final Set<String> concreteIndices,
         final ClusterHealthRequest.Level healthLevel
     ) {
         numberOfNodes = clusterState.nodes().getSize();

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -706,7 +706,7 @@ public class IndexNameExpressionResolver {
         if (routing != null) {
             Set<String> r = Sets.newHashSet(Strings.splitStringByCommaToArray(routing));
             Map<String, Set<String>> routings = new HashMap<>();
-            String[] concreteIndices = metadata.getConcreteAllIndices();
+            Set<String> concreteIndices = metadata.getConcreteAllIndices();
             for (String index : concreteIndices) {
                 routings.put(index, r);
             }
@@ -746,7 +746,7 @@ public class IndexNameExpressionResolver {
      */
     boolean isPatternMatchingAllIndices(Metadata metadata, String[] indicesOrAliases, String[] concreteIndices) {
         // if we end up matching on all indices, check, if its a wildcard parameter, or a "-something" structure
-        if (concreteIndices.length == metadata.getConcreteAllIndices().length && indicesOrAliases.length > 0) {
+        if (concreteIndices.length == metadata.getConcreteAllIndices().size() && indicesOrAliases.length > 0) {
 
             // we might have something like /-test1,+test1 that would identify all indices
             // or something like /-test1 with test1 index missing and IndicesOptions.lenient()
@@ -1182,17 +1182,17 @@ public class IndexNameExpressionResolver {
 
         private static List<String> resolveEmptyOrTrivialWildcard(IndicesOptions options, Metadata metadata) {
             if (options.expandWildcardsOpen() && options.expandWildcardsClosed() && options.expandWildcardsHidden()) {
-                return Arrays.asList(metadata.getConcreteAllIndices());
+                return List.copyOf(metadata.getConcreteAllIndices());
             } else if (options.expandWildcardsOpen() && options.expandWildcardsClosed()) {
-                return Arrays.asList(metadata.getConcreteVisibleIndices());
+                return metadata.getConcreteVisibleIndices();
             } else if (options.expandWildcardsOpen() && options.expandWildcardsHidden()) {
-                return Arrays.asList(metadata.getConcreteAllOpenIndices());
+                return metadata.getConcreteAllOpenIndices();
             } else if (options.expandWildcardsOpen()) {
-                return Arrays.asList(metadata.getConcreteVisibleOpenIndices());
+                return metadata.getConcreteVisibleOpenIndices();
             } else if (options.expandWildcardsClosed() && options.expandWildcardsHidden()) {
-                return Arrays.asList(metadata.getConcreteAllClosedIndices());
+                return metadata.getConcreteAllClosedIndices();
             } else if (options.expandWildcardsClosed()) {
-                return Arrays.asList(metadata.getConcreteVisibleClosedIndices());
+                return metadata.getConcreteVisibleClosedIndices();
             } else {
                 return Collections.emptyList();
             }

--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -166,7 +166,7 @@ public class RemoteStoreRestoreService {
             }
         } else {
             List<String> filteredIndices = filterIndices(
-                List.of(currentState.metadata().getConcreteAllIndices()),
+                List.copyOf(currentState.metadata().getConcreteAllIndices()),
                 indexNames,
                 IndicesOptions.fromOptions(true, true, true, true)
             );

--- a/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
@@ -62,6 +62,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -93,7 +94,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
         TimeValue pendingTaskInQueueTime = TimeValue.timeValueMillis(randomIntBetween(1000, 100000));
         ClusterHealthResponse clusterHealth = new ClusterHealthResponse(
             "bla",
-            new String[] { Metadata.ALL },
+            Set.of(Metadata.ALL),
             clusterState,
             pendingTasks,
             inFlight,
@@ -121,7 +122,7 @@ public class ClusterHealthResponsesTests extends AbstractSerializingTestCase<Clu
         TimeValue pendingTaskInQueueTime = TimeValue.timeValueMillis(randomIntBetween(1000, 100000));
         ClusterHealthResponse clusterHealth = new ClusterHealthResponse(
             "bla",
-            new String[] { Metadata.ALL },
+            Set.of(Metadata.ALL),
             clusterState,
             pendingTasks,
             inFlight,

--- a/server/src/test/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthActionTests.java
@@ -50,6 +50,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -57,7 +58,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 public class TransportClusterHealthActionTests extends OpenSearchTestCase {
 
     public void testWaitForInitializingShards() throws Exception {
-        final String[] indices = { "test" };
+        final Set<String> indices = Set.of("test");
         final ClusterHealthRequest request = new ClusterHealthRequest();
         request.waitForNoInitializingShards(true);
         ClusterState clusterState = randomClusterStateWithInitializingShards("test", 0);
@@ -76,7 +77,7 @@ public class TransportClusterHealthActionTests extends OpenSearchTestCase {
     }
 
     public void testWaitForAllShards() {
-        final String[] indices = { "test" };
+        final Set<String> indices = Set.of("test");
         final ClusterHealthRequest request = new ClusterHealthRequest();
         request.waitForActiveShards(ActiveShardCount.ALL);
 

--- a/server/src/test/java/org/opensearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/opensearch/cluster/health/ClusterStateHealthTests.java
@@ -217,10 +217,8 @@ public class ClusterStateHealthTests extends OpenSearchTestCase {
             .routingTable(routingTable.build())
             .nodes(clusterService.state().nodes())
             .build();
-        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(
-            clusterState,
-            IndicesOptions.strictExpand(),
-            (String[]) null
+        Set<String> concreteIndices = Set.of(
+            indexNameExpressionResolver.concreteIndexNames(clusterState, IndicesOptions.strictExpand(), (String[]) null)
         );
         ClusterStateHealth clusterStateHealth = new ClusterStateHealth(clusterState, concreteIndices);
         logger.info("cluster status: {}, expected {}", clusterStateHealth.getStatus(), counter.status());
@@ -240,7 +238,7 @@ public class ClusterStateHealthTests extends OpenSearchTestCase {
 
     public void testClusterHealthOnIndexCreation() {
         final String indexName = "test-idx";
-        final String[] indices = new String[] { indexName };
+        final Set<String> indices = Set.of(indexName);
         final List<ClusterState> clusterStates = simulateIndexCreationStates(indexName, false);
         for (int i = 0; i < clusterStates.size(); i++) {
             // make sure cluster health is always YELLOW, up until the last state where it should be GREEN
@@ -256,7 +254,7 @@ public class ClusterStateHealthTests extends OpenSearchTestCase {
 
     public void testClusterHealthOnIndexCreationWithFailedAllocations() {
         final String indexName = "test-idx";
-        final String[] indices = new String[] { indexName };
+        final Set<String> indices = Set.of(indexName);
         final List<ClusterState> clusterStates = simulateIndexCreationStates(indexName, true);
         for (int i = 0; i < clusterStates.size(); i++) {
             // make sure cluster health is YELLOW up until the final cluster state, which contains primary shard
@@ -273,7 +271,7 @@ public class ClusterStateHealthTests extends OpenSearchTestCase {
 
     public void testClusterHealthOnClusterRecovery() {
         final String indexName = "test-idx";
-        final String[] indices = new String[] { indexName };
+        final Set<String> indices = Set.of(indexName);
         final List<ClusterState> clusterStates = simulateClusterRecoveryStates(indexName, false, false);
         for (int i = 0; i < clusterStates.size(); i++) {
             // make sure cluster health is YELLOW up until the final cluster state, when it turns GREEN
@@ -289,7 +287,7 @@ public class ClusterStateHealthTests extends OpenSearchTestCase {
 
     public void testClusterHealthOnClusterRecoveryWithFailures() {
         final String indexName = "test-idx";
-        final String[] indices = new String[] { indexName };
+        final Set<String> indices = Set.of(indexName);
         final List<ClusterState> clusterStates = simulateClusterRecoveryStates(indexName, false, true);
         for (int i = 0; i < clusterStates.size(); i++) {
             // make sure cluster health is YELLOW up until the final cluster state, which contains primary shard
@@ -306,7 +304,7 @@ public class ClusterStateHealthTests extends OpenSearchTestCase {
 
     public void testClusterHealthOnClusterRecoveryWithPreviousAllocationIds() {
         final String indexName = "test-idx";
-        final String[] indices = new String[] { indexName };
+        final Set<String> indices = Set.of(indexName);
         final List<ClusterState> clusterStates = simulateClusterRecoveryStates(indexName, true, false);
         for (int i = 0; i < clusterStates.size(); i++) {
             // because there were previous allocation ids, we should be RED until the primaries are started,
@@ -329,7 +327,7 @@ public class ClusterStateHealthTests extends OpenSearchTestCase {
 
     public void testClusterHealthOnClusterRecoveryWithPreviousAllocationIdsAndAllocationFailures() {
         final String indexName = "test-idx";
-        final String[] indices = new String[] { indexName };
+        final Set<String> indices = Set.of(indexName);
         for (final ClusterState clusterState : simulateClusterRecoveryStates(indexName, true, true)) {
             final ClusterStateHealth health = new ClusterStateHealth(clusterState, indices);
             // if the inactive primaries are due solely to recovery (not failed allocation or previously being allocated)


### PR DESCRIPTION
### Description
Changed the arrays to immutable List instances, added new versions of the getters which returns List instances.

### Related Issues
Resolves #8647

Signed-off-by: Abdul Muneer Kolarkunnu [muneer.kolarkunnu@netapp.com]

### Check List
- [x] New functionality includes testing.
- [x] All tests pass
- [ ] ~New functionality has been documented.~
- [x] New functionality has javadoc added
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [ ] ~Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))~
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
