### PR TITLE
Move timestamp pinning settings to RemoteStoreSettings

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsIT.java
@@ -54,7 +54,7 @@ public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase 
         remoteStorePinnedTimestampService.pinTimestamp(timestamp2, "ss3", noOpActionListener);
         remoteStorePinnedTimestampService.pinTimestamp(timestamp3, "ss4", noOpActionListener);
 
-        remoteStorePinnedTimestampService.setPinnedTimestampsSchedulerInterval(TimeValue.timeValueSeconds(1));
+        remoteStorePinnedTimestampService.rescheduleAsyncUpdatePinnedTimestampTask(TimeValue.timeValueSeconds(1));
 
         assertBusy(() -> {
             Tuple<Long, Set<Long>> pinnedTimestampWithFetchTimestamp_2 = RemoteStorePinnedTimestampService.getPinnedTimestamps();
@@ -63,7 +63,7 @@ public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase 
             assertEquals(Set.of(timestamp1, timestamp2, timestamp3), pinnedTimestampWithFetchTimestamp_2.v2());
         });
 
-        remoteStorePinnedTimestampService.setPinnedTimestampsSchedulerInterval(TimeValue.timeValueMinutes(3));
+        remoteStorePinnedTimestampService.rescheduleAsyncUpdatePinnedTimestampTask(TimeValue.timeValueMinutes(3));
 
         // This should be a no-op as pinning entity is different
         remoteStorePinnedTimestampService.unpinTimestamp(timestamp1, "no-snapshot", noOpActionListener);
@@ -72,7 +72,7 @@ public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase 
         // Adding different entity to already pinned timestamp
         remoteStorePinnedTimestampService.pinTimestamp(timestamp3, "ss5", noOpActionListener);
 
-        remoteStorePinnedTimestampService.setPinnedTimestampsSchedulerInterval(TimeValue.timeValueSeconds(1));
+        remoteStorePinnedTimestampService.rescheduleAsyncUpdatePinnedTimestampTask(TimeValue.timeValueSeconds(1));
 
         assertBusy(() -> {
             Tuple<Long, Set<Long>> pinnedTimestampWithFetchTimestamp_3 = RemoteStorePinnedTimestampService.getPinnedTimestamps();
@@ -81,6 +81,6 @@ public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase 
             assertEquals(Set.of(timestamp1, timestamp3), pinnedTimestampWithFetchTimestamp_3.v2());
         });
 
-        remoteStorePinnedTimestampService.setPinnedTimestampsSchedulerInterval(TimeValue.timeValueMinutes(3));
+        remoteStorePinnedTimestampService.rescheduleAsyncUpdatePinnedTimestampTask(TimeValue.timeValueMinutes(3));
     }
 }

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -142,7 +142,6 @@ import org.opensearch.node.Node;
 import org.opensearch.node.Node.DiscoverySettings;
 import org.opensearch.node.NodeRoleSettings;
 import org.opensearch.node.remotestore.RemoteStoreNodeService;
-import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
 import org.opensearch.node.resource.tracker.ResourceTrackerSettings;
 import org.opensearch.persistent.PersistentTasksClusterService;
 import org.opensearch.persistent.decider.EnableAssignmentDecider;
@@ -759,9 +758,10 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_PATH_HASH_ALGORITHM_SETTING,
                 RemoteStoreSettings.CLUSTER_REMOTE_MAX_TRANSLOG_READERS,
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_METADATA,
-                SearchService.CLUSTER_ALLOW_DERIVED_FIELD_SETTING,
+                RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL,
+                RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_LOOKBACK_INTERVAL,
 
-                RemoteStorePinnedTimestampService.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL,
+                SearchService.CLUSTER_ALLOW_DERIVED_FIELD_SETTING,
 
                 // Composite index settings
                 CompositeIndexSettings.STAR_TREE_INDEX_ENABLED_SETTING,

--- a/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
+++ b/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
@@ -134,6 +134,27 @@ public class RemoteStoreSettings {
         Property.Dynamic
     );
 
+    /**
+     * Controls pinned timestamp scheduler interval
+     */
+    public static final Setting<TimeValue> CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL = Setting.timeSetting(
+        "cluster.remote_store.pinned_timestamps.scheduler_interval",
+        TimeValue.timeValueMinutes(3),
+        TimeValue.timeValueMinutes(1),
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Controls allowed timestamp values to be pinned from past
+     */
+    public static final Setting<TimeValue> CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_LOOKBACK_INTERVAL = Setting.timeSetting(
+        "cluster.remote_store.pinned_timestamps.lookback_interval",
+        TimeValue.timeValueMinutes(1),
+        TimeValue.timeValueMinutes(1),
+        TimeValue.timeValueMinutes(5),
+        Setting.Property.NodeScope
+    );
+
     private volatile TimeValue clusterRemoteTranslogBufferInterval;
     private volatile int minRemoteSegmentMetadataFiles;
     private volatile TimeValue clusterRemoteTranslogTransferTimeout;
@@ -142,6 +163,8 @@ public class RemoteStoreSettings {
     private volatile RemoteStoreEnums.PathHashAlgorithm pathHashAlgorithm;
     private volatile int maxRemoteTranslogReaders;
     private volatile boolean isTranslogMetadataEnabled;
+    private volatile TimeValue pinnedTimestampsSchedulerInterval;
+    private volatile TimeValue pinnedTimestampsLookbackInterval;
 
     public RemoteStoreSettings(Settings settings, ClusterSettings clusterSettings) {
         clusterRemoteTranslogBufferInterval = CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING.get(settings);
@@ -179,6 +202,9 @@ public class RemoteStoreSettings {
             CLUSTER_REMOTE_SEGMENT_TRANSFER_TIMEOUT_SETTING,
             this::setClusterRemoteSegmentTransferTimeout
         );
+
+        pinnedTimestampsSchedulerInterval = CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL.get(settings);
+        pinnedTimestampsLookbackInterval = CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_LOOKBACK_INTERVAL.get(settings);
     }
 
     public TimeValue getClusterRemoteTranslogBufferInterval() {
@@ -245,5 +271,13 @@ public class RemoteStoreSettings {
 
     private void setMaxRemoteTranslogReaders(int maxRemoteTranslogReaders) {
         this.maxRemoteTranslogReaders = maxRemoteTranslogReaders;
+    }
+
+    public TimeValue getPinnedTimestampsSchedulerInterval() {
+        return pinnedTimestampsSchedulerInterval;
+    }
+
+    public TimeValue getPinnedTimestampsLookbackInterval() {
+        return pinnedTimestampsLookbackInterval;
     }
 }

--- a/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
+++ b/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
@@ -163,8 +163,8 @@ public class RemoteStoreSettings {
     private volatile RemoteStoreEnums.PathHashAlgorithm pathHashAlgorithm;
     private volatile int maxRemoteTranslogReaders;
     private volatile boolean isTranslogMetadataEnabled;
-    private volatile TimeValue pinnedTimestampsSchedulerInterval;
-    private volatile TimeValue pinnedTimestampsLookbackInterval;
+    private static volatile TimeValue pinnedTimestampsSchedulerInterval;
+    private static volatile TimeValue pinnedTimestampsLookbackInterval;
 
     public RemoteStoreSettings(Settings settings, ClusterSettings clusterSettings) {
         clusterRemoteTranslogBufferInterval = CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING.get(settings);
@@ -273,11 +273,11 @@ public class RemoteStoreSettings {
         this.maxRemoteTranslogReaders = maxRemoteTranslogReaders;
     }
 
-    public TimeValue getPinnedTimestampsSchedulerInterval() {
+    public static TimeValue getPinnedTimestampsSchedulerInterval() {
         return pinnedTimestampsSchedulerInterval;
     }
 
-    public TimeValue getPinnedTimestampsLookbackInterval() {
+    public static TimeValue getPinnedTimestampsLookbackInterval() {
         return pinnedTimestampsLookbackInterval;
     }
 }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -785,6 +785,7 @@ public class Node implements Closeable {
                 clusterService.getClusterSettings(),
                 threadPool::relativeTimeInMillis
             );
+            final RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(settings, settingsModule.getClusterSettings());
             final RemoteClusterStateService remoteClusterStateService;
             final RemoteClusterStateCleanupManager remoteClusterStateCleanupManager;
             final RemoteIndexPathUploader remoteIndexPathUploader;
@@ -817,7 +818,8 @@ public class Node implements Closeable {
                     repositoriesServiceReference::get,
                     settings,
                     threadPool,
-                    clusterService
+                    clusterService,
+                    remoteStoreSettings
                 );
                 resourcesToClose.add(remoteStorePinnedTimestampService);
             } else {
@@ -865,7 +867,6 @@ public class Node implements Closeable {
 
             final RecoverySettings recoverySettings = new RecoverySettings(settings, settingsModule.getClusterSettings());
 
-            final RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(settings, settingsModule.getClusterSettings());
             final CompositeIndexSettings compositeIndexSettings = new CompositeIndexSettings(settings, settingsModule.getClusterSettings());
 
             final IndexStorePlugin.DirectoryFactory remoteDirectoryFactory = new RemoteSegmentStoreDirectoryFactory(

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -785,7 +785,6 @@ public class Node implements Closeable {
                 clusterService.getClusterSettings(),
                 threadPool::relativeTimeInMillis
             );
-            final RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(settings, settingsModule.getClusterSettings());
             final RemoteClusterStateService remoteClusterStateService;
             final RemoteClusterStateCleanupManager remoteClusterStateCleanupManager;
             final RemoteIndexPathUploader remoteIndexPathUploader;
@@ -866,6 +865,7 @@ public class Node implements Closeable {
 
             final RecoverySettings recoverySettings = new RecoverySettings(settings, settingsModule.getClusterSettings());
 
+            final RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(settings, settingsModule.getClusterSettings());
             final CompositeIndexSettings compositeIndexSettings = new CompositeIndexSettings(settings, settingsModule.getClusterSettings());
 
             final IndexStorePlugin.DirectoryFactory remoteDirectoryFactory = new RemoteSegmentStoreDirectoryFactory(

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -818,8 +818,7 @@ public class Node implements Closeable {
                     repositoriesServiceReference::get,
                     settings,
                     threadPool,
-                    clusterService,
-                    remoteStoreSettings
+                    clusterService
                 );
                 resourcesToClose.add(remoteStorePinnedTimestampService);
             } else {

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -57,7 +57,6 @@ public class RemoteStorePinnedTimestampService implements Closeable {
     private final Settings settings;
     private final ThreadPool threadPool;
     private final ClusterService clusterService;
-    private final RemoteStoreSettings remoteStoreSettings;
     private BlobStoreRepository blobStoreRepository;
     private BlobStoreTransferService blobStoreTransferService;
     private RemoteStorePinnedTimestampsBlobStore pinnedTimestampsBlobStore;
@@ -68,14 +67,12 @@ public class RemoteStorePinnedTimestampService implements Closeable {
         Supplier<RepositoriesService> repositoriesService,
         Settings settings,
         ThreadPool threadPool,
-        ClusterService clusterService,
-        RemoteStoreSettings remoteStoreSettings
+        ClusterService clusterService
     ) {
         this.repositoriesService = repositoriesService;
         this.settings = settings;
         this.threadPool = threadPool;
         this.clusterService = clusterService;
-        this.remoteStoreSettings = remoteStoreSettings;
     }
 
     /**
@@ -86,7 +83,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
     public void start() {
         validateRemoteStoreConfiguration();
         initializeComponents();
-        startAsyncUpdateTask(remoteStoreSettings.getPinnedTimestampsSchedulerInterval());
+        startAsyncUpdateTask(RemoteStoreSettings.getPinnedTimestampsSchedulerInterval());
     }
 
     private void validateRemoteStoreConfiguration() {
@@ -126,7 +123,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
     public void pinTimestamp(long timestamp, String pinningEntity, ActionListener<Void> listener) {
         // If a caller uses current system time to pin the timestamp, following check will almost always fail.
         // So, we allow pinning timestamp in the past upto some buffer
-        long lookbackIntervalInMills = remoteStoreSettings.getPinnedTimestampsLookbackInterval().millis();
+        long lookbackIntervalInMills = RemoteStoreSettings.getPinnedTimestampsLookbackInterval().millis();
         if (timestamp < (System.currentTimeMillis() - lookbackIntervalInMills)) {
             throw new IllegalArgumentException(
                 "Timestamp to be pinned is less than current timestamp - value of cluster.remote_store.pinned_timestamps.lookback_interval"

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -15,7 +15,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.collect.Tuple;
-import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.AbstractAsyncTask;
@@ -24,6 +23,7 @@ import org.opensearch.gateway.remote.model.RemotePinnedTimestamps;
 import org.opensearch.gateway.remote.model.RemotePinnedTimestamps.PinnedTimestamps;
 import org.opensearch.gateway.remote.model.RemoteStorePinnedTimestampsBlobStore;
 import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.node.Node;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
@@ -57,46 +57,25 @@ public class RemoteStorePinnedTimestampService implements Closeable {
     private final Settings settings;
     private final ThreadPool threadPool;
     private final ClusterService clusterService;
+    private final RemoteStoreSettings remoteStoreSettings;
     private BlobStoreRepository blobStoreRepository;
     private BlobStoreTransferService blobStoreTransferService;
     private RemoteStorePinnedTimestampsBlobStore pinnedTimestampsBlobStore;
     private AsyncUpdatePinnedTimestampTask asyncUpdatePinnedTimestampTask;
-    private volatile TimeValue pinnedTimestampsSchedulerInterval;
     private final Semaphore updateTimetampPinningSemaphore = new Semaphore(1);
-
-    /**
-     * Controls pinned timestamp scheduler interval
-     */
-    public static final Setting<TimeValue> CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL = Setting.timeSetting(
-        "cluster.remote_store.pinned_timestamps.scheduler_interval",
-        TimeValue.timeValueMinutes(3),
-        TimeValue.timeValueMinutes(1),
-        Setting.Property.NodeScope
-    );
-
-    /**
-     * Controls allowed timestamp values to be pinned from past
-     */
-    public static final Setting<TimeValue> CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_LOOKBACK_INTERVAL = Setting.timeSetting(
-        "cluster.remote_store.pinned_timestamps.lookback_interval",
-        TimeValue.timeValueMinutes(1),
-        TimeValue.timeValueMinutes(1),
-        TimeValue.timeValueMinutes(5),
-        Setting.Property.NodeScope
-    );
 
     public RemoteStorePinnedTimestampService(
         Supplier<RepositoriesService> repositoriesService,
         Settings settings,
         ThreadPool threadPool,
-        ClusterService clusterService
+        ClusterService clusterService,
+        RemoteStoreSettings remoteStoreSettings
     ) {
         this.repositoriesService = repositoriesService;
         this.settings = settings;
         this.threadPool = threadPool;
         this.clusterService = clusterService;
-
-        pinnedTimestampsSchedulerInterval = CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL.get(settings);
+        this.remoteStoreSettings = remoteStoreSettings;
     }
 
     /**
@@ -107,7 +86,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
     public void start() {
         validateRemoteStoreConfiguration();
         initializeComponents();
-        startAsyncUpdateTask();
+        startAsyncUpdateTask(remoteStoreSettings.getPinnedTimestampsSchedulerInterval());
     }
 
     private void validateRemoteStoreConfiguration() {
@@ -132,7 +111,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
         );
     }
 
-    private void startAsyncUpdateTask() {
+    private void startAsyncUpdateTask(TimeValue pinnedTimestampsSchedulerInterval) {
         asyncUpdatePinnedTimestampTask = new AsyncUpdatePinnedTimestampTask(logger, threadPool, pinnedTimestampsSchedulerInterval, true);
     }
 
@@ -147,8 +126,8 @@ public class RemoteStorePinnedTimestampService implements Closeable {
     public void pinTimestamp(long timestamp, String pinningEntity, ActionListener<Void> listener) {
         // If a caller uses current system time to pin the timestamp, following check will almost always fail.
         // So, we allow pinning timestamp in the past upto some buffer
-        long lookbackIntervalInMills = CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_LOOKBACK_INTERVAL.get(settings).millis();
-        if (timestamp < TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - lookbackIntervalInMills) {
+        long lookbackIntervalInMills = remoteStoreSettings.getPinnedTimestampsLookbackInterval().millis();
+        if (timestamp < (System.currentTimeMillis() - lookbackIntervalInMills)) {
             throw new IllegalArgumentException(
                 "Timestamp to be pinned is less than current timestamp - value of cluster.remote_store.pinned_timestamps.lookback_interval"
             );
@@ -256,17 +235,12 @@ public class RemoteStorePinnedTimestampService implements Closeable {
         asyncUpdatePinnedTimestampTask.close();
     }
 
-    // Visible for testing
-    public void setPinnedTimestampsSchedulerInterval(TimeValue pinnedTimestampsSchedulerInterval) {
-        this.pinnedTimestampsSchedulerInterval = pinnedTimestampsSchedulerInterval;
-        rescheduleAsyncUpdatePinnedTimestampTask();
-    }
-
-    private void rescheduleAsyncUpdatePinnedTimestampTask() {
+    // Used in integ tests
+    public void rescheduleAsyncUpdatePinnedTimestampTask(TimeValue pinnedTimestampsSchedulerInterval) {
         if (pinnedTimestampsSchedulerInterval != null) {
             pinnedTimestampsSet = new Tuple<>(-1L, Set.of());
             asyncUpdatePinnedTimestampTask.close();
-            startAsyncUpdateTask();
+            startAsyncUpdateTask(pinnedTimestampsSchedulerInterval);
         }
     }
 


### PR DESCRIPTION
### Description
- We introduced 2 new cluster settings as part of timestamp pinning in remote store. These settings are present in `RemoteStorePinnedTimestampService` class.
- But we already have a class to consolidate all the remote store related settings: `RemoteStoreSettings`.
- In this PR, we move the timestamp pinning settings to `RemoteStoreSettings`.
- This also helps in avoiding un-necessary injection of `RemoteStorePinnedTimestampService` to lower components.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
