### PR TITLE
fix cluster not able to spin up issue when disk usage exceeds threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix protobuf-java leak through client library dependencies ([#16254](https://github.com/opensearch-project/OpenSearch/pull/16254))
 - Fix multi-search with template doesn't return status code ([#16265](https://github.com/opensearch-project/OpenSearch/pull/16265))
 - Fix wrong default value when setting `index.number_of_routing_shards` to null on index creation ([#16331](https://github.com/opensearch-project/OpenSearch/pull/16331))
+- Fix disk usage exceeds threshold cluster can't spin up issue ([#15258](https://github.com/opensearch-project/OpenSearch/pull/15258)))
+
 
 ### Security
 

--- a/distribution/tools/keystore-cli/src/test/java/org/opensearch/bootstrap/BootstrapTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/opensearch/bootstrap/BootstrapTests.java
@@ -150,7 +150,7 @@ public class BootstrapTests extends OpenSearchTestCase {
 
         LogConfigurator.registerErrorListener();
         Bootstrap testBootstrap = new Bootstrap(mockThread, mockNode);
-        testBootstrap.setInstance(testBootstrap);
+        Bootstrap.setInstance(testBootstrap);
 
         Bootstrap.startInstance(testBootstrap);
 

--- a/distribution/tools/keystore-cli/src/test/java/org/opensearch/bootstrap/BootstrapTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/opensearch/bootstrap/BootstrapTests.java
@@ -31,9 +31,6 @@
 
 package org.opensearch.bootstrap;
 
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.opensearch.cli.UserException;
 import org.opensearch.common.logging.LogConfigurator;
 import org.opensearch.common.settings.KeyStoreCommandTestCase;
 import org.opensearch.common.settings.KeyStoreWrapper;
@@ -43,7 +40,6 @@ import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.common.settings.SecureString;
 import org.opensearch.env.Environment;
 import org.opensearch.node.Node;
-import org.opensearch.node.NodeValidationException;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -60,12 +56,9 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class BootstrapTests extends OpenSearchTestCase {
     Environment env;

--- a/distribution/tools/keystore-cli/src/test/java/org/opensearch/bootstrap/BootstrapTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/opensearch/bootstrap/BootstrapTests.java
@@ -31,6 +31,11 @@
 
 package org.opensearch.bootstrap;
 
+import org.mockito.InOrder;
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.common.UUIDs;
 import org.opensearch.common.settings.KeyStoreCommandTestCase;
 import org.opensearch.common.settings.KeyStoreWrapper;
 import org.opensearch.common.settings.SecureSettings;
@@ -38,6 +43,10 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.common.settings.SecureString;
 import org.opensearch.env.Environment;
+import org.opensearch.node.MockNode;
+import org.opensearch.node.Node;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.MockHttpTransport;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -45,14 +54,22 @@ import org.junit.Before;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 public class BootstrapTests extends OpenSearchTestCase {
     Environment env;
@@ -131,4 +148,44 @@ public class BootstrapTests extends OpenSearchTestCase {
         }
     }
 
+
+    public void testInitExecutionOrder() {
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            try {
+                // Create mock objects for Thread and Node
+                Thread mockThread = mock(Thread.class);
+                Node mockNode = mock(Node.class);
+
+                // Use reflection to set the INSTANCE to null before the test
+                Field instanceField = Bootstrap.class.getDeclaredField("INSTANCE");
+                instanceField.setAccessible(true);
+                instanceField.set(null, null);
+
+                // Use reflection to replace the private fields with our mocks
+                Bootstrap bootstrap = new Bootstrap();
+                Field threadField = Bootstrap.class.getDeclaredField("keepAliveThread");
+                threadField.setAccessible(true);
+                threadField.set(bootstrap, mockThread);
+
+                Field nodeField = Bootstrap.class.getDeclaredField("node");
+                nodeField.setAccessible(true);
+                nodeField.set(bootstrap, mockNode);
+
+                // Set the INSTANCE to our modified bootstrap
+                instanceField.set(null, bootstrap);
+
+                // Call the startInstance method
+                Bootstrap.startInstance(bootstrap);
+
+                // Verify the order of execution
+                InOrder inOrder = inOrder(mockThread, mockNode);
+                inOrder.verify(mockThread).start();
+                inOrder.verify(mockNode).start();
+            } catch (Exception e) {
+                fail(e.getMessage());
+            }
+            return null;
+        });
+
+    }
 }

--- a/distribution/tools/keystore-cli/src/test/java/org/opensearch/bootstrap/BootstrapTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/opensearch/bootstrap/BootstrapTests.java
@@ -32,10 +32,6 @@
 package org.opensearch.bootstrap;
 
 import org.mockito.InOrder;
-import org.opensearch.Version;
-import org.opensearch.cluster.node.DiscoveryNode;
-import org.opensearch.cluster.node.DiscoveryNodeRole;
-import org.opensearch.common.UUIDs;
 import org.opensearch.common.settings.KeyStoreCommandTestCase;
 import org.opensearch.common.settings.KeyStoreWrapper;
 import org.opensearch.common.settings.SecureSettings;
@@ -43,10 +39,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.common.settings.SecureString;
 import org.opensearch.env.Environment;
-import org.opensearch.node.MockNode;
 import org.opensearch.node.Node;
-import org.opensearch.plugins.Plugin;
-import org.opensearch.test.MockHttpTransport;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -63,13 +56,10 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 
 public class BootstrapTests extends OpenSearchTestCase {
     Environment env;

--- a/distribution/tools/keystore-cli/src/test/java/org/opensearch/bootstrap/BootstrapTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/opensearch/bootstrap/BootstrapTests.java
@@ -140,9 +140,7 @@ public class BootstrapTests extends OpenSearchTestCase {
     public void testInitExecutionOrder() throws Exception {
         AtomicInteger order = new AtomicInteger(0);
 
-        Thread mockThread = new Thread(() -> {
-            assertEquals(0, order.getAndIncrement());
-        });
+        Thread mockThread = new Thread(() -> { assertEquals(0, order.getAndIncrement()); });
 
         Node mockNode = mock(Node.class);
         doAnswer(invocation -> {
@@ -159,6 +157,5 @@ public class BootstrapTests extends OpenSearchTestCase {
         verify(mockNode).start();
         assertEquals(2, order.get());
     }
-
 
 }

--- a/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
@@ -336,6 +336,8 @@ final class Bootstrap {
     }
 
     private void start() throws NodeValidationException {
+        // keepAliveThread should start first than node to ensure the cluster can spin up successfully in edge cases:
+        // https://github.com/opensearch-project/OpenSearch/issues/14791
         keepAliveThread.start();
         node.start();
     }

--- a/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
@@ -412,7 +412,7 @@ final class Bootstrap {
                 throw new BootstrapException(e);
             }
 
-            INSTANCE.start();
+            startInstance(INSTANCE);
 
             // We don't close stderr if `--quiet` is passed, because that
             // hides fatal startup errors. For example, if OpenSearch is
@@ -462,6 +462,10 @@ final class Bootstrap {
 
             throw e;
         }
+    }
+
+    static void startInstance(Bootstrap instance) throws NodeValidationException {
+        instance.start();
     }
 
     @SuppressForbidden(reason = "System#out")

--- a/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
@@ -94,7 +94,7 @@ final class Bootstrap {
     private final Spawner spawner = new Spawner();
 
     // For testing purpose
-    void setInstance(Bootstrap bootstrap) {
+    static void setInstance(Bootstrap bootstrap) {
         INSTANCE = bootstrap;
     }
 

--- a/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
@@ -336,8 +336,8 @@ final class Bootstrap {
     }
 
     private void start() throws NodeValidationException {
-        node.start();
         keepAliveThread.start();
+        node.start();
     }
 
     static void stop() throws IOException {

--- a/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
@@ -93,6 +93,17 @@ final class Bootstrap {
     private final Thread keepAliveThread;
     private final Spawner spawner = new Spawner();
 
+    // For testing purpose
+    void setInstance(Bootstrap bootstrap) {
+        INSTANCE = bootstrap;
+    }
+
+    // For testing purpose
+    Bootstrap(Thread keepAliveThread, Node node) {
+        this.keepAliveThread = keepAliveThread;
+        this.node = node;
+    }
+
     /** creates a new instance */
     Bootstrap() {
         keepAliveThread = new Thread(new Runnable() {

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -165,9 +165,6 @@ grant {
   // otherwise can be provided only to test libraries
   permission java.lang.RuntimePermission "fileSystemProvider";
 
-  // needed for UT test in BootstrapTests
-  permission java.lang.RuntimePermission "shutdownHooks";
-
   // needed by jvminfo for monitoring the jvm
   permission java.lang.management.ManagementPermission "monitor";
 

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -165,6 +165,9 @@ grant {
   // otherwise can be provided only to test libraries
   permission java.lang.RuntimePermission "fileSystemProvider";
 
+  // needed for UT test in BootstrapTests
+  permission java.lang.RuntimePermission "shutdownHooks";
+
   // needed by jvminfo for monitoring the jvm
   permission java.lang.management.ManagementPermission "monitor";
 


### PR DESCRIPTION
### Description
root cause:

1. Observability plugin creates system index during cluster startup: [link](https://github.com/opensearch-project/observability/blob/2.x/src/main/kotlin/org/opensearch/observability/ObservabilityPlugin.kt#L96), and if cluster has index block state persisted, during the node startup this block will be applied to cluster state and index creation fails, then this exception is been [thrown](https://github.com/opensearch-project/observability/blob/main/src/main/kotlin/org/opensearch/observability/index/ObservabilityIndex.kt#L110).
2. OpenSearch starts cluster in this [method](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java#L339) and the error will be thrown again util the OpenSearch [startup](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/bootstrap/OpenSearch.java#L87) command execution finished.
3. At the moment of the startup command complete, the JVM only has daemon threads without any non-daemon threads, and thus JVM exits, then cluster been shut down.

Changing the code of cluster start part to first start the `keepAliveThread` which is a non-daemon thread to make sure at least one non-daemon thread is running thus the JVM won't exit.


### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/14791

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
