### PR TITLE
Change RemoteSegmentStoreDirectory init at given timestamp to ignore pinned timestamp setting

### DIFF
--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
@@ -391,15 +391,24 @@ public class RemoteStoreUtils {
      * @param pinnedTimestampSet A set of timestamps representing pinned points in time.
      * @param getTimestampFunction A function that extracts the timestamp from a metadata file name.
      * @param prefixFunction A function that extracts a tuple of prefix information from a metadata file name.
+     * @param ignorePinnedTimestampEnabledSetting A flag to ignore pinned timestamp enabled setting
      * @return A set of metadata file names that are implicitly locked based on the pinned timestamps.
      */
     public static Set<String> getPinnedTimestampLockedFiles(
         List<String> metadataFiles,
         Set<Long> pinnedTimestampSet,
         Function<String, Long> getTimestampFunction,
-        Function<String, Tuple<String, String>> prefixFunction
+        Function<String, Tuple<String, String>> prefixFunction,
+        boolean ignorePinnedTimestampEnabledSetting
     ) {
-        return getPinnedTimestampLockedFiles(metadataFiles, pinnedTimestampSet, new HashMap<>(), getTimestampFunction, prefixFunction);
+        return getPinnedTimestampLockedFiles(
+            metadataFiles,
+            pinnedTimestampSet,
+            new HashMap<>(),
+            getTimestampFunction,
+            prefixFunction,
+            ignorePinnedTimestampEnabledSetting
+        );
     }
 
     /**
@@ -432,9 +441,27 @@ public class RemoteStoreUtils {
         Function<String, Long> getTimestampFunction,
         Function<String, Tuple<String, String>> prefixFunction
     ) {
+        return getPinnedTimestampLockedFiles(
+            metadataFiles,
+            pinnedTimestampSet,
+            metadataFilePinnedTimestampMap,
+            getTimestampFunction,
+            prefixFunction,
+            false
+        );
+    }
+
+    private static Set<String> getPinnedTimestampLockedFiles(
+        List<String> metadataFiles,
+        Set<Long> pinnedTimestampSet,
+        Map<Long, String> metadataFilePinnedTimestampMap,
+        Function<String, Long> getTimestampFunction,
+        Function<String, Tuple<String, String>> prefixFunction,
+        boolean ignorePinnedTimestampEnabledSetting
+    ) {
         Set<String> implicitLockedFiles = new HashSet<>();
 
-        if (RemoteStoreSettings.isPinnedTimestampsEnabled() == false) {
+        if (ignorePinnedTimestampEnabledSetting == false && RemoteStoreSettings.isPinnedTimestampsEnabled() == false) {
             return implicitLockedFiles;
         }
 

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -196,7 +196,8 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             metadataFiles,
             Set.of(timestamp),
             MetadataFilenameUtils::getTimestamp,
-            MetadataFilenameUtils::getNodeIdByPrimaryTermAndGen
+            MetadataFilenameUtils::getNodeIdByPrimaryTermAndGen,
+            true
         );
         if (lockedMetadataFiles.isEmpty()) {
             return null;

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -306,6 +306,7 @@ import static org.opensearch.common.util.FeatureFlags.TELEMETRY;
 import static org.opensearch.env.NodeEnvironment.collectFileCacheDataPath;
 import static org.opensearch.index.ShardIndexingPressureSettings.SHARD_INDEXING_PRESSURE_ENABLED_ATTRIBUTE_KEY;
 import static org.opensearch.indices.RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED;
+import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.isRemoteDataAttributePresent;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.isRemoteStoreAttributePresent;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.isRemoteStoreClusterStateEnabled;
 
@@ -813,7 +814,7 @@ public class Node implements Closeable {
                 remoteClusterStateCleanupManager = null;
             }
             final RemoteStorePinnedTimestampService remoteStorePinnedTimestampService;
-            if (isRemoteStoreAttributePresent(settings) && CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.get(settings)) {
+            if (isRemoteDataAttributePresent(settings) && CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.get(settings)) {
                 remoteStorePinnedTimestampService = new RemoteStorePinnedTimestampService(
                     repositoriesServiceReference::get,
                     settings,

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -1141,6 +1141,62 @@ public class RemoteSegmentStoreDirectoryTests extends BaseRemoteSegmentStoreDire
         assertEquals(14, count);
     }
 
+    public void testInitializeToSpecificTimestampNoMetadataFiles() throws IOException {
+        when(
+            remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
+                RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
+                Integer.MAX_VALUE
+            )
+        ).thenReturn(new ArrayList<>());
+        assertNull(remoteSegmentStoreDirectory.initializeToSpecificTimestamp(1234L));
+    }
+
+    public void testInitializeToSpecificTimestampNoMdMatchingTimestamp() throws IOException {
+        String metadataPrefix = "metadata__1__2__3__4__5__";
+        List<String> metadataFiles = new ArrayList<>();
+        metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(2000));
+        metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(3000));
+        metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(4000));
+
+        when(
+            remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
+                RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
+                Integer.MAX_VALUE
+            )
+        ).thenReturn(metadataFiles);
+        assertNull(remoteSegmentStoreDirectory.initializeToSpecificTimestamp(1234L));
+    }
+
+    public void testInitializeToSpecificTimestampMatchingMdFile() throws IOException {
+        String metadataPrefix = "metadata__1__2__3__4__5__";
+        List<String> metadataFiles = new ArrayList<>();
+        metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(1000));
+        metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(2000));
+        metadataFiles.add(metadataPrefix + RemoteStoreUtils.invertLong(3000));
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("_0.cfe", "_0.cfe::_0.cfe__" + UUIDs.base64UUID() + "::1234::512::" + Version.LATEST.major);
+        metadata.put("_0.cfs", "_0.cfs::_0.cfs__" + UUIDs.base64UUID() + "::2345::1024::" + Version.LATEST.major);
+
+        when(
+            remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
+                RemoteSegmentStoreDirectory.MetadataFilenameUtils.METADATA_PREFIX,
+                Integer.MAX_VALUE
+            )
+        ).thenReturn(metadataFiles);
+        when(remoteMetadataDirectory.getBlobStream(metadataPrefix + RemoteStoreUtils.invertLong(1000))).thenReturn(
+            createMetadataFileBytes(metadata, indexShard.getLatestReplicationCheckpoint(), segmentInfos)
+        );
+
+        RemoteSegmentMetadata remoteSegmentMetadata = remoteSegmentStoreDirectory.initializeToSpecificTimestamp(1234L);
+        assertNotNull(remoteSegmentMetadata);
+        Map<String, RemoteSegmentStoreDirectory.UploadedSegmentMetadata> uploadedSegments = remoteSegmentStoreDirectory
+            .getSegmentsUploadedToRemoteStore();
+        assertEquals(2, uploadedSegments.size());
+        assertTrue(uploadedSegments.containsKey("_0.cfe"));
+        assertTrue(uploadedSegments.containsKey("_0.cfs"));
+    }
+
     private static class WrapperIndexOutput extends IndexOutput {
         public IndexOutput indexOutput;
 


### PR DESCRIPTION
### Description
- This PR addresses following comments on the earlier PRs:
  - https://github.com/opensearch-project/OpenSearch/pull/15017#discussion_r1732636725
  - https://github.com/opensearch-project/OpenSearch/pull/15180/files#r1719741169

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
