### PR TITLE
Bump jakarta.ws.rs:jakarta.ws.rs-api from 3.1.0 to 4.0.0 and resteasy to v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - OpenJDK Update (July 2024 Patch releases) ([#14998](https://github.com/opensearch-project/OpenSearch/pull/14998))
 - Bump `com.microsoft.azure:msal4j` from 1.16.1 to 1.16.2 ([#14995](https://github.com/opensearch-project/OpenSearch/pull/14995))
 - Bump `actions/github-script` from 6 to 7 ([#14997](https://github.com/opensearch-project/OpenSearch/pull/14997))
+- Bump `jakarta.ws.rs:jakarta.ws.rs-api` from 3.1.0 to 4.0.0 and resteasy to v7 ([#15050](https://github.com/opensearch-project/OpenSearch/pull/15050))
 
 ### Changed
 - Add lower limit for primary and replica batch allocators timeout ([#14979](https://github.com/opensearch-project/OpenSearch/pull/14979))

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -71,7 +71,7 @@ zstd              = 1.5.5-5
 
 jzlib             = 1.1.3
 
-resteasy          = 6.2.4.Final
+resteasy          = 7.0.0.Alpha2
 
 # opentelemetry dependencies
 opentelemetry         = 1.40.0

--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -43,7 +43,7 @@ dependencies {
   providedCompile('jakarta.enterprise:jakarta.enterprise.cdi-api:4.1.0') {
     exclude module: 'jakarta.annotation-api'
   }
-  providedCompile 'jakarta.ws.rs:jakarta.ws.rs-api:3.1.0'
+  providedCompile 'jakarta.ws.rs:jakarta.ws.rs-api:4.0.0'
   providedCompile "org.jboss.resteasy:resteasy-core:${versions.resteasy}"
   providedCompile "org.jboss.resteasy:resteasy-core-spi:${versions.resteasy}"
   api("org.jboss.resteasy:resteasy-jackson2-provider:${versions.resteasy}") {


### PR DESCRIPTION
### Description

Picking up this stale [dependabot PR](https://github.com/opensearch-project/OpenSearch/pull/13558). In order to bump rs-api, resteasy needed to be bumped in tandem.

The only usage of these jars is in :qa:wildfly. They are not used outside of the :qa module.

### Check List
- [X] Functionality includes testing.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
