### PR TITLE
Fix version check in yml test for the bug fix of constant_keyword field type not working

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/110_constant_keyword.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/110_constant_keyword.yml
@@ -8,8 +8,8 @@
 
 "Mappings and Supported queries":
   - skip:
-      version: " - 2.99.99"
-      reason: "fixed in 3.0.0"
+      version: " - 2.15.99"
+      reason: "fixed in 2.16.0"
 
   # Create index with constant_keyword field type
   - do:


### PR DESCRIPTION
### Description
After the PR https://github.com/opensearch-project/OpenSearch/pull/14807 is backported to 2.x, we need to fix the version check in the related yml test to make sure the test case can run against an old version node in a mixed version cluster.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/14638

### Check List
<del>- [ ] Functionality includes testing.</del>
<del>- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.</del>
<del>- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.</del>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
