### PR TITLE
Fix approximate pointrangequery tests

### DIFF
--- a/server/src/test/java/org/opensearch/search/approximate/ApproximatePointRangeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/approximate/ApproximatePointRangeQueryTests.java
@@ -126,9 +126,9 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
                     }
                     doc.add(new LongPoint("point", scratch));
                     iw.addDocument(doc);
-                    if (i % 15 == 0) iw.flush();
                 }
                 iw.flush();
+                iw.forceMerge(1);
                 try (IndexReader reader = iw.getReader()) {
                     try {
                         long lower = 0;
@@ -166,6 +166,7 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
                     iw.addDocument(doc);
                 }
                 iw.flush();
+                iw.forceMerge(1);
                 try (IndexReader reader = iw.getReader()) {
                     try {
                         long lower = 0;
@@ -183,7 +184,7 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
                         };
                         IndexSearcher searcher = new IndexSearcher(reader);
                         TopDocs topDocs = searcher.search(approximateQuery, 11000);
-                        assertEquals(topDocs.totalHits, new TotalHits(11001, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO));
+                        assertEquals(topDocs.totalHits, new TotalHits(11000, TotalHits.Relation.EQUAL_TO));
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -210,6 +211,7 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
                     if (i % 10 == 0) iw.flush();
                 }
                 iw.flush();
+                iw.forceMerge(1);
                 try (IndexReader reader = iw.getReader()) {
                     try {
                         long lower = 0;
@@ -255,6 +257,7 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
                     iw.addDocument(doc);
                 }
                 iw.flush();
+                iw.forceMerge(1);
                 try (IndexReader reader = iw.getReader()) {
                     try {
                         long lower = 0;
@@ -281,12 +284,12 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
                         assertNotEquals(topDocs.totalHits, topDocs1.totalHits);
                         assertEquals(topDocs.totalHits, new TotalHits(10, TotalHits.Relation.EQUAL_TO));
                         assertEquals(topDocs1.totalHits, new TotalHits(21, TotalHits.Relation.EQUAL_TO));
-                        assertEquals(topDocs.scoreDocs[0].doc, 0);
-                        assertEquals(topDocs.scoreDocs[1].doc, 1);
-                        assertEquals(topDocs.scoreDocs[2].doc, 2);
-                        assertEquals(topDocs.scoreDocs[3].doc, 3);
-                        assertEquals(topDocs.scoreDocs[4].doc, 4);
-                        assertEquals(topDocs.scoreDocs[5].doc, 5);
+                        assertEquals(topDocs.scoreDocs[0].doc, topDocs1.scoreDocs[0].doc);
+                        assertEquals(topDocs.scoreDocs[1].doc, topDocs1.scoreDocs[1].doc);
+                        assertEquals(topDocs.scoreDocs[2].doc, topDocs1.scoreDocs[2].doc);
+                        assertEquals(topDocs.scoreDocs[3].doc, topDocs1.scoreDocs[3].doc);
+                        assertEquals(topDocs.scoreDocs[4].doc, topDocs1.scoreDocs[4].doc);
+                        assertEquals(topDocs.scoreDocs[5].doc, topDocs1.scoreDocs[5].doc);
 
                     } catch (IOException e) {
                         throw new RuntimeException(e);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
I noticed while backporting #13788 that some of the tests were flaky due to multiple segments being created and the correctness being harder to evaluate. Making small fixes to address the flakiness of the tests.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
