### PR TITLE
Add setting to disable diff application in remote publication

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/PublicationTransportHandler.java
@@ -68,6 +68,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_PUBLICATION_APPLY_FULL_STATE;
+
 /**
  * Transport handler for publication
  *
@@ -243,7 +245,12 @@ public class PublicationTransportHandler {
         }
         boolean applyFullState = false;
         final ClusterState lastSeen = lastSeenClusterState.get();
-        if (lastSeen == null) {
+        if (remoteClusterStateService.getRemotePublicationApplyFullState()) {
+            logger.debug(
+                () -> "Using full state for publication as " + REMOTE_PUBLICATION_APPLY_FULL_STATE.getKey() + " setting is enabled"
+            );
+            applyFullState = true;
+        } else if (lastSeen == null) {
             logger.debug(() -> "Diff cannot be applied as there is no last cluster state");
             applyFullState = true;
         } else if (manifest.getDiffManifest() == null) {

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -735,6 +735,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 IndicesService.CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING,
                 RemoteRoutingTableBlobStore.REMOTE_ROUTING_TABLE_PATH_TYPE_SETTING,
                 RemoteRoutingTableBlobStore.REMOTE_ROUTING_TABLE_PATH_HASH_ALGO_SETTING,
+                RemoteClusterStateService.REMOTE_PUBLICATION_APPLY_FULL_STATE,
 
                 // Admission Control Settings
                 AdmissionControlSettings.ADMISSION_CONTROL_TRANSPORT_LAYER_MODE,


### PR DESCRIPTION
### Description
Added a setting `cluster.remote_publication.apply_full_state` to control remote publication flows. If enabled, the remote publication flow will always apply full state and not use the diff. This is to be used as an andon cord in case we want to rebuild the full cluster state on nodes from remote. If disabled, we will use the diff manifest shared by cluster manager to build the cluster state on nodes.

### Related Issues

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
