### PR TITLE
Modify create snapshot v2 response when wait_for_completion is false

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
@@ -810,18 +810,13 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         String snapshotName2 = "test-create-snapshot2";
 
-        // verify even if waitForCompletion is not true, the request executes in a sync manner
-        CreateSnapshotResponse createSnapshotResponse2 = client().admin()
+        // verify response status if waitForCompletion is not true
+        RestStatus createSnapshotResponseStatus = client().admin()
             .cluster()
             .prepareCreateSnapshot(snapshotRepoName, snapshotName2)
-            .get();
-        snapshotInfo = createSnapshotResponse2.getSnapshotInfo();
-        assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
-        assertThat(snapshotInfo.successfulShards(), greaterThan(0));
-        assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
-        assertThat(snapshotInfo.snapshotId().getName(), equalTo(snapshotName2));
-        assertThat(snapshotInfo.getPinnedTimestamp(), greaterThan(0L));
-
+            .get()
+            .status();
+        assertEquals(RestStatus.ACCEPTED, createSnapshotResponseStatus);
     }
 
     public void testMixedSnapshotCreationWithV2RepositorySetting() throws Exception {
@@ -897,6 +892,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         CreateSnapshotResponse createSnapshotResponse2 = client().admin()
             .cluster()
             .prepareCreateSnapshot(snapshotRepoName, snapshotName2)
+            .setWaitForCompletion(true)
             .get();
         snapshotInfo = createSnapshotResponse2.getSnapshotInfo();
         assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
@@ -958,6 +954,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                     CreateSnapshotResponse createSnapshotResponse2 = client().admin()
                         .cluster()
                         .prepareCreateSnapshot(snapshotRepoName, snapshotName)
+                        .setWaitForCompletion(true)
                         .get();
                     SnapshotInfo snapshotInfo = createSnapshotResponse2.getSnapshotInfo();
                     assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
@@ -1033,6 +1030,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         CreateSnapshotResponse createSnapshotResponse2 = client().admin()
             .cluster()
             .prepareCreateSnapshot(snapshotRepoName, snapshotName1)
+            .setWaitForCompletion(true)
             .get();
         SnapshotInfo snapshotInfo = createSnapshotResponse2.getSnapshotInfo();
         assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
@@ -1101,6 +1099,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         CreateSnapshotResponse createSnapshotResponse2 = client().admin()
             .cluster()
             .prepareCreateSnapshot(snapshotRepoName, snapshotName1)
+            .setWaitForCompletion(true)
             .get();
 
         SnapshotInfo snapshotInfo = createSnapshotResponse2.getSnapshotInfo();
@@ -1221,6 +1220,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 CreateSnapshotResponse createSnapshotResponse = client().admin()
                     .cluster()
                     .prepareCreateSnapshot(snapshotRepoName, snapshotName1)
+                    .setWaitForCompletion(true)
                     .get();
                 snapshotInfo[0] = createSnapshotResponse.getSnapshotInfo();
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
@@ -113,8 +113,10 @@ public class TransportCreateSnapshotAction extends TransportClusterManagerNodeAc
     ) {
         Repository repository = repositoriesService.repository(request.repository());
         boolean isSnapshotV2 = SHALLOW_SNAPSHOT_V2.get(repository.getMetadata().settings());
-        if (request.waitForCompletion() || isSnapshotV2) {
+        if (request.waitForCompletion()) {
             snapshotsService.executeSnapshot(request, ActionListener.map(listener, CreateSnapshotResponse::new));
+        } else if (isSnapshotV2) {
+            snapshotsService.executeSnapshot(request, ActionListener.map(listener, snapshot -> new CreateSnapshotResponse()));
         } else {
             snapshotsService.createSnapshot(request, ActionListener.map(listener, snapshot -> new CreateSnapshotResponse()));
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
With current implementation of shallow snapshot v2, the create api respond with snapshot info details irrespective of value set for `wait_for_completion` in the request.

**Expected Response** 

For shallow snapshots v2, if `wait_for_completion=false`, the api response should be 
```
{
  "accepted" : true
}
```
if `wait_for_completion=true`, the api response should be
```
{
  "snapshot" : {
    "snapshot" : "my_snapshot_3",
    "uuid" : "URJArTYOTOmIFtbv6mbSXQ",
    "version_id" : 137217827,
    "version" : "3.0.0",
    "remote_store_index_shallow_copy" : true,
    "pinned_timestamp" : 1724855317025,
    "indices" : [
      "my-index-1"
    ],
    "data_streams" : [ ],
    "include_global_state" : true,
    "state" : "SUCCESS",
    "start_time" : "2024-08-28T14:28:37.025Z",
    "start_time_in_millis" : 1724855317025,
    "end_time" : "2024-08-28T14:28:37.026Z",
    "end_time_in_millis" : 1724855317026,
    "duration_in_millis" : 1,
    "failures" : [ ],
    "shards" : {
      "total" : 1,
      "failed" : 0,
      "successful" : 1
    }
  }
}
```

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/15516
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
