### PR TITLE
Mute test testRemoteStoreCleanupForDeletedIndexForSnapshotV2

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotV2IT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotV2IT.java
@@ -206,6 +206,7 @@ public class DeleteSnapshotV2IT extends AbstractSnapshotIntegTestCase {
 
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/15692")
     public void testRemoteStoreCleanupForDeletedIndexForSnapshotV2() throws Exception {
         disableRepoConsistencyCheck("Remote store repository is being used in the test");
         final Path remoteStoreRepoPath = randomRepoPath();


### PR DESCRIPTION
Mute test testRemoteStoreCleanupForDeletedIndexForSnapshotV2. Related https://github.com/opensearch-project/OpenSearch/issues/15692.

I would revert here but this is not a clean revert with multiple changes since it was introduced, so muting for now.