### PR TITLE
[Backport 2.16] Optimized ClusterStatsIndices to precomute shard stats (#14426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Refactor remote-routing-table service inline with remote state interfaces([#14668](https://github.com/opensearch-project/OpenSearch/pull/14668))
 - Add rest, transport layer changes for hot to warm tiering - dedicated setup (([#13980](https://github.com/opensearch-project/OpenSearch/pull/13980))
 - Enabling term version check on local state for all ClusterManager Read Transport Actions ([#14273](https://github.com/opensearch-project/OpenSearch/pull/14273))
+- Optimize Cluster Stats Indices to precomute node level stats ([#14426](https://github.com/opensearch-project/OpenSearch/pull/14426))
 
 ### Dependencies
 - Update to Apache Lucene 9.11.1 ([#14042](https://github.com/opensearch-project/OpenSearch/pull/14042), [#14576](https://github.com/opensearch-project/OpenSearch/pull/14576))

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIndices.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIndices.java
@@ -78,26 +78,49 @@ public class ClusterStatsIndices implements ToXContentFragment {
         this.segments = new SegmentsStats();
 
         for (ClusterStatsNodeResponse r : nodeResponses) {
-            for (org.opensearch.action.admin.indices.stats.ShardStats shardStats : r.shardsStats()) {
-                ShardStats indexShardStats = countsPerIndex.get(shardStats.getShardRouting().getIndexName());
-                if (indexShardStats == null) {
-                    indexShardStats = new ShardStats();
-                    countsPerIndex.put(shardStats.getShardRouting().getIndexName(), indexShardStats);
+            // Aggregated response from the node
+            if (r.getAggregatedNodeLevelStats() != null) {
+
+                for (Map.Entry<String, ClusterStatsNodeResponse.AggregatedIndexStats> entry : r.getAggregatedNodeLevelStats().indexStatsMap
+                    .entrySet()) {
+                    ShardStats indexShardStats = countsPerIndex.get(entry.getKey());
+                    if (indexShardStats == null) {
+                        indexShardStats = new ShardStats(entry.getValue());
+                        countsPerIndex.put(entry.getKey(), indexShardStats);
+                    } else {
+                        indexShardStats.addStatsFrom(entry.getValue());
+                    }
                 }
 
-                indexShardStats.total++;
+                docs.add(r.getAggregatedNodeLevelStats().commonStats.docs);
+                store.add(r.getAggregatedNodeLevelStats().commonStats.store);
+                fieldData.add(r.getAggregatedNodeLevelStats().commonStats.fieldData);
+                queryCache.add(r.getAggregatedNodeLevelStats().commonStats.queryCache);
+                completion.add(r.getAggregatedNodeLevelStats().commonStats.completion);
+                segments.add(r.getAggregatedNodeLevelStats().commonStats.segments);
+            } else {
+                // Default response from the node
+                for (org.opensearch.action.admin.indices.stats.ShardStats shardStats : r.shardsStats()) {
+                    ShardStats indexShardStats = countsPerIndex.get(shardStats.getShardRouting().getIndexName());
+                    if (indexShardStats == null) {
+                        indexShardStats = new ShardStats();
+                        countsPerIndex.put(shardStats.getShardRouting().getIndexName(), indexShardStats);
+                    }
 
-                CommonStats shardCommonStats = shardStats.getStats();
+                    indexShardStats.total++;
 
-                if (shardStats.getShardRouting().primary()) {
-                    indexShardStats.primaries++;
-                    docs.add(shardCommonStats.docs);
+                    CommonStats shardCommonStats = shardStats.getStats();
+
+                    if (shardStats.getShardRouting().primary()) {
+                        indexShardStats.primaries++;
+                        docs.add(shardCommonStats.docs);
+                    }
+                    store.add(shardCommonStats.store);
+                    fieldData.add(shardCommonStats.fieldData);
+                    queryCache.add(shardCommonStats.queryCache);
+                    completion.add(shardCommonStats.completion);
+                    segments.add(shardCommonStats.segments);
                 }
-                store.add(shardCommonStats.store);
-                fieldData.add(shardCommonStats.fieldData);
-                queryCache.add(shardCommonStats.queryCache);
-                completion.add(shardCommonStats.completion);
-                segments.add(shardCommonStats.segments);
             }
         }
 
@@ -201,6 +224,11 @@ public class ClusterStatsIndices implements ToXContentFragment {
         double maxIndexReplication = -1;
 
         public ShardStats() {}
+
+        public ShardStats(ClusterStatsNodeResponse.AggregatedIndexStats aggregatedIndexStats) {
+            this.total = aggregatedIndexStats.total;
+            this.primaries = aggregatedIndexStats.primaries;
+        }
 
         /**
          * number of indices in the cluster
@@ -327,6 +355,11 @@ public class ClusterStatsIndices implements ToXContentFragment {
                 maxIndexPrimaryShards = Math.max(maxIndexPrimaryShards, indexShardCount.primaries);
                 maxIndexReplication = Math.max(maxIndexReplication, indexShardCount.getReplication());
             }
+        }
+
+        public void addStatsFrom(ClusterStatsNodeResponse.AggregatedIndexStats incomingStats) {
+            this.total += incomingStats.total;
+            this.primaries += incomingStats.primaries;
         }
 
         /**

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
@@ -32,17 +32,29 @@
 
 package org.opensearch.action.admin.cluster.stats;
 
+import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.node.info.NodeInfo;
 import org.opensearch.action.admin.cluster.node.stats.NodeStats;
+import org.opensearch.action.admin.indices.stats.CommonStats;
 import org.opensearch.action.admin.indices.stats.ShardStats;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.index.cache.query.QueryCacheStats;
+import org.opensearch.index.engine.SegmentsStats;
+import org.opensearch.index.fielddata.FieldDataStats;
+import org.opensearch.index.shard.DocsStats;
+import org.opensearch.index.store.StoreStats;
+import org.opensearch.search.suggest.completion.CompletionStats;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Transport action for obtaining cluster stats from node level
@@ -55,6 +67,7 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
     private final NodeStats nodeStats;
     private final ShardStats[] shardsStats;
     private ClusterHealthStatus clusterStatus;
+    private AggregatedNodeLevelStats aggregatedNodeLevelStats;
 
     public ClusterStatsNodeResponse(StreamInput in) throws IOException {
         super(in);
@@ -64,7 +77,12 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
         }
         this.nodeInfo = new NodeInfo(in);
         this.nodeStats = new NodeStats(in);
-        shardsStats = in.readArray(ShardStats::new, ShardStats[]::new);
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            this.shardsStats = in.readOptionalArray(ShardStats::new, ShardStats[]::new);
+            this.aggregatedNodeLevelStats = in.readOptionalWriteable(AggregatedNodeLevelStats::new);
+        } else {
+            this.shardsStats = in.readArray(ShardStats::new, ShardStats[]::new);
+        }
     }
 
     public ClusterStatsNodeResponse(
@@ -77,6 +95,24 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
         super(node);
         this.nodeInfo = nodeInfo;
         this.nodeStats = nodeStats;
+        this.shardsStats = shardsStats;
+        this.clusterStatus = clusterStatus;
+    }
+
+    public ClusterStatsNodeResponse(
+        DiscoveryNode node,
+        @Nullable ClusterHealthStatus clusterStatus,
+        NodeInfo nodeInfo,
+        NodeStats nodeStats,
+        ShardStats[] shardsStats,
+        boolean useAggregatedNodeLevelResponses
+    ) {
+        super(node);
+        this.nodeInfo = nodeInfo;
+        this.nodeStats = nodeStats;
+        if (useAggregatedNodeLevelResponses) {
+            this.aggregatedNodeLevelStats = new AggregatedNodeLevelStats(node, shardsStats);
+        }
         this.shardsStats = shardsStats;
         this.clusterStatus = clusterStatus;
     }
@@ -101,6 +137,10 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
         return this.shardsStats;
     }
 
+    public AggregatedNodeLevelStats getAggregatedNodeLevelStats() {
+        return aggregatedNodeLevelStats;
+    }
+
     public static ClusterStatsNodeResponse readNodeResponse(StreamInput in) throws IOException {
         return new ClusterStatsNodeResponse(in);
     }
@@ -116,6 +156,95 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
         }
         nodeInfo.writeTo(out);
         nodeStats.writeTo(out);
-        out.writeArray(shardsStats);
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            if (aggregatedNodeLevelStats != null) {
+                out.writeOptionalArray(null);
+                out.writeOptionalWriteable(aggregatedNodeLevelStats);
+            } else {
+                out.writeOptionalArray(shardsStats);
+                out.writeOptionalWriteable(null);
+            }
+        } else {
+            out.writeArray(shardsStats);
+        }
+    }
+
+    /**
+     * Node level statistics used for ClusterStatsIndices for _cluster/stats call.
+     */
+    public class AggregatedNodeLevelStats extends BaseNodeResponse {
+
+        CommonStats commonStats;
+        Map<String, AggregatedIndexStats> indexStatsMap;
+
+        protected AggregatedNodeLevelStats(StreamInput in) throws IOException {
+            super(in);
+            commonStats = in.readOptionalWriteable(CommonStats::new);
+            indexStatsMap = in.readMap(StreamInput::readString, AggregatedIndexStats::new);
+        }
+
+        protected AggregatedNodeLevelStats(DiscoveryNode node, ShardStats[] indexShardsStats) {
+            super(node);
+            this.commonStats = new CommonStats();
+            this.commonStats.docs = new DocsStats();
+            this.commonStats.store = new StoreStats();
+            this.commonStats.fieldData = new FieldDataStats();
+            this.commonStats.queryCache = new QueryCacheStats();
+            this.commonStats.completion = new CompletionStats();
+            this.commonStats.segments = new SegmentsStats();
+            this.indexStatsMap = new HashMap<>();
+
+            // Index Level Stats
+            for (org.opensearch.action.admin.indices.stats.ShardStats shardStats : indexShardsStats) {
+                AggregatedIndexStats indexShardStats = this.indexStatsMap.get(shardStats.getShardRouting().getIndexName());
+                if (indexShardStats == null) {
+                    indexShardStats = new AggregatedIndexStats();
+                    this.indexStatsMap.put(shardStats.getShardRouting().getIndexName(), indexShardStats);
+                }
+
+                indexShardStats.total++;
+
+                CommonStats shardCommonStats = shardStats.getStats();
+
+                if (shardStats.getShardRouting().primary()) {
+                    indexShardStats.primaries++;
+                    this.commonStats.docs.add(shardCommonStats.docs);
+                }
+                this.commonStats.store.add(shardCommonStats.store);
+                this.commonStats.fieldData.add(shardCommonStats.fieldData);
+                this.commonStats.queryCache.add(shardCommonStats.queryCache);
+                this.commonStats.completion.add(shardCommonStats.completion);
+                this.commonStats.segments.add(shardCommonStats.segments);
+            }
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeOptionalWriteable(commonStats);
+            out.writeMap(indexStatsMap, StreamOutput::writeString, (stream, stats) -> stats.writeTo(stream));
+        }
+    }
+
+    /**
+     * Node level statistics used for ClusterStatsIndices for _cluster/stats call.
+     */
+    @PublicApi(since = "2.16.0")
+    public static class AggregatedIndexStats implements Writeable {
+        public int total = 0;
+        public int primaries = 0;
+
+        public AggregatedIndexStats(StreamInput in) throws IOException {
+            total = in.readVInt();
+            primaries = in.readVInt();
+        }
+
+        public AggregatedIndexStats() {}
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVInt(total);
+            out.writeVInt(primaries);
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
@@ -77,7 +77,7 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
         }
         this.nodeInfo = new NodeInfo(in);
         this.nodeStats = new NodeStats(in);
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_2_16_0)) {
             this.shardsStats = in.readOptionalArray(ShardStats::new, ShardStats[]::new);
             this.aggregatedNodeLevelStats = in.readOptionalWriteable(AggregatedNodeLevelStats::new);
         } else {
@@ -156,7 +156,7 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
         }
         nodeInfo.writeTo(out);
         nodeStats.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_2_16_0)) {
             if (aggregatedNodeLevelStats != null) {
                 out.writeOptionalArray(null);
                 out.writeOptionalWriteable(aggregatedNodeLevelStats);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequest.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.action.admin.cluster.stats;
 
+import org.opensearch.Version;
 import org.opensearch.action.support.nodes.BaseNodesRequest;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -49,7 +50,12 @@ public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
 
     public ClusterStatsRequest(StreamInput in) throws IOException {
         super(in);
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            useAggregatedNodeLevelResponses = in.readOptionalBoolean();
+        }
     }
+
+    private Boolean useAggregatedNodeLevelResponses = false;
 
     /**
      * Get stats from nodes based on the nodes ids specified. If none are passed, stats
@@ -59,9 +65,20 @@ public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
         super(nodesIds);
     }
 
+    public boolean useAggregatedNodeLevelResponses() {
+        return useAggregatedNodeLevelResponses;
+    }
+
+    public void useAggregatedNodeLevelResponses(boolean useAggregatedNodeLevelResponses) {
+        this.useAggregatedNodeLevelResponses = useAggregatedNodeLevelResponses;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeOptionalBoolean(useAggregatedNodeLevelResponses);
+        }
     }
 
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequest.java
@@ -50,7 +50,7 @@ public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
 
     public ClusterStatsRequest(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_2_16_0)) {
             useAggregatedNodeLevelResponses = in.readOptionalBoolean();
         }
     }
@@ -76,7 +76,7 @@ public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_2_16_0)) {
             out.writeOptionalBoolean(useAggregatedNodeLevelResponses);
         }
     }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequestBuilder.java
@@ -50,4 +50,9 @@ public class ClusterStatsRequestBuilder extends NodesOperationRequestBuilder<
     public ClusterStatsRequestBuilder(OpenSearchClient client, ClusterStatsAction action) {
         super(client, action, new ClusterStatsRequest());
     }
+
+    public final ClusterStatsRequestBuilder useAggregatedNodeLevelResponses(boolean useAggregatedNodeLevelResponses) {
+        request.useAggregatedNodeLevelResponses(useAggregatedNodeLevelResponses);
+        return this;
+    }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -217,9 +217,9 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             clusterStatus,
             nodeInfo,
             nodeStats,
-            shardsStats.toArray(new ShardStats[shardsStats.size()])
+            shardsStats.toArray(new ShardStats[0]),
+            nodeRequest.request.useAggregatedNodeLevelResponses()
         );
-
     }
 
     /**

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterStatsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterStatsAction.java
@@ -67,6 +67,7 @@ public class RestClusterStatsAction extends BaseRestHandler {
         ClusterStatsRequest clusterStatsRequest = new ClusterStatsRequest().nodesIds(request.paramAsStringArray("nodeId", null));
         clusterStatsRequest.timeout(request.param("timeout"));
         clusterStatsRequest.setIncludeDiscoveryNodes(false);
+        clusterStatsRequest.useAggregatedNodeLevelResponses(true);
         return channel -> client.admin().cluster().clusterStats(clusterStatsRequest, new NodesResponseRestListener<>(channel));
     }
 


### PR DESCRIPTION
Optimize Cluster Stats Indices to precomute node level stats

PR - https://github.com/opensearch-project/OpenSearch/pull/14426

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
