### PR TITLE
Ingest pipeline supports modifying the op_type parameter of an indexing request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix for hasInitiatedFetching to fix allocation explain and manual reroute APIs (([#14972](https://github.com/opensearch-project/OpenSearch/pull/14972))
 - [Workload Management] Add queryGroupId to Task ([14708](https://github.com/opensearch-project/OpenSearch/pull/14708))
 - Add basic aggregation support for derived fields ([#14618](https://github.com/opensearch-project/OpenSearch/pull/14618))
+- Ingest pipeline supports modifying the op_type parameter of an indexing request
 
 ### Dependencies
 - Bump `org.apache.commons:commons-lang3` from 3.14.0 to 3.15.0 ([#14861](https://github.com/opensearch-project/OpenSearch/pull/14861))

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/SetProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/SetProcessorTests.java
@@ -32,6 +32,9 @@
 
 package org.opensearch.ingest.common;
 
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.ingest.IngestDocument;
 import org.opensearch.ingest.IngestDocument.Metadata;
 import org.opensearch.ingest.Processor;
@@ -153,6 +156,14 @@ public class SetProcessorTests extends OpenSearchTestCase {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(Metadata.IF_PRIMARY_TERM.getFieldName(), Long.class), Matchers.equalTo(ifPrimaryTerm));
+    }
+
+    public void testSetMetadataOpType() throws Exception {
+        DocWriteRequest.OpType opType = RandomPicks.randomFrom(random(), DocWriteRequest.OpType.values());
+        Processor processor = createSetProcessor(Metadata.OP_TYPE.getFieldName(), opType.getLowercase(), true, false);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue(Metadata.OP_TYPE.getFieldName(), String.class), Matchers.equalTo(opType.getLowercase()));
     }
 
     private static Processor createSetProcessor(String fieldName, Object fieldValue, boolean overrideEnabled, boolean ignoreEmptyValue) {

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/270_set_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/270_set_processor.yml
@@ -1,8 +1,68 @@
+setup:
+  - do:
+      ingest.put_pipeline:
+        id: "pipeline1"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "field" : "_op_type",
+                  "value": "create"
+                }
+              }
+            ]
+          }
+  - do:
+      ingest.put_pipeline:
+        id: "pipeline2"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "field" : "_op_type",
+                  "value": "invalidOpType"
+                }
+              }
+            ]
+          }
+  - do:
+      indices.put_index_template:
+        name: test_index_template_for_data_stream
+        body:
+          index_patterns: test_data_stream1*
+          data_stream: {}
+          template:
+            settings:
+              number_of_shards:   1
+              number_of_replicas: 0
+  - do:
+      indices.create_data_stream:
+        name: test_data_stream1
 ---
 teardown:
   - do:
       ingest.delete_pipeline:
         id: "1"
+        ignore: 404
+  - do:
+      ingest.delete_pipeline:
+        id: "pipeline1"
+        ignore: 404
+  - do:
+      ingest.delete_pipeline:
+        id: "pipeline2"
+        ignore: 404
+  - do:
+      indices.delete_index_template:
+        name: test_index_template_for_data_stream
+        ignore: 404
+  - do:
+      indices.delete:
+        name: test_data_stream1
         ignore: 404
 
 ---
@@ -101,3 +161,35 @@ teardown:
         pipeline: 1
         require_alias: true
         body:    { foo: bar }
+
+---
+"Test modifying op_type by set processor":
+  - skip:
+      version: " - 2.99.99"
+      reason: "introduced in 3.0.0"
+
+  - do:
+      index:
+        index:    test_data_stream1
+        id:       1
+        op_type:  index
+        pipeline: pipeline1
+        body:   { "foo": "bar", "@timestamp": "2099-03-08T11:04:05.000Z" }
+  - match: { result: "created" }
+
+  - do:
+      get:
+        index: test_data_stream1
+        id: 1
+  - match: { _source: {"foo": "bar", "@timestamp": "2099-03-08T11:04:05.000Z"} }
+
+  - do:
+      index:
+        index:    test_data_stream1
+        id:       1
+        op_type:  index
+        pipeline: pipeline2
+        body:   { "foo": "bar", "@timestamp": "2099-03-08T11:04:05.000Z" }
+  - match: { items.0.status: 400  }
+  - match: { items.0.error.type: "illegal_argument_exception"  }
+  - match: { items.0.error.reason: "opType must be 'create' or 'index', found: [invalidOpType]"  }

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/70_bulk.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/70_bulk.yml
@@ -30,7 +30,34 @@ setup:
               }
             ]
           }
-
+  - do:
+      ingest.put_pipeline:
+        id: "pipeline3"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "field" : "_op_type",
+                  "value": "create"
+                }
+              }
+            ]
+          }
+  - do:
+      indices.put_index_template:
+        name: test_index_template_for_data_stream
+        body:
+          index_patterns: test_data_stream1*
+          data_stream: {}
+          template:
+            settings:
+              number_of_shards:   1
+              number_of_replicas: 0
+  - do:
+    indices.create_data_stream:
+      name: test_data_stream1
 ---
 teardown:
   - do:
@@ -42,8 +69,20 @@ teardown:
         id: "pipeline2"
         ignore: 404
   - do:
+      ingest.delete_pipeline:
+        id: "pipeline3"
+        ignore: 404
+  - do:
       indices.delete_index_template:
         name: test_index_template_for_bulk
+        ignore: 404
+  - do:
+      indices.delete_index_template:
+        name: test_index_template_for_data_stream
+        ignore: 404
+  - do:
+      indices.delete:
+        name: test_data_stream1
         ignore: 404
 
 ---
@@ -261,3 +300,30 @@ teardown:
           - '{"text": "text1"}'
           - '{"index": {"_index": "test_index", "_id": "test_id2"}}'
           - '{"text": "text2"}'
+
+---
+"Test modifying op_type by set processor":
+  - skip:
+      version: " - 2.99.99"
+      reason: "introduced in 3.0.0"
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "test_data_stream1", "pipeline": "pipeline3"}}'
+          - '{"foo": "bar", "@timestamp": "2099-03-08T11:04:05.000Z"}'
+  - match: { errors: false }
+  - match: { items.0.create.result: created }
+
+  - do:
+      search:
+        index: test_data_stream1
+        body: {
+          query: {
+            match_all: {}
+          }
+        }
+
+  - length:   { hits.hits: 1  }
+  - match: { hits.hits.0._source: {"foo": "bar", "@timestamp": "2099-03-08T11:04:05.000Z"} }

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/90_simulate.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/90_simulate.yml
@@ -1158,3 +1158,40 @@ teardown:
   - match: { docs.0.processor_results.1.doc._source.foo.foo: "bar" }
   - match: { docs.0.processor_results.1.status: "success" }
   - match: { docs.0.processor_results.1.processor_type: "script" }
+
+---
+"Test simulate with modifying op_type by set processor":
+  - skip:
+      version: " - 2.99.99"
+      reason: "introduced in 3.0.0"
+
+  - do:
+      ingest.simulate:
+        body: >
+          {
+            "pipeline": {
+              "description": "_description",
+              "processors": [
+                {
+                  "set" : {
+                    "field": "_op_type",
+                    "value": "create"
+                  }
+                }
+              ]
+            },
+            "docs": [
+              {
+                "_index": "index",
+                "_op_type": "index",
+                "_source": {
+                  "foo": "bar"
+                }
+              }
+            ]
+          }
+
+  - length: { docs: 1 }
+  - match: { docs.0.doc._index: "index" }
+  - match: { docs.0.doc._op_type: "create" }
+  - match: { docs.0.doc._source.foo: "bar" }

--- a/server/src/main/java/org/opensearch/action/ingest/SimulatePipelineRequest.java
+++ b/server/src/main/java/org/opensearch/action/ingest/SimulatePipelineRequest.java
@@ -35,6 +35,7 @@ package org.opensearch.action.ingest;
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.xcontent.XContentType;
@@ -233,7 +234,13 @@ public class SimulatePipelineRequest extends ActionRequest implements ToXContent
                     ConfigurationUtils.readStringProperty(null, null, dataMap, Metadata.VERSION_TYPE.getFieldName())
                 );
             }
-            IngestDocument ingestDocument = new IngestDocument(index, id, routing, version, versionType, document);
+            DocWriteRequest.OpType opType = null;
+            if (dataMap.containsKey(Metadata.OP_TYPE.getFieldName())) {
+                opType = DocWriteRequest.OpType.fromString(
+                    ConfigurationUtils.readStringProperty(null, null, dataMap, Metadata.OP_TYPE.getFieldName())
+                );
+            }
+            IngestDocument ingestDocument = new IngestDocument(index, id, routing, version, versionType, opType, document);
             if (dataMap.containsKey(Metadata.IF_SEQ_NO.getFieldName())) {
                 Object ifSeqNoFieldValue = ConfigurationUtils.readObject(null, null, dataMap, Metadata.IF_SEQ_NO.getFieldName());
                 if (ifSeqNoFieldValue instanceof Integer || ifSeqNoFieldValue instanceof Long) {

--- a/server/src/main/java/org/opensearch/action/ingest/WriteableIngestDocument.java
+++ b/server/src/main/java/org/opensearch/action/ingest/WriteableIngestDocument.java
@@ -81,8 +81,11 @@ final class WriteableIngestDocument implements Writeable, ToXContentFragment {
             if (a[4] != null) {
                 sourceAndMetadata.put(Metadata.VERSION_TYPE.getFieldName(), a[4]);
             }
-            sourceAndMetadata.putAll((Map<String, Object>) a[5]);
-            return new WriteableIngestDocument(new IngestDocument(sourceAndMetadata, (Map<String, Object>) a[6]));
+            if (a[5] != null) {
+                sourceAndMetadata.put(Metadata.OP_TYPE.getFieldName(), a[5]);
+            }
+            sourceAndMetadata.putAll((Map<String, Object>) a[6]);
+            return new WriteableIngestDocument(new IngestDocument(sourceAndMetadata, (Map<String, Object>) a[7]));
         }
     );
     static {
@@ -91,6 +94,7 @@ final class WriteableIngestDocument implements Writeable, ToXContentFragment {
         INGEST_DOC_PARSER.declareString(optionalConstructorArg(), new ParseField(Metadata.ROUTING.getFieldName()));
         INGEST_DOC_PARSER.declareLong(optionalConstructorArg(), new ParseField(Metadata.VERSION.getFieldName()));
         INGEST_DOC_PARSER.declareString(optionalConstructorArg(), new ParseField(Metadata.VERSION_TYPE.getFieldName()));
+        INGEST_DOC_PARSER.declareString(optionalConstructorArg(), new ParseField(Metadata.OP_TYPE.getFieldName()));
         INGEST_DOC_PARSER.declareObject(constructorArg(), (p, c) -> p.map(), new ParseField(SOURCE_FIELD));
         INGEST_DOC_PARSER.declareObject(constructorArg(), (p, c) -> {
             Map<String, Object> ingestMap = p.map();

--- a/server/src/main/java/org/opensearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/opensearch/ingest/IngestDocument.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.ingest;
 
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.index.VersionType;
@@ -79,6 +80,18 @@ public final class IngestDocument {
     private final Set<String> executedPipelines = new LinkedHashSet<>();
 
     public IngestDocument(String index, String id, String routing, Long version, VersionType versionType, Map<String, Object> source) {
+        this(index, id, routing, version, versionType, null, source);
+    }
+
+    public IngestDocument(
+        String index,
+        String id,
+        String routing,
+        Long version,
+        VersionType versionType,
+        DocWriteRequest.OpType opType,
+        Map<String, Object> source
+    ) {
         this.sourceAndMetadata = new HashMap<>();
         this.sourceAndMetadata.putAll(source);
         this.sourceAndMetadata.put(Metadata.INDEX.getFieldName(), index);
@@ -91,6 +104,9 @@ public final class IngestDocument {
         }
         if (versionType != null) {
             sourceAndMetadata.put(Metadata.VERSION_TYPE.getFieldName(), VersionType.toString(versionType));
+        }
+        if (opType != null) {
+            sourceAndMetadata.put(Metadata.OP_TYPE.getFieldName(), opType.getLowercase());
         }
 
         this.ingestMetadata = new HashMap<>();
@@ -862,7 +878,8 @@ public final class IngestDocument {
         VERSION(VersionFieldMapper.NAME),
         VERSION_TYPE("_version_type"),
         IF_SEQ_NO("_if_seq_no"),
-        IF_PRIMARY_TERM("_if_primary_term");
+        IF_PRIMARY_TERM("_if_primary_term"),
+        OP_TYPE("_op_type");
 
         private final String fieldName;
 

--- a/server/src/main/java/org/opensearch/ingest/IngestService.java
+++ b/server/src/main/java/org/opensearch/ingest/IngestService.java
@@ -971,8 +971,9 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         String routing = indexRequest.routing();
         Long version = indexRequest.version();
         VersionType versionType = indexRequest.versionType();
+        DocWriteRequest.OpType opType = indexRequest.opType();
         Map<String, Object> sourceAsMap = indexRequest.sourceAsMap();
-        IngestDocument ingestDocument = new IngestDocument(index, id, routing, version, versionType, sourceAsMap);
+        IngestDocument ingestDocument = new IngestDocument(index, id, routing, version, versionType, opType, sourceAsMap);
         ingestDocument.executePipeline(pipeline, (result, e) -> {
             long ingestTimeInMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeInNanos);
             totalMetrics.after(ingestTimeInMillis);
@@ -1253,6 +1254,9 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         if (metadataMap.get(IngestDocument.Metadata.IF_PRIMARY_TERM) != null) {
             indexRequest.setIfPrimaryTerm(((Number) metadataMap.get(IngestDocument.Metadata.IF_PRIMARY_TERM)).longValue());
         }
+        if (metadataMap.get(IngestDocument.Metadata.OP_TYPE) != null) {
+            indexRequest.opType((String) metadataMap.get(IngestDocument.Metadata.OP_TYPE));
+        }
         indexRequest.source(ingestDocument.getSourceAndMetadata(), indexRequest.getContentType());
     }
 
@@ -1263,6 +1267,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
             indexRequest.routing(),
             indexRequest.version(),
             indexRequest.versionType(),
+            indexRequest.opType(),
             indexRequest.sourceAsMap()
         );
     }

--- a/server/src/test/java/org/opensearch/ingest/IngestDocumentTests.java
+++ b/server/src/test/java/org/opensearch/ingest/IngestDocumentTests.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.ingest;
 
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 
@@ -1100,4 +1101,9 @@ public class IngestDocumentTests extends OpenSearchTestCase {
         }
     }
 
+    public void testConstructorWithOpType() {
+        Map<String, Object> document = new HashMap<>();
+        IngestDocument ingestDocument = new IngestDocument("index", "id", null, null, null, DocWriteRequest.OpType.CREATE, document);
+        assertThat(ingestDocument.getSourceAndMetadata().get("_op_type"), equalTo(DocWriteRequest.OpType.CREATE.getLowercase()));
+    }
 }

--- a/test/framework/src/main/java/org/opensearch/ingest/RandomDocumentPicks.java
+++ b/test/framework/src/main/java/org/opensearch/ingest/RandomDocumentPicks.java
@@ -36,6 +36,7 @@ import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.index.VersionType;
 
 import java.util.ArrayList;
@@ -164,6 +165,7 @@ public final class RandomDocumentPicks {
         String id = randomString(random);
         String routing = null;
         Long version = randomNonNegtiveLong(random);
+        DocWriteRequest.OpType opType = null;
         VersionType versionType = RandomPicks.randomFrom(
             random,
             new VersionType[] { VersionType.INTERNAL, VersionType.EXTERNAL, VersionType.EXTERNAL_GTE }
@@ -171,7 +173,10 @@ public final class RandomDocumentPicks {
         if (random.nextBoolean()) {
             routing = randomString(random);
         }
-        return new IngestDocument(index, id, routing, version, versionType, source);
+        if (random.nextBoolean()) {
+            opType = RandomPicks.randomFrom(random, DocWriteRequest.OpType.values());
+        }
+        return new IngestDocument(index, id, routing, version, versionType, opType, source);
     }
 
     public static Map<String, Object> randomSource(Random random) {


### PR DESCRIPTION
### Description

This PR adds a new metadata field `_op_type` to the `IngestDocument`, which makes the ingest processor can modify the `op_type` parameter of an indexing request, this is useful when users change the indexing requests' target from a ordinary index to a data stream, but because data stream only supports setting `op_type` to `create`, so the following bulk request will fail with exception `only write ops with an op_type of create are allowed in data streams`:
```
PUT _index_template/template_2
{
  "index_patterns": [
    "ds*"
  ],
  "data_stream":{

  },
  "template": {
    "settings": {
      "number_of_replicas": 0
    },
    "mappings": {
    }
  },
  "priority": 500
}

PUT _data_stream/ds1

PUT /ds1/_bulk?refresh
{"index":{ }}
{ "@timestamp": "2024-03-08T11:04:05.000Z", "foo":"bar" }
```
, users have to change the `op_type` to `create` in the request body:
```
PUT /ds1/_bulk?refresh
{"create":{ }}
{ "@timestamp": "2024-03-08T11:04:05.000Z", "foo":"bar" }
```
, and index API also has this issue.

So this PR gives users an option that they can setup an ingest pipeline with modifying the `op_type` parameter to `create` to avoid changing the client code, the usage is:
```
PUT _ingest/pipeline/set_processor
{
  "processors": [
      {
        "set": {
          "field": "_op_type",
          "value": "create"
        }
      }
    ]
}
PUT ds1/_settings
{
  "index.default_pipeline":"set_processor"
}

PUT /ds1/_bulk?refresh

{"index":{ }}
{ "@timestamp": "2024-03-08T11:04:05.000Z", "foo":"bar" }
```
### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/2856.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
