### PR TITLE
Add RuntimePermission for markAsSystemContext and allow core to perform the method

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/opensearch/cluster/service/ClusterApplierService.java
@@ -67,6 +67,8 @@ import org.opensearch.telemetry.metrics.tags.Tags;
 import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -396,7 +398,10 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
         final ThreadContext threadContext = threadPool.getThreadContext();
         final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(true);
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
-            threadContext.markAsSystemContext();
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                threadContext.markAsSystemContext();
+                return null;
+            });
             final UpdateTask updateTask = new UpdateTask(
                 config.priority(),
                 source,

--- a/server/src/main/java/org/opensearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/opensearch/cluster/service/MasterService.java
@@ -76,6 +76,8 @@ import org.opensearch.telemetry.metrics.tags.Tags;
 import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -1022,7 +1024,10 @@ public class MasterService extends AbstractLifecycleComponent {
         final ThreadContext threadContext = threadPool.getThreadContext();
         final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(true);
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
-            threadContext.markAsSystemContext();
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                threadContext.markAsSystemContext();
+                return null;
+            });
 
             List<Batcher.UpdateTask> safeTasks = tasks.entrySet()
                 .stream()

--- a/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
@@ -120,7 +120,7 @@ public final class ThreadContext implements Writeable {
     private final long maxWarningHeaderSize;
     private final List<ThreadContextStatePropagator> propagators;
 
-    public static final Permission ACCESS_SYSTEM_THREAD_CONTEXT_PERMISSION = new RuntimePermission("markAsSystemContext");
+    private static final Permission ACCESS_SYSTEM_THREAD_CONTEXT_PERMISSION = new RuntimePermission("markAsSystemContext");
 
     /**
      * Creates a new ThreadContext instance

--- a/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
@@ -50,6 +50,7 @@ import org.opensearch.tasks.TaskThreadContextStatePropagator;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -118,6 +119,8 @@ public final class ThreadContext implements Writeable {
     private final int maxWarningHeaderCount;
     private final long maxWarningHeaderSize;
     private final List<ThreadContextStatePropagator> propagators;
+
+    public static final Permission ACCESS_SYSTEM_THREAD_CONTEXT_PERMISSION = new RuntimePermission("markAsSystemContext");
 
     /**
      * Creates a new ThreadContext instance
@@ -556,6 +559,10 @@ public final class ThreadContext implements Writeable {
      * by the system itself rather than by a user action.
      */
     public void markAsSystemContext() {
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(ACCESS_SYSTEM_THREAD_CONTEXT_PERMISSION);
+        }
         threadLocal.set(threadLocal.get().setSystemContext(propagators));
     }
 

--- a/server/src/main/java/org/opensearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/opensearch/index/seqno/RetentionLeaseSyncAction.java
@@ -69,6 +69,8 @@ import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Map;
 import java.util.Objects;
 
@@ -137,7 +139,10 @@ public class RetentionLeaseSyncAction extends TransportWriteAction<
         final ThreadContext threadContext = threadPool.getThreadContext();
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             // we have to execute under the system context so that if security is enabled the sync is authorized
-            threadContext.markAsSystemContext();
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                threadContext.markAsSystemContext();
+                return null;
+            });
             final Request request = new Request(shardId, retentionLeases);
             final ReplicationTask task = (ReplicationTask) taskManager.register("transport", "retention_lease_sync", request);
             transportService.sendChildRequest(

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointAction.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishCheckpointAction.java
@@ -41,6 +41,8 @@ import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Objects;
 
 /**
@@ -113,7 +115,10 @@ public class PublishCheckpointAction extends TransportReplicationAction<
         final ThreadContext threadContext = threadPool.getThreadContext();
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             // we have to execute under the system context so that if security is enabled the sync is authorized
-            threadContext.markAsSystemContext();
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                threadContext.markAsSystemContext();
+                return null;
+            });
             PublishCheckpointRequest request = new PublishCheckpointRequest(checkpoint);
             final ReplicationTask task = (ReplicationTask) taskManager.register("transport", "segrep_publish_checkpoint", request);
             final ReplicationTimer timer = new ReplicationTimer();

--- a/server/src/main/java/org/opensearch/transport/RemoteClusterConnection.java
+++ b/server/src/main/java/org/opensearch/transport/RemoteClusterConnection.java
@@ -47,6 +47,8 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.function.Function;
 
 /**
@@ -136,7 +138,10 @@ final class RemoteClusterConnection implements Closeable {
                 new ContextPreservingActionListener<>(threadContext.newRestorableContext(false), listener);
             try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
                 // we stash any context here since this is an internal execution and should not leak any existing context information
-                threadContext.markAsSystemContext();
+                AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                    threadContext.markAsSystemContext();
+                    return null;
+                });
 
                 final ClusterStateRequest request = new ClusterStateRequest();
                 request.clear();

--- a/server/src/main/java/org/opensearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/opensearch/transport/SniffConnectionStrategy.java
@@ -59,6 +59,8 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -349,7 +351,10 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
                 try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
                     // we stash any context here since this is an internal execution and should not leak any
                     // existing context information.
-                    threadContext.markAsSystemContext();
+                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                        threadContext.markAsSystemContext();
+                        return null;
+                    });
                     transportService.sendRequest(
                         connection,
                         ClusterStateAction.NAME,

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -48,6 +48,7 @@ grant codeBase "${codebase.opensearch}" {
   permission java.lang.RuntimePermission "setContextClassLoader";
   // needed for SPI class loading
   permission java.lang.RuntimePermission "accessDeclaredMembers";
+  permission java.lang.RuntimePermission "markAsSystemContext";
 };
 
 //// Very special jar permissions:

--- a/server/src/test/java/org/opensearch/cluster/metadata/TemplateUpgradeServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/TemplateUpgradeServiceTests.java
@@ -56,6 +56,8 @@ import org.opensearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -225,7 +227,10 @@ public class TemplateUpgradeServiceTests extends OpenSearchTestCase {
         service.upgradesInProgress.set(additionsCount + deletionsCount + 2); // +2 to skip tryFinishUpgrade
         final ThreadContext threadContext = threadPool.getThreadContext();
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
-            threadContext.markAsSystemContext();
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                threadContext.markAsSystemContext();
+                return null;
+            });
             service.upgradeTemplates(additions, deletions);
         }
 

--- a/server/src/test/java/org/opensearch/telemetry/tracing/ThreadContextBasedTracerContextStorageTests.java
+++ b/server/src/test/java/org/opensearch/telemetry/tracing/ThreadContextBasedTracerContextStorageTests.java
@@ -21,6 +21,8 @@ import org.opensearch.test.telemetry.tracing.MockTracingTelemetry;
 import org.junit.After;
 import org.junit.Before;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -260,7 +262,10 @@ public class ThreadContextBasedTracerContextStorageTests extends OpenSearchTestC
             try (StoredContext ignored = threadContext.stashContext()) {
                 assertThat(threadContext.getTransient(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(not(nullValue())));
                 assertThat(threadContextStorage.get(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(span));
-                threadContext.markAsSystemContext();
+                AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                    threadContext.markAsSystemContext();
+                    return null;
+                });
                 assertThat(threadContext.getTransient(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(nullValue()));
             }
         }

--- a/server/src/test/resources/org/opensearch/bootstrap/test.policy
+++ b/server/src/test/resources/org/opensearch/bootstrap/test.policy
@@ -7,7 +7,8 @@
  */
 
 grant {
-  // allow to test Security policy and codebases 
+  // allow to test Security policy and codebases
   permission java.util.PropertyPermission "*", "read,write";
   permission java.security.SecurityPermission "createPolicy.JavaPolicy";
+  permission java.lang.RuntimePermission "markAsSystemContext";
 };

--- a/test/framework/src/main/java/org/opensearch/cluster/service/FakeThreadPoolClusterManagerService.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/service/FakeThreadPoolClusterManagerService.java
@@ -49,6 +49,8 @@ import org.opensearch.node.Node;
 import org.opensearch.telemetry.metrics.noop.NoopMetricsRegistry;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -134,7 +136,10 @@ public class FakeThreadPoolClusterManagerService extends ClusterManagerService {
                     scheduledNextTask = false;
                     final ThreadContext threadContext = threadPool.getThreadContext();
                     try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
-                        threadContext.markAsSystemContext();
+                        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                            threadContext.markAsSystemContext();
+                            return null;
+                        });
                         task.run();
                     }
                     if (waitForPublish == false) {


### PR DESCRIPTION
### Description

This PR replaces a [previous PR](https://github.com/opensearch-project/OpenSearch/pull/14988) and takes a different approach to protect methods in the ThreadContext class. Instead of changing the access modifier, this PR shows how permissions can be declared to protect methods within the ThreadContext class that should not be accessible outside of the core without explicit permission. 

With this change, plugins would be able to utilize the method but permission needs to be granted through an entry in the `plugin-security.policy` file. The permissions would be:

```
permission java.lang.RuntimePermission "markAsSystemContext";
```

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/14931

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
