### PR TITLE
Added support for msearch API to pass search pipeline name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Implement WithFieldName interface in ValuesSourceAggregationBuilder & FieldSortBuilder ([#15916](https://github.com/opensearch-project/OpenSearch/pull/15916))
 - Add successfulSearchShardIndices in searchRequestContext ([#15967](https://github.com/opensearch-project/OpenSearch/pull/15967))
 - Remove identity-related feature flagged code from the RestController ([#15430](https://github.com/opensearch-project/OpenSearch/pull/15430))
+- Add support for msearch API to pass search pipeline name - ([#15923](https://github.com/opensearch-project/OpenSearch/pull/15923))
 
 ### Dependencies
 - Bump `com.azure:azure-identity` from 1.13.0 to 1.13.2 ([#15578](https://github.com/opensearch-project/OpenSearch/pull/15578))

--- a/server/src/main/java/org/opensearch/action/search/MultiSearchRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/MultiSearchRequest.java
@@ -310,6 +310,10 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
             ) {
                 consumer.accept(searchRequest, parser);
             }
+
+            if (searchRequest.source() != null && searchRequest.source().pipeline() != null) {
+                searchRequest.pipeline(searchRequest.source().pipeline());
+            }
             // move pointers
             from = nextMarker + 1;
         }

--- a/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
@@ -210,7 +210,7 @@ public class RestSearchAction extends BaseRestHandler {
         searchRequest.routing(request.param("routing"));
         searchRequest.preference(request.param("preference"));
         searchRequest.indicesOptions(IndicesOptions.fromRequest(request, searchRequest.indicesOptions()));
-        searchRequest.pipeline(request.param("search_pipeline"));
+        searchRequest.pipeline(request.param("search_pipeline", searchRequest.source().pipeline()));
 
         checkRestTotalHits(request, searchRequest);
         request.paramAsBoolean(INCLUDE_NAMED_QUERIES_SCORE_PARAM, false);

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -299,7 +299,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                 derivedFields = in.readList(DerivedField::new);
             }
         }
-        if (in.getVersion().onOrAfter(Version.V_2_18_0)) {
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
             searchPipeline = in.readOptionalString();
         }
     }
@@ -382,7 +382,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                 out.writeList(derivedFields);
             }
         }
-        if (out.getVersion().onOrAfter(Version.V_2_18_0)) {
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
             out.writeOptionalString(searchPipeline);
         }
     }
@@ -1239,6 +1239,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         rewrittenBuilder.pointInTimeBuilder = pointInTimeBuilder;
         rewrittenBuilder.derivedFieldsObject = derivedFieldsObject;
         rewrittenBuilder.derivedFields = derivedFields;
+        rewrittenBuilder.searchPipeline = searchPipeline;
         return rewrittenBuilder;
     }
 
@@ -1637,6 +1638,10 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
         }
 
+        if (searchPipeline != null) {
+            builder.field(SEARCH_PIPELINE.getPreferredName(), searchPipeline);
+        }
+
         return builder;
     }
 
@@ -1914,7 +1919,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             trackTotalHitsUpTo,
             pointInTimeBuilder,
             derivedFieldsObject,
-            derivedFields
+            derivedFields,
+            searchPipeline
         );
     }
 
@@ -1959,7 +1965,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             && Objects.equals(trackTotalHitsUpTo, other.trackTotalHitsUpTo)
             && Objects.equals(pointInTimeBuilder, other.pointInTimeBuilder)
             && Objects.equals(derivedFieldsObject, other.derivedFieldsObject)
-            && Objects.equals(derivedFields, other.derivedFields);
+            && Objects.equals(derivedFields, other.derivedFields)
+            && Objects.equals(searchPipeline, other.searchPipeline);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -275,7 +275,6 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         seqNoAndPrimaryTerm = in.readOptionalBoolean();
         extBuilders = in.readNamedWriteableList(SearchExtBuilder.class);
         profile = in.readBoolean();
-        searchPipeline = in.readOptionalString();
         searchAfterBuilder = in.readOptionalWriteable(SearchAfterBuilder::new);
         sliceBuilder = in.readOptionalWriteable(SliceBuilder::new);
         collapse = in.readOptionalWriteable(CollapseBuilder::new);
@@ -299,6 +298,9 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             if (in.readBoolean()) {
                 derivedFields = in.readList(DerivedField::new);
             }
+        }
+        if (in.getVersion().onOrAfter(Version.V_2_18_0)) {
+            searchPipeline = in.readOptionalString();
         }
     }
 
@@ -350,7 +352,6 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         out.writeOptionalBoolean(seqNoAndPrimaryTerm);
         out.writeNamedWriteableList(extBuilders);
         out.writeBoolean(profile);
-        out.writeOptionalString(searchPipeline);
         out.writeOptionalWriteable(searchAfterBuilder);
         out.writeOptionalWriteable(sliceBuilder);
         out.writeOptionalWriteable(collapse);
@@ -380,6 +381,9 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             if (hasDerivedFields) {
                 out.writeList(derivedFields);
             }
+        }
+        if (out.getVersion().onOrAfter(Version.V_2_18_0)) {
+            out.writeOptionalString(searchPipeline);
         }
     }
 

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -224,6 +224,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
     private Map<String, Object> searchPipelineSource = null;
 
+    private String searchPipeline;
+
     /**
      * Constructs a new search source builder.
      */
@@ -273,6 +275,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         seqNoAndPrimaryTerm = in.readOptionalBoolean();
         extBuilders = in.readNamedWriteableList(SearchExtBuilder.class);
         profile = in.readBoolean();
+        searchPipeline = in.readOptionalString();
         searchAfterBuilder = in.readOptionalWriteable(SearchAfterBuilder::new);
         sliceBuilder = in.readOptionalWriteable(SliceBuilder::new);
         collapse = in.readOptionalWriteable(CollapseBuilder::new);
@@ -347,6 +350,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         out.writeOptionalBoolean(seqNoAndPrimaryTerm);
         out.writeNamedWriteableList(extBuilders);
         out.writeBoolean(profile);
+        out.writeOptionalString(searchPipeline);
         out.writeOptionalWriteable(searchAfterBuilder);
         out.writeOptionalWriteable(sliceBuilder);
         out.writeOptionalWriteable(collapse);
@@ -1112,10 +1116,25 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     }
 
     /**
+     * @return a search pipeline name defined within the search source (see {@link org.opensearch.search.pipeline.SearchPipelineService})
+     */
+    public String pipeline() {
+        return searchPipeline;
+    }
+
+    /**
      * Define a search pipeline to process this search request and/or its response. See {@link org.opensearch.search.pipeline.SearchPipelineService}.
      */
     public SearchSourceBuilder searchPipelineSource(Map<String, Object> searchPipelineSource) {
         this.searchPipelineSource = searchPipelineSource;
+        return this;
+    }
+
+    /**
+     * Define a search pipeline name to process this search request and/or its response. See {@link org.opensearch.search.pipeline.SearchPipelineService}.
+     */
+    public SearchSourceBuilder pipeline(String searchPipeline) {
+        this.searchPipeline = searchPipeline;
         return this;
     }
 
@@ -1283,6 +1302,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                     sort(parser.text());
                 } else if (PROFILE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     profile = parser.booleanValue();
+                } else if (SEARCH_PIPELINE.match(currentFieldName, parser.getDeprecationHandler())) {
+                    searchPipeline = parser.text();
                 } else {
                     throw new ParsingException(
                         parser.getTokenLocation(),

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -395,6 +395,9 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
             if (searchRequest.pipeline() != null) {
                 // Named pipeline specified for the request
                 pipelineId = searchRequest.pipeline();
+            } else if (searchRequest.source() != null && searchRequest.source().pipeline() != null) {
+                // Inline pipeline specified for the request
+                pipelineId = searchRequest.source().pipeline();
             } else if (state != null && searchRequest.indices() != null && searchRequest.indices().length != 0) {
                 try {
                     // Check for index default pipeline

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -395,9 +395,6 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
             if (searchRequest.pipeline() != null) {
                 // Named pipeline specified for the request
                 pipelineId = searchRequest.pipeline();
-            } else if (searchRequest.source() != null && searchRequest.source().pipeline() != null) {
-                // Inline pipeline specified for the request
-                pipelineId = searchRequest.source().pipeline();
             } else if (state != null && searchRequest.indices() != null && searchRequest.indices().length != 0) {
                 try {
                     // Check for index default pipeline

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
@@ -56,7 +56,6 @@ import org.opensearch.test.rest.FakeRestRequest;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.IntConsumer;
 
@@ -247,44 +246,6 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         assertEquals(deserializedRequest, searchRequest);
         assertEquals(deserializedRequest.hashCode(), searchRequest.hashCode());
         assertNotSame(deserializedRequest, searchRequest);
-    }
-
-    public void testParseSearchRequest() throws IOException {
-        RestRequest restRequest = new FakeRestRequest();
-        SearchRequest searchRequest = createSearchRequest();
-        IntConsumer setSize = mock(IntConsumer.class);
-
-        restRequest.params().put("index", "index1,index2");
-        restRequest.params().put("batched_reduce_size", "512");
-        restRequest.params().put("pre_filter_shard_size", "128");
-        restRequest.params().put("max_concurrent_shard_requests", "10");
-        restRequest.params().put("allow_partial_search_results", "true");
-        restRequest.params().put("phase_took", "false");
-        restRequest.params().put("search_type", "dfs_query_then_fetch");
-        restRequest.params().put("request_cache", "true");
-        restRequest.params().put("scroll", "1m");
-        restRequest.params().put("routing", "routing_value");
-        restRequest.params().put("preference", "preference_value");
-        restRequest.params().put("search_pipeline", "pipeline_value");
-        restRequest.params().put("ccs_minimize_roundtrips", "true");
-        restRequest.params().put("cancel_after_time_interval", "5s");
-
-        RestSearchAction.parseSearchRequest(searchRequest, restRequest, null, namedWriteableRegistry, setSize);
-
-        assertEquals(Arrays.asList("index1", "index2"), Arrays.asList(searchRequest.indices()));
-        assertEquals(512, searchRequest.getBatchedReduceSize());
-        assertEquals(Integer.valueOf(128), searchRequest.getPreFilterShardSize());
-        assertEquals(10, searchRequest.getMaxConcurrentShardRequests());
-        assertTrue(searchRequest.allowPartialSearchResults());
-        assertFalse(searchRequest.isPhaseTook());
-        assertEquals(DFS_QUERY_THEN_FETCH, searchRequest.searchType());
-        assertEquals(true, searchRequest.requestCache());
-        assertEquals(TimeValue.timeValueMinutes(1), searchRequest.scroll().keepAlive());
-        assertEquals("routing_value", searchRequest.routing());
-        assertEquals("preference_value", searchRequest.preference());
-        assertEquals("pipeline_value", searchRequest.pipeline());
-        assertTrue(searchRequest.isCcsMinimizeRoundtrips());
-        assertEquals(TimeValue.timeValueSeconds(5), searchRequest.getCancelAfterTimeInterval());
     }
 
     public void testParseSearchRequestWithUnsupportedSearchType() throws IOException {


### PR DESCRIPTION
### Description
Added support for msearch API to pass search pipeline name.
With this change a search pipeline name can be provided while making a msearch call
```
{ "index": "test"}
{ "query": { "match_all": {} }, "from": 0, "size": 10, "search_pipeline": "my_pipeline"}
{ "index": "test-1", "search_type": "dfs_query_then_fetch"}
{ "query": { "match_all": {} }, "search_pipeline": "my_pipeline1" }
```

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/15748

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. - https://github.com/opensearch-project/documentation-website/pull/8372

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
