### PR TITLE
Reset discovery nodes in all transport node actions request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Remote Publication] Added checksum validation for cluster state behind a cluster setting ([#15218](https://github.com/opensearch-project/OpenSearch/pull/15218))
 - Add canRemain method to TargetPoolAllocationDecider to move shards from local to remote pool for hot to warm tiering ([#15010](https://github.com/opensearch-project/OpenSearch/pull/15010))
 - ClusterManagerTaskThrottler Improvements ([#15508](https://github.com/opensearch-project/OpenSearch/pull/15508))
+- Reset DiscoveryNodes in all transport node actions request ([#15131](https://github.com/opensearch-project/OpenSearch/pull/15131))
 
 ### Dependencies
 - Bump `netty` from 4.1.111.Final to 4.1.112.Final ([#15081](https://github.com/opensearch-project/OpenSearch/pull/15081))

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
@@ -70,7 +70,7 @@ public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequ
      * threads for all nodes is used.
      */
     public NodesHotThreadsRequest(String... nodesIds) {
-        super(nodesIds);
+        super(false, nodesIds);
     }
 
     public int threads() {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -72,7 +72,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * for all nodes will be returned.
      */
     public NodesInfoRequest(String... nodesIds) {
-        super(nodesIds);
+        super(false, nodesIds);
         defaultMetrics();
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -58,7 +58,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
     private final Set<String> requestedMetrics = new HashSet<>();
 
     public NodesStatsRequest() {
-        super((String[]) null);
+        super(false, (String[]) null);
     }
 
     public NodesStatsRequest(StreamInput in) throws IOException {
@@ -74,7 +74,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
      * for all nodes will be returned.
      */
     public NodesStatsRequest(String... nodesIds) {
-        super(nodesIds);
+        super(false, nodesIds);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/usage/NodesUsageRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/usage/NodesUsageRequest.java
@@ -61,7 +61,7 @@ public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
      * passed, usage for all nodes will be returned.
      */
     public NodesUsageRequest(String... nodesIds) {
-        super(nodesIds);
+        super(false, nodesIds);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -161,7 +161,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
         }
 
         public Request(String[] nodesIds) {
-            super(nodesIds);
+            super(false, nodesIds);
         }
 
         public Request snapshots(Snapshot[] snapshots) {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequest.java
@@ -62,7 +62,7 @@ public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
      * based on all nodes will be returned.
      */
     public ClusterStatsRequest(String... nodesIds) {
-        super(nodesIds);
+        super(false, nodesIds);
     }
 
     public boolean useAggregatedNodeLevelResponses() {

--- a/server/src/main/java/org/opensearch/action/admin/indices/dangling/find/FindDanglingIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/dangling/find/FindDanglingIndexRequest.java
@@ -53,7 +53,7 @@ public class FindDanglingIndexRequest extends BaseNodesRequest<FindDanglingIndex
     }
 
     public FindDanglingIndexRequest(String indexUUID) {
-        super(Strings.EMPTY_ARRAY);
+        super(false, Strings.EMPTY_ARRAY);
         this.indexUUID = indexUUID;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/dangling/list/ListDanglingIndicesRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/dangling/list/ListDanglingIndicesRequest.java
@@ -58,12 +58,12 @@ public class ListDanglingIndicesRequest extends BaseNodesRequest<ListDanglingInd
     }
 
     public ListDanglingIndicesRequest() {
-        super(Strings.EMPTY_ARRAY);
+        super(false, Strings.EMPTY_ARRAY);
         this.indexUUID = null;
     }
 
     public ListDanglingIndicesRequest(String indexUUID) {
-        super(Strings.EMPTY_ARRAY);
+        super(false, Strings.EMPTY_ARRAY);
         this.indexUUID = indexUUID;
     }
 

--- a/server/src/main/java/org/opensearch/action/search/GetAllPitNodesRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/GetAllPitNodesRequest.java
@@ -27,7 +27,7 @@ public class GetAllPitNodesRequest extends BaseNodesRequest<GetAllPitNodesReques
 
     @Inject
     public GetAllPitNodesRequest(DiscoveryNode... concreteNodes) {
-        super(concreteNodes);
+        super(false, concreteNodes);
     }
 
     public GetAllPitNodesRequest(StreamInput in) throws IOException {

--- a/server/src/main/java/org/opensearch/action/support/nodes/BaseNodesRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/nodes/BaseNodesRequest.java
@@ -73,6 +73,7 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
      * Setting default behavior as `true` but can be explicitly changed in requests that do not require.
      */
     private boolean includeDiscoveryNodes = true;
+
     private final TimeValue DEFAULT_TIMEOUT_SECS = TimeValue.timeValueSeconds(30);
 
     private TimeValue timeout;
@@ -88,9 +89,20 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
         this.nodesIds = nodesIds;
     }
 
+    protected BaseNodesRequest(boolean includeDiscoveryNodes, String... nodesIds) {
+        this.nodesIds = nodesIds;
+        this.includeDiscoveryNodes = includeDiscoveryNodes;
+    }
+
     protected BaseNodesRequest(DiscoveryNode... concreteNodes) {
         this.nodesIds = null;
         this.concreteNodes = concreteNodes;
+    }
+
+    protected BaseNodesRequest(boolean includeDiscoveryNodes, DiscoveryNode... concreteNodes) {
+        this.nodesIds = null;
+        this.concreteNodes = concreteNodes;
+        this.includeDiscoveryNodes = includeDiscoveryNodes;
     }
 
     public final String[] nodesIds() {
@@ -125,10 +137,6 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
 
     public void setConcreteNodes(DiscoveryNode[] concreteNodes) {
         this.concreteNodes = concreteNodes;
-    }
-
-    public void setIncludeDiscoveryNodes(boolean value) {
-        includeDiscoveryNodes = value;
     }
 
     public boolean getIncludeDiscoveryNodes() {

--- a/server/src/main/java/org/opensearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/opensearch/action/support/nodes/TransportNodesAction.java
@@ -240,18 +240,16 @@ public abstract class TransportNodesAction<
             }
             this.responses = new AtomicReferenceArray<>(request.concreteNodes().length);
             this.concreteNodes = request.concreteNodes();
-
             if (request.getIncludeDiscoveryNodes() == false) {
-                // As we transfer the ownership of discovery nodes to route the request to into the AsyncAction class, we
-                // remove the list of DiscoveryNodes from the request. This reduces the payload of the request and improves
+                // As we transfer the ownership of discovery nodes to route the request to into the AsyncAction class,
+                // we remove the list of DiscoveryNodes from the request. This reduces the payload of the request and improves
                 // the number of concrete nodes in the memory.
                 request.setConcreteNodes(null);
             }
         }
 
         void start() {
-            final DiscoveryNode[] nodes = this.concreteNodes;
-            if (nodes.length == 0) {
+            if (this.concreteNodes.length == 0) {
                 // nothing to notify
                 threadPool.generic().execute(() -> listener.onResponse(newResponse(request, responses)));
                 return;
@@ -260,9 +258,9 @@ public abstract class TransportNodesAction<
             if (request.timeout() != null) {
                 builder.withTimeout(request.timeout());
             }
-            for (int i = 0; i < nodes.length; i++) {
+            for (int i = 0; i < this.concreteNodes.length; i++) {
                 final int idx = i;
-                final DiscoveryNode node = nodes[i];
+                final DiscoveryNode node = this.concreteNodes[i];
                 final String nodeId = node.getId();
                 try {
                     TransportRequest nodeRequest = newNodeRequest(request);

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayMetaState.java
@@ -133,7 +133,7 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<
         }
 
         public Request(String... nodesIds) {
-            super(nodesIds);
+            super(false, nodesIds);
         }
     }
 

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -197,7 +197,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
         }
 
         public Request(ShardId shardId, String customDataPath, DiscoveryNode[] nodes) {
-            super(nodes);
+            super(false, nodes);
             this.shardId = Objects.requireNonNull(shardId);
             this.customDataPath = Objects.requireNonNull(customDataPath);
         }

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayStartedShardsBatch.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayStartedShardsBatch.java
@@ -182,7 +182,7 @@ public class TransportNodesListGatewayStartedShardsBatch extends TransportNodesA
         }
 
         public Request(DiscoveryNode[] nodes, Map<ShardId, ShardAttributes> shardAttributes) {
-            super(nodes);
+            super(false, nodes);
             this.shardAttributes = Objects.requireNonNull(shardAttributes);
         }
 

--- a/server/src/main/java/org/opensearch/indices/store/TransportNodesListShardStoreMetadata.java
+++ b/server/src/main/java/org/opensearch/indices/store/TransportNodesListShardStoreMetadata.java
@@ -176,7 +176,7 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         }
 
         public Request(ShardId shardId, String customDataPath, DiscoveryNode[] nodes) {
-            super(nodes);
+            super(false, nodes);
             this.shardId = Objects.requireNonNull(shardId);
             this.customDataPath = Objects.requireNonNull(customDataPath);
         }

--- a/server/src/main/java/org/opensearch/indices/store/TransportNodesListShardStoreMetadataBatch.java
+++ b/server/src/main/java/org/opensearch/indices/store/TransportNodesListShardStoreMetadataBatch.java
@@ -188,7 +188,7 @@ public class TransportNodesListShardStoreMetadataBatch extends TransportNodesAct
         }
 
         public Request(Map<ShardId, ShardAttributes> shardAttributes, DiscoveryNode[] nodes) {
-            super(nodes);
+            super(false, nodes);
             this.shardAttributes = Objects.requireNonNull(shardAttributes);
         }
 

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterStatsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterStatsAction.java
@@ -66,7 +66,6 @@ public class RestClusterStatsAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         ClusterStatsRequest clusterStatsRequest = new ClusterStatsRequest().nodesIds(request.paramAsStringArray("nodeId", null));
         clusterStatsRequest.timeout(request.param("timeout"));
-        clusterStatsRequest.setIncludeDiscoveryNodes(false);
         clusterStatsRequest.useAggregatedNodeLevelResponses(true);
         return channel -> client.admin().cluster().clusterStats(clusterStatsRequest, new NodesResponseRestListener<>(channel));
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestNodesInfoAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestNodesInfoAction.java
@@ -88,7 +88,6 @@ public class RestNodesInfoAction extends BaseRestHandler {
         final NodesInfoRequest nodesInfoRequest = prepareRequest(request);
         nodesInfoRequest.timeout(request.param("timeout"));
         settingsFilter.addFilterSettingParams(request);
-        nodesInfoRequest.setIncludeDiscoveryNodes(false);
         return channel -> client.admin().cluster().nodesInfo(nodesInfoRequest, new NodesResponseRestListener<>(channel));
     }
 

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestNodesStatsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestNodesStatsAction.java
@@ -232,7 +232,6 @@ public class RestNodesStatsAction extends BaseRestHandler {
         // If no levels are passed in this results in an empty array.
         String[] levels = Strings.splitStringByCommaToArray(request.param("level"));
         nodesStatsRequest.indices().setLevels(levels);
-        nodesStatsRequest.setIncludeDiscoveryNodes(false);
         nodesStatsRequest.indices().setIncludeIndicesStatsByLevel(true);
 
         return channel -> client.admin().cluster().nodesStats(nodesStatsRequest, new NodesResponseRestListener<>(channel));

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestNodesAction.java
@@ -125,7 +125,6 @@ public class RestNodesAction extends AbstractCatAction {
             public void processResponse(final ClusterStateResponse clusterStateResponse) {
                 NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
                 nodesInfoRequest.timeout(request.param("timeout"));
-                nodesInfoRequest.setIncludeDiscoveryNodes(false);
                 nodesInfoRequest.clear()
                     .addMetrics(
                         NodesInfoRequest.Metric.JVM.metricName(),
@@ -138,7 +137,6 @@ public class RestNodesAction extends AbstractCatAction {
                     public void processResponse(final NodesInfoResponse nodesInfoResponse) {
                         NodesStatsRequest nodesStatsRequest = new NodesStatsRequest();
                         nodesStatsRequest.timeout(request.param("timeout"));
-                        nodesStatsRequest.setIncludeDiscoveryNodes(false);
                         nodesStatsRequest.clear()
                             .indices(true)
                             .addMetrics(

--- a/server/src/test/java/org/opensearch/action/support/nodes/TransportClusterStatsActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/nodes/TransportClusterStatsActionTests.java
@@ -34,47 +34,11 @@ import java.util.Map;
 public class TransportClusterStatsActionTests extends TransportNodesActionTests {
 
     /**
-     * By default, we send discovery nodes list to each request that is sent across from the coordinator node. This
-     * behavior is asserted in this test.
-     */
-    public void testClusterStatsActionWithRetentionOfDiscoveryNodesList() {
-        ClusterStatsRequest request = new ClusterStatsRequest();
-        request.setIncludeDiscoveryNodes(true);
-        Map<String, List<MockClusterStatsNodeRequest>> combinedSentRequest = performNodesInfoAction(request);
-
-        assertNotNull(combinedSentRequest);
-        combinedSentRequest.forEach((node, capturedRequestList) -> {
-            assertNotNull(capturedRequestList);
-            capturedRequestList.forEach(sentRequest -> {
-                assertNotNull(sentRequest.getDiscoveryNodes());
-                assertEquals(sentRequest.getDiscoveryNodes().length, clusterService.state().nodes().getSize());
-            });
-        });
-    }
-
-    public void testClusterStatsActionWithPreFilledConcreteNodesAndWithRetentionOfDiscoveryNodesList() {
-        ClusterStatsRequest request = new ClusterStatsRequest();
-        Collection<DiscoveryNode> discoveryNodes = clusterService.state().getNodes().getNodes().values();
-        request.setConcreteNodes(discoveryNodes.toArray(DiscoveryNode[]::new));
-        Map<String, List<MockClusterStatsNodeRequest>> combinedSentRequest = performNodesInfoAction(request);
-
-        assertNotNull(combinedSentRequest);
-        combinedSentRequest.forEach((node, capturedRequestList) -> {
-            assertNotNull(capturedRequestList);
-            capturedRequestList.forEach(sentRequest -> {
-                assertNotNull(sentRequest.getDiscoveryNodes());
-                assertEquals(sentRequest.getDiscoveryNodes().length, clusterService.state().nodes().getSize());
-            });
-        });
-    }
-
-    /**
      * In the optimized ClusterStats Request, we do not send the DiscoveryNodes List to each node. This behavior is
      * asserted in this test.
      */
     public void testClusterStatsActionWithoutRetentionOfDiscoveryNodesList() {
         ClusterStatsRequest request = new ClusterStatsRequest();
-        request.setIncludeDiscoveryNodes(false);
         Map<String, List<MockClusterStatsNodeRequest>> combinedSentRequest = performNodesInfoAction(request);
 
         assertNotNull(combinedSentRequest);
@@ -88,7 +52,6 @@ public class TransportClusterStatsActionTests extends TransportNodesActionTests 
         ClusterStatsRequest request = new ClusterStatsRequest();
         Collection<DiscoveryNode> discoveryNodes = clusterService.state().getNodes().getNodes().values();
         request.setConcreteNodes(discoveryNodes.toArray(DiscoveryNode[]::new));
-        request.setIncludeDiscoveryNodes(false);
         Map<String, List<MockClusterStatsNodeRequest>> combinedSentRequest = performNodesInfoAction(request);
 
         assertNotNull(combinedSentRequest);

--- a/server/src/test/java/org/opensearch/action/support/nodes/TransportNodesActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/nodes/TransportNodesActionTests.java
@@ -62,6 +62,7 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -71,6 +72,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static org.opensearch.test.ClusterServiceUtils.createClusterService;
 import static org.opensearch.test.ClusterServiceUtils.setState;
@@ -164,6 +166,36 @@ public class TransportNodesActionTests extends OpenSearchTestCase {
             assertTrue(clusterService.state().nodes().get(nodeTarget).isDataNode());
         }
         assertEquals(clusterService.state().nodes().getDataNodes().size(), capturedRequests.size());
+    }
+
+    public void testTransportNodesActionWithDiscoveryNodesIncluded() {
+        String[] nodeIds = clusterService.state().nodes().getNodes().keySet().toArray(new String[0]);
+        TestNodesRequest request = new TestNodesRequest(true, nodeIds);
+        getTestTransportNodesAction().new AsyncAction(null, request, new PlainActionFuture<>()).start();
+        Map<String, List<CapturingTransport.CapturedRequest>> capturedRequests = transport.getCapturedRequestsByTargetNodeAndClear();
+        List<TestNodeRequest> capturedTransportNodeRequestList = capturedRequests.values()
+            .stream()
+            .flatMap(Collection::stream)
+            .map(capturedRequest -> (TestNodeRequest) capturedRequest.request)
+            .collect(Collectors.toList());
+        assertEquals(nodeIds.length, capturedTransportNodeRequestList.size());
+        capturedTransportNodeRequestList.forEach(
+            capturedRequest -> assertEquals(nodeIds.length, capturedRequest.testNodesRequest.concreteNodes().length)
+        );
+    }
+
+    public void testTransportNodesActionWithDiscoveryNodesReset() {
+        String[] nodeIds = clusterService.state().nodes().getNodes().keySet().toArray(new String[0]);
+        TestNodesRequest request = new TestNodesRequest(false, nodeIds);
+        getTestTransportNodesAction().new AsyncAction(null, request, new PlainActionFuture<>()).start();
+        Map<String, List<CapturingTransport.CapturedRequest>> capturedRequests = transport.getCapturedRequestsByTargetNodeAndClear();
+        List<TestNodeRequest> capturedTransportNodeRequestList = capturedRequests.values()
+            .stream()
+            .flatMap(Collection::stream)
+            .map(capturedRequest -> (TestNodeRequest) capturedRequest.request)
+            .collect(Collectors.toList());
+        assertEquals(nodeIds.length, capturedTransportNodeRequestList.size());
+        capturedTransportNodeRequestList.forEach(capturedRequest -> assertNull(capturedRequest.testNodesRequest.concreteNodes()));
     }
 
     private <T> List<T> mockList(Supplier<T> supplier, int size) {
@@ -314,7 +346,7 @@ public class TransportNodesActionTests extends OpenSearchTestCase {
 
         @Override
         protected TestNodeRequest newNodeRequest(TestNodesRequest request) {
-            return new TestNodeRequest();
+            return new TestNodeRequest(request);
         }
 
         @Override
@@ -357,6 +389,10 @@ public class TransportNodesActionTests extends OpenSearchTestCase {
         TestNodesRequest(String... nodesIds) {
             super(nodesIds);
         }
+
+        TestNodesRequest(boolean includeDiscoveryNodes, String... nodesIds) {
+            super(includeDiscoveryNodes, nodesIds);
+        }
     }
 
     private static class TestNodesResponse extends BaseNodesResponse<TestNodeResponse> {
@@ -385,10 +421,24 @@ public class TransportNodesActionTests extends OpenSearchTestCase {
     }
 
     private static class TestNodeRequest extends TransportRequest {
+
+        protected TestNodesRequest testNodesRequest;
+
         TestNodeRequest() {}
+
+        TestNodeRequest(TestNodesRequest testNodesRequest) {
+            this.testNodesRequest = testNodesRequest;
+        }
 
         TestNodeRequest(StreamInput in) throws IOException {
             super(in);
+            testNodesRequest = new TestNodesRequest(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            testNodesRequest.writeTo(out);
         }
     }
 

--- a/server/src/test/java/org/opensearch/action/support/nodes/TransportNodesInfoActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/nodes/TransportNodesInfoActionTests.java
@@ -32,31 +32,11 @@ import java.util.Map;
 public class TransportNodesInfoActionTests extends TransportNodesActionTests {
 
     /**
-     * By default, we send discovery nodes list to each request that is sent across from the coordinator node. This
-     * behavior is asserted in this test.
-     */
-    public void testNodesInfoActionWithRetentionOfDiscoveryNodesList() {
-        NodesInfoRequest request = new NodesInfoRequest();
-        request.setIncludeDiscoveryNodes(true);
-        Map<String, List<MockNodesInfoRequest>> combinedSentRequest = performNodesInfoAction(request);
-
-        assertNotNull(combinedSentRequest);
-        combinedSentRequest.forEach((node, capturedRequestList) -> {
-            assertNotNull(capturedRequestList);
-            capturedRequestList.forEach(sentRequest -> {
-                assertNotNull(sentRequest.getDiscoveryNodes());
-                assertEquals(sentRequest.getDiscoveryNodes().length, clusterService.state().nodes().getSize());
-            });
-        });
-    }
-
-    /**
      * In the optimized ClusterStats Request, we do not send the DiscoveryNodes List to each node. This behavior is
      * asserted in this test.
      */
     public void testNodesInfoActionWithoutRetentionOfDiscoveryNodesList() {
         NodesInfoRequest request = new NodesInfoRequest();
-        request.setIncludeDiscoveryNodes(false);
         Map<String, List<MockNodesInfoRequest>> combinedSentRequest = performNodesInfoAction(request);
 
         assertNotNull(combinedSentRequest);

--- a/server/src/test/java/org/opensearch/action/support/nodes/TransportNodesStatsActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/nodes/TransportNodesStatsActionTests.java
@@ -31,31 +31,11 @@ import java.util.Map;
 public class TransportNodesStatsActionTests extends TransportNodesActionTests {
 
     /**
-     * By default, we send discovery nodes list to each request that is sent across from the coordinator node. This
-     * behavior is asserted in this test.
-     */
-    public void testNodesStatsActionWithRetentionOfDiscoveryNodesList() {
-        NodesStatsRequest request = new NodesStatsRequest();
-        request.setIncludeDiscoveryNodes(true);
-        Map<String, List<MockNodeStatsRequest>> combinedSentRequest = performNodesStatsAction(request);
-
-        assertNotNull(combinedSentRequest);
-        combinedSentRequest.forEach((node, capturedRequestList) -> {
-            assertNotNull(capturedRequestList);
-            capturedRequestList.forEach(sentRequest -> {
-                assertNotNull(sentRequest.getDiscoveryNodes());
-                assertEquals(sentRequest.getDiscoveryNodes().length, clusterService.state().nodes().getSize());
-            });
-        });
-    }
-
-    /**
-     * By default, we send discovery nodes list to each request that is sent across from the coordinator node. This
-     * behavior is asserted in this test.
+     * We don't want to send discovery nodes list to each request that is sent across from the coordinator node.
+     * This behavior is asserted in this test.
      */
     public void testNodesStatsActionWithoutRetentionOfDiscoveryNodesList() {
         NodesStatsRequest request = new NodesStatsRequest();
-        request.setIncludeDiscoveryNodes(false);
         Map<String, List<MockNodeStatsRequest>> combinedSentRequest = performNodesStatsAction(request);
 
         assertNotNull(combinedSentRequest);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Continuation to https://github.com/opensearch-project/OpenSearch/pull/14749, we don't required discovery nodes information in most of the transport actions extending TransportNodesActions, hence un-setting the discovery nodes object for such action before sending transport request to individual nodes this will prevent unnecessary serialization/deserialization of the discovery nodes object.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/OpenSearch/issues/14713

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
