### PR TITLE
Fixing Query Group stats OpenSearch API annotation errors

### DIFF
--- a/server/src/main/java/org/opensearch/wlm/stats/QueryGroupStats.java
+++ b/server/src/main/java/org/opensearch/wlm/stats/QueryGroupStats.java
@@ -145,7 +145,7 @@ public class QueryGroupStats implements ToXContentObject, Writeable {
         }
 
         /**
-         * Writes the {@param statsHolder} to {@param out}
+         * Writes the @param {statsHolder} to @param {out}
          * @param out StreamOutput
          * @param statsHolder QueryGroupStatsHolder
          * @throws IOException exception
@@ -235,7 +235,7 @@ public class QueryGroupStats implements ToXContentObject, Writeable {
         }
 
         /**
-         * Writes the {@param stats} to {@param out}
+         * Writes the @param {stats} to @param {out}
          * @param out StreamOutput
          * @param stats QueryGroupStatsHolder
          * @throws IOException exception


### PR DESCRIPTION
### Description
Query Group stats was added in https://github.com/opensearch-project/OpenSearch/commit/c0bcacb52155c9114352765c5105a7caa19dc763
I am seeing build failure by OpenSearch API spec annotation:
```
➜  sarat-opensearch git:(main) ✗ ./gradlew run
Executing Gradle on JVM versions 16 and lower has been deprecated. This will fail with an error in Gradle 9.0. Use JVM 17 or greater to execute Gradle. Projects can continue to use older JVM versions via toolchains. Consult the upgrading guide for further information: https://docs.gradle.org/8.10/userguide/upgrading_version_8.html#minimum_daemon_jvm_version

> Configure project :
========================= WARNING =========================
         Backwards compatibility tests are disabled!
See https://github.com/opensearch-project/OpenSearch/issues/4173
===========================================================
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.10
  JDK Version           : 11 (Amazon Corretto JDK)
  In FIPS 140 mode      : false
=======================================

> Task :server:compileJava
Note: Processing Log4j annotations
Note: Annotations processed
Note: Processing OpenSearch Api annotations
Note: Processing Log4j annotations
Note: No elements to process
Note: Processing OpenSearch Api annotations
/Users/vemsarat/Desktop/Workspace/Code/sarat-opensearch/server/src/main/java/org/opensearch/wlm/stats/QueryGroupStats.java:148: error: no tag name after @
         * Writes the {@param statsHolder} to {@param out}
                      ^
/Users/vemsarat/Desktop/Workspace/Code/sarat-opensearch/server/src/main/java/org/opensearch/wlm/stats/QueryGroupStats.java:148: error: no tag name after @
         * Writes the {@param statsHolder} to {@param out}
                                              ^
/Users/vemsarat/Desktop/Workspace/Code/sarat-opensearch/server/src/main/java/org/opensearch/wlm/stats/QueryGroupStats.java:238: error: no tag name after @
         * Writes the {@param stats} to {@param out}
                      ^
/Users/vemsarat/Desktop/Workspace/Code/sarat-opensearch/server/src/main/java/org/opensearch/wlm/stats/QueryGroupStats.java:238: error: no tag name after @
         * Writes the {@param stats} to {@param out}
                                        ^
/Users/vemsarat/Desktop/Workspace/Code/sarat-opensearch/server/src/main/java/org/opensearch/search/aggregations/bucket/filterrewrite/AggregatorBridge.java:80: warning: no description for @param
     * @param ranges
       ^
/Users/vemsarat/Desktop/Workspace/Code/sarat-opensearch/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/BaseStarTreeBuilder.java:712: warning: no description for @return
     * @return
       ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
4 errors
2 warnings
``` 
This PR fixes this. Im seeing problems on JDK 11 on Mac OSX.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
