### PR TITLE
Allow maintainers to opt-out of perf workflow approval requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,3 +35,6 @@
 /.github/ @jed326 @peternied
 
 /MAINTAINERS.md @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @dblock @dbwiddis @gaobinlong @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @peternied @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
+
+# Workflow specific approvals checks
+/workflows/performance-benchmarks @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @dblock @dbwiddis @gaobinlong @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah

--- a/.github/actions/workflow-approvers.yml
+++ b/.github/actions/workflow-approvers.yml
@@ -1,0 +1,20 @@
+name: 'Get the list of approvers for a workflow'
+
+inputs:
+  workflow-name:
+    description: 'The name of the workflow to check for approvals, e.g. performance-benchmarks'
+    required: true
+
+outputs:
+  workflow-approvers:
+    description: 'The list of approvers for this workflow'
+    value: ${{ steps.extract-approvers.outputs.workflow-approvers }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: extract-approvers
+      shell: bash
+      run: |
+        approvers=$(grep "/workflows/${{ inputs.workflow-name }}" .github/CODEOWNERS | cut -d' ' -f2- | sed 's/@//g' | tr ' ' ',')
+        echo "approvers=$approvers" >> $GITHUB_ENV

--- a/.github/workflows/benchmark-pull-request.yml
+++ b/.github/workflows/benchmark-pull-request.yml
@@ -124,6 +124,7 @@ jobs:
             // Any maintainers that do not want to be included on these requests
             const excludedMaintainers = [
               'peternied',
+              'hyandell',
             ];
             return maintainersResponse.data
               .map(item => item.login)
@@ -136,7 +137,7 @@ jobs:
           approvers: ${{ steps.get_approvers.outputs.result }}
           minimum-approvals: 1
           issue-title: 'Request to approve/deny benchmark run for PR #${{ env.PR_NUMBER }}'
-          issue-body: "Please approve or deny the benchmark run for PR #${{ env.PR_NUMBER }}"
+          issue-body: "Please approve or deny the benchmark run for PR #${{ env.PR_NUMBER }}, please update this [workflow](../tree/main/.github/workflows/benchmark-pull-request.yml) to opt-out of future requests."
           exclude-workflow-initiator-as-approver: false
       - name: Checkout PR Repo
         uses: actions/checkout@v4

--- a/.github/workflows/benchmark-pull-request.yml
+++ b/.github/workflows/benchmark-pull-request.yml
@@ -121,7 +121,14 @@ jobs:
               affiliation: 'all',
               per_page: 100
               });
-            return maintainersResponse.data.map(item => item.login).join(', ');
+            // Any maintainers that do not want to be included on these requests
+            const excludedMaintainers = [
+              'peternied',
+            ];
+            return maintainersResponse.data
+              .map(item => item.login)
+              .filter(approvers => !excludedMaintainers.includes(approvers))
+              .join(', ');
       - uses: trstringer/manual-approval@v1
         if: (!contains(steps.get_approvers.outputs.result, github.event.comment.user.login))
         with:

--- a/.github/workflows/benchmark-pull-request.yml
+++ b/.github/workflows/benchmark-pull-request.yml
@@ -107,37 +107,18 @@ jobs:
           headRefSha=$(echo '${{ steps.get_pr.outputs.result }}' | jq -r '.headRefSha')
           echo "prHeadRepo=$headRepo" >> $GITHUB_ENV
           echo "prHeadRefSha=$headRefSha" >> $GITHUB_ENV
-      - id: get_approvers
-        uses: actions/github-script@v7
+      - id: workflow_approvers
+        uses: ./.github/actions/get-workflow-approvers
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          result-encoding: string
-          script: |
-            // Get the collaborators - filtered to maintainer permissions
-            const maintainersResponse = await github.request('GET /repos/{owner}/{repo}/collaborators', {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              permission: 'maintain',
-              affiliation: 'all',
-              per_page: 100
-              });
-            // Any maintainers that do not want to be included on these requests
-            const excludedMaintainers = [
-              'peternied',
-              'hyandell',
-            ];
-            return maintainersResponse.data
-              .map(item => item.login)
-              .filter(approvers => !excludedMaintainers.includes(approvers))
-              .join(', ');
+          workflow-name: 'performance-benchmarks'
       - uses: trstringer/manual-approval@v1
-        if: (!contains(steps.get_approvers.outputs.result, github.event.comment.user.login))
+        if: (!contains(steps.workflow_approvers.outputs.result, github.event.comment.user.login))
         with:
           secret: ${{ github.TOKEN }}
-          approvers: ${{ steps.get_approvers.outputs.result }}
+          approvers: ${{ steps.workflow_approvers.outputs.result }}
           minimum-approvals: 1
           issue-title: 'Request to approve/deny benchmark run for PR #${{ env.PR_NUMBER }}'
-          issue-body: "Please approve or deny the benchmark run for PR #${{ env.PR_NUMBER }}, please update this [workflow](../tree/main/.github/workflows/benchmark-pull-request.yml) to opt-out of future requests."
+          issue-body: "Please approve or deny the benchmark run for PR #${{ env.PR_NUMBER }}, please update [CODEOWNERS](../tree/main/.github/CODEOWNERS) to opt-out of future workflow approval requests."
           exclude-workflow-initiator-as-approver: false
       - name: Checkout PR Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description
Tweak the logic for the maintainer list that becomes the assigned approvers on GitHub issues so that maintainers can opt out of this approval process.

### Related Issues
- Related to #15236

### Check List
- [ ] ~Functionality includes testing.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
