### PR TITLE
[Remote Store] Add minTranslogGeneration to remote translog metadata filename

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -101,6 +101,7 @@ public class TranslogTransferMetadata {
                 RemoteStoreUtils.invertLong(generation),
                 RemoteStoreUtils.invertLong(createdAt),
                 String.valueOf(Objects.hash(nodeId)),
+                RemoteStoreUtils.invertLong(minTranslogGeneration),
                 String.valueOf(CURRENT_VERSION)
             )
         );

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferManagerTests.java
@@ -623,7 +623,7 @@ public class TranslogTransferManagerTests extends OpenSearchTestCase {
         String mdFilename = tm.getFileName();
         long count = mdFilename.chars().filter(ch -> ch == METADATA_SEPARATOR.charAt(0)).count();
         // There should not be any `_` in mdFile name as it is used a separator .
-        assertEquals(10, count);
+        assertEquals(12, count);
         Thread.sleep(1);
         TranslogTransferMetadata tm2 = new TranslogTransferMetadata(1, 1, 1, 2, "node--2");
         String mdFilename2 = tm2.getFileName();


### PR DESCRIPTION
### Description
- Currently, remote translog metadata file has following format:
`metadata__<inverted primary term>__<inverted tranlog generation>__<inverted creation timestamp>__nodeId__<metadata version>`
- Although this works for ordering metadata files in reverse chronological order, just by looking at the metadata file name, it does not provide info on min generation referred.
- To make debugging easy, in this PR, we are adding min translog generation as part of remote translog metadata.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
