### PR TITLE
[Backport] [1.3] OpenJDK Update (July 2024 Patch releases)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 ### Dependencies
+- OpenJDK Update (July 2024 Patch releases) ([#15002](https://github.com/opensearch-project/OpenSearch/pull/15002))
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/test/DistroTestPlugin.java
@@ -75,9 +75,9 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class DistroTestPlugin implements Plugin<Project> {
-    private static final String SYSTEM_JDK_VERSION = "8u412-b08";
+    private static final String SYSTEM_JDK_VERSION = "8.0.422+5.1";
     private static final String SYSTEM_JDK_VENDOR = "adoptium";
-    private static final String GRADLE_JDK_VERSION = "11.0.23+9";
+    private static final String GRADLE_JDK_VERSION = "11.0.24+8";
     private static final String GRADLE_JDK_VENDOR = "adoptium";
 
     // all distributions used by distro tests. this is temporary until tests are per distribution

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -2,7 +2,7 @@ opensearch        = 1.3.19
 lucene            = 8.10.1
 
 bundled_jdk_vendor = adoptium
-bundled_jdk = 11.0.23+9
+bundled_jdk = 11.0.24+8
 
 # optional dependencies
 spatial4j         = 0.7


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/15002 to `1.3`