### PR TITLE
Removing task Id using remove() in TaskCancellationMonitoringService

### DIFF
--- a/server/src/main/java/org/opensearch/tasks/TaskCancellationMonitoringService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskCancellationMonitoringService.java
@@ -125,7 +125,7 @@ public class TaskCancellationMonitoringService extends AbstractLifecycleComponen
         if (!TASKS_TO_TRACK.contains(task.getClass())) {
             return;
         }
-        this.cancelledTaskTracker.entrySet().removeIf(entry -> entry.getKey() == task.getId());
+        this.cancelledTaskTracker.remove(task.getId());
     }
 
     /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
In TaskCancellationMonitoringService, we track long cancelled tasks via hashmap. Once they are completed, we remove such tasks from the tracker. To do so, earlier we used to traverse the whole entrySet, find the taskId and then remove it which is basically a O(n) operation and unnecessary. Changed it to use remove() directly.

As we saw in one occasion, if a domain is facing too many cancellations and tasks are not getting cleared up, this traversal might become heavy on CPU.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
