### PR TITLE
Throw UnsupportedOperationException in unused methods

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/TranslogLeafReader.java
+++ b/server/src/main/java/org/opensearch/index/engine/TranslogLeafReader.java
@@ -264,13 +264,13 @@ public final class TranslogLeafReader extends LeafReader {
     }
 
     @Override
-    public FloatVectorValues getFloatVectorValues(String field) throws IOException {
-        return getFloatVectorValues(field);
+    public FloatVectorValues getFloatVectorValues(String field) {
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    public ByteVectorValues getByteVectorValues(String field) throws IOException {
-        return getByteVectorValues(field);
+    public ByteVectorValues getByteVectorValues(String field) {
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
These methods infinitely recurse as currently implemented. This change makes them throw UnsupportedOperationException similar to many other methods in this class.

### Related Issues
Resolves #15387

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
