### PR TITLE
[Backport] [1.3] Add Gao Binlong as maintainer (#14796)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,16 @@
-*   @reta @anasalkouz @andrross @reta @Bukhtawar @CEHENKLE @dblock @gbbafna @setiah @kartg @kotwanikunal @mch2 @nknize @owaiskazi19 @adnapibar @Rishikesh1159 @ryanbogan @saratvemulapalli @shwetathareja @dreamer-89 @tlfeng @VachaShah @xuezhou25
+# CODEOWNERS manages notifications, not PR approvals
+# For PR approvals see /.github/workflows/maintainer-approval.yml
+
+# Files have a single rule applied, the last match decides the owner
+# If you would like to more specifically apply ownership, include existing owner in new sub fields
+
+# To verify changes of CODEOWNERS file
+# In VSCode
+#   1. Install extension https://marketplace.visualstudio.com/items?itemName=jasonnutter.vscode-codeowners
+#   2. Go to a file
+#   3. Use the command palette to run the CODEOWNERS: Show owners of current file command, which will display all code owners for the current file.
+
+# Default ownership for all repo files
+* @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @dblock @dbwiddis @gbbafna @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
+
+/MAINTAINERS.md @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @dblock @dbwiddis @gaobinlong @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @peternied @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,19 +1,45 @@
-## Maintainers
+## Overview
 
-| Maintainer | GitHub ID | Affiliation |
-| --------------- | --------- | ----------- |
-| Abbas Hussain | [abbashus](https://github.com/abbashus) | Amazon |
-| Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE) | Amazon |
-| Harold Wang | [harold-wang](https://github.com/harold-wang) | Amazon |
-| Himanshu Setia | [setiah](https://github.com/setiah) | Amazon |
-| Nick Knize | [nknize](https://github.com/nknize) | Amazon | 
-| Rabi Panda | [adnapibar](adnapibar) | Amazon |
-| Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon |
-| Tianli Feng | [tlfeng](https://github.com/tlfeng) | Amazon |
-| Gopala Krishna Ambareesh | [krishna-ggk](https://github.com/krishna-ggk) |Amazon |
-| Vengadanathan Srinivasan | [vengadanathan-s](https://github.com/vengadanathan-s) | Amazon |
-| Shweta Thareja |[shwetathareja](https://github.com/shwetathareja) | Amazon |
-| Itiyama Sadana | [itiyamas](https://github.com/itiyamas) | Amazon | 
-| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock) | Amazon |
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
 
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+## Current Maintainers
+
+| Maintainer               | GitHub ID                                               | Affiliation |
+| ------------------------ | ------------------------------------------------------- | ----------- |
+| Anas Alkouz              | [anasalkouz](https://github.com/anasalkouz)             | Amazon      |
+| Andrew Ross              | [andrross](https://github.com/andrross)                 | Amazon      |
+| Andriy Redko             | [reta](https://github.com/reta)                         | Aiven       |
+| Ashish Singh             | [ashking94](https://github.com/ashking94)               | Amazon      |
+| Bukhtawar Khan           | [Bukhtawar](https://github.com/Bukhtawar)               | Amazon      |
+| Charlotte Henkle         | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
+| Dan Widdis               | [dbwiddis](https://github.com/dbwiddis)                 | Amazon      |
+| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)                     | Amazon      |
+| Gao Binlong              | [gaobinlong](https://github.com/gaobinlong)             | Amazon      |
+| Gaurav Bafna             | [gbbafna](https://github.com/gbbafna)                   | Amazon      |
+| Jay Deng                 | [jed326](https://github.com/jed326)                     | Amazon      |
+| Kunal Kotwani            | [kotwanikunal](https://github.com/kotwanikunal)         | Amazon      |
+| Marc Handalian           | [mch2](https://github.com/mch2)                         | Amazon      |
+| Michael Froh             | [msfroh](https://github.com/msfroh)                     | Amazon      |
+| Nick Knize               | [nknize](https://github.com/nknize)                     | Amazon      |
+| Owais Kazi               | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
+| Peter Nied               | [peternied](https://github.com/peternied)               | Amazon      |
+| Rishikesh Pasham         | [Rishikesh1159](https://github.com/Rishikesh1159)       | Amazon      |
+| Sachin Kale              | [sachinpkale](https://github.com/sachinpkale)           | Amazon      |
+| Sarat Vemulapalli        | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
+| Shweta Thareja           | [shwetathareja](https://github.com/shwetathareja)       | Amazon      |
+| Sorabh Hamirwasia        | [sohami](https://github.com/sohami)                     | Amazon      |
+| Vacha Shah               | [VachaShah](https://github.com/VachaShah)               | Amazon      |
+
+## Emeritus
+
+| Maintainer             | GitHub ID                                   | Affiliation |
+| ---------------------- |-------------------------------------------- | ----------- |
+| Megha Sai Kavikondala  | [meghasaik](https://github.com/meghasaik)   | Amazon      |
+| Xue Zhou               | [xuezhou25](https://github.com/xuezhou25)   | Amazon      |
+| Kartik Ganesh          | [kartg](https://github.com/kartg)           | Amazon      |
+| Abbas Hussain          | [abbashus](https://github.com/abbashus)     | Meta        |
+| Himanshu Setia         | [setiah](https://github.com/setiah)         | Amazon      |
+| Ryan Bogan             | [ryanbogan](https://github.com/ryanbogan)   | Amazon      |
+| Rabi Panda             | [adnapibar](https://github.com/adnapibar)   | Independent |
+| Tianli Feng            | [tlfeng](https://github.com/tlfeng)         | Amazon      |
+| Suraj Singh            | [dreamer-89](https://github.com/dreamer-89) | Amazon      |


### PR DESCRIPTION
Backport of `https://github.com/opensearch-project/OpenSearch/pull/14796` to `1.3`