### PR TITLE
search_after query optimization with missing value comparison

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/90_search_after.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/90_search_after.yml
@@ -785,3 +785,61 @@
   - match: { hits.hits.2._index: test }
   - match: { hits.hits.2._source.unsignedlong: null }
   - match: { hits.hits.2._source.id: 22 }
+
+---
+"search with null search after value":
+  - do:
+      indices.create:
+        index:  test
+        body:
+          mappings:
+            properties:
+              doc:
+                type: keyword
+              name:
+                type: keyword
+
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body: |
+          {"index":{}}
+          { "doc": "doc1", "name": "bob"}
+          {"index":{}}
+          { "doc": "doc2", "name": null}
+          {"index":{}}
+          { "doc": "doc3", "name": null}
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          size: 2
+          track_total_hits: false
+          sort: [{ name: desc }, { doc: desc }]
+
+  - match: {hits.total: -1 }
+  - length: {hits.hits: 2 }
+  - match: {hits.hits.0._index: test }
+  - match: {hits.hits.0._source.doc: doc1 }
+  - match: {hits.hits.1._index: test }
+  - match: {hits.hits.1._source.doc: doc3 }
+  - match: {hits.hits.1.sort: [null, "doc3"] }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          size: 1
+          track_total_hits: false
+          sort: [{ name: desc }, { doc: desc }]
+          search_after: [null, "doc3"]
+
+  - match: {hits.total: -1 }
+  - length: {hits.hits: 1 }
+  - match: {hits.hits.0._index: test }
+  - match: {hits.hits.0._source.doc: doc2 }
+  - match: {hits.hits.0.sort: [null, "doc2"] }

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -36,7 +36,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionRunnable;
 import org.opensearch.action.OriginalIndices;
@@ -135,7 +137,6 @@ import org.opensearch.search.sort.FieldSortBuilder;
 import org.opensearch.search.sort.MinAndMax;
 import org.opensearch.search.sort.SortAndFormats;
 import org.opensearch.search.sort.SortBuilder;
-import org.opensearch.search.sort.SortOrder;
 import org.opensearch.search.suggest.Suggest;
 import org.opensearch.search.suggest.completion.CompletionSuggestion;
 import org.opensearch.tasks.TaskResourceTrackingService;
@@ -1622,7 +1623,10 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 );
                 Rewriteable.rewrite(request.getRewriteable(), context, false);
                 final boolean aliasFilterCanMatch = request.getAliasFilter().getQueryBuilder() instanceof MatchNoneQueryBuilder == false;
-                FieldSortBuilder sortBuilder = FieldSortBuilder.getPrimaryFieldSortOrNull(request.source());
+                final FieldSortBuilder sortBuilder = FieldSortBuilder.getPrimaryFieldSortOrNull(request.source());
+                final SortAndFormats primarySort = sortBuilder != null
+                    ? SortBuilder.buildSort(Collections.singletonList(sortBuilder), context).get()
+                    : null;
                 MinAndMax<?> minMax = sortBuilder != null ? FieldSortBuilder.getMinMaxOrNull(context, sortBuilder) : null;
                 boolean canMatch;
                 if (canRewriteToMatchNone(request.source())) {
@@ -1634,7 +1638,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 }
                 final FieldDoc searchAfterFieldDoc = getSearchAfterFieldDoc(request, context);
                 final Integer trackTotalHitsUpto = request.source() == null ? null : request.source().trackTotalHitsUpTo();
-                canMatch = canMatch && canMatchSearchAfter(searchAfterFieldDoc, minMax, sortBuilder, trackTotalHitsUpto);
+                canMatch = canMatch && canMatchSearchAfter(searchAfterFieldDoc, minMax, primarySort, trackTotalHitsUpto);
 
                 return new CanMatchResponse(canMatch || hasRefreshPending, minMax);
             }
@@ -1644,7 +1648,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     public static boolean canMatchSearchAfter(
         FieldDoc searchAfter,
         MinAndMax<?> minMax,
-        FieldSortBuilder primarySortField,
+        SortAndFormats primarySort,
         Integer trackTotalHitsUpto
     ) {
         // Check for sort.missing == null, since in case of missing values sort queries, if segment/shard's min/max
@@ -1652,24 +1656,55 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         // Skipping search on shard/segment entirely can cause mismatch on total_tracking_hits, hence skip only if
         // track_total_hits is false.
         if (searchAfter != null
+            && searchAfter.fields[0] != null
             && minMax != null
-            && primarySortField != null
-            && primarySortField.missing() == null
+            && primarySort != null
             && Objects.equals(trackTotalHitsUpto, SearchContext.TRACK_TOTAL_HITS_DISABLED)) {
             final Object searchAfterPrimary = searchAfter.fields[0];
-            if (primarySortField.order() == SortOrder.DESC) {
+            SortField primarySortField = primarySort.sort.getSort()[0];
+            if (primarySortField.getReverse()) {
                 if (minMax.compareMin(searchAfterPrimary) > 0) {
                     // In Desc order, if segment/shard minimum is gt search_after, the segment/shard won't be competitive
-                    return false;
+                    return canMatchMissingValue(primarySortField, searchAfterPrimary);
                 }
             } else {
                 if (minMax.compareMax(searchAfterPrimary) < 0) {
                     // In ASC order, if segment/shard maximum is lt search_after, the segment/shard won't be competitive
-                    return false;
+                    return canMatchMissingValue(primarySortField, searchAfterPrimary);
                 }
             }
         }
         return true;
+    }
+
+    private static boolean canMatchMissingValue(SortField primarySortField, Object primarySearchAfter) {
+        final Object missingValue = primarySortField.getMissingValue();
+        if (primarySortField.getReverse()) {
+            // the missing value of Type.STRING can only be SortField.STRING_FIRS or SortField.STRING_LAST
+            if (primarySearchAfter instanceof BytesRef) {
+                return missingValue == SortField.STRING_FIRST;
+            }
+            return compare(primarySearchAfter, missingValue) >= 0;
+        } else {
+            if (primarySearchAfter instanceof BytesRef) {
+                return missingValue == SortField.STRING_LAST;
+            }
+            return compare(primarySearchAfter, missingValue) <= 0;
+        }
+    }
+
+    private static int compare(Object one, Object two) {
+        if (one instanceof Long) {
+            return Long.compare((Long) one, (Long) two);
+        } else if (one instanceof Integer) {
+            return Integer.compare((Integer) one, (Integer) two);
+        } else if (one instanceof Float) {
+            return Float.compare((Float) one, (Float) two);
+        } else if (one instanceof Double) {
+            return Double.compare((Double) one, (Double) two);
+        } else {
+            throw new UnsupportedOperationException("compare type not supported : " + one.getClass());
+        }
     }
 
     private static FieldDoc getSearchAfterFieldDoc(ShardSearchRequest request, QueryShardContext context) throws IOException {

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -526,7 +526,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
                 return SearchService.canMatchSearchAfter(
                     searchContext.searchAfter(),
                     minMax,
-                    primarySortField,
+                    searchContext.sort(),
                     searchContext.trackTotalHitsUpTo()
                 );
             }

--- a/server/src/main/java/org/opensearch/search/searchafter/SearchAfterBuilder.java
+++ b/server/src/main/java/org/opensearch/search/searchafter/SearchAfterBuilder.java
@@ -138,6 +138,10 @@ public class SearchAfterBuilder implements ToXContentObject, Writeable {
             if (values[i] != null) {
                 fieldValues[i] = convertValueFromSortField(values[i], sortField, format);
             } else {
+                SortField.Type sortType = extractSortType(sortField);
+                if (sortType != SortField.Type.STRING && sortType != SortField.Type.STRING_VAL) {
+                    throw new IllegalArgumentException("search after value of type [" + sortType + "] cannot be null");
+                }
                 fieldValues[i] = null;
             }
         }

--- a/server/src/test/java/org/opensearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchServiceTests.java
@@ -36,6 +36,8 @@ import org.apache.lucene.index.FilterDirectoryReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.OriginalIndices;
@@ -106,9 +108,8 @@ import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.internal.ShardSearchContextId;
 import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.query.QuerySearchResult;
-import org.opensearch.search.sort.FieldSortBuilder;
 import org.opensearch.search.sort.MinAndMax;
-import org.opensearch.search.sort.SortOrder;
+import org.opensearch.search.sort.SortAndFormats;
 import org.opensearch.search.suggest.SuggestBuilder;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -1869,111 +1870,132 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
 
     /**
      * Test for ASC order search_after query.
-     * Min = 0L, Max = 9L, search_after = 10L
+     * Min = 0L, Max = 9L, search_after = 10L, missing = Long.MIN_VALUE
      * Expected result is canMatch = false
      */
-    public void testCanMatchSearchAfterAscGreaterThanMax() throws IOException {
+    public void testCanMatchSearchAfterAscGreaterThanMaxAndMissing() throws IOException {
         FieldDoc searchAfter = new FieldDoc(0, 0, new Long[] { 10L });
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
-        FieldSortBuilder primarySort = new FieldSortBuilder("test");
-        primarySort.order(SortOrder.ASC);
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), false);
+        SortField sortField = new SortField("test", SortField.Type.LONG);
+        sortField.setMissingValue(Long.MIN_VALUE);
+        final SortAndFormats primarySort = new SortAndFormats(new Sort(sortField), new DocValueFormat[] { DocValueFormat.RAW });
+        assertFalse(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED));
     }
 
     /**
      * Test for ASC order search_after query.
-     * Min = 0L, Max = 9L, search_after = 7L
+     * Min = 0L, Max = 9L, search_after = 10L, missing = 11L
+     * Expected result is canMatch = true
+     */
+    public void testCanMatchSearchAfterAscGreaterThanMaxAndLessThanMissing() throws IOException {
+        FieldDoc searchAfter = new FieldDoc(0, 0, new Long[] { 10L });
+        MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
+        SortField sortField = new SortField("test", SortField.Type.LONG);
+        sortField.setMissingValue(11L);
+        final SortAndFormats primarySort = new SortAndFormats(new Sort(sortField), new DocValueFormat[] { DocValueFormat.RAW });
+        assertTrue(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED));
+    }
+
+    /**
+     * Test for ASC order search_after query.
+     * Min = 0L, Max = 9L, search_after = 7L, missing = Long.MIN_VALUE/10L
      * Expected result is canMatch = true
      */
     public void testCanMatchSearchAfterAscLessThanMax() throws IOException {
         FieldDoc searchAfter = new FieldDoc(0, 0, new Long[] { 7L });
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
-        FieldSortBuilder primarySort = new FieldSortBuilder("test");
-        primarySort.order(SortOrder.ASC);
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), true);
+        SortField sortField = new SortField("test", SortField.Type.LONG);
+        sortField.setMissingValue(randomFrom(Long.MIN_VALUE, 10L));
+        final SortAndFormats primarySort = new SortAndFormats(new Sort(sortField), new DocValueFormat[] { DocValueFormat.RAW });
+        assertTrue(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED));
     }
 
     /**
      * Test for ASC order search_after query.
-     * Min = 0L, Max = 9L, search_after = 9L
+     * Min = 0L, Max = 9L, search_after = 9L, missing = Long.MIN_VALUE/10L
      * Expected result is canMatch = true
      */
     public void testCanMatchSearchAfterAscEqualMax() throws IOException {
         FieldDoc searchAfter = new FieldDoc(0, 0, new Long[] { 9L });
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
-        FieldSortBuilder primarySort = new FieldSortBuilder("test");
-        primarySort.order(SortOrder.ASC);
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), true);
+        SortField sortField = new SortField("test", SortField.Type.LONG);
+        sortField.setMissingValue(randomFrom(Long.MIN_VALUE, 10L));
+        final SortAndFormats primarySort = new SortAndFormats(new Sort(sortField), new DocValueFormat[] { DocValueFormat.RAW });
+        assertTrue(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED));
     }
 
     /**
      * Test for DESC order search_after query.
-     * Min = 0L, Max = 9L, search_after = 10L
+     * Min = 0L, Max = 9L, search_after = 10L, missing = Long.MAX_VALUE/Long.MIN_VALUE
      * Expected result is canMatch = true
      */
     public void testCanMatchSearchAfterDescGreaterThanMin() throws IOException {
         FieldDoc searchAfter = new FieldDoc(0, 0, new Long[] { 10L });
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
-        FieldSortBuilder primarySort = new FieldSortBuilder("test");
-        primarySort.order(SortOrder.DESC);
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), true);
+        SortField sortField = new SortField("test", SortField.Type.LONG, true);
+        sortField.setMissingValue(randomFrom(Long.MAX_VALUE, Long.MIN_VALUE));
+        final SortAndFormats primarySort = new SortAndFormats(new Sort(sortField), new DocValueFormat[] { DocValueFormat.RAW });
+        assertTrue(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED));
     }
 
     /**
      * Test for DESC order search_after query.
-     * Min = 0L, Max = 9L, search_after = -1L
+     * Min = 0L, Max = 9L, search_after = -1L, missing > search_after
      * Expected result is canMatch = false
      */
-    public void testCanMatchSearchAfterDescLessThanMin() throws IOException {
+    public void testCanMatchSearchAfterDescLessThanMinAndMissing() throws IOException {
         FieldDoc searchAfter = new FieldDoc(0, 0, new Long[] { -1L });
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
-        FieldSortBuilder primarySort = new FieldSortBuilder("test");
-        primarySort.order(SortOrder.DESC);
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), false);
+        SortField sortField = new SortField("test", SortField.Type.LONG, true);
+        sortField.setMissingValue(randomLongBetween(0L, Long.MAX_VALUE));
+        final SortAndFormats primarySort = new SortAndFormats(new Sort(sortField), new DocValueFormat[] { DocValueFormat.RAW });
+        assertFalse(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED));
     }
 
     /**
      * Test for DESC order search_after query.
-     * Min = 0L, Max = 9L, search_after = 0L
+     * Min = 0L, Max = 9L, search_after = 0L, missing > search_after
      * Expected result is canMatch = true
      */
-    public void testCanMatchSearchAfterDescEqualMin() throws IOException {
+    public void testCanMatchSearchAfterDescEqualMinAndLessThanMissing() throws IOException {
         FieldDoc searchAfter = new FieldDoc(0, 0, new Long[] { 0L });
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
-        FieldSortBuilder primarySort = new FieldSortBuilder("test");
-        primarySort.order(SortOrder.DESC);
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), true);
+        SortField sortField = new SortField("test", SortField.Type.LONG, true);
+        sortField.setMissingValue(randomLongBetween(1L, Long.MAX_VALUE));
+        final SortAndFormats primarySort = new SortAndFormats(new Sort(sortField), new DocValueFormat[] { DocValueFormat.RAW });
+        assertTrue(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED));
     }
 
     /**
      * Test canMatchSearchAfter with missing value, even if min/max is out of range
      * Min = 0L, Max = 9L, search_after = -1L
-     * Expected result is canMatch = true
      */
-    public void testCanMatchSearchAfterWithMissing() throws IOException {
+    public void testCanMatchSearchAfterWithMinMaxOutOfRangeAndDifferentMissing() throws IOException {
         FieldDoc searchAfter = new FieldDoc(0, 0, new Long[] { -1L });
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
-        FieldSortBuilder primarySort = new FieldSortBuilder("test");
-        primarySort.order(SortOrder.DESC);
-        // Should be false without missing values
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), false);
-        primarySort.missing("_last");
-        // Should be true with missing values
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED), true);
+        SortField sortField = new SortField("test", SortField.Type.LONG, true);
+        sortField.setMissingValue(randomLongBetween(0L, Long.MAX_VALUE));
+        final SortAndFormats primarySort = new SortAndFormats(new Sort(sortField), new DocValueFormat[] { DocValueFormat.RAW });
+        // Should be false with missing values is larger than search_after
+        assertFalse(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED));
+        sortField.setMissingValue(Long.MIN_VALUE);
+        // Should be true with missing values is less than search_after
+        assertTrue(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, SearchContext.TRACK_TOTAL_HITS_DISABLED));
     }
 
     /**
      * Test for DESC order search_after query with track_total_hits=true.
-     * Min = 0L, Max = 9L, search_after = -1L
+     * Min = 0L, Max = 9L, search_after = -1L, missing > search_after
      * With above min/max and search_after, it should not match, but since
      * track_total_hits = true,
      * Expected result is canMatch = true
      */
-    public void testCanMatchSearchAfterDescLessThanMinWithTrackTotalhits() throws IOException {
+    public void testCanMatchSearchAfterDescLessThanMinAndMissingWithTrackTotalHits() throws IOException {
         FieldDoc searchAfter = new FieldDoc(0, 0, new Long[] { -1L });
         MinAndMax<?> minMax = new MinAndMax<Long>(0L, 9L);
-        FieldSortBuilder primarySort = new FieldSortBuilder("test");
-        primarySort.order(SortOrder.DESC);
-        assertEquals(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, 1000), true);
+        SortField sortField = new SortField("test", SortField.Type.LONG, true);
+        sortField.setMissingValue(randomLongBetween(0L, Long.MAX_VALUE));
+        final SortAndFormats primarySort = new SortAndFormats(new Sort(sortField), new DocValueFormat[] { DocValueFormat.RAW });
+        assertTrue(SearchService.canMatchSearchAfter(searchAfter, minMax, primarySort, 1000));
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
With #8391 we skip search_after short cutting in case of missing is specified, but actually no matter user specifies missing in request or not,  the default missing value is `_last`. This PR takes missing value into consideration of search_after query optimization, for example, if we sort result in asc order and even though min/max value is out of range, the target shard can match in case of missing value is larger than search_after value.

### Related Issues
Resolves #14824 #14825
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
