### PR TITLE
Fix Netty's ByteBuf leak

### DIFF
--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4StreamingHttpChannel.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4StreamingHttpChannel.java
@@ -103,6 +103,7 @@ class ReactorNetty4StreamingHttpChannel implements StreamingHttpChannel {
             }
         } catch (final Exception ex) {
             producer.error(ex);
+        } finally {
             message.close();
         }
     }

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4StreamingRequestConsumer.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4StreamingRequestConsumer.java
@@ -44,7 +44,7 @@ class ReactorNetty4StreamingRequestConsumer<T extends HttpContent> implements Co
     }
 
     HttpChunk createChunk(HttpContent chunk, boolean last) {
-        return new ReactorNetty4HttpChunk(chunk.copy().content().retain(), last);
+        return new ReactorNetty4HttpChunk(chunk.content(), last);
     }
 
     StreamingHttpChannel httpChannel() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix Netty's ByteBuf leak

```
java.lang.AssertionError: 
Expected: an empty collection
     but: <[LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
Recent access records: 
#1:
	org.opensearch.http.reactor.netty4.ReactorNetty4StreamingRequestConsumer.createChunk(ReactorNetty4StreamingRequestConsumer.java:47)
	org.opensearch.http.reactor.netty4.ReactorNetty4StreamingRequestConsumer.accept(ReactorNetty4StreamingRequestConsumer.java:37)
	org.opensearch.http.reactor.netty4.ReactorNetty4StreamingRequestConsumer.accept(ReactorNetty4StreamingRequestConsumer.java:23)
```


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
