### PR TITLE
Fix missing value of FieldSort for unsigned_long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Fix missing value of FieldSort for unsigned_long ([#14963](https://github.com/opensearch-project/OpenSearch/pull/14963))
 
 ### Security
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
@@ -1080,11 +1080,7 @@ public class FieldSortIT extends ParameterizedDynamicSettingsOpenSearchIntegTest
         SearchRequestBuilder searchRequestBuilder = client().prepareSearch()
             .setQuery(matchAllQuery())
             .addSort(SortBuilders.fieldSort("u_value").order(SortOrder.ASC).missing(randomBoolean() ? -1 : "-1"));
-        assertFailures(
-            searchRequestBuilder,
-            RestStatus.BAD_REQUEST,
-            containsString("missing value of type [unsigned_long] must not be negative")
-        );
+        assertFailures(searchRequestBuilder, RestStatus.BAD_REQUEST, containsString("Value [-1] is out of range for an unsigned long"));
     }
 
     public void testSortMissingNumbersMinMax() throws Exception {

--- a/server/src/main/java/org/opensearch/index/fielddata/fieldcomparator/UnsignedLongValuesComparatorSource.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/fieldcomparator/UnsignedLongValuesComparatorSource.java
@@ -81,9 +81,17 @@ public class UnsignedLongValuesComparatorSource extends IndexFieldData.XFieldCom
             return min ? Numbers.MIN_UNSIGNED_LONG_VALUE : Numbers.MAX_UNSIGNED_LONG_VALUE;
         } else {
             if (missingValue instanceof Number) {
-                return ((Number) missingValue);
+                long ul = ((Number) missingValue).longValue();
+                if (ul < 0) {
+                    throw new IllegalArgumentException("missing value of type [unsigned_long] must not be negative");
+                }
+                return BigInteger.valueOf(ul);
             } else {
-                return new BigInteger(missingValue.toString());
+                BigInteger missing = new BigInteger(missingValue.toString());
+                if (missing.signum() < 0) {
+                    throw new IllegalArgumentException("missing value of type [unsigned_long] must not be negative");
+                }
+                return missing;
             }
         }
     }

--- a/server/src/main/java/org/opensearch/index/fielddata/fieldcomparator/UnsignedLongValuesComparatorSource.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/fieldcomparator/UnsignedLongValuesComparatorSource.java
@@ -81,15 +81,11 @@ public class UnsignedLongValuesComparatorSource extends IndexFieldData.XFieldCom
             return min ? Numbers.MIN_UNSIGNED_LONG_VALUE : Numbers.MAX_UNSIGNED_LONG_VALUE;
         } else {
             if (missingValue instanceof Number) {
-                long ul = ((Number) missingValue).longValue();
-                if (ul < 0) {
-                    throw new IllegalArgumentException("missing value of type [unsigned_long] must not be negative");
-                }
-                return BigInteger.valueOf(ul);
+                return Numbers.toUnsignedLongExact((Number) missingValue);
             } else {
                 BigInteger missing = new BigInteger(missingValue.toString());
                 if (missing.signum() < 0) {
-                    throw new IllegalArgumentException("missing value of type [unsigned_long] must not be negative");
+                    throw new IllegalArgumentException("Value [" + missingValue + "] is out of range for an unsigned long");
                 }
                 return missing;
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Two changes here:
1. Fixes parsing numeric missing value of unsigned long type. When we pass a numeric missing value like 4 to unsigned long field sort, the `ClassCastException` will be thrown(`class java.lang.Integer cannot be cast to class java.math.BigInteger `).
2. Requires the missing value of unsigned long type must not be negative.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
