### PR TITLE
Replace and block usages of org.apache.logging.log4j.util.Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Add lower limit for primary and replica batch allocators timeout ([#14979](https://github.com/opensearch-project/OpenSearch/pull/14979))
+- Replace and block usages of org.apache.logging.log4j.util.Strings ([#15238](https://github.com/opensearch-project/OpenSearch/pull/15238))
 
 ### Deprecated
 

--- a/buildSrc/src/main/resources/forbidden/opensearch-all-signatures.txt
+++ b/buildSrc/src/main/resources/forbidden/opensearch-all-signatures.txt
@@ -17,6 +17,9 @@
 java.nio.file.Paths @ Use org.opensearch.common.io.PathUtils.get() instead.
 java.nio.file.FileSystems#getDefault() @ use org.opensearch.common.io.PathUtils.getDefaultFileSystem() instead.
 
+joptsimple.internal.Strings @ use org.opensearch.core.common.Strings instead.
+org.apache.logging.log4j.util.Strings @ use org.opensearch.core.common.Strings instead.
+
 java.nio.file.Files#getFileStore(java.nio.file.Path) @ Use org.opensearch.env.Environment.getFileStore() instead, impacted by JDK-8034057
 java.nio.file.Files#isWritable(java.nio.file.Path) @ Use org.opensearch.env.Environment.isWritable() instead, impacted by JDK-8034057
 

--- a/server/src/main/java/org/opensearch/common/logging/JsonThrowablePatternConverter.java
+++ b/server/src/main/java/org/opensearch/common/logging/JsonThrowablePatternConverter.java
@@ -38,7 +38,7 @@ import org.apache.logging.log4j.core.pattern.ConverterKeys;
 import org.apache.logging.log4j.core.pattern.ExtendedThrowablePatternConverter;
 import org.apache.logging.log4j.core.pattern.PatternConverter;
 import org.apache.logging.log4j.core.pattern.ThrowablePatternConverter;
-import org.apache.logging.log4j.util.Strings;
+import org.opensearch.core.common.Strings;
 
 import java.nio.charset.Charset;
 import java.util.StringJoiner;
@@ -84,7 +84,7 @@ public final class JsonThrowablePatternConverter extends ThrowablePatternConvert
     @Override
     public void format(final LogEvent event, final StringBuilder toAppendTo) {
         String consoleStacktrace = formatStacktrace(event);
-        if (Strings.isNotEmpty(consoleStacktrace)) {
+        if (!Strings.isNullOrEmpty(consoleStacktrace)) {
             String jsonStacktrace = formatJson(consoleStacktrace);
 
             toAppendTo.append(", ");

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -35,7 +35,6 @@ package org.opensearch.env;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.logging.log4j.util.Strings;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.Directory;
@@ -61,6 +60,7 @@ import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
@@ -1300,7 +1300,7 @@ public final class NodeEnvironment implements Closeable {
      * Resolve the custom path for a index's shard.
      */
     public static Path resolveBaseCustomLocation(String customDataPath, Path sharedDataPath, int nodeLockId) {
-        if (Strings.isNotEmpty(customDataPath)) {
+        if (!Strings.isNullOrEmpty(customDataPath)) {
             // This assert is because this should be caught by MetadataCreateIndexService
             assert sharedDataPath != null;
             return sharedDataPath.resolve(customDataPath).resolve(Integer.toString(nodeLockId));

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateCleanupManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateCleanupManager.java
@@ -11,7 +11,6 @@ package org.opensearch.gateway.remote;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.logging.log4j.util.Strings;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.routing.remote.RemoteRoutingTableService;
 import org.opensearch.cluster.service.ClusterApplierService;
@@ -23,6 +22,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.AbstractAsyncTask;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.Strings;
 import org.opensearch.index.translog.transfer.BlobStoreTransferService;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -125,8 +125,8 @@ public class RemoteClusterStateCleanupManager implements Closeable {
         ClusterState currentAppliedState = clusterApplierService.state();
         if (currentAppliedState.nodes().isLocalNodeElectedClusterManager()) {
             long cleanUpAttemptStateVersion = currentAppliedState.version();
-            assert Strings.isNotEmpty(currentAppliedState.getClusterName().value()) : "cluster name is not set";
-            assert Strings.isNotEmpty(currentAppliedState.metadata().clusterUUID()) : "cluster uuid is not set";
+            assert !Strings.isNullOrEmpty(currentAppliedState.getClusterName().value()) : "cluster name is not set";
+            assert !Strings.isNullOrEmpty(currentAppliedState.metadata().clusterUUID()) : "cluster uuid is not set";
             if (cleanUpAttemptStateVersion - lastCleanupAttemptStateVersion > SKIP_CLEANUP_STATE_CHANGES) {
                 logger.info(
                     "Cleaning up stale remote state files for cluster [{}] with uuid [{}]. Last clean was done before {} updates",

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -98,6 +98,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -107,8 +108,6 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
-import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * IndexModule represents the central extension point for index level custom implementations like:
@@ -580,7 +579,7 @@ public final class IndexModule {
 
         public static DataLocalityType getValueOf(final String localityType) {
             Objects.requireNonNull(localityType, "No locality type given.");
-            final String localityTypeName = toRootUpperCase(localityType.trim());
+            final String localityTypeName = localityType.trim().toUpperCase(Locale.ROOT);
             final DataLocalityType type = LOCALITY_TYPES.get(localityTypeName);
             if (type != null) {
                 return type;

--- a/server/src/main/java/org/opensearch/index/shard/ShardPath.java
+++ b/server/src/main/java/org/opensearch/index/shard/ShardPath.java
@@ -32,10 +32,10 @@
 package org.opensearch.index.shard;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.util.Strings;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.NodeEnvironment;
@@ -205,7 +205,7 @@ public final class ShardPath {
         } else {
             final Path dataPath;
             final Path statePath = loadedPath;
-            final boolean hasCustomDataPath = Strings.isNotEmpty(customDataPath);
+            final boolean hasCustomDataPath = !Strings.isNullOrEmpty(customDataPath);
             if (hasCustomDataPath) {
                 dataPath = NodeEnvironment.resolveCustomLocation(customDataPath, shardId, sharedDataPath, nodeLockId);
             } else {

--- a/test/framework/src/main/java/org/opensearch/client/RestClientBuilderTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/client/RestClientBuilderTestCase.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.client;
 
-import joptsimple.internal.Strings;
 import org.apache.hc.core5.http.Header;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -55,7 +54,7 @@ public abstract class RestClientBuilderTestCase extends OpenSearchTestCase {
             assertEquals(expectedValue, header.getValue());
         }
         if (expectedHeaders.isEmpty() == false) {
-            fail("Missing expected headers in rest client: " + Strings.join(expectedHeaders.keySet(), ", "));
+            fail("Missing expected headers in rest client: " + String.join(",", expectedHeaders.keySet()));
         }
     }
 }


### PR DESCRIPTION
### Description

Replaces usages of `org.apache.logging.log4j.util.Strings` and `joptsimple.internal.Strings` with `org.opensearch.core.common.Strings`. This PR also makes the classes forbidden to prevent the precommit check from passing if there are any usages of `org.apache.logging.log4j.util.Strings` or `joptsimple.internal.Strings`.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/15211

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
