### PR TITLE
Add support to skip pinned timestamp in remote translog garbage collector

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -11,15 +11,19 @@ package org.opensearch.index.translog;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.SetOnce;
+import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.util.concurrent.ReleasableLock;
 import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.index.remote.RemoteStorePathStrategy;
+import org.opensearch.index.remote.RemoteStoreUtils;
 import org.opensearch.index.remote.RemoteTranslogTransferTracker;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.translog.transfer.BlobStoreTransferService;
@@ -30,6 +34,7 @@ import org.opensearch.index.translog.transfer.TranslogTransferManager;
 import org.opensearch.index.translog.transfer.TranslogTransferMetadata;
 import org.opensearch.index.translog.transfer.listener.TranslogTransferListener;
 import org.opensearch.indices.RemoteStoreSettings;
+import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.threadpool.ThreadPool;
@@ -39,11 +44,16 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -51,10 +61,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
 
 import static org.opensearch.index.remote.RemoteStoreEnums.DataCategory.TRANSLOG;
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.DATA;
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.METADATA;
+import static org.opensearch.index.translog.transfer.TranslogTransferMetadata.METADATA_SEPARATOR;
 
 /**
  * A Translog implementation which syncs local FS with a remote store
@@ -92,6 +104,8 @@ public class RemoteFsTranslog extends Translog {
     private final Semaphore syncPermit = new Semaphore(SYNC_PERMIT);
     private final AtomicBoolean pauseSync = new AtomicBoolean(false);
     private final boolean isTranslogMetadataEnabled;
+    private final Map<Long, String> metadataFilePinnedTimestampMap;
+    private final Map<String, Tuple<Long, Long>> metadataFileGenerationMap;
 
     public RemoteFsTranslog(
         TranslogConfig config,
@@ -106,12 +120,44 @@ public class RemoteFsTranslog extends Translog {
         RemoteTranslogTransferTracker remoteTranslogTransferTracker,
         RemoteStoreSettings remoteStoreSettings
     ) throws IOException {
+        this(
+            config,
+            translogUUID,
+            deletionPolicy,
+            globalCheckpointSupplier,
+            primaryTermSupplier,
+            persistedSequenceNumberConsumer,
+            blobStoreRepository,
+            threadPool,
+            startedPrimarySupplier,
+            remoteTranslogTransferTracker,
+            remoteStoreSettings,
+            0
+        );
+    }
+
+    public RemoteFsTranslog(
+        TranslogConfig config,
+        String translogUUID,
+        TranslogDeletionPolicy deletionPolicy,
+        LongSupplier globalCheckpointSupplier,
+        LongSupplier primaryTermSupplier,
+        LongConsumer persistedSequenceNumberConsumer,
+        BlobStoreRepository blobStoreRepository,
+        ThreadPool threadPool,
+        BooleanSupplier startedPrimarySupplier,
+        RemoteTranslogTransferTracker remoteTranslogTransferTracker,
+        RemoteStoreSettings remoteStoreSettings,
+        long timestamp
+    ) throws IOException {
         super(config, translogUUID, deletionPolicy, globalCheckpointSupplier, primaryTermSupplier, persistedSequenceNumberConsumer);
         logger = Loggers.getLogger(getClass(), shardId);
         this.startedPrimarySupplier = startedPrimarySupplier;
         this.remoteTranslogTransferTracker = remoteTranslogTransferTracker;
         fileTransferTracker = new FileTransferTracker(shardId, remoteTranslogTransferTracker);
         isTranslogMetadataEnabled = indexSettings().isTranslogMetadataEnabled();
+        this.metadataFilePinnedTimestampMap = new HashMap<>();
+        this.metadataFileGenerationMap = new HashMap<>();
         this.translogTransferManager = buildTranslogTransferManager(
             blobStoreRepository,
             threadPool,
@@ -123,7 +169,7 @@ public class RemoteFsTranslog extends Translog {
             isTranslogMetadataEnabled
         );
         try {
-            download(translogTransferManager, location, logger, config.shouldSeedRemote());
+            download(translogTransferManager, location, logger, config.shouldSeedRemote(), timestamp);
             Checkpoint checkpoint = readCheckpoint(location);
             logger.info("Downloaded data from remote translog till maxSeqNo = {}", checkpoint.maxSeqNo);
             this.readers.addAll(recoverFromFiles(checkpoint));
@@ -175,6 +221,32 @@ public class RemoteFsTranslog extends Translog {
         boolean seedRemote,
         boolean isTranslogMetadataEnabled
     ) throws IOException {
+        download(
+            repository,
+            shardId,
+            threadPool,
+            location,
+            pathStrategy,
+            remoteStoreSettings,
+            logger,
+            seedRemote,
+            isTranslogMetadataEnabled,
+            0
+        );
+    }
+
+    public static void download(
+        Repository repository,
+        ShardId shardId,
+        ThreadPool threadPool,
+        Path location,
+        RemoteStorePathStrategy pathStrategy,
+        RemoteStoreSettings remoteStoreSettings,
+        Logger logger,
+        boolean seedRemote,
+        boolean isTranslogMetadataEnabled,
+        long timestamp
+    ) throws IOException {
         assert repository instanceof BlobStoreRepository : String.format(
             Locale.ROOT,
             "%s repository should be instance of BlobStoreRepository",
@@ -195,11 +267,12 @@ public class RemoteFsTranslog extends Translog {
             remoteStoreSettings,
             isTranslogMetadataEnabled
         );
-        RemoteFsTranslog.download(translogTransferManager, location, logger, seedRemote);
+        RemoteFsTranslog.download(translogTransferManager, location, logger, seedRemote, timestamp);
         logger.trace(remoteTranslogTransferTracker.toString());
     }
 
-    static void download(TranslogTransferManager translogTransferManager, Path location, Logger logger, boolean seedRemote)
+    // Visible for testing
+    static void download(TranslogTransferManager translogTransferManager, Path location, Logger logger, boolean seedRemote, long timestamp)
         throws IOException {
         /*
         In Primary to Primary relocation , there can be concurrent upload and download of translog.
@@ -213,7 +286,7 @@ public class RemoteFsTranslog extends Translog {
             boolean success = false;
             long startTimeMs = System.currentTimeMillis();
             try {
-                downloadOnce(translogTransferManager, location, logger, seedRemote);
+                downloadOnce(translogTransferManager, location, logger, seedRemote, timestamp);
                 success = true;
                 return;
             } catch (FileNotFoundException | NoSuchFileException e) {
@@ -227,13 +300,18 @@ public class RemoteFsTranslog extends Translog {
         throw ex;
     }
 
-    private static void downloadOnce(TranslogTransferManager translogTransferManager, Path location, Logger logger, boolean seedRemote)
-        throws IOException {
+    private static void downloadOnce(
+        TranslogTransferManager translogTransferManager,
+        Path location,
+        Logger logger,
+        boolean seedRemote,
+        long timestamp
+    ) throws IOException {
         logger.debug("Downloading translog files from remote");
         RemoteTranslogTransferTracker statsTracker = translogTransferManager.getRemoteTranslogTransferTracker();
         long prevDownloadBytesSucceeded = statsTracker.getDownloadBytesSucceeded();
         long prevDownloadTimeInMillis = statsTracker.getTotalDownloadTimeInMillis();
-        TranslogTransferMetadata translogMetadata = translogTransferManager.readMetadata();
+        TranslogTransferMetadata translogMetadata = translogTransferManager.readMetadata(timestamp);
         if (translogMetadata != null) {
             if (Files.notExists(location)) {
                 Files.createDirectories(location);
@@ -538,9 +616,31 @@ public class RemoteFsTranslog extends Translog {
         // clean up local translog files and updates readers
         super.trimUnreferencedReaders();
 
+        // Update file tracker to reflect local translog state
+        Optional<Long> minLiveGeneration = readers.stream().map(BaseTranslogReader::getGeneration).min(Long::compareTo);
+        if (minLiveGeneration.isPresent()) {
+            List<String> staleFilesInTracker = new ArrayList<>();
+            for (String file : fileTransferTracker.allUploaded()) {
+                if (file.endsWith(TRANSLOG_FILE_SUFFIX)) {
+                    long generation = Translog.parseIdFromFileName(file);
+                    if (generation < minLiveGeneration.get()) {
+                        staleFilesInTracker.add(file);
+                        staleFilesInTracker.add(Translog.getCommitCheckpointFileName(generation));
+                    }
+                }
+                fileTransferTracker.delete(staleFilesInTracker);
+            }
+        }
+
         // This is to ensure that after the permits are acquired during primary relocation, there are no further modification on remote
         // store.
         if (startedPrimarySupplier.getAsBoolean() == false || pauseSync.get()) {
+            return;
+        }
+
+        // This is to fail fast and avoid listing md files un-necessarily.
+        if (RemoteStoreUtils.isPinnedTimestampStateStale()) {
+            logger.warn("Skipping remote segment store garbage collection as last fetch of pinned timestamp is stale");
             return;
         }
 
@@ -551,34 +651,174 @@ public class RemoteFsTranslog extends Translog {
             return;
         }
 
-        // cleans up remote translog files not referenced in latest uploaded metadata.
-        // This enables us to restore translog from the metadata in case of failover or relocation.
-        Set<Long> generationsToDelete = new HashSet<>();
-        for (long generation = minRemoteGenReferenced - 1 - indexSettings().getRemoteTranslogExtraKeep(); generation >= 0; generation--) {
-            if (fileTransferTracker.uploaded(Translog.getFilename(generation)) == false) {
-                break;
+        ActionListener<List<BlobMetadata>> listMetadataFilesListener = new ActionListener<>() {
+            @Override
+            public void onResponse(List<BlobMetadata> blobMetadata) {
+                List<String> metadataFiles = blobMetadata.stream().map(BlobMetadata::name).collect(Collectors.toList());
+
+                try {
+                    if (metadataFiles.size() <= 1) {
+                        logger.debug("No stale translog metadata files found");
+                        remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+                        return;
+                    }
+
+                    // Check last fetch status of pinned timestamps. If stale, return.
+                    if (RemoteStoreUtils.isPinnedTimestampStateStale()) {
+                        logger.warn("Skipping remote segment store garbage collection as last fetch of pinned timestamp is stale");
+                        remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+                        return;
+                    }
+
+                    List<String> metadataFilesToBeDeleted = getMetadataFilesToBeDeleted(metadataFiles);
+
+                    // If no metadata file is filtered out, make sure to keep latest metadata file
+                    if (metadataFiles.size() == metadataFilesToBeDeleted.size() && metadataFiles.equals(metadataFilesToBeDeleted)) {
+                        metadataFilesToBeDeleted = metadataFiles.subList(1, metadataFiles.size());
+                    }
+
+                    if (metadataFilesToBeDeleted.isEmpty()) {
+                        logger.debug("No metadata files to delete");
+                        remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+                        return;
+                    }
+
+                    Set<Long> generationsToBeDeleted = getGenerationsToBeDeleted(metadataFilesToBeDeleted);
+                    if (generationsToBeDeleted.isEmpty() == false) {
+                        // Delete stale generations
+                        translogTransferManager.deleteGenerationAsync(
+                            primaryTermSupplier.getAsLong(),
+                            generationsToBeDeleted,
+                            remoteGenerationDeletionPermits::release
+                        );
+
+                        // Delete stale metadata files
+                        translogTransferManager.deleteMetadataFilesAsync(
+                            metadataFilesToBeDeleted,
+                            remoteGenerationDeletionPermits::release
+                        );
+
+                        // Delete stale primary terms
+                        deleteStaleRemotePrimaryTerms(metadataFiles);
+                    } else {
+                        remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+                    }
+                } catch (Exception e) {
+                    remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+                }
             }
-            generationsToDelete.add(generation);
-        }
-        if (generationsToDelete.isEmpty() == false) {
-            deleteRemoteGeneration(generationsToDelete);
-            translogTransferManager.deleteStaleTranslogMetadataFilesAsync(remoteGenerationDeletionPermits::release);
-            deleteStaleRemotePrimaryTerms();
-        } else {
-            remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
-        }
+
+            @Override
+            public void onFailure(Exception e) {
+                remoteGenerationDeletionPermits.release(REMOTE_DELETION_PERMITS);
+                logger.error("Exception while listing translog metadata files", e);
+            }
+        };
+        translogTransferManager.listTranslogMetadataFilesAsync(listMetadataFilesListener);
     }
 
-    /**
-     * Deletes remote translog and metadata files asynchronously corresponding to the generations.
-     * @param generations generations to be deleted.
-     */
-    private void deleteRemoteGeneration(Set<Long> generations) {
-        translogTransferManager.deleteGenerationAsync(
-            primaryTermSupplier.getAsLong(),
-            generations,
-            remoteGenerationDeletionPermits::release
+    private Set<Long> getGenerationsToBeDeleted(List<String> metadataFilesToBeDeleted) throws IOException {
+        Set<Long> generationsToBeDeleted = new HashSet<>();
+
+        // From the remaining files, read oldest and latest
+        String oldestMetadataFileToBeDeleted = metadataFilesToBeDeleted.get(metadataFilesToBeDeleted.size() - 1);
+        String latestMetadataFileToBeDeleted = metadataFilesToBeDeleted.get(0);
+
+        // Delete generations
+        long minGenerationToBeDeleted;
+        long maxGenerationToBeDeleted;
+        if (metadataFileGenerationMap.containsKey(latestMetadataFileToBeDeleted) == false) {
+            TranslogTransferMetadata metadata = translogTransferManager.readMetadata(latestMetadataFileToBeDeleted);
+            maxGenerationToBeDeleted = metadata.getMinTranslogGeneration() - 1;
+        } else {
+            maxGenerationToBeDeleted = metadataFileGenerationMap.get(latestMetadataFileToBeDeleted).v1() - 1;
+        }
+        long minGenerationToKeep = minRemoteGenReferenced - 1 - indexSettings().getRemoteTranslogExtraKeep();
+        maxGenerationToBeDeleted = Math.min(maxGenerationToBeDeleted, minGenerationToKeep);
+
+        if (metadataFileGenerationMap.containsKey(oldestMetadataFileToBeDeleted) == false) {
+            TranslogTransferMetadata metadata = translogTransferManager.readMetadata(oldestMetadataFileToBeDeleted);
+            minGenerationToBeDeleted = metadata.getMinTranslogGeneration() - 1;
+        } else {
+            minGenerationToBeDeleted = metadataFileGenerationMap.get(oldestMetadataFileToBeDeleted).v1() - 1;
+        }
+
+        TreeSet<Tuple<Long, Long>> pinnedGenerations = getOrderedPinnedMetadataGenerations();
+        for (long generation = maxGenerationToBeDeleted; generation >= minGenerationToBeDeleted; generation--) {
+            // Check if the generation is not referred by metadata file matching pinned timestamps
+            if (isGenerationPinned(generation, pinnedGenerations) == false) {
+                generationsToBeDeleted.add(generation);
+            }
+        }
+
+        return generationsToBeDeleted;
+    }
+
+    private List<String> getMetadataFilesToBeDeleted(List<String> metadataFiles) {
+        Tuple<Long, Set<Long>> pinnedTimestampsState = RemoteStorePinnedTimestampService.getPinnedTimestamps();
+
+        // Keep files since last successful run of scheduler
+        List<String> metadataFilesToBeDeleted = RemoteStoreUtils.filterOutMetadataFilesBasedOnAge(
+            metadataFiles,
+            file -> RemoteStoreUtils.invertLong(file.split(METADATA_SEPARATOR)[3]),
+            pinnedTimestampsState.v1()
         );
+
+        // Get md files matching pinned timestamps
+        Set<String> implicitLockedFiles = RemoteStoreUtils.getPinnedTimestampLockedFiles(
+            metadataFilesToBeDeleted,
+            pinnedTimestampsState.v2(),
+            metadataFilePinnedTimestampMap,
+            file -> RemoteStoreUtils.invertLong(file.split(METADATA_SEPARATOR)[3]),
+            TranslogTransferMetadata::getNodeIdByPrimaryTermAndGen
+        );
+
+        // For new pinned timestamp, read matching file to get min and max generations
+        try {
+            readAndCacheGenerationForPinnedTimestamp(implicitLockedFiles);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Filter out metadata files matching pinned timestamps
+        metadataFilesToBeDeleted.removeAll(implicitLockedFiles);
+
+        return metadataFilesToBeDeleted;
+    }
+
+    private boolean isGenerationPinned(long generation, TreeSet<Tuple<Long, Long>> pinnedGenerations) {
+        Tuple<Long, Long> ceilingGenerationRange = pinnedGenerations.ceiling(new Tuple<>(generation, generation));
+        if (ceilingGenerationRange != null && generation >= ceilingGenerationRange.v1() && generation <= ceilingGenerationRange.v2()) {
+            return true;
+        }
+        Tuple<Long, Long> floorGenerationRange = pinnedGenerations.floor(new Tuple<>(generation, generation));
+        if (floorGenerationRange != null && generation >= floorGenerationRange.v1() && generation <= floorGenerationRange.v2()) {
+            return true;
+        }
+        return false;
+    }
+
+    private TreeSet<Tuple<Long, Long>> getOrderedPinnedMetadataGenerations() {
+        TreeSet<Tuple<Long, Long>> pinnedGenerations = new TreeSet<>((o1, o2) -> {
+            if (Objects.equals(o1.v1(), o2.v1()) == false) {
+                return o1.v1().compareTo(o2.v1());
+            } else {
+                return o1.v2().compareTo(o2.v2());
+            }
+        });
+        pinnedGenerations.addAll(metadataFileGenerationMap.values());
+        return pinnedGenerations;
+    }
+
+    private void readAndCacheGenerationForPinnedTimestamp(Set<String> implicitLockedFiles) throws IOException {
+        Set<String> nonCachedMetadataFiles = implicitLockedFiles.stream()
+            .filter(f -> metadataFileGenerationMap.containsKey(f) == false)
+            .collect(Collectors.toSet());
+        metadataFileGenerationMap.keySet().retainAll(implicitLockedFiles);
+        for (String metadataFile : nonCachedMetadataFiles) {
+            TranslogTransferMetadata metadata = translogTransferManager.readMetadata(metadataFile);
+            metadataFileGenerationMap.put(metadataFile, new Tuple<>(metadata.getMinTranslogGeneration(), metadata.getGeneration()));
+        }
     }
 
     /**
@@ -587,17 +827,20 @@ public class RemoteFsTranslog extends Translog {
      * <br>
      * This will also delete all stale translog metadata files from remote except the latest basis the metadata file comparator.
      */
-    private void deleteStaleRemotePrimaryTerms() {
+    private void deleteStaleRemotePrimaryTerms(List<String> metadataFiles) {
         // The deletion of older translog files in remote store is on best-effort basis, there is a possibility that there
         // are older files that are no longer needed and should be cleaned up. In here, we delete all files that are part
         // of older primary term.
         if (olderPrimaryCleaned.trySet(Boolean.TRUE)) {
-            if (readers.isEmpty()) {
-                logger.trace("Translog reader list is empty, returning from deleteStaleRemotePrimaryTerms");
+            if (metadataFiles.isEmpty()) {
+                logger.trace("No metadata is uploaded yet, returning from deleteStaleRemotePrimaryTerms");
                 return;
             }
+            Optional<Long> minPrimaryTerm = metadataFiles.stream()
+                .map(file -> RemoteStoreUtils.invertLong(file.split(METADATA_SEPARATOR)[1]))
+                .min(Long::compareTo);
             // First we delete all stale primary terms folders from remote store
-            long minimumReferencedPrimaryTerm = readers.stream().map(BaseTranslogReader::getPrimaryTerm).min(Long::compare).get();
+            long minimumReferencedPrimaryTerm = minPrimaryTerm.get() - 1;
             translogTransferManager.deletePrimaryTermsAsync(minimumReferencedPrimaryTerm);
         }
     }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -906,10 +906,14 @@ public class RemoteFsTranslog extends Translog {
     protected void onDelete() {
         ClusterService.assertClusterOrClusterManagerStateThread();
         // clean up all remote translog files
-        try {
-            trimUnreferencedReaders(true, false);
-        } catch (IOException e) {
-            logger.error("Exception while deleting translog files from remote store", e);
+        if (RemoteStoreSettings.isPinnedTimestampsEnabled()) {
+            try {
+                trimUnreferencedReaders(true, false);
+            } catch (IOException e) {
+                logger.error("Exception while deleting translog files from remote store", e);
+            }
+        } else {
+            translogTransferManager.delete();
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -81,6 +81,8 @@ public class RemoteFsTranslog extends Translog {
 
     private final Logger logger;
     private final TranslogTransferManager translogTransferManager;
+    // This tracker keeps track of local tranlog files that are uploaded to remote store.
+    // Once tlog files are deleted from local, we remove them from tracker even if the files still exist in remote translog.
     private final FileTransferTracker fileTransferTracker;
     private final BooleanSupplier startedPrimarySupplier;
     private final RemoteTranslogTransferTracker remoteTranslogTransferTracker;

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -749,9 +749,10 @@ public class RemoteFsTranslog extends Translog {
 
         if (RemoteStoreSettings.isPinnedTimestampsEnabled()) {
             String latestMetadataFileToBeDeleted = metadataFilesToBeDeleted.get(0);
-            long maxGenerationFromLatestMetadataFile = metadataFileGenerationMap.containsKey(latestMetadataFileToBeDeleted)
-                ? metadataFileGenerationMap.get(latestMetadataFileToBeDeleted).v2()
-                : getMinMaxTranslogGenerationFromMetadataFile(latestMetadataFileToBeDeleted, translogTransferManager).v2();
+            long maxGenerationFromLatestMetadataFile = getMinMaxTranslogGenerationFromMetadataFile(
+                latestMetadataFileToBeDeleted,
+                translogTransferManager
+            ).v2();
 
             if (indexDeleted) {
                 maxGenerationToBeDeleted = maxGenerationFromLatestMetadataFile;
@@ -762,9 +763,8 @@ public class RemoteFsTranslog extends Translog {
 
         // From the remaining files, read the oldest file to get min generation to be deleted
         String oldestMetadataFileToBeDeleted = metadataFilesToBeDeleted.get(metadataFilesToBeDeleted.size() - 1);
-        long minGenerationToBeDeleted = metadataFileGenerationMap.containsKey(oldestMetadataFileToBeDeleted)
-            ? metadataFileGenerationMap.get(oldestMetadataFileToBeDeleted).v1()
-            : getMinMaxTranslogGenerationFromMetadataFile(oldestMetadataFileToBeDeleted, translogTransferManager).v1();
+        long minGenerationToBeDeleted = getMinMaxTranslogGenerationFromMetadataFile(oldestMetadataFileToBeDeleted, translogTransferManager)
+            .v1();
 
         TreeSet<Tuple<Long, Long>> pinnedGenerations = getOrderedPinnedMetadataGenerations(metadataFileGenerationMap);
         for (long generation = maxGenerationToBeDeleted; generation >= minGenerationToBeDeleted; generation--) {

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -694,15 +694,19 @@ public class RemoteFsTranslog extends Translog {
                         return;
                     }
 
+                    logger.debug("metadataFilesToBeDeleted = {}", metadataFilesToBeDeleted);
                     // For all the files that we are keeping, fetch min and max generations
                     List<String> metadataFilesNotToBeDeleted = new ArrayList<>(metadataFiles);
                     metadataFilesNotToBeDeleted.removeAll(metadataFilesToBeDeleted);
 
+                    logger.debug("metadataFilesNotToBeDeleted = {}", metadataFilesNotToBeDeleted);
                     Set<Long> generationsToBeDeleted = getGenerationsToBeDeleted(
                         metadataFilesNotToBeDeleted,
                         metadataFilesToBeDeleted,
                         indexDeleted
                     );
+
+                    logger.debug("generationsToBeDeleted = {}", generationsToBeDeleted);
                     if (generationsToBeDeleted.isEmpty() == false) {
                         // Delete stale generations
                         translogTransferManager.deleteGenerationAsync(
@@ -782,6 +786,12 @@ public class RemoteFsTranslog extends Translog {
             pinnedTimestampsState.v1()
         );
 
+        logger.trace(
+            "metadataFiles.size = {}, metadataFilesToBeDeleted based on age based filtering = {}",
+            metadataFiles.size(),
+            metadataFilesToBeDeleted.size()
+        );
+
         // Get md files matching pinned timestamps
         Set<String> implicitLockedFiles = RemoteStoreUtils.getPinnedTimestampLockedFiles(
             metadataFilesToBeDeleted,
@@ -793,6 +803,12 @@ public class RemoteFsTranslog extends Translog {
 
         // Filter out metadata files matching pinned timestamps
         metadataFilesToBeDeleted.removeAll(implicitLockedFiles);
+
+        logger.trace(
+            "implicitLockedFiles.size = {}, metadataFilesToBeDeleted based on pinned timestamp filtering = {}",
+            implicitLockedFiles.size(),
+            metadataFilesToBeDeleted.size()
+        );
 
         return metadataFilesToBeDeleted;
     }

--- a/server/src/main/java/org/opensearch/index/translog/Translog.java
+++ b/server/src/main/java/org/opensearch/index/translog/Translog.java
@@ -317,6 +317,10 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
      */
     public static long parseIdFromFileName(Path translogFile) {
         final String fileName = translogFile.getFileName().toString();
+        return parseIdFromFileName(fileName);
+    }
+
+    public static long parseIdFromFileName(String fileName) {
         final Matcher matcher = PARSE_STRICT_ID_PATTERN.matcher(fileName);
         if (matcher.matches()) {
             try {

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -349,7 +349,8 @@ public class TranslogTransferManager {
                 metadataFiles,
                 Set.of(timestamp),
                 file -> RemoteStoreUtils.invertLong(file.split(METADATA_SEPARATOR)[3]),
-                TranslogTransferMetadata::getNodeIdByPrimaryTermAndGen
+                TranslogTransferMetadata::getNodeIdByPrimaryTermAndGen,
+                true
             );
             if (metadataFilesMatchingTimestamp.isEmpty()) {
                 return null;

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -339,15 +339,15 @@ public class TranslogTransferManager {
         }
     }
 
-    public TranslogTransferMetadata readMetadata(long timestamp) throws IOException {
-        if (timestamp <= 0) {
+    public TranslogTransferMetadata readMetadata(long pinnedTimestamp) throws IOException {
+        if (pinnedTimestamp <= 0) {
             return readMetadata();
         }
         return readMetadata((blobMetadataList) -> {
             List<String> metadataFiles = blobMetadataList.stream().map(BlobMetadata::name).collect(Collectors.toList());
             Set<String> metadataFilesMatchingTimestamp = RemoteStoreUtils.getPinnedTimestampLockedFiles(
                 metadataFiles,
-                Set.of(timestamp),
+                Set.of(pinnedTimestamp),
                 file -> RemoteStoreUtils.invertLong(file.split(METADATA_SEPARATOR)[3]),
                 TranslogTransferMetadata::getNodeIdByPrimaryTermAndGen,
                 true

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferManager.java
@@ -45,10 +45,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.opensearch.index.translog.transfer.FileSnapshot.TransferFileSnapshot;
 import static org.opensearch.index.translog.transfer.FileSnapshot.TranslogFileSnapshot;
+import static org.opensearch.index.translog.transfer.TranslogTransferMetadata.METADATA_SEPARATOR;
 
 /**
  * The class responsible for orchestrating the transfer of a {@link TransferSnapshot} via a {@link TransferService}
@@ -337,35 +339,53 @@ public class TranslogTransferManager {
         }
     }
 
+    public TranslogTransferMetadata readMetadata(long timestamp) throws IOException {
+        if (timestamp <= 0) {
+            return readMetadata();
+        }
+        return readMetadata((blobMetadataList) -> {
+            List<String> metadataFiles = blobMetadataList.stream().map(BlobMetadata::name).collect(Collectors.toList());
+            Set<String> metadataFilesMatchingTimestamp = RemoteStoreUtils.getPinnedTimestampLockedFiles(
+                metadataFiles,
+                Set.of(timestamp),
+                file -> RemoteStoreUtils.invertLong(file.split(METADATA_SEPARATOR)[3]),
+                TranslogTransferMetadata::getNodeIdByPrimaryTermAndGen
+            );
+            if (metadataFilesMatchingTimestamp.isEmpty()) {
+                return null;
+            }
+            assert metadataFilesMatchingTimestamp.size() == 1 : "There should be only 1 metadata file matching given timestamp";
+            return metadataFilesMatchingTimestamp.stream().findFirst().get();
+        }, Integer.MAX_VALUE);
+    }
+
     public TranslogTransferMetadata readMetadata() throws IOException {
+        return readMetadata((blobMetadataList) -> {
+            RemoteStoreUtils.verifyNoMultipleWriters(
+                blobMetadataList.stream().map(BlobMetadata::name).collect(Collectors.toList()),
+                TranslogTransferMetadata::getNodeIdByPrimaryTermAndGen
+            );
+            return blobMetadataList.get(0).name();
+        }, METADATA_FILES_TO_FETCH);
+    }
+
+    private TranslogTransferMetadata readMetadata(Function<List<BlobMetadata>, String> getMetadataFileToRead, int numberOfFilesToFetch)
+        throws IOException {
         SetOnce<TranslogTransferMetadata> metadataSetOnce = new SetOnce<>();
         SetOnce<IOException> exceptionSetOnce = new SetOnce<>();
         final CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<List<BlobMetadata>> latchedActionListener = new LatchedActionListener<>(
             ActionListener.wrap(blobMetadataList -> {
                 if (blobMetadataList.isEmpty()) return;
-                RemoteStoreUtils.verifyNoMultipleWriters(
-                    blobMetadataList.stream().map(BlobMetadata::name).collect(Collectors.toList()),
-                    TranslogTransferMetadata::getNodeIdByPrimaryTermAndGen
-                );
-                String filename = blobMetadataList.get(0).name();
-                boolean downloadStatus = false;
-                long downloadStartTime = System.nanoTime(), bytesToRead = 0;
-                try (InputStream inputStream = transferService.downloadBlob(remoteMetadataTransferPath, filename)) {
-                    // Capture number of bytes for stats before reading
-                    bytesToRead = inputStream.available();
-                    IndexInput indexInput = new ByteArrayIndexInput("metadata file", inputStream.readAllBytes());
-                    metadataSetOnce.set(metadataStreamWrapper.readStream(indexInput));
-                    downloadStatus = true;
+                String filename = getMetadataFileToRead.apply(blobMetadataList);
+                if (filename == null) {
+                    return;
+                }
+                try {
+                    metadataSetOnce.set(readMetadata(filename));
                 } catch (IOException e) {
                     logger.error(() -> new ParameterizedMessage("Exception while reading metadata file: {}", filename), e);
                     exceptionSetOnce.set(e);
-                } finally {
-                    remoteTranslogTransferTracker.addDownloadTimeInMillis((System.nanoTime() - downloadStartTime) / 1_000_000L);
-                    logger.debug("translogMetadataDownloadStatus={}", downloadStatus);
-                    if (downloadStatus) {
-                        remoteTranslogTransferTracker.addDownloadBytesSucceeded(bytesToRead);
-                    }
                 }
             }, e -> {
                 if (e instanceof RuntimeException) {
@@ -381,12 +401,14 @@ public class TranslogTransferManager {
             transferService.listAllInSortedOrder(
                 remoteMetadataTransferPath,
                 TranslogTransferMetadata.METADATA_PREFIX,
-                METADATA_FILES_TO_FETCH,
+                numberOfFilesToFetch,
                 latchedActionListener
             );
-            latch.await();
+            if (latch.await(remoteStoreSettings.getClusterRemoteTranslogTransferTimeout().millis(), TimeUnit.MILLISECONDS) == false) {
+                throw new RuntimeException("Timed out reading metadata file");
+            }
         } catch (InterruptedException e) {
-            throw new IOException("Exception while reading/downloading metadafile", e);
+            throw new IOException("Exception while reading/downloading metadata file", e);
         }
 
         if (exceptionSetOnce.get() != null) {
@@ -394,6 +416,26 @@ public class TranslogTransferManager {
         }
 
         return metadataSetOnce.get();
+    }
+
+    public TranslogTransferMetadata readMetadata(String metadataFilename) throws IOException {
+        boolean downloadStatus = false;
+        TranslogTransferMetadata translogTransferMetadata = null;
+        long downloadStartTime = System.nanoTime(), bytesToRead = 0;
+        try (InputStream inputStream = transferService.downloadBlob(remoteMetadataTransferPath, metadataFilename)) {
+            // Capture number of bytes for stats before reading
+            bytesToRead = inputStream.available();
+            IndexInput indexInput = new ByteArrayIndexInput("metadata file", inputStream.readAllBytes());
+            translogTransferMetadata = metadataStreamWrapper.readStream(indexInput);
+            downloadStatus = true;
+        } finally {
+            remoteTranslogTransferTracker.addDownloadTimeInMillis((System.nanoTime() - downloadStartTime) / 1_000_000L);
+            logger.debug("translogMetadataDownloadStatus={}", downloadStatus);
+            if (downloadStatus) {
+                remoteTranslogTransferTracker.addDownloadBytesSucceeded(bytesToRead);
+            }
+        }
+        return translogTransferMetadata;
     }
 
     private TransferFileSnapshot prepareMetadata(TransferSnapshot transferSnapshot) throws IOException {
@@ -549,6 +591,16 @@ public class TranslogTransferManager {
         });
     }
 
+    public void listTranslogMetadataFilesAsync(ActionListener<List<BlobMetadata>> listener) {
+        transferService.listAllInSortedOrderAsync(
+            ThreadPool.Names.REMOTE_PURGE,
+            remoteMetadataTransferPath,
+            TranslogTransferMetadata.METADATA_PREFIX,
+            Integer.MAX_VALUE,
+            listener
+        );
+    }
+
     public void deleteStaleTranslogMetadataFilesAsync(Runnable onCompletion) {
         try {
             transferService.listAllInSortedOrderAsync(
@@ -635,7 +687,7 @@ public class TranslogTransferManager {
      * @param files list of metadata files to be deleted.
      * @param onCompletion runnable to run on completion of deletion regardless of success/failure.
      */
-    private void deleteMetadataFilesAsync(List<String> files, Runnable onCompletion) {
+    public void deleteMetadataFilesAsync(List<String> files, Runnable onCompletion) {
         try {
             transferService.deleteBlobsAsync(ThreadPool.Names.REMOTE_PURGE, remoteMetadataTransferPath, files, new ActionListener<>() {
                 @Override

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -8,6 +8,10 @@
 
 package org.opensearch.index.translog.transfer;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.Version;
 import org.opensearch.common.SetOnce;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.index.remote.RemoteStoreUtils;
@@ -24,6 +28,8 @@ import java.util.Objects;
  * @opensearch.internal
  */
 public class TranslogTransferMetadata {
+
+    public static final Logger logger = LogManager.getLogger(TranslogTransferMetadata.class);
 
     private final long primaryTerm;
 
@@ -130,12 +136,20 @@ public class TranslogTransferMetadata {
 
     public static Tuple<Long, Long> getMinMaxTranslogGenerationFromFilename(String filename) {
         String[] tokens = filename.split(METADATA_SEPARATOR);
-        if (tokens.length != 7) {
+        if (tokens.length < 7) {
             // For versions < 2.17, we don't have min translog generation.
             return null;
         }
-
-        return new Tuple<>(RemoteStoreUtils.invertLong(tokens[5]), RemoteStoreUtils.invertLong(tokens[2]));
+        assert Version.CURRENT.onOrAfter(Version.V_2_17_0);
+        try {
+            // instead of direct index, we go backwards to avoid running into same separator in nodeId
+            String minGeneration = tokens[tokens.length - 2];
+            String maxGeneration = tokens[2];
+            return new Tuple<>(RemoteStoreUtils.invertLong(minGeneration), RemoteStoreUtils.invertLong(maxGeneration));
+        } catch (NumberFormatException e) {
+            logger.error(() -> new ParameterizedMessage("Exception while getting min and max translog generation from: {}", filename), e);
+            return null;
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -130,10 +130,11 @@ public class TranslogTransferMetadata {
 
     public static Tuple<Long, Long> getMinMaxTranslogGenerationFromFilename(String filename) {
         String[] tokens = filename.split(METADATA_SEPARATOR);
-        if (tokens.length < 7) {
+        if (tokens.length != 7) {
             // For versions < 2.17, we don't have min translog generation.
             return null;
         }
+
         return new Tuple<>(RemoteStoreUtils.invertLong(tokens[5]), RemoteStoreUtils.invertLong(tokens[2]));
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -128,6 +128,15 @@ public class TranslogTransferMetadata {
         return new Tuple<>(primaryTermAndGen, nodeId);
     }
 
+    public static Tuple<Long, Long> getMinMaxTranslogGenerationFromFilename(String filename) {
+        String[] tokens = filename.split(METADATA_SEPARATOR);
+        if (tokens.length < 7) {
+            // For versions < 2.17, we don't have min translog generation.
+            return null;
+        }
+        return new Tuple<>(RemoteStoreUtils.invertLong(tokens[5]), RemoteStoreUtils.invertLong(tokens[2]));
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(primaryTerm, generation);

--- a/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
+++ b/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
@@ -292,6 +292,11 @@ public class RemoteStoreSettings {
         return pinnedTimestampsLookbackInterval;
     }
 
+    // Visible for testing
+    public static void setPinnedTimestampsLookbackInterval(TimeValue pinnedTimestampsLookbackInterval) {
+        RemoteStoreSettings.pinnedTimestampsLookbackInterval = pinnedTimestampsLookbackInterval;
+    }
+
     public static boolean isPinnedTimestampsEnabled() {
         return isPinnedTimestampsEnabled;
     }

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
@@ -121,12 +121,12 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
     private AtomicLong globalCheckpoint;
     protected Path translogDir;
     // A default primary term is used by translog instances created in this test.
-    private final AtomicLong primaryTerm = new AtomicLong();
+    protected final AtomicLong primaryTerm = new AtomicLong();
     private final AtomicBoolean primaryMode = new AtomicBoolean(true);
     private final AtomicReference<LongConsumer> persistedSeqNoConsumer = new AtomicReference<>();
     private ThreadPool threadPool;
-    private final static String METADATA_DIR = "metadata";
-    private final static String DATA_DIR = "data";
+    protected final static String METADATA_DIR = "metadata";
+    protected final static String DATA_DIR = "data";
     AtomicInteger writeCalls = new AtomicInteger();
     BlobStoreRepository repository;
 
@@ -277,7 +277,7 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
         return loc;
     }
 
-    private Translog.Location addToTranslogAndListAndUpload(Translog translog, List<Translog.Operation> list, Translog.Operation op)
+    protected Translog.Location addToTranslogAndListAndUpload(Translog translog, List<Translog.Operation> list, Translog.Operation op)
         throws IOException {
         Translog.Location loc = translog.add(op);
         translog.ensureSynced(loc);
@@ -914,7 +914,7 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
         assertBusy(() -> assertEquals(1, blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR)).size()));
     }
 
-    private BlobPath getTranslogDirectory() {
+    protected BlobPath getTranslogDirectory() {
         return repository.basePath().add(shardId.getIndex().getUUID()).add(String.valueOf(shardId.id())).add(TRANSLOG.getName());
     }
 

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
@@ -489,13 +489,9 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
             // Trims from remote now
             translog.trimUnreferencedReaders();
             assertBusy(() -> assertTrue(translog.isRemoteGenerationDeletionPermitsAvailable()));
-            Set<String> dataFiles = blobStoreTransferService.listAll(
-                getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))
-            );
-            assertEquals(10, dataFiles.size());
-            blobStoreTransferService.deleteBlobs(
-                getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get())),
-                new ArrayList<>(dataFiles)
+            assertEquals(
+                6,
+                blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))).size()
             );
         }
 
@@ -728,7 +724,7 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
         assertBusy(() -> {
             assertEquals(4, translog.allUploaded().size());
             assertEquals(
-                6,
+                4,
                 blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))).size()
             );
         });
@@ -742,7 +738,7 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
         assertBusy(() -> {
             assertEquals(2, translog.allUploaded().size());
             assertEquals(
-                6,
+                4,
                 blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))).size()
             );
         });
@@ -761,11 +757,10 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
         assertBusy(() -> {
             assertEquals(2, translog.allUploaded().size());
             assertEquals(
-                6,
+                4,
                 blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))).size()
             );
         });
-
     }
 
     public void testMetadataFileDeletion() throws Exception {

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
@@ -124,7 +124,7 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
     protected final AtomicLong primaryTerm = new AtomicLong();
     private final AtomicBoolean primaryMode = new AtomicBoolean(true);
     private final AtomicReference<LongConsumer> persistedSeqNoConsumer = new AtomicReference<>();
-    private ThreadPool threadPool;
+    protected ThreadPool threadPool;
     protected final static String METADATA_DIR = "metadata";
     protected final static String DATA_DIR = "data";
     AtomicInteger writeCalls = new AtomicInteger();
@@ -390,7 +390,7 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
 
     }
 
-    private TranslogConfig getConfig(int gensToKeep) {
+    protected TranslogConfig getConfig(int gensToKeep) {
         Path tempDir = createTempDir();
         final TranslogConfig temp = getTranslogConfig(tempDir, gensToKeep);
         final TranslogConfig config = new TranslogConfig(
@@ -405,7 +405,7 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
         return config;
     }
 
-    private ChannelFactory getChannelFactory() {
+    protected ChannelFactory getChannelFactory() {
         writeCalls = new AtomicInteger();
         final ChannelFactory channelFactory = (file, openOption) -> {
             FileChannel delegate = FileChannel.open(file, openOption);

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogWithPinnedTimestampTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogWithPinnedTimestampTests.java
@@ -1,0 +1,214 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.translog;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.opensearch.cluster.metadata.RepositoryMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.blobstore.BlobMetadata;
+import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.gateway.remote.model.RemoteStorePinnedTimestampsBlobStore;
+import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.indices.RemoteStoreSettings;
+import org.opensearch.node.Node;
+import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
+import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.repositories.blobstore.BlobStoreTestUtil;
+import org.opensearch.repositories.fs.FsRepository;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.Before;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.zip.CRC32;
+import java.util.zip.CheckedInputStream;
+
+import org.mockito.Mockito;
+
+import static org.opensearch.indices.RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@LuceneTestCase.SuppressFileSystems("ExtrasFS")
+public class RemoteFsTranslogWithPinnedTimestampTests extends RemoteFsTranslogTests {
+
+    Runnable updatePinnedTimstampTask;
+    BlobStoreTransferService pinnedTimestampBlobStoreTransferService;
+    RemoteStorePinnedTimestampsBlobStore remoteStorePinnedTimestampsBlobStore;
+    RemoteStorePinnedTimestampService remoteStorePinnedTimestampServiceSpy;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(
+            Settings.builder().put(CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), true).build(),
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
+
+        Supplier<RepositoriesService> repositoriesServiceSupplier = mock(Supplier.class);
+        Settings settings = Settings.builder()
+            .put(Node.NODE_ATTRIBUTES.getKey() + RemoteStoreNodeAttribute.REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY, "remote-repo")
+            .build();
+        RepositoriesService repositoriesService = mock(RepositoriesService.class);
+        when(repositoriesServiceSupplier.get()).thenReturn(repositoriesService);
+        BlobStoreRepository blobStoreRepository = mock(BlobStoreRepository.class);
+        when(repositoriesService.repository("remote-repo")).thenReturn(blobStoreRepository);
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.schedule(any(), any(), any())).then(invocationOnMock -> {
+            updatePinnedTimstampTask = invocationOnMock.getArgument(0);
+            updatePinnedTimstampTask.run();
+            return null;
+        }).then(subsequentInvocationsOnMock -> null);
+
+        RepositoryMetadata repositoryMetadata = new RepositoryMetadata(randomAlphaOfLength(10), FsRepository.TYPE, settings);
+        final ClusterService clusterService = BlobStoreTestUtil.mockClusterService(repositoryMetadata);
+
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = new RemoteStorePinnedTimestampService(
+            repositoriesServiceSupplier,
+            settings,
+            threadPool,
+            clusterService
+        );
+        remoteStorePinnedTimestampServiceSpy = Mockito.spy(remoteStorePinnedTimestampService);
+
+        remoteStorePinnedTimestampsBlobStore = mock(RemoteStorePinnedTimestampsBlobStore.class);
+        pinnedTimestampBlobStoreTransferService = mock(BlobStoreTransferService.class);
+        when(remoteStorePinnedTimestampServiceSpy.pinnedTimestampsBlobStore()).thenReturn(remoteStorePinnedTimestampsBlobStore);
+        when(remoteStorePinnedTimestampServiceSpy.blobStoreTransferService()).thenReturn(pinnedTimestampBlobStoreTransferService);
+
+        doAnswer(invocationOnMock -> {
+            ActionListener<List<BlobMetadata>> actionListener = invocationOnMock.getArgument(3);
+            actionListener.onResponse(new ArrayList<>());
+            return null;
+        }).when(pinnedTimestampBlobStoreTransferService).listAllInSortedOrder(any(), any(), eq(1), any());
+
+        remoteStorePinnedTimestampServiceSpy.start();
+    }
+
+    @Override
+    public void testSimpleOperationsUpload() throws Exception {
+        ArrayList<Translog.Operation> ops = new ArrayList<>();
+        try (Translog.Snapshot snapshot = translog.newSnapshot()) {
+            assertThat(snapshot, SnapshotMatchers.size(0));
+        }
+
+        addToTranslogAndListAndUpload(translog, ops, new Translog.Index("1", 0, primaryTerm.get(), new byte[] { 1 }));
+        try (Translog.Snapshot snapshot = translog.newSnapshot()) {
+            assertThat(snapshot, SnapshotMatchers.equalsTo(ops));
+            assertEquals(ops.size(), snapshot.totalOperations());
+        }
+
+        assertEquals(2, translog.allUploaded().size());
+
+        addToTranslogAndListAndUpload(translog, ops, new Translog.Index("1", 1, primaryTerm.get(), new byte[] { 1 }));
+        assertEquals(4, translog.allUploaded().size());
+
+        translog.rollGeneration();
+        assertEquals(4, translog.allUploaded().size());
+
+        Set<String> mdFiles = blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR));
+        assertEquals(2, mdFiles.size());
+        logger.info("All md files {}", mdFiles);
+
+        Set<String> tlogFiles = blobStoreTransferService.listAll(
+            getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))
+        );
+        logger.info("All data files {}", tlogFiles);
+
+        // assert content of ckp and tlog files
+        BlobPath path = getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()));
+        for (TranslogReader reader : translog.readers) {
+            final long readerGeneration = reader.getGeneration();
+            logger.error("Asserting content of {}", readerGeneration);
+            Path translogPath = reader.path();
+            try (
+                InputStream stream = new CheckedInputStream(Files.newInputStream(translogPath), new CRC32());
+                InputStream tlogStream = blobStoreTransferService.downloadBlob(path, Translog.getFilename(readerGeneration));
+            ) {
+                byte[] content = stream.readAllBytes();
+                byte[] tlog = tlogStream.readAllBytes();
+                assertArrayEquals(tlog, content);
+            }
+
+            Path checkpointPath = translog.location().resolve(Translog.getCommitCheckpointFileName(readerGeneration));
+            try (
+                CheckedInputStream stream = new CheckedInputStream(Files.newInputStream(checkpointPath), new CRC32());
+                InputStream ckpStream = blobStoreTransferService.downloadBlob(path, Translog.getCommitCheckpointFileName(readerGeneration))
+            ) {
+                byte[] content = stream.readAllBytes();
+                byte[] ckp = ckpStream.readAllBytes();
+                assertArrayEquals(ckp, content);
+            }
+        }
+
+        // expose the new checkpoint (simulating a commit), before we trim the translog
+        // simulating the remote segment upload .
+        translog.setMinSeqNoToKeep(0);
+        // This should not trim anything from local
+        translog.trimUnreferencedReaders();
+        assertBusy(() -> assertTrue(translog.isRemoteGenerationDeletionPermitsAvailable()));
+        assertEquals(2, translog.readers.size());
+        assertBusy(() -> {
+            assertEquals(4, translog.allUploaded().size());
+            assertEquals(
+                6,
+                blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))).size()
+            );
+        });
+
+        // This should trim tlog-2 from local
+        // This should not trim tlog-2.* files from remote as we not uploading any more translog to remote
+        translog.setMinSeqNoToKeep(1);
+        translog.trimUnreferencedReaders();
+        assertBusy(() -> assertTrue(translog.isRemoteGenerationDeletionPermitsAvailable()));
+        assertEquals(1, translog.readers.size());
+        assertBusy(() -> {
+            assertEquals(2, translog.allUploaded().size());
+            assertEquals(
+                6,
+                blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))).size()
+            );
+        });
+
+        // this should now trim as tlog-2 files from remote, but not tlog-3 and tlog-4
+        addToTranslogAndListAndUpload(translog, ops, new Translog.Index("2", 2, primaryTerm.get(), new byte[] { 1 }));
+        assertEquals(2, translog.stats().estimatedNumberOfOperations());
+        assertBusy(() -> assertTrue(translog.isRemoteGenerationDeletionPermitsAvailable()));
+
+        translog.setMinSeqNoToKeep(2);
+        // this should now trim as tlog-2 files from remote, but not tlog-3 and tlog-4
+        translog.trimUnreferencedReaders();
+        assertBusy(() -> assertTrue(translog.isRemoteGenerationDeletionPermitsAvailable()));
+        assertEquals(1, translog.readers.size());
+        assertEquals(1, translog.stats().estimatedNumberOfOperations());
+        assertBusy(() -> {
+            assertEquals(2, translog.allUploaded().size());
+            assertEquals(
+                8,
+                blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))).size()
+            );
+        });
+
+    }
+}

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogWithPinnedTimestampTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogWithPinnedTimestampTests.java
@@ -190,6 +190,7 @@ public class RemoteFsTranslogWithPinnedTimestampTests extends RemoteFsTranslogTe
         addToTranslogAndListAndUpload(translog, ops, new Translog.Index("3", 3, primaryTerm.get(), new byte[] { 1 }));
         addToTranslogAndListAndUpload(translog, ops, new Translog.Index("4", 4, primaryTerm.get(), new byte[] { 1 }));
 
+        assertBusy(() -> assertTrue(translog.isRemoteGenerationDeletionPermitsAvailable()));
         updatePinnedTimstampTask.run();
         translog.trimUnreferencedReaders(true, false);
 

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogWithPinnedTimestampTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogWithPinnedTimestampTests.java
@@ -13,11 +13,18 @@ import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.blobstore.support.PlainBlobMetadata;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.gateway.remote.model.RemotePinnedTimestamps;
 import org.opensearch.gateway.remote.model.RemoteStorePinnedTimestampsBlobStore;
+import org.opensearch.index.remote.RemoteStoreUtils;
 import org.opensearch.index.translog.transfer.BlobStoreTransferService;
+import org.opensearch.index.translog.transfer.TranslogTransferManager;
+import org.opensearch.index.translog.transfer.TranslogTransferMetadata;
 import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.node.Node;
 import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
@@ -29,15 +36,13 @@ import org.opensearch.repositories.fs.FsRepository;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.Before;
 
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeSet;
 import java.util.function.Supplier;
-import java.util.zip.CRC32;
-import java.util.zip.CheckedInputStream;
 
 import org.mockito.Mockito;
 
@@ -46,6 +51,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @LuceneTestCase.SuppressFileSystems("ExtrasFS")
@@ -109,106 +115,268 @@ public class RemoteFsTranslogWithPinnedTimestampTests extends RemoteFsTranslogTe
     @Override
     public void testSimpleOperationsUpload() throws Exception {
         ArrayList<Translog.Operation> ops = new ArrayList<>();
-        try (Translog.Snapshot snapshot = translog.newSnapshot()) {
-            assertThat(snapshot, SnapshotMatchers.size(0));
-        }
 
-        addToTranslogAndListAndUpload(translog, ops, new Translog.Index("1", 0, primaryTerm.get(), new byte[] { 1 }));
-        try (Translog.Snapshot snapshot = translog.newSnapshot()) {
-            assertThat(snapshot, SnapshotMatchers.equalsTo(ops));
-            assertEquals(ops.size(), snapshot.totalOperations());
-        }
-
-        assertEquals(2, translog.allUploaded().size());
-
+        addToTranslogAndListAndUpload(translog, ops, new Translog.Index("0", 0, primaryTerm.get(), new byte[] { 1 }));
         addToTranslogAndListAndUpload(translog, ops, new Translog.Index("1", 1, primaryTerm.get(), new byte[] { 1 }));
-        assertEquals(4, translog.allUploaded().size());
 
-        translog.rollGeneration();
-        assertEquals(4, translog.allUploaded().size());
-
-        Set<String> mdFiles = blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR));
-        assertEquals(2, mdFiles.size());
-        logger.info("All md files {}", mdFiles);
-
-        Set<String> tlogFiles = blobStoreTransferService.listAll(
-            getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))
-        );
-        logger.info("All data files {}", tlogFiles);
-
-        // assert content of ckp and tlog files
-        BlobPath path = getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()));
-        for (TranslogReader reader : translog.readers) {
-            final long readerGeneration = reader.getGeneration();
-            logger.error("Asserting content of {}", readerGeneration);
-            Path translogPath = reader.path();
-            try (
-                InputStream stream = new CheckedInputStream(Files.newInputStream(translogPath), new CRC32());
-                InputStream tlogStream = blobStoreTransferService.downloadBlob(path, Translog.getFilename(readerGeneration));
-            ) {
-                byte[] content = stream.readAllBytes();
-                byte[] tlog = tlogStream.readAllBytes();
-                assertArrayEquals(tlog, content);
-            }
-
-            Path checkpointPath = translog.location().resolve(Translog.getCommitCheckpointFileName(readerGeneration));
-            try (
-                CheckedInputStream stream = new CheckedInputStream(Files.newInputStream(checkpointPath), new CRC32());
-                InputStream ckpStream = blobStoreTransferService.downloadBlob(path, Translog.getCommitCheckpointFileName(readerGeneration))
-            ) {
-                byte[] content = stream.readAllBytes();
-                byte[] ckp = ckpStream.readAllBytes();
-                assertArrayEquals(ckp, content);
-            }
-        }
-
-        // expose the new checkpoint (simulating a commit), before we trim the translog
-        // simulating the remote segment upload .
-        translog.setMinSeqNoToKeep(0);
-        // This should not trim anything from local
-        translog.trimUnreferencedReaders();
-        assertBusy(() -> assertTrue(translog.isRemoteGenerationDeletionPermitsAvailable()));
-        assertEquals(2, translog.readers.size());
+        // First reader is created at the init of translog
+        assertEquals(3, translog.readers.size());
+        assertEquals(2, blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR)).size());
         assertBusy(() -> {
-            assertEquals(4, translog.allUploaded().size());
+            assertEquals(6, translog.allUploaded().size());
             assertEquals(
                 6,
                 blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))).size()
             );
         });
 
-        // This should trim tlog-2 from local
-        // This should not trim tlog-2.* files from remote as we not uploading any more translog to remote
-        translog.setMinSeqNoToKeep(1);
-        translog.trimUnreferencedReaders();
-        assertBusy(() -> assertTrue(translog.isRemoteGenerationDeletionPermitsAvailable()));
-        assertEquals(1, translog.readers.size());
-        assertBusy(() -> {
-            assertEquals(2, translog.allUploaded().size());
-            assertEquals(
-                6,
-                blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))).size()
-            );
-        });
-
-        // this should now trim as tlog-2 files from remote, but not tlog-3 and tlog-4
         addToTranslogAndListAndUpload(translog, ops, new Translog.Index("2", 2, primaryTerm.get(), new byte[] { 1 }));
-        assertEquals(2, translog.stats().estimatedNumberOfOperations());
+        addToTranslogAndListAndUpload(translog, ops, new Translog.Index("3", 3, primaryTerm.get(), new byte[] { 1 }));
+        addToTranslogAndListAndUpload(translog, ops, new Translog.Index("4", 4, primaryTerm.get(), new byte[] { 1 }));
+        addToTranslogAndListAndUpload(translog, ops, new Translog.Index("5", 5, primaryTerm.get(), new byte[] { 1 }));
+        addToTranslogAndListAndUpload(translog, ops, new Translog.Index("6", 6, primaryTerm.get(), new byte[] { 1 }));
+
         assertBusy(() -> assertTrue(translog.isRemoteGenerationDeletionPermitsAvailable()));
 
-        translog.setMinSeqNoToKeep(2);
-        // this should now trim as tlog-2 files from remote, but not tlog-3 and tlog-4
+        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+        updatePinnedTimstampTask.run();
+
+        translog.setMinSeqNoToKeep(4);
         translog.trimUnreferencedReaders();
+        addToTranslogAndListAndUpload(translog, ops, new Translog.Index("7", 7, primaryTerm.get(), new byte[] { 1 }));
+        addToTranslogAndListAndUpload(translog, ops, new Translog.Index("8", 8, primaryTerm.get(), new byte[] { 1 }));
         assertBusy(() -> assertTrue(translog.isRemoteGenerationDeletionPermitsAvailable()));
-        assertEquals(1, translog.readers.size());
-        assertEquals(1, translog.stats().estimatedNumberOfOperations());
+
+        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+        updatePinnedTimstampTask.run();
+        translog.trimUnreferencedReaders();
+
+        assertBusy(() -> assertTrue(translog.isRemoteGenerationDeletionPermitsAvailable()));
+        assertEquals(5, translog.readers.size());
         assertBusy(() -> {
-            assertEquals(2, translog.allUploaded().size());
+            assertEquals(1, blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR)).size());
+            assertEquals(10, translog.allUploaded().size());
             assertEquals(
-                8,
+                10,
                 blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))).size()
             );
         });
+    }
 
+    // getGenerationsToBeDeleted
+    public void testGetGenerationsToBeDeleted() {
+        // translog.readAndCacheGenerationForPinnedTimestamp
+        // translog.getGenerationsToBeDeleted
+    }
+
+    public void testGetMetadataFilesToBeDeletedNoExclusion() {
+        updatePinnedTimstampTask.run();
+
+        List<String> metadataFiles = List.of(
+            "metadata__9223372036438563903__9223372036854774799__9223370311919910393__31__9223372036854775106__1",
+            "metadata__9223372036438563903__9223372036854775800__9223370311919910398__31__9223372036854775803__1",
+            "metadata__9223372036438563903__9223372036854775701__9223370311919910403__31__9223372036854775701__1"
+        );
+
+        assertEquals(metadataFiles, translog.getMetadataFilesToBeDeleted(metadataFiles));
+    }
+
+    public void testGetMetadataFilesToBeDeletedExclusionBasedOnAgeOnly() {
+        updatePinnedTimstampTask.run();
+        long currentTimeInMillis = System.currentTimeMillis();
+        String md1Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 100000);
+        String md2Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis + 30000);
+        String md3Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis + 60000);
+
+        List<String> metadataFiles = List.of(
+            "metadata__9223372036438563903__9223372036854774799__" + md1Timestamp + "__31__9223372036854775106__1",
+            "metadata__9223372036438563903__9223372036854775800__" + md2Timestamp + "__31__9223372036854775803__1",
+            "metadata__9223372036438563903__9223372036854775701__" + md3Timestamp + "__31__9223372036854775701__1"
+        );
+
+        List<String> metadataFilesToBeDeleted = translog.getMetadataFilesToBeDeleted(metadataFiles);
+        assertEquals(1, metadataFilesToBeDeleted.size());
+        assertEquals(metadataFiles.get(0), metadataFilesToBeDeleted.get(0));
+    }
+
+    public void testGetMetadataFilesToBeDeletedExclusionBasedOnPinningOnly() throws IOException {
+        long currentTimeInMillis = System.currentTimeMillis();
+        String md1Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 100000);
+        String md2Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 300000);
+        String md3Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 600000);
+
+        doAnswer(invocationOnMock -> {
+            ActionListener<List<BlobMetadata>> actionListener = invocationOnMock.getArgument(3);
+            actionListener.onResponse(List.of(new PlainBlobMetadata("pinned_timestamp_123", 1000)));
+            return null;
+        }).when(pinnedTimestampBlobStoreTransferService).listAllInSortedOrder(any(), any(), eq(1), any());
+
+        long pinnedTimestamp = RemoteStoreUtils.invertLong(md2Timestamp) + 10000;
+        when(remoteStorePinnedTimestampsBlobStore.read(any())).thenReturn(
+            new RemotePinnedTimestamps.PinnedTimestamps(Map.of(pinnedTimestamp, List.of("xyz")))
+        );
+        when(remoteStorePinnedTimestampsBlobStore.getBlobPathForUpload(any())).thenReturn(new BlobPath());
+
+        updatePinnedTimstampTask.run();
+
+        List<String> metadataFiles = List.of(
+            "metadata__9223372036438563903__9223372036854774799__" + md1Timestamp + "__31__9223372036854775106__1",
+            "metadata__9223372036438563903__9223372036854775600__" + md2Timestamp + "__31__9223372036854775803__1",
+            "metadata__9223372036438563903__9223372036854775701__" + md3Timestamp + "__31__9223372036854775701__1"
+        );
+
+        List<String> metadataFilesToBeDeleted = translog.getMetadataFilesToBeDeleted(metadataFiles);
+        assertEquals(2, metadataFilesToBeDeleted.size());
+        assertEquals(metadataFiles.get(0), metadataFilesToBeDeleted.get(0));
+        assertEquals(metadataFiles.get(2), metadataFilesToBeDeleted.get(1));
+    }
+
+    public void testGetMetadataFilesToBeDeletedExclusionBasedOnAgeAndPinning() throws IOException {
+        long currentTimeInMillis = System.currentTimeMillis();
+        String md1Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis + 100000);
+        String md2Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 300000);
+        String md3Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 600000);
+
+        doAnswer(invocationOnMock -> {
+            ActionListener<List<BlobMetadata>> actionListener = invocationOnMock.getArgument(3);
+            actionListener.onResponse(List.of(new PlainBlobMetadata("pinned_timestamp_123", 1000)));
+            return null;
+        }).when(pinnedTimestampBlobStoreTransferService).listAllInSortedOrder(any(), any(), eq(1), any());
+
+        long pinnedTimestamp = RemoteStoreUtils.invertLong(md2Timestamp) + 10000;
+        when(remoteStorePinnedTimestampsBlobStore.read(any())).thenReturn(
+            new RemotePinnedTimestamps.PinnedTimestamps(Map.of(pinnedTimestamp, List.of("xyz")))
+        );
+        when(remoteStorePinnedTimestampsBlobStore.getBlobPathForUpload(any())).thenReturn(new BlobPath());
+
+        updatePinnedTimstampTask.run();
+
+        List<String> metadataFiles = List.of(
+            "metadata__9223372036438563903__9223372036854774799__" + md1Timestamp + "__31__9223372036854775106__1",
+            "metadata__9223372036438563903__9223372036854775600__" + md2Timestamp + "__31__9223372036854775803__1",
+            "metadata__9223372036438563903__9223372036854775701__" + md3Timestamp + "__31__9223372036854775701__1"
+        );
+
+        List<String> metadataFilesToBeDeleted = translog.getMetadataFilesToBeDeleted(metadataFiles);
+        assertEquals(1, metadataFilesToBeDeleted.size());
+        assertEquals(metadataFiles.get(2), metadataFilesToBeDeleted.get(0));
+    }
+
+    public void testIsGenerationPinned() {
+        TreeSet<Tuple<Long, Long>> pinnedGenerations = new TreeSet<>(new TreeSet<>((o1, o2) -> {
+            if (Objects.equals(o1.v1(), o2.v1()) == false) {
+                return o1.v1().compareTo(o2.v1());
+            } else {
+                return o1.v2().compareTo(o2.v2());
+            }
+        }));
+
+        pinnedGenerations.add(new Tuple<>(12L, 34L));
+        pinnedGenerations.add(new Tuple<>(121L, 140L));
+        pinnedGenerations.add(new Tuple<>(142L, 160L));
+        pinnedGenerations.add(new Tuple<>(12L, 120L));
+        pinnedGenerations.add(new Tuple<>(12L, 78L));
+        pinnedGenerations.add(new Tuple<>(142L, 170L));
+        pinnedGenerations.add(new Tuple<>(1L, 1L));
+        pinnedGenerations.add(new Tuple<>(12L, 56L));
+        pinnedGenerations.add(new Tuple<>(142L, 180L));
+        pinnedGenerations.add(new Tuple<>(4L, 9L));
+
+        assertFalse(translog.isGenerationPinned(3, pinnedGenerations));
+        assertFalse(translog.isGenerationPinned(10, pinnedGenerations));
+        assertFalse(translog.isGenerationPinned(141, pinnedGenerations));
+        assertFalse(translog.isGenerationPinned(181, pinnedGenerations));
+        assertFalse(translog.isGenerationPinned(5000, pinnedGenerations));
+        assertFalse(translog.isGenerationPinned(0, pinnedGenerations));
+
+        assertTrue(translog.isGenerationPinned(1, pinnedGenerations));
+        assertTrue(translog.isGenerationPinned(120, pinnedGenerations));
+        assertTrue(translog.isGenerationPinned(121, pinnedGenerations));
+        assertTrue(translog.isGenerationPinned(156, pinnedGenerations));
+        assertTrue(translog.isGenerationPinned(12, pinnedGenerations));
+    }
+
+    public void testGetMinMaxTranslogGenerationFromMetadataFile() throws IOException {
+        TranslogTransferManager translogTransferManager = mock(TranslogTransferManager.class);
+
+        // Fetch generations directly from the filename
+        assertEquals(
+            new Tuple<>(701L, 1008L),
+            translog.getMinMaxTranslogGenerationFromMetadataFile(
+                "metadata__9223372036438563903__9223372036854774799__9223370311919910393__31__9223372036854775106__1",
+                translogTransferManager
+            )
+        );
+        assertEquals(
+            new Tuple<>(4L, 7L),
+            translog.getMinMaxTranslogGenerationFromMetadataFile(
+                "metadata__9223372036438563903__9223372036854775800__9223370311919910398__31__9223372036854775803__1",
+                translogTransferManager
+            )
+        );
+        assertEquals(
+            new Tuple<>(106L, 106L),
+            translog.getMinMaxTranslogGenerationFromMetadataFile(
+                "metadata__9223372036438563903__9223372036854775701__9223370311919910403__31__9223372036854775701__1",
+                translogTransferManager
+            )
+        );
+        assertEquals(
+            new Tuple<>(4573L, 99964L),
+            translog.getMinMaxTranslogGenerationFromMetadataFile(
+                "metadata__9223372036438563903__9223372036854675843__9223370311919910408__31__9223372036854771234__1",
+                translogTransferManager
+            )
+        );
+        assertEquals(
+            new Tuple<>(1L, 4L),
+            translog.getMinMaxTranslogGenerationFromMetadataFile(
+                "metadata__9223372036438563903__9223372036854775803__9223370311919910413__31__9223372036854775806__1",
+                translogTransferManager
+            )
+        );
+        assertEquals(
+            new Tuple<>(2474L, 3462L),
+            translog.getMinMaxTranslogGenerationFromMetadataFile(
+                "metadata__9223372036438563903__9223372036854772345__9223370311919910429__31__9223372036854773333__1",
+                translogTransferManager
+            )
+        );
+        assertEquals(
+            new Tuple<>(5807L, 7917L),
+            translog.getMinMaxTranslogGenerationFromMetadataFile(
+                "metadata__9223372036438563903__9223372036854767890__9223370311919910434__31__9223372036854770000__1",
+                translogTransferManager
+            )
+        );
+
+        // For older md filenames, it needs to read the content
+        TranslogTransferMetadata md1 = mock(TranslogTransferMetadata.class);
+        when(md1.getMinTranslogGeneration()).thenReturn(701L);
+        when(md1.getGeneration()).thenReturn(1008L);
+        when(translogTransferManager.readMetadata("metadata__9223372036438563903__9223372036854774799__9223370311919910393__31__1"))
+            .thenReturn(md1);
+        assertEquals(
+            new Tuple<>(701L, 1008L),
+            translog.getMinMaxTranslogGenerationFromMetadataFile(
+                "metadata__9223372036438563903__9223372036854774799__9223370311919910393__31__1",
+                translogTransferManager
+            )
+        );
+        TranslogTransferMetadata md2 = mock(TranslogTransferMetadata.class);
+        when(md2.getMinTranslogGeneration()).thenReturn(4L);
+        when(md2.getGeneration()).thenReturn(7L);
+        when(translogTransferManager.readMetadata("metadata__9223372036438563903__9223372036854775800__9223370311919910398__31__1"))
+            .thenReturn(md2);
+        assertEquals(
+            new Tuple<>(4L, 7L),
+            translog.getMinMaxTranslogGenerationFromMetadataFile(
+                "metadata__9223372036438563903__9223372036854775800__9223370311919910398__31__1",
+                translogTransferManager
+            )
+        );
+
+        verify(translogTransferManager).readMetadata("metadata__9223372036438563903__9223372036854774799__9223370311919910393__31__1");
+        verify(translogTransferManager).readMetadata("metadata__9223372036438563903__9223372036854775800__9223370311919910398__31__1");
     }
 }


### PR DESCRIPTION
### Description
- As part of shallow snapshot optimisations, we are introducing timestamp based implicit locking support. This feature will be called Timestamp Pinning in remote backed storage. When a timestamp is pinned, remote store garbage collectors will skip deleting data corresponding to the timestamp.
- Changes to segment store garbage collection are made as part of PR: https://github.com/opensearch-project/OpenSearch/pull/15017
- In this PR, we are making following changes to translog garbage collection:
  - Fetch metadata files in reverse-chronological order
  - Filter out metadata files that match with pinned timestamp and metadata files that are created post successful fetch of pinned timestamp.
  - From the remaining metadata files, read min and max generation and filter out generations by pinned timestamp metadata files.

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/15064

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
