### PR TITLE
Update skip versions for flat_object tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/100_partial_flat_object.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/100_partial_flat_object.yml
@@ -114,8 +114,8 @@ teardown:
 # and no dynamic fields were created.
 "Mappings":
   - skip:
-      version: " - 2.99.99"
-      reason: "flat_object is introduced in 3.0.0 in main branch"
+      version: " - 2.16.99"
+      reason: "flat_object field with null (doc 4) throws exception before 2.17"
 
   - do:
       indices.get_mapping:
@@ -131,8 +131,8 @@ teardown:
 ---
 "Supported queries":
   - skip:
-      version: " - 2.99.99"
-      reason: "flat_object is introduced in 3.0.0 in main branch"
+      version: " - 2.16.99"
+      reason: "flat_object field with null (doc 4) throws exception before 2.17"
 
 
   # Verify Document Count

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/105_partial_flat_object_nested.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/105_partial_flat_object_nested.yml
@@ -89,8 +89,8 @@ teardown:
 # and no dynamic fields were created.
 "Mappings":
   - skip:
-      version: " - 2.99.99"
-      reason: "flat_object is introduced in 3.0.0 in main branch"
+      version: " - 2.6.99"
+      reason: "flat_object is introduced in 2.7"
 
   - do:
       indices.get_mapping:
@@ -106,8 +106,8 @@ teardown:
 ---
 "Supported queries":
   - skip:
-      version: " - 2.99.99"
-      reason: "flat_object is introduced in 3.0.0 in main branch"
+      version: " - 2.6.99"
+      reason: "flat_object is introduced in 2.7"
 
 
   # Verify Document Count

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/90_flat_object.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/90_flat_object.yml
@@ -97,8 +97,8 @@ teardown:
 ---
 "Supported queries":
   - skip:
-      version: " - 2.99.99"
-      reason: "flat_object is introduced in 3.0.0 in main branch"
+      version: " - 2.6.99"
+      reason: "flat_object is introduced in 2.7"
 
   # Verify Document Count
   - do:
@@ -607,8 +607,8 @@ teardown:
 ---
 "Unsupported":
   - skip:
-      version: " - 2.99.99"
-      reason: "flat_object is introduced in 3.0.0 in main branch"
+      version: " - 2.6.99"
+      reason: "flat_object is introduced in 2.7"
 
   # Mapping parameters (such as index/search analyzers) are currently not supported
   # The plan is to support them in the next version


### PR DESCRIPTION
### Description
While fixing a flat_object bug, I noticed that we were skipping all related yamlRestTests on pre-3.0 versions. Since the flat object field type was added in 2.7, that should be the correct skip level for most tests. The bug I fixed is still present in 2.16 and earlier, so the test that covers that fix needs to be skipped pre-2.17.

### Related Issues
https://github.com/opensearch-project/OpenSearch/pull/15431

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
