### PR TITLE
Handle unsupported media type properly for streaming requests

### DIFF
--- a/plugins/transport-reactor-netty4/src/javaRestTest/java/org/opensearch/rest/ReactorNetty4BadRequestIT.java
+++ b/plugins/transport-reactor-netty4/src/javaRestTest/java/org/opensearch/rest/ReactorNetty4BadRequestIT.java
@@ -112,4 +112,16 @@ public class ReactorNetty4BadRequestIT extends OpenSearchRestTestCase {
         assertThat(map.get("type"), equalTo("content_type_header_exception"));
         assertThat(map.get("reason"), equalTo("java.lang.IllegalArgumentException: invalid Content-Type header []"));
     }
+
+    public void testUnsupportedContentType() throws IOException {
+        final Request request = new Request("POST", "/_bulk/stream");
+        final RequestOptions.Builder options = request.getOptions().toBuilder();
+        request.setOptions(options);
+        final ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(request));
+        final Response response = e.getResponse();
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(406));
+        final ObjectPath objectPath = ObjectPath.createFromResponse(response);
+        final String error = objectPath.evaluate("error");
+        assertThat(error, equalTo("Content-Type header [] is not supported"));
+    }
 }

--- a/server/src/main/java/org/opensearch/rest/RestController.java
+++ b/server/src/main/java/org/opensearch/rest/RestController.java
@@ -326,8 +326,8 @@ public class RestController implements HttpServerTransport.Dispatcher {
 
     private void dispatchRequest(RestRequest request, RestChannel channel, RestHandler handler) throws Exception {
         final int contentLength = request.content().length();
+        final MediaType mediaType = request.getMediaType();
         if (contentLength > 0) {
-            final MediaType mediaType = request.getMediaType();
             if (mediaType == null) {
                 sendContentTypeErrorMessage(request.getAllHeaderValues("Content-Type"), channel);
                 return;
@@ -343,6 +343,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
                 return;
             }
         }
+
         RestChannel responseChannel = channel;
         try {
             if (handler.canTripCircuitBreaker()) {
@@ -363,6 +364,11 @@ public class RestController implements HttpServerTransport.Dispatcher {
                             + request.getHttpRequest().method()
                             + "]"
                     );
+                }
+
+                if (mediaType == null) {
+                    sendContentTypeErrorMessage(request.getAllHeaderValues("Content-Type"), responseChannel);
+                    return;
                 }
             } else {
                 // if we could reserve bytes for the request we need to send the response also over this channel


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Handle unsupported media type properly for streaming requests

### Related Issues

Fixes the NPE in `RestBulkStreamingAction` when content type header (media type) is not specified:

```
java.lang.NullPointerException: Cannot invoke "org.opensearch.core.xcontent.MediaType.mediaTypeWithoutParameters()" because "mediaType" is null                    
        at org.opensearch.rest.action.document.RestBulkStreamingAction.lambda$prepareRequest$6(RestBulkStreamingAction.java:127) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]                                                                                                                                                                    
        at org.opensearch.rest.action.document.RestBulkStreamingAction.lambda$prepareRequest$7(RestBulkStreamingAction.java:213) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]                                                                                                                                                                    
        at org.opensearch.rest.BaseRestHandler.handleRequest(BaseRestHandler.java:128) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]                                    
        at org.opensearch.rest.RestController.dispatchRequest(RestController.java:383) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]                              
        at org.opensearch.rest.RestController.tryAllHandlers(RestController.java:474) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]        

```

How to reproduce:

```
$ curl -X POST http://localhost:9200/_bulk/stream  -d '
{ "delete": { "_index": "movies", "_id": "tt2229499" } }
'
```

now returns:

```
{"error":"Content-Type header [application/x-www-form-urlencoded] is not supported","status":406}
```

<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
