### PR TITLE
Latency improvements to Multi Term Aggregations 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add changes to block calls in cat shards, indices and segments based on dynamic limit settings ([#15986](https://github.com/opensearch-project/OpenSearch/pull/15986))
 - New `phone` & `phone-search` analyzer + tokenizer ([#15915](https://github.com/opensearch-project/OpenSearch/pull/15915))
 - Add _list/shards API as paginated alternate to _cat/shards ([#14641](https://github.com/opensearch-project/OpenSearch/pull/14641))
+- Latency and Memory allocation improvements to Multi Term Aggregation queries ([#14993](https://github.com/opensearch-project/OpenSearch/pull/14993))
 
 ### Dependencies
 - Bump `com.azure:azure-identity` from 1.13.0 to 1.13.2 ([#15578](https://github.com/opensearch-project/OpenSearch/pull/15578))

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
@@ -397,7 +397,7 @@ public class MultiTermsAggregator extends DeferableBucketAggregator {
                     int doc
                 ) throws IOException {
                     if (collectedValues.size() == index) {
-                        // Avoid performing a deep copy of the composite key by inlining
+                        // Avoid performing a deep copy of the composite key by inlining.
                         long bucketOrd = bucketOrds.add(owningBucketOrd, scratch.bytes().toBytesRef());
                         if (collectBucketOrds) {
                             if (bucketOrd < 0) {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
@@ -365,6 +365,13 @@ public class MultiTermsAggregator extends DeferableBucketAggregator {
             }
             boolean collectBucketOrds = aggregator != null && sub != null;
             return new MultiTermsValuesSourceCollector() {
+
+                /**
+                 * This method does the following : <br>
+                 * <li>Fetches the values of every field present in the doc List<List<TermValue<?>>> via @{@link InternalValuesSourceCollector}</li>
+                 * <li>Generates Composite keys from the fetched values for all fields present in the aggregation.</li>
+                 * <li>Adds every composite key to the @{@link BytesKeyedBucketOrds} and Optionally collects them via @{@link BucketsAggregator#collectBucket(LeafBucketCollector, int, long)}</li>
+                 */
                 @Override
                 public void apply(int doc, long owningBucketOrd) throws IOException {
                     // TODO A new list creation can be avoided for every doc.
@@ -379,7 +386,7 @@ public class MultiTermsAggregator extends DeferableBucketAggregator {
 
                 /**
                  * This generates and collects all Composite keys in their buckets by performing a cartesian product <br>
-                 * of all the values of all fields for the given doc recursively.
+                 * of all the values in all the fields ( used in agg ) for the given doc recursively.
                  * @param collectedValues : Values of all fields present in the aggregation for the @doc
                  * @param index : Points to the field being added to generate the composite key
                  */

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
@@ -275,8 +275,8 @@ public class MultiTermsAggregator extends DeferableBucketAggregator {
     @FunctionalInterface
     interface MultiTermsValuesSourceCollector {
         /**
-         * Collect a list values of multi_terms on each doc.
-         * Each terms could have multi_values, so the result is the cartesian product of each term's values.
+         * Generates the cartesian product of all fields used in aggregation and
+         * collects them in buckets using the composite key of their field values.
          */
         void apply(int doc, long owningBucketOrd) throws IOException;
 

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregatorTests.java
@@ -673,7 +673,10 @@ public class MultiTermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testIpAndKeyword() throws IOException {
-        testAggregation(new MatchAllDocsQuery(), fieldConfigs(asList(KEYWORD_FIELD, IP_FIELD)), NONE_DECORATOR, iw -> {
+        testAggregation(new MatchAllDocsQuery(), fieldConfigs(asList(KEYWORD_FIELD, IP_FIELD)), multiTermsAggregationBuilder -> {
+            multiTermsAggregationBuilder.minDocCount(0);
+            multiTermsAggregationBuilder.size(100);
+        }, iw -> {
             iw.addDocument(
                 asList(
                     new SortedDocValuesField(KEYWORD_FIELD, new BytesRef("a")),


### PR DESCRIPTION
### Description

This PR aims to introduce the following improvements : 

- Reduces the latency of Multi Term Aggregation queries by 7-10 seconds
- Reduces the memory footprint of multi term aggregation queries by decreasing its allocations. 

Testing was done on a `c5.9xlarge` with 20GB of JVM heap and store type as `mmapfs` to ensure any affect of EBS Latencies doesn't affect the result much. The same was verified using `lsof` on the OS pid to ensure all index files are m-mapped ( `mem` is the type in such cases )

The numbers below are averaged after 20 iterations of each type of query with and w/o changes. 

| Workload | Field1 | Field2 | WithoutChanges | WithChanges |
| ------------- | ------------- |------------- | ------------- |------------- |
| big5 | agent_name | host_name | 236 secs | 226 secs | 
| big5 | process_name | agent_id | 45 secs | 38 secs | 
| nyc_taxi | store_and_fwd_flag | payment_type | 53 secs | 44 secs | 

<details>
  <summary>Sample Aggregation Query</summary>

```
curl -k -H 'Content-Type: application/json' https://localhost:9200/nyc_taxis/_search -u 'admin:xxx' -d '{
  "aggs": {
    "flag_and_payment_type": {
      "multi_terms": {
        "terms": [{
          "field": "store_and_fwd_flag"
        }, {
          "field": "payment_type"
        }]
      }
    }
  }
}'
```
</details>

Multi term aggregation goes through all the docs given by the collector of the filter query ( MatchAllDocs Query if no filter is present ) 

For every document given by the collector, it generates cartesian product of all the values for all the fields present in the aggregation [here](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java#L372-L380) 

A deep copy is generated for every composite key [here](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java#L397) which is eventually copied again ( only for the first time ) while adding to the bucket. This PR refactors the code to remove the need for a deep copy of every composite key. 

We also perform a deep copy of the field values retrieved by Lucene [here](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java#L444) This is only essential for fields with multiple values in a document and can be avoided for fields with single value in a document. 

## Allocation Profiling 

**For Big5 Benchmark Process Name and Agent Id ( LOW CARDINALITY )**

Deep Copy of composite key and for single valued fields takes around 25% of the overall allocations for a multi term aggregation query. 

![Screenshot 2024-07-29 at 4 55 27 PM](https://github.com/user-attachments/assets/4db4efef-8d7d-439a-aa53-d5622f6ac3d1)

Collecting all the composite keys for every document in a list [here](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java#L376) also takes around 9% of the overall allocations. 

![Screenshot 2024-07-29 at 4 59 16 PM](https://github.com/user-attachments/assets/935fe7a5-452f-4339-8022-8bb03bb14e7c)

**For Big5 Benchmark Agent Name and Host Name ( HIGH CARDINALITY )**

19% of overall allocations spent in deep copy of composite key 

![Screenshot 2024-07-29 at 5 02 47 PM](https://github.com/user-attachments/assets/016f04e3-8348-4a5e-a782-a8f7978d164f)

Collecting all composite keys taking around 9% same as before. 

Also, for each loop to go over the field values for a document [here](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java#L402) contributes to 17% of overall allocations because of creating a new Iterator every time. Changed the same to use a regular for loop. 

![Screenshot 2024-07-29 at 5 10 36 PM](https://github.com/user-attachments/assets/b848c7bb-572d-45e7-be73-e51f3b4adbc6)


## Testing

- I ensured that results of the output were same with and without my changes for aggregation queries for different fields of the Big5 dataset. 
- Testing was done for concurrent search using different field combinations and the results were the same. 

Will see the existing integs and UTs for Multi term aggregations to ensure if any corner cases are not covered. 