### PR TITLE
Fix version check in yml test for the bug fix of delete index template failed

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete_index_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete_index_template/10_basic.yml
@@ -40,8 +40,8 @@ teardown:
 ---
 "Delete index template which is not used by data stream but index pattern matches":
   - skip:
-      version: " - 2.99.99"
-      reason: "fixed in 3.0.0"
+      version: " - 2.16.99"
+      reason: "fixed in 2.17.0"
 
   - do:
       indices.create_data_stream:


### PR DESCRIPTION
### Description

Fix the version check in yml test file after the [PR](https://github.com/opensearch-project/OpenSearch/pull/15080) is backport to 2.x branch.

No need to backport this PR to 2.x because it has been changed yet.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/9194

### Check List
<del>- [ ] Functionality includes testing.<del>
<del>- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.<del>
<del>- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.<del>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
