### PR TITLE
Add more wait time to assertBusy to fix RemoteFsTimestampAwareTranslo…

### DIFF
--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslogTests.java
@@ -55,6 +55,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -310,7 +311,6 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
     }
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/15731")
     public void testSimpleOperationsUpload() throws Exception {
         ArrayList<Translog.Operation> ops = new ArrayList<>();
 
@@ -366,7 +366,7 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
                 10,
                 blobStoreTransferService.listAll(getTranslogDirectory().add(DATA_DIR).add(String.valueOf(primaryTerm.get()))).size()
             );
-        });
+        }, 60, TimeUnit.SECONDS);
     }
 
     @Override


### PR DESCRIPTION
### Description
- `RemoteFsTimestampAwareTranslogTests.testSimpleOperationsUpload` test is flaky at assertion which checks for number of metadata files in remote translog after `trimUnreferencedReaders` is called.
- As stale metadata files deletion happen in async manner, if the build server is overloaded, it can take time to actually delete the stale metadata files.
- Ran the test locally for 1000+ times without any failures.
- As part of this change, we are increasing `assertBusy` timeout.

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/15818

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
