### PR TITLE
[Backport 2.x] Fix constant_keyword field type not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix NPE in ReplicaShardAllocator ([#14385](https://github.com/opensearch-project/OpenSearch/pull/14385))
 - Use circuit breaker in InternalHistogram when adding empty buckets ([#14754](https://github.com/opensearch-project/OpenSearch/pull/14754))
 - Fix searchable snapshot failure with scripted fields ([#14411](https://github.com/opensearch-project/OpenSearch/pull/14411))
+- Fix constant_keyword field type not working when creating index ([#14807](https://github.com/opensearch-project/OpenSearch/pull/14807))
 
 ### Security
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/110_constant_keyword.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/110_constant_keyword.yml
@@ -1,0 +1,70 @@
+---
+# The test setup includes:
+# - Create index with constant_keyword field type
+# - Check mapping
+# - Index two example documents
+# - Search
+# - Delete Index when connection is teardown
+
+"Mappings and Supported queries":
+  - skip:
+      version: " - 2.99.99"
+      reason: "fixed in 3.0.0"
+
+  # Create index with constant_keyword field type
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              genre:
+                type: "constant_keyword"
+                value: "1"
+
+  # Index document
+  - do:
+      index:
+        index: test
+        id: 1
+        body: {
+          "genre": "1"
+        }
+
+  - do:
+      index:
+        index: test
+        id: 2
+        body: {
+          "genre": 1
+        }
+
+  - do:
+      indices.refresh:
+        index: test
+
+  # Check mapping
+  - do:
+      indices.get_mapping:
+        index: test
+  - is_true: test.mappings
+  - match: { test.mappings.properties.genre.type: constant_keyword }
+  - length: { test.mappings.properties.genre: 2 }
+
+  # Verify Document Count
+  - do:
+      search:
+        body: {
+          query: {
+            match_all: {}
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.genre: "1" }
+  - match: { hits.hits.1._source.genre: 1 }
+
+  # Delete Index when connection is teardown
+  - do:
+      indices.delete:
+        index: test

--- a/server/src/main/java/org/opensearch/index/mapper/ConstantKeywordFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ConstantKeywordFieldMapper.java
@@ -68,11 +68,11 @@ public class ConstantKeywordFieldMapper extends ParametrizedFieldMapper {
      */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
-        private final Parameter<String> value;
+        private final Parameter<String> value = Parameter.stringParam(valuePropertyName, false, m -> toType(m).value, null);
 
         public Builder(String name, String value) {
             super(name);
-            this.value = Parameter.stringParam(valuePropertyName, false, m -> toType(m).value, value);
+            this.value.setValue(value);
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/index/mapper/ConstantKeywordFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ConstantKeywordFieldMapperTests.java
@@ -105,6 +105,14 @@ public class ConstantKeywordFieldMapperTests extends OpenSearchSingleNodeTestCas
         assertThat(e.getMessage(), containsString("Field [field] is missing required parameter [value]"));
     }
 
+    public void testBuilderToXContent() throws IOException {
+        ConstantKeywordFieldMapper.Builder builder = new ConstantKeywordFieldMapper.Builder("name", "value1");
+        XContentBuilder xContentBuilder = JsonXContent.contentBuilder().startObject();
+        builder.toXContent(xContentBuilder, false);
+        xContentBuilder.endObject();
+        assertEquals("{\"value\":\"value1\"}", xContentBuilder.toString());
+    }
+
     private final SourceToParse source(CheckedConsumer<XContentBuilder, IOException> build) throws IOException {
         XContentBuilder builder = JsonXContent.contentBuilder().startObject();
         build.accept(builder);


### PR DESCRIPTION
Backport https://github.com/opensearch-project/OpenSearch/commit/a252b29c37f36f3ddaae0787b4f4562d2227cfa0 from https://github.com/opensearch-project/OpenSearch/pull/14807