### PR TITLE
Release latch listeners in case of no-op RoutingTableService

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/remote/NoopRemoteRoutingTableService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/remote/NoopRemoteRoutingTableService.java
@@ -43,7 +43,7 @@ public class NoopRemoteRoutingTableService extends AbstractLifecycleComponent im
         IndexRoutingTable indexRouting,
         LatchedActionListener<ClusterMetadataManifest.UploadedMetadata> latchedActionListener
     ) {
-        // noop
+        latchedActionListener.onResponse(null);
     }
 
     @Override
@@ -54,7 +54,7 @@ public class NoopRemoteRoutingTableService extends AbstractLifecycleComponent im
         StringKeyDiffProvider<IndexRoutingTable> routingTableDiff,
         LatchedActionListener<ClusterMetadataManifest.UploadedMetadata> latchedActionListener
     ) {
-        // noop
+        latchedActionListener.onResponse(null);
     }
 
     @Override
@@ -73,7 +73,7 @@ public class NoopRemoteRoutingTableService extends AbstractLifecycleComponent im
         String uploadedFilename,
         LatchedActionListener<IndexRoutingTable> latchedActionListener
     ) {
-        // noop
+        latchedActionListener.onResponse(null);
     }
 
     @Override
@@ -82,7 +82,7 @@ public class NoopRemoteRoutingTableService extends AbstractLifecycleComponent im
         String uploadedFilename,
         LatchedActionListener<Diff<RoutingTable>> latchedActionListener
     ) {
-        // noop
+        latchedActionListener.onResponse(null);
     }
 
     @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
We are currently blocking the latched listeners in case of NoopRemoteRoutingTableService read and write actions. In case of publication is being disabled or enabled by rolling restart. Some nodes will be running on Noop service but will timeout downloading the cluster state.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
