### PR TITLE
[Backport] [2.x] Bump org.apache.logging.log4j:log4j-core from 2.23.1 to 2.24.0 in /buildSrc/src/testKit/thirdPartyAudit/sample_jars (#15858)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add path prefix support to hashed prefix snapshots ([#15664](https://github.com/opensearch-project/OpenSearch/pull/15664))
 
 ### Dependencies
+- Bump `org.apache.logging.log4j:log4j-core` from 2.23.1 to 2.24.0 ([#15858](https://github.com/opensearch-project/OpenSearch/pull/15858))
 - Bump `com.azure:azure-identity` from 1.13.0 to 1.13.2 ([#15578](https://github.com/opensearch-project/OpenSearch/pull/15578))
 
 ### Changed

--- a/buildSrc/src/testKit/thirdPartyAudit/sample_jars/build.gradle
+++ b/buildSrc/src/testKit/thirdPartyAudit/sample_jars/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-  implementation "org.apache.logging.log4j:log4j-core:2.23.1"
+  implementation "org.apache.logging.log4j:log4j-core:2.24.0"
 }
 
 ["0.0.1", "0.0.2"].forEach { v ->


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/15858 to `2.x`