### PR TITLE
Add listenable TransportRequestHandler in TransportNodesAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Indexed IP field supports `terms_query` with more than 1025 IP masks [#16391](https://github.com/opensearch-project/OpenSearch/pull/16391)
 - Make entries for dependencies from server/build.gradle to gradle version catalog ([#16707](https://github.com/opensearch-project/OpenSearch/pull/16707))
+- Add listenable TransportRequestHandler in TransportNodesAction ([#15166](https://github.com/opensearch-project/OpenSearch/pull/15166))
 
 ### Deprecated
 - Performing update operation with default pipeline or final pipeline is deprecated ([#16712](https://github.com/opensearch-project/OpenSearch/pull/16712))


### PR DESCRIPTION
### Description
Add listenable TransportRequestHandler in TransportNodesAction.

**Use case:**
In [ml-commons](https://github.com/opensearch-project/ml-commons), a scenario is to [deploy model to the cluster](https://github.com/opensearch-project/ml-commons/blob/main/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelOnNodeAction.java#L128), this action needs to read the model metadata from index first and then do time-consuming operation for locally running model and non time-consuming operations for remote running model.

The thing is the current `TransportNodesAction` limited the API that developers have to return a response when performing [nodeOperation](https://github.com/opensearch-project/ml-commons/blob/main/plugin/src/main/java/org/opensearch/ml/action/deploy/TransportDeployModelOnNodeAction.java#L124), so we have to workaround this by forwarding the deploy result to a listener to update the model status, the workflow looks like below:
![deploy_model](https://github.com/user-attachments/assets/7ecdd2c3-1bdd-4393-ac8e-9fe20ff190cc)

This works fine for the time-consuming models(run locally) but not for remote models because deploying remote models is lightweight which only needs create several object in memory after metadata read. Once we enhanced this API to support listenableTransportRequestHandler, then we can pass the listener to the noOperation and return actual model status instead of `deploying`.

Also recently we found an issue of model deployment which is caused by the `forwarding deploy result to listener` part, simply put, if a node crash during the model deploy, then the listener will not able to receive all responses and not updating the model status, please refer: https://github.com/opensearch-project/ml-commons/issues/2970. 

So enhancing this class offering a straightforward solution to this scenario and I believe it can benefit other similar cases which accept a listener during the nodeOperation.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/15165

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
