### PR TITLE
[Backport 2.17] Add prefix support to hashed prefix & infix path types on remote store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add index creation using the context field ([#15290](https://github.com/opensearch-project/OpenSearch/pull/15290))
 - [Remote Publication] Add remote download stats ([#15291](https://github.com/opensearch-project/OpenSearch/pull/15291))
 - Add support to upload snapshot shard blobs with hashed prefix ([#15426](https://github.com/opensearch-project/OpenSearch/pull/15426))
+- Add prefix support to hashed prefix & infix path types on remote store ([#15557](https://github.com/opensearch-project/OpenSearch/pull/15557))
 - Add canRemain method to TargetPoolAllocationDecider to move shards from local to remote pool for hot to warm tiering ([#15010](https://github.com/opensearch-project/OpenSearch/pull/15010))
 - Add support for pluggable deciders for concurrent search ([#15363](https://github.com/opensearch-project/OpenSearch/pull/15363))
 - [Remote Publication] Added checksum validation for cluster state behind a cluster setting ([#15218](https://github.com/opensearch-project/OpenSearch/pull/15218))

--- a/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemotePrimaryLocalRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemotePrimaryLocalRecoveryIT.java
@@ -19,6 +19,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.index.remote.RemoteSegmentStats;
 import org.opensearch.index.translog.RemoteTranslogStats;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
@@ -67,6 +68,7 @@ public class RemotePrimaryLocalRecoveryIT extends MigrationBaseTestCase {
                 assertTrue(remoteSegmentStats.getUploadBytesSucceeded() > 0);
             }
 
+            String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
             assertBusy(() -> {
                 String shardPath = getShardLevelBlobPath(
                     client(),
@@ -74,7 +76,8 @@ public class RemotePrimaryLocalRecoveryIT extends MigrationBaseTestCase {
                     new BlobPath(),
                     String.valueOf(shardRouting.getId()),
                     SEGMENTS,
-                    DATA
+                    DATA,
+                    segmentsPathFixedPrefix
                 ).buildAsString();
                 Path segmentDataRepoPath = segmentRepoPath.resolve(shardPath);
                 List<String> segmentsNFilesInRepo = Arrays.stream(FileSystemUtils.files(segmentDataRepoPath))

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
@@ -443,13 +443,15 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
 
     void assertRemoteSegmentsAndTranslogUploaded(String idx) throws IOException {
         Client client = client();
-        String path = getShardLevelBlobPath(client, idx, new BlobPath(), "0", TRANSLOG, METADATA).buildAsString();
+        String translogPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.get(getNodeSettings());
+        String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
+        String path = getShardLevelBlobPath(client, idx, new BlobPath(), "0", TRANSLOG, METADATA, translogPathFixedPrefix).buildAsString();
         Path remoteTranslogMetadataPath = Path.of(remoteRepoPath + "/" + path);
-        path = getShardLevelBlobPath(client, idx, new BlobPath(), "0", TRANSLOG, DATA).buildAsString();
+        path = getShardLevelBlobPath(client, idx, new BlobPath(), "0", TRANSLOG, DATA, translogPathFixedPrefix).buildAsString();
         Path remoteTranslogDataPath = Path.of(remoteRepoPath + "/" + path);
-        path = getShardLevelBlobPath(client, idx, new BlobPath(), "0", SEGMENTS, METADATA).buildAsString();
+        path = getShardLevelBlobPath(client, idx, new BlobPath(), "0", SEGMENTS, METADATA, segmentsPathFixedPrefix).buildAsString();
         Path segmentMetadataPath = Path.of(remoteRepoPath + "/" + path);
-        path = getShardLevelBlobPath(client, idx, new BlobPath(), "0", SEGMENTS, DATA).buildAsString();
+        path = getShardLevelBlobPath(client, idx, new BlobPath(), "0", SEGMENTS, DATA, segmentsPathFixedPrefix).buildAsString();
         Path segmentDataPath = Path.of(remoteRepoPath + "/" + path);
 
         try (

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -205,7 +205,16 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 10000l, -1));
         int numberOfIterations = randomIntBetween(5, 15);
         indexData(numberOfIterations, true, INDEX_NAME);
-        String shardPath = getShardLevelBlobPath(client(), INDEX_NAME, BlobPath.cleanPath(), "0", SEGMENTS, METADATA).buildAsString();
+        String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
+        String shardPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            SEGMENTS,
+            METADATA,
+            segmentsPathFixedPrefix
+        ).buildAsString();
         Path indexPath = Path.of(segmentRepoPath + "/" + shardPath);
         ;
         IndexShard indexShard = getIndexShard(dataNode, INDEX_NAME);
@@ -236,7 +245,16 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 10000l, -1));
         int numberOfIterations = randomIntBetween(5, 15);
         indexData(numberOfIterations, false, INDEX_NAME);
-        String shardPath = getShardLevelBlobPath(client(), INDEX_NAME, BlobPath.cleanPath(), "0", SEGMENTS, METADATA).buildAsString();
+        String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
+        String shardPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            SEGMENTS,
+            METADATA,
+            segmentsPathFixedPrefix
+        ).buildAsString();
         Path indexPath = Path.of(segmentRepoPath + "/" + shardPath);
         int actualFileCount = getFileCount(indexPath);
         // We also allow (numberOfIterations + 1) as index creation also triggers refresh.
@@ -247,11 +265,19 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         Settings.Builder settings = Settings.builder()
             .put(RemoteStoreSettings.CLUSTER_REMOTE_INDEX_SEGMENT_METADATA_RETENTION_MAX_COUNT_SETTING.getKey(), "3");
         internalCluster().startNode(settings);
-
+        String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
         createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 10000l, -1));
         int numberOfIterations = randomIntBetween(5, 15);
         indexData(numberOfIterations, true, INDEX_NAME);
-        String shardPath = getShardLevelBlobPath(client(), INDEX_NAME, BlobPath.cleanPath(), "0", SEGMENTS, METADATA).buildAsString();
+        String shardPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            SEGMENTS,
+            METADATA,
+            segmentsPathFixedPrefix
+        ).buildAsString();
         Path indexPath = Path.of(segmentRepoPath + "/" + shardPath);
         int actualFileCount = getFileCount(indexPath);
         // We also allow (numberOfIterations + 1) as index creation also triggers refresh.
@@ -271,7 +297,16 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 10000l, -1));
         int numberOfIterations = randomIntBetween(12, 18);
         indexData(numberOfIterations, true, INDEX_NAME);
-        String shardPath = getShardLevelBlobPath(client(), INDEX_NAME, BlobPath.cleanPath(), "0", SEGMENTS, METADATA).buildAsString();
+        String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
+        String shardPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            SEGMENTS,
+            METADATA,
+            segmentsPathFixedPrefix
+        ).buildAsString();
         Path indexPath = Path.of(segmentRepoPath + "/" + shardPath);
         ;
         int actualFileCount = getFileCount(indexPath);
@@ -604,8 +639,10 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         indexBulk(INDEX_NAME, 50);
         flushAndRefresh(INDEX_NAME);
 
+        String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
         // 3. Delete data from remote segment store
-        String shardPath = getShardLevelBlobPath(client(), INDEX_NAME, BlobPath.cleanPath(), "0", SEGMENTS, DATA).buildAsString();
+        String shardPath = getShardLevelBlobPath(client(), INDEX_NAME, BlobPath.cleanPath(), "0", SEGMENTS, DATA, segmentsPathFixedPrefix)
+            .buildAsString();
         Path segmentDataPath = Path.of(segmentRepoPath + "/" + shardPath);
 
         try (Stream<Path> files = Files.list(segmentDataPath)) {
@@ -844,7 +881,16 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
             .get()
             .getSetting(INDEX_NAME, IndexMetadata.SETTING_INDEX_UUID);
 
-        String shardPath = getShardLevelBlobPath(client(), INDEX_NAME, BlobPath.cleanPath(), "0", TRANSLOG, METADATA).buildAsString();
+        String translogPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.get(getNodeSettings());
+        String shardPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            METADATA,
+            translogPathFixedPrefix
+        ).buildAsString();
         Path translogMetaDataPath = Path.of(translogRepoPath + "/" + shardPath);
 
         try (Stream<Path> files = Files.list(translogMetaDataPath)) {

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRefreshListenerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRefreshListenerIT.java
@@ -13,6 +13,7 @@ import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.nio.file.Path;
@@ -50,7 +51,10 @@ public class RemoteStoreRefreshListenerIT extends AbstractRemoteStoreMockReposit
 
         String indexName = response.getShards()[0].getShardRouting().index().getName();
         String indexUuid = response.getShards()[0].getShardRouting().index().getUUID();
-        String shardPath = getShardLevelBlobPath(client(), indexName, new BlobPath(), "0", SEGMENTS, DATA).buildAsString();
+
+        String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
+        String shardPath = getShardLevelBlobPath(client(), indexName, new BlobPath(), "0", SEGMENTS, DATA, segmentsPathFixedPrefix)
+            .buildAsString();
         Path segmentDataRepoPath = location.resolve(shardPath);
         String segmentDataLocalPath = String.format(Locale.ROOT, "%s/indices/%s/0/index", response.getShards()[0].getDataPath(), indexUuid);
 

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
@@ -325,13 +325,15 @@ public class DeleteSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         final RepositoriesService repositoriesService = internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class);
         final BlobStoreRepository remoteStoreRepository = (BlobStoreRepository) repositoriesService.repository(REMOTE_REPO_NAME);
+        String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
         BlobPath shardLevelBlobPath = getShardLevelBlobPath(
             client(),
             remoteStoreEnabledIndexName,
             remoteStoreRepository.basePath(),
             "0",
             SEGMENTS,
-            LOCK_FILES
+            LOCK_FILES,
+            segmentsPathFixedPrefix
         );
         BlobContainer blobContainer = remoteStoreRepository.blobStore().blobContainer(shardLevelBlobPath);
         String[] lockFiles;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/repositories/cleanup/TransportCleanupRepositoryAction.java
@@ -55,6 +55,7 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.index.store.lockmanager.RemoteStoreLockManagerFactory;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.RepositoryCleanupResult;
@@ -113,7 +114,8 @@ public final class TransportCleanupRepositoryAction extends TransportClusterMana
         SnapshotsService snapshotsService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        IndexNameExpressionResolver indexNameExpressionResolver
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        RemoteStoreSettings remoteStoreSettings
     ) {
         super(
             CleanupRepositoryAction.NAME,
@@ -126,7 +128,10 @@ public final class TransportCleanupRepositoryAction extends TransportClusterMana
         );
         this.repositoriesService = repositoriesService;
         this.snapshotsService = snapshotsService;
-        this.remoteStoreLockManagerFactory = new RemoteStoreLockManagerFactory(() -> repositoriesService);
+        this.remoteStoreLockManagerFactory = new RemoteStoreLockManagerFactory(
+            () -> repositoriesService,
+            remoteStoreSettings.getSegmentsPathFixedPrefix()
+        );
         // We add a state applier that will remove any dangling repository cleanup actions on cluster-manager failover.
         // This is safe to do since cleanups will increment the repository state id before executing any operations to prevent concurrent
         // operations from corrupting the repository. This is the same safety mechanism used by snapshot deletes.

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -769,6 +769,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL,
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_LOOKBACK_INTERVAL,
                 RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED,
+                RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX,
+                RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX,
 
                 SystemTemplatesService.SETTING_APPLICATION_BASED_CONFIGURATION_TEMPLATES_ENABLED,
 

--- a/server/src/main/java/org/opensearch/index/remote/RemoteIndexPath.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteIndexPath.java
@@ -20,6 +20,7 @@ import org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm;
 import org.opensearch.index.remote.RemoteStoreEnums.PathType;
 import org.opensearch.index.remote.RemoteStorePathStrategy.BasePathInput;
 import org.opensearch.index.remote.RemoteStorePathStrategy.PathInput;
+import org.opensearch.indices.RemoteStoreSettings;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -68,6 +69,7 @@ public class RemoteIndexPath implements ToXContentFragment {
     private final Iterable<String> basePath;
     private final PathType pathType;
     private final PathHashAlgorithm pathHashAlgorithm;
+    private final RemoteStoreSettings remoteStoreSettings;
 
     /**
      * This keeps the map of paths that would be present in the content of the index path file. For eg - It is possible
@@ -82,7 +84,8 @@ public class RemoteIndexPath implements ToXContentFragment {
         Iterable<String> basePath,
         PathType pathType,
         PathHashAlgorithm pathHashAlgorithm,
-        Map<DataCategory, List<DataType>> pathCreationMap
+        Map<DataCategory, List<DataType>> pathCreationMap,
+        RemoteStoreSettings remoteStoreSettings
     ) {
         if (Objects.isNull(pathCreationMap)
             || Objects.isNull(pathType)
@@ -119,6 +122,7 @@ public class RemoteIndexPath implements ToXContentFragment {
         this.pathType = pathType;
         this.pathHashAlgorithm = pathHashAlgorithm;
         this.pathCreationMap = pathCreationMap;
+        this.remoteStoreSettings = remoteStoreSettings;
     }
 
     @Override
@@ -148,6 +152,11 @@ public class RemoteIndexPath implements ToXContentFragment {
                         .shardId(Integer.toString(shardNo))
                         .dataCategory(dataCategory)
                         .dataType(type)
+                        .fixedPrefix(
+                            dataCategory == TRANSLOG
+                                ? remoteStoreSettings.getTranslogPathFixedPrefix()
+                                : remoteStoreSettings.getSegmentsPathFixedPrefix()
+                        )
                         .build();
                     builder.value(pathType.path(pathInput, pathHashAlgorithm).buildAsString());
                 }

--- a/server/src/main/java/org/opensearch/index/remote/RemoteIndexPathUploader.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteIndexPathUploader.java
@@ -25,6 +25,7 @@ import org.opensearch.core.index.Index;
 import org.opensearch.gateway.remote.IndexMetadataUploadListener;
 import org.opensearch.gateway.remote.RemoteStateTransferException;
 import org.opensearch.index.remote.RemoteStoreEnums.PathType;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.node.Node;
 import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
 import org.opensearch.repositories.RepositoriesService;
@@ -79,6 +80,7 @@ public class RemoteIndexPathUploader extends IndexMetadataUploadListener {
     private final Settings settings;
     private final boolean isRemoteDataAttributePresent;
     private final boolean isTranslogSegmentRepoSame;
+    private final RemoteStoreSettings remoteStoreSettings;
     private final Supplier<RepositoriesService> repositoriesService;
     private volatile TimeValue metadataUploadTimeout;
 
@@ -89,7 +91,8 @@ public class RemoteIndexPathUploader extends IndexMetadataUploadListener {
         ThreadPool threadPool,
         Settings settings,
         Supplier<RepositoriesService> repositoriesService,
-        ClusterSettings clusterSettings
+        ClusterSettings clusterSettings,
+        RemoteStoreSettings remoteStoreSettings
     ) {
         super(threadPool, ThreadPool.Names.GENERIC);
         this.settings = Objects.requireNonNull(settings);
@@ -100,6 +103,7 @@ public class RemoteIndexPathUploader extends IndexMetadataUploadListener {
         Objects.requireNonNull(clusterSettings);
         metadataUploadTimeout = clusterSettings.get(GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING);
         clusterSettings.addSettingsUpdateConsumer(GLOBAL_METADATA_UPLOAD_TIMEOUT_SETTING, this::setMetadataUploadTimeout);
+        this.remoteStoreSettings = remoteStoreSettings;
     }
 
     @Override
@@ -208,7 +212,8 @@ public class RemoteIndexPathUploader extends IndexMetadataUploadListener {
                 basePath,
                 pathType,
                 hashAlgorithm,
-                pathCreationMap
+                pathCreationMap,
+                remoteStoreSettings
             );
             String fileName = generateFileName(indexUUID, idxMD.getVersion(), remoteIndexPath.getVersion());
             REMOTE_INDEX_PATH_FORMAT.writeAsyncWithUrgentPriority(remoteIndexPath, blobContainer, fileName, actionListener);

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreEnums.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreEnums.java
@@ -13,6 +13,7 @@ import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.hash.FNV1a;
+import org.opensearch.core.common.Strings;
 import org.opensearch.index.remote.RemoteStorePathStrategy.BasePathInput;
 
 import java.util.HashMap;
@@ -107,7 +108,11 @@ public class RemoteStoreEnums {
             @Override
             public BlobPath generatePath(BasePathInput pathInput, PathHashAlgorithm hashAlgorithm) {
                 assert Objects.nonNull(hashAlgorithm) : "hashAlgorithm is expected to be non-null";
-                return BlobPath.cleanPath().add(hashAlgorithm.hash(pathInput)).add(pathInput.basePath()).add(pathInput.fixedSubPath());
+                String fixedPrefix = pathInput.fixedPrefix();
+                return BlobPath.cleanPath()
+                    .add(Strings.isNullOrEmpty(fixedPrefix) ? hashAlgorithm.hash(pathInput) : fixedPrefix + hashAlgorithm.hash(pathInput))
+                    .add(pathInput.basePath())
+                    .add(pathInput.fixedSubPath());
             }
 
             @Override
@@ -119,7 +124,10 @@ public class RemoteStoreEnums {
             @Override
             public BlobPath generatePath(BasePathInput pathInput, PathHashAlgorithm hashAlgorithm) {
                 assert Objects.nonNull(hashAlgorithm) : "hashAlgorithm is expected to be non-null";
-                return pathInput.basePath().add(hashAlgorithm.hash(pathInput)).add(pathInput.fixedSubPath());
+                String fixedPrefix = pathInput.fixedPrefix();
+                return pathInput.basePath()
+                    .add(Strings.isNullOrEmpty(fixedPrefix) ? hashAlgorithm.hash(pathInput) : fixedPrefix + hashAlgorithm.hash(pathInput))
+                    .add(pathInput.fixedSubPath());
             }
 
             @Override

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePathStrategy.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePathStrategy.java
@@ -94,6 +94,7 @@ public class RemoteStorePathStrategy {
         public BasePathInput(BlobPath basePath, String indexUUID) {
             this.basePath = basePath;
             this.indexUUID = indexUUID;
+            this.fixedPrefix = null;
         }
 
         public BasePathInput(Builder<?> builder) {

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStorePathStrategy.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStorePathStrategy.java
@@ -88,6 +88,7 @@ public class RemoteStorePathStrategy {
     public static class BasePathInput {
         private final BlobPath basePath;
         private final String indexUUID;
+        private final String fixedPrefix;
 
         // Adding for BWC
         public BasePathInput(BlobPath basePath, String indexUUID) {
@@ -98,6 +99,7 @@ public class RemoteStorePathStrategy {
         public BasePathInput(Builder<?> builder) {
             this.basePath = Objects.requireNonNull(builder.basePath);
             this.indexUUID = Objects.requireNonNull(builder.indexUUID);
+            this.fixedPrefix = Objects.isNull(builder.fixedPrefix) ? "" : builder.fixedPrefix;
         }
 
         BlobPath basePath() {
@@ -106,6 +108,10 @@ public class RemoteStorePathStrategy {
 
         String indexUUID() {
             return indexUUID;
+        }
+
+        String fixedPrefix() {
+            return fixedPrefix;
         }
 
         BlobPath fixedSubPath() {
@@ -137,6 +143,7 @@ public class RemoteStorePathStrategy {
         public static class Builder<T extends Builder<T>> {
             private BlobPath basePath;
             private String indexUUID;
+            private String fixedPrefix;
 
             public T basePath(BlobPath basePath) {
                 this.basePath = basePath;
@@ -145,6 +152,11 @@ public class RemoteStorePathStrategy {
 
             public T indexUUID(String indexUUID) {
                 this.indexUUID = indexUUID;
+                return self();
+            }
+
+            public T fixedPrefix(String fixedPrefix) {
+                this.fixedPrefix = fixedPrefix;
                 return self();
             }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2899,7 +2899,14 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             assert recoveryState.getRecoverySource().getType() == RecoverySource.Type.SNAPSHOT : "invalid recovery type: "
                 + recoveryState.getRecoverySource();
             StoreRecovery storeRecovery = new StoreRecovery(shardId, logger);
-            storeRecovery.recoverFromSnapshotAndRemoteStore(this, repository, repositoriesService, listener, threadPool);
+            storeRecovery.recoverFromSnapshotAndRemoteStore(
+                this,
+                repository,
+                repositoriesService,
+                listener,
+                remoteStoreSettings.getSegmentsPathFixedPrefix(),
+                threadPool
+            );
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/opensearch/index/shard/StoreRecovery.java
@@ -367,6 +367,7 @@ final class StoreRecovery {
         Repository repository,
         RepositoriesService repositoriesService,
         ActionListener<Boolean> listener,
+        String segmentsPathFixedPrefix,
         ThreadPool threadPool
     ) {
         try {
@@ -397,7 +398,8 @@ final class StoreRecovery {
 
                 RemoteSegmentStoreDirectoryFactory directoryFactory = new RemoteSegmentStoreDirectoryFactory(
                     () -> repositoriesService,
-                    threadPool
+                    threadPool,
+                    segmentsPathFixedPrefix
                 );
                 RemoteSegmentStoreDirectory sourceRemoteDirectory = (RemoteSegmentStoreDirectory) directoryFactory.newDirectory(
                     remoteStoreRepository,

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactory.java
@@ -40,11 +40,17 @@ import static org.opensearch.index.remote.RemoteStoreEnums.DataType.METADATA;
 @PublicApi(since = "2.3.0")
 public class RemoteSegmentStoreDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
     private final Supplier<RepositoriesService> repositoriesService;
+    private final String segmentsPathFixedPrefix;
 
     private final ThreadPool threadPool;
 
-    public RemoteSegmentStoreDirectoryFactory(Supplier<RepositoriesService> repositoriesService, ThreadPool threadPool) {
+    public RemoteSegmentStoreDirectoryFactory(
+        Supplier<RepositoriesService> repositoriesService,
+        ThreadPool threadPool,
+        String segmentsPathFixedPrefix
+    ) {
         this.repositoriesService = repositoriesService;
+        this.segmentsPathFixedPrefix = segmentsPathFixedPrefix;
         this.threadPool = threadPool;
     }
 
@@ -71,6 +77,7 @@ public class RemoteSegmentStoreDirectoryFactory implements IndexStorePlugin.Dire
                 .shardId(shardIdStr)
                 .dataCategory(SEGMENTS)
                 .dataType(DATA)
+                .fixedPrefix(segmentsPathFixedPrefix)
                 .build();
             // Derive the path for data directory of SEGMENTS
             BlobPath dataPath = pathStrategy.generatePath(dataPathInput);
@@ -87,6 +94,7 @@ public class RemoteSegmentStoreDirectoryFactory implements IndexStorePlugin.Dire
                 .shardId(shardIdStr)
                 .dataCategory(SEGMENTS)
                 .dataType(METADATA)
+                .fixedPrefix(segmentsPathFixedPrefix)
                 .build();
             // Derive the path for metadata directory of SEGMENTS
             BlobPath mdPath = pathStrategy.generatePath(mdPathInput);
@@ -98,7 +106,8 @@ public class RemoteSegmentStoreDirectoryFactory implements IndexStorePlugin.Dire
                 repositoryName,
                 indexUUID,
                 shardIdStr,
-                pathStrategy
+                pathStrategy,
+                segmentsPathFixedPrefix
             );
 
             return new RemoteSegmentStoreDirectory(dataDirectory, metadataDirectory, mdLockManager, threadPool, shardId);

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactory.java
@@ -44,6 +44,11 @@ public class RemoteSegmentStoreDirectoryFactory implements IndexStorePlugin.Dire
 
     private final ThreadPool threadPool;
 
+    // Added for passing breaking change check
+    public RemoteSegmentStoreDirectoryFactory(Supplier<RepositoriesService> repositoriesService, ThreadPool threadPool) {
+        this(repositoriesService, threadPool, null);
+    }
+
     public RemoteSegmentStoreDirectoryFactory(
         Supplier<RepositoriesService> repositoriesService,
         ThreadPool threadPool,

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerFactory.java
@@ -31,9 +31,11 @@ import static org.opensearch.index.remote.RemoteStoreEnums.DataType.LOCK_FILES;
 @PublicApi(since = "2.8.0")
 public class RemoteStoreLockManagerFactory {
     private final Supplier<RepositoriesService> repositoriesService;
+    private final String segmentsPathFixedPrefix;
 
-    public RemoteStoreLockManagerFactory(Supplier<RepositoriesService> repositoriesService) {
+    public RemoteStoreLockManagerFactory(Supplier<RepositoriesService> repositoriesService, String segmentsPathFixedPrefix) {
         this.repositoriesService = repositoriesService;
+        this.segmentsPathFixedPrefix = segmentsPathFixedPrefix;
     }
 
     public RemoteStoreLockManager newLockManager(
@@ -42,7 +44,7 @@ public class RemoteStoreLockManagerFactory {
         String shardId,
         RemoteStorePathStrategy pathStrategy
     ) {
-        return newLockManager(repositoriesService.get(), repositoryName, indexUUID, shardId, pathStrategy);
+        return newLockManager(repositoriesService.get(), repositoryName, indexUUID, shardId, pathStrategy, segmentsPathFixedPrefix);
     }
 
     public static RemoteStoreMetadataLockManager newLockManager(
@@ -50,7 +52,8 @@ public class RemoteStoreLockManagerFactory {
         String repositoryName,
         String indexUUID,
         String shardId,
-        RemoteStorePathStrategy pathStrategy
+        RemoteStorePathStrategy pathStrategy,
+        String segmentsPathFixedPrefix
     ) {
         try (Repository repository = repositoriesService.repository(repositoryName)) {
             assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
@@ -62,6 +65,7 @@ public class RemoteStoreLockManagerFactory {
                 .shardId(shardId)
                 .dataCategory(SEGMENTS)
                 .dataType(LOCK_FILES)
+                .fixedPrefix(segmentsPathFixedPrefix)
                 .build();
             BlobPath lockDirectoryPath = pathStrategy.generatePath(lockFilesPathInput);
             BlobContainer lockDirectoryBlobContainer = ((BlobStoreRepository) repository).blobStore().blobContainer(lockDirectoryPath);

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerFactory.java
@@ -33,6 +33,12 @@ public class RemoteStoreLockManagerFactory {
     private final Supplier<RepositoriesService> repositoriesService;
     private final String segmentsPathFixedPrefix;
 
+    // Added for passing breaking change check
+    public RemoteStoreLockManagerFactory(Supplier<RepositoriesService> repositoriesService) {
+        this.repositoriesService = repositoriesService;
+        this.segmentsPathFixedPrefix = null;
+    }
+
     public RemoteStoreLockManagerFactory(Supplier<RepositoriesService> repositoriesService, String segmentsPathFixedPrefix) {
         this.repositoriesService = repositoriesService;
         this.segmentsPathFixedPrefix = segmentsPathFixedPrefix;
@@ -45,6 +51,17 @@ public class RemoteStoreLockManagerFactory {
         RemoteStorePathStrategy pathStrategy
     ) {
         return newLockManager(repositoriesService.get(), repositoryName, indexUUID, shardId, pathStrategy, segmentsPathFixedPrefix);
+    }
+
+    // Added for passing breaking change check
+    public static RemoteStoreMetadataLockManager newLockManager(
+        RepositoriesService repositoriesService,
+        String repositoryName,
+        String indexUUID,
+        String shardId,
+        RemoteStorePathStrategy pathStrategy
+    ) {
+        return newLockManager(repositoriesService, repositoryName, indexUUID, shardId, pathStrategy, null);
     }
 
     public static RemoteStoreMetadataLockManager newLockManager(

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -372,6 +372,7 @@ public class RemoteFsTranslog extends Translog {
             .shardId(shardIdStr)
             .dataCategory(TRANSLOG)
             .dataType(DATA)
+            .fixedPrefix(remoteStoreSettings.getTranslogPathFixedPrefix())
             .build();
         BlobPath dataPath = pathStrategy.generatePath(dataPathInput);
         RemoteStorePathStrategy.PathInput mdPathInput = RemoteStorePathStrategy.PathInput.builder()
@@ -380,6 +381,7 @@ public class RemoteFsTranslog extends Translog {
             .shardId(shardIdStr)
             .dataCategory(TRANSLOG)
             .dataType(METADATA)
+            .fixedPrefix(remoteStoreSettings.getTranslogPathFixedPrefix())
             .build();
         BlobPath mdPath = pathStrategy.generatePath(mdPathInput);
         BlobStoreTransferService transferService = new BlobStoreTransferService(blobStoreRepository.blobStore(), threadPool);

--- a/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
+++ b/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
@@ -164,6 +164,26 @@ public class RemoteStoreSettings {
         Setting.Property.NodeScope
     );
 
+    /**
+     * Controls the fixed prefix for the translog path on remote store.
+     */
+    public static final Setting<String> CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX = Setting.simpleString(
+        "cluster.remote_store.translog.path.prefix",
+        "",
+        Property.NodeScope,
+        Property.Final
+    );
+
+    /**
+     * Controls the fixed prefix for the segments path on remote store.
+     */
+    public static final Setting<String> CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX = Setting.simpleString(
+        "cluster.remote_store.segments.path.prefix",
+        "",
+        Property.NodeScope,
+        Property.Final
+    );
+
     private volatile TimeValue clusterRemoteTranslogBufferInterval;
     private volatile int minRemoteSegmentMetadataFiles;
     private volatile TimeValue clusterRemoteTranslogTransferTimeout;
@@ -175,6 +195,8 @@ public class RemoteStoreSettings {
     private static volatile boolean isPinnedTimestampsEnabled;
     private static volatile TimeValue pinnedTimestampsSchedulerInterval;
     private static volatile TimeValue pinnedTimestampsLookbackInterval;
+    private final String translogPathFixedPrefix;
+    private final String segmentsPathFixedPrefix;
 
     public RemoteStoreSettings(Settings settings, ClusterSettings clusterSettings) {
         clusterRemoteTranslogBufferInterval = CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING.get(settings);
@@ -216,6 +238,9 @@ public class RemoteStoreSettings {
         pinnedTimestampsSchedulerInterval = CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_SCHEDULER_INTERVAL.get(settings);
         pinnedTimestampsLookbackInterval = CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_LOOKBACK_INTERVAL.get(settings);
         isPinnedTimestampsEnabled = CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.get(settings);
+
+        translogPathFixedPrefix = CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.get(settings);
+        segmentsPathFixedPrefix = CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(settings);
     }
 
     public TimeValue getClusterRemoteTranslogBufferInterval() {
@@ -299,5 +324,13 @@ public class RemoteStoreSettings {
 
     public static boolean isPinnedTimestampsEnabled() {
         return isPinnedTimestampsEnabled;
+    }
+
+    public String getTranslogPathFixedPrefix() {
+        return translogPathFixedPrefix;
+    }
+
+    public String getSegmentsPathFixedPrefix() {
+        return segmentsPathFixedPrefix;
     }
 }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -788,6 +788,7 @@ public class Node implements Closeable {
                 clusterService.getClusterSettings(),
                 threadPool::relativeTimeInMillis
             );
+            final RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(settings, settingsModule.getClusterSettings());
             final RemoteClusterStateService remoteClusterStateService;
             final RemoteClusterStateCleanupManager remoteClusterStateCleanupManager;
             final RemoteIndexPathUploader remoteIndexPathUploader;
@@ -796,7 +797,8 @@ public class Node implements Closeable {
                     threadPool,
                     settings,
                     repositoriesServiceReference::get,
-                    clusterService.getClusterSettings()
+                    clusterService.getClusterSettings(),
+                    remoteStoreSettings
                 );
                 remoteClusterStateService = new RemoteClusterStateService(
                     nodeEnvironment.nodeId(),
@@ -868,12 +870,12 @@ public class Node implements Closeable {
 
             final RecoverySettings recoverySettings = new RecoverySettings(settings, settingsModule.getClusterSettings());
 
-            final RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(settings, settingsModule.getClusterSettings());
             final CompositeIndexSettings compositeIndexSettings = new CompositeIndexSettings(settings, settingsModule.getClusterSettings());
 
             final IndexStorePlugin.DirectoryFactory remoteDirectoryFactory = new RemoteSegmentStoreDirectoryFactory(
                 repositoriesServiceReference::get,
-                threadPool
+                threadPool,
+                remoteStoreSettings.getSegmentsPathFixedPrefix()
             );
 
             final TaskResourceTrackingService taskResourceTrackingService = new TaskResourceTrackingService(
@@ -1203,7 +1205,8 @@ public class Node implements Closeable {
                 repositoryService,
                 transportService,
                 actionModule.getActionFilters(),
-                remoteStorePinnedTimestampService
+                remoteStorePinnedTimestampService,
+                remoteStoreSettings
             );
             SnapshotShardsService snapshotShardsService = new SnapshotShardsService(
                 settings,
@@ -1406,6 +1409,7 @@ public class Node implements Closeable {
                 b.bind(SnapshotsInfoService.class).toInstance(snapshotsInfoService);
                 b.bind(GatewayMetaState.class).toInstance(gatewayMetaState);
                 b.bind(Discovery.class).toInstance(discoveryModule.getDiscovery());
+                b.bind(RemoteStoreSettings.class).toInstance(remoteStoreSettings);
                 {
                     b.bind(PeerRecoverySourceService.class)
                         .toInstance(new PeerRecoverySourceService(transportService, indicesService, recoverySettings));

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -130,6 +130,7 @@ import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.index.store.lockmanager.FileLockInfo;
 import org.opensearch.index.store.lockmanager.RemoteStoreLockManager;
 import org.opensearch.index.store.lockmanager.RemoteStoreLockManagerFactory;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.repositories.IndexId;
@@ -421,6 +422,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     private final RecoverySettings recoverySettings;
 
+    private final RemoteStoreSettings remoteStoreSettings;
+
     private final NamedXContentRegistry namedXContentRegistry;
 
     /**
@@ -476,6 +479,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         this.threadPool = clusterService.getClusterApplierService().threadPool();
         this.clusterService = clusterService;
         this.recoverySettings = recoverySettings;
+        this.remoteStoreSettings = new RemoteStoreSettings(clusterService.getSettings(), clusterService.getClusterSettings());
     }
 
     @Override
@@ -1366,7 +1370,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             // related issue: https://github.com/opensearch-project/OpenSearch/issues/8469
             RemoteSegmentStoreDirectoryFactory remoteDirectoryFactory = new RemoteSegmentStoreDirectoryFactory(
                 remoteStoreLockManagerFactory.getRepositoriesService(),
-                threadPool
+                threadPool,
+                remoteStoreSettings.getSegmentsPathFixedPrefix()
             );
             remoteDirectoryCleanupAsync(
                 remoteDirectoryFactory,

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -93,6 +93,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.store.lockmanager.RemoteStoreLockManagerFactory;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
 import org.opensearch.repositories.IndexId;
 import org.opensearch.repositories.RepositoriesService;
@@ -236,12 +237,16 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         RepositoriesService repositoriesService,
         TransportService transportService,
         ActionFilters actionFilters,
-        @Nullable RemoteStorePinnedTimestampService remoteStorePinnedTimestampService
+        @Nullable RemoteStorePinnedTimestampService remoteStorePinnedTimestampService,
+        RemoteStoreSettings remoteStoreSettings
     ) {
         this.clusterService = clusterService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.repositoriesService = repositoriesService;
-        this.remoteStoreLockManagerFactory = new RemoteStoreLockManagerFactory(() -> repositoriesService);
+        this.remoteStoreLockManagerFactory = new RemoteStoreLockManagerFactory(
+            () -> repositoriesService,
+            remoteStoreSettings.getSegmentsPathFixedPrefix()
+        );
         this.threadPool = transportService.getThreadPool();
         this.transportService = transportService;
         this.remoteStorePinnedTimestampService = remoteStorePinnedTimestampService;

--- a/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -73,6 +73,7 @@ import org.opensearch.gateway.remote.model.RemoteClusterStateManifestInfo;
 import org.opensearch.index.recovery.RemoteStoreRestoreService;
 import org.opensearch.index.recovery.RemoteStoreRestoreService.RemoteRestoreResult;
 import org.opensearch.index.remote.RemoteIndexPathUploader;
+import org.opensearch.indices.DefaultRemoteStoreSettings;
 import org.opensearch.node.Node;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.fs.FsRepository;
@@ -504,7 +505,15 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
                         clusterService,
                         () -> 0L,
                         threadPool,
-                        List.of(new RemoteIndexPathUploader(threadPool, settings, repositoriesServiceSupplier, clusterSettings)),
+                        List.of(
+                            new RemoteIndexPathUploader(
+                                threadPool,
+                                settings,
+                                repositoriesServiceSupplier,
+                                clusterSettings,
+                                DefaultRemoteStoreSettings.INSTANCE
+                            )
+                        ),
                         writableRegistry()
                     );
                 } else {

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -62,6 +62,7 @@ import org.opensearch.gateway.remote.model.RemotePersistentSettingsMetadata;
 import org.opensearch.gateway.remote.model.RemoteReadResult;
 import org.opensearch.gateway.remote.model.RemoteTransientSettingsMetadata;
 import org.opensearch.index.remote.RemoteIndexPathUploader;
+import org.opensearch.indices.DefaultRemoteStoreSettings;
 import org.opensearch.indices.IndicesModule;
 import org.opensearch.repositories.FilterRepository;
 import org.opensearch.repositories.RepositoriesService;
@@ -254,7 +255,15 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             clusterService,
             () -> 0L,
             threadPool,
-            List.of(new RemoteIndexPathUploader(threadPool, settings, repositoriesServiceSupplier, clusterSettings)),
+            List.of(
+                new RemoteIndexPathUploader(
+                    threadPool,
+                    settings,
+                    repositoriesServiceSupplier,
+                    clusterSettings,
+                    DefaultRemoteStoreSettings.INSTANCE
+                )
+            ),
             namedWriteableRegistry
         );
     }
@@ -291,7 +300,15 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
                 clusterService,
                 () -> 0L,
                 threadPool,
-                List.of(new RemoteIndexPathUploader(threadPool, settings, repositoriesServiceSupplier, clusterSettings)),
+                List.of(
+                    new RemoteIndexPathUploader(
+                        threadPool,
+                        settings,
+                        repositoriesServiceSupplier,
+                        clusterSettings,
+                        DefaultRemoteStoreSettings.INSTANCE
+                    )
+                ),
                 writableRegistry()
             )
         );
@@ -363,7 +380,15 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             clusterService,
             () -> 0L,
             threadPool,
-            List.of(new RemoteIndexPathUploader(threadPool, settings, repositoriesServiceSupplier, clusterSettings)),
+            List.of(
+                new RemoteIndexPathUploader(
+                    threadPool,
+                    settings,
+                    repositoriesServiceSupplier,
+                    clusterSettings,
+                    DefaultRemoteStoreSettings.INSTANCE
+                )
+            ),
             writableRegistry()
         );
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager())
@@ -733,7 +758,15 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             clusterService,
             () -> 0L,
             threadPool,
-            List.of(new RemoteIndexPathUploader(threadPool, settings, repositoriesServiceSupplier, clusterSettings)),
+            List.of(
+                new RemoteIndexPathUploader(
+                    threadPool,
+                    settings,
+                    repositoriesServiceSupplier,
+                    clusterSettings,
+                    DefaultRemoteStoreSettings.INSTANCE
+                )
+            ),
             writableRegistry()
         );
         final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
@@ -2635,7 +2668,15 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             clusterService,
             () -> 0L,
             threadPool,
-            List.of(new RemoteIndexPathUploader(threadPool, newSettings, repositoriesServiceSupplier, clusterSettings)),
+            List.of(
+                new RemoteIndexPathUploader(
+                    threadPool,
+                    newSettings,
+                    repositoriesServiceSupplier,
+                    clusterSettings,
+                    DefaultRemoteStoreSettings.INSTANCE
+                )
+            ),
             writableRegistry()
         );
         assertTrue(remoteClusterStateService.getRemoteRoutingTableService() instanceof InternalRemoteRoutingTableService);
@@ -2906,7 +2947,15 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             clusterService,
             () -> 0L,
             threadPool,
-            List.of(new RemoteIndexPathUploader(threadPool, newSettings, repositoriesServiceSupplier, clusterSettings)),
+            List.of(
+                new RemoteIndexPathUploader(
+                    threadPool,
+                    newSettings,
+                    repositoriesServiceSupplier,
+                    clusterSettings,
+                    DefaultRemoteStoreSettings.INSTANCE
+                )
+            ),
             writableRegistry()
         );
     }

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -2978,7 +2978,15 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             clusterService,
             () -> 0L,
             threadPool,
-            List.of(new RemoteIndexPathUploader(threadPool, newSettings, repositoriesServiceSupplier, clusterSettings)),
+            List.of(
+                new RemoteIndexPathUploader(
+                    threadPool,
+                    newSettings,
+                    repositoriesServiceSupplier,
+                    clusterSettings,
+                    DefaultRemoteStoreSettings.INSTANCE
+                )
+            ),
             writableRegistry()
         );
     }

--- a/server/src/test/java/org/opensearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexModuleTests.java
@@ -259,7 +259,7 @@ public class IndexModuleTests extends OpenSearchTestCase {
             writableRegistry(),
             () -> false,
             null,
-            new RemoteSegmentStoreDirectoryFactory(() -> repositoriesService, threadPool),
+            new RemoteSegmentStoreDirectoryFactory(() -> repositoriesService, threadPool, ""),
             translogFactorySupplier,
             () -> IndexSettings.DEFAULT_REFRESH_INTERVAL,
             DefaultRecoverySettings.INSTANCE,

--- a/server/src/test/java/org/opensearch/index/remote/RemoteIndexPathTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteIndexPathTests.java
@@ -9,12 +9,16 @@
 package org.opensearch.index.remote;
 
 import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm;
 import org.opensearch.index.remote.RemoteStoreEnums.PathType;
+import org.opensearch.indices.DefaultRemoteStoreSettings;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -40,7 +44,8 @@ public class RemoteIndexPathTests extends OpenSearchTestCase {
             new BlobPath().add("djsd878ndjh").add("hcs87cj8"),
             PathType.HASHED_PREFIX,
             PathHashAlgorithm.FNV_1A_BASE64,
-            RemoteIndexPath.SEGMENT_PATH
+            RemoteIndexPath.SEGMENT_PATH,
+            DefaultRemoteStoreSettings.INSTANCE
         );
         XContentBuilder xContentBuilder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
         xContentBuilder.startObject();
@@ -49,6 +54,28 @@ public class RemoteIndexPathTests extends OpenSearchTestCase {
         String expected =
             "{\"version\":\"1\",\"index_uuid\":\"djjsid73he8yd7usduh\",\"shard_count\":2,\"path_type\":\"HASHED_PREFIX\",\"path_hash_algorithm\":\"FNV_1A_BASE64\",\"path_creation_map\":{\"segments\":[\"data\",\"metadata\",\"lock_files\"]},\"paths\":[\"9BmBinD5HYs/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/0/segments/data/\",\"ExCNOD8_5ew/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/1/segments/data/\",\"z8wtf0yr2l4/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/0/segments/metadata/\",\"VheHVwFlExE/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/1/segments/metadata/\",\"IgFKbsDeUpQ/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/0/segments/lock_files/\",\"pA3gy_GZtns/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/1/segments/lock_files/\"]}";
         assertEquals(expected, xContentBuilder.toString());
+
+        // Fixed prefix
+        Settings settings = Settings.builder().put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.getKey(), ".").build();
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(settings, clusterSettings);
+        indexPath = new RemoteIndexPath(
+            "djjsid73he8yd7usduh",
+            2,
+            new BlobPath().add("djsd878ndjh").add("hcs87cj8"),
+            PathType.HASHED_PREFIX,
+            PathHashAlgorithm.FNV_1A_BASE64,
+            RemoteIndexPath.SEGMENT_PATH,
+            remoteStoreSettings
+        );
+        xContentBuilder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        xContentBuilder.startObject();
+        xContentBuilder = indexPath.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+        expected =
+            "{\"version\":\"1\",\"index_uuid\":\"djjsid73he8yd7usduh\",\"shard_count\":2,\"path_type\":\"HASHED_PREFIX\",\"path_hash_algorithm\":\"FNV_1A_BASE64\",\"path_creation_map\":{\"segments\":[\"data\",\"metadata\",\"lock_files\"]},\"paths\":[\".9BmBinD5HYs/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/0/segments/data/\",\".ExCNOD8_5ew/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/1/segments/data/\",\".z8wtf0yr2l4/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/0/segments/metadata/\",\".VheHVwFlExE/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/1/segments/metadata/\",\".IgFKbsDeUpQ/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/0/segments/lock_files/\",\".pA3gy_GZtns/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/1/segments/lock_files/\"]}";
+        assertEquals(expected, xContentBuilder.toString());
+
     }
 
     /**
@@ -61,7 +88,8 @@ public class RemoteIndexPathTests extends OpenSearchTestCase {
             new BlobPath().add("djsd878ndjh").add("hcs87cj8"),
             PathType.HASHED_PREFIX,
             PathHashAlgorithm.FNV_1A_BASE64,
-            RemoteIndexPath.TRANSLOG_PATH
+            RemoteIndexPath.TRANSLOG_PATH,
+            DefaultRemoteStoreSettings.INSTANCE
         );
         XContentBuilder xContentBuilder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
         xContentBuilder.startObject();
@@ -69,6 +97,27 @@ public class RemoteIndexPathTests extends OpenSearchTestCase {
         xContentBuilder.endObject();
         String expected =
             "{\"version\":\"1\",\"index_uuid\":\"djjsid73he8yd7usduh\",\"shard_count\":2,\"path_type\":\"HASHED_PREFIX\",\"path_hash_algorithm\":\"FNV_1A_BASE64\",\"path_creation_map\":{\"translog\":[\"data\",\"metadata\"]},\"paths\":[\"2EaVODaKBck/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/0/translog/data/\",\"dTS2VqEOUNo/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/1/translog/data/\",\"PVNKNGonmZw/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/0/translog/metadata/\",\"NXmt0Y6NjA8/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/1/translog/metadata/\"]}";
+        assertEquals(expected, xContentBuilder.toString());
+
+        // Fixed prefix
+        Settings settings = Settings.builder().put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.getKey(), ".").build();
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(settings, clusterSettings);
+        indexPath = new RemoteIndexPath(
+            "djjsid73he8yd7usduh",
+            2,
+            new BlobPath().add("djsd878ndjh").add("hcs87cj8"),
+            PathType.HASHED_PREFIX,
+            PathHashAlgorithm.FNV_1A_BASE64,
+            RemoteIndexPath.TRANSLOG_PATH,
+            remoteStoreSettings
+        );
+        xContentBuilder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        xContentBuilder.startObject();
+        xContentBuilder = indexPath.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+        expected =
+            "{\"version\":\"1\",\"index_uuid\":\"djjsid73he8yd7usduh\",\"shard_count\":2,\"path_type\":\"HASHED_PREFIX\",\"path_hash_algorithm\":\"FNV_1A_BASE64\",\"path_creation_map\":{\"translog\":[\"data\",\"metadata\"]},\"paths\":[\".2EaVODaKBck/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/0/translog/data/\",\".dTS2VqEOUNo/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/1/translog/data/\",\".PVNKNGonmZw/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/0/translog/metadata/\",\".NXmt0Y6NjA8/djsd878ndjh/hcs87cj8/djjsid73he8yd7usduh/1/translog/metadata/\"]}";
         assertEquals(expected, xContentBuilder.toString());
     }
 
@@ -85,7 +134,8 @@ public class RemoteIndexPathTests extends OpenSearchTestCase {
             new BlobPath().add("nxf9yv0").add("c3ejoi"),
             PathType.HASHED_PREFIX,
             PathHashAlgorithm.FNV_1A_BASE64,
-            pathCreationMap
+            pathCreationMap,
+            DefaultRemoteStoreSettings.INSTANCE
         );
         XContentBuilder xContentBuilder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
         xContentBuilder.startObject();
@@ -94,9 +144,42 @@ public class RemoteIndexPathTests extends OpenSearchTestCase {
         String expected =
             "{\"version\":\"1\",\"index_uuid\":\"csbdqiu8a7sdnjdks\",\"shard_count\":3,\"path_type\":\"HASHED_PREFIX\",\"path_hash_algorithm\":\"FNV_1A_BASE64\",\"path_creation_map\":{\"translog\":[\"data\",\"metadata\"],\"segments\":[\"data\",\"metadata\",\"lock_files\"]},\"paths\":[\"Cjo0F6kNjYk/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/0/segments/data/\",\"kpayyhxct1I/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/1/segments/data/\",\"p2RlgnHeIgc/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/2/segments/data/\",\"gkPIurBtB1w/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/0/segments/metadata/\",\"Y4YhlbxAB1c/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/1/segments/metadata/\",\"HYc8fyVPouI/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/2/segments/metadata/\",\"igzyZCz1ysI/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/0/segments/lock_files/\",\"uEluEiYmptk/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/1/segments/lock_files/\",\"TfAD8f06_7A/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/2/segments/lock_files/\",\"QqKEpasbEGs/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/0/translog/data/\",\"sNyoimoe1Bw/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/1/translog/data/\",\"d4YQtONfq50/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/2/translog/data/\",\"zLr4UXjK8T4/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/0/translog/metadata/\",\"_s8i7ZmlXGE/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/1/translog/metadata/\",\"tvtD3-k5ISg/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/2/translog/metadata/\"]}";
         assertEquals(expected, xContentBuilder.toString());
+
+        // Fixed prefix
+        Settings settings = Settings.builder()
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.getKey(), ".")
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.getKey(), ".")
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(settings, clusterSettings);
+        indexPath = new RemoteIndexPath(
+            "csbdqiu8a7sdnjdks",
+            3,
+            new BlobPath().add("nxf9yv0").add("c3ejoi"),
+            PathType.HASHED_PREFIX,
+            PathHashAlgorithm.FNV_1A_BASE64,
+            pathCreationMap,
+            remoteStoreSettings
+        );
+        xContentBuilder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        xContentBuilder.startObject();
+        xContentBuilder = indexPath.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+        expected =
+            "{\"version\":\"1\",\"index_uuid\":\"csbdqiu8a7sdnjdks\",\"shard_count\":3,\"path_type\":\"HASHED_PREFIX\",\"path_hash_algorithm\":\"FNV_1A_BASE64\",\"path_creation_map\":{\"translog\":[\"data\",\"metadata\"],\"segments\":[\"data\",\"metadata\",\"lock_files\"]},\"paths\":[\".Cjo0F6kNjYk/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/0/segments/data/\",\".kpayyhxct1I/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/1/segments/data/\",\".p2RlgnHeIgc/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/2/segments/data/\",\".gkPIurBtB1w/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/0/segments/metadata/\",\".Y4YhlbxAB1c/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/1/segments/metadata/\",\".HYc8fyVPouI/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/2/segments/metadata/\",\".igzyZCz1ysI/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/0/segments/lock_files/\",\".uEluEiYmptk/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/1/segments/lock_files/\",\".TfAD8f06_7A/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/2/segments/lock_files/\",\".QqKEpasbEGs/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/0/translog/data/\",\".sNyoimoe1Bw/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/1/translog/data/\",\".d4YQtONfq50/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/2/translog/data/\",\".zLr4UXjK8T4/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/0/translog/metadata/\",\"._s8i7ZmlXGE/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/1/translog/metadata/\",\".tvtD3-k5ISg/nxf9yv0/c3ejoi/csbdqiu8a7sdnjdks/2/translog/metadata/\"]}";
+        assertEquals(expected, xContentBuilder.toString());
     }
 
-    public void testRemoteIndexPathWithInvalidPathCreationMap() throws IOException {
+    public void testRemoteIndexPathWithInvalidPathCreationMap() {
+        Settings.Builder builder = Settings.builder();
+        if (randomBoolean()) {
+            builder.put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.getKey(), ".");
+        }
+        if (randomBoolean()) {
+            builder.put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.getKey(), ".");
+        }
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(builder.build(), clusterSettings);
         IllegalArgumentException ex = assertThrows(
             IllegalArgumentException.class,
             () -> new RemoteIndexPath(
@@ -105,7 +188,8 @@ public class RemoteIndexPathTests extends OpenSearchTestCase {
                 new BlobPath().add("djsd878ndjh").add("hcs87cj8"),
                 PathType.HASHED_PREFIX,
                 PathHashAlgorithm.FNV_1A_BASE64,
-                new HashMap<>()
+                new HashMap<>(),
+                remoteStoreSettings
             )
         );
         assertEquals(
@@ -124,6 +208,15 @@ public class RemoteIndexPathTests extends OpenSearchTestCase {
     }
 
     public void testInvalidPathCreationMap() {
+        Settings.Builder builder = Settings.builder();
+        if (randomBoolean()) {
+            builder.put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.getKey(), ".");
+        }
+        if (randomBoolean()) {
+            builder.put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.getKey(), ".");
+        }
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(builder.build(), clusterSettings);
         IllegalArgumentException ex = assertThrows(
             IllegalArgumentException.class,
             () -> new RemoteIndexPath(
@@ -132,7 +225,8 @@ public class RemoteIndexPathTests extends OpenSearchTestCase {
                 new BlobPath().add("djsd878ndjh").add("hcs87cj8"),
                 PathType.HASHED_PREFIX,
                 PathHashAlgorithm.FNV_1A_BASE64,
-                Map.of(TRANSLOG, List.of(LOCK_FILES))
+                Map.of(TRANSLOG, List.of(LOCK_FILES)),
+                remoteStoreSettings
             )
         );
         assertEquals("pathCreationMap={TRANSLOG=[LOCK_FILES]} is having illegal combination of category and type", ex.getMessage());

--- a/server/src/test/java/org/opensearch/index/remote/RemoteIndexPathUploaderTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteIndexPathUploaderTests.java
@@ -25,6 +25,7 @@ import org.opensearch.gateway.remote.RemoteClusterStateService;
 import org.opensearch.gateway.remote.RemoteStateTransferException;
 import org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm;
 import org.opensearch.index.remote.RemoteStoreEnums.PathType;
+import org.opensearch.indices.DefaultRemoteStoreSettings;
 import org.opensearch.node.Node;
 import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
 import org.opensearch.repositories.RepositoriesService;
@@ -131,7 +132,8 @@ public class RemoteIndexPathUploaderTests extends OpenSearchTestCase {
             threadPool,
             settings,
             () -> repositoriesService,
-            clusterSettings
+            clusterSettings,
+            DefaultRemoteStoreSettings.INSTANCE
         );
         List<IndexMetadata> indexMetadataList = Mockito.<List>mock(List.class);
         ActionListener<Void> actionListener = ActionListener.wrap(
@@ -149,7 +151,8 @@ public class RemoteIndexPathUploaderTests extends OpenSearchTestCase {
             threadPool,
             settings,
             () -> repositoriesService,
-            clusterSettings
+            clusterSettings,
+            DefaultRemoteStoreSettings.INSTANCE
         );
         remoteIndexPathUploader.start();
         ActionListener<Void> actionListener = ActionListener.wrap(
@@ -166,7 +169,8 @@ public class RemoteIndexPathUploaderTests extends OpenSearchTestCase {
             threadPool,
             settings,
             () -> repositoriesService,
-            clusterSettings
+            clusterSettings,
+            DefaultRemoteStoreSettings.INSTANCE
         );
         remoteIndexPathUploader.start();
         ActionListener<Void> actionListener = ActionListener.wrap(
@@ -228,7 +232,8 @@ public class RemoteIndexPathUploaderTests extends OpenSearchTestCase {
             threadPool,
             settings,
             () -> repositoriesService,
-            clusterSettings
+            clusterSettings,
+            DefaultRemoteStoreSettings.INSTANCE
         );
         remoteIndexPathUploader.start();
         ActionListener<Void> actionListener = ActionListener.wrap(
@@ -251,7 +256,8 @@ public class RemoteIndexPathUploaderTests extends OpenSearchTestCase {
             threadPool,
             settings,
             () -> repositoriesService,
-            clusterSettings
+            clusterSettings,
+            DefaultRemoteStoreSettings.INSTANCE
         );
         remoteIndexPathUploader.start();
         ActionListener<Void> actionListener = ActionListener.wrap(
@@ -271,7 +277,8 @@ public class RemoteIndexPathUploaderTests extends OpenSearchTestCase {
             threadPool,
             settings,
             () -> repositoriesService,
-            clusterSettings
+            clusterSettings,
+            DefaultRemoteStoreSettings.INSTANCE
         );
         remoteIndexPathUploader.start();
 
@@ -302,7 +309,8 @@ public class RemoteIndexPathUploaderTests extends OpenSearchTestCase {
             threadPool,
             settings,
             () -> repositoriesService,
-            clusterSettings
+            clusterSettings,
+            DefaultRemoteStoreSettings.INSTANCE
         );
         remoteIndexPathUploader.start();
         Settings settings = Settings.builder()

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreCustomMetadataResolverTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreCustomMetadataResolverTests.java
@@ -220,4 +220,50 @@ public class RemoteStoreCustomMetadataResolverTests extends OpenSearchTestCase {
         assertFalse(resolver.isTranslogMetadataEnabled());
     }
 
+    public void testTranslogPathFixedPathSetting() {
+
+        // Default settings
+        Settings settings = Settings.builder().build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(settings, clusterSettings);
+        assertEquals("", remoteStoreSettings.getTranslogPathFixedPrefix());
+
+        // Any other random value
+        String randomPrefix = randomAlphaOfLengthBetween(2, 5);
+        settings = Settings.builder().put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.getKey(), randomPrefix).build();
+        remoteStoreSettings = new RemoteStoreSettings(settings, clusterSettings);
+        assertEquals(randomPrefix, remoteStoreSettings.getTranslogPathFixedPrefix());
+
+        // Set any other random value, the setting still points to the old value
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.getKey(), randomAlphaOfLengthBetween(2, 5))
+                .build()
+        );
+        assertEquals(randomPrefix, remoteStoreSettings.getTranslogPathFixedPrefix());
+    }
+
+    public void testSegmentsPathFixedPathSetting() {
+
+        // Default settings
+        Settings settings = Settings.builder().build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(settings, clusterSettings);
+        assertEquals("", remoteStoreSettings.getSegmentsPathFixedPrefix());
+
+        // Any other random value
+        String randomPrefix = randomAlphaOfLengthBetween(2, 5);
+        settings = Settings.builder().put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.getKey(), randomPrefix).build();
+        remoteStoreSettings = new RemoteStoreSettings(settings, clusterSettings);
+        assertEquals(randomPrefix, remoteStoreSettings.getSegmentsPathFixedPrefix());
+
+        // Set any other random value, the setting still points to the old value
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.getKey(), randomAlphaOfLengthBetween(2, 5))
+                .build()
+        );
+        assertEquals(randomPrefix, remoteStoreSettings.getSegmentsPathFixedPrefix());
+
+    }
 }

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreEnumsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreEnumsTests.java
@@ -142,6 +142,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
         String shardId = String.valueOf(randomInt(100));
         DataCategory dataCategory = TRANSLOG;
         DataType dataType = DATA;
+        String fixedPrefix = ".";
 
         String basePath = getPath(pathList) + indexUUID + SEPARATOR + shardId;
         // Translog Data
@@ -151,11 +152,20 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         BlobPath result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertTrue(
             result.buildAsString()
-                .startsWith(String.join(SEPARATOR, FNV_1A_BASE64.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+                .startsWith(
+                    String.join(
+                        SEPARATOR,
+                        fixedPrefix + FNV_1A_BASE64.hash(pathInput),
+                        basePath,
+                        dataCategory.getName(),
+                        dataType.getName()
+                    )
+                )
         );
 
         // assert with exact value for known base path
@@ -168,9 +178,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
-        assertEquals("DgSI70IciXs/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/data/", result.buildAsString());
+        assertEquals(".DgSI70IciXs/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/data/", result.buildAsString());
 
         // Translog Metadata
         dataType = METADATA;
@@ -180,11 +191,20 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertTrue(
             result.buildAsString()
-                .startsWith(String.join(SEPARATOR, FNV_1A_BASE64.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+                .startsWith(
+                    String.join(
+                        SEPARATOR,
+                        fixedPrefix + FNV_1A_BASE64.hash(pathInput),
+                        basePath,
+                        dataCategory.getName(),
+                        dataType.getName()
+                    )
+                )
         );
 
         // assert with exact value for known base path
@@ -194,9 +214,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
-        assertEquals("oKU5SjILiy4/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/metadata/", result.buildAsString());
+        assertEquals(".oKU5SjILiy4/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/metadata/", result.buildAsString());
 
         // Segment Data
         dataCategory = SEGMENTS;
@@ -207,11 +228,20 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertTrue(
             result.buildAsString()
-                .startsWith(String.join(SEPARATOR, FNV_1A_BASE64.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+                .startsWith(
+                    String.join(
+                        SEPARATOR,
+                        fixedPrefix + FNV_1A_BASE64.hash(pathInput),
+                        basePath,
+                        dataCategory.getName(),
+                        dataType.getName()
+                    )
+                )
         );
 
         // assert with exact value for known base path
@@ -221,9 +251,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
-        assertEquals("AUBRfCIuWdk/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/data/", result.buildAsString());
+        assertEquals(".AUBRfCIuWdk/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/data/", result.buildAsString());
 
         // Segment Metadata
         dataType = METADATA;
@@ -233,11 +264,20 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertTrue(
             result.buildAsString()
-                .startsWith(String.join(SEPARATOR, FNV_1A_BASE64.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+                .startsWith(
+                    String.join(
+                        SEPARATOR,
+                        fixedPrefix + FNV_1A_BASE64.hash(pathInput),
+                        basePath,
+                        dataCategory.getName(),
+                        dataType.getName()
+                    )
+                )
         );
 
         // assert with exact value for known base path
@@ -247,9 +287,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
-        assertEquals("erwR-G735Uw/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/metadata/", result.buildAsString());
+        assertEquals(".erwR-G735Uw/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/metadata/", result.buildAsString());
 
         // Segment Lockfiles
         dataType = LOCK_FILES;
@@ -259,11 +300,20 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
         assertTrue(
             result.buildAsString()
-                .startsWith(String.join(SEPARATOR, FNV_1A_BASE64.hash(pathInput), basePath, dataCategory.getName(), dataType.getName()))
+                .startsWith(
+                    String.join(
+                        SEPARATOR,
+                        fixedPrefix + FNV_1A_BASE64.hash(pathInput),
+                        basePath,
+                        dataCategory.getName(),
+                        dataType.getName()
+                    )
+                )
         );
 
         // assert with exact value for known base path
@@ -273,12 +323,14 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
-        assertEquals("KeYDIk0mJXI/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/lock_files/", result.buildAsString());
+        assertEquals(".KeYDIk0mJXI/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/lock_files/", result.buildAsString());
     }
 
     public void testGeneratePathForHashedPrefixTypeAndFNVCompositeHashAlgorithm() {
+        String fixedPrefix = ".";
         BlobPath blobPath = new BlobPath();
         List<String> pathList = getPathList();
         for (String path : pathList) {
@@ -298,12 +350,19 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         BlobPath result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
         assertTrue(
             result.buildAsString()
                 .startsWith(
-                    String.join(SEPARATOR, FNV_1A_COMPOSITE_1.hash(pathInput), basePath, dataCategory.getName(), dataType.getName())
+                    String.join(
+                        SEPARATOR,
+                        fixedPrefix + FNV_1A_COMPOSITE_1.hash(pathInput),
+                        basePath,
+                        dataCategory.getName(),
+                        dataType.getName()
+                    )
                 )
         );
 
@@ -317,9 +376,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
-        assertEquals("D10000001001000/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/data/", result.buildAsString());
+        assertEquals(".D10000001001000/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/data/", result.buildAsString());
 
         // Translog Metadata
         dataType = METADATA;
@@ -329,12 +389,19 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
         assertTrue(
             result.buildAsString()
                 .startsWith(
-                    String.join(SEPARATOR, FNV_1A_COMPOSITE_1.hash(pathInput), basePath, dataCategory.getName(), dataType.getName())
+                    String.join(
+                        SEPARATOR,
+                        fixedPrefix + FNV_1A_COMPOSITE_1.hash(pathInput),
+                        basePath,
+                        dataCategory.getName(),
+                        dataType.getName()
+                    )
                 )
         );
 
@@ -345,10 +412,11 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
         assertEquals(
-            "o00101001010011/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/metadata/",
+            ".o00101001010011/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/translog/metadata/",
             result.buildAsString()
         );
 
@@ -361,12 +429,19 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
         assertTrue(
             result.buildAsString()
                 .startsWith(
-                    String.join(SEPARATOR, FNV_1A_COMPOSITE_1.hash(pathInput), basePath, dataCategory.getName(), dataType.getName())
+                    String.join(
+                        SEPARATOR,
+                        fixedPrefix + FNV_1A_COMPOSITE_1.hash(pathInput),
+                        basePath,
+                        dataCategory.getName(),
+                        dataType.getName()
+                    )
                 )
         );
 
@@ -377,9 +452,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
-        assertEquals("A01010000000101/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/data/", result.buildAsString());
+        assertEquals(".A01010000000101/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/data/", result.buildAsString());
 
         // Segment Metadata
         dataType = METADATA;
@@ -389,12 +465,19 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
         assertTrue(
             result.buildAsString()
                 .startsWith(
-                    String.join(SEPARATOR, FNV_1A_COMPOSITE_1.hash(pathInput), basePath, dataCategory.getName(), dataType.getName())
+                    String.join(
+                        SEPARATOR,
+                        fixedPrefix + FNV_1A_COMPOSITE_1.hash(pathInput),
+                        basePath,
+                        dataCategory.getName(),
+                        dataType.getName()
+                    )
                 )
         );
 
@@ -405,10 +488,11 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
         assertEquals(
-            "e10101111000001/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/metadata/",
+            ".e10101111000001/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/metadata/",
             result.buildAsString()
         );
 
@@ -420,12 +504,19 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
         assertTrue(
             result.buildAsString()
                 .startsWith(
-                    String.join(SEPARATOR, FNV_1A_COMPOSITE_1.hash(pathInput), basePath, dataCategory.getName(), dataType.getName())
+                    String.join(
+                        SEPARATOR,
+                        fixedPrefix + FNV_1A_COMPOSITE_1.hash(pathInput),
+                        basePath,
+                        dataCategory.getName(),
+                        dataType.getName()
+                    )
                 )
         );
 
@@ -436,10 +527,11 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
         assertEquals(
-            "K01111001100000/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/lock_files/",
+            ".K01111001100000/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/k2ijhe877d7yuhx7/10/segments/lock_files/",
             result.buildAsString()
         );
     }
@@ -455,6 +547,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
         String shardId = String.valueOf(randomInt(100));
         DataCategory dataCategory = TRANSLOG;
         DataType dataType = DATA;
+        String fixedPrefix = ".";
 
         String basePath = getPath(pathList);
         basePath = basePath.isEmpty() ? basePath : basePath.substring(0, basePath.length() - 1);
@@ -465,9 +558,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         BlobPath result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
-        String expected = derivePath(basePath, pathInput);
+        String expected = derivePath(basePath, pathInput, fixedPrefix);
         String actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
 
@@ -481,9 +575,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
-        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/DgSI70IciXs/k2ijhe877d7yuhx7/10/translog/data/";
+        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/.DgSI70IciXs/k2ijhe877d7yuhx7/10/translog/data/";
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
 
@@ -495,10 +590,11 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
 
         result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
-        expected = derivePath(basePath, pathInput);
+        expected = derivePath(basePath, pathInput, fixedPrefix);
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
 
@@ -509,9 +605,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
-        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/oKU5SjILiy4/k2ijhe877d7yuhx7/10/translog/metadata/";
+        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/.oKU5SjILiy4/k2ijhe877d7yuhx7/10/translog/metadata/";
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
 
@@ -524,9 +621,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
-        expected = derivePath(basePath, pathInput);
+        expected = derivePath(basePath, pathInput, fixedPrefix);
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
 
@@ -537,9 +635,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
-        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/AUBRfCIuWdk/k2ijhe877d7yuhx7/10/segments/data/";
+        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/.AUBRfCIuWdk/k2ijhe877d7yuhx7/10/segments/data/";
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
 
@@ -551,9 +650,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
-        expected = derivePath(basePath, pathInput);
+        expected = derivePath(basePath, pathInput, fixedPrefix);
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
 
@@ -564,9 +664,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
-        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/erwR-G735Uw/k2ijhe877d7yuhx7/10/segments/metadata/";
+        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/.erwR-G735Uw/k2ijhe877d7yuhx7/10/segments/metadata/";
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
 
@@ -578,9 +679,10 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
-        expected = derivePath(basePath, pathInput);
+        expected = derivePath(basePath, pathInput, fixedPrefix);
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
 
@@ -591,14 +693,16 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .shardId(fixedShardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
-        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/KeYDIk0mJXI/k2ijhe877d7yuhx7/10/segments/lock_files/";
+        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/.KeYDIk0mJXI/k2ijhe877d7yuhx7/10/segments/lock_files/";
         actual = result.buildAsString();
         assertTrue(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual.startsWith(expected));
     }
 
     public void testGeneratePathForSnapshotShardPathInput() {
+        String fixedPrefix = "snap";
         BlobPath blobPath = BlobPath.cleanPath().add("xjsdhj").add("ddjsha").add("yudy7sd").add("32hdhua7").add("89jdij");
         String indexUUID = "dsdkjsu8832njn";
         String shardId = "10";
@@ -606,6 +710,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             .basePath(blobPath)
             .indexUUID(indexUUID)
             .shardId(shardId)
+            .fixedPrefix(fixedPrefix)
             .build();
 
         // FIXED PATH
@@ -616,34 +721,34 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
 
         // HASHED_PREFIX - FNV_1A_COMPOSITE_1
         result = HASHED_PREFIX.path(pathInput, FNV_1A_COMPOSITE_1);
-        expected = "_11001000010110/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/indices/dsdkjsu8832njn/10/";
+        expected = "snap_11001000010110/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/indices/dsdkjsu8832njn/10/";
         actual = result.buildAsString();
         assertEquals(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual, expected);
 
         // HASHED_PREFIX - FNV_1A_BASE64
         result = HASHED_PREFIX.path(pathInput, FNV_1A_BASE64);
-        expected = "_yFiSl_VGGM/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/indices/dsdkjsu8832njn/10/";
+        expected = "snap_yFiSl_VGGM/xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/indices/dsdkjsu8832njn/10/";
         actual = result.buildAsString();
         assertEquals(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual, expected);
 
         // HASHED_INFIX - FNV_1A_COMPOSITE_1
         result = HASHED_INFIX.path(pathInput, FNV_1A_COMPOSITE_1);
-        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/_11001000010110/indices/dsdkjsu8832njn/10/";
+        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/snap_11001000010110/indices/dsdkjsu8832njn/10/";
         actual = result.buildAsString();
         assertEquals(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual, expected);
 
         // HASHED_INFIX - FNV_1A_BASE64
         result = HASHED_INFIX.path(pathInput, FNV_1A_BASE64);
-        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/_yFiSl_VGGM/indices/dsdkjsu8832njn/10/";
+        expected = "xjsdhj/ddjsha/yudy7sd/32hdhua7/89jdij/snap_yFiSl_VGGM/indices/dsdkjsu8832njn/10/";
         actual = result.buildAsString();
         assertEquals(new ParameterizedMessage("expected={} actual={}", expected, actual).getFormattedMessage(), actual, expected);
     }
 
-    private String derivePath(String basePath, PathInput pathInput) {
+    private String derivePath(String basePath, PathInput pathInput, String fixedPrefix) {
         return "".equals(basePath)
             ? String.join(
                 SEPARATOR,
-                FNV_1A_BASE64.hash(pathInput),
+                fixedPrefix + FNV_1A_BASE64.hash(pathInput),
                 pathInput.indexUUID(),
                 pathInput.shardId(),
                 pathInput.dataCategory().getName(),
@@ -652,7 +757,7 @@ public class RemoteStoreEnumsTests extends OpenSearchTestCase {
             : String.join(
                 SEPARATOR,
                 basePath,
-                FNV_1A_BASE64.hash(pathInput),
+                fixedPrefix + FNV_1A_BASE64.hash(pathInput),
                 pathInput.indexUUID(),
                 pathInput.shardId(),
                 pathInput.dataCategory().getName(),

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactoryTests.java
@@ -57,7 +57,7 @@ public class RemoteSegmentStoreDirectoryFactoryTests extends OpenSearchTestCase 
         repositoriesService = mock(RepositoriesService.class);
         threadPool = mock(ThreadPool.class);
         when(repositoriesServiceSupplier.get()).thenReturn(repositoriesService);
-        remoteSegmentStoreDirectoryFactory = new RemoteSegmentStoreDirectoryFactory(repositoriesServiceSupplier, threadPool);
+        remoteSegmentStoreDirectoryFactory = new RemoteSegmentStoreDirectoryFactory(repositoriesServiceSupplier, threadPool, "");
     }
 
     public void testNewDirectory() throws IOException {

--- a/server/src/test/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerFactoryTests.java
@@ -42,7 +42,7 @@ public class RemoteStoreLockManagerFactoryTests extends OpenSearchTestCase {
         repositoriesServiceSupplier = mock(Supplier.class);
         repositoriesService = mock(RepositoriesService.class);
         when(repositoriesServiceSupplier.get()).thenReturn(repositoriesService);
-        remoteStoreLockManagerFactory = new RemoteStoreLockManagerFactory(repositoriesServiceSupplier);
+        remoteStoreLockManagerFactory = new RemoteStoreLockManagerFactory(repositoriesServiceSupplier, "");
     }
 
     public void testNewLockManager() throws IOException {

--- a/server/src/test/java/org/opensearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/opensearch/repositories/RepositoriesServiceTests.java
@@ -62,6 +62,7 @@ import org.opensearch.common.crypto.MasterKeyProvider;
 import org.opensearch.common.io.InputStreamContainer;
 import org.opensearch.common.lifecycle.Lifecycle;
 import org.opensearch.common.lifecycle.LifecycleListener;
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
@@ -147,6 +148,10 @@ public class RepositoriesServiceTests extends OpenSearchTestCase {
         ClusterState currentClusterState = mock(ClusterState.class);
         when(currentClusterState.getNodes()).thenReturn(nodes);
         when(clusterService.state()).thenReturn(currentClusterState);
+
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
         RepositoriesService repositoriesService = new RepositoriesService(
             Settings.EMPTY,

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryHelperTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryHelperTests.java
@@ -23,6 +23,7 @@ import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.store.RemoteBufferedOutputDirectory;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.plugins.Plugin;
@@ -59,13 +60,16 @@ public class BlobStoreRepositoryHelperTests extends OpenSearchSingleNodeTestCase
     protected String[] getLockFilesInRemoteStore(String remoteStoreIndex, String remoteStoreRepository) throws IOException {
         final RepositoriesService repositoriesService = getInstanceFromNode(RepositoriesService.class);
         final BlobStoreRepository remoteStorerepository = (BlobStoreRepository) repositoriesService.repository(remoteStoreRepository);
+        ClusterService clusterService = getInstanceFromNode(ClusterService.class);
+        String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(clusterService.getSettings());
         BlobPath shardLevelBlobPath = getShardLevelBlobPath(
             client(),
             remoteStoreIndex,
             remoteStorerepository.basePath(),
             "0",
             SEGMENTS,
-            LOCK_FILES
+            LOCK_FILES,
+            segmentsPathFixedPrefix
         );
         BlobContainer blobContainer = remoteStorerepository.blobStore().blobContainer(shardLevelBlobPath);
         try (RemoteBufferedOutputDirectory lockDirectory = new RemoteBufferedOutputDirectory(blobContainer)) {

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -2013,7 +2013,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     repositoriesService,
                     transportService,
                     actionFilters,
-                    null
+                    null,
+                    DefaultRemoteStoreSettings.INSTANCE
                 );
                 nodeEnv = new NodeEnvironment(settings, environment);
                 final NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(Collections.emptyList());
@@ -2070,7 +2071,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     emptyMap(),
                     null,
                     emptyMap(),
-                    new RemoteSegmentStoreDirectoryFactory(() -> repositoriesService, threadPool),
+                    new RemoteSegmentStoreDirectoryFactory(() -> repositoriesService, threadPool, ""),
                     repositoriesServiceReference::get,
                     null,
                     new RemoteStoreStatsTrackerFactory(clusterService, settings),
@@ -2367,7 +2368,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         snapshotsService,
                         threadPool,
                         actionFilters,
-                        indexNameExpressionResolver
+                        indexNameExpressionResolver,
+                        DefaultRemoteStoreSettings.INSTANCE
                     )
                 );
                 actions.put(

--- a/test/framework/src/main/java/org/opensearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/test/framework/src/main/java/org/opensearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -51,6 +51,8 @@ import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.blobstore.BlobStore;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.core.common.Strings;
@@ -463,6 +465,9 @@ public final class BlobStoreTestUtil {
             return null;
         }).when(clusterService).addStateApplier(any(ClusterStateApplier.class));
         when(clusterApplierService.threadPool()).thenReturn(threadPool);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         return clusterService;
     }
 

--- a/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -66,6 +66,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.store.RemoteBufferedOutputDirectory;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.node.NodeClosedException;
 import org.opensearch.plugins.Plugin;
@@ -554,13 +555,15 @@ public abstract class AbstractSnapshotIntegTestCase extends OpenSearchIntegTestC
     protected String[] getLockFilesInRemoteStore(String remoteStoreIndex, String remoteStoreRepositoryName) throws IOException {
         final RepositoriesService repositoriesService = internalCluster().getCurrentClusterManagerNodeInstance(RepositoriesService.class);
         final BlobStoreRepository remoteStoreRepository = (BlobStoreRepository) repositoriesService.repository(remoteStoreRepositoryName);
+        String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
         BlobPath shardLevelBlobPath = getShardLevelBlobPath(
             client(),
             remoteStoreIndex,
             remoteStoreRepository.basePath(),
             "0",
             SEGMENTS,
-            LOCK_FILES
+            LOCK_FILES,
+            segmentsPathFixedPrefix
         );
         BlobContainer blobContainer = remoteStoreRepository.blobStore().blobContainer(shardLevelBlobPath);
         try (RemoteBufferedOutputDirectory lockDirectory = new RemoteBufferedOutputDirectory(blobContainer)) {

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -404,9 +404,15 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
 
     private static Boolean prefixModeVerificationEnable;
 
+    private static Boolean translogPathFixedPrefix;
+
+    private static Boolean segmentsPathFixedPrefix;
+
     @BeforeClass
     public static void beforeClass() throws Exception {
         prefixModeVerificationEnable = randomBoolean();
+        translogPathFixedPrefix = randomBoolean();
+        segmentsPathFixedPrefix = randomBoolean();
         testClusterRule.beforeClass();
     }
 
@@ -2604,6 +2610,12 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         putRepository(clusterAdmin(), repoName, type, null, settings);
     }
 
+    public Settings getNodeSettings() {
+        InternalTestCluster internalTestCluster = internalCluster();
+        ClusterService clusterService = internalTestCluster.getInstance(ClusterService.class, internalTestCluster.getClusterManagerName());
+        return clusterService.getSettings();
+    }
+
     public static void putRepository(ClusterAdminClient adminClient, String repoName, String type, Settings.Builder settings) {
         assertAcked(putRepositoryRequestBuilder(adminClient, repoName, type, true, settings, null, false));
     }
@@ -2906,6 +2918,8 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         settings.put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), randomFrom(PathType.values()));
         settings.put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_METADATA.getKey(), randomBoolean());
         settings.put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), false);
+        settings.put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.getKey(), translogPathFixedPrefix ? "a" : "");
+        settings.put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.getKey(), segmentsPathFixedPrefix ? "b" : "");
         return settings.build();
     }
 

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchTestCase.java
@@ -1817,7 +1817,8 @@ public abstract class OpenSearchTestCase extends LuceneTestCase {
         BlobPath basePath,
         String shardId,
         RemoteStoreEnums.DataCategory dataCategory,
-        RemoteStoreEnums.DataType dataType
+        RemoteStoreEnums.DataType dataType,
+        String fixedPrefix
     ) {
         String indexUUID = client.admin()
             .indices()
@@ -1842,6 +1843,7 @@ public abstract class OpenSearchTestCase extends LuceneTestCase {
             .shardId(shardId)
             .dataCategory(dataCategory)
             .dataType(dataType)
+            .fixedPrefix(fixedPrefix)
             .build();
         return type.path(pathInput, hashAlgorithm);
     }


### PR DESCRIPTION
Backport https://github.com/opensearch-project/OpenSearch/commit/33be5a9d161e496517842ded0bc4b04ecca674ff from https://github.com/opensearch-project/OpenSearch/pull/15557