### PR TITLE
Make remote snapshot (local)block size configurable

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockIndexInput.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockIndexInput.java
@@ -385,7 +385,7 @@ abstract class OnDemandBlockIndexInput extends IndexInput implements RandomAcces
         private int blockSize = 1 << blockSizeShift;
         private int blockMask = blockSize - 1;
 
-        private Builder() {}
+        public Builder() {}
 
         public Builder resourceDescription(String resourceDescription) {
             this.resourceDescription = resourceDescription;
@@ -407,7 +407,7 @@ abstract class OnDemandBlockIndexInput extends IndexInput implements RandomAcces
             return this;
         }
 
-        Builder blockSizeShift(int blockSizeShift) {
+        public Builder blockSizeShift(int blockSizeShift) {
             assert blockSizeShift < 31 : "blockSizeShift must be < 31";
             this.blockSizeShift = blockSizeShift;
             this.blockSize = 1 << blockSizeShift;

--- a/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInput.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/file/OnDemandBlockSnapshotIndexInput.java
@@ -96,7 +96,7 @@ public class OnDemandBlockSnapshotIndexInput extends OnDemandBlockIndexInput {
         );
     }
 
-    OnDemandBlockSnapshotIndexInput(
+    public OnDemandBlockSnapshotIndexInput(
         OnDemandBlockIndexInput.Builder builder,
         FileInfo fileInfo,
         FSDirectory directory,

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheSettings.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheSettings.java
@@ -33,6 +33,20 @@ public class FileCacheSettings {
         Setting.Property.Dynamic
     );
 
+    /**
+     * The size in bytes of blocks downloaded from the remote store into local file cache to service requests.
+     * Note that almost always the full block is downloaded, regardless of how much data from the block is actually
+     * required for an operation.
+     */
+    public static final Setting<Integer> FILE_CACHE_LOCAL_BLOCK_SHIFT_SETTING = Setting.intSetting(
+        "cluster.filecache.block_shift",
+        23,
+        10,
+        30,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     private volatile double remoteDataRatio;
 
     public FileCacheSettings(Settings settings, ClusterSettings clusterSettings) {


### PR DESCRIPTION
### Description
To perform a search on a remote snapshot we download only the specific blocks of the snapshot needed to complete the search. These blocks have a set 8Mib size and are stored in a local reference counted file cache. The default 8Mib block size has significant disk usage and likely performance implications as there is no mechanism to vary the block size depending on the data we expect to read at runtime.

For example, when lucene opens an index input into a [compound file](https://lucene.apache.org/core/8_0_0/core/org/apache/lucene/codecs/lucene50/Lucene50CompoundFormat.html) with the intention of only reading the Header, which can be quite small, we will download the entire 8Mib block from our remote snapshot repo.

This is particularly noticeable during snapshot restore, as Lucene downloads various blocks containing metadata for each segment. Lucene keeps this metadata in memory and so the blocks are persistent for the lifetime of the cache and never evicted. By selecting a smaller block size users might drastically reduce the size of their baseline searchable snapshots file cache.

[Sample benchmarks.](https://github.com/opensearch-project/OpenSearch/issues/14990)

### Related Issues
Feature request issue #14990
Potentially alleviates #11676

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
