### PR TITLE
[Backport 2.17] Schedule reroute after allocator timed out (#15565)

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterModule.java
@@ -52,6 +52,7 @@ import org.opensearch.cluster.metadata.QueryGroupMetadata;
 import org.opensearch.cluster.metadata.RepositoriesMetadata;
 import org.opensearch.cluster.metadata.WeightedRoutingMetadata;
 import org.opensearch.cluster.routing.DelayedAllocationService;
+import org.opensearch.cluster.routing.RerouteService;
 import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
@@ -471,4 +472,7 @@ public class ClusterModule extends AbstractModule {
         allocationService.setExistingShardsAllocators(existingShardsAllocators);
     }
 
+    public void setRerouteServiceForAllocator(RerouteService rerouteService) {
+        shardsAllocator.setRerouteService(rerouteService);
+    }
 }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/ShardsAllocator.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/ShardsAllocator.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.cluster.routing.allocation.allocator;
 
+import org.opensearch.cluster.routing.RerouteService;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.allocation.AllocateUnassignedDecision;
 import org.opensearch.cluster.routing.allocation.MoveDecision;
@@ -73,4 +74,6 @@ public interface ShardsAllocator {
      * the cluster explain API, then this method should throw a {@code UnsupportedOperationException}.
      */
     ShardAllocationDecision decideShardAllocation(ShardRouting shard, RoutingAllocation allocation);
+
+    default void setRerouteService(RerouteService rerouteService) {}
 }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -865,6 +865,7 @@ public class Node implements Closeable {
             final RerouteService rerouteService = new BatchedRerouteService(clusterService, clusterModule.getAllocationService()::reroute);
             rerouteServiceReference.set(rerouteService);
             clusterService.setRerouteService(rerouteService);
+            clusterModule.setRerouteServiceForAllocator(rerouteService);
 
             final RecoverySettings recoverySettings = new RecoverySettings(settings, settingsModule.getClusterSettings());
 

--- a/server/src/test/java/org/opensearch/cluster/ClusterModuleTests.java
+++ b/server/src/test/java/org/opensearch/cluster/ClusterModuleTests.java
@@ -337,6 +337,19 @@ public class ClusterModuleTests extends ModuleTestCase {
         );
     }
 
+    public void testRerouteServiceSetForBalancedShardsAllocator() {
+        ClusterModule clusterModule = new ClusterModule(
+            Settings.EMPTY,
+            clusterService,
+            Collections.emptyList(),
+            clusterInfoService,
+            null,
+            threadContext,
+            new ClusterManagerMetrics(NoopMetricsRegistry.INSTANCE)
+        );
+        clusterModule.setRerouteServiceForAllocator((reason, priority, listener) -> listener.onResponse(clusterService.state()));
+    }
+
     private static ClusterPlugin existingShardsAllocatorPlugin(final String allocatorName) {
         return new ClusterPlugin() {
             @Override

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/allocator/TimeBoundBalancedShardsAllocatorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/allocator/TimeBoundBalancedShardsAllocatorTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.cluster.routing.allocation.allocator;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterInfo;
 import org.opensearch.cluster.ClusterName;
@@ -17,6 +18,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.RerouteService;
 import org.opensearch.cluster.routing.RoutingNodes;
 import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
@@ -26,14 +28,20 @@ import org.opensearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.opensearch.cluster.routing.allocation.decider.Decision;
 import org.opensearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Priority;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.test.ClusterServiceUtils;
+import org.opensearch.threadpool.TestThreadPool;
+import org.junit.After;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.opensearch.cluster.routing.ShardRoutingState.INITIALIZING;
 import static org.opensearch.cluster.routing.ShardRoutingState.STARTED;
@@ -41,26 +49,49 @@ import static org.opensearch.cluster.routing.allocation.allocator.BalancedShards
 
 public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationTestCase {
 
+    private TestThreadPool threadPool;
+    private ClusterService clusterService;
+    private ClusterState state;
+
     private final DiscoveryNode node1 = newNode("node1", "node1", Collections.singletonMap("zone", "1a"));
     private final DiscoveryNode node2 = newNode("node2", "node2", Collections.singletonMap("zone", "1b"));
     private final DiscoveryNode node3 = newNode("node3", "node3", Collections.singletonMap("zone", "1c"));
 
-    public void testAllUnassignedShardsAllocatedWhenNoTimeOut() {
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        if (threadPool != null) {
+            final boolean terminated = terminate(threadPool);
+            assert terminated;
+        }
+        if (clusterService != null) {
+            clusterService.close();
+        }
+    }
+
+    public void setupStateAndService(Metadata metadata, RoutingTable routingTable) {
+        state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .routingTable(routingTable)
+            .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
+            .build();
+        threadPool = new TestThreadPool(getTestName());
+        clusterService = ClusterServiceUtils.createClusterService(state, threadPool);
+    }
+
+    public void testAllUnassignedShardsAllocatedWhenNoTimeOutAndRerouteNotScheduled() {
         int numberOfIndices = 2;
         int numberOfShards = 5;
         int numberOfReplicas = 1;
         int totalPrimaryCount = numberOfIndices * numberOfShards;
         int totalShardCount = numberOfIndices * (numberOfShards * (numberOfReplicas + 1));
         Settings.Builder settings = Settings.builder();
-        // passing total shard count for timed out latch such that no shard times out
-        BalancedShardsAllocator allocator = new TestBalancedShardsAllocator(settings.build(), new CountDownLatch(totalShardCount));
+        // passing sufficiently high count for timeout latch to simulate no time out
+        BalancedShardsAllocator allocator = new TestBalancedShardsAllocator(settings.build(), new CountDownLatch(Integer.MAX_VALUE));
         Metadata metadata = buildMetadata(Metadata.builder(), numberOfIndices, numberOfShards, numberOfReplicas);
         RoutingTable routingTable = buildRoutingTable(metadata);
-        ClusterState state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .metadata(metadata)
-            .routingTable(routingTable)
-            .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
-            .build();
+        setupStateAndService(metadata, routingTable);
         RoutingAllocation allocation = new RoutingAllocation(
             yesAllocationDeciders(),
             new RoutingNodes(state, false),
@@ -69,6 +100,18 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
             null,
             System.nanoTime()
         );
+        AtomicBoolean rerouteScheduled = new AtomicBoolean(false);
+        final RerouteService rerouteService = (reason, priority, listener) -> {
+            if (randomBoolean()) {
+                listener.onFailure(new OpenSearchException("simulated"));
+            } else {
+                listener.onResponse(clusterService.state());
+            }
+            assertEquals("reroute after balanced shards allocator timed out", reason);
+            assertEquals(Priority.HIGH, priority);
+            rerouteScheduled.compareAndSet(false, true);
+        };
+        allocator.setRerouteService(rerouteService);
         allocator.allocate(allocation);
         List<ShardRouting> initializingShards = allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING);
         int node1Recoveries = allocation.routingNodes().getInitialPrimariesIncomingRecoveries(node1.getId());
@@ -77,9 +120,10 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
         assertEquals(totalShardCount, initializingShards.size());
         assertEquals(0, allocation.routingNodes().unassigned().ignored().size());
         assertEquals(totalPrimaryCount, node1Recoveries + node2Recoveries + node3Recoveries);
+        assertFalse(rerouteScheduled.get());
     }
 
-    public void testAllUnassignedShardsIgnoredWhenTimedOut() {
+    public void testAllUnassignedShardsIgnoredWhenTimedOutAndRerouteScheduled() {
         int numberOfIndices = 2;
         int numberOfShards = 5;
         int numberOfReplicas = 1;
@@ -89,11 +133,7 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
         BalancedShardsAllocator allocator = new TestBalancedShardsAllocator(settings.build(), new CountDownLatch(0));
         Metadata metadata = buildMetadata(Metadata.builder(), numberOfIndices, numberOfShards, numberOfReplicas);
         RoutingTable routingTable = buildRoutingTable(metadata);
-        ClusterState state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .metadata(metadata)
-            .routingTable(routingTable)
-            .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
-            .build();
+        setupStateAndService(metadata, routingTable);
         RoutingAllocation allocation = new RoutingAllocation(
             yesAllocationDeciders(),
             new RoutingNodes(state, false),
@@ -102,6 +142,18 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
             null,
             System.nanoTime()
         );
+        AtomicBoolean rerouteScheduled = new AtomicBoolean(false);
+        final RerouteService rerouteService = (reason, priority, listener) -> {
+            if (randomBoolean()) {
+                listener.onFailure(new OpenSearchException("simulated"));
+            } else {
+                listener.onResponse(clusterService.state());
+            }
+            assertEquals("reroute after balanced shards allocator timed out", reason);
+            assertEquals(Priority.HIGH, priority);
+            rerouteScheduled.compareAndSet(false, true);
+        };
+        allocator.setRerouteService(rerouteService);
         allocator.allocate(allocation);
         List<ShardRouting> initializingShards = allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING);
         int node1Recoveries = allocation.routingNodes().getInitialPrimariesIncomingRecoveries(node1.getId());
@@ -110,9 +162,10 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
         assertEquals(0, initializingShards.size());
         assertEquals(totalShardCount, allocation.routingNodes().unassigned().ignored().size());
         assertEquals(0, node1Recoveries + node2Recoveries + node3Recoveries);
+        assertTrue(rerouteScheduled.get());
     }
 
-    public void testAllocatePartialPrimaryShardsUntilTimedOut() {
+    public void testAllocatePartialPrimaryShardsUntilTimedOutAndRerouteScheduled() {
         int numberOfIndices = 2;
         int numberOfShards = 5;
         int numberOfReplicas = 1;
@@ -123,11 +176,7 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
         BalancedShardsAllocator allocator = new TestBalancedShardsAllocator(settings.build(), new CountDownLatch(shardsToAllocate));
         Metadata metadata = buildMetadata(Metadata.builder(), numberOfIndices, numberOfShards, numberOfReplicas);
         RoutingTable routingTable = buildRoutingTable(metadata);
-        ClusterState state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .metadata(metadata)
-            .routingTable(routingTable)
-            .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
-            .build();
+        setupStateAndService(metadata, routingTable);
         RoutingAllocation allocation = new RoutingAllocation(
             yesAllocationDeciders(),
             new RoutingNodes(state, false),
@@ -136,6 +185,18 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
             null,
             System.nanoTime()
         );
+        AtomicBoolean rerouteScheduled = new AtomicBoolean(false);
+        final RerouteService rerouteService = (reason, priority, listener) -> {
+            if (randomBoolean()) {
+                listener.onFailure(new OpenSearchException("simulated"));
+            } else {
+                listener.onResponse(clusterService.state());
+            }
+            assertEquals("reroute after balanced shards allocator timed out", reason);
+            assertEquals(Priority.HIGH, priority);
+            rerouteScheduled.compareAndSet(false, true);
+        };
+        allocator.setRerouteService(rerouteService);
         allocator.allocate(allocation);
         List<ShardRouting> initializingShards = allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING);
         int node1Recoveries = allocation.routingNodes().getInitialPrimariesIncomingRecoveries(node1.getId());
@@ -144,9 +205,10 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
         assertEquals(shardsToAllocate, initializingShards.size());
         assertEquals(totalShardCount - shardsToAllocate, allocation.routingNodes().unassigned().ignored().size());
         assertEquals(shardsToAllocate, node1Recoveries + node2Recoveries + node3Recoveries);
+        assertTrue(rerouteScheduled.get());
     }
 
-    public void testAllocateAllPrimaryShardsAndPartialReplicaShardsUntilTimedOut() {
+    public void testAllocateAllPrimaryShardsAndPartialReplicaShardsUntilTimedOutAndRerouteScheduled() {
         int numberOfIndices = 2;
         int numberOfShards = 5;
         int numberOfReplicas = 1;
@@ -158,11 +220,7 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
         BalancedShardsAllocator allocator = new TestBalancedShardsAllocator(settings.build(), new CountDownLatch(shardsToAllocate));
         Metadata metadata = buildMetadata(Metadata.builder(), numberOfIndices, numberOfShards, numberOfReplicas);
         RoutingTable routingTable = buildRoutingTable(metadata);
-        ClusterState state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .metadata(metadata)
-            .routingTable(routingTable)
-            .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
-            .build();
+        setupStateAndService(metadata, routingTable);
         RoutingAllocation allocation = new RoutingAllocation(
             yesAllocationDeciders(),
             new RoutingNodes(state, false),
@@ -171,6 +229,18 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
             null,
             System.nanoTime()
         );
+        AtomicBoolean rerouteScheduled = new AtomicBoolean(false);
+        final RerouteService rerouteService = (reason, priority, listener) -> {
+            if (randomBoolean()) {
+                listener.onFailure(new OpenSearchException("simulated"));
+            } else {
+                listener.onResponse(clusterService.state());
+            }
+            assertEquals("reroute after balanced shards allocator timed out", reason);
+            assertEquals(Priority.HIGH, priority);
+            rerouteScheduled.compareAndSet(false, true);
+        };
+        allocator.setRerouteService(rerouteService);
         allocator.allocate(allocation);
         List<ShardRouting> initializingShards = allocation.routingNodes().shardsWithState(ShardRoutingState.INITIALIZING);
         int node1Recoveries = allocation.routingNodes().getInitialPrimariesIncomingRecoveries(node1.getId());
@@ -179,20 +249,17 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
         assertEquals(shardsToAllocate, initializingShards.size());
         assertEquals(totalShardCount - shardsToAllocate, allocation.routingNodes().unassigned().ignored().size());
         assertEquals(numberOfShards * numberOfIndices, node1Recoveries + node2Recoveries + node3Recoveries);
+        assertTrue(rerouteScheduled.get());
     }
 
-    public void testAllShardsMoveWhenExcludedAndTimeoutNotBreached() {
+    public void testAllShardsMoveWhenExcludedAndTimeoutNotBreachedAndRerouteNotScheduled() {
         int numberOfIndices = 3;
         int numberOfShards = 5;
         int numberOfReplicas = 1;
         int totalShardCount = numberOfIndices * (numberOfShards * (numberOfReplicas + 1));
         Metadata metadata = buildMetadata(Metadata.builder(), numberOfIndices, numberOfShards, numberOfReplicas);
         RoutingTable routingTable = buildRoutingTable(metadata);
-        ClusterState state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .metadata(metadata)
-            .routingTable(routingTable)
-            .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
-            .build();
+        setupStateAndService(metadata, routingTable);
         MockAllocationService allocationService = createAllocationService();
         state = applyStartedShardsUntilNoChange(state, allocationService);
         // check all shards allocated
@@ -200,8 +267,7 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
         assertEquals(totalShardCount, state.getRoutingNodes().shardsWithState(STARTED).size());
         int node1ShardCount = state.getRoutingNodes().node("node1").size();
         Settings settings = Settings.builder().put("cluster.routing.allocation.exclude.zone", "1a").build();
-        int shardsToMove = 10 + 1000; // such that time out is never breached
-        BalancedShardsAllocator allocator = new TestBalancedShardsAllocator(settings, new CountDownLatch(shardsToMove));
+        BalancedShardsAllocator allocator = new TestBalancedShardsAllocator(settings, new CountDownLatch(Integer.MAX_VALUE));
         RoutingAllocation allocation = new RoutingAllocation(
             allocationDecidersForExcludeAPI(settings),
             new RoutingNodes(state, false),
@@ -210,30 +276,39 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
             null,
             System.nanoTime()
         );
+        AtomicBoolean rerouteScheduled = new AtomicBoolean(false);
+        final RerouteService rerouteService = (reason, priority, listener) -> {
+            if (randomBoolean()) {
+                listener.onFailure(new OpenSearchException("simulated"));
+            } else {
+                listener.onResponse(clusterService.state());
+            }
+            assertEquals("reroute after balanced shards allocator timed out", reason);
+            assertEquals(Priority.HIGH, priority);
+            rerouteScheduled.compareAndSet(false, true);
+        };
+        allocator.setRerouteService(rerouteService);
         allocator.allocate(allocation);
         List<ShardRouting> relocatingShards = allocation.routingNodes().shardsWithState(ShardRoutingState.RELOCATING);
         assertEquals(node1ShardCount, relocatingShards.size());
+        assertFalse(rerouteScheduled.get());
     }
 
-    public void testNoShardsMoveWhenExcludedAndTimeoutBreached() {
+    public void testNoShardsMoveWhenExcludedAndTimeoutBreachedAndRerouteScheduled() {
         int numberOfIndices = 3;
         int numberOfShards = 5;
         int numberOfReplicas = 1;
         int totalShardCount = numberOfIndices * (numberOfShards * (numberOfReplicas + 1));
         Metadata metadata = buildMetadata(Metadata.builder(), numberOfIndices, numberOfShards, numberOfReplicas);
         RoutingTable routingTable = buildRoutingTable(metadata);
-        ClusterState state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .metadata(metadata)
-            .routingTable(routingTable)
-            .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
-            .build();
+        setupStateAndService(metadata, routingTable);
         MockAllocationService allocationService = createAllocationService();
         state = applyStartedShardsUntilNoChange(state, allocationService);
         // check all shards allocated
         assertEquals(0, state.getRoutingNodes().shardsWithState(INITIALIZING).size());
         assertEquals(totalShardCount, state.getRoutingNodes().shardsWithState(STARTED).size());
         Settings settings = Settings.builder().put("cluster.routing.allocation.exclude.zone", "1a").build();
-        int shardsToMove = 0; // such that time out is never breached
+        int shardsToMove = 0; // such that time out is breached
         BalancedShardsAllocator allocator = new TestBalancedShardsAllocator(settings, new CountDownLatch(shardsToMove));
         RoutingAllocation allocation = new RoutingAllocation(
             allocationDecidersForExcludeAPI(settings),
@@ -243,23 +318,32 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
             null,
             System.nanoTime()
         );
+        AtomicBoolean rerouteScheduled = new AtomicBoolean(false);
+        final RerouteService rerouteService = (reason, priority, listener) -> {
+            if (randomBoolean()) {
+                listener.onFailure(new OpenSearchException("simulated"));
+            } else {
+                listener.onResponse(clusterService.state());
+            }
+            assertEquals("reroute after balanced shards allocator timed out", reason);
+            assertEquals(Priority.HIGH, priority);
+            rerouteScheduled.compareAndSet(false, true);
+        };
+        allocator.setRerouteService(rerouteService);
         allocator.allocate(allocation);
         List<ShardRouting> relocatingShards = allocation.routingNodes().shardsWithState(ShardRoutingState.RELOCATING);
         assertEquals(0, relocatingShards.size());
+        assertTrue(rerouteScheduled.get());
     }
 
-    public void testPartialShardsMoveWhenExcludedAndTimeoutBreached() {
+    public void testPartialShardsMoveWhenExcludedAndTimeoutBreachedAndRerouteScheduled() {
         int numberOfIndices = 3;
         int numberOfShards = 5;
         int numberOfReplicas = 1;
         int totalShardCount = numberOfIndices * (numberOfShards * (numberOfReplicas + 1));
         Metadata metadata = buildMetadata(Metadata.builder(), numberOfIndices, numberOfShards, numberOfReplicas);
         RoutingTable routingTable = buildRoutingTable(metadata);
-        ClusterState state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .metadata(metadata)
-            .routingTable(routingTable)
-            .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
-            .build();
+        setupStateAndService(metadata, routingTable);
         MockAllocationService allocationService = createAllocationService();
         state = applyStartedShardsUntilNoChange(state, allocationService);
         // check all shards allocated
@@ -279,23 +363,32 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
             null,
             System.nanoTime()
         );
+        AtomicBoolean rerouteScheduled = new AtomicBoolean(false);
+        final RerouteService rerouteService = (reason, priority, listener) -> {
+            if (randomBoolean()) {
+                listener.onFailure(new OpenSearchException("simulated"));
+            } else {
+                listener.onResponse(clusterService.state());
+            }
+            assertEquals("reroute after balanced shards allocator timed out", reason);
+            assertEquals(Priority.HIGH, priority);
+            rerouteScheduled.compareAndSet(false, true);
+        };
+        allocator.setRerouteService(rerouteService);
         allocator.allocate(allocation);
         List<ShardRouting> relocatingShards = allocation.routingNodes().shardsWithState(ShardRoutingState.RELOCATING);
         assertEquals(shardsToMove / 3, relocatingShards.size());
+        assertTrue(rerouteScheduled.get());
     }
 
-    public void testClusterRebalancedWhenNotTimedOut() {
+    public void testClusterRebalancedWhenNotTimedOutAndRerouteNotScheduled() {
         int numberOfIndices = 1;
         int numberOfShards = 15;
         int numberOfReplicas = 1;
         int totalShardCount = numberOfIndices * (numberOfShards * (numberOfReplicas + 1));
         Metadata metadata = buildMetadata(Metadata.builder(), numberOfIndices, numberOfShards, numberOfReplicas);
         RoutingTable routingTable = buildRoutingTable(metadata);
-        ClusterState state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .metadata(metadata)
-            .routingTable(routingTable)
-            .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
-            .build();
+        setupStateAndService(metadata, routingTable);
         MockAllocationService allocationService = createAllocationService(
             Settings.builder().put("cluster.routing.allocation.exclude.zone", "1a").build()
         ); // such that no shards are allocated to node1
@@ -306,8 +399,7 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
         assertEquals(totalShardCount, state.getRoutingNodes().shardsWithState(STARTED).size());
         assertEquals(0, node1ShardCount);
         Settings newSettings = Settings.builder().put("cluster.routing.allocation.exclude.zone", "").build();
-        int shardsToMove = 1000; // such that time out is never breached
-        BalancedShardsAllocator allocator = new TestBalancedShardsAllocator(newSettings, new CountDownLatch(shardsToMove));
+        BalancedShardsAllocator allocator = new TestBalancedShardsAllocator(newSettings, new CountDownLatch(Integer.MAX_VALUE));
         RoutingAllocation allocation = new RoutingAllocation(
             allocationDecidersForExcludeAPI(newSettings),
             new RoutingNodes(state, false),
@@ -316,23 +408,32 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
             null,
             System.nanoTime()
         );
+        AtomicBoolean rerouteScheduled = new AtomicBoolean(false);
+        final RerouteService rerouteService = (reason, priority, listener) -> {
+            if (randomBoolean()) {
+                listener.onFailure(new OpenSearchException("simulated"));
+            } else {
+                listener.onResponse(clusterService.state());
+            }
+            assertEquals("reroute after balanced shards allocator timed out", reason);
+            assertEquals(Priority.HIGH, priority);
+            rerouteScheduled.compareAndSet(false, true);
+        };
+        allocator.setRerouteService(rerouteService);
         allocator.allocate(allocation);
         List<ShardRouting> relocatingShards = allocation.routingNodes().shardsWithState(ShardRoutingState.RELOCATING);
         assertEquals(totalShardCount / 3, relocatingShards.size());
+        assertFalse(rerouteScheduled.get());
     }
 
-    public void testClusterNotRebalancedWhenTimedOut() {
+    public void testClusterNotRebalancedWhenTimedOutAndRerouteScheduled() {
         int numberOfIndices = 1;
         int numberOfShards = 15;
         int numberOfReplicas = 1;
         int totalShardCount = numberOfIndices * (numberOfShards * (numberOfReplicas + 1));
         Metadata metadata = buildMetadata(Metadata.builder(), numberOfIndices, numberOfShards, numberOfReplicas);
         RoutingTable routingTable = buildRoutingTable(metadata);
-        ClusterState state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .metadata(metadata)
-            .routingTable(routingTable)
-            .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
-            .build();
+        setupStateAndService(metadata, routingTable);
         MockAllocationService allocationService = createAllocationService(
             Settings.builder().put("cluster.routing.allocation.exclude.zone", "1a").build()
         ); // such that no shards are allocated to node1
@@ -353,23 +454,32 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
             null,
             System.nanoTime()
         );
+        AtomicBoolean rerouteScheduled = new AtomicBoolean(false);
+        final RerouteService rerouteService = (reason, priority, listener) -> {
+            if (randomBoolean()) {
+                listener.onFailure(new OpenSearchException("simulated"));
+            } else {
+                listener.onResponse(clusterService.state());
+            }
+            assertEquals("reroute after balanced shards allocator timed out", reason);
+            assertEquals(Priority.HIGH, priority);
+            rerouteScheduled.compareAndSet(false, true);
+        };
+        allocator.setRerouteService(rerouteService);
         allocator.allocate(allocation);
         List<ShardRouting> relocatingShards = allocation.routingNodes().shardsWithState(ShardRoutingState.RELOCATING);
         assertEquals(0, relocatingShards.size());
+        assertTrue(rerouteScheduled.get());
     }
 
-    public void testClusterPartialRebalancedWhenTimedOut() {
+    public void testClusterPartialRebalancedWhenTimedOutAndRerouteScheduled() {
         int numberOfIndices = 1;
         int numberOfShards = 15;
         int numberOfReplicas = 1;
         int totalShardCount = numberOfIndices * (numberOfShards * (numberOfReplicas + 1));
         Metadata metadata = buildMetadata(Metadata.builder(), numberOfIndices, numberOfShards, numberOfReplicas);
         RoutingTable routingTable = buildRoutingTable(metadata);
-        ClusterState state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .metadata(metadata)
-            .routingTable(routingTable)
-            .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
-            .build();
+        setupStateAndService(metadata, routingTable);
         MockAllocationService allocationService = createAllocationService(
             Settings.builder().put("cluster.routing.allocation.exclude.zone", "1a").build()
         ); // such that no shards are allocated to node1
@@ -404,9 +514,22 @@ public class TimeBoundBalancedShardsAllocatorTests extends OpenSearchAllocationT
             null,
             System.nanoTime()
         );
+        AtomicBoolean rerouteScheduled = new AtomicBoolean(false);
+        final RerouteService rerouteService = (reason, priority, listener) -> {
+            if (randomBoolean()) {
+                listener.onFailure(new OpenSearchException("simulated"));
+            } else {
+                listener.onResponse(clusterService.state());
+            }
+            assertEquals("reroute after balanced shards allocator timed out", reason);
+            assertEquals(Priority.HIGH, priority);
+            rerouteScheduled.compareAndSet(false, true);
+        };
+        allocator.setRerouteService(rerouteService);
         allocator.allocate(allocation);
         List<ShardRouting> relocatingShards = allocation.routingNodes().shardsWithState(ShardRoutingState.RELOCATING);
         assertEquals(3, relocatingShards.size());
+        assertTrue(rerouteScheduled.get());
     }
 
     public void testAllocatorNeverTimedOutIfValueIsMinusOne() {

--- a/server/src/test/java/org/opensearch/gateway/GatewayAllocatorTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayAllocatorTests.java
@@ -10,6 +10,7 @@ package org.opensearch.gateway;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchException;
 import org.opensearch.Version;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.cluster.ClusterInfo;
@@ -22,6 +23,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.IndexRoutingTable;
 import org.opensearch.cluster.routing.IndexShardRoutingTable;
 import org.opensearch.cluster.routing.RecoverySource;
+import org.opensearch.cluster.routing.RerouteService;
 import org.opensearch.cluster.routing.RoutingNodes;
 import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
@@ -30,6 +32,8 @@ import org.opensearch.cluster.routing.TestShardRouting;
 import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.cluster.routing.allocation.RoutingAllocation;
 import org.opensearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Priority;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -37,7 +41,9 @@ import org.opensearch.common.util.BatchRunnableExecutor;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.snapshots.SnapshotShardSizeInfo;
+import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.gateway.TestShardBatchGatewayAllocator;
+import org.opensearch.threadpool.TestThreadPool;
 import org.junit.Before;
 
 import java.util.ArrayList;
@@ -47,13 +53,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.opensearch.gateway.ShardsBatchGatewayAllocator.PRIMARY_BATCH_ALLOCATOR_TIMEOUT_SETTING;
 import static org.opensearch.gateway.ShardsBatchGatewayAllocator.PRIMARY_BATCH_ALLOCATOR_TIMEOUT_SETTING_KEY;
 import static org.opensearch.gateway.ShardsBatchGatewayAllocator.REPLICA_BATCH_ALLOCATOR_TIMEOUT_SETTING;
 import static org.opensearch.gateway.ShardsBatchGatewayAllocator.REPLICA_BATCH_ALLOCATOR_TIMEOUT_SETTING_KEY;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class GatewayAllocatorTests extends OpenSearchAllocationTestCase {
 
@@ -426,22 +432,37 @@ public class GatewayAllocatorTests extends OpenSearchAllocationTestCase {
         assertEquals(-1, REPLICA_BATCH_ALLOCATOR_TIMEOUT_SETTING.get(build).getMillis());
     }
 
-    public void testCollectTimedOutShards() throws InterruptedException {
+    public void testCollectTimedOutShardsAndScheduleReroute() throws InterruptedException {
         createIndexAndUpdateClusterState(2, 5, 2);
-        CountDownLatch latch = new CountDownLatch(10);
-        testShardsBatchGatewayAllocator = new TestShardBatchGatewayAllocator(latch);
+        TestThreadPool threadPool = new TestThreadPool(getTestName());
+        ClusterService clusterService = ClusterServiceUtils.createClusterService(clusterState, threadPool);
+        final CountDownLatch rerouteLatch = new CountDownLatch(2);
+        final RerouteService rerouteService = (reason, priority, listener) -> {
+            if (randomBoolean()) {
+                listener.onFailure(new OpenSearchException("simulated"));
+            } else {
+                listener.onResponse(clusterService.state());
+            }
+            assertThat(rerouteLatch.getCount(), greaterThanOrEqualTo(0L));
+            assertEquals("reroute after existing shards allocator timed out", reason);
+            assertEquals(Priority.HIGH, priority);
+            rerouteLatch.countDown();
+        };
+        CountDownLatch timedOutShardsLatch = new CountDownLatch(20);
+        testShardsBatchGatewayAllocator = new TestShardBatchGatewayAllocator(timedOutShardsLatch, 1000, rerouteService);
         testShardsBatchGatewayAllocator.setPrimaryBatchAllocatorTimeout(TimeValue.ZERO);
         testShardsBatchGatewayAllocator.setReplicaBatchAllocatorTimeout(TimeValue.ZERO);
         BatchRunnableExecutor executor = testShardsBatchGatewayAllocator.allocateAllUnassignedShards(testAllocation, true);
         executor.run();
-        assertTrue(latch.await(1, TimeUnit.MINUTES));
-        latch = new CountDownLatch(10);
-        testShardsBatchGatewayAllocator = new TestShardBatchGatewayAllocator(latch);
-        testShardsBatchGatewayAllocator.setPrimaryBatchAllocatorTimeout(TimeValue.ZERO);
-        testShardsBatchGatewayAllocator.setReplicaBatchAllocatorTimeout(TimeValue.ZERO);
+        assertEquals(timedOutShardsLatch.getCount(), 10);
+        assertEquals(1, rerouteLatch.getCount());
         executor = testShardsBatchGatewayAllocator.allocateAllUnassignedShards(testAllocation, false);
         executor.run();
-        assertTrue(latch.await(1, TimeUnit.MINUTES));
+        assertEquals(timedOutShardsLatch.getCount(), 0);
+        assertEquals(0, rerouteLatch.getCount()); // even with failure it doesn't leak any listeners
+        final boolean terminated = terminate(threadPool);
+        assert terminated;
+        clusterService.close();
     }
 
     private void createIndexAndUpdateClusterState(int count, int numberOfShards, int numberOfReplicas) {

--- a/test/framework/src/main/java/org/opensearch/test/gateway/TestShardBatchGatewayAllocator.java
+++ b/test/framework/src/main/java/org/opensearch/test/gateway/TestShardBatchGatewayAllocator.java
@@ -10,6 +10,7 @@ package org.opensearch.test.gateway;
 
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.RerouteService;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.allocation.AllocateUnassignedDecision;
 import org.opensearch.cluster.routing.allocation.RoutingAllocation;
@@ -39,12 +40,13 @@ public class TestShardBatchGatewayAllocator extends ShardsBatchGatewayAllocator 
 
     }
 
-    public TestShardBatchGatewayAllocator(CountDownLatch latch) {
+    public TestShardBatchGatewayAllocator(CountDownLatch latch, long maxBatchSize, RerouteService rerouteService) {
+        super(maxBatchSize, rerouteService);
         this.latch = latch;
     }
 
     public TestShardBatchGatewayAllocator(long maxBatchSize) {
-        super(maxBatchSize);
+        super(maxBatchSize, null);
     }
 
     Map<String /* node id */, Map<ShardId, ShardRouting>> knownAllocations = new HashMap<>();


### PR DESCRIPTION
* Schedule reroute after allocator timed out

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backport #15565 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
