### PR TITLE
[Backport 2.16] fix constant_keyword field type (#14807)

### DIFF
--- a/release-notes/opensearch.release-notes-2.16.0.md
+++ b/release-notes/opensearch.release-notes-2.16.0.md
@@ -90,3 +90,4 @@
 - Use circuit breaker in InternalHistogram when adding empty buckets ([#14754](https://github.com/opensearch-project/OpenSearch/pull/14754))
 - Create new IndexInput for multi part upload ([#14888](https://github.com/opensearch-project/OpenSearch/pull/14888))
 - Fix searchable snapshot failure with scripted fields ([#14411](https://github.com/opensearch-project/OpenSearch/pull/14411))
+- Fix constant_keyword field type used when creating index ([#14807](https://github.com/opensearch-project/OpenSearch/pull/14807))

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/110_constant_keyword.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/110_constant_keyword.yml
@@ -1,0 +1,70 @@
+---
+# The test setup includes:
+# - Create index with constant_keyword field type
+# - Check mapping
+# - Index two example documents
+# - Search
+# - Delete Index when connection is teardown
+
+"Mappings and Supported queries":
+  - skip:
+      version: " - 2.99.99"
+      reason: "fixed in 3.0.0"
+
+  # Create index with constant_keyword field type
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              genre:
+                type: "constant_keyword"
+                value: "1"
+
+  # Index document
+  - do:
+      index:
+        index: test
+        id: 1
+        body: {
+          "genre": "1"
+        }
+
+  - do:
+      index:
+        index: test
+        id: 2
+        body: {
+          "genre": 1
+        }
+
+  - do:
+      indices.refresh:
+        index: test
+
+  # Check mapping
+  - do:
+      indices.get_mapping:
+        index: test
+  - is_true: test.mappings
+  - match: { test.mappings.properties.genre.type: constant_keyword }
+  - length: { test.mappings.properties.genre: 2 }
+
+  # Verify Document Count
+  - do:
+      search:
+        body: {
+          query: {
+            match_all: {}
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source.genre: "1" }
+  - match: { hits.hits.1._source.genre: 1 }
+
+  # Delete Index when connection is teardown
+  - do:
+      indices.delete:
+        index: test

--- a/server/src/main/java/org/opensearch/index/mapper/ConstantKeywordFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ConstantKeywordFieldMapper.java
@@ -68,11 +68,11 @@ public class ConstantKeywordFieldMapper extends ParametrizedFieldMapper {
      */
     public static class Builder extends ParametrizedFieldMapper.Builder {
 
-        private final Parameter<String> value;
+        private final Parameter<String> value = Parameter.stringParam(valuePropertyName, false, m -> toType(m).value, null);
 
         public Builder(String name, String value) {
             super(name);
-            this.value = Parameter.stringParam(valuePropertyName, false, m -> toType(m).value, value);
+            this.value.setValue(value);
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/index/mapper/ConstantKeywordFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ConstantKeywordFieldMapperTests.java
@@ -105,6 +105,14 @@ public class ConstantKeywordFieldMapperTests extends OpenSearchSingleNodeTestCas
         assertThat(e.getMessage(), containsString("Field [field] is missing required parameter [value]"));
     }
 
+    public void testBuilderToXContent() throws IOException {
+        ConstantKeywordFieldMapper.Builder builder = new ConstantKeywordFieldMapper.Builder("name", "value1");
+        XContentBuilder xContentBuilder = JsonXContent.contentBuilder().startObject();
+        builder.toXContent(xContentBuilder, false);
+        xContentBuilder.endObject();
+        assertEquals("{\"value\":\"value1\"}", xContentBuilder.toString());
+    }
+
     private final SourceToParse source(CheckedConsumer<XContentBuilder, IOException> build) throws IOException {
         XContentBuilder builder = JsonXContent.contentBuilder().startObject();
         build.accept(builder);


### PR DESCRIPTION
### Description

Backport https://github.com/opensearch-project/OpenSearch/pull/14807 to 2.16.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/14638

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
