### PR TITLE
Extend ActionRequest and TransportService for Resource permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add took time to request nodes stats ([#15054](https://github.com/opensearch-project/OpenSearch/pull/15054))
 - [Workload Management] QueryGroup resource tracking framework changes ([#13897](https://github.com/opensearch-project/OpenSearch/pull/13897))
 - Add slice execution listeners to SearchOperationListener interface ([#15153](https://github.com/opensearch-project/OpenSearch/pull/15153))
+- Modify ActionRequest and TransportService to allow for defining resources while making a request ([#15230]Extend ActionRequest and TransportService for Resource permissions)
 
 ### Dependencies
 - Bump `netty` from 4.1.111.Final to 4.1.112.Final ([#15081](https://github.com/opensearch-project/OpenSearch/pull/15081))

--- a/server/src/main/java/org/opensearch/action/ActionRequest.java
+++ b/server/src/main/java/org/opensearch/action/ActionRequest.java
@@ -38,6 +38,8 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.transport.TransportRequest;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Base action request implemented by plugins.
@@ -56,6 +58,14 @@ public abstract class ActionRequest extends TransportRequest {
 
     public ActionRequest(StreamInput in) throws IOException {
         super(in);
+    }
+
+    /**
+     * Should be overwritten by implementing plugins with the resources each actionRequest requires.
+     * Bypasses resource evaluation by default.
+     */
+    public List<String> getResources() {
+        return Collections.emptyList();
     }
 
     public abstract ActionRequestValidationException validate();

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -1106,7 +1106,8 @@ public class TransportService extends AbstractLifecycleComponent
                 "cluster:monitor",
                 "cluster:internal",
                 "internal:",
-                "views:"
+                "views:",
+                "resource:"
             )
         )
     );


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]
This PR makes a minor change to the ActionRequest and TransportService files. In ActionRequest, it adds a new method to the interface 

```
     /**
     * Should be overwritten by implementing plugins with the resources each actionRequest requires.
     * Bypasses resource evaluation by default.
     */
    public List<String> getResources() {
        return Collections.emptyList();
    }
```
As described, this method is intended to be overwritten by plugins so that their ActionRequest implementations can return a list of the resources they act upon.

The TransportService change simply adds a new accepted prefix for actions of `resource:`

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
This change is part of: 
https://github.com/opensearch-project/security/issues/4500

It is required for further work on: 
https://github.com/opensearch-project/security/issues/4562

An example of the work can be found here: https://github.com/opensearch-project/security/pull/4638

### Check List
- [ ] ~Functionality includes testing.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
