### PR TITLE
Use OtlpJsonLoggingMetricExporter to export otlp metrics to log file

### DIFF
--- a/plugins/telemetry-otel/build.gradle
+++ b/plugins/telemetry-otel/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   api "io.opentelemetry:opentelemetry-sdk-trace:${versions.opentelemetry}"
   api "io.opentelemetry:opentelemetry-sdk-metrics:${versions.opentelemetry}"
   api "io.opentelemetry:opentelemetry-exporter-logging:${versions.opentelemetry}"
+  api "io.opentelemetry:opentelemetry-exporter-logging-otlp:${versions.opentelemetry}"
   api "io.opentelemetry.semconv:opentelemetry-semconv:${versions.opentelemetrysemconv}"
   api "io.opentelemetry:opentelemetry-sdk-logs:${versions.opentelemetry}"
   api "io.opentelemetry:opentelemetry-exporter-otlp:${versions.opentelemetry}"

--- a/plugins/telemetry-otel/config/telemetry-otel/log4j2.properties
+++ b/plugins/telemetry-otel/config/telemetry-otel/log4j2.properties
@@ -41,7 +41,7 @@ appender.metrics.strategy.type = DefaultRolloverStrategy
 appender.metrics.strategy.max = 4
 
 
-logger.metrics_exporter.name = io.opentelemetry.exporter.logging.LoggingMetricExporter
+logger.metrics_exporter.name = io.opentelemetry.exporter.logging.OtlpJsonLoggingMetricExporter
 logger.metrics_exporter.level = INFO
 logger.metrics_exporter.appenderRef.tracing.ref = metrics
 logger.metrics_exporter.additivity = false

--- a/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/OTelTelemetrySettings.java
+++ b/plugins/telemetry-otel/src/main/java/org/opensearch/telemetry/OTelTelemetrySettings.java
@@ -23,7 +23,7 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.List;
 
-import io.opentelemetry.exporter.logging.LoggingMetricExporter;
+import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingMetricExporter;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -99,7 +99,7 @@ public final class OTelTelemetrySettings {
     @SuppressWarnings({ "unchecked", "removal" })
     public static final Setting<Class<MetricExporter>> OTEL_METRICS_EXPORTER_CLASS_SETTING = new Setting<>(
         "telemetry.otel.metrics.exporter.class",
-        LoggingMetricExporter.class.getName(),
+        OtlpJsonLoggingMetricExporter.class.getName(),
         className -> {
             // Check we ourselves are not being called by unprivileged code.
             SpecialPermission.check();

--- a/plugins/telemetry-otel/src/test/java/org/opensearch/telemetry/metrics/exporter/OTelMetricsExporterFactoryTests.java
+++ b/plugins/telemetry-otel/src/test/java/org/opensearch/telemetry/metrics/exporter/OTelMetricsExporterFactoryTests.java
@@ -8,11 +8,12 @@
 
 package org.opensearch.telemetry.metrics.exporter;
 
+import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingMetricExporter;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.telemetry.OTelTelemetrySettings;
 import org.opensearch.test.OpenSearchTestCase;
 
-import io.opentelemetry.exporter.logging.LoggingMetricExporter;
+import io.opentelemetry.exporter.logging.OtlpJsonLoggingMetricExporter;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 
@@ -21,18 +22,18 @@ public class OTelMetricsExporterFactoryTests extends OpenSearchTestCase {
     public void testMetricsExporterDefault() {
         Settings settings = Settings.builder().build();
         MetricExporter metricExporter = OTelMetricsExporterFactory.create(settings);
-        assertTrue(metricExporter instanceof LoggingMetricExporter);
+        assertTrue(metricExporter instanceof OtlpJsonLoggingMetricExporter);
     }
 
     public void testMetricsExporterLogging() {
         Settings settings = Settings.builder()
             .put(
                 OTelTelemetrySettings.OTEL_METRICS_EXPORTER_CLASS_SETTING.getKey(),
-                "io.opentelemetry.exporter.logging.LoggingMetricExporter"
+                "io.opentelemetry.exporter.logging.OtlpJsonLoggingMetricExporter"
             )
             .build();
         MetricExporter metricExporter = OTelMetricsExporterFactory.create(settings);
-        assertTrue(metricExporter instanceof LoggingMetricExporter);
+        assertTrue(metricExporter instanceof OtlpJsonLoggingMetricExporter);
     }
 
     public void testMetricExporterInvalid() {


### PR DESCRIPTION
### Description
Previously we used `LoggingMetricExporter` to export otel metrics to log file. However, this format is not parsable and is mainly used for debugging purposes. [Created a discussion in OpenTelemetry forums to confirm the same](https://github.com/open-telemetry/opentelemetry-java/discussions/6628). 

We should use `OtlpJsonLoggingMetricExporter` that conforms to OTLP format and is easy to parse and ingest anywhere.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
