### PR TITLE
Update affiliation for @nknize.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,7 +22,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Varun Bansal             | [linuxpi](https://github.com/linuxpi)                   | Amazon      |
 | Marc Handalian           | [mch2](https://github.com/mch2)                         | Amazon      |
 | Michael Froh             | [msfroh](https://github.com/msfroh)                     | Amazon      |
-| Nick Knize               | [nknize](https://github.com/nknize)                     | Amazon      |
+| Nick Knize               | [nknize](https://github.com/nknize)                     | Lucenia     |
 | Owais Kazi               | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
 | Peter Nied               | [peternied](https://github.com/peternied)               | Amazon      |
 | Rishikesh Pasham         | [Rishikesh1159](https://github.com/Rishikesh1159)       | Amazon      |


### PR DESCRIPTION
### Description

Updated affiliation for @nknize in MAINTAINERS.md.

@nknize lmk if you prefer to be moved to Emeritus or would like a different affiliation since we haven't seen you here in a while.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
