### PR TITLE
Improved cat help description

### DIFF
--- a/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
@@ -694,8 +694,8 @@ public class RestIndicesAction extends AbstractCatAction {
         table.addCell("suggest.total", "sibling:pri;alias:suto,suggestTotal;default:false;text-align:right;desc:number of suggest ops");
         table.addCell("pri.suggest.total", "default:false;text-align:right;desc:number of suggest ops");
 
-        table.addCell("memory.total", "sibling:pri;alias:tm,memoryTotal;default:false;text-align:right;desc:total used memory");
-        table.addCell("pri.memory.total", "default:false;text-align:right;desc:total user memory");
+        table.addCell("memory.total", "sibling:pri;alias:tm,memoryTotal;default:false;text-align:right;desc:total used memory of primaries & replicas");
+        table.addCell("pri.memory.total", "default:false;text-align:right;desc:total used memory of primary");
 
         table.addCell("search.throttled", "alias:sth;default:false;desc:indicates if the index is search throttled");
 


### PR DESCRIPTION
### Description
The _cat API's help returns (in part) the following:
Header | Description
memory.total | total used memory
pri.memory.total | total **user** memory

The word 'user' is almost certainly a typo. However, I also strongly suspect that this is total used memory **for primary shards** and that should be explained more clearly.

### Related Issues

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Landon Lengyel <landon@almonde.org>