### PR TITLE
Refactor remote writeable entity and store to make it more reusable

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/remote/InternalRemoteRoutingTableService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/remote/InternalRemoteRoutingTableService.java
@@ -20,14 +20,15 @@ import org.opensearch.cluster.routing.RoutingTableIncrementalDiff;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.lifecycle.AbstractLifecycleComponent;
 import org.opensearch.common.remote.RemoteWritableEntityStore;
+import org.opensearch.common.remote.RemoteWriteableEntityBlobStore;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.gateway.remote.ClusterMetadataManifest;
+import org.opensearch.gateway.remote.RemoteClusterStateUtils;
 import org.opensearch.gateway.remote.RemoteStateTransferException;
-import org.opensearch.gateway.remote.model.RemoteClusterStateBlobStore;
 import org.opensearch.gateway.remote.model.RemoteRoutingTableBlobStore;
 import org.opensearch.gateway.remote.routingtable.RemoteIndexRoutingTable;
 import org.opensearch.gateway.remote.routingtable.RemoteRoutingTableDiff;
@@ -262,12 +263,13 @@ public class InternalRemoteRoutingTableService extends AbstractLifecycleComponen
             clusterSettings
         );
 
-        this.remoteRoutingTableDiffStore = new RemoteClusterStateBlobStore<>(
+        this.remoteRoutingTableDiffStore = new RemoteWriteableEntityBlobStore<>(
             new BlobStoreTransferService(blobStoreRepository.blobStore(), threadPool),
             blobStoreRepository,
             clusterName,
             threadPool,
-            ThreadPool.Names.REMOTE_STATE_READ
+            ThreadPool.Names.REMOTE_STATE_READ,
+            RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
         );
     }
 

--- a/server/src/main/java/org/opensearch/common/remote/AbstractClusterMetadataWriteableBlobEntity.java
+++ b/server/src/main/java/org/opensearch/common/remote/AbstractClusterMetadataWriteableBlobEntity.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.remote;
+
+import org.opensearch.core.compress.Compressor;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedMetadata;
+
+/**
+ * An extension of {@link RemoteWriteableEntity} class which caters to the use case of writing to and reading from a blob storage
+ *
+ * @param <T> The class type which can be uploaded to or downloaded from a blob storage.
+ */
+public abstract class AbstractClusterMetadataWriteableBlobEntity<T> extends RemoteWriteableBlobEntity<T> {
+
+    protected final NamedXContentRegistry namedXContentRegistry;
+
+    public AbstractClusterMetadataWriteableBlobEntity(
+        final String clusterUUID,
+        final Compressor compressor,
+        final NamedXContentRegistry namedXContentRegistry
+    ) {
+        super(clusterUUID, compressor);
+        this.namedXContentRegistry = namedXContentRegistry;
+    }
+
+    public AbstractClusterMetadataWriteableBlobEntity(final String clusterUUID, final Compressor compressor) {
+        super(clusterUUID, compressor);
+        this.namedXContentRegistry = null;
+    }
+
+    public abstract UploadedMetadata getUploadedMetadata();
+
+    public NamedXContentRegistry getNamedXContentRegistry() {
+        return namedXContentRegistry;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/remote/AbstractRemoteWritableEntityManager.java
+++ b/server/src/main/java/org/opensearch/common/remote/AbstractRemoteWritableEntityManager.java
@@ -31,7 +31,7 @@ public abstract class AbstractRemoteWritableEntityManager implements RemoteWrita
      * @return the remote writable entity store for the given entity
      * @throws IllegalArgumentException if the entity type is unknown
      */
-    protected RemoteWritableEntityStore getStore(AbstractRemoteWritableBlobEntity entity) {
+    protected RemoteWritableEntityStore getStore(AbstractClusterMetadataWriteableBlobEntity entity) {
         RemoteWritableEntityStore remoteStore = remoteWritableEntityStores.get(entity.getType());
         if (remoteStore == null) {
             throw new IllegalArgumentException("Unknown entity type [" + entity.getType() + "]");
@@ -49,7 +49,7 @@ public abstract class AbstractRemoteWritableEntityManager implements RemoteWrita
      */
     protected abstract ActionListener<Void> getWrappedWriteListener(
         String component,
-        AbstractRemoteWritableBlobEntity remoteEntity,
+        AbstractClusterMetadataWriteableBlobEntity remoteEntity,
         ActionListener<ClusterMetadataManifest.UploadedMetadata> listener
     );
 
@@ -64,21 +64,21 @@ public abstract class AbstractRemoteWritableEntityManager implements RemoteWrita
      */
     protected abstract ActionListener<Object> getWrappedReadListener(
         String component,
-        AbstractRemoteWritableBlobEntity remoteEntity,
+        AbstractClusterMetadataWriteableBlobEntity remoteEntity,
         ActionListener<RemoteReadResult> listener
     );
 
     @Override
     public void writeAsync(
         String component,
-        AbstractRemoteWritableBlobEntity entity,
+        AbstractClusterMetadataWriteableBlobEntity entity,
         ActionListener<ClusterMetadataManifest.UploadedMetadata> listener
     ) {
         getStore(entity).writeAsync(entity, getWrappedWriteListener(component, entity, listener));
     }
 
     @Override
-    public void readAsync(String component, AbstractRemoteWritableBlobEntity entity, ActionListener<RemoteReadResult> listener) {
+    public void readAsync(String component, AbstractClusterMetadataWriteableBlobEntity entity, ActionListener<RemoteReadResult> listener) {
         getStore(entity).readAsync(entity, getWrappedReadListener(component, entity, listener));
     }
 }

--- a/server/src/main/java/org/opensearch/common/remote/RemoteWritableEntityManager.java
+++ b/server/src/main/java/org/opensearch/common/remote/RemoteWritableEntityManager.java
@@ -29,7 +29,7 @@ public interface RemoteWritableEntityManager {
      *                 {@link ActionListener#onFailure(Exception)} method is called with
      *                 an exception if the read operation fails.
      */
-    void readAsync(String component, AbstractRemoteWritableBlobEntity entity, ActionListener<RemoteReadResult> listener);
+    void readAsync(String component, AbstractClusterMetadataWriteableBlobEntity entity, ActionListener<RemoteReadResult> listener);
 
     /**
      * Performs an asynchronous write operation for the specified component and entity.
@@ -43,5 +43,5 @@ public interface RemoteWritableEntityManager {
      *                 {@link ActionListener#onFailure(Exception)} method is called with
      *                 an exception if the write operation fails.
      */
-    void writeAsync(String component, AbstractRemoteWritableBlobEntity entity, ActionListener<UploadedMetadata> listener);
+    void writeAsync(String component, AbstractClusterMetadataWriteableBlobEntity entity, ActionListener<UploadedMetadata> listener);
 }

--- a/server/src/main/java/org/opensearch/common/remote/RemoteWriteableBlobEntity.java
+++ b/server/src/main/java/org/opensearch/common/remote/RemoteWriteableBlobEntity.java
@@ -10,38 +10,25 @@ package org.opensearch.common.remote;
 
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.core.compress.Compressor;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedMetadata;
 
 import static org.opensearch.gateway.remote.RemoteClusterStateUtils.PATH_DELIMITER;
 
 /**
- * An extension of {@link RemoteWriteableEntity} class which caters to the use case of writing to and reading from a blob storage
- *
- * @param <T> The class type which can be uploaded to or downloaded from a blob storage.
+ * The abstract class which represents a {@link RemoteWriteableEntity} that can be written to a store
+ * @param <T>
  */
-public abstract class AbstractRemoteWritableBlobEntity<T> implements RemoteWriteableEntity<T> {
+public abstract class RemoteWriteableBlobEntity<T> implements RemoteWriteableEntity<T> {
 
     protected String blobFileName;
 
     protected String blobName;
     private final String clusterUUID;
     private final Compressor compressor;
-    private final NamedXContentRegistry namedXContentRegistry;
     private String[] pathTokens;
 
-    public AbstractRemoteWritableBlobEntity(
-        final String clusterUUID,
-        final Compressor compressor,
-        final NamedXContentRegistry namedXContentRegistry
-    ) {
+    public RemoteWriteableBlobEntity(final String clusterUUID, final Compressor compressor) {
         this.clusterUUID = clusterUUID;
         this.compressor = compressor;
-        this.namedXContentRegistry = namedXContentRegistry;
-    }
-
-    public AbstractRemoteWritableBlobEntity(final String clusterUUID, final Compressor compressor) {
-        this(clusterUUID, compressor, null);
     }
 
     public abstract BlobPathParameters getBlobPathParameters();
@@ -80,14 +67,8 @@ public abstract class AbstractRemoteWritableBlobEntity<T> implements RemoteWrite
         return clusterUUID;
     }
 
-    public abstract UploadedMetadata getUploadedMetadata();
-
     public void setFullBlobName(BlobPath blobPath) {
         this.blobName = blobPath.buildAsString() + blobFileName;
-    }
-
-    public NamedXContentRegistry getNamedXContentRegistry() {
-        return namedXContentRegistry;
     }
 
     protected Compressor getCompressor() {

--- a/server/src/main/java/org/opensearch/common/remote/RemoteWriteableBlobEntity.java
+++ b/server/src/main/java/org/opensearch/common/remote/RemoteWriteableBlobEntity.java
@@ -15,7 +15,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.PATH_DELIMIT
 
 /**
  * The abstract class which represents a {@link RemoteWriteableEntity} that can be written to a store
- * @param <T>
+ * @param <T> the entity to be written
  */
 public abstract class RemoteWriteableBlobEntity<T> implements RemoteWriteableEntity<T> {
 

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateAttributesManager.java
@@ -11,12 +11,12 @@ package org.opensearch.gateway.remote;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.DiffableUtils;
 import org.opensearch.cluster.DiffableUtils.NonDiffableValueSerializer;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.AbstractRemoteWritableEntityManager;
+import org.opensearch.common.remote.RemoteWriteableEntityBlobStore;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.gateway.remote.model.RemoteClusterBlocks;
-import org.opensearch.gateway.remote.model.RemoteClusterStateBlobStore;
 import org.opensearch.gateway.remote.model.RemoteClusterStateCustoms;
 import org.opensearch.gateway.remote.model.RemoteDiscoveryNodes;
 import org.opensearch.gateway.remote.model.RemoteReadResult;
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.Map;
 
 /**
- * A Manager which provides APIs to upload and download attributes of ClusterState to the {@link RemoteClusterStateBlobStore}
+ * A Manager which provides APIs to upload and download attributes of ClusterState to the {@link RemoteWriteableEntityBlobStore}
  *
  * @opensearch.internal
  */
@@ -47,32 +47,35 @@ public class RemoteClusterStateAttributesManager extends AbstractRemoteWritableE
     ) {
         this.remoteWritableEntityStores.put(
             RemoteDiscoveryNodes.DISCOVERY_NODES,
-            new RemoteClusterStateBlobStore<>(
+            new RemoteWriteableEntityBlobStore<>(
                 blobStoreTransferService,
                 blobStoreRepository,
                 clusterName,
                 threadpool,
-                ThreadPool.Names.REMOTE_STATE_READ
+                ThreadPool.Names.REMOTE_STATE_READ,
+                RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
             )
         );
         this.remoteWritableEntityStores.put(
             RemoteClusterBlocks.CLUSTER_BLOCKS,
-            new RemoteClusterStateBlobStore<>(
+            new RemoteWriteableEntityBlobStore<>(
                 blobStoreTransferService,
                 blobStoreRepository,
                 clusterName,
                 threadpool,
-                ThreadPool.Names.REMOTE_STATE_READ
+                ThreadPool.Names.REMOTE_STATE_READ,
+                RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
             )
         );
         this.remoteWritableEntityStores.put(
             RemoteClusterStateCustoms.CLUSTER_STATE_CUSTOM,
-            new RemoteClusterStateBlobStore<>(
+            new RemoteWriteableEntityBlobStore<>(
                 blobStoreTransferService,
                 blobStoreRepository,
                 clusterName,
                 threadpool,
-                ThreadPool.Names.REMOTE_STATE_READ
+                ThreadPool.Names.REMOTE_STATE_READ,
+                RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
             )
         );
     }
@@ -80,7 +83,7 @@ public class RemoteClusterStateAttributesManager extends AbstractRemoteWritableE
     @Override
     protected ActionListener<Void> getWrappedWriteListener(
         String component,
-        AbstractRemoteWritableBlobEntity remoteEntity,
+        AbstractClusterMetadataWriteableBlobEntity remoteEntity,
         ActionListener<ClusterMetadataManifest.UploadedMetadata> listener
     ) {
         return ActionListener.wrap(
@@ -92,7 +95,7 @@ public class RemoteClusterStateAttributesManager extends AbstractRemoteWritableE
     @Override
     protected ActionListener<Object> getWrappedReadListener(
         String component,
-        AbstractRemoteWritableBlobEntity remoteEntity,
+        AbstractClusterMetadataWriteableBlobEntity remoteEntity,
         ActionListener<RemoteReadResult> listener
     ) {
         return ActionListener.wrap(

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManager.java
@@ -16,8 +16,9 @@ import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.Metadata.Custom;
 import org.opensearch.cluster.metadata.Metadata.XContentContext;
 import org.opensearch.cluster.metadata.TemplatesMetadata;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.AbstractRemoteWritableEntityManager;
+import org.opensearch.common.remote.RemoteWriteableEntityBlobStore;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
@@ -26,7 +27,6 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.gateway.remote.model.RemoteClusterStateBlobStore;
 import org.opensearch.gateway.remote.model.RemoteCoordinationMetadata;
 import org.opensearch.gateway.remote.model.RemoteCustomMetadata;
 import org.opensearch.gateway.remote.model.RemoteGlobalMetadata;
@@ -85,72 +85,79 @@ public class RemoteGlobalMetadataManager extends AbstractRemoteWritableEntityMan
         this.namedWriteableRegistry = namedWriteableRegistry;
         this.remoteWritableEntityStores.put(
             RemoteGlobalMetadata.GLOBAL_METADATA,
-            new RemoteClusterStateBlobStore<>(
+            new RemoteWriteableEntityBlobStore<>(
                 blobStoreTransferService,
                 blobStoreRepository,
                 clusterName,
                 threadpool,
-                ThreadPool.Names.REMOTE_STATE_READ
+                ThreadPool.Names.REMOTE_STATE_READ,
+                RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
             )
         );
         this.remoteWritableEntityStores.put(
             RemoteCoordinationMetadata.COORDINATION_METADATA,
-            new RemoteClusterStateBlobStore<>(
+            new RemoteWriteableEntityBlobStore<>(
                 blobStoreTransferService,
                 blobStoreRepository,
                 clusterName,
                 threadpool,
-                ThreadPool.Names.REMOTE_STATE_READ
+                ThreadPool.Names.REMOTE_STATE_READ,
+                RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
             )
         );
         this.remoteWritableEntityStores.put(
             RemotePersistentSettingsMetadata.SETTING_METADATA,
-            new RemoteClusterStateBlobStore<>(
+            new RemoteWriteableEntityBlobStore<>(
                 blobStoreTransferService,
                 blobStoreRepository,
                 clusterName,
                 threadpool,
-                ThreadPool.Names.REMOTE_STATE_READ
+                ThreadPool.Names.REMOTE_STATE_READ,
+                RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
             )
         );
         this.remoteWritableEntityStores.put(
             RemoteTransientSettingsMetadata.TRANSIENT_SETTING_METADATA,
-            new RemoteClusterStateBlobStore<>(
+            new RemoteWriteableEntityBlobStore<>(
                 blobStoreTransferService,
                 blobStoreRepository,
                 clusterName,
                 threadpool,
-                ThreadPool.Names.REMOTE_STATE_READ
+                ThreadPool.Names.REMOTE_STATE_READ,
+                RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
             )
         );
         this.remoteWritableEntityStores.put(
             RemoteHashesOfConsistentSettings.HASHES_OF_CONSISTENT_SETTINGS,
-            new RemoteClusterStateBlobStore<>(
+            new RemoteWriteableEntityBlobStore<>(
                 blobStoreTransferService,
                 blobStoreRepository,
                 clusterName,
                 threadpool,
-                ThreadPool.Names.REMOTE_STATE_READ
+                ThreadPool.Names.REMOTE_STATE_READ,
+                RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
             )
         );
         this.remoteWritableEntityStores.put(
             RemoteTemplatesMetadata.TEMPLATES_METADATA,
-            new RemoteClusterStateBlobStore<>(
+            new RemoteWriteableEntityBlobStore<>(
                 blobStoreTransferService,
                 blobStoreRepository,
                 clusterName,
                 threadpool,
-                ThreadPool.Names.REMOTE_STATE_READ
+                ThreadPool.Names.REMOTE_STATE_READ,
+                RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
             )
         );
         this.remoteWritableEntityStores.put(
             RemoteCustomMetadata.CUSTOM_METADATA,
-            new RemoteClusterStateBlobStore<>(
+            new RemoteWriteableEntityBlobStore<>(
                 blobStoreTransferService,
                 blobStoreRepository,
                 clusterName,
                 threadpool,
-                ThreadPool.Names.REMOTE_STATE_READ
+                ThreadPool.Names.REMOTE_STATE_READ,
+                RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
             )
         );
         clusterSettings.addSettingsUpdateConsumer(GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING, this::setGlobalMetadataUploadTimeout);
@@ -159,7 +166,7 @@ public class RemoteGlobalMetadataManager extends AbstractRemoteWritableEntityMan
     @Override
     protected ActionListener<Void> getWrappedWriteListener(
         String component,
-        AbstractRemoteWritableBlobEntity remoteEntity,
+        AbstractClusterMetadataWriteableBlobEntity remoteEntity,
         ActionListener<ClusterMetadataManifest.UploadedMetadata> listener
     ) {
         return ActionListener.wrap(
@@ -171,7 +178,7 @@ public class RemoteGlobalMetadataManager extends AbstractRemoteWritableEntityMan
     @Override
     protected ActionListener<Object> getWrappedReadListener(
         String component,
-        AbstractRemoteWritableBlobEntity remoteEntity,
+        AbstractClusterMetadataWriteableBlobEntity remoteEntity,
         ActionListener<RemoteReadResult> listener
     ) {
         return ActionListener.wrap(

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteIndexMetadataManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteIndexMetadataManager.java
@@ -9,15 +9,15 @@
 package org.opensearch.gateway.remote;
 
 import org.opensearch.cluster.metadata.IndexMetadata;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.AbstractRemoteWritableEntityManager;
+import org.opensearch.common.remote.RemoteWriteableEntityBlobStore;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.gateway.remote.model.RemoteClusterStateBlobStore;
 import org.opensearch.gateway.remote.model.RemoteIndexMetadata;
 import org.opensearch.gateway.remote.model.RemoteReadResult;
 import org.opensearch.index.translog.transfer.BlobStoreTransferService;
@@ -58,12 +58,13 @@ public class RemoteIndexMetadataManager extends AbstractRemoteWritableEntityMana
     ) {
         this.remoteWritableEntityStores.put(
             RemoteIndexMetadata.INDEX,
-            new RemoteClusterStateBlobStore<>(
+            new RemoteWriteableEntityBlobStore<>(
                 blobStoreTransferService,
                 blobStoreRepository,
                 clusterName,
                 threadpool,
-                ThreadPool.Names.REMOTE_STATE_READ
+                ThreadPool.Names.REMOTE_STATE_READ,
+                RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
             )
         );
         this.namedXContentRegistry = blobStoreRepository.getNamedXContentRegistry();
@@ -106,7 +107,7 @@ public class RemoteIndexMetadataManager extends AbstractRemoteWritableEntityMana
     @Override
     protected ActionListener<Void> getWrappedWriteListener(
         String component,
-        AbstractRemoteWritableBlobEntity remoteEntity,
+        AbstractClusterMetadataWriteableBlobEntity remoteEntity,
         ActionListener<ClusterMetadataManifest.UploadedMetadata> listener
     ) {
         return ActionListener.wrap(
@@ -118,7 +119,7 @@ public class RemoteIndexMetadataManager extends AbstractRemoteWritableEntityMana
     @Override
     protected ActionListener<Object> getWrappedReadListener(
         String component,
-        AbstractRemoteWritableBlobEntity remoteEntity,
+        AbstractClusterMetadataWriteableBlobEntity remoteEntity,
         ActionListener<RemoteReadResult> listener
     ) {
         return ActionListener.wrap(

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteManifestManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteManifestManager.java
@@ -16,6 +16,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.remote.RemoteWriteableEntityBlobStore;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.TimeValue;
@@ -23,7 +24,6 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.gateway.remote.model.RemoteClusterMetadataManifest;
-import org.opensearch.gateway.remote.model.RemoteClusterStateBlobStore;
 import org.opensearch.gateway.remote.model.RemoteClusterStateManifestInfo;
 import org.opensearch.index.remote.RemoteStoreUtils;
 import org.opensearch.index.translog.transfer.BlobStoreTransferService;
@@ -62,7 +62,7 @@ public class RemoteManifestManager {
 
     private volatile TimeValue metadataManifestUploadTimeout;
     private final String nodeId;
-    private final RemoteClusterStateBlobStore<ClusterMetadataManifest, RemoteClusterMetadataManifest> manifestBlobStore;
+    private final RemoteWriteableEntityBlobStore<ClusterMetadataManifest, RemoteClusterMetadataManifest> manifestBlobStore;
     private final Compressor compressor;
     private final NamedXContentRegistry namedXContentRegistry;
     // todo remove blobStorerepo from here
@@ -78,12 +78,13 @@ public class RemoteManifestManager {
     ) {
         this.metadataManifestUploadTimeout = clusterSettings.get(METADATA_MANIFEST_UPLOAD_TIMEOUT_SETTING);
         this.nodeId = nodeId;
-        this.manifestBlobStore = new RemoteClusterStateBlobStore<>(
+        this.manifestBlobStore = new RemoteWriteableEntityBlobStore<>(
             blobStoreTransferService,
             blobStoreRepository,
             clusterName,
             threadpool,
-            ThreadPool.Names.REMOTE_STATE_READ
+            ThreadPool.Names.REMOTE_STATE_READ,
+            RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
         );
         ;
         clusterSettings.addSettingsUpdateConsumer(METADATA_MANIFEST_UPLOAD_TIMEOUT_SETTING, this::setMetadataManifestUploadTimeout);

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterBlocks.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterBlocks.java
@@ -10,7 +10,7 @@ package org.opensearch.gateway.remote.model;
 
 import org.opensearch.cluster.block.ClusterBlocks;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedMetadata;
@@ -29,7 +29,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
 /**
  * Wrapper class for uploading/downloading {@link ClusterBlocks} to/from remote blob store
  */
-public class RemoteClusterBlocks extends AbstractRemoteWritableBlobEntity<ClusterBlocks> {
+public class RemoteClusterBlocks extends AbstractClusterMetadataWriteableBlobEntity<ClusterBlocks> {
 
     public static final String CLUSTER_BLOCKS = "blocks";
     public static final ChecksumWritableBlobStoreFormat<ClusterBlocks> CLUSTER_BLOCKS_FORMAT = new ChecksumWritableBlobStoreFormat<>(

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterMetadataManifest.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterMetadataManifest.java
@@ -9,7 +9,7 @@
 package org.opensearch.gateway.remote.model;
 
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -29,7 +29,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
 /**
  * Wrapper class for uploading/downloading {@link ClusterMetadataManifest} to/from remote blob store
  */
-public class RemoteClusterMetadataManifest extends AbstractRemoteWritableBlobEntity<ClusterMetadataManifest> {
+public class RemoteClusterMetadataManifest extends AbstractClusterMetadataWriteableBlobEntity<ClusterMetadataManifest> {
 
     public static final String MANIFEST = "manifest";
     public static final int SPLITTED_MANIFEST_FILE_LENGTH = 6;

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterStateCustoms.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteClusterStateCustoms.java
@@ -11,7 +11,7 @@ package org.opensearch.gateway.remote.model;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterState.Custom;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -32,7 +32,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
 /**
  * Wrapper class for uploading/downloading {@link Custom} to/from remote blob store
  */
-public class RemoteClusterStateCustoms extends AbstractRemoteWritableBlobEntity<Custom> {
+public class RemoteClusterStateCustoms extends AbstractClusterMetadataWriteableBlobEntity<Custom> {
     public static final String CLUSTER_STATE_CUSTOM = "cluster-state-custom";
     public final ChecksumWritableBlobStoreFormat<ClusterState.Custom> clusterStateCustomsFormat;
 

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteCoordinationMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteCoordinationMetadata.java
@@ -10,7 +10,7 @@ package org.opensearch.gateway.remote.model;
 
 import org.opensearch.cluster.coordination.CoordinationMetadata;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -31,7 +31,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAM
 /**
  * Wrapper class for uploading/downloading {@link CoordinationMetadata} to/from remote blob store
  */
-public class RemoteCoordinationMetadata extends AbstractRemoteWritableBlobEntity<CoordinationMetadata> {
+public class RemoteCoordinationMetadata extends AbstractClusterMetadataWriteableBlobEntity<CoordinationMetadata> {
 
     public static final String COORDINATION_METADATA = "coordination";
     public static final ChecksumBlobStoreFormat<CoordinationMetadata> COORDINATION_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteCustomMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteCustomMetadata.java
@@ -10,7 +10,7 @@ package org.opensearch.gateway.remote.model;
 
 import org.opensearch.cluster.metadata.Metadata.Custom;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
@@ -32,7 +32,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.GLOBAL_METAD
 /**
  * Wrapper class for uploading/downloading {@link Custom} to/from remote blob store
  */
-public class RemoteCustomMetadata extends AbstractRemoteWritableBlobEntity<Custom> {
+public class RemoteCustomMetadata extends AbstractClusterMetadataWriteableBlobEntity<Custom> {
 
     public static final String CUSTOM_METADATA = "custom";
     public static final String CUSTOM_DELIMITER = "--";

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteDiscoveryNodes.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteDiscoveryNodes.java
@@ -10,7 +10,7 @@ package org.opensearch.gateway.remote.model;
 
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.gateway.remote.ClusterMetadataManifest.UploadedMetadata;
@@ -29,7 +29,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
 /**
  * Wrapper class for uploading/downloading {@link DiscoveryNodes} to/from remote blob store
  */
-public class RemoteDiscoveryNodes extends AbstractRemoteWritableBlobEntity<DiscoveryNodes> {
+public class RemoteDiscoveryNodes extends AbstractClusterMetadataWriteableBlobEntity<DiscoveryNodes> {
 
     public static final String DISCOVERY_NODES = "nodes";
     public static final ChecksumWritableBlobStoreFormat<DiscoveryNodes> DISCOVERY_NODES_FORMAT = new ChecksumWritableBlobStoreFormat<>(

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteGlobalMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteGlobalMetadata.java
@@ -10,7 +10,7 @@ package org.opensearch.gateway.remote.model;
 
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -25,7 +25,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAM
 /**
  * Wrapper class for uploading/downloading global metadata ({@link Metadata}) to/from remote blob store
  */
-public class RemoteGlobalMetadata extends AbstractRemoteWritableBlobEntity<Metadata> {
+public class RemoteGlobalMetadata extends AbstractClusterMetadataWriteableBlobEntity<Metadata> {
     public static final String GLOBAL_METADATA = "global_metadata";
 
     public static final ChecksumBlobStoreFormat<Metadata> GLOBAL_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteHashesOfConsistentSettings.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteHashesOfConsistentSettings.java
@@ -10,7 +10,7 @@ package org.opensearch.gateway.remote.model;
 
 import org.opensearch.cluster.metadata.DiffableStringMap;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.gateway.remote.ClusterMetadataManifest;
@@ -28,7 +28,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.GLOBAL_METAD
 /**
  * Wrapper class for uploading/downloading {@link DiffableStringMap} to/from remote blob store
  */
-public class RemoteHashesOfConsistentSettings extends AbstractRemoteWritableBlobEntity<DiffableStringMap> {
+public class RemoteHashesOfConsistentSettings extends AbstractClusterMetadataWriteableBlobEntity<DiffableStringMap> {
     public static final String HASHES_OF_CONSISTENT_SETTINGS = "hashes-of-consistent-settings";
     public static final ChecksumWritableBlobStoreFormat<DiffableStringMap> HASHES_OF_CONSISTENT_SETTINGS_FORMAT =
         new ChecksumWritableBlobStoreFormat<>("hashes-of-consistent-settings", DiffableStringMap::readFrom);

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteIndexMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteIndexMetadata.java
@@ -10,7 +10,7 @@ package org.opensearch.gateway.remote.model;
 
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -29,7 +29,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAM
 /**
  * Wrapper class for uploading/downloading {@link IndexMetadata} to/from remote blob store
  */
-public class RemoteIndexMetadata extends AbstractRemoteWritableBlobEntity<IndexMetadata> {
+public class RemoteIndexMetadata extends AbstractClusterMetadataWriteableBlobEntity<IndexMetadata> {
 
     public static final int INDEX_METADATA_CURRENT_CODEC_VERSION = 2;
 

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemotePersistentSettingsMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemotePersistentSettingsMetadata.java
@@ -9,7 +9,7 @@
 package org.opensearch.gateway.remote.model;
 
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.compress.Compressor;
@@ -31,7 +31,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAM
 /**
  * Wrapper class for uploading/downloading persistent {@link Settings} to/from remote blob store
  */
-public class RemotePersistentSettingsMetadata extends AbstractRemoteWritableBlobEntity<Settings> {
+public class RemotePersistentSettingsMetadata extends AbstractClusterMetadataWriteableBlobEntity<Settings> {
 
     public static final String SETTING_METADATA = "settings";
 

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteRoutingTableBlobStore.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteRoutingTableBlobStore.java
@@ -9,10 +9,13 @@
 package org.opensearch.gateway.remote.model;
 
 import org.opensearch.common.blobstore.BlobPath;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
+import org.opensearch.common.remote.RemoteWriteableBlobEntity;
 import org.opensearch.common.remote.RemoteWriteableEntity;
+import org.opensearch.common.remote.RemoteWriteableEntityBlobStore;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
+import org.opensearch.gateway.remote.RemoteClusterStateUtils;
 import org.opensearch.gateway.remote.routingtable.RemoteIndexRoutingTable;
 import org.opensearch.index.remote.RemoteStoreEnums;
 import org.opensearch.index.remote.RemoteStorePathStrategy;
@@ -28,8 +31,8 @@ import static org.opensearch.gateway.remote.routingtable.RemoteIndexRoutingTable
  * @param <IndexRoutingTable> which can be uploaded to / downloaded from blob store
  * @param <U> The concrete class implementing {@link RemoteWriteableEntity} which is used as a wrapper for IndexRoutingTable entity.
  */
-public class RemoteRoutingTableBlobStore<IndexRoutingTable, U extends AbstractRemoteWritableBlobEntity<IndexRoutingTable>> extends
-    RemoteClusterStateBlobStore<IndexRoutingTable, U> {
+public class RemoteRoutingTableBlobStore<IndexRoutingTable, U extends AbstractClusterMetadataWriteableBlobEntity<IndexRoutingTable>> extends
+    RemoteWriteableEntityBlobStore<IndexRoutingTable, U> {
 
     /**
      * This setting is used to set the remote routing table store blob store path type strategy.
@@ -66,7 +69,14 @@ public class RemoteRoutingTableBlobStore<IndexRoutingTable, U extends AbstractRe
         String executor,
         ClusterSettings clusterSettings
     ) {
-        super(blobStoreTransferService, blobStoreRepository, clusterName, threadPool, executor);
+        super(
+            blobStoreTransferService,
+            blobStoreRepository,
+            clusterName,
+            threadPool,
+            executor,
+            RemoteClusterStateUtils.CLUSTER_STATE_PATH_TOKEN
+        );
         this.pathType = clusterSettings.get(REMOTE_ROUTING_TABLE_PATH_TYPE_SETTING);
         this.pathHashAlgo = clusterSettings.get(REMOTE_ROUTING_TABLE_PATH_HASH_ALGO_SETTING);
         clusterSettings.addSettingsUpdateConsumer(REMOTE_ROUTING_TABLE_PATH_TYPE_SETTING, this::setPathTypeSetting);
@@ -74,7 +84,7 @@ public class RemoteRoutingTableBlobStore<IndexRoutingTable, U extends AbstractRe
     }
 
     @Override
-    public BlobPath getBlobPathForUpload(final AbstractRemoteWritableBlobEntity<IndexRoutingTable> obj) {
+    public BlobPath getBlobPathForUpload(final RemoteWriteableBlobEntity<IndexRoutingTable> obj) {
         assert obj.getBlobPathParameters().getPathTokens().size() == 1 : "Unexpected tokens in RemoteRoutingTableObject";
         BlobPath indexRoutingPath = getBlobPathPrefix(obj.clusterUUID()).add(INDEX_ROUTING_TABLE);
 

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteTemplatesMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteTemplatesMetadata.java
@@ -10,7 +10,7 @@ package org.opensearch.gateway.remote.model;
 
 import org.opensearch.cluster.metadata.TemplatesMetadata;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -31,7 +31,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAM
 /**
  * Wrapper class for uploading/downloading {@link TemplatesMetadata} to/from remote blob store
  */
-public class RemoteTemplatesMetadata extends AbstractRemoteWritableBlobEntity<TemplatesMetadata> {
+public class RemoteTemplatesMetadata extends AbstractClusterMetadataWriteableBlobEntity<TemplatesMetadata> {
 
     public static final String TEMPLATES_METADATA = "templates";
 

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteTransientSettingsMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteTransientSettingsMetadata.java
@@ -9,7 +9,7 @@
 package org.opensearch.gateway.remote.model;
 
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.compress.Compressor;
@@ -32,7 +32,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.METADATA_NAM
 /**
  * Wrapper class for uploading/downloading transient {@link Settings} to/from remote blob store
  */
-public class RemoteTransientSettingsMetadata extends AbstractRemoteWritableBlobEntity<Settings> {
+public class RemoteTransientSettingsMetadata extends AbstractClusterMetadataWriteableBlobEntity<Settings> {
 
     public static final String TRANSIENT_SETTING_METADATA = "transient-settings";
 

--- a/server/src/main/java/org/opensearch/gateway/remote/routingtable/RemoteIndexRoutingTable.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/routingtable/RemoteIndexRoutingTable.java
@@ -10,7 +10,7 @@ package org.opensearch.gateway.remote.routingtable;
 
 import org.opensearch.cluster.routing.IndexRoutingTable;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.core.index.Index;
@@ -27,7 +27,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
 /**
  * Remote store object for IndexRoutingTable
  */
-public class RemoteIndexRoutingTable extends AbstractRemoteWritableBlobEntity<IndexRoutingTable> {
+public class RemoteIndexRoutingTable extends AbstractClusterMetadataWriteableBlobEntity<IndexRoutingTable> {
 
     public static final String INDEX_ROUTING_TABLE = "index-routing";
     public static final String INDEX_ROUTING_METADATA_PREFIX = "indexRouting--";

--- a/server/src/main/java/org/opensearch/gateway/remote/routingtable/RemoteRoutingTableDiff.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/routingtable/RemoteRoutingTableDiff.java
@@ -12,7 +12,7 @@ import org.opensearch.cluster.Diff;
 import org.opensearch.cluster.routing.IndexRoutingTable;
 import org.opensearch.cluster.routing.RoutingTableIncrementalDiff;
 import org.opensearch.common.io.Streams;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.remote.BlobPathParameters;
 import org.opensearch.core.compress.Compressor;
 import org.opensearch.gateway.remote.ClusterMetadataManifest;
@@ -30,7 +30,7 @@ import static org.opensearch.gateway.remote.RemoteClusterStateUtils.DELIMITER;
  * Represents a incremental difference between {@link org.opensearch.cluster.routing.RoutingTable} objects that can be serialized and deserialized.
  * This class is responsible for writing and reading the differences between RoutingTables to and from an input/output stream.
  */
-public class RemoteRoutingTableDiff extends AbstractRemoteWritableBlobEntity<RoutingTableIncrementalDiff> {
+public class RemoteRoutingTableDiff extends AbstractClusterMetadataWriteableBlobEntity<RoutingTableIncrementalDiff> {
     private final RoutingTableIncrementalDiff routingTableIncrementalDiff;
 
     private long term;

--- a/server/src/test/java/org/opensearch/common/remote/AbstractRemoteWritableEntityManagerTests.java
+++ b/server/src/test/java/org/opensearch/common/remote/AbstractRemoteWritableEntityManagerTests.java
@@ -24,7 +24,7 @@ public class AbstractRemoteWritableEntityManagerTests extends OpenSearchTestCase
         String knownEntityType = "knownType";
         RemoteWritableEntityStore mockStore = mock(RemoteWritableEntityStore.class);
         manager.remoteWritableEntityStores.put(knownEntityType, mockStore);
-        AbstractRemoteWritableBlobEntity mockEntity = mock(AbstractRemoteWritableBlobEntity.class);
+        AbstractClusterMetadataWriteableBlobEntity mockEntity = mock(AbstractClusterMetadataWriteableBlobEntity.class);
         when(mockEntity.getType()).thenReturn(knownEntityType);
 
         RemoteWritableEntityStore store = manager.getStore(mockEntity);
@@ -35,7 +35,7 @@ public class AbstractRemoteWritableEntityManagerTests extends OpenSearchTestCase
     public void testGetStoreWithUnknownEntityType() {
         AbstractRemoteWritableEntityManager manager = new ConcreteRemoteWritableEntityManager();
         String unknownEntityType = "unknownType";
-        AbstractRemoteWritableBlobEntity mockEntity = mock(AbstractRemoteWritableBlobEntity.class);
+        AbstractClusterMetadataWriteableBlobEntity mockEntity = mock(AbstractClusterMetadataWriteableBlobEntity.class);
         when(mockEntity.getType()).thenReturn(unknownEntityType);
 
         assertThrows(IllegalArgumentException.class, () -> manager.getStore(mockEntity));
@@ -46,7 +46,7 @@ public class AbstractRemoteWritableEntityManagerTests extends OpenSearchTestCase
         @Override
         protected ActionListener<Void> getWrappedWriteListener(
             String component,
-            AbstractRemoteWritableBlobEntity remoteEntity,
+            AbstractClusterMetadataWriteableBlobEntity remoteEntity,
             ActionListener<ClusterMetadataManifest.UploadedMetadata> listener
         ) {
             return null;
@@ -55,7 +55,7 @@ public class AbstractRemoteWritableEntityManagerTests extends OpenSearchTestCase
         @Override
         protected ActionListener<Object> getWrappedReadListener(
             String component,
-            AbstractRemoteWritableBlobEntity remoteEntity,
+            AbstractClusterMetadataWriteableBlobEntity remoteEntity,
             ActionListener<RemoteReadResult> listener
         ) {
             return null;

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -42,7 +42,7 @@ import org.opensearch.common.blobstore.transfer.RemoteTransferContainer;
 import org.opensearch.common.compress.DeflateCompressor;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.common.network.NetworkModule;
-import org.opensearch.common.remote.AbstractRemoteWritableBlobEntity;
+import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
@@ -3464,7 +3464,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         return DiscoveryNodes.builder().clusterManagerNodeId("cluster-manager-id").localNodeId("cluster-manager-id").add(localNode).build();
     }
 
-    private class BlobNameMatcher implements ArgumentMatcher<AbstractRemoteWritableBlobEntity> {
+    private class BlobNameMatcher implements ArgumentMatcher<AbstractClusterMetadataWriteableBlobEntity> {
         private final String expectedBlobName;
 
         BlobNameMatcher(String expectedBlobName) {
@@ -3472,7 +3472,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         }
 
         @Override
-        public boolean matches(AbstractRemoteWritableBlobEntity argument) {
+        public boolean matches(AbstractClusterMetadataWriteableBlobEntity argument) {
             return argument != null && expectedBlobName.equals(argument.getFullBlobName());
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Aims to make the remote entity classes more reusable by moving them to commons and removing dependencies around remote cluster state

### Related Issues
Resolves #15180
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
