### PR TITLE
Fix missing order field in TemplatesMetadata deserialization

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/TemplatesMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/TemplatesMetadata.java
@@ -133,16 +133,15 @@ public class TemplatesMetadata extends AbstractDiffable<TemplatesMetadata> imple
             String currentFieldName = parser.currentName();
             if (currentFieldName == null) {
                 token = parser.nextToken();
-                if (token == XContentParser.Token.START_OBJECT) {
-                    // move to the field name
-                    token = parser.nextToken();
-                }
-                currentFieldName = parser.currentName();
             }
-            if (currentFieldName != null) {
-                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.START_OBJECT) {
+                // move to the field name
+                token = parser.nextToken();
+            }
+            if (parser.currentName() != null && token != XContentParser.Token.END_OBJECT) {
+                do {
                     builder.put(IndexTemplateMetadata.Builder.fromXContent(parser, parser.currentName()));
-                }
+                } while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT);
             }
             return builder.build();
         }

--- a/server/src/test/java/org/opensearch/gateway/remote/model/RemoteTemplatesMetadataTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/model/RemoteTemplatesMetadataTests.java
@@ -231,7 +231,17 @@ public class RemoteTemplatesMetadataTests extends OpenSearchTestCase {
         return TemplatesMetadata.builder()
             .put(
                 IndexTemplateMetadata.builder("template" + randomAlphaOfLength(3))
+                    .order(1234)
                     .patterns(Arrays.asList("bar-*", "foo-*"))
+                    .settings(
+                        Settings.builder().put("index.random_index_setting_" + randomAlphaOfLength(3), randomAlphaOfLength(5)).build()
+                    )
+                    .build()
+            )
+            .put(
+                IndexTemplateMetadata.builder("template" + randomAlphaOfLength(3))
+                    .order(5678)
+                    .patterns(Arrays.asList("test-*"))
                     .settings(
                         Settings.builder().put("index.random_index_setting_" + randomAlphaOfLength(3), randomAlphaOfLength(5)).build()
                     )


### PR DESCRIPTION
### Description
`order` field is missing while deserializing TemplatesMetadata object. This is because it is the first field in the serialized content and we are moving to the next token just before deserialization.


### Related Issues
NA

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
