### PR TITLE
Update version check for fix the bug of missing validation for the search_backpressure.mode setting

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.put_settings/10_basic.yml
@@ -85,8 +85,8 @@
 "Test set invalid search backpressure mode":
 
   - skip:
-      version: "- 2.99.99"
-      reason: "Parsing and validation of SearchBackpressureMode does not exist in versions < 3.0"
+      version: "- 2.8.99"
+      reason: "Fixed in 2.9.0"
 
   - do:
       catch: bad_request


### PR DESCRIPTION
### Description

This PR fixed the bug of the validation for the cluster level `search_backpressure.mode` setting is missing, we need to update the version check in the yaml test file.

Changelog is not needed, backport 2.x is needed.

### Related Issues
No issue.

### Check List
<del>- [ ] Functionality includes testing.
<del>- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
<del>- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
