### PR TITLE
Make `ThreadContext.stashAndMergeHeaders` package-private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `org.apache.commons:commons-lang3` from 3.14.0 to 3.15.0 ([#14861](https://github.com/opensearch-project/OpenSearch/pull/14861))
 
 ### Changed
+- Make ThreadContext.stashAndMergeHeaders package-private ([#14983](https://github.com/opensearch-project/OpenSearch/pull/14983))
 
 ### Deprecated
 

--- a/server/src/main/java/org/opensearch/client/support/AbstractClient.java
+++ b/server/src/main/java/org/opensearch/client/support/AbstractClient.java
@@ -408,14 +408,13 @@ import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.client.AdminClient;
 import org.opensearch.client.Client;
 import org.opensearch.client.ClusterAdminClient;
-import org.opensearch.client.FilterClient;
 import org.opensearch.client.IndicesAdminClient;
 import org.opensearch.client.OpenSearchClient;
 import org.opensearch.cluster.metadata.IndexMetadata.APIBlock;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.util.concurrent.StashAndMergeHeadersFilterClient;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.bytes.BytesReference;
@@ -2140,18 +2139,6 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public Client filterWithHeader(Map<String, String> headers) {
-        return new FilterClient(this) {
-            @Override
-            protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
-                ActionType<Response> action,
-                Request request,
-                ActionListener<Response> listener
-            ) {
-                ThreadContext threadContext = threadPool().getThreadContext();
-                try (ThreadContext.StoredContext ctx = threadContext.stashAndMergeHeaders(headers)) {
-                    super.doExecute(action, request, listener);
-                }
-            }
-        };
+        return new StashAndMergeHeadersFilterClient(this, headers);
     }
 }

--- a/server/src/main/java/org/opensearch/common/util/concurrent/StashAndMergeHeadersFilterClient.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/StashAndMergeHeadersFilterClient.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.util.concurrent;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionType;
+import org.opensearch.client.Client;
+import org.opensearch.client.FilterClient;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+
+import java.util.Map;
+
+/**
+ * This class is used for simulating request headers for testing. Used in TasksIT to
+ * assert that request headers are carried to task info
+ *
+ * @opensearch.internal
+ */
+public class StashAndMergeHeadersFilterClient extends FilterClient {
+    private Map<String, String> headers;
+
+    public StashAndMergeHeadersFilterClient(Client in, Map<String, String> headers) {
+        super(in);
+        this.headers = headers;
+    }
+
+    @Override
+    protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+        ActionType<Response> action,
+        Request request,
+        ActionListener<Response> listener
+    ) {
+        ThreadContext threadContext = threadPool().getThreadContext();
+        try (ThreadContext.StoredContext ctx = threadContext.stashAndMergeHeaders(headers)) {
+            super.doExecute(action, request, listener);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
@@ -217,7 +217,7 @@ public final class ThreadContext implements Writeable {
      * The removed context can be restored when closing the returned {@link StoredContext}. The merge strategy is that headers
      * that are already existing are preserved unless they are defaults.
      */
-    public StoredContext stashAndMergeHeaders(Map<String, String> headers) {
+    StoredContext stashAndMergeHeaders(Map<String, String> headers) {
         final ThreadContextStruct context = threadLocal.get();
         Map<String, String> newHeader = new HashMap<>(headers);
         newHeader.putAll(context.requestHeaders);


### PR DESCRIPTION
### Description

The ThreadContext class overly exposes many methods as public. Currently, `stashAndMergeHeaders` is publicly exposed, but its only usage is in testing. This PR changes the access modifier on this method to package-private to prevent this internally used method from being exposed publicly. 

### Related Issues

Related to https://github.com/opensearch-project/OpenSearch/issues/14931

### Check List
- [X] Functionality includes testing.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
