### PR TITLE
[Backport 2.x] Set Version to 2.17 for hashed prefix snapshots

### DIFF
--- a/server/src/main/java/org/opensearch/repositories/IndexId.java
+++ b/server/src/main/java/org/opensearch/repositories/IndexId.java
@@ -78,7 +78,7 @@ public final class IndexId implements Writeable, ToXContentObject {
     public IndexId(final StreamInput in) throws IOException {
         this.name = in.readString();
         this.id = in.readString();
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {
+        if (in.getVersion().onOrAfter(Version.V_2_17_0)) {
             this.shardPathType = in.readVInt();
         } else {
             this.shardPathType = DEFAULT_SHARD_PATH_TYPE;
@@ -145,7 +145,7 @@ public final class IndexId implements Writeable, ToXContentObject {
     public void writeTo(final StreamOutput out) throws IOException {
         out.writeString(name);
         out.writeString(id);
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {
+        if (out.getVersion().onOrAfter(Version.V_2_17_0)) {
             out.writeVInt(shardPathType);
         }
     }

--- a/server/src/main/java/org/opensearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoryData.java
@@ -552,7 +552,7 @@ public final class RepositoryData {
 
     // Visible for testing only
     public XContentBuilder snapshotsToXContent(final XContentBuilder builder, final Version repoMetaVersion) throws IOException {
-        return snapshotsToXContent(builder, repoMetaVersion, Version.CURRENT);
+        return snapshotsToXContent(builder, repoMetaVersion, Version.V_2_17_0);
     }
 
     /**
@@ -594,7 +594,7 @@ public final class RepositoryData {
         for (final IndexId indexId : getIndices().values()) {
             builder.startObject(indexId.getName());
             builder.field(INDEX_ID, indexId.getId());
-            if (minNodeVersion.onOrAfter(Version.CURRENT)) {
+            if (minNodeVersion.onOrAfter(Version.V_2_17_0)) {
                 builder.field(IndexId.SHARD_PATH_TYPE, indexId.getShardPathType());
             }
             builder.startArray(SNAPSHOTS);

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -528,7 +528,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
                 logger.trace("[{}][{}] creating snapshot for indices [{}]", repositoryName, snapshotName, indices);
 
-                int pathType = clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.CURRENT)
+                int pathType = clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_2_17_0)
                     ? SHARD_PATH_TYPE.get(repository.getMetadata().settings()).getCode()
                     : IndexId.DEFAULT_SHARD_PATH_TYPE;
                 final List<IndexId> indexIds = repositoryData.resolveNewIndices(
@@ -1354,7 +1354,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                                     assert entry.shards().isEmpty();
                                     hadAbortedInitializations = true;
                                 } else {
-                                    int pathType = clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.CURRENT)
+                                    int pathType = clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_2_17_0)
                                         ? SHARD_PATH_TYPE.get(repository.getMetadata().settings()).getCode()
                                         : IndexId.DEFAULT_SHARD_PATH_TYPE;
                                     final List<IndexId> indexIds = repositoryData.resolveNewIndices(

--- a/server/src/test/java/org/opensearch/repositories/IndexIdTests.java
+++ b/server/src/test/java/org/opensearch/repositories/IndexIdTests.java
@@ -86,7 +86,7 @@ public class IndexIdTests extends OpenSearchTestCase {
     public void testSerialization() throws IOException {
         IndexId indexId = new IndexId(randomAlphaOfLength(8), UUIDs.randomBase64UUID(), randomIntBetween(0, 2));
         BytesStreamOutput out = new BytesStreamOutput();
-        out.setVersion(Version.CURRENT);
+        out.setVersion(Version.V_2_17_0);
         indexId.writeTo(out);
         assertEquals(indexId, new IndexId(out.bytes().streamInput()));
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Set Version to 2.17 for hashed prefix snapshots

### Related Issues
Related to https://github.com/opensearch-project/OpenSearch/pull/15426

### Check List
- ~[ ] Functionality includes testing.~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
