### PR TITLE
[Forwardport] [main] Fix create or update alias API doesn't throw exception for unsupported parameters

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_alias/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_alias/10_basic.yml
@@ -273,8 +273,8 @@
 ---
 "Can set is_hidden":
   - skip:
-      version: " - 2.99.99"
-      reason: "Fix was introduced in 3.0.0"
+      version: " - 2.15.99"
+      reason: "Fix was introduced in 2.16.0"
   - do:
       indices.create:
         index: test_index
@@ -295,8 +295,8 @@
 ---
 "Throws exception with invalid parameters":
   - skip:
-      version: " - 2.99.99"
-      reason: "Fix was introduced in 3.0.0"
+      version: " - 2.15.99"
+      reason: "Fix was introduced in 2.16.0"
 
   - do:
       indices.create:


### PR DESCRIPTION
Forwardport of https://github.com/opensearch-project/OpenSearch/pull/14756 to `main`