### PR TITLE
Health api memory optimisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Relax the join validation for Remote State publication ([#15471](https://github.com/opensearch-project/OpenSearch/pull/15471))
 - MultiTermQueries in keyword fields now default to `indexed` approach and gated behind cluster setting ([#15637](https://github.com/opensearch-project/OpenSearch/pull/15637))
 - Making _cat/allocation API use indexLevelStats ([#15292](https://github.com/opensearch-project/OpenSearch/pull/15292))
+- Memory optimisations in _cluster/health API ([#15492](https://github.com/opensearch-project/OpenSearch/pull/15492))
 
 ### Dependencies
 - Bump `netty` from 4.1.111.Final to 4.1.112.Final ([#15081](https://github.com/opensearch-project/OpenSearch/pull/15081))

--- a/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemoteStoreMigrationSettingsUpdateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemoteStoreMigrationSettingsUpdateIT.java
@@ -11,6 +11,7 @@ package org.opensearch.remotemigration;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsException;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
@@ -109,7 +110,7 @@ public class RemoteStoreMigrationSettingsUpdateIT extends RemoteStoreMigrationSh
         setDirection(REMOTE_STORE.direction);
         String restoredIndexName2 = TEST_INDEX + "-restored2";
         restoreSnapshot(snapshotRepoName, snapshotName, restoredIndexName2);
-        ensureGreen(restoredIndexName2);
+        ensureGreen(TimeValue.timeValueSeconds(90), restoredIndexName2);
 
         logger.info("Verify that restored index is non remote-backed");
         assertRemoteStoreBackedIndex(restoredIndexName2);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -76,6 +76,17 @@ public class ClusterHealthRequest extends ClusterManagerNodeReadRequest<ClusterH
      */
     private Level level = Level.CLUSTER;
 
+    /**
+     * This flag will be used by the TransportClusterHealthAction to decide if indices/shards info is required in the ClusterHealthResponse or not.
+     * When the flag is disabled - indices/shard info will be returned in ClusterHealthResponse regardless of the health level requested.
+     * When the flag is enabled - indices/shards info will be set according to health level requested.
+     *                  For Level.CLUSTER (or) Level.AWARENESS_ATTRIBUTES - information on indices/shards will NOT be returned to the transport client
+     *                  For Level.INDICES - information on indices will be returned to the transport client.
+     *                  For Level.SHARDS - information on indices and shards will be returned to the transport client
+     * By default, the flag is disabled.
+     */
+    private boolean applyLevelAtTransportLayer = false;
+
     public ClusterHealthRequest() {}
 
     public ClusterHealthRequest(String... indices) {
@@ -103,6 +114,9 @@ public class ClusterHealthRequest extends ClusterManagerNodeReadRequest<ClusterH
         }
         if (in.getVersion().onOrAfter(Version.V_2_6_0)) {
             ensureNodeWeighedIn = in.readBoolean();
+        }
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            applyLevelAtTransportLayer = in.readBoolean();
         }
     }
 
@@ -138,6 +152,9 @@ public class ClusterHealthRequest extends ClusterManagerNodeReadRequest<ClusterH
         }
         if (out.getVersion().onOrAfter(Version.V_2_6_0)) {
             out.writeBoolean(ensureNodeWeighedIn);
+        }
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeBoolean(applyLevelAtTransportLayer);
         }
     }
 
@@ -335,6 +352,14 @@ public class ClusterHealthRequest extends ClusterManagerNodeReadRequest<ClusterH
      */
     public final boolean ensureNodeWeighedIn() {
         return ensureNodeWeighedIn;
+    }
+
+    public boolean isApplyLevelAtTransportLayer() {
+        return applyLevelAtTransportLayer;
+    }
+
+    public void setApplyLevelAtTransportLayer(boolean applyLevelAtTransportLayer) {
+        this.applyLevelAtTransportLayer = applyLevelAtTransportLayer;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
@@ -171,4 +171,9 @@ public class ClusterHealthRequestBuilder extends ClusterManagerNodeReadOperation
         request.ensureNodeWeighedIn(ensureNodeCommissioned);
         return this;
     }
+
+    public ClusterHealthRequestBuilder setApplyLevelAtTransportLayer(boolean applyLevelAtTransportLayer) {
+        request.setApplyLevelAtTransportLayer(applyLevelAtTransportLayer);
+        return this;
+    }
 }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java
@@ -237,6 +237,26 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
         this.clusterHealthStatus = clusterStateHealth.getStatus();
     }
 
+    public ClusterHealthResponse(
+        String clusterName,
+        String[] concreteIndices,
+        ClusterHealthRequest clusterHealthRequest,
+        ClusterState clusterState,
+        int numberOfPendingTasks,
+        int numberOfInFlightFetch,
+        TimeValue taskMaxWaitingTime
+    ) {
+        this.clusterName = clusterName;
+        this.numberOfPendingTasks = numberOfPendingTasks;
+        this.numberOfInFlightFetch = numberOfInFlightFetch;
+        this.taskMaxWaitingTime = taskMaxWaitingTime;
+        this.clusterStateHealth = clusterHealthRequest.isApplyLevelAtTransportLayer()
+            ? new ClusterStateHealth(clusterState, concreteIndices, clusterHealthRequest.level())
+            : new ClusterStateHealth(clusterState, concreteIndices);
+        this.clusterHealthStatus = clusterStateHealth.getStatus();
+        this.delayedUnassignedShards = clusterStateHealth.getDelayedUnassignedShards();
+    }
+
     // Awareness Attribute health
     public ClusterHealthResponse(
         String clusterName,
@@ -256,6 +276,29 @@ public class ClusterHealthResponse extends ActionResponse implements StatusToXCo
             numberOfPendingTasks,
             numberOfInFlightFetch,
             delayedUnassignedShards,
+            taskMaxWaitingTime
+        );
+        this.clusterAwarenessHealth = new ClusterAwarenessHealth(clusterState, clusterSettings, awarenessAttributeName);
+    }
+
+    public ClusterHealthResponse(
+        String clusterName,
+        ClusterHealthRequest clusterHealthRequest,
+        ClusterState clusterState,
+        ClusterSettings clusterSettings,
+        String[] concreteIndices,
+        String awarenessAttributeName,
+        int numberOfPendingTasks,
+        int numberOfInFlightFetch,
+        TimeValue taskMaxWaitingTime
+    ) {
+        this(
+            clusterName,
+            concreteIndices,
+            clusterHealthRequest,
+            clusterState,
+            numberOfPendingTasks,
+            numberOfInFlightFetch,
             taskMaxWaitingTime
         );
         this.clusterAwarenessHealth = new ClusterAwarenessHealth(clusterState, clusterSettings, awarenessAttributeName);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -52,7 +52,6 @@ import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.ProcessClusterEventTimeoutException;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.NodeWeighedAwayException;
-import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.routing.WeightedRoutingUtils;
 import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.cluster.service.ClusterService;
@@ -487,7 +486,12 @@ public class TransportClusterHealthAction extends TransportClusterManagerNodeRea
         TimeValue pendingTaskTimeInQueue
     ) {
         if (logger.isTraceEnabled()) {
-            logger.trace("Calculating health based on state version [{}]", clusterState.version());
+            logger.trace(
+                "Calculating health based on state version [{}] for health level [{}] and applyLevelAtTransportLayer set to [{}]",
+                clusterState.version(),
+                request.level(),
+                request.isApplyLevelAtTransportLayer()
+            );
         }
 
         String[] concreteIndices;
@@ -496,13 +500,13 @@ public class TransportClusterHealthAction extends TransportClusterManagerNodeRea
             concreteIndices = clusterState.getMetadata().getConcreteAllIndices();
             return new ClusterHealthResponse(
                 clusterState.getClusterName().value(),
+                request,
                 clusterState,
                 clusterService.getClusterSettings(),
                 concreteIndices,
                 awarenessAttribute,
                 numberOfPendingTasks,
                 numberOfInFlightFetch,
-                UnassignedInfo.getNumberOfDelayedUnassigned(clusterState),
                 pendingTaskTimeInQueue
             );
         }
@@ -514,10 +518,10 @@ public class TransportClusterHealthAction extends TransportClusterManagerNodeRea
             ClusterHealthResponse response = new ClusterHealthResponse(
                 clusterState.getClusterName().value(),
                 Strings.EMPTY_ARRAY,
+                request,
                 clusterState,
                 numberOfPendingTasks,
                 numberOfInFlightFetch,
-                UnassignedInfo.getNumberOfDelayedUnassigned(clusterState),
                 pendingTaskTimeInQueue
             );
             response.setStatus(ClusterHealthStatus.RED);
@@ -527,10 +531,10 @@ public class TransportClusterHealthAction extends TransportClusterManagerNodeRea
         return new ClusterHealthResponse(
             clusterState.getClusterName().value(),
             concreteIndices,
+            request,
             clusterState,
             numberOfPendingTasks,
             numberOfInFlightFetch,
-            UnassignedInfo.getNumberOfDelayedUnassigned(clusterState),
             pendingTaskTimeInQueue
         );
     }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -34,6 +34,7 @@ package org.opensearch.action.admin.cluster.stats;
 
 import org.apache.lucene.store.AlreadyClosedException;
 import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.cluster.node.info.NodeInfo;
 import org.opensearch.action.admin.cluster.node.stats.NodeStats;
 import org.opensearch.action.admin.indices.stats.CommonStats;
@@ -209,7 +210,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
 
         ClusterHealthStatus clusterStatus = null;
         if (clusterService.state().nodes().isLocalNodeElectedClusterManager()) {
-            clusterStatus = new ClusterStateHealth(clusterService.state()).getStatus();
+            clusterStatus = new ClusterStateHealth(clusterService.state(), ClusterHealthRequest.Level.CLUSTER).getStatus();
         }
 
         return new ClusterStatsNodeResponse(

--- a/server/src/main/java/org/opensearch/cluster/health/ClusterStateHealth.java
+++ b/server/src/main/java/org/opensearch/cluster/health/ClusterStateHealth.java
@@ -31,6 +31,7 @@
 
 package org.opensearch.cluster.health;
 
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.IndexRoutingTable;
@@ -63,6 +64,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
     private final int activePrimaryShards;
     private final int initializingShards;
     private final int unassignedShards;
+    private int delayedUnassignedShards;
     private final double activeShardsPercent;
     private final ClusterHealthStatus status;
     private final Map<String, ClusterIndexHealth> indices;
@@ -74,6 +76,10 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
      */
     public ClusterStateHealth(final ClusterState clusterState) {
         this(clusterState, clusterState.metadata().getConcreteAllIndices());
+    }
+
+    public ClusterStateHealth(final ClusterState clusterState, final ClusterHealthRequest.Level clusterHealthLevel) {
+        this(clusterState, clusterState.metadata().getConcreteAllIndices(), clusterHealthLevel);
     }
 
     /**
@@ -105,6 +111,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         int computeRelocatingShards = 0;
         int computeInitializingShards = 0;
         int computeUnassignedShards = 0;
+        int computeDelayedUnassignedShards = 0;
 
         for (ClusterIndexHealth indexHealth : indices.values()) {
             computeActivePrimaryShards += indexHealth.getActivePrimaryShards();
@@ -112,10 +119,76 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
             computeRelocatingShards += indexHealth.getRelocatingShards();
             computeInitializingShards += indexHealth.getInitializingShards();
             computeUnassignedShards += indexHealth.getUnassignedShards();
-            if (indexHealth.getStatus() == ClusterHealthStatus.RED) {
-                computeStatus = ClusterHealthStatus.RED;
-            } else if (indexHealth.getStatus() == ClusterHealthStatus.YELLOW && computeStatus != ClusterHealthStatus.RED) {
-                computeStatus = ClusterHealthStatus.YELLOW;
+            computeDelayedUnassignedShards += indexHealth.getDelayedUnassignedShards();
+            computeStatus = getClusterHealthStatus(indexHealth, computeStatus);
+        }
+
+        if (clusterState.blocks().hasGlobalBlockWithStatus(RestStatus.SERVICE_UNAVAILABLE)) {
+            computeStatus = ClusterHealthStatus.RED;
+        }
+
+        this.status = computeStatus;
+        this.activePrimaryShards = computeActivePrimaryShards;
+        this.activeShards = computeActiveShards;
+        this.relocatingShards = computeRelocatingShards;
+        this.initializingShards = computeInitializingShards;
+        this.unassignedShards = computeUnassignedShards;
+        this.delayedUnassignedShards = computeDelayedUnassignedShards;
+
+        // shortcut on green
+        if (ClusterHealthStatus.GREEN.equals(computeStatus)) {
+            this.activeShardsPercent = 100;
+        } else {
+            List<ShardRouting> shardRoutings = clusterState.getRoutingTable().allShards();
+            int activeShardCount = 0;
+            int totalShardCount = 0;
+            for (ShardRouting shardRouting : shardRoutings) {
+                if (shardRouting.active()) activeShardCount++;
+                totalShardCount++;
+            }
+            this.activeShardsPercent = (((double) activeShardCount) / totalShardCount) * 100;
+        }
+    }
+
+    public ClusterStateHealth(
+        final ClusterState clusterState,
+        final String[] concreteIndices,
+        final ClusterHealthRequest.Level healthLevel
+    ) {
+        numberOfNodes = clusterState.nodes().getSize();
+        numberOfDataNodes = clusterState.nodes().getDataNodes().size();
+        hasDiscoveredClusterManager = clusterState.nodes().getClusterManagerNodeId() != null;
+        indices = new HashMap<>();
+        boolean isIndexOrShardLevelHealthRequired = healthLevel == ClusterHealthRequest.Level.INDICES
+            || healthLevel == ClusterHealthRequest.Level.SHARDS;
+
+        ClusterHealthStatus computeStatus = ClusterHealthStatus.GREEN;
+        int computeActivePrimaryShards = 0;
+        int computeActiveShards = 0;
+        int computeRelocatingShards = 0;
+        int computeInitializingShards = 0;
+        int computeUnassignedShards = 0;
+        int computeDelayedUnassignedShards = 0;
+
+        for (String index : concreteIndices) {
+            IndexRoutingTable indexRoutingTable = clusterState.routingTable().index(index);
+            IndexMetadata indexMetadata = clusterState.metadata().index(index);
+            if (indexRoutingTable == null) {
+                continue;
+            }
+
+            ClusterIndexHealth indexHealth = new ClusterIndexHealth(indexMetadata, indexRoutingTable, healthLevel);
+            computeActivePrimaryShards += indexHealth.getActivePrimaryShards();
+            computeActiveShards += indexHealth.getActiveShards();
+            computeRelocatingShards += indexHealth.getRelocatingShards();
+            computeInitializingShards += indexHealth.getInitializingShards();
+            computeUnassignedShards += indexHealth.getUnassignedShards();
+            computeDelayedUnassignedShards += indexHealth.getDelayedUnassignedShards();
+            computeStatus = getClusterHealthStatus(indexHealth, computeStatus);
+
+            if (isIndexOrShardLevelHealthRequired) {
+                // Store ClusterIndexHealth only when the health is requested at Index or Shard level
+                indices.put(indexHealth.getIndex(), indexHealth);
             }
         }
 
@@ -129,9 +202,10 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         this.relocatingShards = computeRelocatingShards;
         this.initializingShards = computeInitializingShards;
         this.unassignedShards = computeUnassignedShards;
+        this.delayedUnassignedShards = computeDelayedUnassignedShards;
 
         // shortcut on green
-        if (computeStatus.equals(ClusterHealthStatus.GREEN)) {
+        if (ClusterHealthStatus.GREEN.equals(computeStatus)) {
             this.activeShardsPercent = 100;
         } else {
             List<ShardRouting> shardRoutings = clusterState.getRoutingTable().allShards();
@@ -142,6 +216,22 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
                 totalShardCount++;
             }
             this.activeShardsPercent = (((double) activeShardCount) / totalShardCount) * 100;
+        }
+    }
+
+    private static ClusterHealthStatus getClusterHealthStatus(ClusterIndexHealth indexHealth, ClusterHealthStatus computeStatus) {
+        switch (indexHealth.getStatus()) {
+            case RED:
+                return ClusterHealthStatus.RED;
+            case YELLOW:
+                // do not override an existing red
+                if (computeStatus != ClusterHealthStatus.RED) {
+                    return ClusterHealthStatus.YELLOW;
+                } else {
+                    return ClusterHealthStatus.RED;
+                }
+            default:
+                return computeStatus;
         }
     }
 
@@ -211,6 +301,10 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
 
     public int getUnassignedShards() {
         return unassignedShards;
+    }
+
+    public int getDelayedUnassignedShards() {
+        return delayedUnassignedShards;
     }
 
     public int getNumberOfNodes() {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationService.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.Version;
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.cluster.ClusterInfoService;
 import org.opensearch.cluster.ClusterManagerMetrics;
 import org.opensearch.cluster.ClusterState;
@@ -196,7 +197,11 @@ public class AllocationService {
     protected ClusterState buildResultAndLogHealthChange(ClusterState oldState, RoutingAllocation allocation, String reason) {
         ClusterState newState = buildResult(oldState, allocation);
 
-        logClusterHealthStateChange(new ClusterStateHealth(oldState), new ClusterStateHealth(newState), reason);
+        logClusterHealthStateChange(
+            new ClusterStateHealth(oldState, ClusterHealthRequest.Level.CLUSTER),
+            new ClusterStateHealth(newState, ClusterHealthRequest.Level.CLUSTER),
+            reason
+        );
 
         return newState;
     }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestClusterHealthAction.java
@@ -105,6 +105,7 @@ public class RestClusterHealthAction extends BaseRestHandler {
         if (level != null) {
             clusterHealthRequest.setLevel(level);
         }
+        clusterHealthRequest.setApplyLevelAtTransportLayer(true);
         String waitForStatus = request.param("wait_for_status");
         if (waitForStatus != null) {
             clusterHealthRequest.waitForStatus(ClusterHealthStatus.valueOf(waitForStatus.toUpperCase(Locale.ROOT)));

--- a/server/src/test/java/org/opensearch/cluster/health/ClusterIndexHealthTests.java
+++ b/server/src/test/java/org/opensearch/cluster/health/ClusterIndexHealthTests.java
@@ -69,13 +69,20 @@ public class ClusterIndexHealthTests extends AbstractSerializingTestCase<Cluster
         IndexRoutingTable indexRoutingTable = routingTableGenerator.genIndexRoutingTable(indexMetadata, counter);
 
         ClusterIndexHealth indexHealth = new ClusterIndexHealth(indexMetadata, indexRoutingTable);
-        assertIndexHealth(indexHealth, counter, indexMetadata);
+        assertIndexHealth(indexHealth, counter, indexMetadata, ClusterHealthRequest.Level.SHARDS);
+
+        indexHealth = new ClusterIndexHealth(indexMetadata, indexRoutingTable, ClusterHealthRequest.Level.INDICES);
+        assertIndexHealth(indexHealth, counter, indexMetadata, ClusterHealthRequest.Level.INDICES);
+
+        indexHealth = new ClusterIndexHealth(indexMetadata, indexRoutingTable, ClusterHealthRequest.Level.SHARDS);
+        assertIndexHealth(indexHealth, counter, indexMetadata, ClusterHealthRequest.Level.SHARDS);
     }
 
     private void assertIndexHealth(
         ClusterIndexHealth indexHealth,
         RoutingTableGenerator.ShardCounter counter,
-        IndexMetadata indexMetadata
+        IndexMetadata indexMetadata,
+        ClusterHealthRequest.Level clusterHealthRequestLevel
     ) {
         assertThat(indexHealth.getStatus(), equalTo(counter.status()));
         assertThat(indexHealth.getNumberOfShards(), equalTo(indexMetadata.getNumberOfShards()));
@@ -84,13 +91,17 @@ public class ClusterIndexHealthTests extends AbstractSerializingTestCase<Cluster
         assertThat(indexHealth.getRelocatingShards(), equalTo(counter.relocating));
         assertThat(indexHealth.getInitializingShards(), equalTo(counter.initializing));
         assertThat(indexHealth.getUnassignedShards(), equalTo(counter.unassigned));
-        assertThat(indexHealth.getShards().size(), equalTo(indexMetadata.getNumberOfShards()));
-        int totalShards = 0;
-        for (ClusterShardHealth shardHealth : indexHealth.getShards().values()) {
-            totalShards += shardHealth.getActiveShards() + shardHealth.getInitializingShards() + shardHealth.getUnassignedShards();
-        }
+        if (ClusterHealthRequest.Level.SHARDS.equals(clusterHealthRequestLevel)) {
+            assertThat(indexHealth.getShards().size(), equalTo(indexMetadata.getNumberOfShards()));
+            int totalShards = 0;
+            for (ClusterShardHealth shardHealth : indexHealth.getShards().values()) {
+                totalShards += shardHealth.getActiveShards() + shardHealth.getInitializingShards() + shardHealth.getUnassignedShards();
+            }
 
-        assertThat(totalShards, equalTo(indexMetadata.getNumberOfShards() * (1 + indexMetadata.getNumberOfReplicas())));
+            assertThat(totalShards, equalTo(indexMetadata.getNumberOfShards() * (1 + indexMetadata.getNumberOfReplicas())));
+        } else {
+            assertTrue(indexHealth.getShards().isEmpty());
+        }
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/opensearch/cluster/health/ClusterStateHealthTests.java
@@ -73,6 +73,7 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -83,6 +84,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static org.opensearch.action.admin.cluster.health.ClusterHealthRequest.Level.CLUSTER;
+import static org.opensearch.action.admin.cluster.health.ClusterHealthRequest.Level.INDICES;
+import static org.opensearch.action.admin.cluster.health.ClusterHealthRequest.Level.SHARDS;
 import static org.opensearch.test.ClusterServiceUtils.createClusterService;
 import static org.opensearch.test.ClusterServiceUtils.setState;
 import static org.hamcrest.CoreMatchers.allOf;
@@ -225,7 +229,13 @@ public class ClusterStateHealthTests extends OpenSearchTestCase {
             clusterStateHealth.hasDiscoveredClusterManager(),
             equalTo(clusterService.state().nodes().getClusterManagerNodeId() != null)
         );
-        assertClusterHealth(clusterStateHealth, counter);
+        assertClusterHealth(clusterStateHealth, counter, SHARDS);
+        clusterStateHealth = new ClusterStateHealth(clusterState, concreteIndices, ClusterHealthRequest.Level.CLUSTER);
+        assertClusterHealth(clusterStateHealth, counter, CLUSTER);
+        clusterStateHealth = new ClusterStateHealth(clusterState, concreteIndices, INDICES);
+        assertClusterHealth(clusterStateHealth, counter, INDICES);
+        clusterStateHealth = new ClusterStateHealth(clusterState, concreteIndices, SHARDS);
+        assertClusterHealth(clusterStateHealth, counter, SHARDS);
     }
 
     public void testClusterHealthOnIndexCreation() {
@@ -586,7 +596,11 @@ public class ClusterStateHealthTests extends OpenSearchTestCase {
         return true;
     }
 
-    private void assertClusterHealth(ClusterStateHealth clusterStateHealth, RoutingTableGenerator.ShardCounter counter) {
+    private void assertClusterHealth(
+        ClusterStateHealth clusterStateHealth,
+        RoutingTableGenerator.ShardCounter counter,
+        ClusterHealthRequest.Level level
+    ) {
         assertThat(clusterStateHealth.getStatus(), equalTo(counter.status()));
         assertThat(clusterStateHealth.getActiveShards(), equalTo(counter.active));
         assertThat(clusterStateHealth.getActivePrimaryShards(), equalTo(counter.primaryActive));
@@ -594,5 +608,16 @@ public class ClusterStateHealthTests extends OpenSearchTestCase {
         assertThat(clusterStateHealth.getRelocatingShards(), equalTo(counter.relocating));
         assertThat(clusterStateHealth.getUnassignedShards(), equalTo(counter.unassigned));
         assertThat(clusterStateHealth.getActiveShardsPercent(), is(allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(100.0))));
+        if (level.equals(INDICES) || level.equals(SHARDS)) {
+            assertTrue(clusterStateHealth.getIndices().size() > 0);
+            if (level.equals(SHARDS)) {
+                Collection<ClusterIndexHealth> clusterIndexHealths = clusterStateHealth.getIndices().values();
+                for (ClusterIndexHealth clusterIndexHealth : clusterIndexHealths) {
+                    assertFalse(clusterIndexHealth.getShards().isEmpty());
+                }
+            }
+        } else {
+            assertTrue(clusterStateHealth.getIndices().isEmpty());
+        }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
 
https://github.com/opensearch-project/OpenSearch/issues/11684 - on a large cluster the memory allocation of TransportClusterHealthAction is around 33%. Memory/compute requirement of TransportClusterHealthAction is proportional to the number of indices and shards on the cluster. Transport ClusterHealthResponse maintains health objects for individual indices and shards that can increase the memory allocation of this with the growth of indices and shards count.  At rest layer, there is a room for optimization for _cluster/health API when request is at cluster/indices level by performing inline aggregations and not creating and maintaing shard health objects. 

Changes:
- Introducing a flag ```honourClusterHealthLevel``` in ClusterHealthRequest to identify if the request param ```level```  should be honored or not when computing health response in TransportClusterHealthAction - Currently ```level``` param is only used at REST layer for generating response from the transport response based on the level requested ([usage](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/admin/cluster/health/ClusterHealthResponse.java#L455)) and has no meaning at transport layer. This flag will help TransportClusterHealthAction in differentiating if indices/shards level health information is required in the transport response or not. By default this flag is set to false to keep the change backward compatible.
- Initializing ClusterIndexHealth without creating the ClusterShardHealth objects per shard when requested level for cluster health is not at shards level, health aggregation are made inline.
-  ClusterHealthResponse computes the delayed unassigned shards information by iterating over all shards of the cluster([reference](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java#L533)).This is avoided by computing the delayed unassigned shards along with computation of other shard states in ClusterStateHealth. 
- Using index based iteration for iterating over ShardRoutings of a shard. For each loop iteration uses an iterator under the hood and since the ShardRouting list maintained in the IndexShardRoutingTable is un-modifiable, a new iterator object is created on the heap.

Memory allocation 5 min profile of an idle cluster before and after optimisation
**Before Optimisation**
<img width="1918" alt="Base Profile" src="https://github.com/user-attachments/assets/fb7612dc-b867-482b-8a56-b2fe09820ce2">
**After Optimisation**
<img width="959" alt="Memory Optimisation Profile" src="https://github.com/user-attachments/assets/559b6dea-f11d-449e-88c5-bd394c51758b">

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
