### PR TITLE
Fix bwc test failures by updating wire compatibility on NodeIndicesStats

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -101,7 +101,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
             includeCaches = in.readEnumSet(CacheType.class);
             levels = in.readStringArray();
         }
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_2_17_0)) {
             includeIndicesStatsByLevel = in.readBoolean();
         }
     }
@@ -128,7 +128,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
             out.writeEnumSet(includeCaches);
             out.writeStringArrayNullable(levels);
         }
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_2_17_0)) {
             out.writeBoolean(includeIndicesStatsByLevel);
         }
     }

--- a/server/src/main/java/org/opensearch/indices/NodeIndicesStats.java
+++ b/server/src/main/java/org/opensearch/indices/NodeIndicesStats.java
@@ -83,7 +83,7 @@ public class NodeIndicesStats implements Writeable, ToXContentFragment {
 
     public NodeIndicesStats(StreamInput in) throws IOException {
         stats = new CommonStats(in);
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_2_17_0)) {
             // contains statsByIndex
             if (in.readBoolean()) {
                 statsByIndex = readStatsByIndex(in);
@@ -284,7 +284,7 @@ public class NodeIndicesStats implements Writeable, ToXContentFragment {
     public void writeTo(StreamOutput out) throws IOException {
         stats.writeTo(out);
 
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_2_17_0)) {
             out.writeBoolean(statsByIndex != null);
             if (statsByIndex != null) {
                 writeStatsByIndex(out);


### PR DESCRIPTION
2.x has updated to V_2_17_0, forward port to main to fix bwc.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
https://github.com/opensearch-project/OpenSearch/pull/15678/files and https://github.com/opensearch-project/OpenSearch/commit/d2ae53eb0767e2e45e4b12e79a7be1c43f61bb4c were updated on current 2.17 branches, this updates 3.0 to the correct version.

### Related Issues
my sanity

<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
