### PR TITLE
Add restriction to have a single repository with shallow snapshot v2 setting

### DIFF
--- a/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
@@ -68,7 +68,9 @@ import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
+import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
 import org.opensearch.repositories.blobstore.MeteredBlobStoreRepository;
+import org.opensearch.snapshots.SnapshotsService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
@@ -84,6 +86,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.opensearch.repositories.blobstore.BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY;
+import static org.opensearch.repositories.blobstore.BlobStoreRepository.SHALLOW_SNAPSHOT_V2;
 import static org.opensearch.repositories.blobstore.BlobStoreRepository.SYSTEM_REPOSITORY_SETTING;
 
 /**
@@ -123,6 +126,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
     private final RepositoriesStatsArchive repositoriesStatsArchive;
     private final ClusterManagerTaskThrottler.ThrottlingKey putRepositoryTaskKey;
     private final ClusterManagerTaskThrottler.ThrottlingKey deleteRepositoryTaskKey;
+    private final Settings settings;
 
     public RepositoriesService(
         Settings settings,
@@ -132,6 +136,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
         Map<String, Repository.Factory> internalTypesRegistry,
         ThreadPool threadPool
     ) {
+        this.settings = settings;
         this.typesRegistry = typesRegistry;
         this.internalTypesRegistry = internalTypesRegistry;
         this.clusterService = clusterService;
@@ -173,7 +178,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
             CryptoMetadata.fromRequest(request.cryptoSettings())
         );
         validate(request.name());
-        validateRepositoryMetadataSettings(clusterService, request.name(), request.settings());
+        validateRepositoryMetadataSettings(clusterService, request.name(), request.settings(), repositories, settings, this);
         if (newRepositoryMetadata.cryptoMetadata() != null) {
             validate(newRepositoryMetadata.cryptoMetadata().keyProviderName());
         }
@@ -684,7 +689,10 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
     public static void validateRepositoryMetadataSettings(
         ClusterService clusterService,
         final String repositoryName,
-        final Settings repositoryMetadataSettings
+        final Settings repositoryMetadataSettings,
+        Map<String, Repository> repositories,
+        Settings settings,
+        RepositoriesService repositoriesService
     ) {
         // We can add more validations here for repository settings in the future.
         Version minVersionInCluster = clusterService.state().getNodes().getMinNodeVersion();
@@ -699,6 +707,41 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                     + minVersionInCluster
             );
         }
+        if (SHALLOW_SNAPSHOT_V2.get(repositoryMetadataSettings)) {
+            if (minVersionInCluster.onOrAfter(Version.V_2_17_0) == false) {
+                throw new RepositoryException(
+                    repositoryName,
+                    "setting "
+                        + SHALLOW_SNAPSHOT_V2.getKey()
+                        + " cannot be enabled as some of the nodes in cluster are on version older than "
+                        + Version.V_2_17_0
+                        + ". Minimum node version in cluster is: "
+                        + minVersionInCluster
+                );
+            }
+            if (repositoryWithShallowV2Exists(repositories)) {
+                throw new RepositoryException(
+                    repositoryName,
+                    "setting "
+                        + SHALLOW_SNAPSHOT_V2.getKey()
+                        + " cannot be enabled as this setting can be enabled only on one repository "
+                        + " and one or more repositories in the cluster have the setting as enabled"
+                );
+            }
+            try {
+                if (pinnedTimestampExistsWithDifferentRepository(repositoryName, settings, repositoriesService)) {
+                    throw new RepositoryException(
+                        repositoryName,
+                        "setting "
+                            + SHALLOW_SNAPSHOT_V2.getKey()
+                            + " cannot be enabled if there are existing snapshots created with shallow V2 "
+                            + "setting using different repository."
+                    );
+                }
+            } catch (IOException e) {
+                throw new RepositoryException(repositoryName, "Exception while fetching pinned timestamp details");
+            }
+        }
         // Validation to not allow users to create system repository via put repository call.
         if (isSystemRepositorySettingPresent(repositoryMetadataSettings)) {
             throw new RepositoryException(
@@ -708,6 +751,36 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                     + " cannot provide system repository setting; this setting is managed by OpenSearch"
             );
         }
+    }
+
+    private static boolean repositoryWithShallowV2Exists(Map<String, Repository> repositories) {
+        return repositories.values().stream().anyMatch(repo -> SHALLOW_SNAPSHOT_V2.get(repo.getMetadata().settings()));
+    }
+
+    private static boolean pinnedTimestampExistsWithDifferentRepository(
+        String newRepoName,
+        Settings settings,
+        RepositoriesService repositoriesService
+    ) throws IOException {
+        Map<String, Set<Long>> pinningEntityTimestampMap = RemoteStorePinnedTimestampService.fetchPinnedTimestamps(
+            settings,
+            repositoriesService
+        );
+        for (String pinningEntiy : pinningEntityTimestampMap.keySet()) {
+            String[] tokens = pinningEntiy.split(SnapshotsService.SNAPSHOT_PINNED_TIMESTAMP_DELIMITER);
+            if (tokens.length > 2) {
+                logger.warn(
+                    "With more than one {} in the pinning entity = {}, not able to determine if there is a pinned timestamp created with different repository",
+                    SnapshotsService.SNAPSHOT_PINNED_TIMESTAMP_DELIMITER,
+                    pinningEntiy
+                );
+                return true;
+            }
+            if (tokens[0].equals(newRepoName) == false) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static void ensureRepositoryNotInUse(ClusterState clusterState, String repository) {

--- a/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/opensearch/repositories/RepositoriesService.java
@@ -719,6 +719,16 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                         + minVersionInCluster
                 );
             }
+            if (repositoryName.contains(SnapshotsService.SNAPSHOT_PINNED_TIMESTAMP_DELIMITER)) {
+                throw new RepositoryException(
+                    repositoryName,
+                    "setting "
+                        + SHALLOW_SNAPSHOT_V2.getKey()
+                        + " cannot be enabled for repository with "
+                        + SnapshotsService.SNAPSHOT_PINNED_TIMESTAMP_DELIMITER
+                        + " in the name as this delimiter is used to create pinning entity"
+                );
+            }
             if (repositoryWithShallowV2Exists(repositories)) {
                 throw new RepositoryException(
                     repositoryName,
@@ -766,17 +776,9 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
             settings,
             repositoriesService
         );
-        for (String pinningEntiy : pinningEntityTimestampMap.keySet()) {
-            String[] tokens = pinningEntiy.split(SnapshotsService.SNAPSHOT_PINNED_TIMESTAMP_DELIMITER);
-            if (tokens.length > 2) {
-                logger.warn(
-                    "With more than one {} in the pinning entity = {}, not able to determine if there is a pinned timestamp created with different repository",
-                    SnapshotsService.SNAPSHOT_PINNED_TIMESTAMP_DELIMITER,
-                    pinningEntiy
-                );
-                return true;
-            }
-            if (tokens[0].equals(newRepoName) == false) {
+        for (String pinningEntity : pinningEntityTimestampMap.keySet()) {
+            String repoNameWithPinnedTimestamps = pinningEntity.split(SnapshotsService.SNAPSHOT_PINNED_TIMESTAMP_DELIMITER)[0];
+            if (repoNameWithPinnedTimestamps.equals(newRepoName) == false) {
                 return true;
             }
         }

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRemoteIndexTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRemoteIndexTests.java
@@ -52,6 +52,7 @@ import org.opensearch.repositories.RepositoryException;
 import org.opensearch.repositories.fs.FsRepository;
 import org.opensearch.snapshots.SnapshotId;
 import org.opensearch.snapshots.SnapshotInfo;
+import org.opensearch.snapshots.SnapshotsService;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
@@ -390,6 +391,18 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
             .put(REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), true)
             .put(SHALLOW_SNAPSHOT_V2.getKey(), true)
             .build();
+
+        String invalidRepoName = "test" + SnapshotsService.SNAPSHOT_PINNED_TIMESTAMP_DELIMITER + "repo-1";
+        try {
+            createRepository(client, invalidRepoName, snapshotRepoSettings1);
+        } catch (RepositoryException e) {
+            assertEquals(
+                "["
+                    + invalidRepoName
+                    + "] setting shallow_snapshot_v2 cannot be enabled for repository with __ in the name as this delimiter is used to create pinning entity",
+                e.getMessage()
+            );
+        }
 
         // Create repo with shallow snapshot V2 enabled
         createRepository(client, "test-repo-1", snapshotRepoSettings1);

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRemoteIndexTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryRemoteIndexTests.java
@@ -33,6 +33,8 @@
 package org.opensearch.repositories.blobstore;
 
 import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
+import org.opensearch.action.admin.cluster.repositories.verify.VerifyRepositoryResponse;
+import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.common.settings.Settings;
@@ -41,10 +43,12 @@ import org.opensearch.env.Environment;
 import org.opensearch.gateway.remote.RemoteClusterStateService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.snapshots.blobstore.RemoteStoreShardShallowCopySnapshot;
+import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.repositories.IndexId;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.RepositoryData;
+import org.opensearch.repositories.RepositoryException;
 import org.opensearch.repositories.fs.FsRepository;
 import org.opensearch.snapshots.SnapshotId;
 import org.opensearch.snapshots.SnapshotInfo;
@@ -64,6 +68,9 @@ import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_ST
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEY;
+import static org.opensearch.repositories.blobstore.BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY;
+import static org.opensearch.repositories.blobstore.BlobStoreRepository.SHALLOW_SNAPSHOT_V2;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -81,6 +88,7 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
             .put(Environment.PATH_HOME_SETTING.getKey(), tempDir)
             .put(Environment.PATH_REPO_SETTING.getKey(), tempDir.resolve("repo"))
             .put(Environment.PATH_SHARED_DATA_SETTING.getKey(), tempDir.getParent())
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), true)
             .build();
     }
 
@@ -373,4 +381,107 @@ public class BlobStoreRepositoryRemoteIndexTests extends BlobStoreRepositoryHelp
         assertThat(snapshotIds, equalTo(originalSnapshots));
     }
 
+    public void testRepositoryCreationShallowV2() throws Exception {
+        Client client = client();
+
+        Settings snapshotRepoSettings1 = Settings.builder()
+            .put(node().settings())
+            .put("location", OpenSearchIntegTestCase.randomRepoPath(node().settings()))
+            .put(REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), true)
+            .put(SHALLOW_SNAPSHOT_V2.getKey(), true)
+            .build();
+
+        // Create repo with shallow snapshot V2 enabled
+        createRepository(client, "test-repo-1", snapshotRepoSettings1);
+
+        logger.info("--> verify the repository");
+        VerifyRepositoryResponse verifyRepositoryResponse = client.admin().cluster().prepareVerifyRepository("test-repo-1").get();
+        assertNotNull(verifyRepositoryResponse.getNodes());
+
+        GetRepositoriesResponse getRepositoriesResponse = client.admin().cluster().prepareGetRepositories("test-repo-1").get();
+        assertTrue(SHALLOW_SNAPSHOT_V2.get(getRepositoriesResponse.repositories().get(0).settings()));
+
+        Settings snapshotRepoSettings2 = Settings.builder()
+            .put(node().settings())
+            .put("location", OpenSearchIntegTestCase.randomRepoPath(node().settings()))
+            .put(REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), true)
+            .put(SHALLOW_SNAPSHOT_V2.getKey(), true)
+            .build();
+
+        // Create another repo with shallow snapshot V2 enabled, this should fail.
+        try {
+            createRepository(client, "test-repo-2", snapshotRepoSettings2);
+        } catch (RepositoryException e) {
+            assertEquals(
+                "[test-repo-2] setting shallow_snapshot_v2 cannot be enabled as this setting can be enabled only on one repository  and one or more repositories in the cluster have the setting as enabled",
+                e.getMessage()
+            );
+        }
+
+        // Disable shallow snapshot V2 setting on test-repo-1
+        updateRepository(
+            client,
+            "test-repo-1",
+            Settings.builder().put(snapshotRepoSettings1).put(SHALLOW_SNAPSHOT_V2.getKey(), false).build()
+        );
+        getRepositoriesResponse = client.admin().cluster().prepareGetRepositories("test-repo-1").get();
+        assertFalse(SHALLOW_SNAPSHOT_V2.get(getRepositoriesResponse.repositories().get(0).settings()));
+
+        // Create test-repo-2 with shallow snapshot V2 enabled, this should pass now.
+        createRepository(client, "test-repo-2", snapshotRepoSettings2);
+        getRepositoriesResponse = client.admin().cluster().prepareGetRepositories("test-repo-2").get();
+        assertTrue(SHALLOW_SNAPSHOT_V2.get(getRepositoriesResponse.repositories().get(0).settings()));
+
+        final String indexName = "test-idx";
+        createIndex(indexName);
+        ensureGreen();
+        indexDocuments(client, indexName);
+
+        // Create pinned timestamp snapshot in test-repo-2
+        SnapshotInfo snapshotInfo = createSnapshot("test-repo-2", "test-snap-2", new ArrayList<>());
+        assertNotNull(snapshotInfo.snapshotId());
+
+        // As snapshot is present, even after disabling shallow snapshot setting in test-repo-2, we will not be able to
+        // enable shallow snapshot v2 setting in test-repo-1
+        updateRepository(
+            client,
+            "test-repo-2",
+            Settings.builder().put(snapshotRepoSettings2).put(SHALLOW_SNAPSHOT_V2.getKey(), false).build()
+        );
+        getRepositoriesResponse = client.admin().cluster().prepareGetRepositories("test-repo-2").get();
+        assertFalse(SHALLOW_SNAPSHOT_V2.get(getRepositoriesResponse.repositories().get(0).settings()));
+
+        try {
+            updateRepository(client, "test-repo-1", snapshotRepoSettings1);
+        } catch (RepositoryException e) {
+            assertEquals(
+                "[test-repo-1] setting shallow_snapshot_v2 cannot be enabled if there are existing snapshots created with shallow V2 setting using different repository.",
+                e.getMessage()
+            );
+        }
+
+        // After deleting the snapshot, we will be able to enable shallow snapshot v2 setting in test-repo-1
+        AcknowledgedResponse deleteSnapshotResponse = client().admin().cluster().prepareDeleteSnapshot("test-repo-2", "test-snap-2").get();
+
+        assertAcked(deleteSnapshotResponse);
+
+        updateRepository(client, "test-repo-1", snapshotRepoSettings1);
+        getRepositoriesResponse = client.admin().cluster().prepareGetRepositories("test-repo-1").get();
+        assertTrue(SHALLOW_SNAPSHOT_V2.get(getRepositoriesResponse.repositories().get(0).settings()));
+
+        // Having a snapshot in the same repo should allow disabling and re-enabling shallow snapshot v2 setting
+        snapshotInfo = createSnapshot("test-repo-1", "test-snap-1", new ArrayList<>());
+        assertNotNull(snapshotInfo.snapshotId());
+        updateRepository(
+            client,
+            "test-repo-1",
+            Settings.builder().put(snapshotRepoSettings1).put(SHALLOW_SNAPSHOT_V2.getKey(), false).build()
+        );
+        getRepositoriesResponse = client.admin().cluster().prepareGetRepositories("test-repo-1").get();
+        assertFalse(SHALLOW_SNAPSHOT_V2.get(getRepositoriesResponse.repositories().get(0).settings()));
+
+        updateRepository(client, "test-repo-1", snapshotRepoSettings1);
+        getRepositoriesResponse = client.admin().cluster().prepareGetRepositories("test-repo-1").get();
+        assertTrue(SHALLOW_SNAPSHOT_V2.get(getRepositoriesResponse.repositories().get(0).settings()));
+    }
 }


### PR DESCRIPTION
### Description
- Shallow snapshot V2 setting is introduced to enable creating snapshot which uses pinned timestamp functionality of remote store.
- As pinned timestamps are created at cluster level, if multiple repositories enable this feature and create snapshots, clean-up of data from remote store on snapshot deletion becomes tricky and we may end up leaving zombie data in the remote store.
- To avoid this, in this PR, we have added a restriction to have only 1 repository with shallow snapshot V2 enabled.
- In order to enable shallow snapshot V2 setting on another repository, we need to disable this setting on the previously enabled repository as well as delete any snapshots that are created with the previous repo.
- We will ease up this restriction in the upcoming releases.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
