### PR TITLE
Fix test RestStatusTests.testStatusReturnsFailureStatusWhenFailuresExist

### DIFF
--- a/server/src/test/java/org/opensearch/core/RestStatusTests.java
+++ b/server/src/test/java/org/opensearch/core/RestStatusTests.java
@@ -55,7 +55,11 @@ public class RestStatusTests extends OpenSearchTestCase {
             heapOfFailures.add(failure);
         }
 
-        assertEquals(heapOfFailures.peek().status(), RestStatus.status(successfulShards, totalShards, failures));
+        final RestStatus status = heapOfFailures.peek().status();
+        // RestStatus.status will return RestStatus.OK when the highest failure code is 100 level.
+        final RestStatus expected = status.getStatusFamilyCode() == 1 ? RestStatus.OK : status;
+
+        assertEquals(expected, RestStatus.status(successfulShards, totalShards, failures));
     }
 
     public void testSerialization() throws IOException {


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This test has a reproducible failure when the highest "failure" status is 100 level. This happens because RestStatus.status treats these as OK.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/15008

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
