### PR TITLE
Fix yml test {p0=indices.delete_index_template/10_basic} is flaky

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete_index_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete_index_template/10_basic.yml
@@ -16,7 +16,7 @@ setup:
 
   - do:
       allowed_warnings:
-        - "index template [test_template_2] has index patterns [test-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test_template_1] will take precedence during new index creation"
+        - "index template [test_template_2] has index patterns [test-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test_template_2] will take precedence during new index creation"
       indices.put_index_template:
         name: test_template_2
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete_index_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete_index_template/10_basic.yml
@@ -1,5 +1,9 @@
 setup:
+  - skip:
+      features: allowed_warnings
   - do:
+      allowed_warnings:
+        - "index template [test_template_1] has index patterns [test-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test_template_1] will take precedence during new index creation"
       indices.put_index_template:
         name: test_template_1
         body:
@@ -11,6 +15,8 @@ setup:
           "priority": 50
 
   - do:
+      allowed_warnings:
+        - "index template [test_template_2] has index patterns [test-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test_template_1] will take precedence during new index creation"
       indices.put_index_template:
         name: test_template_2
         body:


### PR DESCRIPTION
### Description
`org.opensearch.backwards.MixedClusterClientYamlTestSuiteIT.test {p0=indices.delete_index_template/10_basic/Delete index template which is not used by data stream but index pattern matches}` is flaky, the reason is that the mixed version cluster has a template with index patterns `*`, so when creating a new index template, the API returns a warning header `index template [test_template_1] has index patterns [test-*]...`. 

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/15161

### Check List
<del>- [ ] Functionality includes testing.
<del>- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
<del>- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
