### PR TITLE
[Remote State] Disable remote publication if remote state disabled

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/CoordinationState.java
@@ -105,7 +105,8 @@ public class CoordinationState {
             .getLastAcceptedConfiguration();
         this.publishVotes = new VoteCollection();
         this.isRemoteStateEnabled = isRemoteStoreClusterStateEnabled(settings);
-        this.isRemotePublicationEnabled = FeatureFlags.isEnabled(REMOTE_PUBLICATION_EXPERIMENTAL)
+        this.isRemotePublicationEnabled = isRemoteStateEnabled
+            && FeatureFlags.isEnabled(REMOTE_PUBLICATION_EXPERIMENTAL)
             && localNode.isRemoteStatePublicationEnabled();
     }
 


### PR DESCRIPTION
### Description
Fall back to legacy Transport publication if Remote State is disabled. We were earlier trying to use remote publication when remote state was disabled, as the remote state was disabled RemoteClusterStateService instance is null and we were hitting null pointer.


### Related Issues
Resolves #15182


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
