### PR TITLE
[Batch Fetch] Fix for hasInitiatedFetching to fix allocation explain and manual reroute APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 2.x]
 ### Added
+- Fix for hasInitiatedFetching to fix allocation explain and manual reroute APIs (([#14972](https://github.com/opensearch-project/OpenSearch/pull/14972))
 
 ### Dependencies
 - Bump `org.apache.commons:commons-lang3` from 3.14.0 to 3.15.0 ([#14861](https://github.com/opensearch-project/OpenSearch/pull/14861))

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
@@ -797,7 +797,9 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
         );
         assertTrue(ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_BATCH_MODE.get(internalCluster().clusterService().getSettings()));
         assertEquals(1, gatewayAllocator.getNumberOfStartedShardBatches());
-        assertEquals(1, gatewayAllocator.getNumberOfStoreShardBatches());
+        // Replica shard would be marked ineligible since there are no data nodes.
+        // It would then be removed from any batch and batches would get deleted, so we would have 0 replica batches
+        assertEquals(0, gatewayAllocator.getNumberOfStoreShardBatches());
 
         // Now start both data nodes and ensure batch mode is working
         logger.info("--> restarting the stopped nodes");
@@ -1300,7 +1302,9 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
         );
         assertTrue(ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_BATCH_MODE.get(internalCluster().clusterService().getSettings()));
         assertEquals(10, gatewayAllocator.getNumberOfStartedShardBatches());
-        assertEquals(10, gatewayAllocator.getNumberOfStoreShardBatches());
+        // All replica shards would be marked ineligible since there are no data nodes.
+        // They would then be removed from any batch and batches would get deleted, so we would have 0 replica batches
+        assertEquals(0, gatewayAllocator.getNumberOfStoreShardBatches());
         health = client(internalCluster().getClusterManagerName()).admin().cluster().health(Requests.clusterHealthRequest()).actionGet();
         assertFalse(health.isTimedOut());
         assertEquals(RED, health.getStatus());
@@ -1389,7 +1393,9 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
         );
         assertTrue(ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_BATCH_MODE.get(internalCluster().clusterService().getSettings()));
         assertEquals(1, gatewayAllocator.getNumberOfStartedShardBatches());
-        assertEquals(1, gatewayAllocator.getNumberOfStoreShardBatches());
+        // Replica shard would be marked ineligible since there are no data nodes.
+        // It would then be removed from any batch and batches would get deleted, so we would have 0 replica batches
+        assertEquals(0, gatewayAllocator.getNumberOfStoreShardBatches());
         assertTrue(clusterRerouteResponse.isAcknowledged());
         health = client(internalCluster().getClusterManagerName()).admin().cluster().health(Requests.clusterHealthRequest()).actionGet();
         assertFalse(health.isTimedOut());

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
@@ -845,7 +845,9 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
         );
         assertTrue(ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_BATCH_MODE.get(internalCluster().clusterService().getSettings()));
         assertEquals(1, gatewayAllocator.getNumberOfStartedShardBatches());
-        assertEquals(1, gatewayAllocator.getNumberOfStoreShardBatches());
+        // Replica shard would be marked ineligible since there are no data nodes.
+        // It would then be removed from any batch and batches would get deleted, so we would have 0 replica batches
+        assertEquals(0, gatewayAllocator.getNumberOfStoreShardBatches());
 
         // Now start both data nodes and ensure batch mode is working
         logger.info("--> restarting the stopped nodes");
@@ -910,7 +912,9 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
 
         assertTrue(ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_BATCH_MODE.get(internalCluster().clusterService().getSettings()));
         assertEquals(10, gatewayAllocator.getNumberOfStartedShardBatches());
-        assertEquals(10, gatewayAllocator.getNumberOfStoreShardBatches());
+        // All replica shards would be marked ineligible since there are no data nodes.
+        // They would then be removed from any batch and batches would get deleted, so we would have 0 replica batches
+        assertEquals(0, gatewayAllocator.getNumberOfStoreShardBatches());
         health = client(internalCluster().getClusterManagerName()).admin().cluster().health(Requests.clusterHealthRequest()).actionGet();
         assertFalse(health.isTimedOut());
         assertEquals(RED, health.getStatus());

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
@@ -802,9 +802,22 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
         // It would then be removed from any batch and batches would get deleted, so we would have 0 replica batches
         assertEquals(0, gatewayAllocator.getNumberOfStoreShardBatches());
 
-        // Now start both data nodes and ensure batch mode is working
-        logger.info("--> restarting the stopped nodes");
+        // Now start one data node
+        logger.info("--> restarting the first stopped node");
         internalCluster().startDataOnlyNode(Settings.builder().put("node.name", dataOnlyNodes.get(0)).put(node0DataPathSettings).build());
+        ensureStableCluster(2);
+        ensureYellow("test");
+        assertEquals(0, gatewayAllocator.getNumberOfStartedShardBatches());
+        assertEquals(0, gatewayAllocator.getNumberOfStoreShardBatches());
+        assertEquals(0, gatewayAllocator.getNumberOfInFlightFetches());
+
+        // calling reroute and asserting on reroute response
+        logger.info("--> calling reroute while cluster is yellow");
+        clusterRerouteResponse = client().admin().cluster().prepareReroute().setRetryFailed(true).get();
+        assertTrue(clusterRerouteResponse.isAcknowledged());
+
+        // Now start last data node and ensure batch mode is working and cluster goes green
+        logger.info("--> restarting the second stopped node");
         internalCluster().startDataOnlyNode(Settings.builder().put("node.name", dataOnlyNodes.get(1)).put(node1DataPathSettings).build());
         ensureStableCluster(3);
         ensureGreen("test");
@@ -849,9 +862,22 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
         // It would then be removed from any batch and batches would get deleted, so we would have 0 replica batches
         assertEquals(0, gatewayAllocator.getNumberOfStoreShardBatches());
 
-        // Now start both data nodes and ensure batch mode is working
-        logger.info("--> restarting the stopped nodes");
+        // Now start one data nodes and ensure batch mode is working
+        logger.info("--> restarting the first stopped node");
         internalCluster().startDataOnlyNode(Settings.builder().put("node.name", dataOnlyNodes.get(0)).put(node0DataPathSettings).build());
+        ensureStableCluster(2);
+        ensureYellow("test");
+        assertEquals(0, gatewayAllocator.getNumberOfStartedShardBatches());
+        assertEquals(0, gatewayAllocator.getNumberOfStoreShardBatches());
+        assertEquals(0, gatewayAllocator.getNumberOfInFlightFetches());
+
+        // calling reroute and asserting on reroute response
+        logger.info("--> calling reroute while cluster is yellow");
+        clusterRerouteResponse = client().admin().cluster().prepareReroute().setRetryFailed(true).get();
+        assertTrue(clusterRerouteResponse.isAcknowledged());
+
+        // Now start last data node and ensure batch mode is working and cluster goes green
+        logger.info("--> restarting the second stopped node");
         internalCluster().startDataOnlyNode(Settings.builder().put("node.name", dataOnlyNodes.get(1)).put(node1DataPathSettings).build());
         ensureStableCluster(3);
         ensureGreen("test");
@@ -1061,191 +1087,13 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
     public void testAllocationExplainReturnsNoWhenExtraReplicaShardInNonBatchMode() throws Exception {
         // Non batch mode - This test is to validate that we don't return AWAITING_INFO in allocation explain API when the deciders are
         // returning NO
-        internalCluster().startClusterManagerOnlyNodes(
-            1,
-            Settings.builder().put(ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_BATCH_MODE.getKey(), false).build()
-        );
-        internalCluster().startDataOnlyNodes(5);
-        createIndex(
-            "test",
-            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 4).build()
-        );
-        ensureGreen("test");
-        ensureStableCluster(6);
-
-        // Stop one of the nodes to make the cluster yellow
-        // We cannot directly create an index with replica = data node count because then the whole flow will get skipped due to
-        // INDEX_CREATED
-        List<String> nodesWithReplicaShards = findNodesWithShard(false);
-        Settings replicaNodeDataPathSettings = internalCluster().dataPathSettings(nodesWithReplicaShards.get(0));
-        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(nodesWithReplicaShards.get(0)));
-
-        ensureStableCluster(5);
-        ensureYellow("test");
-
-        logger.info("--> calling allocation explain API");
-        // shard should have decision NO because there is no valid node for the extra replica to go to
-        AllocateUnassignedDecision aud = client().admin()
-            .cluster()
-            .prepareAllocationExplain()
-            .setIndex("test")
-            .setShard(0)
-            .setPrimary(false)
-            .get()
-            .getExplanation()
-            .getShardAllocationDecision()
-            .getAllocateDecision();
-
-        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
-        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
-
-        // Now creating a new index with too many replicas and trying again
-        createIndex(
-            "test2",
-            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 5).build()
-        );
-
-        ensureYellowAndNoInitializingShards("test2");
-
-        logger.info("--> calling allocation explain API again");
-        // shard should have decision NO because there are 6 replicas and 4 data nodes
-        aud = client().admin()
-            .cluster()
-            .prepareAllocationExplain()
-            .setIndex("test2")
-            .setShard(0)
-            .setPrimary(false)
-            .get()
-            .getExplanation()
-            .getShardAllocationDecision()
-            .getAllocateDecision();
-
-        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
-        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
-
-        logger.info("--> restarting the stopped node");
-        internalCluster().startDataOnlyNode(
-            Settings.builder().put("node.name", nodesWithReplicaShards.get(0)).put(replicaNodeDataPathSettings).build()
-        );
-
-        ensureStableCluster(6);
-        ensureGreen("test");
-
-        logger.info("--> calling allocation explain API 3rd time");
-        // shard should still have decision NO because there are 6 replicas and 5 data nodes
-        aud = client().admin()
-            .cluster()
-            .prepareAllocationExplain()
-            .setIndex("test2")
-            .setShard(0)
-            .setPrimary(false)
-            .get()
-            .getExplanation()
-            .getShardAllocationDecision()
-            .getAllocateDecision();
-
-        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
-        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
-
-        internalCluster().startDataOnlyNodes(1);
-
-        ensureStableCluster(7);
-        ensureGreen("test2");
+        this.allocationExplainReturnsNoWhenExtraReplicaShard(false);
     }
 
     public void testAllocationExplainReturnsNoWhenExtraReplicaShardInBatchMode() throws Exception {
         // Batch mode - This test is to validate that we don't return AWAITING_INFO in allocation explain API when the deciders are
         // returning NO
-        internalCluster().startClusterManagerOnlyNodes(
-            1,
-            Settings.builder().put(ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_BATCH_MODE.getKey(), true).build()
-        );
-        internalCluster().startDataOnlyNodes(5);
-        createIndex(
-            "test",
-            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 4).build()
-        );
-        ensureGreen("test");
-        ensureStableCluster(6);
-
-        // Stop one of the nodes to make the cluster yellow
-        // We cannot directly create an index with replica = data node count because then the whole flow will get skipped due to
-        // INDEX_CREATED
-        List<String> nodesWithReplicaShards = findNodesWithShard(false);
-        Settings replicaNodeDataPathSettings = internalCluster().dataPathSettings(nodesWithReplicaShards.get(0));
-        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(nodesWithReplicaShards.get(0)));
-
-        ensureStableCluster(5);
-        ensureYellow("test");
-
-        logger.info("--> calling allocation explain API");
-        // shard should have decision NO because there is no valid node for the extra replica to go to
-        AllocateUnassignedDecision aud = client().admin()
-            .cluster()
-            .prepareAllocationExplain()
-            .setIndex("test")
-            .setShard(0)
-            .setPrimary(false)
-            .get()
-            .getExplanation()
-            .getShardAllocationDecision()
-            .getAllocateDecision();
-
-        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
-        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
-
-        // Now creating a new index with too many replicas and trying again
-        createIndex(
-            "test2",
-            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 5).build()
-        );
-
-        ensureYellowAndNoInitializingShards("test2");
-
-        logger.info("--> calling allocation explain API again");
-        // shard should have decision NO because there are 6 replicas and 4 data nodes
-        aud = client().admin()
-            .cluster()
-            .prepareAllocationExplain()
-            .setIndex("test2")
-            .setShard(0)
-            .setPrimary(false)
-            .get()
-            .getExplanation()
-            .getShardAllocationDecision()
-            .getAllocateDecision();
-
-        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
-        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
-
-        logger.info("--> restarting the stopped node");
-        internalCluster().startDataOnlyNode(
-            Settings.builder().put("node.name", nodesWithReplicaShards.get(0)).put(replicaNodeDataPathSettings).build()
-        );
-
-        ensureStableCluster(6);
-        ensureGreen("test");
-
-        logger.info("--> calling allocation explain API 3rd time");
-        // shard should still have decision NO because there are 6 replicas and 5 data nodes
-        aud = client().admin()
-            .cluster()
-            .prepareAllocationExplain()
-            .setIndex("test2")
-            .setShard(0)
-            .setPrimary(false)
-            .get()
-            .getExplanation()
-            .getShardAllocationDecision()
-            .getAllocateDecision();
-
-        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
-        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
-
-        internalCluster().startDataOnlyNodes(1);
-
-        ensureStableCluster(7);
-        ensureGreen("test2");
+        this.allocationExplainReturnsNoWhenExtraReplicaShard(true);
     }
 
     public void testNBatchesCreationAndAssignment() throws Exception {
@@ -1711,5 +1559,98 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
             .collect(Collectors.toList());
         Collections.shuffle(requiredStartedShards, random());
         return requiredStartedShards.stream().map(shard -> state.nodes().get(shard.currentNodeId()).getName()).collect(Collectors.toList());
+    }
+
+    private void allocationExplainReturnsNoWhenExtraReplicaShard(boolean batchModeEnabled) throws Exception {
+        internalCluster().startClusterManagerOnlyNodes(
+            1,
+            Settings.builder().put(ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_BATCH_MODE.getKey(), batchModeEnabled).build()
+        );
+        internalCluster().startDataOnlyNodes(5);
+        createIndex(
+            "test",
+            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 4).build()
+        );
+        ensureGreen("test");
+        ensureStableCluster(6);
+
+        // Stop one of the nodes to make the cluster yellow
+        // We cannot directly create an index with replica = data node count because then the whole flow will get skipped due to
+        // INDEX_CREATED
+        List<String> nodesWithReplicaShards = findNodesWithShard(false);
+        Settings replicaNodeDataPathSettings = internalCluster().dataPathSettings(nodesWithReplicaShards.get(0));
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(nodesWithReplicaShards.get(0)));
+
+        ensureStableCluster(5);
+        ensureYellow("test");
+
+        logger.info("--> calling allocation explain API");
+        // shard should have decision NO because there is no valid node for the extra replica to go to
+        AllocateUnassignedDecision aud = client().admin()
+            .cluster()
+            .prepareAllocationExplain()
+            .setIndex("test")
+            .setShard(0)
+            .setPrimary(false)
+            .get()
+            .getExplanation()
+            .getShardAllocationDecision()
+            .getAllocateDecision();
+
+        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
+        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
+
+        // Now creating a new index with too many replicas and trying again
+        createIndex(
+            "test2",
+            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 5).build()
+        );
+
+        ensureYellowAndNoInitializingShards("test2");
+
+        logger.info("--> calling allocation explain API again");
+        // shard should have decision NO because there are 6 replicas and 4 data nodes
+        aud = client().admin()
+            .cluster()
+            .prepareAllocationExplain()
+            .setIndex("test2")
+            .setShard(0)
+            .setPrimary(false)
+            .get()
+            .getExplanation()
+            .getShardAllocationDecision()
+            .getAllocateDecision();
+
+        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
+        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
+
+        logger.info("--> restarting the stopped node");
+        internalCluster().startDataOnlyNode(
+            Settings.builder().put("node.name", nodesWithReplicaShards.get(0)).put(replicaNodeDataPathSettings).build()
+        );
+
+        ensureStableCluster(6);
+        ensureGreen("test");
+
+        logger.info("--> calling allocation explain API 3rd time");
+        // shard should still have decision NO because there are 6 replicas and 5 data nodes
+        aud = client().admin()
+            .cluster()
+            .prepareAllocationExplain()
+            .setIndex("test2")
+            .setShard(0)
+            .setPrimary(false)
+            .get()
+            .getExplanation()
+            .getShardAllocationDecision()
+            .getAllocateDecision();
+
+        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
+        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
+
+        internalCluster().startDataOnlyNodes(1);
+
+        ensureStableCluster(7);
+        ensureGreen("test2");
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/RecoveryFromGatewayIT.java
@@ -57,6 +57,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.UnassignedInfo;
+import org.opensearch.cluster.routing.allocation.AllocateUnassignedDecision;
 import org.opensearch.cluster.routing.allocation.AllocationDecision;
 import org.opensearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.opensearch.cluster.service.ClusterService;
@@ -1080,20 +1081,19 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
 
         logger.info("--> calling allocation explain API");
         // shard should have decision NO because there is no valid node for the extra replica to go to
-        assertEquals(
-            AllocationDecision.NO,
-            client().admin()
-                .cluster()
-                .prepareAllocationExplain()
-                .setIndex("test")
-                .setShard(0)
-                .setPrimary(false)
-                .get()
-                .getExplanation()
-                .getShardAllocationDecision()
-                .getAllocateDecision()
-                .getAllocationDecision()
-        );
+        AllocateUnassignedDecision aud = client().admin()
+            .cluster()
+            .prepareAllocationExplain()
+            .setIndex("test")
+            .setShard(0)
+            .setPrimary(false)
+            .get()
+            .getExplanation()
+            .getShardAllocationDecision()
+            .getAllocateDecision();
+
+        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
+        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
 
         // Now creating a new index with too many replicas and trying again
         createIndex(
@@ -1105,20 +1105,19 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
 
         logger.info("--> calling allocation explain API again");
         // shard should have decision NO because there are 6 replicas and 4 data nodes
-        assertEquals(
-            AllocationDecision.NO,
-            client().admin()
-                .cluster()
-                .prepareAllocationExplain()
-                .setIndex("test2")
-                .setShard(0)
-                .setPrimary(false)
-                .get()
-                .getExplanation()
-                .getShardAllocationDecision()
-                .getAllocateDecision()
-                .getAllocationDecision()
-        );
+        aud = client().admin()
+            .cluster()
+            .prepareAllocationExplain()
+            .setIndex("test2")
+            .setShard(0)
+            .setPrimary(false)
+            .get()
+            .getExplanation()
+            .getShardAllocationDecision()
+            .getAllocateDecision();
+
+        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
+        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
 
         logger.info("--> restarting the stopped node");
         internalCluster().startDataOnlyNode(
@@ -1130,20 +1129,19 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
 
         logger.info("--> calling allocation explain API 3rd time");
         // shard should still have decision NO because there are 6 replicas and 5 data nodes
-        assertEquals(
-            AllocationDecision.NO,
-            client().admin()
-                .cluster()
-                .prepareAllocationExplain()
-                .setIndex("test2")
-                .setShard(0)
-                .setPrimary(false)
-                .get()
-                .getExplanation()
-                .getShardAllocationDecision()
-                .getAllocateDecision()
-                .getAllocationDecision()
-        );
+        aud = client().admin()
+            .cluster()
+            .prepareAllocationExplain()
+            .setIndex("test2")
+            .setShard(0)
+            .setPrimary(false)
+            .get()
+            .getExplanation()
+            .getShardAllocationDecision()
+            .getAllocateDecision();
+
+        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
+        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
 
         internalCluster().startDataOnlyNodes(1);
 
@@ -1178,20 +1176,19 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
 
         logger.info("--> calling allocation explain API");
         // shard should have decision NO because there is no valid node for the extra replica to go to
-        assertEquals(
-            AllocationDecision.NO,
-            client().admin()
-                .cluster()
-                .prepareAllocationExplain()
-                .setIndex("test")
-                .setShard(0)
-                .setPrimary(false)
-                .get()
-                .getExplanation()
-                .getShardAllocationDecision()
-                .getAllocateDecision()
-                .getAllocationDecision()
-        );
+        AllocateUnassignedDecision aud = client().admin()
+            .cluster()
+            .prepareAllocationExplain()
+            .setIndex("test")
+            .setShard(0)
+            .setPrimary(false)
+            .get()
+            .getExplanation()
+            .getShardAllocationDecision()
+            .getAllocateDecision();
+
+        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
+        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
 
         // Now creating a new index with too many replicas and trying again
         createIndex(
@@ -1203,20 +1200,19 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
 
         logger.info("--> calling allocation explain API again");
         // shard should have decision NO because there are 6 replicas and 4 data nodes
-        assertEquals(
-            AllocationDecision.NO,
-            client().admin()
-                .cluster()
-                .prepareAllocationExplain()
-                .setIndex("test2")
-                .setShard(0)
-                .setPrimary(false)
-                .get()
-                .getExplanation()
-                .getShardAllocationDecision()
-                .getAllocateDecision()
-                .getAllocationDecision()
-        );
+        aud = client().admin()
+            .cluster()
+            .prepareAllocationExplain()
+            .setIndex("test2")
+            .setShard(0)
+            .setPrimary(false)
+            .get()
+            .getExplanation()
+            .getShardAllocationDecision()
+            .getAllocateDecision();
+
+        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
+        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
 
         logger.info("--> restarting the stopped node");
         internalCluster().startDataOnlyNode(
@@ -1228,20 +1224,19 @@ public class RecoveryFromGatewayIT extends OpenSearchIntegTestCase {
 
         logger.info("--> calling allocation explain API 3rd time");
         // shard should still have decision NO because there are 6 replicas and 5 data nodes
-        assertEquals(
-            AllocationDecision.NO,
-            client().admin()
-                .cluster()
-                .prepareAllocationExplain()
-                .setIndex("test2")
-                .setShard(0)
-                .setPrimary(false)
-                .get()
-                .getExplanation()
-                .getShardAllocationDecision()
-                .getAllocateDecision()
-                .getAllocationDecision()
-        );
+        aud = client().admin()
+            .cluster()
+            .prepareAllocationExplain()
+            .setIndex("test2")
+            .setShard(0)
+            .setPrimary(false)
+            .get()
+            .getExplanation()
+            .getShardAllocationDecision()
+            .getAllocateDecision();
+
+        assertEquals(AllocationDecision.NO, aud.getAllocationDecision());
+        assertEquals("cannot allocate because allocation is not permitted to any of the nodes", aud.getExplanation());
 
         internalCluster().startDataOnlyNodes(1);
 

--- a/server/src/main/java/org/opensearch/gateway/AsyncShardBatchFetch.java
+++ b/server/src/main/java/org/opensearch/gateway/AsyncShardBatchFetch.java
@@ -80,6 +80,14 @@ public abstract class AsyncShardBatchFetch<T extends BaseNodeResponse, V> extend
         this.cache.deleteShard(shardId);
     }
 
+    public boolean hasEmptyCache() {
+        return this.cache.getCache().isEmpty();
+    }
+
+    public AsyncShardFetchCache<T> getCache() {
+        return this.cache;
+    }
+
     /**
      * Cache implementation of transport actions returning batch of shards related data in the response.
      * Store node level responses of transport actions like {@link TransportNodesListGatewayStartedShardsBatch} or

--- a/server/src/main/java/org/opensearch/gateway/ReplicaShardBatchAllocator.java
+++ b/server/src/main/java/org/opensearch/gateway/ReplicaShardBatchAllocator.java
@@ -183,7 +183,7 @@ public abstract class ReplicaShardBatchAllocator extends ReplicaShardAllocator {
         if (allocationDecision.type() != Decision.Type.YES && (!explain || !hasInitiatedFetching(shardRouting))) {
             // only return early if we are not in explain mode, or we are in explain mode but we have not
             // yet attempted to fetch any shard data
-            logger.trace("{}: ignoring allocation, can't be allocated on any node", shardRouting);
+            logger.trace("{}: ignoring allocation, can't be allocated on any node. Decision: {}", shardRouting, allocationDecision.type());
             return AllocateUnassignedDecision.no(
                 UnassignedInfo.AllocationStatus.fromDecision(allocationDecision.type()),
                 result.v2() != null ? new ArrayList<>(result.v2().values()) : null

--- a/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java
+++ b/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java
@@ -594,12 +594,14 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
              * see {@link AsyncShardFetchCache#findNodesToFetch()}
              */
             String batchId = getBatchId(shard, shard.primary());
+            if (batchId == null) {
+                return false;
+            }
             logger.trace("Checking if fetching done for batch id {}", batchId);
             ShardsBatch shardsBatch = shard.primary() ? batchIdToStartedShardBatch.get(batchId) : batchIdToStoreShardBatch.get(batchId);
-
             // if fetchData has never been called, the per node cache will be empty and have no nodes
             // this is because cache.fillShardCacheWithDataNodes(nodes) initialises this map and is called in AsyncShardFetch.fetchData
-            if (shardsBatch.getAsyncFetcher().hasEmptyCache()) {
+            if (shardsBatch == null || shardsBatch.getAsyncFetcher().hasEmptyCache()) {
                 logger.trace("Batch cache is empty for batch {} ", batchId);
                 return false;
             }

--- a/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java
+++ b/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java
@@ -583,6 +583,8 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
              * Allocation explain and manual reroute APIs try to append shard store information (matching bytes) to the allocation decision.
              * However, these APIs do not want to trigger a new asyncFetch for these ineligible shards, unless the data from nodes is already there.
              * This function is used to see if a fetch has happened to decide if it is possible to append shard store info without a new async fetch.
+             * In the case when shard has a batch but no fetch has happened before, it would be because it is a new batch.
+             * In the case when shard has a batch, and a fetch has happened before, and no fetch is ongoing, it would be because we have already completed fetch for all nodes.
              *
              * In order to check if a fetch has ever happened, we check 2 things:
              * 1. If the shard batch cache is empty, we know that fetch has never happened so we return false.


### PR DESCRIPTION
### Description
This change fixes the bug in `hasInitiatedFetching()` where it always returns true in batch mode, causing allocation explain to show `AWAITING_INFO` even for shards for which decider is returning NO.

The idea here is we want to populate shard store information (number of matching bytes per node) IN ADDITION to the decision made by deciders.
This function is meant to check if it is possible to get the above information, without triggering a new asyncFetch.

The intended behaviour is for this function to return true if a fetch has ever happened before, or is ongoing for a batch.
It should return false if there has never been a fetch for this batch.
This is so that it does not trigger a new asyncFetch call, but also uses the data from existing ones or wait for ongoing ones to populate shard store info.

Details of above points are mentioned in [#14903]

We start by comparing batch mode vs non-batch mode implementations.

Non-batch mode logic for deciding if shard is eligible for fetching

https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/ReplicaShardAllocator.java#L202-L228

Batch mode logic for deciding if shard is eligible for fetching - logic is same.

https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/ReplicaShardBatchAllocator.java#L171-L196

`hasInitiatedFetching()` has a different implementation though - this is the key difference. In non batch-mode it works as intended, but in batch mode it always returns true.

### Details of fix for `hasinitiatedFetching()`

#### Implementation in non-batch mode:

https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/GatewayAllocator.java#L351-L353

Here, we check if `asyncFetchStore` has an entry for this `shardId`.
The intention here is to check if `fetchData()` call has ever happened for this shard before.

`asyncFetchStore` entries are populated as part of `GatewayAllocator$InternalReplicaShardAllocator.fetchData()`
We are essentially using the fact that if `GatewayAllocator$InternalReplicaShardAllocator.fetchData()` was ever called for this shard, then `asyncFetchStore` would have an entry

https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/GatewayAllocator.java#L313-L355

For batch mode, we also need a similar idea - we need to know if `fetchData()` call has ever happened for this **batch** before.
Let's check the corresponding code for fetchData in batch mode and see if there is any property we can check to establish this fact.

#### Implementation in batch mode: 

Corresponding to `asyncFetchStore` in non-batch mode, we have `batchIdToStoreShardBatch`.
However, the logic in batch mode is different, this structure `batchIdToStoreShardBatch` is defined when we create the batches, which happens before any fetching/assignment logic is called. 

Reroute flow:
https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java#L238-L241

Allocation explain flow:
https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java#L444-L458

Batch creation logic:

Line 349 - `addBatch` updates this `batchIdToStoreShardBatch` with the entry.
https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java#L333-L355

https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java#L381-L387

Since `batchIdToStoreShardBatch` is getting updated before `fetchData()`, we cannot use it to determine if fetching has happened before.

Corresponding to `GatewayAllocator$InternalReplicaShardAllocator.fetchData()` in non-batch mode,  we have `ShardsBatchGatewayAllocator$InternalReplicaBatchShardAllocator.fetchData()` in batch mode.
Let's check the implementation of this function in batch mode to see if there are other ways.


https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java#L561-L575

Nothing we can use here either:
https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java#L584-L627

In the case the batch is empty or all nodes are ignored, `asyncFetcher.fetchData()` will not get called. 
If the batch is non empty, then `asyncFetcher.fetchData()` will get called. (line 619)

`asyncFetcher` is of type `AsyncShardBatchFetch` which extends `AsyncShardFetch` class, but does not override `fetchData()`. So we can check `AsyncShardFetch.fetchData()` for the exact implementation here.

https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/AsyncShardFetch.java#L146

https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/AsyncShardFetch.java#L172-L181

We can see in lines 172 that the batch cache entries are created for any missing nodes here.
In line 173, we see if any node still needs to be fetched.
And if so, we mark those nodes as fetching and trigger `asyncFetch()`

https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/AsyncShardBatchFetch.java#L94

Structure of batch cache ^

https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/AsyncShardFetchCache.java#L94-L103

`initData()` has custom implementation for batch cache:

https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/AsyncShardBatchFetch.java#L141-L144

So if this code has run and triggered the async Fetch, we can conclude that the following statements will be true:

1.  The batch cache will be non empty and have at least 1 entry. 
2. All nodes currently part of the cluster will either have data in the cache already, or be marked as fetching and have a fetch ongoing. 


So we can use these 2 facts as an invariant to see if any async fetching has actually happened before for a batch.
We add checks for these 2 facts in `hasInitiatedFetching()` to validate if a fetch has happened before or not.

To check 1, we use:

```
if (shardsBatch.getAsyncFetcher().hasEmptyCache()) {
                logger.trace("Batch cache is empty for batch {} ", batchId);
                return false;
}
```

To check 2, we use the `findNodesToFetch()` function. 

This function returns all nodes that have no data and also have no fetches initiated. So if we have a case where this function returns even 1 node, we can say return false from `hasInitiatedFetching()`,  because we don't info from all nodes to populate all the shard store information.

https://github.com/opensearch-project/OpenSearch/blob/fcc231dfc349e092c3f68e49f49e32a062313f71/server/src/main/java/org/opensearch/gateway/AsyncShardFetchCache.java#L109-L117

### Related Issues
Resolves #14903
<!-- List any other related issues here -->

### Check List
- [Y] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


### Testing

Added a new UT for batch mode and non batch mode to simulate allocation explain case.
Verified that allocation explain returns `NO` decision and does not show `AWAITING_INFO`.

Also manually tested manual reroutes on a 15 data node, 3 master node setup, and verified that shards with decision NO are not getting added to the batches now.

To repro this:
 - Create a cluster with 15 data nodes, 3 master nodes
 - Create an index with 1 primary and 14 replicas
 - After cluster goes green, shut down 1 node
 - Cluster should go yellow now. Run allocation explain - it should show decision NO.
 - Run manual reroute, no asyncFetch() should get triggered. (verified with `inFlightFetches` metric and arthas profiling)
