### PR TITLE
[Backport 2.x] Initial commit to support a search only replica for RW separation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add runAs to Subject interface and introduce IdentityAwarePlugin extension point ([#14630](https://github.com/opensearch-project/OpenSearch/pull/14630))
 - [Workload Management] Add rejection logic for co-ordinator and shard level requests ([#15428](https://github.com/opensearch-project/OpenSearch/pull/15428)))
 - Adding translog durability validation in index templates ([#15494](https://github.com/opensearch-project/OpenSearch/pull/15494))
+- [Reader Writer Separation] Add searchOnly replica routing configuration ([#15410](https://github.com/opensearch-project/OpenSearch/pull/15410))
 
 ### Dependencies
 - Bump `netty` from 4.1.111.Final to 4.1.112.Final ([#15081](https://github.com/opensearch-project/OpenSearch/pull/15081))

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/SearchOnlyReplicaFeatureFlagIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/SearchOnlyReplicaFeatureFlagIT.java
@@ -10,7 +10,6 @@ package org.opensearch.indices.settings;
 
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.settings.SettingsException;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -33,8 +32,8 @@ public class SearchOnlyReplicaFeatureFlagIT extends OpenSearchIntegTestCase {
 
     public void testCreateFeatureFlagDisabled() {
         Settings settings = Settings.builder().put(indexSettings()).put(FeatureFlags.READER_WRITER_SPLIT_EXPERIMENTAL, false).build();
-        SettingsException settingsException = expectThrows(SettingsException.class, () -> createIndex(TEST_INDEX, settings));
-        assertTrue(settingsException.getMessage().contains("unknown setting"));
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> createIndex(TEST_INDEX, settings));
+        assertTrue(exception.getMessage().contains("unknown setting"));
     }
 
     public void testUpdateFeatureFlagDisabled() {
@@ -44,13 +43,13 @@ public class SearchOnlyReplicaFeatureFlagIT extends OpenSearchIntegTestCase {
             .build();
 
         createIndex(TEST_INDEX, settings);
-        SettingsException settingsException = expectThrows(SettingsException.class, () -> {
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> {
             client().admin()
                 .indices()
                 .prepareUpdateSettings(TEST_INDEX)
                 .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SEARCH_REPLICAS, 1))
                 .get();
         });
-        assertTrue(settingsException.getMessage().contains("unknown setting"));
+        assertTrue(exception.getMessage().contains("unknown setting"));
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/SearchOnlyReplicaFeatureFlagIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/SearchOnlyReplicaFeatureFlagIT.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.settings;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsException;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SEARCH_REPLICAS;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 1)
+public class SearchOnlyReplicaFeatureFlagIT extends OpenSearchIntegTestCase {
+
+    private static final String TEST_INDEX = "test_index";
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder()
+            .put(super.featureFlagSettings())
+            .put(FeatureFlags.READER_WRITER_SPLIT_EXPERIMENTAL, Boolean.FALSE)
+            .build();
+    }
+
+    public void testCreateFeatureFlagDisabled() {
+        Settings settings = Settings.builder().put(indexSettings()).put(FeatureFlags.READER_WRITER_SPLIT_EXPERIMENTAL, false).build();
+        SettingsException settingsException = expectThrows(SettingsException.class, () -> createIndex(TEST_INDEX, settings));
+        assertTrue(settingsException.getMessage().contains("unknown setting"));
+    }
+
+    public void testUpdateFeatureFlagDisabled() {
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .build();
+
+        createIndex(TEST_INDEX, settings);
+        SettingsException settingsException = expectThrows(SettingsException.class, () -> {
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(TEST_INDEX)
+                .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SEARCH_REPLICAS, 1))
+                .get();
+        });
+        assertTrue(settingsException.getMessage().contains("unknown setting"));
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/SearchOnlyReplicaIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/SearchOnlyReplicaIT.java
@@ -1,0 +1,210 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.settings;
+
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.routing.IndexShardRoutingTable;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.InternalTestCluster;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.io.IOException;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SEARCH_REPLICAS;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
+import static org.opensearch.cluster.routing.UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class SearchOnlyReplicaIT extends OpenSearchIntegTestCase {
+
+    private static final String TEST_INDEX = "test_index";
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.READER_WRITER_SPLIT_EXPERIMENTAL, Boolean.TRUE).build();
+    }
+
+    private final String expectedFailureMessage =
+        "To set index.number_of_search_only_replicas, index.replication.type must be set to SEGMENT";
+
+    @Override
+    public Settings indexSettings() {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SEARCH_REPLICAS, 1)
+            .put(INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "0ms") // so that after we punt a node we can immediately try to
+                                                                          // reallocate after node left.
+            .put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .build();
+    }
+
+    public void testCreateDocRepFails() {
+        Settings settings = Settings.builder().put(indexSettings()).put(SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT).build();
+
+        IllegalArgumentException illegalArgumentException = expectThrows(
+            IllegalArgumentException.class,
+            () -> createIndex(TEST_INDEX, settings)
+        );
+        assertEquals(expectedFailureMessage, illegalArgumentException.getMessage());
+    }
+
+    public void testUpdateDocRepFails() {
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT)
+            .build();
+        // create succeeds
+        createIndex(TEST_INDEX, settings);
+
+        // update fails
+        IllegalArgumentException illegalArgumentException = expectThrows(IllegalArgumentException.class, () -> {
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(TEST_INDEX)
+                .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SEARCH_REPLICAS, 1))
+                .get();
+        });
+        assertEquals(expectedFailureMessage, illegalArgumentException.getMessage());
+    }
+
+    public void testFailoverWithSearchReplica_WithWriterReplicas() throws IOException {
+        int numSearchReplicas = 1;
+        int numWriterReplicas = 1;
+        internalCluster().startClusterManagerOnlyNode();
+        String primaryNodeName = internalCluster().startDataOnlyNode();
+        createIndex(
+            TEST_INDEX,
+            Settings.builder()
+                .put(indexSettings())
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numWriterReplicas)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SEARCH_REPLICAS, numSearchReplicas)
+                .build()
+        );
+        ensureYellow(TEST_INDEX);
+        // add 2 nodes for the replicas
+        internalCluster().startDataOnlyNodes(2);
+        ensureGreen(TEST_INDEX);
+
+        // assert shards are on separate nodes & all active
+        assertActiveShardCounts(numSearchReplicas, numWriterReplicas);
+
+        // stop the primary and ensure search shard is not promoted:
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNodeName));
+        ensureYellowAndNoInitializingShards(TEST_INDEX);
+
+        assertActiveShardCounts(numSearchReplicas, 0); // 1 repl is inactive that was promoted to primary
+        // add back a node
+        internalCluster().startDataOnlyNode();
+        ensureGreen(TEST_INDEX);
+
+    }
+
+    public void testFailoverWithSearchReplica_WithoutWriterReplicas() throws IOException {
+        int numSearchReplicas = 1;
+        int numWriterReplicas = 0;
+        internalCluster().startClusterManagerOnlyNode();
+        String primaryNodeName = internalCluster().startDataOnlyNode();
+        createIndex(
+            TEST_INDEX,
+            Settings.builder()
+                .put(indexSettings())
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numWriterReplicas)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SEARCH_REPLICAS, numSearchReplicas)
+                .build()
+        );
+        ensureYellow(TEST_INDEX);
+        client().prepareIndex(TEST_INDEX).setId("1").setSource("foo", "bar").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        // start a node for our search replica
+        String replica = internalCluster().startDataOnlyNode();
+        ensureGreen(TEST_INDEX);
+        assertActiveSearchShards(numSearchReplicas);
+        assertHitCount(client(replica).prepareSearch(TEST_INDEX).setSize(0).setPreference("_only_local").get(), 1);
+
+        // stop the primary and ensure search shard is not promoted:
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNodeName));
+        ensureRed(TEST_INDEX);
+        assertActiveSearchShards(numSearchReplicas);
+        // while red our search shard is still searchable
+        assertHitCount(client(replica).prepareSearch(TEST_INDEX).setSize(0).setPreference("_only_local").get(), 1);
+    }
+
+    public void testSearchReplicaScaling() {
+        internalCluster().startNodes(2);
+        createIndex(TEST_INDEX);
+        ensureGreen(TEST_INDEX);
+        // assert settings
+        Metadata metadata = client().admin().cluster().prepareState().get().getState().metadata();
+        int numSearchReplicas = Integer.parseInt(metadata.index(TEST_INDEX).getSettings().get(SETTING_NUMBER_OF_SEARCH_REPLICAS));
+        assertEquals(1, numSearchReplicas);
+
+        // assert cluster state & routing table
+        assertActiveSearchShards(1);
+
+        // Add another node and search replica
+        internalCluster().startDataOnlyNode();
+        client().admin()
+            .indices()
+            .prepareUpdateSettings(TEST_INDEX)
+            .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SEARCH_REPLICAS, 2))
+            .get();
+
+        ensureGreen(TEST_INDEX);
+        assertActiveSearchShards(2);
+
+        // remove all search shards
+        client().admin()
+            .indices()
+            .prepareUpdateSettings(TEST_INDEX)
+            .setSettings(Settings.builder().put(SETTING_NUMBER_OF_SEARCH_REPLICAS, 0))
+            .get();
+        ensureGreen(TEST_INDEX);
+        assertActiveSearchShards(0);
+    }
+
+    /**
+     * Helper to assert counts of active shards for each type.
+     */
+    private void assertActiveShardCounts(int expectedSearchReplicaCount, int expectedWriteReplicaCount) {
+        // assert routing table
+        IndexShardRoutingTable indexShardRoutingTable = getIndexShardRoutingTable();
+        // assert search replica count
+        int activeCount = expectedSearchReplicaCount + expectedWriteReplicaCount;
+        assertEquals(expectedSearchReplicaCount, indexShardRoutingTable.searchOnlyReplicas().stream().filter(ShardRouting::active).count());
+        assertEquals(expectedWriteReplicaCount, indexShardRoutingTable.writerReplicas().stream().filter(ShardRouting::active).count());
+        assertEquals(
+            expectedWriteReplicaCount + expectedSearchReplicaCount,
+            indexShardRoutingTable.replicaShards().stream().filter(ShardRouting::active).count()
+        );
+
+        // assert routing nodes
+        ClusterState clusterState = getClusterState();
+        assertEquals(activeCount, clusterState.getRoutingNodes().shards(r -> r.active() && !r.primary()).size());
+        assertEquals(expectedSearchReplicaCount, clusterState.getRoutingNodes().shards(r -> r.active() && r.isSearchOnly()).size());
+        assertEquals(
+            expectedWriteReplicaCount,
+            clusterState.getRoutingNodes().shards(r -> r.active() && !r.primary() && !r.isSearchOnly()).size()
+        );
+    }
+
+    private void assertActiveSearchShards(int expectedSearchReplicaCount) {
+        assertActiveShardCounts(expectedSearchReplicaCount, 0);
+    }
+
+    private IndexShardRoutingTable getIndexShardRoutingTable() {
+        return getClusterState().routingTable().index(TEST_INDEX).shards().values().stream().findFirst().get();
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -69,6 +69,7 @@ import org.opensearch.gateway.MetadataStateFormat;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.indices.replication.SegmentReplicationSource;
 import org.opensearch.indices.replication.common.ReplicationType;
 
 import java.io.IOException;
@@ -238,6 +239,22 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final Setting<Integer> INDEX_NUMBER_OF_REPLICAS_SETTING = Setting.intSetting(
         SETTING_NUMBER_OF_REPLICAS,
         1,
+        0,
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /**
+     * Setting to control the number of search only replicas for an index.
+     * A search only replica exists solely to perform read operations for a shard and are designed to achieve
+     * isolation from writers (primary shards).  This means they are not primary eligible and do not have any direct communication
+     * with their primary.  Search replicas require the use of Segment Replication on the index and poll their {@link SegmentReplicationSource} for
+     * updates.  //TODO: Once physical isolation is introduced, reference the setting here.
+     */
+    public static final String SETTING_NUMBER_OF_SEARCH_REPLICAS = "index.number_of_search_only_replicas";
+    public static final Setting<Integer> INDEX_NUMBER_OF_SEARCH_REPLICAS_SETTING = Setting.intSetting(
+        SETTING_NUMBER_OF_SEARCH_REPLICAS,
+        0,
         0,
         Property.Dynamic,
         Property.IndexScope
@@ -650,6 +667,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     private final int numberOfShards;
     private final int numberOfReplicas;
+    private final int numberOfSearchOnlyReplicas;
 
     private final Index index;
     private final long version;
@@ -701,6 +719,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         final State state,
         final int numberOfShards,
         final int numberOfReplicas,
+        final int numberOfSearchOnlyReplicas,
         final Settings settings,
         final Map<String, MappingMetadata> mappings,
         final Map<String, AliasMetadata> aliases,
@@ -733,7 +752,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         this.state = state;
         this.numberOfShards = numberOfShards;
         this.numberOfReplicas = numberOfReplicas;
-        this.totalNumberOfShards = numberOfShards * (numberOfReplicas + 1);
+        this.numberOfSearchOnlyReplicas = numberOfSearchOnlyReplicas;
+        this.totalNumberOfShards = numberOfShards * (numberOfReplicas + numberOfSearchOnlyReplicas + 1);
         this.settings = settings;
         this.mappings = Collections.unmodifiableMap(mappings);
         this.customData = Collections.unmodifiableMap(customData);
@@ -833,6 +853,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     public int getNumberOfReplicas() {
         return numberOfReplicas;
+    }
+
+    public int getNumberOfSearchOnlyReplicas() {
+        return numberOfSearchOnlyReplicas;
     }
 
     public int getRoutingPartitionSize() {
@@ -1348,6 +1372,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             return this;
         }
 
+        public Builder numberOfSearchReplicas(int numberOfSearchReplicas) {
+            settings = Settings.builder().put(settings).put(SETTING_NUMBER_OF_SEARCH_REPLICAS, numberOfSearchReplicas).build();
+            return this;
+        }
+
         public Builder routingPartitionSize(int routingPartitionSize) {
             settings = Settings.builder().put(settings).put(SETTING_ROUTING_PARTITION_SIZE, routingPartitionSize).build();
             return this;
@@ -1535,6 +1564,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 throw new IllegalArgumentException("must specify number of replicas for index [" + index + "]");
             }
             final int numberOfReplicas = INDEX_NUMBER_OF_REPLICAS_SETTING.get(settings);
+            final int numberOfSearchReplicas = INDEX_NUMBER_OF_SEARCH_REPLICAS_SETTING.get(settings);
 
             int routingPartitionSize = INDEX_ROUTING_PARTITION_SIZE_SETTING.get(settings);
             if (routingPartitionSize != 1 && routingPartitionSize >= getRoutingNumShards()) {
@@ -1630,6 +1660,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 state,
                 numberOfShards,
                 numberOfReplicas,
+                numberOfSearchReplicas,
                 tmpSettings,
                 mappings,
                 tmpAliases,

--- a/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Metadata.java
@@ -1508,6 +1508,24 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             return this;
         }
 
+        /**
+         * Update the number of search replicas for the specified indices.
+         *
+         * @param numberOfSearchReplicas the number of search replicas
+         * @param indices          the indices to update the number of replicas for
+         * @return the builder
+         */
+        public Builder updateNumberOfSearchReplicas(final int numberOfSearchReplicas, final String[] indices) {
+            for (String index : indices) {
+                IndexMetadata indexMetadata = this.indices.get(index);
+                if (indexMetadata == null) {
+                    throw new IndexNotFoundException(index);
+                }
+                put(IndexMetadata.builder(indexMetadata).numberOfSearchReplicas(numberOfSearchReplicas));
+            }
+            return this;
+        }
+
         public Builder coordinationMetadata(CoordinationMetadata coordinationMetadata) {
             this.coordinationMetadata = coordinationMetadata;
             return this;

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -76,6 +76,7 @@ import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
@@ -134,12 +135,14 @@ import java.util.stream.IntStream;
 
 import static java.util.stream.Collectors.toList;
 import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING;
+import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SEARCH_REPLICAS_SETTING;
 import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING;
 import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_REPLICATION_TYPE_SETTING;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SEARCH_REPLICAS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_SEGMENT_STORE_REPOSITORY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_STORE_ENABLED;
@@ -969,6 +972,9 @@ public class MetadataCreateIndexService {
 
         updateReplicationStrategy(indexSettingsBuilder, request.settings(), settings, combinedTemplateSettings, clusterSettings);
         updateRemoteStoreSettings(indexSettingsBuilder, currentState, clusterSettings, settings, request.index());
+        if (FeatureFlags.isEnabled(FeatureFlags.READER_WRITER_SPLIT_EXPERIMENTAL_SETTING)) {
+            updateSearchOnlyReplicas(request.settings(), indexSettingsBuilder);
+        }
 
         if (sourceMetadata != null) {
             assert request.resizeType() != null;
@@ -1004,8 +1010,24 @@ public class MetadataCreateIndexService {
         validateStoreTypeSettings(indexSettings);
         validateRefreshIntervalSettings(request.settings(), clusterSettings);
         validateTranslogDurabilitySettings(request.settings(), clusterSettings, settings);
-
         return indexSettings;
+    }
+
+    private static void updateSearchOnlyReplicas(Settings requestSettings, Settings.Builder builder) {
+        if (INDEX_NUMBER_OF_SEARCH_REPLICAS_SETTING.exists(builder) && builder.get(SETTING_NUMBER_OF_SEARCH_REPLICAS) != null) {
+            if (INDEX_NUMBER_OF_SEARCH_REPLICAS_SETTING.get(requestSettings) > 0
+                && ReplicationType.parseString(builder.get(INDEX_REPLICATION_TYPE_SETTING.getKey())).equals(ReplicationType.DOCUMENT)) {
+                throw new IllegalArgumentException(
+                    "To set "
+                        + SETTING_NUMBER_OF_SEARCH_REPLICAS
+                        + ", "
+                        + INDEX_REPLICATION_TYPE_SETTING.getKey()
+                        + " must be set to "
+                        + ReplicationType.SEGMENT
+                );
+            }
+            builder.put(SETTING_NUMBER_OF_SEARCH_REPLICAS, INDEX_NUMBER_OF_SEARCH_REPLICAS_SETTING.get(requestSettings));
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/IndexShardRoutingTable.java
@@ -212,6 +212,24 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
     }
 
     /**
+     * Returns a {@link List} of the search only shards in the RoutingTable
+     *
+     * @return a {@link List} of shards
+     */
+    public List<ShardRouting> searchOnlyReplicas() {
+        return replicas.stream().filter(ShardRouting::isSearchOnly).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a {@link List} of the writer replicas (primary eligible) shards in the RoutingTable
+     *
+     * @return a {@link List} of shards
+     */
+    public List<ShardRouting> writerReplicas() {
+        return replicas.stream().filter(r -> r.isSearchOnly() == false).collect(Collectors.toList());
+    }
+
+    /**
      * Returns a {@link List} of active shards
      *
      * @return a {@link List} of shards

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingTable.java
@@ -520,7 +520,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                     // ignore index missing failure, its closed...
                     continue;
                 }
-                int currentNumberOfReplicas = indexRoutingTable.shards().get(0).size() - 1; // remove the required primary
+                int currentNumberOfReplicas = indexRoutingTable.shards().get(0).writerReplicas().size();
                 IndexRoutingTable.Builder builder = new IndexRoutingTable.Builder(indexRoutingTable.getIndex());
                 // re-add all the shards
                 for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
@@ -534,6 +534,45 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                 } else if (currentNumberOfReplicas > numberOfReplicas) {
                     for (int i = 0; i < (currentNumberOfReplicas - numberOfReplicas); i++) {
                         builder.removeReplica();
+                    }
+                }
+                indicesRouting.put(index, builder.build());
+            }
+            return this;
+        }
+
+        /**
+         * Update the number of search replicas for the specified indices.
+         *
+         * @param numberOfSearchReplicas the number of replicas
+         * @param indices          the indices to update the number of replicas for
+         * @return the builder
+         */
+        public Builder updateNumberOfSearchReplicas(final int numberOfSearchReplicas, final String[] indices) {
+            if (indicesRouting == null) {
+                throw new IllegalStateException("once build is called the builder cannot be reused");
+            }
+            for (String index : indices) {
+                IndexRoutingTable indexRoutingTable = indicesRouting.get(index);
+                if (indexRoutingTable == null) {
+                    // ignore index missing failure, its closed...
+                    continue;
+                }
+                IndexShardRoutingTable shardRoutings = indexRoutingTable.shards().get(0);
+                int currentNumberOfSearchReplicas = shardRoutings.searchOnlyReplicas().size();
+                IndexRoutingTable.Builder builder = new IndexRoutingTable.Builder(indexRoutingTable.getIndex());
+                // re-add all the shards
+                for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
+                    builder.addIndexShard(indexShardRoutingTable);
+                }
+                if (currentNumberOfSearchReplicas < numberOfSearchReplicas) {
+                    // now, add "empty" ones
+                    for (int i = 0; i < (numberOfSearchReplicas - currentNumberOfSearchReplicas); i++) {
+                        builder.addSearchReplica();
+                    }
+                } else if (currentNumberOfSearchReplicas > numberOfSearchReplicas) {
+                    for (int i = 0; i < (currentNumberOfSearchReplicas - numberOfSearchReplicas); i++) {
+                        builder.removeSearchReplica();
                     }
                 }
                 indicesRouting.put(index, builder.build());

--- a/server/src/main/java/org/opensearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/ShardRouting.java
@@ -358,7 +358,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
         currentNodeId = in.readOptionalString();
         relocatingNodeId = in.readOptionalString();
         primary = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_2_17_0)) {
             searchOnly = in.readBoolean();
         } else {
             searchOnly = false;
@@ -396,7 +396,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
         out.writeOptionalString(currentNodeId);
         out.writeOptionalString(relocatingNodeId);
         out.writeBoolean(primary);
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_2_17_0)) {
             out.writeBoolean(searchOnly);
         }
         out.writeByte(state.value());

--- a/server/src/main/java/org/opensearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/ShardRouting.java
@@ -32,11 +32,13 @@
 
 package org.opensearch.cluster.routing;
 
+import org.opensearch.Version;
 import org.opensearch.cluster.routing.RecoverySource.ExistingStoreRecoverySource;
 import org.opensearch.cluster.routing.RecoverySource.PeerRecoverySource;
 import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -67,6 +69,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
     private final String currentNodeId;
     private final String relocatingNodeId;
     private final boolean primary;
+    private final boolean searchOnly;
     private final ShardRoutingState state;
     private final RecoverySource recoverySource;
     private final UnassignedInfo unassignedInfo;
@@ -85,6 +88,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
         String currentNodeId,
         String relocatingNodeId,
         boolean primary,
+        boolean searchOnly,
         ShardRoutingState state,
         RecoverySource recoverySource,
         UnassignedInfo unassignedInfo,
@@ -95,6 +99,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
         this.currentNodeId = currentNodeId;
         this.relocatingNodeId = relocatingNodeId;
         this.primary = primary;
+        this.searchOnly = searchOnly;
         this.state = state;
         this.recoverySource = recoverySource;
         this.unassignedInfo = unassignedInfo;
@@ -116,6 +121,31 @@ public class ShardRouting implements Writeable, ToXContentObject {
             + this;
     }
 
+    protected ShardRouting(
+        ShardId shardId,
+        String relocatingNodeId,
+        String currentNodeId,
+        boolean primary,
+        ShardRoutingState shardRoutingState,
+        RecoverySource recoverySource,
+        UnassignedInfo unassignedInfo,
+        AllocationId allocationId,
+        long expectedShardSize
+    ) {
+        this(
+            shardId,
+            relocatingNodeId,
+            currentNodeId,
+            primary,
+            false,
+            shardRoutingState,
+            recoverySource,
+            unassignedInfo,
+            allocationId,
+            expectedShardSize
+        );
+    }
+
     @Nullable
     private ShardRouting initializeTargetRelocatingShard() {
         if (state == ShardRoutingState.RELOCATING) {
@@ -124,6 +154,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
                 relocatingNodeId,
                 currentNodeId,
                 primary,
+                searchOnly,
                 ShardRoutingState.INITIALIZING,
                 PeerRecoverySource.INSTANCE,
                 unassignedInfo,
@@ -144,11 +175,25 @@ public class ShardRouting implements Writeable, ToXContentObject {
         RecoverySource recoverySource,
         UnassignedInfo unassignedInfo
     ) {
+        return newUnassigned(shardId, primary, false, recoverySource, unassignedInfo);
+    }
+
+    /**
+     * Creates a new unassigned shard, overloaded for bwc for searchOnly addition.
+     */
+    public static ShardRouting newUnassigned(
+        ShardId shardId,
+        boolean primary,
+        boolean search,
+        RecoverySource recoverySource,
+        UnassignedInfo unassignedInfo
+    ) {
         return new ShardRouting(
             shardId,
             null,
             null,
             primary,
+            search,
             ShardRoutingState.UNASSIGNED,
             recoverySource,
             unassignedInfo,
@@ -281,6 +326,13 @@ public class ShardRouting implements Writeable, ToXContentObject {
     }
 
     /**
+     * Returns <code>true</code> iff this shard is a search only replica.
+     */
+    public boolean isSearchOnly() {
+        return searchOnly;
+    }
+
+    /**
      * The shard state.
      */
     public ShardRoutingState state() {
@@ -306,6 +358,11 @@ public class ShardRouting implements Writeable, ToXContentObject {
         currentNodeId = in.readOptionalString();
         relocatingNodeId = in.readOptionalString();
         primary = in.readBoolean();
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            searchOnly = in.readBoolean();
+        } else {
+            searchOnly = false;
+        }
         state = ShardRoutingState.fromValue(in.readByte());
         if (state == ShardRoutingState.UNASSIGNED || state == ShardRoutingState.INITIALIZING) {
             recoverySource = RecoverySource.readFrom(in);
@@ -339,6 +396,9 @@ public class ShardRouting implements Writeable, ToXContentObject {
         out.writeOptionalString(currentNodeId);
         out.writeOptionalString(relocatingNodeId);
         out.writeBoolean(primary);
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeBoolean(searchOnly);
+        }
         out.writeByte(state.value());
         if (state == ShardRoutingState.UNASSIGNED || state == ShardRoutingState.INITIALIZING) {
             recoverySource.writeTo(out);
@@ -364,6 +424,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
             currentNodeId,
             relocatingNodeId,
             primary,
+            searchOnly,
             state,
             recoverySource,
             unassignedInfo,
@@ -392,6 +453,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
             null,
             null,
             primary,
+            searchOnly,
             ShardRoutingState.UNASSIGNED,
             recoverySource,
             unassignedInfo,
@@ -419,6 +481,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
             nodeId,
             null,
             primary,
+            searchOnly,
             ShardRoutingState.INITIALIZING,
             recoverySource,
             unassignedInfo,
@@ -439,6 +502,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
             currentNodeId,
             relocatingNodeId,
             primary,
+            searchOnly,
             ShardRoutingState.RELOCATING,
             recoverySource,
             null,
@@ -460,6 +524,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
             currentNodeId,
             null,
             primary,
+            searchOnly,
             ShardRoutingState.STARTED,
             recoverySource,
             null,
@@ -483,6 +548,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
             currentNodeId,
             null,
             primary,
+            searchOnly,
             state,
             recoverySource,
             unassignedInfo,
@@ -503,6 +569,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
             currentNodeId,
             null,
             primary,
+            searchOnly,
             ShardRoutingState.INITIALIZING,
             recoverySource,
             unassignedInfo,
@@ -528,6 +595,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
             currentNodeId,
             null,
             primary,
+            searchOnly,
             ShardRoutingState.STARTED,
             null,
             null,
@@ -546,10 +614,14 @@ public class ShardRouting implements Writeable, ToXContentObject {
         if (!primary) {
             throw new IllegalShardRoutingStateException(this, "Not a primary shard, can't move to replica");
         }
+        if (searchOnly) {
+            throw new IllegalShardRoutingStateException(this, "Cannot move a primary to a search only replica");
+        }
         return new ShardRouting(
             shardId,
             currentNodeId,
             relocatingNodeId,
+            false,
             false,
             state,
             recoverySource,
@@ -569,11 +641,15 @@ public class ShardRouting implements Writeable, ToXContentObject {
         if (primary) {
             throw new IllegalShardRoutingStateException(this, "Already primary, can't move to primary");
         }
+        if (searchOnly) {
+            throw new IllegalShardRoutingStateException(this, "Cannot move a search only replica to primary");
+        }
         return new ShardRouting(
             shardId,
             currentNodeId,
             relocatingNodeId,
             true,
+            false,
             state,
             recoverySource,
             unassignedInfo,
@@ -811,7 +887,11 @@ public class ShardRouting implements Writeable, ToXContentObject {
         if (primary) {
             sb.append("[P]");
         } else {
-            sb.append("[R]");
+            if (searchOnly) {
+                sb.append("[S]");
+            } else {
+                sb.append("[R]");
+            }
         }
         if (recoverySource != null) {
             sb.append(", recovery_source[").append(recoverySource).append("]");
@@ -831,10 +911,11 @@ public class ShardRouting implements Writeable, ToXContentObject {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject()
-            .field("state", state())
-            .field("primary", primary())
-            .field("node", currentNodeId())
+        XContentBuilder fieldBuilder = builder.startObject().field("state", state()).field("primary", primary());
+        if (FeatureFlags.isEnabled(FeatureFlags.READER_WRITER_SPLIT_EXPERIMENTAL)) {
+            fieldBuilder.field("searchOnly", isSearchOnly());
+        }
+        fieldBuilder.field("node", currentNodeId())
             .field("relocating_node", relocatingNodeId())
             .field("shard", id())
             .field("index", getIndexName());

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/IndexMetadataUpdater.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/IndexMetadataUpdater.java
@@ -259,7 +259,9 @@ public class IndexMetadataUpdater extends RoutingChangesObserver.AbstractRouting
             // We use number_of_replicas + 1 (= possible active shard copies) to bound the inSyncAllocationIds set
             // Only trim the set of allocation ids when it grows, otherwise we might trim too eagerly when the number
             // of replicas was decreased while shards were unassigned.
-            int maxActiveShards = oldIndexMetadata.getNumberOfReplicas() + 1; // +1 for the primary
+            int maxActiveShards = oldIndexMetadata.getNumberOfReplicas() + oldIndexMetadata.getNumberOfSearchOnlyReplicas() + 1; // +1 for
+                                                                                                                                 // the
+                                                                                                                                 // primary
             IndexShardRoutingTable newShardRoutingTable = newRoutingTable.shardRoutingTable(shardId);
             assert newShardRoutingTable.assignedShards()
                 .stream()

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -357,7 +357,7 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
     @Override
     public Decision canMoveAway(ShardRouting shardRouting, RoutingAllocation allocation) {
         int outgoingRecoveries = 0;
-        if (!shardRouting.primary()) {
+        if (!shardRouting.primary() && !shardRouting.isSearchOnly()) {
             ShardRouting primaryShard = allocation.routingNodes().activePrimary(shardRouting.shardId());
             outgoingRecoveries = allocation.routingNodes().getOutgoingRecoveries(primaryShard.currentNodeId());
         } else {

--- a/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
@@ -39,6 +39,7 @@ public class FeatureFlagSettings extends AbstractScopedSettings {
         FeatureFlags.PLUGGABLE_CACHE_SETTING,
         FeatureFlags.REMOTE_PUBLICATION_EXPERIMENTAL_SETTING,
         FeatureFlags.APPLICATION_BASED_CONFIGURATION_TEMPLATES_SETTING,
-        FeatureFlags.STAR_TREE_INDEX_SETTING
+        FeatureFlags.STAR_TREE_INDEX_SETTING,
+        FeatureFlags.READER_WRITER_SPLIT_EXPERIMENTAL_SETTING
     );
 }

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -274,7 +274,9 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
      */
     public static final Map<String, List<Setting>> FEATURE_FLAGGED_INDEX_SETTINGS = Map.of(
         FeatureFlags.TIERED_REMOTE_INDEX,
-        List.of(IndexModule.INDEX_STORE_LOCALITY_SETTING, IndexModule.INDEX_TIERING_STATE)
+        List.of(IndexModule.INDEX_STORE_LOCALITY_SETTING, IndexModule.INDEX_TIERING_STATE),
+        FeatureFlags.READER_WRITER_SPLIT_EXPERIMENTAL,
+        List.of(IndexMetadata.INDEX_NUMBER_OF_SEARCH_REPLICAS_SETTING)
     );
 
     public static final IndexScopedSettings DEFAULT_SCOPED_SETTINGS = new IndexScopedSettings(Settings.EMPTY, BUILT_IN_INDEX_SETTINGS);

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -72,6 +72,8 @@ public class FeatureFlags {
      */
     public static final String REMOTE_PUBLICATION_EXPERIMENTAL = "opensearch.experimental.feature.remote_store.publication.enabled";
 
+    public static final String READER_WRITER_SPLIT_EXPERIMENTAL = "opensearch.experimental.feature.read.write.split.enabled";
+
     public static final Setting<Boolean> REMOTE_STORE_MIGRATION_EXPERIMENTAL_SETTING = Setting.boolSetting(
         REMOTE_STORE_MIGRATION_EXPERIMENTAL,
         false,
@@ -96,6 +98,12 @@ public class FeatureFlags {
 
     public static final Setting<Boolean> REMOTE_PUBLICATION_EXPERIMENTAL_SETTING = Setting.boolSetting(
         REMOTE_PUBLICATION_EXPERIMENTAL,
+        false,
+        Property.NodeScope
+    );
+
+    public static final Setting<Boolean> READER_WRITER_SPLIT_EXPERIMENTAL_SETTING = Setting.boolSetting(
+        READER_WRITER_SPLIT_EXPERIMENTAL,
         false,
         Property.NodeScope
     );
@@ -127,7 +135,8 @@ public class FeatureFlags {
         PLUGGABLE_CACHE_SETTING,
         REMOTE_PUBLICATION_EXPERIMENTAL_SETTING,
         APPLICATION_BASED_CONFIGURATION_TEMPLATES_SETTING,
-        STAR_TREE_INDEX_SETTING
+        STAR_TREE_INDEX_SETTING,
+        READER_WRITER_SPLIT_EXPERIMENTAL_SETTING
     );
 
     /**

--- a/server/src/main/java/org/opensearch/index/shard/ReplicationGroup.java
+++ b/server/src/main/java/org/opensearch/index/shard/ReplicationGroup.java
@@ -72,7 +72,8 @@ public class ReplicationGroup {
         this.replicationTargets = new ArrayList<>();
         this.skippedShards = new ArrayList<>();
         for (final ShardRouting shard : routingTable) {
-            if (shard.unassigned()) {
+            // search only replicas never receive any replicated operations
+            if (shard.unassigned() || shard.isSearchOnly()) {
                 assert shard.primary() == false : "primary shard should not be unassigned in a replication group: " + shard;
                 skippedShards.add(shard);
             } else {

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -171,7 +171,7 @@ public class SegmentReplicationTargetService extends AbstractLifecycleComponent 
                 if (indexService.getIndexSettings().isSegRepEnabledOrRemoteNode()
                     && event.indexRoutingTableChanged(indexService.index().getName())) {
                     for (IndexShard shard : indexService) {
-                        if (shard.routingEntry().primary() == false) {
+                        if (shard.routingEntry().primary() == false && shard.routingEntry().isSearchOnly() == false) {
                             // for this shard look up its primary routing, if it has completed a relocation trigger replication
                             final String previousNode = event.previousState()
                                 .routingTable()

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestShardsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestShardsAction.java
@@ -321,7 +321,11 @@ public class RestShardsAction extends AbstractCatAction {
             if (shard.primary()) {
                 table.addCell("p");
             } else {
-                table.addCell("r");
+                if (shard.isSearchOnly()) {
+                    table.addCell("s");
+                } else {
+                    table.addCell("r");
+                }
             }
             table.addCell(shard.state());
             table.addCell(getOrNull(commonStats, CommonStats::getDocs, DocsStats::getCount));

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -129,10 +129,12 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING;
+import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SEARCH_REPLICAS_SETTING;
 import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING;
 import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_READ_ONLY_BLOCK;
 import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_REPLICATION_TYPE_SETTING;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SEARCH_REPLICAS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_SEGMENT_STORE_REPOSITORY;
@@ -146,6 +148,7 @@ import static org.opensearch.cluster.metadata.MetadataCreateIndexService.cluster
 import static org.opensearch.cluster.metadata.MetadataCreateIndexService.getIndexNumberOfRoutingShards;
 import static org.opensearch.cluster.metadata.MetadataCreateIndexService.parseV1Mappings;
 import static org.opensearch.cluster.metadata.MetadataCreateIndexService.resolveAndValidateAliases;
+import static org.opensearch.common.util.FeatureFlags.READER_WRITER_SPLIT_EXPERIMENTAL;
 import static org.opensearch.common.util.FeatureFlags.REMOTE_STORE_MIGRATION_EXPERIMENTAL;
 import static org.opensearch.index.IndexModule.INDEX_STORE_TYPE_SETTING;
 import static org.opensearch.index.IndexSettings.INDEX_REFRESH_INTERVAL_SETTING;
@@ -1205,7 +1208,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         assertThat(mappings, Matchers.hasKey(MapperService.SINGLE_MAPPING_NAME));
     }
 
-    public void testvalidateIndexSettings() {
+    public void testValidateIndexSettings() {
         ClusterService clusterService = mock(ClusterService.class);
         Metadata metadata = Metadata.builder()
             .transientSettings(Settings.builder().put(Metadata.DEFAULT_REPLICA_COUNT_SETTING.getKey(), 1).build())
@@ -2238,6 +2241,71 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
                 "cannot create index with index setting \"index.store.type\" set to \"remote_snapshot\". Store type can be set to \"remote_snapshot\" only when restoring a remote snapshot by using \"storage_type\": \"remote_snapshot\""
             )
         );
+    }
+
+    public void testDefaultSearchReplicasSetting() {
+        FeatureFlags.initializeFeatureFlags(Settings.builder().put(READER_WRITER_SPLIT_EXPERIMENTAL, Boolean.TRUE).build());
+        Settings templateSettings = Settings.EMPTY;
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        final Settings.Builder requestSettings = Settings.builder();
+        request.settings(requestSettings.build());
+        Settings indexSettings = aggregateIndexSettings(
+            ClusterState.EMPTY_STATE,
+            request,
+            templateSettings,
+            null,
+            Settings.EMPTY,
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            randomShardLimitService(),
+            Collections.emptySet(),
+            clusterSettings
+        );
+        assertFalse(INDEX_NUMBER_OF_SEARCH_REPLICAS_SETTING.exists(indexSettings));
+    }
+
+    public void testSearchReplicasValidationWithSegmentReplication() {
+        FeatureFlags.initializeFeatureFlags(Settings.builder().put(READER_WRITER_SPLIT_EXPERIMENTAL, Boolean.TRUE).build());
+        Settings templateSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build();
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        final Settings.Builder requestSettings = Settings.builder().put(SETTING_NUMBER_OF_SEARCH_REPLICAS, 2);
+        request.settings(requestSettings.build());
+        Settings indexSettings = aggregateIndexSettings(
+            ClusterState.EMPTY_STATE,
+            request,
+            templateSettings,
+            null,
+            Settings.EMPTY,
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            randomShardLimitService(),
+            Collections.emptySet(),
+            clusterSettings
+        );
+        assertEquals("2", indexSettings.get(SETTING_NUMBER_OF_SEARCH_REPLICAS));
+        assertEquals(ReplicationType.SEGMENT.toString(), indexSettings.get(SETTING_REPLICATION_TYPE));
+    }
+
+    public void testSearchReplicasValidationWithDocumentReplication() {
+        FeatureFlags.initializeFeatureFlags(Settings.builder().put(READER_WRITER_SPLIT_EXPERIMENTAL, Boolean.TRUE).build());
+        Settings templateSettings = Settings.builder().put(SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT).build();
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        final Settings.Builder requestSettings = Settings.builder().put(SETTING_NUMBER_OF_SEARCH_REPLICAS, 2);
+        request.settings(requestSettings.build());
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> aggregateIndexSettings(
+                ClusterState.EMPTY_STATE,
+                request,
+                templateSettings,
+                null,
+                Settings.EMPTY,
+                IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+                randomShardLimitService(),
+                Collections.emptySet(),
+                clusterSettings
+            )
+        );
+        assertEquals("To set index.number_of_search_only_replicas, index.replication.type must be set to SEGMENT", exception.getMessage());
     }
 
     private IndexTemplateMetadata addMatchingTemplate(Consumer<IndexTemplateMetadata.Builder> configurator) {

--- a/server/src/test/java/org/opensearch/cluster/metadata/SearchOnlyReplicaTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/SearchOnlyReplicaTests.java
@@ -1,0 +1,214 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.metadata;
+
+import org.opensearch.Version;
+import org.opensearch.action.admin.cluster.reroute.ClusterRerouteRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.opensearch.action.support.ActiveShardCount;
+import org.opensearch.action.support.replication.ClusterStateCreationUtils;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.cluster.routing.IndexShardRoutingTable;
+import org.opensearch.cluster.routing.ShardRoutingState;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.indices.ShardLimitValidator;
+import org.opensearch.indices.cluster.ClusterStateChanges;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_REPLICATION_TYPE_SETTING;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SEARCH_REPLICAS;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+import static org.opensearch.common.util.FeatureFlags.READER_WRITER_SPLIT_EXPERIMENTAL;
+
+public class SearchOnlyReplicaTests extends OpenSearchTestCase {
+
+    public void testUpdateSearchReplicaCount() {
+        FeatureFlags.initializeFeatureFlags(Settings.builder().put(READER_WRITER_SPLIT_EXPERIMENTAL, "true").build());
+        final ThreadPool threadPool = new TestThreadPool(getClass().getName());
+        final ClusterStateChanges cluster = new ClusterStateChanges(xContentRegistry(), threadPool);
+
+        try {
+            List<DiscoveryNode> allNodes = new ArrayList<>();
+            // node for primary/local
+            DiscoveryNode localNode = createNode(Version.CURRENT, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE, DiscoveryNodeRole.DATA_ROLE);
+            allNodes.add(localNode);
+            // node for search replicas - we'll start with 1 and add another
+            for (int i = 0; i < 2; i++) {
+                allNodes.add(createNode(Version.CURRENT, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE, DiscoveryNodeRole.DATA_ROLE));
+            }
+            ClusterState state = ClusterStateCreationUtils.state(localNode, localNode, allNodes.toArray(new DiscoveryNode[0]));
+
+            CreateIndexRequest request = new CreateIndexRequest(
+                "index",
+                Settings.builder()
+                    .put(SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(INDEX_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT)
+                    .put(SETTING_NUMBER_OF_SEARCH_REPLICAS, 1)
+                    .build()
+            ).waitForActiveShards(ActiveShardCount.NONE);
+            state = cluster.createIndex(state, request);
+            assertTrue(state.metadata().hasIndex("index"));
+            rerouteUntilActive(state, cluster);
+            IndexShardRoutingTable indexShardRoutingTable = state.getRoutingTable().index("index").getShards().get(0);
+            assertEquals(1, indexShardRoutingTable.replicaShards().size());
+            assertEquals(1, indexShardRoutingTable.searchOnlyReplicas().size());
+            assertEquals(0, indexShardRoutingTable.writerReplicas().size());
+
+            // add another replica
+            state = cluster.updateSettings(
+                state,
+                new UpdateSettingsRequest("index").settings(Settings.builder().put(SETTING_NUMBER_OF_SEARCH_REPLICAS, 2).build())
+            );
+            rerouteUntilActive(state, cluster);
+            indexShardRoutingTable = state.getRoutingTable().index("index").getShards().get(0);
+            assertEquals(2, indexShardRoutingTable.replicaShards().size());
+            assertEquals(2, indexShardRoutingTable.searchOnlyReplicas().size());
+            assertEquals(0, indexShardRoutingTable.writerReplicas().size());
+
+            // remove all replicas
+            state = cluster.updateSettings(
+                state,
+                new UpdateSettingsRequest("index").settings(Settings.builder().put(SETTING_NUMBER_OF_SEARCH_REPLICAS, 0).build())
+            );
+            rerouteUntilActive(state, cluster);
+            indexShardRoutingTable = state.getRoutingTable().index("index").getShards().get(0);
+            assertEquals(0, indexShardRoutingTable.replicaShards().size());
+            assertEquals(0, indexShardRoutingTable.searchOnlyReplicas().size());
+            assertEquals(0, indexShardRoutingTable.writerReplicas().size());
+        } finally {
+            terminate(threadPool);
+        }
+    }
+
+    public void testUpdateSearchReplicasOverShardLimit() {
+        FeatureFlags.initializeFeatureFlags(Settings.builder().put(READER_WRITER_SPLIT_EXPERIMENTAL, "true").build());
+        final ThreadPool threadPool = new TestThreadPool(getClass().getName());
+        final ClusterStateChanges cluster = new ClusterStateChanges(xContentRegistry(), threadPool);
+
+        try {
+            List<DiscoveryNode> allNodes = new ArrayList<>();
+            // node for primary/local
+            DiscoveryNode localNode = createNode(Version.CURRENT, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE, DiscoveryNodeRole.DATA_ROLE);
+            allNodes.add(localNode);
+
+            allNodes.add(createNode(Version.CURRENT, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE, DiscoveryNodeRole.DATA_ROLE));
+
+            ClusterState state = ClusterStateCreationUtils.state(localNode, localNode, allNodes.toArray(new DiscoveryNode[0]));
+
+            CreateIndexRequest request = new CreateIndexRequest(
+                "index",
+                Settings.builder()
+                    .put(SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(INDEX_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT)
+                    .put(SETTING_NUMBER_OF_SEARCH_REPLICAS, 1)
+                    .build()
+            ).waitForActiveShards(ActiveShardCount.NONE);
+            state = cluster.createIndex(state, request);
+            assertTrue(state.metadata().hasIndex("index"));
+            rerouteUntilActive(state, cluster);
+
+            // add another replica
+            ClusterState finalState = state;
+            Integer maxShardPerNode = ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getDefault(Settings.EMPTY);
+            expectThrows(
+                RuntimeException.class,
+                () -> cluster.updateSettings(
+                    finalState,
+                    new UpdateSettingsRequest("index").settings(
+                        Settings.builder().put(SETTING_NUMBER_OF_SEARCH_REPLICAS, maxShardPerNode * 2).build()
+                    )
+                )
+            );
+
+        } finally {
+            terminate(threadPool);
+        }
+    }
+
+    public void testUpdateSearchReplicasOnDocrepCluster() {
+        FeatureFlags.initializeFeatureFlags(Settings.builder().put(READER_WRITER_SPLIT_EXPERIMENTAL, "true").build());
+        final ThreadPool threadPool = new TestThreadPool(getClass().getName());
+        final ClusterStateChanges cluster = new ClusterStateChanges(xContentRegistry(), threadPool);
+
+        try {
+            List<DiscoveryNode> allNodes = new ArrayList<>();
+            // node for primary/local
+            DiscoveryNode localNode = createNode(Version.CURRENT, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE, DiscoveryNodeRole.DATA_ROLE);
+            allNodes.add(localNode);
+
+            allNodes.add(createNode(Version.CURRENT, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE, DiscoveryNodeRole.DATA_ROLE));
+
+            ClusterState state = ClusterStateCreationUtils.state(localNode, localNode, allNodes.toArray(new DiscoveryNode[0]));
+
+            CreateIndexRequest request = new CreateIndexRequest(
+                "index",
+                Settings.builder()
+                    .put(SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(INDEX_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.DOCUMENT)
+                    .build()
+            ).waitForActiveShards(ActiveShardCount.NONE);
+            state = cluster.createIndex(state, request);
+            assertTrue(state.metadata().hasIndex("index"));
+            rerouteUntilActive(state, cluster);
+
+            // add another replica
+            ClusterState finalState = state;
+            Integer maxShardPerNode = ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getDefault(Settings.EMPTY);
+            expectThrows(
+                RuntimeException.class,
+                () -> cluster.updateSettings(
+                    finalState,
+                    new UpdateSettingsRequest("index").settings(
+                        Settings.builder().put(SETTING_NUMBER_OF_SEARCH_REPLICAS, maxShardPerNode * 2).build()
+                    )
+                )
+            );
+        } finally {
+            terminate(threadPool);
+        }
+    }
+
+    private static void rerouteUntilActive(ClusterState state, ClusterStateChanges cluster) {
+        while (state.routingTable().index("index").shard(0).allShardsStarted() == false) {
+            state = cluster.applyStartedShards(
+                state,
+                state.routingTable().index("index").shard(0).shardsWithState(ShardRoutingState.INITIALIZING)
+            );
+            state = cluster.reroute(state, new ClusterRerouteRequest());
+        }
+    }
+
+    private static final AtomicInteger nodeIdGenerator = new AtomicInteger();
+
+    protected DiscoveryNode createNode(Version version, DiscoveryNodeRole... mustHaveRoles) {
+        Set<DiscoveryNodeRole> roles = new HashSet<>(randomSubsetOf(DiscoveryNodeRole.BUILT_IN_ROLES));
+        Collections.addAll(roles, mustHaveRoles);
+        final String id = String.format(Locale.ROOT, "node_%03d", nodeIdGenerator.incrementAndGet());
+        return new DiscoveryNode(id, id, buildNewFakeTransportAddress(), Collections.emptyMap(), roles, version);
+    }
+}

--- a/server/src/test/java/org/opensearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/ClusterStateChanges.java
@@ -94,8 +94,8 @@ import org.opensearch.common.Priority;
 import org.opensearch.common.SetOnce;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.settings.ClusterSettings;
-import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsModule;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.index.Index;
@@ -291,10 +291,13 @@ public class ClusterStateChanges {
 
         final AwarenessReplicaBalance awarenessReplicaBalance = new AwarenessReplicaBalance(SETTINGS, clusterService.getClusterSettings());
 
+        // build IndexScopedSettings from a settingsModule so that all settings gated by enabled featureFlags are registered.
+        SettingsModule settingsModule = new SettingsModule(Settings.EMPTY);
+
         MetadataUpdateSettingsService metadataUpdateSettingsService = new MetadataUpdateSettingsService(
             clusterService,
             allocationService,
-            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            settingsModule.getIndexScopedSettings(),
             indicesService,
             shardLimitValidator,
             threadPool,
@@ -308,7 +311,7 @@ public class ClusterStateChanges {
             new AliasValidator(),
             shardLimitValidator,
             environment,
-            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            settingsModule.getIndexScopedSettings(),
             threadPool,
             xContentRegistry,
             systemIndices,

--- a/test/framework/src/main/java/org/opensearch/cluster/routing/TestShardRouting.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/routing/TestShardRouting.java
@@ -319,4 +319,27 @@ public class TestShardRouting {
             )
         );
     }
+
+    public static ShardRouting newShardRouting(
+        ShardId shardId,
+        String currentNodeId,
+        String relocatingNodeId,
+        boolean primary,
+        boolean searchOnly,
+        ShardRoutingState state,
+        UnassignedInfo unassignedInfo
+    ) {
+        return new ShardRouting(
+            shardId,
+            currentNodeId,
+            relocatingNodeId,
+            primary,
+            searchOnly,
+            state,
+            buildRecoveryTarget(primary, state),
+            unassignedInfo,
+            buildAllocationId(state),
+            -1
+        );
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Manual backport of https://github.com/opensearch-project/OpenSearch/pull/15410 to 2.x line.
This backport resolves merge conflicts and includes one src change - the wire compatibility in ShardRouting is changed from 3_0_0 to 2_17_0.  2.x also does validation differently from main for update settings / create index, and throws IAE instead of a SettingsException, so updated test to reflect that.

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
