### PR TITLE
[Backport 2.x] Fix read/write in stream method for Diff Manifest when shard diff file is null

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/remote/ClusterStateDiffManifest.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/ClusterStateDiffManifest.java
@@ -129,7 +129,6 @@ public class ClusterStateDiffManifest implements ToXContentFragment, Writeable {
         clusterStateCustomUpdated = new ArrayList<>(clusterStateCustomDiff.getDiffs().keySet());
         clusterStateCustomUpdated.addAll(clusterStateCustomDiff.getUpserts().keySet());
         clusterStateCustomDeleted = clusterStateCustomDiff.getDeletes();
-        List<String> indicie1s = indicesRoutingUpdated;
     }
 
     public ClusterStateDiffManifest(
@@ -190,7 +189,7 @@ public class ClusterStateDiffManifest implements ToXContentFragment, Writeable {
         this.hashesOfConsistentSettingsUpdated = in.readBoolean();
         this.clusterStateCustomUpdated = in.readStringList();
         this.clusterStateCustomDeleted = in.readStringList();
-        this.indicesRoutingDiffPath = in.readString();
+        this.indicesRoutingDiffPath = in.readOptionalString();
     }
 
     @Override
@@ -535,7 +534,8 @@ public class ClusterStateDiffManifest implements ToXContentFragment, Writeable {
             indicesRoutingDeleted,
             hashesOfConsistentSettingsUpdated,
             clusterStateCustomUpdated,
-            clusterStateCustomDeleted
+            clusterStateCustomDeleted,
+            indicesRoutingDiffPath
         );
     }
 
@@ -562,7 +562,7 @@ public class ClusterStateDiffManifest implements ToXContentFragment, Writeable {
         out.writeBoolean(hashesOfConsistentSettingsUpdated);
         out.writeStringCollection(clusterStateCustomUpdated);
         out.writeStringCollection(clusterStateCustomDeleted);
-        out.writeString(indicesRoutingDiffPath);
+        out.writeOptionalString(indicesRoutingDiffPath);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/gateway/remote/RemotePersistenceStats.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemotePersistenceStats.java
@@ -51,10 +51,10 @@ public class RemotePersistenceStats extends PersistedStateStats {
     }
 
     public void indicesRoutingDiffFileCleanupAttemptFailed() {
-        indexRoutingFilesCleanupAttemptFailedCount.incrementAndGet();
+        indicesRoutingDiffFilesCleanupAttemptFailedCount.incrementAndGet();
     }
 
     public long getIndicesRoutingDiffFileCleanupAttemptFailedCount() {
-        return indexRoutingFilesCleanupAttemptFailedCount.get();
+        return indicesRoutingDiffFilesCleanupAttemptFailedCount.get();
     }
 }

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateCleanupManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateCleanupManagerTests.java
@@ -652,7 +652,7 @@ public class RemoteClusterStateCleanupManagerTests extends OpenSearchTestCase {
             assertEquals(0, remoteClusterStateCleanupManager.getStats().getIndicesRoutingDiffFileCleanupAttemptFailedCount());
         });
 
-        doThrow(IOException.class).when(remoteRoutingTableService).deleteStaleIndexRoutingPaths(any());
+        doThrow(IOException.class).when(remoteRoutingTableService).deleteStaleIndexRoutingDiffPaths(any());
         remoteClusterStateCleanupManager.deleteClusterMetadata(clusterName, clusterUUID, activeBlobs, inactiveBlobs);
         assertBusy(() -> {
             // wait for stats to get updated


### PR DESCRIPTION
Backport [5744eae](https://github.com/opensearch-project/OpenSearch/commit/5744eae80dfe466397f4254acf995794855db370) from https://github.com/opensearch-project/OpenSearch/pull/14938