### PR TITLE
Fix RepositoriesServiceIT.testUpdateRepository from #15426

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/repositories/RepositoriesServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/repositories/RepositoriesServiceIT.java
@@ -69,7 +69,13 @@ public class RepositoriesServiceIT extends OpenSearchIntegTestCase {
             .next();
 
         final Settings.Builder repoSettings = Settings.builder().put("location", randomRepoPath());
-        createRepository(repositoryName, FsRepository.TYPE, repoSettings);
+        OpenSearchIntegTestCase.putRepositoryWithNoSettingOverrides(
+            client().admin().cluster(),
+            repositoryName,
+            FsRepository.TYPE,
+            true,
+            repoSettings
+        );
 
         final GetRepositoriesResponse originalGetRepositoriesResponse = client.admin()
             .cluster()
@@ -87,7 +93,13 @@ public class RepositoriesServiceIT extends OpenSearchIntegTestCase {
         final boolean updated = randomBoolean();
         final String updatedRepositoryType = updated ? "mock" : FsRepository.TYPE;
 
-        createRepository(repositoryName, updatedRepositoryType, repoSettings);
+        OpenSearchIntegTestCase.putRepositoryWithNoSettingOverrides(
+            client().admin().cluster(),
+            repositoryName,
+            updatedRepositoryType,
+            true,
+            repoSettings
+        );
 
         final GetRepositoriesResponse updatedGetRepositoriesResponse = client.admin()
             .cluster()


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The RepositoriesServiceIT.testUpdateRepository had become flaky after the PR #15426. Build failure link - https://build.ci.opensearch.org/job/gradle-check/46080/. In the earlier PR, we had made a change to randomise the shard_path_type for all the existing snapshot ITs. This tests check that if the repository has no changes then the instance of repository should remain the same. Due to the randomness introduced earlier, this lead to different instance of repository before the update and after the update. This is now fixed by ensuring that we don't change the repository settings when it is not expected to.

### Check List
- [x] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
