### PR TITLE
[Backport 2.x] Modify create snapshot v2 response when wait_for_completion is false

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
@@ -845,18 +845,13 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         String snapshotName2 = "test-create-snapshot2";
 
-        // verify even if waitForCompletion is not true, the request executes in a sync manner
-        CreateSnapshotResponse createSnapshotResponse2 = client().admin()
+        // verify response status if waitForCompletion is not true
+        RestStatus createSnapshotResponseStatus = client().admin()
             .cluster()
             .prepareCreateSnapshot(snapshotRepoName, snapshotName2)
-            .get();
-        snapshotInfo = createSnapshotResponse2.getSnapshotInfo();
-        assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
-        assertThat(snapshotInfo.successfulShards(), greaterThan(0));
-        assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
-        assertThat(snapshotInfo.snapshotId().getName(), equalTo(snapshotName2));
-        assertThat(snapshotInfo.getPinnedTimestamp(), greaterThan(0L));
-
+            .get()
+            .status();
+        assertEquals(RestStatus.ACCEPTED, createSnapshotResponseStatus);
     }
 
     public void testMixedSnapshotCreationWithV2RepositorySetting() throws Exception {
@@ -932,6 +927,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         CreateSnapshotResponse createSnapshotResponse2 = client().admin()
             .cluster()
             .prepareCreateSnapshot(snapshotRepoName, snapshotName2)
+            .setWaitForCompletion(true)
             .get();
         snapshotInfo = createSnapshotResponse2.getSnapshotInfo();
         assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
@@ -993,6 +989,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                     CreateSnapshotResponse createSnapshotResponse2 = client().admin()
                         .cluster()
                         .prepareCreateSnapshot(snapshotRepoName, snapshotName)
+                        .setWaitForCompletion(true)
                         .get();
                     SnapshotInfo snapshotInfo = createSnapshotResponse2.getSnapshotInfo();
                     assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
@@ -1068,6 +1065,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         CreateSnapshotResponse createSnapshotResponse2 = client().admin()
             .cluster()
             .prepareCreateSnapshot(snapshotRepoName, snapshotName1)
+            .setWaitForCompletion(true)
             .get();
         SnapshotInfo snapshotInfo = createSnapshotResponse2.getSnapshotInfo();
         assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
@@ -1136,6 +1134,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         CreateSnapshotResponse createSnapshotResponse2 = client().admin()
             .cluster()
             .prepareCreateSnapshot(snapshotRepoName, snapshotName1)
+            .setWaitForCompletion(true)
             .get();
 
         SnapshotInfo snapshotInfo = createSnapshotResponse2.getSnapshotInfo();
@@ -1256,6 +1255,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 CreateSnapshotResponse createSnapshotResponse = client().admin()
                     .cluster()
                     .prepareCreateSnapshot(snapshotRepoName, snapshotName1)
+                    .setWaitForCompletion(true)
                     .get();
                 snapshotInfo[0] = createSnapshotResponse.getSnapshotInfo();
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
@@ -111,18 +111,22 @@ public class TransportCreateSnapshotAction extends TransportClusterManagerNodeAc
         ClusterState state,
         final ActionListener<CreateSnapshotResponse> listener
     ) {
+
         if (state.nodes().getMinNodeVersion().before(SnapshotsService.NO_REPO_INITIALIZE_VERSION)) {
             if (request.waitForCompletion()) {
                 snapshotsService.executeSnapshotLegacy(request, ActionListener.map(listener, CreateSnapshotResponse::new));
             } else {
                 snapshotsService.createSnapshotLegacy(request, ActionListener.map(listener, snapshot -> new CreateSnapshotResponse()));
             }
+
         } else {
             Repository repository = repositoriesService.repository(request.repository());
             boolean isSnapshotV2 = SHALLOW_SNAPSHOT_V2.get(repository.getMetadata().settings());
 
-            if (request.waitForCompletion() || isSnapshotV2) {
+            if (request.waitForCompletion()) {
                 snapshotsService.executeSnapshot(request, ActionListener.map(listener, CreateSnapshotResponse::new));
+            } else if (isSnapshotV2) {
+                snapshotsService.executeSnapshot(request, ActionListener.map(listener, snapshot -> new CreateSnapshotResponse()));
             } else {
                 snapshotsService.createSnapshot(request, ActionListener.map(listener, snapshot -> new CreateSnapshotResponse()));
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backport for https://github.com/opensearch-project/OpenSearch/pull/15499

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
