### PR TITLE
Fix version check for adding rangeQuery and regexpQuery support for constant_keyword field type

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/115_constant_keyword.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/115_constant_keyword.yml
@@ -70,8 +70,8 @@
 ---
 "Queries":
   - skip:
-      version: " - 2.99.99"
-      reason: "rangeQuery and regexpQuery are supported in 3.0.0 in main branch"
+      version: " - 2.16.99"
+      reason: "rangeQuery and regexpQuery are introduced in 2.17.0"
 
   - do:
       indices.create:


### PR DESCRIPTION
### Description

This a follow-up PR for https://github.com/opensearch-project/OpenSearch/pull/14711, we need to change the version check to 2.17.0 after the original PR is backported to 2.x branch.

In addition, I found the number prefix of the file `110_constant_keyword.yml` conflicts with `110_strict_allow_templates.yml`, so I renamed `110_constant_keyword.yml` to `115_constant_keyword.yml`.

### Related Issues
No issue.

### Check List
<del>- [ ] Functionality includes testing.<del>
<del>- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.<del>
<del>- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.<del>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
