### PR TITLE
Add timestamp pinning service and scheduler to update in-memory state

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsIT.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.remotestore;
 
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
@@ -15,7 +16,6 @@ import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.util.Set;
-import org.opensearch.common.collect.Tuple;
 
 import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING;
 
@@ -40,14 +40,20 @@ public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase 
         prepareCluster(1, 1, INDEX_NAME, 0, 2);
         ensureGreen(INDEX_NAME);
 
-        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(RemoteStorePinnedTimestampService.class, primaryNodeName(INDEX_NAME));
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(
+            RemoteStorePinnedTimestampService.class,
+            primaryNodeName(INDEX_NAME)
+        );
 
         Tuple<Long, Set<Long>> pinnedTimestampWithFetchTimestamp = RemoteStorePinnedTimestampService.getPinnedTimestamps();
         long lastFetchTimestamp = pinnedTimestampWithFetchTimestamp.v1();
         assertEquals(-1L, lastFetchTimestamp);
         assertEquals(Set.of(), pinnedTimestampWithFetchTimestamp.v2());
 
-        assertThrows(IllegalArgumentException.class, () -> remoteStorePinnedTimestampService.pinTimestamp(1234L, "ss1", noOpActionListener));
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> remoteStorePinnedTimestampService.pinTimestamp(1234L, "ss1", noOpActionListener)
+        );
 
         long timestamp1 = System.currentTimeMillis() + 30000L;
         long timestamp2 = System.currentTimeMillis() + 60000L;

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsIT.java
@@ -9,15 +9,12 @@
 package org.opensearch.remotestore;
 
 import org.opensearch.common.collect.Tuple;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.util.Set;
-
-import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase {
@@ -30,11 +27,6 @@ public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase 
         @Override
         public void onFailure(Exception e) {}
     };
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder().put(super.nodeSettings(nodeOrdinal)).put(REMOTE_CLUSTER_STATE_ENABLED_SETTING.getKey(), true).build();
-    }
 
     public void testTimestampPinUnpin() throws Exception {
         prepareCluster(1, 1, INDEX_NAME, 0, 2);

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsIT.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotestore;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Set;
+import org.opensearch.common.collect.Tuple;
+
+import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase {
+    static final String INDEX_NAME = "remote-store-test-idx-1";
+
+    ActionListener<Void> noOpActionListener = new ActionListener<>() {
+        @Override
+        public void onResponse(Void unused) {}
+
+        @Override
+        public void onFailure(Exception e) {}
+    };
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal)).put(REMOTE_CLUSTER_STATE_ENABLED_SETTING.getKey(), true).build();
+    }
+
+    public void testTimestampPinUnpin() throws Exception {
+        prepareCluster(1, 1, INDEX_NAME, 0, 2);
+        ensureGreen(INDEX_NAME);
+
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(RemoteStorePinnedTimestampService.class, primaryNodeName(INDEX_NAME));
+
+        Tuple<Long, Set<Long>> pinnedTimestampWithFetchTimestamp = RemoteStorePinnedTimestampService.getPinnedTimestamps();
+        long lastFetchTimestamp = pinnedTimestampWithFetchTimestamp.v1();
+        assertEquals(-1L, lastFetchTimestamp);
+        assertEquals(Set.of(), pinnedTimestampWithFetchTimestamp.v2());
+
+        assertThrows(IllegalArgumentException.class, () -> remoteStorePinnedTimestampService.pinTimestamp(1234L, "ss1", noOpActionListener));
+
+        long timestamp1 = System.currentTimeMillis() + 30000L;
+        long timestamp2 = System.currentTimeMillis() + 60000L;
+        long timestamp3 = System.currentTimeMillis() + 900000L;
+        remoteStorePinnedTimestampService.pinTimestamp(timestamp1, "ss2", noOpActionListener);
+        remoteStorePinnedTimestampService.pinTimestamp(timestamp2, "ss3", noOpActionListener);
+        remoteStorePinnedTimestampService.pinTimestamp(timestamp3, "ss4", noOpActionListener);
+
+        remoteStorePinnedTimestampService.setPinnedTimestampsSchedulerInterval(TimeValue.timeValueSeconds(1));
+
+        assertBusy(() -> {
+            Tuple<Long, Set<Long>> pinnedTimestampWithFetchTimestamp_2 = RemoteStorePinnedTimestampService.getPinnedTimestamps();
+            long lastFetchTimestamp_2 = pinnedTimestampWithFetchTimestamp_2.v1();
+            assertTrue(lastFetchTimestamp_2 != -1);
+            assertEquals(Set.of(timestamp1, timestamp2, timestamp3), pinnedTimestampWithFetchTimestamp_2.v2());
+        });
+
+        remoteStorePinnedTimestampService.setPinnedTimestampsSchedulerInterval(TimeValue.timeValueMinutes(3));
+
+        // This should be a no-op as pinning entity is different
+        remoteStorePinnedTimestampService.unpinTimestamp(timestamp1, "no-snapshot", noOpActionListener);
+        // Unpinning already pinned entity
+        remoteStorePinnedTimestampService.unpinTimestamp(timestamp2, "ss3", noOpActionListener);
+        // Adding different entity to already pinned timestamp
+        remoteStorePinnedTimestampService.pinTimestamp(timestamp3, "ss5", noOpActionListener);
+
+        remoteStorePinnedTimestampService.setPinnedTimestampsSchedulerInterval(TimeValue.timeValueSeconds(1));
+
+        assertBusy(() -> {
+            Tuple<Long, Set<Long>> pinnedTimestampWithFetchTimestamp_3 = RemoteStorePinnedTimestampService.getPinnedTimestamps();
+            long lastFetchTimestamp_3 = pinnedTimestampWithFetchTimestamp_3.v1();
+            assertTrue(lastFetchTimestamp_3 != -1);
+            assertEquals(Set.of(timestamp1, timestamp3), pinnedTimestampWithFetchTimestamp_3.v2());
+        });
+
+        remoteStorePinnedTimestampService.setPinnedTimestampsSchedulerInterval(TimeValue.timeValueMinutes(3));
+    }
+}

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -142,6 +142,7 @@ import org.opensearch.node.Node;
 import org.opensearch.node.Node.DiscoverySettings;
 import org.opensearch.node.NodeRoleSettings;
 import org.opensearch.node.remotestore.RemoteStoreNodeService;
+import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
 import org.opensearch.node.resource.tracker.ResourceTrackerSettings;
 import org.opensearch.persistent.PersistentTasksClusterService;
 import org.opensearch.persistent.decider.EnableAssignmentDecider;
@@ -759,6 +760,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 RemoteStoreSettings.CLUSTER_REMOTE_MAX_TRANSLOG_READERS,
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_METADATA,
                 SearchService.CLUSTER_ALLOW_DERIVED_FIELD_SETTING,
+
+                RemoteStorePinnedTimestampService.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL,
 
                 // Composite index settings
                 CompositeIndexSettings.STAR_TREE_INDEX_ENABLED_SETTING,

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemotePinnedTimestamps.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemotePinnedTimestamps.java
@@ -77,7 +77,11 @@ public class RemotePinnedTimestamps extends RemoteWriteableBlobEntity<RemotePinn
          */
         public void unpin(Long timestamp, String pinningEntity) {
             logger.debug("Unpinning timestamp = {} against entity = {}", timestamp, pinningEntity);
-            pinnedTimestampPinningEntityMap.computeIfPresent(timestamp, (k, v) -> {
+            if (pinnedTimestampPinningEntityMap.containsKey(timestamp) == false
+                || pinnedTimestampPinningEntityMap.get(timestamp).contains(pinningEntity) == false) {
+                logger.warn("Timestamp: {} is not pinned by entity: {}", timestamp, pinningEntity);
+            }
+            pinnedTimestampPinningEntityMap.compute(timestamp, (k, v) -> {
                 v.remove(pinningEntity);
                 return v.isEmpty() ? null : v;
             });

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemotePinnedTimestamps.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemotePinnedTimestamps.java
@@ -38,6 +38,10 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
 public class RemotePinnedTimestamps extends RemoteWriteableBlobEntity<RemotePinnedTimestamps.PinnedTimestamps> {
     private static final Logger logger = LogManager.getLogger(RemotePinnedTimestamps.class);
 
+    /**
+     * Represents a collection of pinned timestamps and their associated pinning entities.
+     * This class is thread-safe and implements the Writeable interface for serialization.
+     */
     public static class PinnedTimestamps implements Writeable {
         private final Map<Long, List<String>> pinnedTimestampPinningEntityMap;
 
@@ -54,11 +58,23 @@ public class RemotePinnedTimestamps extends RemoteWriteableBlobEntity<RemotePinn
             return new PinnedTimestamps(in.readMap(StreamInput::readLong, StreamInput::readStringList));
         }
 
+        /**
+         * Pins a timestamp against a pinning entity.
+         *
+         * @param timestamp The timestamp to pin.
+         * @param pinningEntity The entity pinning the timestamp.
+         */
         public void pin(Long timestamp, String pinningEntity) {
             logger.debug("Pinning timestamp = {} against entity = {}", timestamp, pinningEntity);
             pinnedTimestampPinningEntityMap.computeIfAbsent(timestamp, k -> new ArrayList<>()).add(pinningEntity);
         }
 
+        /**
+         * Unpins a timestamp for a specific pinning entity.
+         *
+         * @param timestamp The timestamp to unpin.
+         * @param pinningEntity The entity unpinning the timestamp.
+         */
         public void unpin(Long timestamp, String pinningEntity) {
             logger.debug("Unpinning timestamp = {} against entity = {}", timestamp, pinningEntity);
             pinnedTimestampPinningEntityMap.computeIfPresent(timestamp, (k, v) -> {

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemotePinnedTimestamps.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemotePinnedTimestamps.java
@@ -10,13 +10,12 @@ package org.opensearch.gateway.remote.model;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.cluster.AbstractDiffable;
-import org.opensearch.cluster.block.ClusterBlocks;
 import org.opensearch.common.io.Streams;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.common.remote.RemoteWriteableBlobEntity;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.index.remote.RemoteStoreUtils;
 import org.opensearch.repositories.blobstore.ChecksumWritableBlobStoreFormat;
@@ -39,7 +38,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
 public class RemotePinnedTimestamps extends RemoteWriteableBlobEntity<RemotePinnedTimestamps.PinnedTimestamps> {
     private static final Logger logger = LogManager.getLogger(RemotePinnedTimestamps.class);
 
-    public static class PinnedTimestamps extends AbstractDiffable<ClusterBlocks> {
+    public static class PinnedTimestamps implements Writeable {
         private final Map<Long, List<String>> pinnedTimestampPinningEntityMap;
 
         public PinnedTimestamps(Map<Long, List<String>> pinnedTimestampPinningEntityMap) {

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemotePinnedTimestamps.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemotePinnedTimestamps.java
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote.model;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.AbstractDiffable;
+import org.opensearch.cluster.block.ClusterBlocks;
+import org.opensearch.common.io.Streams;
+import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.BlobPathParameters;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.compress.Compressor;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.gateway.remote.ClusterMetadataManifest;
+import org.opensearch.index.remote.RemoteStoreUtils;
+import org.opensearch.repositories.blobstore.ChecksumWritableBlobStoreFormat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
+
+/**
+ * Wrapper class for uploading/downloading {@link RemotePinnedTimestamps} to/from remote blob store
+ *
+ * @opensearch.internal
+ */
+public class RemotePinnedTimestamps extends AbstractRemoteWritableBlobEntity<RemotePinnedTimestamps.PinnedTimestamps> {
+    private static final Logger logger = LogManager.getLogger(RemotePinnedTimestamps.class);
+
+    public static class PinnedTimestamps extends AbstractDiffable<ClusterBlocks> {
+        private final Map<Long, List<String>> pinnedTimestampPinningEntityMap;
+
+        public PinnedTimestamps(Map<Long, List<String>> pinnedTimestampPinningEntityMap) {
+            this.pinnedTimestampPinningEntityMap = new ConcurrentHashMap<>(pinnedTimestampPinningEntityMap);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeMap(pinnedTimestampPinningEntityMap, StreamOutput::writeLong, StreamOutput::writeStringCollection);
+        }
+
+        public static PinnedTimestamps readFrom(StreamInput in) throws IOException {
+            return new PinnedTimestamps(in.readMap(StreamInput::readLong, StreamInput::readStringList));
+        }
+
+        public void pin(Long timestamp, String pinningEntity) {
+            logger.debug("Pinning timestamp = {} against entity = {}", timestamp, pinningEntity);
+            pinnedTimestampPinningEntityMap.computeIfAbsent(timestamp, k -> new ArrayList<>()).add(pinningEntity);
+        }
+
+        public void unpin(Long timestamp, String pinningEntity) {
+            logger.debug("Unpinning timestamp = {} against entity = {}", timestamp, pinningEntity);
+            pinnedTimestampPinningEntityMap.computeIfPresent(timestamp, (k, v) -> {
+                v.remove(pinningEntity);
+                return v.isEmpty() ? null : v;
+            });
+        }
+
+        public Map<Long, List<String>> getPinnedTimestampPinningEntityMap() {
+            return new HashMap<>(pinnedTimestampPinningEntityMap);
+        }
+    }
+
+    public static final String PINNED_TIMESTAMPS = "pinned_timestamps";
+    public static final ChecksumWritableBlobStoreFormat<PinnedTimestamps> PINNED_TIMESTAMPS_FORMAT = new ChecksumWritableBlobStoreFormat<>(
+        PINNED_TIMESTAMPS,
+        PinnedTimestamps::readFrom
+    );
+
+    private PinnedTimestamps pinnedTimestamps;
+
+    public RemotePinnedTimestamps(String clusterUUID, Compressor compressor, NamedXContentRegistry namedXContentRegistry) {
+        super(clusterUUID, compressor, namedXContentRegistry);
+        pinnedTimestamps = new PinnedTimestamps(new HashMap<>());
+    }
+
+    @Override
+    public BlobPathParameters getBlobPathParameters() {
+        return new BlobPathParameters(List.of(PINNED_TIMESTAMPS), PINNED_TIMESTAMPS);
+    }
+
+    @Override
+    public String getType() {
+        return PINNED_TIMESTAMPS;
+    }
+
+    @Override
+    public String generateBlobFileName() {
+        return this.blobFileName = String.join(DELIMITER, PINNED_TIMESTAMPS, RemoteStoreUtils.invertLong(System.currentTimeMillis()));
+    }
+
+    @Override
+    public ClusterMetadataManifest.UploadedMetadata getUploadedMetadata() {
+        return null;
+    }
+
+    @Override
+    public InputStream serialize() throws IOException {
+        return PINNED_TIMESTAMPS_FORMAT.serialize(pinnedTimestamps, generateBlobFileName(), getCompressor()).streamInput();
+    }
+
+    @Override
+    public PinnedTimestamps deserialize(InputStream inputStream) throws IOException {
+        return PINNED_TIMESTAMPS_FORMAT.deserialize(blobName, Streams.readFully(inputStream));
+    }
+
+    public void setBlobFileName(String blobFileName) {
+        this.blobFileName = blobFileName;
+    }
+
+    public void setPinnedTimestamps(PinnedTimestamps pinnedTimestamps) {
+        this.pinnedTimestamps = pinnedTimestamps;
+    }
+
+    public PinnedTimestamps getPinnedTimestamps() {
+        return pinnedTimestamps;
+    }
+}

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemotePinnedTimestamps.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemotePinnedTimestamps.java
@@ -13,13 +13,11 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.AbstractDiffable;
 import org.opensearch.cluster.block.ClusterBlocks;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
+import org.opensearch.common.remote.RemoteWriteableBlobEntity;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.compress.Compressor;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.gateway.remote.ClusterMetadataManifest;
 import org.opensearch.index.remote.RemoteStoreUtils;
 import org.opensearch.repositories.blobstore.ChecksumWritableBlobStoreFormat;
 
@@ -38,7 +36,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
  *
  * @opensearch.internal
  */
-public class RemotePinnedTimestamps extends AbstractRemoteWritableBlobEntity<RemotePinnedTimestamps.PinnedTimestamps> {
+public class RemotePinnedTimestamps extends RemoteWriteableBlobEntity<RemotePinnedTimestamps.PinnedTimestamps> {
     private static final Logger logger = LogManager.getLogger(RemotePinnedTimestamps.class);
 
     public static class PinnedTimestamps extends AbstractDiffable<ClusterBlocks> {
@@ -83,8 +81,8 @@ public class RemotePinnedTimestamps extends AbstractRemoteWritableBlobEntity<Rem
 
     private PinnedTimestamps pinnedTimestamps;
 
-    public RemotePinnedTimestamps(String clusterUUID, Compressor compressor, NamedXContentRegistry namedXContentRegistry) {
-        super(clusterUUID, compressor, namedXContentRegistry);
+    public RemotePinnedTimestamps(String clusterUUID, Compressor compressor) {
+        super(clusterUUID, compressor);
         pinnedTimestamps = new PinnedTimestamps(new HashMap<>());
     }
 
@@ -101,11 +99,6 @@ public class RemotePinnedTimestamps extends AbstractRemoteWritableBlobEntity<Rem
     @Override
     public String generateBlobFileName() {
         return this.blobFileName = String.join(DELIMITER, PINNED_TIMESTAMPS, RemoteStoreUtils.invertLong(System.currentTimeMillis()));
-    }
-
-    @Override
-    public ClusterMetadataManifest.UploadedMetadata getUploadedMetadata() {
-        return null;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteStorePinnedTimestampsBlobStore.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteStorePinnedTimestampsBlobStore.java
@@ -36,6 +36,6 @@ public class RemoteStorePinnedTimestampsBlobStore extends RemoteClusterStateBlob
 
     @Override
     public BlobPath getBlobPathForUpload(final AbstractRemoteWritableBlobEntity<RemotePinnedTimestamps.PinnedTimestamps> obj) {
-        return blobStoreRepository.basePath();
+        return blobStoreRepository.basePath().add("pinned_timestamps");
     }
 }

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteStorePinnedTimestampsBlobStore.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteStorePinnedTimestampsBlobStore.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote.model;
+
+import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.threadpool.ThreadPool;
+
+/**
+ * Extends the RemoteClusterStateBlobStore to support {@link RemotePinnedTimestamps}
+ */
+public class RemoteStorePinnedTimestampsBlobStore extends RemoteClusterStateBlobStore<
+    RemotePinnedTimestamps.PinnedTimestamps,
+    RemotePinnedTimestamps> {
+
+    private final BlobStoreRepository blobStoreRepository;
+
+    public RemoteStorePinnedTimestampsBlobStore(
+        BlobStoreTransferService blobStoreTransferService,
+        BlobStoreRepository blobStoreRepository,
+        String clusterName,
+        ThreadPool threadPool,
+        String executor
+    ) {
+        super(blobStoreTransferService, blobStoreRepository, clusterName, threadPool, executor);
+        this.blobStoreRepository = blobStoreRepository;
+    }
+
+    @Override
+    public BlobPath getBlobPathForUpload(final AbstractRemoteWritableBlobEntity<RemotePinnedTimestamps.PinnedTimestamps> obj) {
+        return blobStoreRepository.basePath();
+    }
+}

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteStorePinnedTimestampsBlobStore.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteStorePinnedTimestampsBlobStore.java
@@ -9,7 +9,8 @@
 package org.opensearch.gateway.remote.model;
 
 import org.opensearch.common.blobstore.BlobPath;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.RemoteWriteableBlobEntity;
+import org.opensearch.common.remote.RemoteWriteableEntityBlobStore;
 import org.opensearch.index.translog.transfer.BlobStoreTransferService;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.threadpool.ThreadPool;
@@ -17,10 +18,11 @@ import org.opensearch.threadpool.ThreadPool;
 /**
  * Extends the RemoteClusterStateBlobStore to support {@link RemotePinnedTimestamps}
  */
-public class RemoteStorePinnedTimestampsBlobStore extends RemoteClusterStateBlobStore<
+public class RemoteStorePinnedTimestampsBlobStore extends RemoteWriteableEntityBlobStore<
     RemotePinnedTimestamps.PinnedTimestamps,
     RemotePinnedTimestamps> {
 
+    public static final String PINNED_TIMESTAMPS_PATH_TOKEN = "pinned_timestamps";
     private final BlobStoreRepository blobStoreRepository;
 
     public RemoteStorePinnedTimestampsBlobStore(
@@ -30,12 +32,12 @@ public class RemoteStorePinnedTimestampsBlobStore extends RemoteClusterStateBlob
         ThreadPool threadPool,
         String executor
     ) {
-        super(blobStoreTransferService, blobStoreRepository, clusterName, threadPool, executor);
+        super(blobStoreTransferService, blobStoreRepository, clusterName, threadPool, executor, PINNED_TIMESTAMPS_PATH_TOKEN);
         this.blobStoreRepository = blobStoreRepository;
     }
 
     @Override
-    public BlobPath getBlobPathForUpload(final AbstractRemoteWritableBlobEntity<RemotePinnedTimestamps.PinnedTimestamps> obj) {
-        return blobStoreRepository.basePath().add("pinned_timestamps");
+    public BlobPath getBlobPathForUpload(final RemoteWriteableBlobEntity<RemotePinnedTimestamps.PinnedTimestamps> obj) {
+        return blobStoreRepository.basePath().add(PINNED_TIMESTAMPS_PATH_TOKEN);
     }
 }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -785,7 +785,6 @@ public class Node implements Closeable {
             final RemoteClusterStateService remoteClusterStateService;
             final RemoteClusterStateCleanupManager remoteClusterStateCleanupManager;
             final RemoteIndexPathUploader remoteIndexPathUploader;
-            final RemoteStorePinnedTimestampService remoteStorePinnedTimestampService;
             if (isRemoteStoreClusterStateEnabled(settings)) {
                 remoteIndexPathUploader = new RemoteIndexPathUploader(
                     threadPool,
@@ -803,6 +802,14 @@ public class Node implements Closeable {
                     List.of(remoteIndexPathUploader),
                     namedWriteableRegistry
                 );
+                remoteClusterStateCleanupManager = remoteClusterStateService.getCleanupManager();
+            } else {
+                remoteClusterStateService = null;
+                remoteIndexPathUploader = null;
+                remoteClusterStateCleanupManager = null;
+            }
+            final RemoteStorePinnedTimestampService remoteStorePinnedTimestampService;
+            if (isRemoteStoreAttributePresent(settings)) {
                 remoteStorePinnedTimestampService = new RemoteStorePinnedTimestampService(
                     repositoriesServiceReference::get,
                     settings,
@@ -810,11 +817,7 @@ public class Node implements Closeable {
                     clusterService
                 );
                 resourcesToClose.add(remoteStorePinnedTimestampService);
-                remoteClusterStateCleanupManager = remoteClusterStateService.getCleanupManager();
             } else {
-                remoteClusterStateService = null;
-                remoteIndexPathUploader = null;
-                remoteClusterStateCleanupManager = null;
                 remoteStorePinnedTimestampService = null;
             }
 

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -185,6 +185,7 @@ import org.opensearch.monitor.fs.FsHealthService;
 import org.opensearch.monitor.fs.FsProbe;
 import org.opensearch.monitor.jvm.JvmInfo;
 import org.opensearch.node.remotestore.RemoteStoreNodeService;
+import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
 import org.opensearch.node.resource.tracker.NodeResourceUsageTracker;
 import org.opensearch.persistent.PersistentTasksClusterService;
 import org.opensearch.persistent.PersistentTasksExecutor;
@@ -784,6 +785,7 @@ public class Node implements Closeable {
             final RemoteClusterStateService remoteClusterStateService;
             final RemoteClusterStateCleanupManager remoteClusterStateCleanupManager;
             final RemoteIndexPathUploader remoteIndexPathUploader;
+            final RemoteStorePinnedTimestampService remoteStorePinnedTimestampService;
             if (isRemoteStoreClusterStateEnabled(settings)) {
                 remoteIndexPathUploader = new RemoteIndexPathUploader(
                     threadPool,
@@ -801,11 +803,19 @@ public class Node implements Closeable {
                     List.of(remoteIndexPathUploader),
                     namedWriteableRegistry
                 );
+                remoteStorePinnedTimestampService = new RemoteStorePinnedTimestampService(
+                    repositoriesServiceReference::get,
+                    settings,
+                    threadPool,
+                    clusterService
+                );
+                resourcesToClose.add(remoteStorePinnedTimestampService);
                 remoteClusterStateCleanupManager = remoteClusterStateService.getCleanupManager();
             } else {
                 remoteClusterStateService = null;
                 remoteIndexPathUploader = null;
                 remoteClusterStateCleanupManager = null;
+                remoteStorePinnedTimestampService = null;
             }
 
             // collect engine factory providers from plugins
@@ -1170,7 +1180,8 @@ public class Node implements Closeable {
                 clusterModule.getIndexNameExpressionResolver(),
                 repositoryService,
                 transportService,
-                actionModule.getActionFilters()
+                actionModule.getActionFilters(),
+                remoteStorePinnedTimestampService
             );
             SnapshotShardsService snapshotShardsService = new SnapshotShardsService(
                 settings,
@@ -1416,6 +1427,7 @@ public class Node implements Closeable {
                 b.bind(MetricsRegistry.class).toInstance(metricsRegistry);
                 b.bind(RemoteClusterStateService.class).toProvider(() -> remoteClusterStateService);
                 b.bind(RemoteIndexPathUploader.class).toProvider(() -> remoteIndexPathUploader);
+                b.bind(RemoteStorePinnedTimestampService.class).toProvider(() -> remoteStorePinnedTimestampService);
                 b.bind(RemoteClusterStateCleanupManager.class).toProvider(() -> remoteClusterStateCleanupManager);
                 b.bind(PersistedStateRegistry.class).toInstance(persistedStateRegistry);
                 b.bind(SegmentReplicationStatsTracker.class).toInstance(segmentReplicationStatsTracker);
@@ -1568,6 +1580,12 @@ public class Node implements Closeable {
         final RemoteIndexPathUploader remoteIndexPathUploader = injector.getInstance(RemoteIndexPathUploader.class);
         if (remoteIndexPathUploader != null) {
             remoteIndexPathUploader.start();
+        }
+        final RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = injector.getInstance(
+            RemoteStorePinnedTimestampService.class
+        );
+        if (remoteStorePinnedTimestampService != null) {
+            remoteStorePinnedTimestampService.start();
         }
         // Load (and maybe upgrade) the metadata stored on disk
         final GatewayMetaState gatewayMetaState = injector.getInstance(GatewayMetaState.class);

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -1,0 +1,279 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.node.remotestore;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.blobstore.BlobMetadata;
+import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.AbstractAsyncTask;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.gateway.remote.model.RemotePinnedTimestamps;
+import org.opensearch.gateway.remote.model.RemoteStorePinnedTimestampsBlobStore;
+import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.node.Node;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.repositories.Repository;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.isRemoteStoreClusterStateEnabled;
+
+/**
+ * Service for managing pinned timestamps in a remote store.
+ * This service handles pinning and unpinning of timestamps, as well as periodic updates of the pinned timestamps set.
+ *
+ * @opensearch.internal
+ */
+public class RemoteStorePinnedTimestampService implements Closeable {
+    private static final Logger logger = LogManager.getLogger(RemoteStorePinnedTimestampService.class);
+    private Tuple<Long, Set<Long>> pinnedTimestampsSet = new Tuple<>(-1L, Set.of());
+    public static final int PINNED_TIMESTAMP_FILES_TO_KEEP = 5;
+
+    private final Supplier<RepositoriesService> repositoriesService;
+    private final Settings settings;
+    private final ThreadPool threadPool;
+    private final ClusterService clusterService;
+    private BlobStoreRepository blobStoreRepository;
+    private BlobStoreTransferService blobStoreTransferService;
+    private RemoteStorePinnedTimestampsBlobStore pinnedTimestampsBlobStore;
+    private AsyncUpdatePinnedTimestampTask asyncUpdatePinnedTimestampTask;
+    private volatile TimeValue pinnedTimestampsSchedulerInterval;
+
+    /**
+     * Controls pinned timestamp scheduler interval
+     */
+    public static final Setting<TimeValue> CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL = Setting.timeSetting(
+        "cluster.remote_store.pinned_timestamps.scheduler_interval",
+        TimeValue.timeValueMinutes(3),
+        TimeValue.timeValueMinutes(1),
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    public RemoteStorePinnedTimestampService(
+        Supplier<RepositoriesService> repositoriesService,
+        Settings settings,
+        ThreadPool threadPool,
+        ClusterService clusterService
+    ) {
+        this.repositoriesService = repositoriesService;
+        this.settings = settings;
+        this.threadPool = threadPool;
+        this.clusterService = clusterService;
+
+        pinnedTimestampsSchedulerInterval = CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL.get(settings);
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL,
+                this::setPinnedTimestampsSchedulerInterval
+            );
+    }
+
+    /**
+     * Starts the RemoteStorePinnedTimestampService.
+     * This method validates the remote store configuration, initializes components,
+     * and starts the asynchronous update task.
+     */
+    public void start() {
+        validateRemoteStoreConfiguration();
+        initializeComponents();
+        startAsyncUpdateTask();
+    }
+
+    private void validateRemoteStoreConfiguration() {
+        assert isRemoteStoreClusterStateEnabled(settings) : "Remote cluster state is not enabled";
+        final String remoteStoreRepo = settings.get(
+            Node.NODE_ATTRIBUTES.getKey() + RemoteStoreNodeAttribute.REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY
+        );
+        assert remoteStoreRepo != null : "Remote Cluster State repository is not configured";
+        final Repository repository = repositoriesService.get().repository(remoteStoreRepo);
+        assert repository instanceof BlobStoreRepository : "Repository should be instance of BlobStoreRepository";
+        blobStoreRepository = (BlobStoreRepository) repository;
+    }
+
+    private void initializeComponents() {
+        String clusterName = ClusterName.CLUSTER_NAME_SETTING.get(settings).value();
+        blobStoreTransferService = new BlobStoreTransferService(blobStoreRepository.blobStore(), this.threadPool);
+        pinnedTimestampsBlobStore = new RemoteStorePinnedTimestampsBlobStore(
+            blobStoreTransferService,
+            blobStoreRepository,
+            clusterName,
+            this.threadPool,
+            ThreadPool.Names.REMOTE_STATE_READ
+        );
+    }
+
+    private void startAsyncUpdateTask() {
+        asyncUpdatePinnedTimestampTask = new AsyncUpdatePinnedTimestampTask(logger, threadPool, pinnedTimestampsSchedulerInterval, true);
+    }
+
+    /**
+     * Pins a timestamp in the remote store.
+     *
+     * @param timestamp The timestamp to be pinned
+     * @param pinningEntity The entity responsible for pinning the timestamp
+     * @param listener A listener to be notified when the pinning operation completes
+     * @throws IOException If an I/O error occurs during the pinning process
+     * @throws IllegalArgumentException If the timestamp is less than the current time minus one second
+     */
+    public void pinTimestamp(long timestamp, String pinningEntity, ActionListener<Void> listener) throws IOException {
+        if (timestamp < System.currentTimeMillis() - 1000) {
+            throw new IllegalArgumentException("Timestamp to be pinned is less than current timestamp");
+        }
+        updatePinning(pinnedTimestamps -> pinnedTimestamps.pin(timestamp, pinningEntity), listener);
+    }
+
+    /**
+     * Unpins a timestamp from the remote store.
+     *
+     * @param timestamp The timestamp to be unpinned
+     * @param pinningEntity The entity responsible for unpinning the timestamp
+     * @param listener A listener to be notified when the unpinning operation completes
+     */
+    public void unpinTimestamp(long timestamp, String pinningEntity, ActionListener<Void> listener) {
+        updatePinning(pinnedTimestamps -> pinnedTimestamps.unpin(timestamp, pinningEntity), listener);
+    }
+
+    private void updatePinning(Consumer<RemotePinnedTimestamps.PinnedTimestamps> updateConsumer, ActionListener<Void> listener) {
+        RemotePinnedTimestamps remotePinnedTimestamps = new RemotePinnedTimestamps(
+            clusterService.state().metadata().clusterUUID(),
+            blobStoreRepository.getCompressor(),
+            blobStoreRepository.getNamedXContentRegistry()
+        );
+        BlobPath path = pinnedTimestampsBlobStore.getBlobPathForUpload(remotePinnedTimestamps);
+        blobStoreTransferService.listAllInSortedOrder(path, remotePinnedTimestamps.getType(), Integer.MAX_VALUE, new ActionListener<>() {
+            @Override
+            public void onResponse(List<BlobMetadata> blobMetadata) {
+                RemotePinnedTimestamps.PinnedTimestamps pinnedTimestamps = remotePinnedTimestamps.getPinnedTimestamps();
+                if (blobMetadata.isEmpty() == false) {
+                    pinnedTimestamps = readExistingPinnedTimestamps(blobMetadata.get(0).name(), remotePinnedTimestamps);
+                }
+                updateConsumer.accept(pinnedTimestamps);
+                remotePinnedTimestamps.setPinnedTimestamps(pinnedTimestamps);
+                pinnedTimestampsBlobStore.writeAsync(remotePinnedTimestamps, listener);
+
+                // Delete older pinnedTimestamp files
+                if (blobMetadata.size() > PINNED_TIMESTAMP_FILES_TO_KEEP) {
+                    List<String> oldFilesToBeDeleted = blobMetadata.subList(PINNED_TIMESTAMP_FILES_TO_KEEP, blobMetadata.size())
+                        .stream()
+                        .map(BlobMetadata::name)
+                        .collect(Collectors.toList());
+                    try {
+                        blobStoreTransferService.deleteBlobs(
+                            pinnedTimestampsBlobStore.getBlobPathForUpload(remotePinnedTimestamps),
+                            oldFilesToBeDeleted
+                        );
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    private RemotePinnedTimestamps.PinnedTimestamps readExistingPinnedTimestamps(
+        String blobFilename,
+        RemotePinnedTimestamps remotePinnedTimestamps
+    ) {
+        remotePinnedTimestamps.setBlobFileName(blobFilename);
+        remotePinnedTimestamps.setFullBlobName(pinnedTimestampsBlobStore.getBlobPathForUpload(remotePinnedTimestamps));
+        try {
+            return pinnedTimestampsBlobStore.read(remotePinnedTimestamps);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read existing pinned timestamps", e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        asyncUpdatePinnedTimestampTask.close();
+    }
+
+    public void setPinnedTimestampsSchedulerInterval(TimeValue pinnedTimestampsSchedulerInterval) {
+        this.pinnedTimestampsSchedulerInterval = pinnedTimestampsSchedulerInterval;
+        rescheduleAsyncUpdatePinnedTimestampTask();
+    }
+
+    private void rescheduleAsyncUpdatePinnedTimestampTask() {
+        if (pinnedTimestampsSchedulerInterval != null) {
+            pinnedTimestampsSet = new Tuple<>(-1L, Set.of());
+            asyncUpdatePinnedTimestampTask.close();
+            startAsyncUpdateTask();
+        }
+    }
+
+    /**
+     * Inner class for asynchronously updating the pinned timestamp set.
+     */
+    private final class AsyncUpdatePinnedTimestampTask extends AbstractAsyncTask {
+        private AsyncUpdatePinnedTimestampTask(Logger logger, ThreadPool threadPool, TimeValue interval, boolean autoReschedule) {
+            super(logger, threadPool, interval, autoReschedule);
+            rescheduleIfNecessary();
+        }
+
+        @Override
+        protected boolean mustReschedule() {
+            return true;
+        }
+
+        @Override
+        protected void runInternal() {
+            long triggerTimestamp = System.currentTimeMillis();
+            RemotePinnedTimestamps remotePinnedTimestamps = new RemotePinnedTimestamps(
+                clusterService.state().metadata().clusterUUID(),
+                blobStoreRepository.getCompressor(),
+                blobStoreRepository.getNamedXContentRegistry()
+            );
+            BlobPath path = pinnedTimestampsBlobStore.getBlobPathForUpload(remotePinnedTimestamps);
+            blobStoreTransferService.listAllInSortedOrder(path, remotePinnedTimestamps.getType(), 1, new ActionListener<>() {
+                @Override
+                public void onResponse(List<BlobMetadata> blobMetadata) {
+                    if (blobMetadata.isEmpty()) {
+                        return;
+                    }
+                    RemotePinnedTimestamps.PinnedTimestamps pinnedTimestamps = readExistingPinnedTimestamps(
+                        blobMetadata.get(0).name(),
+                        remotePinnedTimestamps
+                    );
+                    logger.debug(
+                        "Fetched pinned timestamps from remote store: {} - {}",
+                        triggerTimestamp,
+                        pinnedTimestamps.getPinnedTimestampPinningEntityMap().keySet()
+                    );
+                    pinnedTimestampsSet = new Tuple<>(triggerTimestamp, pinnedTimestamps.getPinnedTimestampPinningEntityMap().keySet());
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    logger.error("Exception while listing pinned timestamp files", e);
+                }
+            });
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -184,7 +184,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
                             oldFilesToBeDeleted
                         );
                     } catch (IOException e) {
-                        throw new RuntimeException(e);
+                        logger.error("Exception while deleting stale pinned timestamps", e);
                     }
                 }
             }

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -158,8 +158,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
     private void updatePinning(Consumer<RemotePinnedTimestamps.PinnedTimestamps> updateConsumer, ActionListener<Void> listener) {
         RemotePinnedTimestamps remotePinnedTimestamps = new RemotePinnedTimestamps(
             clusterService.state().metadata().clusterUUID(),
-            blobStoreRepository.getCompressor(),
-            blobStoreRepository.getNamedXContentRegistry()
+            blobStoreRepository.getCompressor()
         );
         BlobPath path = pinnedTimestampsBlobStore.getBlobPathForUpload(remotePinnedTimestamps);
         blobStoreTransferService.listAllInSortedOrder(path, remotePinnedTimestamps.getType(), Integer.MAX_VALUE, new ActionListener<>() {
@@ -252,8 +251,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
             long triggerTimestamp = System.currentTimeMillis();
             RemotePinnedTimestamps remotePinnedTimestamps = new RemotePinnedTimestamps(
                 clusterService.state().metadata().clusterUUID(),
-                blobStoreRepository.getCompressor(),
-                blobStoreRepository.getNamedXContentRegistry()
+                blobStoreRepository.getCompressor()
             );
             BlobPath path = pinnedTimestampsBlobStore.getBlobPathForUpload(remotePinnedTimestamps);
             blobStoreTransferService.listAllInSortedOrder(path, remotePinnedTimestamps.getType(), 1, new ActionListener<>() {

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -67,8 +67,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
         "cluster.remote_store.pinned_timestamps.scheduler_interval",
         TimeValue.timeValueMinutes(3),
         TimeValue.timeValueMinutes(1),
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.NodeScope
     );
 
     public RemoteStorePinnedTimestampService(
@@ -83,11 +82,6 @@ public class RemoteStorePinnedTimestampService implements Closeable {
         this.clusterService = clusterService;
 
         pinnedTimestampsSchedulerInterval = CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL.get(settings);
-        clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(
-                CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL,
-                this::setPinnedTimestampsSchedulerInterval
-            );
     }
 
     /**

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -40,8 +40,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.isRemoteStoreClusterStateEnabled;
-
 /**
  * Service for managing pinned timestamps in a remote store.
  * This service handles pinning and unpinning of timestamps, as well as periodic updates of the pinned timestamps set.
@@ -100,9 +98,8 @@ public class RemoteStorePinnedTimestampService implements Closeable {
     }
 
     private void validateRemoteStoreConfiguration() {
-        assert isRemoteStoreClusterStateEnabled(settings) : "Remote cluster state is not enabled";
         final String remoteStoreRepo = settings.get(
-            Node.NODE_ATTRIBUTES.getKey() + RemoteStoreNodeAttribute.REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY
+            Node.NODE_ATTRIBUTES.getKey() + RemoteStoreNodeAttribute.REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY
         );
         assert remoteStoreRepo != null : "Remote Cluster State repository is not configured";
         final Repository repository = repositoriesService.get().repository(remoteStoreRepo);
@@ -132,7 +129,6 @@ public class RemoteStorePinnedTimestampService implements Closeable {
      * @param timestamp The timestamp to be pinned
      * @param pinningEntity The entity responsible for pinning the timestamp
      * @param listener A listener to be notified when the pinning operation completes
-     * @throws IOException If an I/O error occurs during the pinning process
      * @throws IllegalArgumentException If the timestamp is less than the current time minus one second
      */
     public void pinTimestamp(long timestamp, String pinningEntity, ActionListener<Void> listener) {

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -47,7 +47,7 @@ import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.isRemoteS
  */
 public class RemoteStorePinnedTimestampService implements Closeable {
     private static final Logger logger = LogManager.getLogger(RemoteStorePinnedTimestampService.class);
-    private Tuple<Long, Set<Long>> pinnedTimestampsSet = new Tuple<>(-1L, Set.of());
+    private static Tuple<Long, Set<Long>> pinnedTimestampsSet = new Tuple<>(-1L, Set.of());
     public static final int PINNED_TIMESTAMP_FILES_TO_KEEP = 5;
 
     private final Supplier<RepositoriesService> repositoriesService;
@@ -215,6 +215,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
         asyncUpdatePinnedTimestampTask.close();
     }
 
+    // Visible for testing
     public void setPinnedTimestampsSchedulerInterval(TimeValue pinnedTimestampsSchedulerInterval) {
         this.pinnedTimestampsSchedulerInterval = pinnedTimestampsSchedulerInterval;
         rescheduleAsyncUpdatePinnedTimestampTask();
@@ -226,6 +227,10 @@ public class RemoteStorePinnedTimestampService implements Closeable {
             asyncUpdatePinnedTimestampTask.close();
             startAsyncUpdateTask();
         }
+    }
+
+    public static Tuple<Long, Set<Long>> getPinnedTimestamps() {
+        return pinnedTimestampsSet;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -92,6 +92,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.store.lockmanager.RemoteStoreLockManagerFactory;
+import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
 import org.opensearch.repositories.IndexId;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
@@ -180,6 +181,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     private final UpdateSnapshotStatusAction updateSnapshotStatusHandler;
 
     private final TransportService transportService;
+    private final RemoteStorePinnedTimestampService remoteStorePinnedTimestampService;
 
     private final OngoingRepositoryOperations repositoryOperations = new OngoingRepositoryOperations();
 
@@ -210,12 +212,25 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         TransportService transportService,
         ActionFilters actionFilters
     ) {
+        this(settings, clusterService, indexNameExpressionResolver, repositoriesService, transportService, actionFilters, null);
+    }
+
+    public SnapshotsService(
+        Settings settings,
+        ClusterService clusterService,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        RepositoriesService repositoriesService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService
+    ) {
         this.clusterService = clusterService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.repositoriesService = repositoriesService;
         this.remoteStoreLockManagerFactory = new RemoteStoreLockManagerFactory(() -> repositoriesService);
         this.threadPool = transportService.getThreadPool();
         this.transportService = transportService;
+        this.remoteStorePinnedTimestampService = remoteStorePinnedTimestampService;
 
         // The constructor of UpdateSnapshotStatusAction will register itself to the TransportService.
         this.updateSnapshotStatusHandler = new UpdateSnapshotStatusAction(

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -210,19 +210,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         IndexNameExpressionResolver indexNameExpressionResolver,
         RepositoriesService repositoriesService,
         TransportService transportService,
-        ActionFilters actionFilters
-    ) {
-        this(settings, clusterService, indexNameExpressionResolver, repositoriesService, transportService, actionFilters, null);
-    }
-
-    public SnapshotsService(
-        Settings settings,
-        ClusterService clusterService,
-        IndexNameExpressionResolver indexNameExpressionResolver,
-        RepositoriesService repositoriesService,
-        TransportService transportService,
         ActionFilters actionFilters,
-        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService
+        @Nullable RemoteStorePinnedTimestampService remoteStorePinnedTimestampService
     ) {
         this.clusterService = clusterService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;

--- a/server/src/test/java/org/opensearch/gateway/remote/model/RemotePinnedTimestampsTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/model/RemotePinnedTimestampsTests.java
@@ -13,7 +13,6 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.BytesStreamInput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.compress.Compressor;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 
@@ -24,8 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.mockito.Mockito.mock;
-
 public class RemotePinnedTimestampsTests extends OpenSearchTestCase {
 
     private RemotePinnedTimestamps remotePinnedTimestamps;
@@ -33,8 +30,7 @@ public class RemotePinnedTimestampsTests extends OpenSearchTestCase {
     @Before
     public void setup() {
         Compressor compressor = new DeflateCompressor();
-        NamedXContentRegistry mockNamedXContentRegistry = mock(NamedXContentRegistry.class);
-        remotePinnedTimestamps = new RemotePinnedTimestamps("testClusterUUID", compressor, mockNamedXContentRegistry);
+        remotePinnedTimestamps = new RemotePinnedTimestamps("testClusterUUID", compressor);
     }
 
     public void testGenerateBlobFileName() {

--- a/server/src/test/java/org/opensearch/gateway/remote/model/RemotePinnedTimestampsTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/model/RemotePinnedTimestampsTests.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote.model;
+
+import org.opensearch.common.compress.DeflateCompressor;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.BytesStreamInput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.compress.Compressor;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+public class RemotePinnedTimestampsTests extends OpenSearchTestCase {
+
+    private RemotePinnedTimestamps remotePinnedTimestamps;
+
+    @Before
+    public void setup() {
+        Compressor compressor = new DeflateCompressor();
+        NamedXContentRegistry mockNamedXContentRegistry = mock(NamedXContentRegistry.class);
+        remotePinnedTimestamps = new RemotePinnedTimestamps("testClusterUUID", compressor, mockNamedXContentRegistry);
+    }
+
+    public void testGenerateBlobFileName() {
+        String fileName = remotePinnedTimestamps.generateBlobFileName();
+        assertTrue(fileName.startsWith(RemotePinnedTimestamps.PINNED_TIMESTAMPS));
+        assertEquals(fileName, remotePinnedTimestamps.getBlobFileName());
+    }
+
+    public void testSerializeAndDeserialize() throws IOException {
+        RemotePinnedTimestamps.PinnedTimestamps pinnedTimestamps = new RemotePinnedTimestamps.PinnedTimestamps(new HashMap<>());
+        pinnedTimestamps.pin(1000L, "entity1");
+        pinnedTimestamps.pin(2000L, "entity2");
+        remotePinnedTimestamps.setPinnedTimestamps(pinnedTimestamps);
+
+        InputStream serialized = remotePinnedTimestamps.serialize();
+        RemotePinnedTimestamps.PinnedTimestamps deserialized = remotePinnedTimestamps.deserialize(serialized);
+
+        assertEquals(pinnedTimestamps.getPinnedTimestampPinningEntityMap(), deserialized.getPinnedTimestampPinningEntityMap());
+    }
+
+    public void testSetAndGetPinnedTimestamps() {
+        RemotePinnedTimestamps.PinnedTimestamps pinnedTimestamps = new RemotePinnedTimestamps.PinnedTimestamps(new HashMap<>());
+        remotePinnedTimestamps.setPinnedTimestamps(pinnedTimestamps);
+        assertEquals(pinnedTimestamps, remotePinnedTimestamps.getPinnedTimestamps());
+    }
+
+    public void testPinnedTimestampsPin() {
+        RemotePinnedTimestamps.PinnedTimestamps pinnedTimestamps = new RemotePinnedTimestamps.PinnedTimestamps(new HashMap<>());
+        pinnedTimestamps.pin(1000L, "entity1");
+        pinnedTimestamps.pin(1000L, "entity2");
+        pinnedTimestamps.pin(2000L, "entity3");
+
+        Map<Long, List<String>> expected = new HashMap<>();
+        expected.put(1000L, Arrays.asList("entity1", "entity2"));
+        expected.put(2000L, List.of("entity3"));
+
+        assertEquals(expected, pinnedTimestamps.getPinnedTimestampPinningEntityMap());
+    }
+
+    public void testPinnedTimestampsUnpin() {
+        RemotePinnedTimestamps.PinnedTimestamps pinnedTimestamps = new RemotePinnedTimestamps.PinnedTimestamps(new HashMap<>());
+        pinnedTimestamps.pin(1000L, "entity1");
+        pinnedTimestamps.pin(1000L, "entity2");
+        pinnedTimestamps.pin(2000L, "entity3");
+
+        pinnedTimestamps.unpin(1000L, "entity1");
+        pinnedTimestamps.unpin(2000L, "entity3");
+
+        Map<Long, List<String>> expected = new HashMap<>();
+        expected.put(1000L, List.of("entity2"));
+
+        assertEquals(expected, pinnedTimestamps.getPinnedTimestampPinningEntityMap());
+    }
+
+    public void testPinnedTimestampsReadFromAndWriteTo() throws IOException {
+        RemotePinnedTimestamps.PinnedTimestamps original = new RemotePinnedTimestamps.PinnedTimestamps(new HashMap<>());
+        original.pin(1000L, "entity1");
+        original.pin(2000L, "entity2");
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+
+        StreamInput in = new BytesStreamInput(out.bytes().toBytesRef().bytes);
+        RemotePinnedTimestamps.PinnedTimestamps deserialized = RemotePinnedTimestamps.PinnedTimestamps.readFrom(in);
+
+        assertEquals(original.getPinnedTimestampPinningEntityMap(), deserialized.getPinnedTimestampPinningEntityMap());
+    }
+}

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -2015,7 +2015,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     indexNameExpressionResolver,
                     repositoriesService,
                     transportService,
-                    actionFilters
+                    actionFilters,
+                    null
                 );
                 nodeEnv = new NodeEnvironment(settings, environment);
                 final NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(Collections.emptyList());


### PR DESCRIPTION
### Description
- As part of [timestamp pinning ](https://github.com/opensearch-project/OpenSearch/issues/15057), we are adding support of pinning the timestamp for remote backed indices.
- In this PR, we introduce a service which provides APIs to `pin` and `unpin` the timestamp.
- Once the pinned timestamp list is updated, we need to modify in-memory data structure at each node. This is done by a scheduler which runs periodically and updates the local state.
- The periodicity of this scheduler is controlled by a dynamic cluster setting.

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/15061
- https://github.com/opensearch-project/OpenSearch/issues/15062

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
