### PR TITLE
Add support to skip pinned timestamp in remote segment garbage collector

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -217,7 +217,10 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
             } else {
                 // As delete is async its possible that the file gets created before the deletion or after
                 // deletion.
-                assertTrue(actualFileCount >= lastNMetadataFilesToKeep);
+                MatcherAssert.assertThat(
+                    actualFileCount,
+                    is(oneOf(lastNMetadataFilesToKeep - 1, lastNMetadataFilesToKeep, lastNMetadataFilesToKeep + 1))
+                );
             }
         }, 30, TimeUnit.SECONDS);
     }
@@ -246,7 +249,7 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         Path indexPath = Path.of(segmentRepoPath + "/" + shardPath);
         int actualFileCount = getFileCount(indexPath);
         // We also allow (numberOfIterations + 1) as index creation also triggers refresh.
-        assertTrue(actualFileCount >= 4);
+        MatcherAssert.assertThat(actualFileCount, is(oneOf(4)));
     }
 
     public void testStaleCommitDeletionWithMinSegmentFiles_Disabled() throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -217,10 +217,7 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
             } else {
                 // As delete is async its possible that the file gets created before the deletion or after
                 // deletion.
-                MatcherAssert.assertThat(
-                    actualFileCount,
-                    is(oneOf(lastNMetadataFilesToKeep - 1, lastNMetadataFilesToKeep, lastNMetadataFilesToKeep + 1))
-                );
+                assertTrue(actualFileCount >= lastNMetadataFilesToKeep);
             }
         }, 30, TimeUnit.SECONDS);
     }
@@ -249,7 +246,7 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         Path indexPath = Path.of(segmentRepoPath + "/" + shardPath);
         int actualFileCount = getFileCount(indexPath);
         // We also allow (numberOfIterations + 1) as index creation also triggers refresh.
-        MatcherAssert.assertThat(actualFileCount, is(oneOf(4)));
+        assertTrue(actualFileCount >= 4);
     }
 
     public void testStaleCommitDeletionWithMinSegmentFiles_Disabled() throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
@@ -19,6 +19,7 @@ import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.store.RemoteBufferedOutputDirectory;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
@@ -287,8 +288,14 @@ public class DeleteSnapshotIT extends AbstractSnapshotIntegTestCase {
     public void testRemoteStoreCleanupForDeletedIndex() throws Exception {
         disableRepoConsistencyCheck("Remote store repository is being used in the test");
         final Path remoteStoreRepoPath = randomRepoPath();
-        internalCluster().startClusterManagerOnlyNode(remoteStoreClusterSettings(REMOTE_REPO_NAME, remoteStoreRepoPath));
-        internalCluster().startDataOnlyNode(remoteStoreClusterSettings(REMOTE_REPO_NAME, remoteStoreRepoPath));
+        Settings settings = remoteStoreClusterSettings(REMOTE_REPO_NAME, remoteStoreRepoPath);
+        // Disabling pinned timestamp as this test is specifically for shallow snapshot.
+        settings = Settings.builder()
+            .put(settings)
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), false)
+            .build();
+        internalCluster().startClusterManagerOnlyNode(settings);
+        internalCluster().startDataOnlyNode(settings);
         final Client clusterManagerClient = internalCluster().clusterManagerClient();
         ensureStableCluster(2);
 

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -40,6 +40,7 @@ import org.opensearch.index.store.lockmanager.RemoteStoreMetadataLockManager;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadataHandler;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.FileNotFoundException;
@@ -91,6 +92,8 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
 
     private final RemoteStoreLockManager mdLockManager;
 
+    private final Map<Long, String> metadataFilePinnedTimestampMap;
+
     private final ThreadPool threadPool;
 
     /**
@@ -132,6 +135,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         this.remoteMetadataDirectory = remoteMetadataDirectory;
         this.mdLockManager = mdLockManager;
         this.threadPool = threadPool;
+        this.metadataFilePinnedTimestampMap = new HashMap<>();
         this.logger = Loggers.getLogger(getClass(), shardId);
         init();
     }
@@ -167,6 +171,38 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
     public RemoteSegmentMetadata initializeToSpecificCommit(long primaryTerm, long commitGeneration, String acquirerId) throws IOException {
         String metadataFilePrefix = MetadataFilenameUtils.getMetadataFilePrefixForCommit(primaryTerm, commitGeneration);
         String metadataFile = ((RemoteStoreMetadataLockManager) mdLockManager).fetchLockedMetadataFile(metadataFilePrefix, acquirerId);
+        RemoteSegmentMetadata remoteSegmentMetadata = readMetadataFile(metadataFile);
+        if (remoteSegmentMetadata != null) {
+            this.segmentsUploadedToRemoteStore = new ConcurrentHashMap<>(remoteSegmentMetadata.getMetadata());
+        } else {
+            this.segmentsUploadedToRemoteStore = new ConcurrentHashMap<>();
+        }
+        return remoteSegmentMetadata;
+    }
+
+    /**
+     * Initializes the remote segment metadata to a specific timestamp.
+     *
+     * @param timestamp The timestamp to initialize the remote segment metadata to.
+     * @return The RemoteSegmentMetadata object corresponding to the specified timestamp, or null if no metadata file is found for that timestamp.
+     * @throws IOException If an I/O error occurs while reading the metadata file.
+     */
+    public RemoteSegmentMetadata initializeToSpecificTimestamp(long timestamp) throws IOException {
+        List<String> metadataFiles = remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
+            MetadataFilenameUtils.METADATA_PREFIX,
+            Integer.MAX_VALUE
+        );
+        Set<String> lockedMetadataFiles = RemoteStoreUtils.getPinnedTimestampLockedFiles(
+            metadataFiles,
+            Set.of(timestamp),
+            MetadataFilenameUtils::getTimestamp,
+            MetadataFilenameUtils::getNodeIdByPrimaryTermAndGen
+        );
+        if (lockedMetadataFiles.isEmpty()) {
+            return null;
+        }
+        assert lockedMetadataFiles.size() == 1 : "Expected exactly one metadata file but got " + lockedMetadataFiles;
+        String metadataFile = lockedMetadataFiles.iterator().next();
         RemoteSegmentMetadata remoteSegmentMetadata = readMetadataFile(metadataFile);
         if (remoteSegmentMetadata != null) {
             this.segmentsUploadedToRemoteStore = new ConcurrentHashMap<>(remoteSegmentMetadata.getMetadata());
@@ -324,7 +360,8 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             long translogGeneration,
             long uploadCounter,
             int metadataVersion,
-            String nodeId
+            String nodeId,
+            long creationTimestamp
         ) {
             return String.join(
                 SEPARATOR,
@@ -334,8 +371,27 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
                 RemoteStoreUtils.invertLong(translogGeneration),
                 RemoteStoreUtils.invertLong(uploadCounter),
                 String.valueOf(Objects.hash(nodeId)),
-                RemoteStoreUtils.invertLong(System.currentTimeMillis()),
+                RemoteStoreUtils.invertLong(creationTimestamp),
                 String.valueOf(metadataVersion)
+            );
+        }
+
+        public static String getMetadataFilename(
+            long primaryTerm,
+            long generation,
+            long translogGeneration,
+            long uploadCounter,
+            int metadataVersion,
+            String nodeId
+        ) {
+            return getMetadataFilename(
+                primaryTerm,
+                generation,
+                translogGeneration,
+                uploadCounter,
+                metadataVersion,
+                nodeId,
+                System.currentTimeMillis()
             );
         }
 
@@ -778,6 +834,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             );
             return;
         }
+
         List<String> sortedMetadataFileList = remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
             MetadataFilenameUtils.METADATA_PREFIX,
             Integer.MAX_VALUE
@@ -791,16 +848,44 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             return;
         }
 
-        List<String> metadataFilesEligibleToDelete = new ArrayList<>(
-            sortedMetadataFileList.subList(lastNMetadataFilesToKeep, sortedMetadataFileList.size())
+        // Check last fetch status of pinned timestamps. If stale, return.
+        if (RemoteStoreUtils.isPinnedTimestampStateStale()) {
+            logger.warn("Skipping remote segment store garbage collection as last fetch of pinned timestamp is stale");
+            return;
+        }
+
+        Tuple<Long, Set<Long>> pinnedTimestampsState = RemoteStorePinnedTimestampService.getPinnedTimestamps();
+
+        Set<String> implicitLockedFiles = RemoteStoreUtils.getPinnedTimestampLockedFiles(
+            sortedMetadataFileList,
+            pinnedTimestampsState.v2(),
+            metadataFilePinnedTimestampMap,
+            MetadataFilenameUtils::getTimestamp,
+            MetadataFilenameUtils::getNodeIdByPrimaryTermAndGen
         );
-        Set<String> allLockFiles;
+        final Set<String> allLockFiles = new HashSet<>(implicitLockedFiles);
+
         try {
-            allLockFiles = ((RemoteStoreMetadataLockManager) mdLockManager).fetchLockedMetadataFiles(MetadataFilenameUtils.METADATA_PREFIX);
+            allLockFiles.addAll(
+                ((RemoteStoreMetadataLockManager) mdLockManager).fetchLockedMetadataFiles(MetadataFilenameUtils.METADATA_PREFIX)
+            );
         } catch (Exception e) {
             logger.error("Exception while fetching segment metadata lock files, skipping deleteStaleSegments", e);
             return;
         }
+
+        List<String> metadataFilesEligibleToDelete = new ArrayList<>(
+            sortedMetadataFileList.subList(lastNMetadataFilesToKeep, sortedMetadataFileList.size())
+        );
+
+        // Along with last N files, we need to keep files since last successful run of scheduler
+        long lastSuccessfulFetchOfPinnedTimestamps = pinnedTimestampsState.v1();
+        metadataFilesEligibleToDelete = RemoteStoreUtils.filterOutMetadataFilesBasedOnAge(
+            metadataFilesEligibleToDelete,
+            MetadataFilenameUtils::getTimestamp,
+            lastSuccessfulFetchOfPinnedTimestamps
+        );
+
         List<String> metadataFilesToBeDeleted = metadataFilesEligibleToDelete.stream()
             .filter(metadataFile -> allLockFiles.contains(metadataFile) == false)
             .collect(Collectors.toList());

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -201,7 +201,11 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         if (lockedMetadataFiles.isEmpty()) {
             return null;
         }
-        assert lockedMetadataFiles.size() == 1 : "Expected exactly one metadata file but got " + lockedMetadataFiles;
+        if (lockedMetadataFiles.size() > 1) {
+            throw new IOException(
+                "Expected exactly one metadata file matching timestamp: " + timestamp + " but got " + lockedMetadataFiles
+            );
+        }
         String metadataFile = lockedMetadataFiles.iterator().next();
         RemoteSegmentMetadata remoteSegmentMetadata = readMetadataFile(metadataFile);
         if (remoteSegmentMetadata != null) {

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -245,6 +245,14 @@ public class RemoteStorePinnedTimestampService implements Closeable {
         return pinnedTimestampsSet;
     }
 
+    public RemoteStorePinnedTimestampsBlobStore pinnedTimestampsBlobStore() {
+        return pinnedTimestampsBlobStore;
+    }
+
+    public BlobStoreTransferService blobStoreTransferService() {
+        return blobStoreTransferService;
+    }
+
     /**
      * Inner class for asynchronously updating the pinned timestamp set.
      */
@@ -266,11 +274,12 @@ public class RemoteStorePinnedTimestampService implements Closeable {
                 clusterService.state().metadata().clusterUUID(),
                 blobStoreRepository.getCompressor()
             );
-            BlobPath path = pinnedTimestampsBlobStore.getBlobPathForUpload(remotePinnedTimestamps);
-            blobStoreTransferService.listAllInSortedOrder(path, remotePinnedTimestamps.getType(), 1, new ActionListener<>() {
+            BlobPath path = pinnedTimestampsBlobStore().getBlobPathForUpload(remotePinnedTimestamps);
+            blobStoreTransferService().listAllInSortedOrder(path, remotePinnedTimestamps.getType(), 1, new ActionListener<>() {
                 @Override
                 public void onResponse(List<BlobMetadata> blobMetadata) {
                     if (blobMetadata.isEmpty()) {
+                        pinnedTimestampsSet = new Tuple<>(triggerTimestamp, Set.of());
                         return;
                     }
                     PinnedTimestamps pinnedTimestamps = readExistingPinnedTimestamps(blobMetadata.get(0).name(), remotePinnedTimestamps);

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -219,9 +219,9 @@ public class RemoteStorePinnedTimestampService implements Closeable {
 
     private PinnedTimestamps readExistingPinnedTimestamps(String blobFilename, RemotePinnedTimestamps remotePinnedTimestamps) {
         remotePinnedTimestamps.setBlobFileName(blobFilename);
-        remotePinnedTimestamps.setFullBlobName(pinnedTimestampsBlobStore.getBlobPathForUpload(remotePinnedTimestamps));
+        remotePinnedTimestamps.setFullBlobName(pinnedTimestampsBlobStore().getBlobPathForUpload(remotePinnedTimestamps));
         try {
-            return pinnedTimestampsBlobStore.read(remotePinnedTimestamps);
+            return pinnedTimestampsBlobStore().read(remotePinnedTimestamps);
         } catch (IOException e) {
             throw new RuntimeException("Failed to read existing pinned timestamps", e);
         }

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
@@ -1081,5 +1081,4 @@ public class RemoteStoreUtilsTests extends OpenSearchTestCase {
         setupRemotePinnedTimestampFeature(true);
         assertTrue(RemoteStoreUtils.isPinnedTimestampStateStale());
     }
-
 }

--- a/server/src/test/java/org/opensearch/index/store/BaseRemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/BaseRemoteSegmentStoreDirectoryTests.java
@@ -49,7 +49,8 @@ public class BaseRemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         34,
         1,
         1,
-        "node-1"
+        "node-1",
+        System.currentTimeMillis() - 300000
     );
 
     protected final String metadataFilenameDup = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
@@ -58,7 +59,8 @@ public class BaseRemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         34,
         2,
         1,
-        "node-2"
+        "node-2",
+        System.currentTimeMillis() - 400000
     );
     protected final String metadataFilename2 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
         12,
@@ -66,7 +68,8 @@ public class BaseRemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         34,
         1,
         1,
-        "node-1"
+        "node-1",
+        System.currentTimeMillis() - 500000
     );
     protected final String metadataFilename3 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
         10,
@@ -74,7 +77,8 @@ public class BaseRemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         34,
         1,
         1,
-        "node-1"
+        "node-1",
+        System.currentTimeMillis() - 600000
     );
     protected final String metadataFilename4 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
         10,
@@ -82,7 +86,8 @@ public class BaseRemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         34,
         1,
         1,
-        "node-1"
+        "node-1",
+        System.currentTimeMillis() - 700000
     );
 
     public void setupRemoteSegmentStoreDirectory() throws IOException {

--- a/server/src/test/java/org/opensearch/index/store/BaseRemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/BaseRemoteSegmentStoreDirectoryTests.java
@@ -43,52 +43,19 @@ public class BaseRemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
     protected SegmentInfos segmentInfos;
     protected ThreadPool threadPool;
 
-    protected final String metadataFilename = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
-        12,
-        23,
-        34,
-        1,
-        1,
-        "node-1",
-        System.currentTimeMillis() - 300000
-    );
+    protected String metadataFilename = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(12, 23, 34, 1, 1, "node-1");
 
-    protected final String metadataFilenameDup = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+    protected String metadataFilenameDup = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
         12,
         23,
         34,
         2,
         1,
-        "node-2",
-        System.currentTimeMillis() - 400000
+        "node-2"
     );
-    protected final String metadataFilename2 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
-        12,
-        13,
-        34,
-        1,
-        1,
-        "node-1",
-        System.currentTimeMillis() - 500000
-    );
-    protected final String metadataFilename3 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
-        10,
-        38,
-        34,
-        1,
-        1,
-        "node-1",
-        System.currentTimeMillis() - 600000
-    );
-    protected final String metadataFilename4 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
-        10,
-        36,
-        34,
-        1,
-        1,
-        "node-1",
-        System.currentTimeMillis() - 700000
-    );
+    protected String metadataFilename2 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(12, 13, 34, 1, 1, "node-1");
+    protected String metadataFilename3 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(10, 38, 34, 1, 1, "node-1");
+    protected String metadataFilename4 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(10, 36, 34, 1, 1, "node-1");
 
     public void setupRemoteSegmentStoreDirectory() throws IOException {
         remoteDataDirectory = mock(RemoteDirectory.class);

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -24,29 +24,23 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.Version;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.blobstore.AsyncMultiStreamBlobContainer;
-import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.common.blobstore.stream.write.WriteContext;
 import org.opensearch.common.io.VersionedCodecStreamWrapper;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
-import org.opensearch.gateway.remote.model.RemoteStorePinnedTimestampsBlobStore;
 import org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm;
 import org.opensearch.index.remote.RemoteStoreEnums.PathType;
 import org.opensearch.index.remote.RemoteStorePathStrategy;
 import org.opensearch.index.remote.RemoteStoreUtils;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadataHandler;
-import org.opensearch.index.translog.transfer.BlobStoreTransferService;
-import org.opensearch.node.Node;
-import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
-import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
-import org.opensearch.repositories.RepositoriesService;
-import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.test.MockLogAppender;
 import org.opensearch.test.junit.annotations.TestLogging;
 import org.opensearch.threadpool.ThreadPool;
@@ -64,19 +58,18 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.mockito.Mockito;
 
 import static org.opensearch.index.store.RemoteSegmentStoreDirectory.METADATA_FILES_TO_FETCH;
 import static org.opensearch.index.store.RemoteSegmentStoreDirectory.MetadataFilenameUtils.SEPARATOR;
+import static org.opensearch.indices.RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED;
 import static org.opensearch.test.RemoteStoreTestUtils.createMetadataFileBytes;
 import static org.opensearch.test.RemoteStoreTestUtils.getDummyMetadata;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
@@ -89,47 +82,9 @@ import static org.mockito.Mockito.when;
 
 public class RemoteSegmentStoreDirectoryTests extends BaseRemoteSegmentStoreDirectoryTests {
 
-    RemoteStorePinnedTimestampService remoteStorePinnedTimestampService;
-
     @Before
     public void setup() throws IOException {
         setupRemoteSegmentStoreDirectory();
-
-        Supplier<RepositoriesService> repositoriesServiceSupplier = mock(Supplier.class);
-        Settings settings = Settings.builder()
-            .put(Node.NODE_ATTRIBUTES.getKey() + RemoteStoreNodeAttribute.REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY, "remote-repo")
-            .build();
-        RepositoriesService repositoriesService = mock(RepositoriesService.class);
-        when(repositoriesServiceSupplier.get()).thenReturn(repositoriesService);
-        BlobStoreRepository blobStoreRepository = mock(BlobStoreRepository.class);
-        when(repositoriesService.repository("remote-repo")).thenReturn(blobStoreRepository);
-
-        when(threadPool.schedule(any(), any(), any())).then(invocationOnMock -> {
-            Runnable runnable = invocationOnMock.getArgument(0);
-            runnable.run();
-            return null;
-        }).then(subsequentInvocationsOnMock -> null);
-
-        remoteStorePinnedTimestampService = new RemoteStorePinnedTimestampService(
-            repositoriesServiceSupplier,
-            settings,
-            threadPool,
-            clusterService
-        );
-        RemoteStorePinnedTimestampService remoteStorePinnedTimestampServiceSpy = Mockito.spy(remoteStorePinnedTimestampService);
-
-        RemoteStorePinnedTimestampsBlobStore remoteStorePinnedTimestampsBlobStore = mock(RemoteStorePinnedTimestampsBlobStore.class);
-        BlobStoreTransferService blobStoreTransferService = mock(BlobStoreTransferService.class);
-        when(remoteStorePinnedTimestampServiceSpy.pinnedTimestampsBlobStore()).thenReturn(remoteStorePinnedTimestampsBlobStore);
-        when(remoteStorePinnedTimestampServiceSpy.blobStoreTransferService()).thenReturn(blobStoreTransferService);
-
-        doAnswer(invocationOnMock -> {
-            ActionListener<List<BlobMetadata>> actionListener = invocationOnMock.getArgument(3);
-            actionListener.onResponse(new ArrayList<>());
-            return null;
-        }).when(blobStoreTransferService).listAllInSortedOrder(any(), any(), eq(1), any());
-
-        remoteStorePinnedTimestampServiceSpy.start();
     }
 
     public void testUploadedSegmentMetadataToString() {
@@ -1190,12 +1145,27 @@ public class RemoteSegmentStoreDirectoryTests extends BaseRemoteSegmentStoreDire
         assertEquals(14, count);
     }
 
+    private void setupRemotePinnedTimestampFeature(boolean enabled) {
+        RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(
+            Settings.builder().put(CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), enabled).build(),
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+    }
+
     public void testInitializeToSpecificTimestampNoMetadataFiles() throws IOException {
-        when(remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX, Integer.MAX_VALUE)).thenReturn(new ArrayList<>());
+        setupRemotePinnedTimestampFeature(true);
+        when(
+            remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
+                RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
+                Integer.MAX_VALUE
+            )
+        ).thenReturn(new ArrayList<>());
         assertNull(remoteSegmentStoreDirectory.initializeToSpecificTimestamp(1234L));
+        setupRemotePinnedTimestampFeature(false);
     }
 
     public void testInitializeToSpecificTimestampNoMdMatchingTimestamp() throws IOException {
+        setupRemotePinnedTimestampFeature(true);
         String metadataPrefix = "metadata__1__2__3__4__5__";
         List<String> metadataFiles = new ArrayList<>();
         metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(2000));
@@ -1209,9 +1179,11 @@ public class RemoteSegmentStoreDirectoryTests extends BaseRemoteSegmentStoreDire
             )
         ).thenReturn(metadataFiles);
         assertNull(remoteSegmentStoreDirectory.initializeToSpecificTimestamp(1234L));
+        setupRemotePinnedTimestampFeature(false);
     }
 
     public void testInitializeToSpecificTimestampMatchingMdFile() throws IOException {
+        setupRemotePinnedTimestampFeature(true);
         String metadataPrefix = "metadata__1__2__3__4__5__";
         List<String> metadataFiles = new ArrayList<>();
         metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(1000));
@@ -1239,6 +1211,7 @@ public class RemoteSegmentStoreDirectoryTests extends BaseRemoteSegmentStoreDire
         assertEquals(2, uploadedSegments.size());
         assertTrue(uploadedSegments.containsKey("_0.cfe"));
         assertTrue(uploadedSegments.containsKey("_0.cfs"));
+        setupRemotePinnedTimestampFeature(false);
     }
 
     private static class WrapperIndexOutput extends IndexOutput {

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryWithPinnedTimestampTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryWithPinnedTimestampTests.java
@@ -1,0 +1,292 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.store;
+
+import org.apache.lucene.util.Version;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.blobstore.BlobMetadata;
+import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.blobstore.support.PlainBlobMetadata;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.gateway.remote.model.RemotePinnedTimestamps;
+import org.opensearch.gateway.remote.model.RemoteStorePinnedTimestampsBlobStore;
+import org.opensearch.index.remote.RemoteStoreUtils;
+import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
+import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.indices.RemoteStoreSettings;
+import org.opensearch.node.Node;
+import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
+import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.mockito.Mockito;
+
+import static org.opensearch.indices.RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED;
+import static org.opensearch.test.RemoteStoreTestUtils.createMetadataFileBytes;
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RemoteSegmentStoreDirectoryWithPinnedTimestampTests extends RemoteSegmentStoreDirectoryTests {
+
+    Runnable updatePinnedTimstampTask;
+    BlobStoreTransferService blobStoreTransferService;
+    RemoteStorePinnedTimestampsBlobStore remoteStorePinnedTimestampsBlobStore;
+    RemoteStorePinnedTimestampService remoteStorePinnedTimestampServiceSpy;
+
+    @Before
+    public void setupPinnedTimestamp() throws IOException {
+        RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(
+            Settings.builder().put(CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), true).build(),
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+
+        Supplier<RepositoriesService> repositoriesServiceSupplier = mock(Supplier.class);
+        Settings settings = Settings.builder()
+            .put(Node.NODE_ATTRIBUTES.getKey() + RemoteStoreNodeAttribute.REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY, "remote-repo")
+            .build();
+        RepositoriesService repositoriesService = mock(RepositoriesService.class);
+        when(repositoriesServiceSupplier.get()).thenReturn(repositoriesService);
+        BlobStoreRepository blobStoreRepository = mock(BlobStoreRepository.class);
+        when(repositoriesService.repository("remote-repo")).thenReturn(blobStoreRepository);
+
+        when(threadPool.schedule(any(), any(), any())).then(invocationOnMock -> {
+            updatePinnedTimstampTask = invocationOnMock.getArgument(0);
+            updatePinnedTimstampTask.run();
+            return null;
+        }).then(subsequentInvocationsOnMock -> null);
+
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = new RemoteStorePinnedTimestampService(
+            repositoriesServiceSupplier,
+            settings,
+            threadPool,
+            clusterService
+        );
+        remoteStorePinnedTimestampServiceSpy = Mockito.spy(remoteStorePinnedTimestampService);
+
+        remoteStorePinnedTimestampsBlobStore = mock(RemoteStorePinnedTimestampsBlobStore.class);
+        blobStoreTransferService = mock(BlobStoreTransferService.class);
+        when(remoteStorePinnedTimestampServiceSpy.pinnedTimestampsBlobStore()).thenReturn(remoteStorePinnedTimestampsBlobStore);
+        when(remoteStorePinnedTimestampServiceSpy.blobStoreTransferService()).thenReturn(blobStoreTransferService);
+
+        doAnswer(invocationOnMock -> {
+            ActionListener<List<BlobMetadata>> actionListener = invocationOnMock.getArgument(3);
+            actionListener.onResponse(new ArrayList<>());
+            return null;
+        }).when(blobStoreTransferService).listAllInSortedOrder(any(), any(), eq(1), any());
+
+        remoteStorePinnedTimestampServiceSpy.start();
+
+        metadataWithOlderTimestamp();
+    }
+
+    private void metadataWithOlderTimestamp() {
+        metadataFilename = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+            12,
+            23,
+            34,
+            1,
+            1,
+            "node-1",
+            System.currentTimeMillis() - 300000
+        );
+        metadataFilename2 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+            12,
+            13,
+            34,
+            1,
+            1,
+            "node-1",
+            System.currentTimeMillis() - 400000
+        );
+        metadataFilename3 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+            10,
+            38,
+            34,
+            1,
+            1,
+            "node-1",
+            System.currentTimeMillis() - 500000
+        );
+        metadataFilename4 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+            10,
+            36,
+            34,
+            1,
+            1,
+            "node-1",
+            System.currentTimeMillis() - 600000
+        );
+    }
+
+    public void testInitializeToSpecificTimestampNoMetadataFiles() throws IOException {
+        when(
+            remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
+                RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
+                Integer.MAX_VALUE
+            )
+        ).thenReturn(new ArrayList<>());
+        assertNull(remoteSegmentStoreDirectory.initializeToSpecificTimestamp(1234L));
+    }
+
+    public void testInitializeToSpecificTimestampNoMdMatchingTimestamp() throws IOException {
+        String metadataPrefix = "metadata__1__2__3__4__5__";
+        List<String> metadataFiles = new ArrayList<>();
+        metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(2000));
+        metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(3000));
+        metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(4000));
+
+        when(
+            remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
+                RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
+                Integer.MAX_VALUE
+            )
+        ).thenReturn(metadataFiles);
+        assertNull(remoteSegmentStoreDirectory.initializeToSpecificTimestamp(1234L));
+    }
+
+    public void testInitializeToSpecificTimestampMatchingMdFile() throws IOException {
+        String metadataPrefix = "metadata__1__2__3__4__5__";
+        List<String> metadataFiles = new ArrayList<>();
+        metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(1000));
+        metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(2000));
+        metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(3000));
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::512::" + Version.LATEST.major);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024::" + Version.LATEST.major);
+
+        when(
+            remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
+                RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
+                Integer.MAX_VALUE
+            )
+        ).thenReturn(metadataFiles);
+        when(remoteMetadataDirectory.getBlobStream(metadataPrefix + RemoteStoreUtils.invertLong(1000))).thenReturn(
+            createMetadataFileBytes(metadata, indexShard.getLatestReplicationCheckpoint(), segmentInfos)
+        );
+
+        RemoteSegmentMetadata remoteSegmentMetadata = remoteSegmentStoreDirectory.initializeToSpecificTimestamp(1234L);
+        assertNotNull(remoteSegmentMetadata);
+        Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> uploadedSegments = remoteSegmentStoreDirectory
+            .getSegmentsUploadedToRemoteStore();
+        assertEquals(2, uploadedSegments.size());
+        assertTrue(uploadedSegments.containsKey("_0.cfe"));
+        assertTrue(uploadedSegments.containsKey("_0.cfs"));
+    }
+
+    public void testDeleteStaleCommitsNoPinnedTimestampMdFilesLatest() throws Exception {
+        metadataFilename = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+            12,
+            23,
+            34,
+            1,
+            1,
+            "node-1",
+            System.currentTimeMillis()
+        );
+        metadataFilename2 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+            12,
+            13,
+            34,
+            1,
+            1,
+            "node-1",
+            System.currentTimeMillis()
+        );
+        metadataFilename3 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getMetadataFilename(
+            10,
+            38,
+            34,
+            1,
+            1,
+            "node-1",
+            System.currentTimeMillis()
+        );
+
+        when(
+            remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
+                eq(RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX),
+                anyInt()
+            )
+        ).thenReturn(List.of(metadataFilename, metadataFilename2, metadataFilename3));
+
+        populateMetadata();
+        remoteSegmentStoreDirectory.init();
+
+        // populateMetadata() adds stub to return 3 metadata files
+        // We are passing lastNMetadataFilesToKeep=2 here so that oldest 1 metadata file will be deleted
+        // But as the oldest metadata file's timestamp is within time threshold since last successful fetch,
+        // GC will skip deleting any data or metadata files.
+        remoteSegmentStoreDirectory.deleteStaleSegmentsAsync(2);
+
+        assertBusy(() -> assertThat(remoteSegmentStoreDirectory.canDeleteStaleCommits.get(), is(true)));
+        verify(remoteDataDirectory, times(0)).deleteFile(any());
+        verify(remoteMetadataDirectory, times(0)).deleteFile(any());
+    }
+
+    public void testDeleteStaleCommitsPinnedTimestampMdFile() throws Exception {
+        when(
+            remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
+                eq(RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX),
+                anyInt()
+            )
+        ).thenReturn(List.of(metadataFilename, metadataFilename2, metadataFilename3));
+
+        doAnswer(invocationOnMock -> {
+            ActionListener<List<BlobMetadata>> actionListener = invocationOnMock.getArgument(3);
+            actionListener.onResponse(List.of(new PlainBlobMetadata("pinned_timestamp_123", 1000)));
+            return null;
+        }).when(blobStoreTransferService).listAllInSortedOrder(any(), any(), eq(1), any());
+
+        long pinnedTimestampMatchingMetadataFilename2 = RemoteSegmentStoreDirectory.MetadataFilenameUtils.getTimestamp(metadataFilename2) + 10;
+        when(remoteStorePinnedTimestampsBlobStore.read(any())).thenReturn(new RemotePinnedTimestamps.PinnedTimestamps(Map.of(pinnedTimestampMatchingMetadataFilename2, List.of("xyz"))));
+        when(remoteStorePinnedTimestampsBlobStore.getBlobPathForUpload(any())).thenReturn(new BlobPath());
+
+        final Map<String, Map<String, String>> metadataFilenameContentMapping = populateMetadata();
+        final List<String> filesToBeDeleted = metadataFilenameContentMapping.get(metadataFilename3)
+            .values()
+            .stream()
+            .map(metadata -> metadata.split(RemoteSegmentStoreDirectory.UploadedSegmentMetadata.SEPARATOR)[1])
+            .collect(Collectors.toList());
+
+        updatePinnedTimstampTask.run();
+
+        remoteSegmentStoreDirectory.init();
+
+        // popluateMetadata() adds stub to return 3 metadata files
+        // We are passing lastNMetadataFilesToKeep=2 here so that oldest 1 metadata file will be deleted
+        remoteSegmentStoreDirectory.deleteStaleSegmentsAsync(1);
+
+        for (final String file : filesToBeDeleted) {
+            verify(remoteDataDirectory).deleteFile(file);
+        }
+        assertBusy(() -> assertThat(remoteSegmentStoreDirectory.canDeleteStaleCommits.get(), is(true)));
+        verify(remoteMetadataDirectory).deleteFile(metadataFilename3);
+        verify(remoteMetadataDirectory, times(0)).deleteFile(metadataFilename2);
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -2792,6 +2792,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         }
         settings.put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), randomFrom(PathType.values()));
         settings.put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_METADATA.getKey(), randomBoolean());
+        settings.put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), randomBoolean());
         return settings.build();
     }
 


### PR DESCRIPTION
### Description
- As part of shallow snapshot optimisations, we are introducing timestamp based implicit locking support. This feature will be called Timestamp Pinning in remote backed storage. When a timestamp is pinned, remote store garbage collectors will skip deleting data corresponding to the timestamp.
- In this PR, we are making following changes to segment store garbage collection:
- Fetch metadata files in reverse-chronological order
- If timestamp of a metadata file `md1` is > `pinned_timestamp_a` and the timestamp of next metadata file `md2` <= `pinned_timestamp_a`, consider `md2` to be locked by pinned timestamp.
- Skip deletion of metadata files that are locked by pinned timestamps and corresponding data files
- Segment garbage collection will continue to skip locked metadata files for backward compatibility.

Along with garbage collection change, this PR also introduces a method to initialise RemoteSegmentStoreDirectory to a given timestamp.

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/15063

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
