### PR TITLE
Add SplitResponseProcessor to allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed array field name omission in flat_object function for nested JSON ([#13620](https://github.com/opensearch-project/OpenSearch/pull/13620))
 - Fix range aggregation optimization ignoring top level queries ([#15194](https://github.com/opensearch-project/OpenSearch/pull/15194))
 - Fix incorrect parameter names in MinHash token filter configuration handling ([#15233](https://github.com/opensearch-project/OpenSearch/pull/15233))
+- Fix split response processor not included in allowlist ([#15393](https://github.com/opensearch-project/OpenSearch/pull/15393))
 
 ### Security
 

--- a/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/SearchPipelineCommonModulePlugin.java
+++ b/modules/search-pipeline-common/src/main/java/org/opensearch/search/pipeline/common/SearchPipelineCommonModulePlugin.java
@@ -97,6 +97,8 @@ public class SearchPipelineCommonModulePlugin extends Plugin implements SearchPi
                 new TruncateHitsResponseProcessor.Factory(),
                 CollapseResponseProcessor.TYPE,
                 new CollapseResponseProcessor.Factory(),
+                SplitResponseProcessor.TYPE,
+                new SplitResponseProcessor.Factory(),
                 SortResponseProcessor.TYPE,
                 new SortResponseProcessor.Factory()
             )

--- a/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/SearchPipelineCommonModulePluginTests.java
+++ b/modules/search-pipeline-common/src/test/java/org/opensearch/search/pipeline/common/SearchPipelineCommonModulePluginTests.java
@@ -47,6 +47,7 @@ public class SearchPipelineCommonModulePluginTests extends OpenSearchTestCase {
             List.of("rename_field", "truncate_hits", "collapse"),
             SearchPipelineCommonModulePlugin::getResponseProcessors
         );
+        runAllowlistTest(key, List.of("split", "sort"), SearchPipelineCommonModulePlugin::getResponseProcessors);
 
         final IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
@@ -82,7 +83,7 @@ public class SearchPipelineCommonModulePluginTests extends OpenSearchTestCase {
         try (SearchPipelineCommonModulePlugin plugin = new SearchPipelineCommonModulePlugin()) {
             assertEquals(Set.of("oversample", "filter_query", "script"), plugin.getRequestProcessors(createParameters(settings)).keySet());
             assertEquals(
-                Set.of("rename_field", "truncate_hits", "collapse", "sort"),
+                Set.of("rename_field", "truncate_hits", "collapse", "split", "sort"),
                 plugin.getResponseProcessors(createParameters(settings)).keySet()
             );
             assertEquals(Set.of(), plugin.getSearchPhaseResultsProcessors(createParameters(settings)).keySet());


### PR DESCRIPTION
### Description

The `SplitResponseProcessor` for Search Pipelines was correctly added here:
https://github.com/opensearch-project/OpenSearch/pull/14800/files#diff-13c9de4d1b7eaef9dac008ddbff90b83b84e00dc13c2547c6c67484f26efc1e2

However, an incorrect (possibly automated) merge conflict resolution inadvertently removed it from the allowlist (and associated tests) here:
https://github.com/opensearch-project/OpenSearch/pull/14785/files#diff-13c9de4d1b7eaef9dac008ddbff90b83b84e00dc13c2547c6c67484f26efc1e2

This PR puts it back.

### Related Issues
Resolves #15229

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable. https://github.com/opensearch-project/opensearch-api-specification/pull/526
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. https://github.com/opensearch-project/documentation-website/issues/8077

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
