### PR TITLE
Mitigation for remote snapshot filecache overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix unchecked cast in dynamic action map getter ([#15394](https://github.com/opensearch-project/OpenSearch/pull/15394))
 - Fix null values indexed as "null" strings in flat_object field ([#14069](https://github.com/opensearch-project/OpenSearch/pull/14069))
 - Fix terms query on wildcard field returns nothing ([#15607](https://github.com/opensearch-project/OpenSearch/pull/15607))
+- Fix remote snapshot file_cache exceeding capacity ([#15077](https://github.com/opensearch-project/OpenSearch/pull/15077))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
@@ -99,7 +99,14 @@ public class TransferManager {
             // If we find available capacity is exceeded, deny further BlobFetchRequests.
             if (fileCache.capacity() < fileCache.usage().usage()) {
                 fileCache.prune();
-                throw new IOException("Local file cache capacity (" + fileCache.capacity() + ") exceeded (" + fileCache.usage().usage() + ") - BlobFetchRequest failed: " + request.getFilePath());
+                throw new IOException(
+                    "Local file cache capacity ("
+                        + fileCache.capacity()
+                        + ") exceeded ("
+                        + fileCache.usage().usage()
+                        + ") - BlobFetchRequest failed: "
+                        + request.getFilePath()
+                );
             }
             if (Files.exists(request.getFilePath()) == false) {
                 logger.trace("Fetching from Remote in createIndexInput of Transfer Manager");

--- a/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTestCase.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTestCase.java
@@ -100,10 +100,10 @@ public abstract class TransferManagerTestCase extends OpenSearchTestCase {
     }
 
     public void testFetchBlobWithConcurrentCacheEvictions() {
-    // Submit 256 tasks to an executor with 16 threads that will each randomly
-    // request one of eight blobs. Given that the cache can only hold two
-    // blobs this will lead to a huge amount of contention and thrashing.
-    final ExecutorService testRunner = Executors.newFixedThreadPool(16);
+        // Submit 256 tasks to an executor with 16 threads that will each randomly
+        // request one of eight blobs. Given that the cache can only hold two
+        // blobs this will lead to a huge amount of contention and thrashing.
+        final ExecutorService testRunner = Executors.newFixedThreadPool(16);
         try {
             final List<Future<?>> futures = new ArrayList<>();
             for (int i = 0; i < 256; i++) {

--- a/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTestCase.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTestCase.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 
 @ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
 public abstract class TransferManagerTestCase extends OpenSearchTestCase {
@@ -104,9 +103,7 @@ public abstract class TransferManagerTestCase extends OpenSearchTestCase {
         IndexInput i1 = fetchBlobWithName("1");
         IndexInput i2 = fetchBlobWithName("2");
 
-        assertThrows(IOException.class, () -> {
-            IndexInput i3 = fetchBlobWithName("3");
-        });
+        assertThrows(IOException.class, () -> { IndexInput i3 = fetchBlobWithName("3"); });
     }
 
     public void testDownloadFails() throws Exception {


### PR DESCRIPTION
### Description
Remote snapshot file_cache does not strictly limit it's disk usage to its configured capacity. This change causes subsequent requests to the file cache to fail when the cache overflows. #11676 for more details.

### Related Issues
Mitigation for #11676

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
