### PR TITLE
Add matchesPluginSystemIndexPattern to SystemIndexRegistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add allowlist setting for ingest-common and search-pipeline-common processors ([#14439](https://github.com/opensearch-project/OpenSearch/issues/14439))
 - Create SystemIndexRegistry with helper method matchesSystemIndex ([#14415](https://github.com/opensearch-project/OpenSearch/pull/14415))
 - Print reason why parent task was cancelled ([#14604](https://github.com/opensearch-project/OpenSearch/issues/14604))
+- Add matchesPluginSystemIndexPattern to SystemIndexRegistry ([#14750](https://github.com/opensearch-project/OpenSearch/pull/14750))
 
 ### Dependencies
 - Bump `org.gradle.test-retry` from 1.5.8 to 1.5.9 ([#13442](https://github.com/opensearch-project/OpenSearch/pull/13442))

--- a/server/src/main/java/org/opensearch/indices/SystemIndexRegistry.java
+++ b/server/src/main/java/org/opensearch/indices/SystemIndexRegistry.java
@@ -45,7 +45,6 @@ public class SystemIndexRegistry {
     );
 
     private volatile static String[] SYSTEM_INDEX_PATTERNS = new String[0];
-    volatile static Collection<SystemIndexDescriptor> SYSTEM_INDEX_DESCRIPTORS = Collections.emptyList();
     volatile static Map<String, Collection<SystemIndexDescriptor>> SYSTEM_INDEX_DESCRIPTORS_MAP = Collections.emptyMap();
 
     static void register(Map<String, Collection<SystemIndexDescriptor>> pluginAndModulesDescriptors) {
@@ -58,7 +57,6 @@ public class SystemIndexRegistry {
         descriptors.add(TASK_INDEX_DESCRIPTOR);
 
         SYSTEM_INDEX_DESCRIPTORS_MAP = descriptorsMap;
-        SYSTEM_INDEX_DESCRIPTORS = descriptors.stream().collect(Collectors.toUnmodifiableList());
         SYSTEM_INDEX_PATTERNS = descriptors.stream().map(SystemIndexDescriptor::getIndexPattern).toArray(String[]::new);
     }
 

--- a/server/src/main/java/org/opensearch/indices/SystemIndexRegistry.java
+++ b/server/src/main/java/org/opensearch/indices/SystemIndexRegistry.java
@@ -72,7 +72,7 @@ public class SystemIndexRegistry {
             .collect(Collectors.toSet());
     }
 
-    public static List<SystemIndexDescriptor> getAllDescriptors() {
+    static List<SystemIndexDescriptor> getAllDescriptors() {
         return SYSTEM_INDEX_DESCRIPTORS_MAP.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
     }
 

--- a/server/src/main/java/org/opensearch/indices/SystemIndexRegistry.java
+++ b/server/src/main/java/org/opensearch/indices/SystemIndexRegistry.java
@@ -45,19 +45,14 @@ public class SystemIndexRegistry {
     );
 
     private volatile static String[] SYSTEM_INDEX_PATTERNS = new String[0];
-    volatile static Map<String, Collection<SystemIndexDescriptor>> SYSTEM_INDEX_DESCRIPTORS_MAP = Collections.emptyMap();
+    private volatile static Map<String, Collection<SystemIndexDescriptor>> SYSTEM_INDEX_DESCRIPTORS_MAP = Collections.emptyMap();
 
     static void register(Map<String, Collection<SystemIndexDescriptor>> pluginAndModulesDescriptors) {
         final Map<String, Collection<SystemIndexDescriptor>> descriptorsMap = buildSystemIndexDescriptorMap(pluginAndModulesDescriptors);
         checkForOverlappingPatterns(descriptorsMap);
-        List<SystemIndexDescriptor> descriptors = pluginAndModulesDescriptors.values()
-            .stream()
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
-        descriptors.add(TASK_INDEX_DESCRIPTOR);
 
         SYSTEM_INDEX_DESCRIPTORS_MAP = descriptorsMap;
-        SYSTEM_INDEX_PATTERNS = descriptors.stream().map(SystemIndexDescriptor::getIndexPattern).toArray(String[]::new);
+        SYSTEM_INDEX_PATTERNS = getAllDescriptors().stream().map(SystemIndexDescriptor::getIndexPattern).toArray(String[]::new);
     }
 
     public static Set<String> matchesSystemIndexPattern(Set<String> indexExpressions) {
@@ -75,6 +70,10 @@ public class SystemIndexRegistry {
         return indexExpressions.stream()
             .filter(pattern -> Regex.simpleMatch(pluginSystemIndexPatterns, pattern))
             .collect(Collectors.toSet());
+    }
+
+    public static List<SystemIndexDescriptor> getAllDescriptors() {
+        return SYSTEM_INDEX_DESCRIPTORS_MAP.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/opensearch/indices/SystemIndices.java
@@ -63,7 +63,9 @@ public class SystemIndices {
 
     public SystemIndices(Map<String, Collection<SystemIndexDescriptor>> pluginAndModulesDescriptors) {
         SystemIndexRegistry.register(pluginAndModulesDescriptors);
-        this.runAutomaton = buildCharacterRunAutomaton(SystemIndexRegistry.SYSTEM_INDEX_DESCRIPTORS);
+        this.runAutomaton = buildCharacterRunAutomaton(
+            SystemIndexRegistry.SYSTEM_INDEX_DESCRIPTORS_MAP.values().stream().flatMap(Collection::stream).collect(Collectors.toList())
+        );
     }
 
     /**
@@ -91,7 +93,11 @@ public class SystemIndices {
      * @throws IllegalStateException if multiple descriptors match the name
      */
     public @Nullable SystemIndexDescriptor findMatchingDescriptor(String name) {
-        final List<SystemIndexDescriptor> matchingDescriptors = SystemIndexRegistry.SYSTEM_INDEX_DESCRIPTORS.stream()
+        List<SystemIndexDescriptor> allDescriptors = SystemIndexRegistry.SYSTEM_INDEX_DESCRIPTORS_MAP.values()
+            .stream()
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+        final List<SystemIndexDescriptor> matchingDescriptors = allDescriptors.stream()
             .filter(descriptor -> descriptor.matchesIndexPattern(name))
             .collect(Collectors.toList());
 

--- a/server/src/main/java/org/opensearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/opensearch/indices/SystemIndices.java
@@ -63,9 +63,7 @@ public class SystemIndices {
 
     public SystemIndices(Map<String, Collection<SystemIndexDescriptor>> pluginAndModulesDescriptors) {
         SystemIndexRegistry.register(pluginAndModulesDescriptors);
-        this.runAutomaton = buildCharacterRunAutomaton(
-            SystemIndexRegistry.SYSTEM_INDEX_DESCRIPTORS_MAP.values().stream().flatMap(Collection::stream).collect(Collectors.toList())
-        );
+        this.runAutomaton = buildCharacterRunAutomaton(SystemIndexRegistry.getAllDescriptors());
     }
 
     /**
@@ -93,11 +91,8 @@ public class SystemIndices {
      * @throws IllegalStateException if multiple descriptors match the name
      */
     public @Nullable SystemIndexDescriptor findMatchingDescriptor(String name) {
-        List<SystemIndexDescriptor> allDescriptors = SystemIndexRegistry.SYSTEM_INDEX_DESCRIPTORS_MAP.values()
+        final List<SystemIndexDescriptor> matchingDescriptors = SystemIndexRegistry.getAllDescriptors()
             .stream()
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
-        final List<SystemIndexDescriptor> matchingDescriptors = allDescriptors.stream()
             .filter(descriptor -> descriptor.matchesIndexPattern(name))
             .collect(Collectors.toList());
 

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -699,7 +699,10 @@ public class Node implements Closeable {
                 pluginsService.filterPlugins(SystemIndexPlugin.class)
                     .stream()
                     .collect(
-                        Collectors.toMap(plugin -> plugin.getClass().getSimpleName(), plugin -> plugin.getSystemIndexDescriptors(settings))
+                        Collectors.toMap(
+                            plugin -> plugin.getClass().getCanonicalName(),
+                            plugin -> plugin.getSystemIndexDescriptors(settings)
+                        )
                     )
             );
             final SystemIndices systemIndices = new SystemIndices(systemIndexDescriptorMap);

--- a/server/src/test/java/org/opensearch/indices/SystemIndicesTests.java
+++ b/server/src/test/java/org/opensearch/indices/SystemIndicesTests.java
@@ -42,8 +42,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -187,6 +189,26 @@ public class SystemIndicesTests extends OpenSearchTestCase {
             equalTo(Set.of(".system-index1", ".system-index-pattern1"))
         );
         assertThat(SystemIndexRegistry.matchesSystemIndexPattern(Set.of(".not-system")), equalTo(Collections.emptySet()));
+    }
+
+    public void testRegisteredSystemIndexGetAllDescriptors() {
+        SystemIndexPlugin plugin1 = new SystemIndexPlugin1();
+        SystemIndexPlugin plugin2 = new SystemIndexPlugin2();
+        SystemIndices pluginSystemIndices = new SystemIndices(
+            Map.of(
+                SystemIndexPlugin1.class.getCanonicalName(),
+                plugin1.getSystemIndexDescriptors(Settings.EMPTY),
+                SystemIndexPlugin2.class.getCanonicalName(),
+                plugin2.getSystemIndexDescriptors(Settings.EMPTY)
+            )
+        );
+        assertEquals(
+            SystemIndexRegistry.getAllDescriptors()
+                .stream()
+                .map(SystemIndexDescriptor::getIndexPattern)
+                .collect(Collectors.toUnmodifiableList()),
+            List.of(SystemIndexPlugin1.SYSTEM_INDEX_1, SystemIndexPlugin2.SYSTEM_INDEX_2, TASK_INDEX + "*")
+        );
     }
 
     public void testRegisteredSystemIndexMatching() {


### PR DESCRIPTION
### Description

Adds a method called `matchesPluginSystemIndexPattern` to [SystemIndexRegistry](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/indices/SystemIndexRegistry.java) which was added in a recent [PR](https://github.com/opensearch-project/OpenSearch/pull/14415).

This PR relates to another open [PR](https://github.com/opensearch-project/OpenSearch/pull/14630) which introduces a new mechanism for plugins to switch context outside of an authenticated user context. 

This new method takes a plugin's canonical class name and set of index expressions in as params to determine if the request matches system indices registered to that particular plugin.

This PR also changes the method signature to accept a Set which fits the [security use-case better](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/privileges/SystemIndexAccessEvaluator.java#L182) and avoids having to convert between array and set.

### Related Issues

Related to https://github.com/opensearch-project/OpenSearch/issues/14733

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
