### PR TITLE
[BUG] Bug fix for checksum validation for mapping metadata

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -1278,7 +1278,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         out.writeByte(state.id());
         writeSettingsToStream(settings, out);
         out.writeVLongArray(primaryTerms);
-        out.writeMapValues(mappings, (stream, val) -> val.writeTo(stream));
+        out.writeMapValues(mappings, (stream, val) -> val.writeVerifiableTo((BufferedChecksumStreamOutput) stream));
         out.writeMapValues(aliases, (stream, val) -> val.writeTo(stream));
         out.writeMap(customData, StreamOutput::writeString, (stream, val) -> val.writeTo(stream));
         out.writeMap(
@@ -1291,6 +1291,44 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         if (out.getVersion().onOrAfter(Version.V_2_17_0)) {
             out.writeOptionalWriteable(context);
         }
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder().append("IndexMetadata{routingNumShards=")
+            .append(routingNumShards)
+            .append(", index=")
+            .append(index)
+            .append(", version=")
+            .append(version)
+            .append(", state=")
+            .append(state)
+            .append(", settingsVersion=")
+            .append(settingsVersion)
+            .append(", mappingVersion=")
+            .append(mappingVersion)
+            .append(", aliasesVersion=")
+            .append(aliasesVersion)
+            .append(", primaryTerms=")
+            .append(Arrays.toString(primaryTerms))
+            .append(", aliases=")
+            .append(aliases)
+            .append(", settings=")
+            .append(settings)
+            .append(", mappings=")
+            .append(mappings)
+            .append(", customData=")
+            .append(customData)
+            .append(", inSyncAllocationIds=")
+            .append(inSyncAllocationIds)
+            .append(", rolloverInfos=")
+            .append(rolloverInfos)
+            .append(", isSystem=")
+            .append(isSystem)
+            .append(", context=")
+            .append(context)
+            .append("}")
+            .toString();
     }
 
     public boolean isSystem() {

--- a/server/src/main/java/org/opensearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MappingMetadata.java
@@ -40,8 +40,10 @@ import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.BufferedChecksumStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.VerifiableWriteable;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.MapperService;
@@ -60,7 +62,7 @@ import static org.opensearch.common.xcontent.support.XContentMapValues.nodeBoole
  * @opensearch.api
  */
 @PublicApi(since = "1.0.0")
-public class MappingMetadata extends AbstractDiffable<MappingMetadata> {
+public class MappingMetadata extends AbstractDiffable<MappingMetadata> implements VerifiableWriteable {
     public static final MappingMetadata EMPTY_MAPPINGS = new MappingMetadata(MapperService.SINGLE_MAPPING_NAME, Collections.emptyMap());
 
     private final String type;
@@ -161,6 +163,13 @@ public class MappingMetadata extends AbstractDiffable<MappingMetadata> {
         out.writeString(type());
         source().writeTo(out);
         // routing
+        out.writeBoolean(routingRequired);
+    }
+
+    @Override
+    public void writeVerifiableTo(BufferedChecksumStreamOutput out) throws IOException {
+        out.writeString(type());
+        source().writeVerifiableTo(out);
         out.writeBoolean(routingRequired);
     }
 

--- a/server/src/main/java/org/opensearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/opensearch/common/compress/CompressedXContent.java
@@ -38,6 +38,7 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.BufferedChecksumStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.compress.Compressor;
@@ -167,6 +168,10 @@ public final class CompressedXContent {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeInt(crc32);
         out.writeByteArray(bytes);
+    }
+
+    public void writeVerifiableTo(BufferedChecksumStreamOutput out) throws IOException {
+        out.writeInt(crc32);
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IndexMetadataTests.java
@@ -249,6 +249,7 @@ public class IndexMetadataTests extends OpenSearchTestCase {
         BytesStreamOutput out = new BytesStreamOutput();
         BufferedChecksumStreamOutput checksumOut = new BufferedChecksumStreamOutput(out);
         metadata1.writeVerifiableTo(checksumOut);
+        assertNotNull(metadata1.toString());
 
         IndexMetadata metadata2 = IndexMetadata.builder(metadata1.getIndex().getName())
             .settings(

--- a/server/src/test/java/org/opensearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IndexMetadataTests.java
@@ -199,7 +199,30 @@ public class IndexMetadataTests extends OpenSearchTestCase {
             ),
             randomNonNegativeLong()
         );
-
+        String mappings = "    {\n"
+            + "        \"_doc\": {\n"
+            + "            \"properties\": {\n"
+            + "                \"actiongroups\": {\n"
+            + "                    \"type\": \"text\",\n"
+            + "                    \"fields\": {\n"
+            + "                        \"keyword\": {\n"
+            + "                            \"type\": \"keyword\",\n"
+            + "                            \"ignore_above\": 256\n"
+            + "                        }\n"
+            + "                    }\n"
+            + "                },\n"
+            + "                \"allowlist\": {\n"
+            + "                    \"type\": \"text\",\n"
+            + "                    \"fields\": {\n"
+            + "                        \"keyword\": {\n"
+            + "                            \"type\": \"keyword\",\n"
+            + "                            \"ignore_above\": 256\n"
+            + "                        }\n"
+            + "                    }\n"
+            + "                }\n"
+            + "            }\n"
+            + "        }\n"
+            + "    }";
         IndexMetadata metadata1 = IndexMetadata.builder("foo")
             .settings(
                 Settings.builder()
@@ -220,6 +243,7 @@ public class IndexMetadataTests extends OpenSearchTestCase {
             .putRolloverInfo(info1)
             .putRolloverInfo(info2)
             .putInSyncAllocationIds(0, Set.of("1", "2", "3"))
+            .putMapping(mappings)
             .build();
 
         BytesStreamOutput out = new BytesStreamOutput();
@@ -246,6 +270,7 @@ public class IndexMetadataTests extends OpenSearchTestCase {
             .putRolloverInfo(info2)
             .putRolloverInfo(info1)
             .putInSyncAllocationIds(0, Set.of("3", "1", "2"))
+            .putMapping(mappings)
             .build();
 
         BytesStreamOutput out2 = new BytesStreamOutput();


### PR DESCRIPTION

### Description
During checksum validation for remote cluster state, for mapping metadata we need to ignore compressed data check.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
