### PR TITLE
Fix array_index_out_of_bounds_exception when indexing documents with field name containing only dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix constraint bug which allows more primary shards than average primary shards per index ([#14908](https://github.com/opensearch-project/OpenSearch/pull/14908))
 - Fix missing value of FieldSort for unsigned_long ([#14963](https://github.com/opensearch-project/OpenSearch/pull/14963))
 - Fix delete index template failed when the index template matches a data stream but is unused ([#15080](https://github.com/opensearch-project/OpenSearch/pull/15080))
-- Fix array_index_out_of_bounds_exception when indexing documents with field name containing only dot
+- Fix array_index_out_of_bounds_exception when indexing documents with field name containing only dot ([#15126](https://github.com/opensearch-project/OpenSearch/pull/15126))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix constraint bug which allows more primary shards than average primary shards per index ([#14908](https://github.com/opensearch-project/OpenSearch/pull/14908))
 - Fix missing value of FieldSort for unsigned_long ([#14963](https://github.com/opensearch-project/OpenSearch/pull/14963))
 - Fix delete index template failed when the index template matches a data stream but is unused ([#15080](https://github.com/opensearch-project/OpenSearch/pull/15080))
+- Fix array_index_out_of_bounds_exception when indexing documents with field name containing only dot
 
 ### Security
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/120_field_name.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/120_field_name.yml
@@ -9,7 +9,7 @@
         index:    test_1
 
   - do:
-      catch: /field name cannot contain only dot/
+      catch: /field name cannot contain only the character \[.\]/
       index:
         index:   test_1
         id:      1
@@ -18,7 +18,7 @@
         }
 
   - do:
-      catch: /field name cannot contain only dot/
+      catch: /field name cannot contain only the character \[.\]/
       index:
         index:   test_1
         id:      1
@@ -27,7 +27,7 @@
         }
 
   - do:
-      catch: /field name cannot contain only dot/
+      catch: /field name cannot contain only the character \[.\]/
       index:
         index:   test_1
         id:      1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/120_field_name.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/120_field_name.yml
@@ -1,0 +1,38 @@
+---
+"Index documents with field name containing only dot fail with an IllegalArgumentException":
+  - skip:
+      version: " - 2.99.99"
+      reason: "introduced in 3.0.0"
+
+  - do:
+      indices.create:
+        index:    test_1
+
+  - do:
+      catch: /field name cannot contain only dot/
+      index:
+        index:   test_1
+        id:      1
+        body:    {
+          .: bar
+        }
+
+  - do:
+      catch: /field name cannot contain only dot/
+      index:
+        index:   test_1
+        id:      1
+        body:    {
+          ..: bar
+        }
+
+  - do:
+      catch: /field name cannot contain only dot/
+      index:
+        index:   test_1
+        id:      1
+        body:    {
+          foo: {
+            .: bar
+          }
+        }

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -206,6 +206,9 @@ final class DocumentParser {
     private static String[] splitAndValidatePath(String fullFieldPath) {
         if (fullFieldPath.contains(".")) {
             String[] parts = fullFieldPath.split("\\.");
+            if (parts.length == 0) {
+                throw new IllegalArgumentException("field name cannot contain only dot");
+            }
             for (String part : parts) {
                 if (Strings.hasText(part) == false) {
                     // check if the field name contains only whitespace

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java
@@ -207,7 +207,7 @@ final class DocumentParser {
         if (fullFieldPath.contains(".")) {
             String[] parts = fullFieldPath.split("\\.");
             if (parts.length == 0) {
-                throw new IllegalArgumentException("field name cannot contain only dot");
+                throw new IllegalArgumentException("field name cannot contain only the character [.]");
             }
             for (String part : parts) {
                 if (Strings.hasText(part) == false) {

--- a/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
@@ -1700,6 +1700,38 @@ public class DocumentParserTests extends MapperServiceTestCase {
         );
     }
 
+    public void testDynamicFieldsWithOnlyDot() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
+
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> {
+            b.startArray("top");
+            {
+                b.startObject();
+                {
+                    b.startObject("inner").field(".", 2).endObject();
+                }
+                b.endObject();
+            }
+            b.endArray();
+        })));
+
+        assertThat(e.getCause(), notNullValue());
+        assertThat(e.getCause().getMessage(), containsString("field name cannot contain only dot"));
+
+        e = expectThrows(
+            MapperParsingException.class,
+            () -> mapper.parse(source(b -> { b.startObject("..").field("foo", 2).endObject(); }))
+        );
+
+        assertThat(e.getCause(), notNullValue());
+        assertThat(e.getCause().getMessage(), containsString("field name cannot contain only dot"));
+
+        e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.field(".", "1234"))));
+
+        assertThat(e.getCause(), notNullValue());
+        assertThat(e.getCause().getMessage(), containsString("field name cannot contain only dot"));
+    }
+
     public void testDynamicFieldsEmptyName() throws Exception {
 
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));

--- a/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DocumentParserTests.java
@@ -1716,7 +1716,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         })));
 
         assertThat(e.getCause(), notNullValue());
-        assertThat(e.getCause().getMessage(), containsString("field name cannot contain only dot"));
+        assertThat(e.getCause().getMessage(), containsString("field name cannot contain only the character [.]"));
 
         e = expectThrows(
             MapperParsingException.class,
@@ -1724,12 +1724,12 @@ public class DocumentParserTests extends MapperServiceTestCase {
         );
 
         assertThat(e.getCause(), notNullValue());
-        assertThat(e.getCause().getMessage(), containsString("field name cannot contain only dot"));
+        assertThat(e.getCause().getMessage(), containsString("field name cannot contain only the character [.]"));
 
         e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.field(".", "1234"))));
 
         assertThat(e.getCause(), notNullValue());
-        assertThat(e.getCause().getMessage(), containsString("field name cannot contain only dot"));
+        assertThat(e.getCause().getMessage(), containsString("field name cannot contain only the character [.]"));
     }
 
     public void testDynamicFieldsEmptyName() throws Exception {


### PR DESCRIPTION
### Description

"." as field name yields `array_index_out_of_bounds_exception`, the reason is that we split the field name by `.` here:
https://github.com/opensearch-project/OpenSearch/blob/49b7cd47b0f0112ca21d1ea3952106f28f8253bb/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java#L208,
, if the field name contains only dot, the split result is an empty array, then yields that exception in this line:
https://github.com/opensearch-project/OpenSearch/blob/0cde7baf438e6ab994114b71dd9fadcacac4e443/server/src/main/java/org/opensearch/index/mapper/DocumentParser.java#L1045.

Since `.` is reserved for object resolution, we can fail the indexing request when the field name contains only dot.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/14911

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
