### PR TITLE
[Backport 2.x] Bump actions/github-script from 6 to 7 (#14997)

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -127,3 +127,32 @@ jobs:
           title: '[AUTO] [main] Add bwc version ${{ env.NEXT_VERSION }}.'
           body: |
             I've noticed that a new tag ${{ env.TAG }} was pushed, and added a bwc version ${{ env.NEXT_VERSION }}.
+
+      - name: Create tracking issue
+        id: create-issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `
+             ### Description
+             A new version of OpenSearch was released, to prepare for the next release new version numbers need to be updated in all active branches of development.
+
+             ### Exit Criteria
+             Review and merged the following pull requests
+             - [ ] ${{ steps.base_pr.outputs.pull-request-url }}
+             - [ ] ${{ steps.base_x_pr.outputs.pull-request-url }}
+             - [ ] ${{ steps.main_pr.outputs.pull-request-url }}
+
+             ### Additional Context
+             See project wide guidance on branching and versions [[link]](https://github.com/opensearch-project/.github/blob/main/RELEASING.md).
+            `
+            const { data: issue }= await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["Build"],
+              title: "Increment version for ${{ env.NEXT_VERSION }}",
+              body: body
+            });
+            console.error(JSON.stringify(issue));
+            return issue.number;
+          result-encoding: string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Dependencies
 - Bump `org.apache.commons:commons-lang3` from 3.14.0 to 3.15.0 ([#14861](https://github.com/opensearch-project/OpenSearch/pull/14861))
 - Bump `com.microsoft.azure:msal4j` from 1.16.1 to 1.16.2 ([#14995](https://github.com/opensearch-project/OpenSearch/pull/14995))
+- Bump `actions/github-script` from 6 to 7 ([#14997](https://github.com/opensearch-project/OpenSearch/pull/14997))
 
 ### Changed
 


### PR DESCRIPTION
### Description
- Backport onto 2.x of #14997

Bumps [actions/github-script](https://github.com/actions/github-script) from 6 to 7.
- [Release notes](https://github.com/actions/github-script/releases)
- [Commits](https://github.com/actions/github-script/compare/v6...v7)

### Check List
- [ ] ~Functionality includes testing.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
