### PR TITLE
add required distribution key in setup-java action

### DIFF
--- a/.github/workflows/benchmark-pull-request.yml
+++ b/.github/workflows/benchmark-pull-request.yml
@@ -129,6 +129,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
+          distribution: 'temurin'
       - name: Build and Assemble OpenSearch from PR
         run: |
           ./gradlew :distribution:archives:linux-tar:assemble -Dbuild.snapshot=false


### PR DESCRIPTION
### Description
There was recent dependabot update for `setup-java` action which updated the version from `v1` to `v4`. See 
https://github.com/opensearch-project/OpenSearch/pull/15104. 
The new version requires `distribution` key to be defined. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- ~[ ] Functionality includes testing.~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
