### PR TITLE
Add javadoc about ThreadContextPermission for stashWithOrigin and stashAndMergeHeaders

### DIFF
--- a/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
@@ -213,6 +213,13 @@ public final class ThreadContext implements Writeable {
      * For example, a user might not have permission to GET from the tasks index
      * but the tasks API will perform a get on their behalf using this method
      * if it can't find the task in memory.
+     *
+     * Usage of stashWithOrigin is guarded by a ThreadContextPermission. In order to use
+     * stashWithOrigin, the codebase needs to explicitly be granted permission in the JSM policy file.
+     *
+     * Add an entry in the grant portion of the policy file like this:
+     *
+     * permission org.opensearch.secure_sm.ThreadContextPermission "stashWithOrigin";
      */
     public StoredContext stashWithOrigin(String origin) {
         SecurityManager sm = System.getSecurityManager();
@@ -228,6 +235,13 @@ public final class ThreadContext implements Writeable {
      * Removes the current context and resets a new context that contains a merge of the current headers and the given headers.
      * The removed context can be restored when closing the returned {@link StoredContext}. The merge strategy is that headers
      * that are already existing are preserved unless they are defaults.
+     *
+     * Usage of stashAndMergeHeaders is guarded by a ThreadContextPermission. In order to use
+     * stashAndMergeHeaders, the codebase needs to explicitly be granted permission in the JSM policy file.
+     *
+     * Add an entry in the grant portion of the policy file like this:
+     *
+     * permission org.opensearch.secure_sm.ThreadContextPermission "stashAndMergeHeaders";
      */
     public StoredContext stashAndMergeHeaders(Map<String, String> headers) {
         SecurityManager sm = System.getSecurityManager();


### PR DESCRIPTION
### Description

Follow-up to https://github.com/opensearch-project/OpenSearch/pull/15039 to add javadoc on the permissions added to ThreadContext.stashWithOrigin and ThreadContext.stashAndMergeHeaders

### Check List
- [X] Functionality includes testing.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
