### PR TITLE
Fix MacOS Mx (arm64) and Linux (arm64, ppc64le, s390x) checks

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -158,7 +158,17 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
         projects.addAll(asList("deb", "rpm"));
 
         if (bwcVersion.onOrAfter("7.0.0")) { // starting with 7.0 we bundle a jdk which means we have platform-specific archives
-            projects.addAll(asList("darwin-tar", "linux-tar", "windows-zip"));
+            projects.addAll(
+                asList(
+                    "darwin-tar",
+                    "darwin-arm64-tar",
+                    "linux-tar",
+                    "linux-arm64-tar",
+                    "linux-ppc64le-tar",
+                    "linux-s390x-tar",
+                    "windows-zip"
+                )
+            );
         } else { // prior to 7.0 we published only a single zip and tar archives
             projects.addAll(asList("zip", "tar"));
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
While working on aarch64 distributions for MacOS, @peterzhuamazon reported an issue that Gradle checks fails to run:

```
* What went wrong:                                                                                                                                                                                                                                                                                                                                    
Could not determine the dependencies of task ':qa:full-cluster-restart:v1.3.19#upgradedClusterTest'.                                                                                                                                                                                                                                                  
> Could not resolve all dependencies for configuration ':qa:full-cluster-restart:opensearch_distro_extracted_testclusters-qa-full-cluster-restart-v1.3.19-0-1.3.19-'.
   > Could not resolve project :distribution:bwc:maintenance.                         
     Required by:                                                                                                                              
         project :qa:full-cluster-restart                                             
      > A dependency was declared on configuration 'expanded-darwin-arm64-tar' which is not declared in the descriptor for project :distribution:bwc:maintenance. 
```

### Related Issues
Part of https://github.com/opensearch-project/opensearch-build/issues/4670

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
