### PR TITLE
Add fieldType to AbstractQueryBuilder and SortBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Workload Management] Add rejection logic for co-ordinator and shard level requests ([#15428](https://github.com/opensearch-project/OpenSearch/pull/15428)))
 - Adding translog durability validation in index templates ([#15494](https://github.com/opensearch-project/OpenSearch/pull/15494))
 - Add index creation using the context field ([#15290](https://github.com/opensearch-project/OpenSearch/pull/15290))
+- Add fieldType to AbstractQueryBuilder and FieldSortBuilder ([#15328](https://github.com/opensearch-project/OpenSearch/pull/15328)))
 
 ### Dependencies
 - Bump `netty` from 4.1.111.Final to 4.1.112.Final ([#15081](https://github.com/opensearch-project/OpenSearch/pull/15081))

--- a/modules/mapper-extras/src/main/java/org/opensearch/index/query/RankFeatureQueryBuilder.java
+++ b/modules/mapper-extras/src/main/java/org/opensearch/index/query/RankFeatureQueryBuilder.java
@@ -401,6 +401,11 @@ public final class RankFeatureQueryBuilder extends AbstractQueryBuilder<RankFeat
     }
 
     @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
+    @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
         final MappedFieldType ft = context.fieldMapper(field);
 

--- a/modules/parent-join/src/main/java/org/opensearch/join/query/HasChildQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/opensearch/join/query/HasChildQueryBuilder.java
@@ -264,6 +264,11 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static HasChildQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String childType = null;

--- a/modules/parent-join/src/main/java/org/opensearch/join/query/HasParentQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/opensearch/join/query/HasParentQueryBuilder.java
@@ -233,6 +233,11 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static HasParentQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String parentType = null;

--- a/modules/parent-join/src/main/java/org/opensearch/join/query/ParentIdQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/opensearch/join/query/ParentIdQueryBuilder.java
@@ -130,6 +130,11 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static ParentIdQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String type = null;

--- a/modules/percolator/src/main/java/org/opensearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/opensearch/percolator/PercolateQueryBuilder.java
@@ -356,6 +356,11 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     private static final ConstructingObjectParser<PercolateQueryBuilder, Void> PARSER = new ConstructingObjectParser<>(NAME, args -> {
         String field = (String) args[0];
         BytesReference document = (BytesReference) args[1];

--- a/server/src/main/java/org/opensearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldTypeLookup.java
@@ -101,7 +101,8 @@ class FieldTypeLookup implements Iterable<MappedFieldType> {
     }
 
     /**
-     * Returns the mapped field type for the given field name.
+     * Returns the {@link MappedFieldType} for the given field name
+     * or null if the field name is not found.
      */
     public MappedFieldType get(String field) {
         String concreteField = aliasToConcreteName.getOrDefault(field, field);

--- a/server/src/main/java/org/opensearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MapperService.java
@@ -622,7 +622,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     }
 
     /**
-     * Given the full name of a field, returns its {@link MappedFieldType}.
+     * Given the full name of a field, returns its {@link MappedFieldType}
+     * or null if the field is not found.
      */
     public MappedFieldType fieldType(String fullName) {
         return this.mapper == null ? null : this.mapper.fieldTypes().get(fullName);

--- a/server/src/main/java/org/opensearch/index/query/AbstractQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/AbstractQueryBuilder.java
@@ -74,6 +74,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
     public static final ParseField BOOST_FIELD = new ParseField("boost");
 
     protected String queryName;
+    protected String fieldType;
     protected float boost = DEFAULT_BOOST;
 
     protected AbstractQueryBuilder() {
@@ -112,6 +113,27 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
         }
     }
 
+    /**
+     * Returns field name as String.
+     * Abstract method to be implemented by all child classes.
+     */
+    public abstract String fieldName();
+
+    /**
+     * Default method for child classes which do not have a custom {@link #fieldName()} implementation.
+     */
+    protected static String getDefaultFieldName() {
+        return null;
+    };
+
+    /**
+     * Returns field type as String for QueryBuilder classes which have a defined fieldName.
+     * Else returns null.
+     */
+    public final String getFieldType() {
+        return fieldType;
+    };
+
     @Override
     public final Query toQuery(QueryShardContext context) throws IOException {
         Query query = doToQuery(context);
@@ -125,6 +147,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
                 context.addNamedQuery(queryName, query);
             }
         }
+        fieldType = context.getFieldTypeString(fieldName());
         return query;
     }
 

--- a/server/src/main/java/org/opensearch/index/query/BoolQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/BoolQueryBuilder.java
@@ -270,6 +270,11 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     private static void doXArrayContent(ParseField field, List<QueryBuilder> clauses, XContentBuilder builder, Params params)
         throws IOException {
         if (clauses.isEmpty()) {

--- a/server/src/main/java/org/opensearch/index/query/BoostingQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/BoostingQueryBuilder.java
@@ -151,6 +151,11 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static BoostingQueryBuilder fromXContent(XContentParser parser) throws IOException {
         QueryBuilder positiveQuery = null;
         boolean positiveQueryFound = false;

--- a/server/src/main/java/org/opensearch/index/query/ConstantScoreQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/ConstantScoreQueryBuilder.java
@@ -101,6 +101,11 @@ public class ConstantScoreQueryBuilder extends AbstractQueryBuilder<ConstantScor
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static ConstantScoreQueryBuilder fromXContent(XContentParser parser) throws IOException {
         QueryBuilder query = null;
         boolean queryFound = false;

--- a/server/src/main/java/org/opensearch/index/query/DisMaxQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/DisMaxQueryBuilder.java
@@ -137,6 +137,11 @@ public class DisMaxQueryBuilder extends AbstractQueryBuilder<DisMaxQueryBuilder>
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static DisMaxQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         float tieBreaker = DisMaxQueryBuilder.DEFAULT_TIE_BREAKER;

--- a/server/src/main/java/org/opensearch/index/query/DistanceFeatureQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/DistanceFeatureQueryBuilder.java
@@ -136,7 +136,8 @@ public class DistanceFeatureQueryBuilder extends AbstractQueryBuilder<DistanceFe
         return fieldType.distanceFeatureQuery(origin.origin(), pivot, 1.0f, context);
     }
 
-    String fieldName() {
+    @Override
+    public String fieldName() {
         return field;
     }
 

--- a/server/src/main/java/org/opensearch/index/query/IdsQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/IdsQueryBuilder.java
@@ -132,6 +132,11 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     private static final ObjectParser<IdsQueryBuilder, Void> PARSER = new ObjectParser<>(NAME, IdsQueryBuilder::new);
 
     static {

--- a/server/src/main/java/org/opensearch/index/query/IntervalQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/IntervalQueryBuilder.java
@@ -95,6 +95,11 @@ public class IntervalQueryBuilder extends AbstractQueryBuilder<IntervalQueryBuil
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static IntervalQueryBuilder fromXContent(XContentParser parser) throws IOException {
         if (parser.nextToken() != XContentParser.Token.FIELD_NAME) {
             throw new ParsingException(parser.getTokenLocation(), "Expected [FIELD_NAME] but got [" + parser.currentToken() + "]");

--- a/server/src/main/java/org/opensearch/index/query/MatchAllQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/MatchAllQueryBuilder.java
@@ -72,6 +72,11 @@ public class MatchAllQueryBuilder extends AbstractQueryBuilder<MatchAllQueryBuil
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     private static final ObjectParser<MatchAllQueryBuilder, Void> PARSER = new ObjectParser<>(NAME, MatchAllQueryBuilder::new);
 
     static {

--- a/server/src/main/java/org/opensearch/index/query/MatchNoneQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/MatchNoneQueryBuilder.java
@@ -71,6 +71,11 @@ public class MatchNoneQueryBuilder extends AbstractQueryBuilder<MatchNoneQueryBu
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static MatchNoneQueryBuilder fromXContent(XContentParser parser) throws IOException {
         String currentFieldName = null;
         XContentParser.Token token;

--- a/server/src/main/java/org/opensearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/MoreLikeThisQueryBuilder.java
@@ -792,6 +792,11 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static MoreLikeThisQueryBuilder fromXContent(XContentParser parser) throws IOException {
         // document inputs
         List<String> fields = null;

--- a/server/src/main/java/org/opensearch/index/query/MultiMatchQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/MultiMatchQueryBuilder.java
@@ -631,6 +631,11 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static MultiMatchQueryBuilder fromXContent(XContentParser parser) throws IOException {
         Object value = null;
         Map<String, Float> fieldsBoosts = new HashMap<>();

--- a/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
@@ -205,6 +205,11 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static NestedQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         ScoreMode scoreMode = ScoreMode.Avg;

--- a/server/src/main/java/org/opensearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/opensearch/index/query/QueryShardContext.java
@@ -364,6 +364,22 @@ public class QueryShardContext extends QueryRewriteContext {
         return failIfFieldMappingNotFound(name, mapperService.fieldType(name));
     }
 
+    /**
+     * Returns field type as String for the given field name.
+     * If field is not mapped or mapperService is null, returns null.
+     */
+    public String getFieldTypeString(String fieldName) {
+        if (fieldName != null) {
+            if (mapperService != null) {
+                MappedFieldType mappedFieldType = mapperService.fieldType(fieldName);
+                if (mappedFieldType != null) {
+                    return mappedFieldType.typeName();
+                }
+            }
+        }
+        return null;
+    }
+
     public ObjectMapper getObjectMapper(String name) {
         return mapperService.getObjectMapper(name);
     }

--- a/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
@@ -647,6 +647,11 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static QueryStringQueryBuilder fromXContent(XContentParser parser) throws IOException {
         String currentFieldName = null;
         XContentParser.Token token;

--- a/server/src/main/java/org/opensearch/index/query/ScriptQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/ScriptQueryBuilder.java
@@ -106,6 +106,11 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static ScriptQueryBuilder fromXContent(XContentParser parser) throws IOException {
         // also, when caching, since its isCacheable is false, will result in loading all bit set...
         Script script = null;

--- a/server/src/main/java/org/opensearch/index/query/SimpleQueryStringBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SimpleQueryStringBuilder.java
@@ -479,6 +479,11 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static SimpleQueryStringBuilder fromXContent(XContentParser parser) throws IOException {
         String currentFieldName = null;
         String queryBody = null;

--- a/server/src/main/java/org/opensearch/index/query/SpanContainingQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanContainingQueryBuilder.java
@@ -117,6 +117,11 @@ public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContain
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static SpanContainingQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String queryName = null;

--- a/server/src/main/java/org/opensearch/index/query/SpanFirstQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanFirstQueryBuilder.java
@@ -120,6 +120,11 @@ public class SpanFirstQueryBuilder extends AbstractQueryBuilder<SpanFirstQueryBu
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static SpanFirstQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
 

--- a/server/src/main/java/org/opensearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanMultiTermQueryBuilder.java
@@ -99,6 +99,11 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static SpanMultiTermQueryBuilder fromXContent(XContentParser parser) throws IOException {
         String currentFieldName = null;
         MultiTermQueryBuilder subQuery = null;

--- a/server/src/main/java/org/opensearch/index/query/SpanNearQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanNearQueryBuilder.java
@@ -167,6 +167,11 @@ public class SpanNearQueryBuilder extends AbstractQueryBuilder<SpanNearQueryBuil
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static SpanNearQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         int slop = DEFAULT_SLOP;

--- a/server/src/main/java/org/opensearch/index/query/SpanNotQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanNotQueryBuilder.java
@@ -181,6 +181,11 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static SpanNotQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
 

--- a/server/src/main/java/org/opensearch/index/query/SpanOrQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanOrQueryBuilder.java
@@ -115,6 +115,11 @@ public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder>
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static SpanOrQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String queryName = null;

--- a/server/src/main/java/org/opensearch/index/query/SpanWithinQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/SpanWithinQueryBuilder.java
@@ -122,6 +122,11 @@ public class SpanWithinQueryBuilder extends AbstractQueryBuilder<SpanWithinQuery
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static SpanWithinQueryBuilder fromXContent(XContentParser parser) throws IOException {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String queryName = null;

--- a/server/src/main/java/org/opensearch/index/query/TermsSetQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/TermsSetQueryBuilder.java
@@ -169,6 +169,11 @@ public final class TermsSetQueryBuilder extends AbstractQueryBuilder<TermsSetQue
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static TermsSetQueryBuilder fromXContent(XContentParser parser) throws IOException {
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {

--- a/server/src/main/java/org/opensearch/index/query/WrapperQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/WrapperQueryBuilder.java
@@ -131,6 +131,11 @@ public class WrapperQueryBuilder extends AbstractQueryBuilder<WrapperQueryBuilde
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static WrapperQueryBuilder fromXContent(XContentParser parser) throws IOException {
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME) {

--- a/server/src/main/java/org/opensearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -300,6 +300,11 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public FunctionScoreQueryBuilder setMinScore(float minScore) {
         this.minScore = minScore;
         return this;

--- a/server/src/main/java/org/opensearch/index/query/functionscore/ScriptScoreQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/ScriptScoreQueryBuilder.java
@@ -155,6 +155,11 @@ public class ScriptScoreQueryBuilder extends AbstractQueryBuilder<ScriptScoreQue
         builder.endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public ScriptScoreQueryBuilder setMinScore(float minScore) {
         this.minScore = minScore;
         return this;

--- a/server/src/main/java/org/opensearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/FieldSortBuilder.java
@@ -559,6 +559,11 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         }
     }
 
+    @Override
+    public String fieldName() {
+        return fieldName;
+    }
+
     private MappedFieldType resolveUnmappedType(QueryShardContext context) {
         if (unmappedType == null) {
             throw new QueryShardException(context, "No mapping found for [" + fieldName + "] in order to sort on");

--- a/server/src/main/java/org/opensearch/search/sort/ScoreSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/ScoreSortBuilder.java
@@ -161,6 +161,11 @@ public class ScoreSortBuilder extends SortBuilder<ScoreSortBuilder> {
     }
 
     @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
+    @Override
     public boolean equals(Object object) {
         if (this == object) {
             return true;

--- a/server/src/main/java/org/opensearch/search/sort/ScriptSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/ScriptSortBuilder.java
@@ -335,6 +335,11 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
         return fieldComparatorSource(context).newBucketedSort(context.bigArrays(), order, DocValueFormat.RAW, bucketSize, extra);
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     private IndexFieldData.XFieldComparatorSource fieldComparatorSource(QueryShardContext context) throws IOException {
         MultiValueMode valueMode = null;
         if (sortMode != null) {

--- a/server/src/main/java/org/opensearch/search/sort/SortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortBuilder.java
@@ -162,7 +162,7 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
         }
     }
 
-    private SortFieldAndFormat buildHelper(QueryShardContext context) throws IOException {
+    SortFieldAndFormat buildHelper(QueryShardContext context) throws IOException {
         SortFieldAndFormat sortFieldAndFormat = build(context);
         fieldType = context.getFieldTypeString(fieldName());
         return sortFieldAndFormat;

--- a/server/src/main/java/org/opensearch/search/sort/SortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortBuilder.java
@@ -71,6 +71,7 @@ import static org.opensearch.index.query.AbstractQueryBuilder.parseInnerQueryBui
 public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWriteable, ToXContentObject, Rewriteable<SortBuilder<?>> {
 
     protected SortOrder order = SortOrder.ASC;
+    protected String fieldType;
 
     // parse fields common to more than one SortBuilder
     public static final ParseField ORDER_FIELD = new ParseField("order");
@@ -161,11 +162,17 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
         }
     }
 
+    private SortFieldAndFormat buildHelper(QueryShardContext context) throws IOException {
+        SortFieldAndFormat sortFieldAndFormat = build(context);
+        fieldType = context.getFieldTypeString(fieldName());
+        return sortFieldAndFormat;
+    }
+
     public static Optional<SortAndFormats> buildSort(List<SortBuilder<?>> sortBuilders, QueryShardContext context) throws IOException {
         List<SortField> sortFields = new ArrayList<>(sortBuilders.size());
         List<DocValueFormat> sortFormats = new ArrayList<>(sortBuilders.size());
         for (SortBuilder<?> builder : sortBuilders) {
-            SortFieldAndFormat sf = builder.build(context);
+            SortFieldAndFormat sf = builder.buildHelper(context);
             sortFields.add(sf.field);
             sortFormats.add(sf.format);
         }
@@ -287,4 +294,25 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
     public String toString() {
         return Strings.toString(MediaTypeRegistry.JSON, this, true, true);
     }
+
+    /**
+     * Returns field name as String.
+     * Abstract method to be implemented by all child classes.
+     */
+    public abstract String fieldName();
+
+    /**
+     * Default method for child classes which do not have a custom {@link #fieldName()} implementation.
+     */
+    protected static String getDefaultFieldName() {
+        return null;
+    };
+
+    /**
+     * Returns field type as String for SortBuilder classes which have a defined fieldName.
+     * Else returns null.
+     */
+    public final String getFieldType() {
+        return fieldType;
+    };
 }

--- a/server/src/test/java/org/opensearch/index/query/plugin/DummyQueryBuilder.java
+++ b/server/src/test/java/org/opensearch/index/query/plugin/DummyQueryBuilder.java
@@ -62,6 +62,11 @@ public class DummyQueryBuilder extends AbstractQueryBuilder<DummyQueryBuilder> {
         builder.startObject(NAME).endObject();
     }
 
+    @Override
+    public final String fieldName() {
+        return getDefaultFieldName();
+    }
+
     public static DummyQueryBuilder fromXContent(XContentParser parser) throws IOException {
         XContentParser.Token token = parser.nextToken();
         assert token == XContentParser.Token.END_OBJECT;

--- a/server/src/test/java/org/opensearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchServiceTests.java
@@ -901,6 +901,11 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
         protected void doXContent(XContentBuilder builder, Params params) {}
 
         @Override
+        public String fieldName() {
+            return getDefaultFieldName();
+        }
+
+        @Override
         protected Query doToQuery(QueryShardContext context) {
             return null;
         }

--- a/server/src/test/java/org/opensearch/search/sort/AbstractSortTestCase.java
+++ b/server/src/test/java/org/opensearch/search/sort/AbstractSortTestCase.java
@@ -55,6 +55,7 @@ import org.opensearch.index.fielddata.IndexFieldDataCache;
 import org.opensearch.index.mapper.ContentPath;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.Mapper.BuilderContext;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.index.mapper.ObjectMapper;
 import org.opensearch.index.mapper.ObjectMapper.Nested;
@@ -199,10 +200,18 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends Ope
     }
 
     protected final QueryShardContext createMockShardContext() {
-        return createMockShardContext(null);
+        return createMockShardContext(null, null);
     }
 
     protected final QueryShardContext createMockShardContext(IndexSearcher searcher) {
+        return createMockShardContext(searcher, null);
+    }
+
+    protected final QueryShardContext createMockShardContext(MapperService mockMapperService) {
+        return createMockShardContext(null, mockMapperService);
+    }
+
+    protected final QueryShardContext createMockShardContext(IndexSearcher searcher, MapperService mapperService) {
         Index index = new Index(randomAlphaOfLengthBetween(1, 10), "_na_");
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(
             index,
@@ -222,7 +231,7 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends Ope
             BigArrays.NON_RECYCLING_INSTANCE,
             bitsetFilterCache,
             indexFieldDataLookup,
-            null,
+            mapperService,
             null,
             scriptService,
             xContentRegistry(),

--- a/server/src/test/java/org/opensearch/search/sort/FieldSortBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/sort/FieldSortBuilderTests.java
@@ -704,6 +704,16 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
         }
     }
 
+    /**
+     * Test that the sort builder fieldType is set properly
+     */
+    public void testSortFieldFieldType() throws IOException {
+        QueryShardContext shardContextMock = createMockShardContext();
+        FieldSortBuilder fieldSortBuilder = new FieldSortBuilder("value");
+        fieldSortBuilder.build(shardContextMock);
+        assertEquals(fieldSortBuilder.getFieldType(), "double");
+    }
+
     @Override
     protected void assertWarnings(FieldSortBuilder testItem) {
         List<String> expectedWarnings = new ArrayList<>();

--- a/server/src/test/java/org/opensearch/search/sort/plugin/CustomSortBuilder.java
+++ b/server/src/test/java/org/opensearch/search/sort/plugin/CustomSortBuilder.java
@@ -76,6 +76,11 @@ public class CustomSortBuilder extends SortBuilder<CustomSortBuilder> {
     }
 
     @Override
+    public String fieldName() {
+        return field;
+    }
+
+    @Override
     public boolean equals(Object object) {
         if (this == object) {
             return true;


### PR DESCRIPTION
### Description
- Added `fieldType` class variable and getter methods in `AbstractQueryBuilder` and `FieldSortBuilder`. 
- Added `fieldName()` as an abstract method in `AbstractQueryBuilder`. This requires all child classes to implement `fieldName()`. Child classes which do not already have a `fieldName()` method defined should call `getDefaultFieldName()` which returns null.

### Related Issues
https://github.com/opensearch-project/query-insights/issues/69

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
