### PR TITLE
Shallow snapshot v2 - create snapshot validations in a cluster state update

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
@@ -1062,7 +1062,7 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertThat(repositoryData.getSnapshotIds().size(), greaterThanOrEqualTo(1));
         thread.join();
     }
-    
+
     public void testCreateSnapshotV2WithRedIndex() throws Exception {
         internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
         internalCluster().startDataOnlyNode(pinnedTimestampSettings());

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
@@ -46,14 +46,11 @@ import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.RepositoryData;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.repositories.fs.FsRepository;
-import org.opensearch.snapshots.AbstractSnapshotIntegTestCase;
 import org.opensearch.snapshots.SnapshotInfo;
 import org.opensearch.snapshots.SnapshotRestoreException;
 import org.opensearch.snapshots.SnapshotState;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
-import org.junit.After;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -83,48 +80,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
-public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
-    private static final String BASE_REMOTE_REPO = "test-rs-repo" + TEST_REMOTE_STORE_REPO_SUFFIX;
-    private Path remoteRepoPath;
-
-    @Before
-    public void setup() {
-        remoteRepoPath = randomRepoPath().toAbsolutePath();
-    }
-
-    @After
-    public void teardown() {
-        clusterAdmin().prepareCleanupRepository(BASE_REMOTE_REPO).get();
-    }
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal))
-            .put(remoteStoreClusterSettings(BASE_REMOTE_REPO, remoteRepoPath))
-            .build();
-    }
-
-    private Settings.Builder getIndexSettings(int numOfShards, int numOfReplicas) {
-        Settings.Builder settingsBuilder = Settings.builder()
-            .put(super.indexSettings())
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numOfShards)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numOfReplicas)
-            .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "300s");
-        return settingsBuilder;
-    }
-
-    private void indexDocuments(Client client, String indexName, int numOfDocs) {
-        indexDocuments(client, indexName, 0, numOfDocs);
-    }
-
-    private void indexDocuments(Client client, String indexName, int fromId, int toId) {
-        for (int i = fromId; i < toId; i++) {
-            String id = Integer.toString(i);
-            client.prepareIndex(indexName).setId(id).setSource("text", "sometext").get();
-        }
-        client.admin().indices().prepareFlush(indexName).get();
-    }
+public class RemoteRestoreSnapshotIT extends RemoteSnapshotIT {
 
     private void assertDocsPresentInIndex(Client client, String indexName, int numOfDocs) {
         for (int i = 0; i < numOfDocs; i++) {
@@ -1386,13 +1342,6 @@ public class RemoteRestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         enableV2Thread.join();
         createV1SnapshotThread.join();
-    }
-
-    private Settings pinnedTimestampSettings() {
-        Settings settings = Settings.builder()
-            .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), true)
-            .build();
-        return settings;
     }
 
 }

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteSnapshotIT.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotestore;
+
+import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesRequest;
+import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.RepositoryMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.indices.RemoteStoreSettings;
+import org.opensearch.repositories.fs.ReloadableFsRepository;
+import org.opensearch.snapshots.AbstractSnapshotIntegTestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import java.nio.file.Path;
+import java.util.concurrent.ExecutionException;
+
+import static org.opensearch.repositories.fs.ReloadableFsRepository.REPOSITORIES_FAILRATE_SETTING;
+
+public abstract class RemoteSnapshotIT extends AbstractSnapshotIntegTestCase {
+    protected static final String BASE_REMOTE_REPO = "test-rs-repo" + TEST_REMOTE_STORE_REPO_SUFFIX;
+    protected Path remoteRepoPath;
+
+    @Before
+    public void setup() {
+        remoteRepoPath = randomRepoPath().toAbsolutePath();
+    }
+
+    @After
+    public void teardown() {
+        clusterAdmin().prepareCleanupRepository(BASE_REMOTE_REPO).get();
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(remoteStoreClusterSettings(BASE_REMOTE_REPO, remoteRepoPath))
+            .build();
+    }
+
+    protected Settings pinnedTimestampSettings() {
+        Settings settings = Settings.builder()
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), true)
+            .build();
+        return settings;
+    }
+
+    protected Settings.Builder getIndexSettings(int numOfShards, int numOfReplicas) {
+        Settings.Builder settingsBuilder = Settings.builder()
+            .put(super.indexSettings())
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numOfShards)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numOfReplicas)
+            .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "300s");
+        return settingsBuilder;
+    }
+
+    protected void indexDocuments(Client client, String indexName, int numOfDocs) {
+        indexDocuments(client, indexName, 0, numOfDocs);
+    }
+
+    void indexDocuments(Client client, String indexName, int fromId, int toId) {
+        for (int i = fromId; i < toId; i++) {
+            String id = Integer.toString(i);
+            client.prepareIndex(indexName).setId(id).setSource("text", "sometext").get();
+        }
+        client.admin().indices().prepareFlush(indexName).get();
+    }
+
+    protected void setFailRate(String repoName, int value) throws ExecutionException, InterruptedException {
+        GetRepositoriesRequest gr = new GetRepositoriesRequest(new String[] { repoName });
+        GetRepositoriesResponse res = client().admin().cluster().getRepositories(gr).get();
+        RepositoryMetadata rmd = res.repositories().get(0);
+        Settings.Builder settings = Settings.builder()
+            .put("location", rmd.settings().get("location"))
+            .put(REPOSITORIES_FAILRATE_SETTING.getKey(), value);
+        createRepository(repoName, ReloadableFsRepository.TYPE, settings);
+    }
+
+}

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/ConcurrentSnapshotsV2IT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/ConcurrentSnapshotsV2IT.java
@@ -1,0 +1,486 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.client.Client;
+import org.opensearch.common.action.ActionFuture;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.common.unit.ByteSizeUnit;
+import org.opensearch.remotestore.RemoteSnapshotIT;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.repositories.Repository;
+import org.opensearch.repositories.RepositoryData;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.repositories.fs.FsRepository;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class ConcurrentSnapshotsV2IT extends RemoteSnapshotIT {
+
+    public void testLongRunningSnapshotDontAllowConcurrentSnapshot() throws Exception {
+        final String clusterManagerName = internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        String indexName1 = "testindex1";
+        String indexName2 = "testindex2";
+        String repoName = "test-create-snapshot-repo";
+        Path absolutePath1 = randomRepoPath().toAbsolutePath();
+        logger.info("Snapshot Path [{}]", absolutePath1);
+
+        Settings.Builder settings = Settings.builder()
+            .put(FsRepository.LOCATION_SETTING.getKey(), absolutePath1)
+            .put(FsRepository.COMPRESS_SETTING.getKey(), randomBoolean())
+            .put(FsRepository.CHUNK_SIZE_SETTING.getKey(), randomIntBetween(100, 1000), ByteSizeUnit.BYTES)
+            .put(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), true)
+            .put(BlobStoreRepository.SHALLOW_SNAPSHOT_V2.getKey(), true);
+        createRepository(repoName, "mock", settings);
+
+        Client client = client();
+        Settings indexSettings = getIndexSettings(20, 0).build();
+        createIndex(indexName1, indexSettings);
+
+        Settings indexSettings2 = getIndexSettings(15, 0).build();
+        createIndex(indexName2, indexSettings2);
+
+        final int numDocsInIndex1 = 10;
+        final int numDocsInIndex2 = 20;
+        indexDocuments(client, indexName1, numDocsInIndex1);
+        indexDocuments(client, indexName2, numDocsInIndex2);
+        ensureGreen(indexName1, indexName2);
+
+        blockClusterManagerOnWriteIndexFile(repoName);
+
+        final ActionFuture<CreateSnapshotResponse> snapshotFuture = startFullSnapshot(repoName, "snapshot-queued");
+        awaitNumberOfSnapshotsInProgress(1);
+
+        try {
+            String snapshotName = "snapshot-concurrent";
+            client().admin().cluster().prepareCreateSnapshot(repoName, snapshotName).setWaitForCompletion(true).get();
+            fail();
+        } catch (Exception e) {}
+
+        unblockNode(repoName, clusterManagerName);
+        CreateSnapshotResponse csr = snapshotFuture.actionGet();
+        List<SnapshotInfo> snapInfo = client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots();
+        assertEquals(1, snapInfo.size());
+        assertThat(snapInfo, contains(csr.getSnapshotInfo()));
+    }
+
+    public void testCreateSnapshotFailInFinalize() throws Exception {
+        final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        String indexName1 = "testindex1";
+        String indexName2 = "testindex2";
+        String repoName = "test-create-snapshot-repo";
+        Path absolutePath1 = randomRepoPath().toAbsolutePath();
+        logger.info("Snapshot Path [{}]", absolutePath1);
+
+        Settings.Builder settings = Settings.builder()
+            .put(FsRepository.LOCATION_SETTING.getKey(), absolutePath1)
+            .put(FsRepository.COMPRESS_SETTING.getKey(), randomBoolean())
+            .put(FsRepository.CHUNK_SIZE_SETTING.getKey(), randomIntBetween(100, 1000), ByteSizeUnit.BYTES)
+            .put(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), true)
+            .put(BlobStoreRepository.SHALLOW_SNAPSHOT_V2.getKey(), true);
+        createRepository(repoName, "mock", settings);
+
+        Client client = client();
+        Settings indexSettings = getIndexSettings(20, 0).build();
+        createIndex(indexName1, indexSettings);
+
+        Settings indexSettings2 = getIndexSettings(15, 0).build();
+        createIndex(indexName2, indexSettings2);
+
+        final int numDocsInIndex1 = 10;
+        final int numDocsInIndex2 = 20;
+        indexDocuments(client, indexName1, numDocsInIndex1);
+        indexDocuments(client, indexName2, numDocsInIndex2);
+        ensureGreen(indexName1, indexName2);
+
+        blockClusterManagerFromFinalizingSnapshotOnIndexFile(repoName);
+        final ActionFuture<CreateSnapshotResponse> snapshotFuture = startFullSnapshot(repoName, "snapshot-queued");
+        awaitNumberOfSnapshotsInProgress(1);
+        waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
+        unblockNode(repoName, clusterManagerNode);
+        expectThrows(SnapshotException.class, snapshotFuture::actionGet);
+
+        final ActionFuture<CreateSnapshotResponse> snapshotFuture2 = startFullSnapshot(repoName, "snapshot-success");
+        // Second create works out cleanly since the repo
+        CreateSnapshotResponse csr = snapshotFuture2.actionGet();
+
+        List<SnapshotInfo> snapInfo = client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots();
+        assertEquals(1, snapInfo.size());
+        assertThat(snapInfo, contains(csr.getSnapshotInfo()));
+    }
+
+    public void testCreateSnapshotV2MasterSwitch() throws Exception {
+        internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
+        internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
+        internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
+
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        String indexName1 = "testindex1";
+        String indexName2 = "testindex2";
+        String repoName = "test-create-snapshot-repo";
+        Path absolutePath1 = randomRepoPath().toAbsolutePath();
+        logger.info("Snapshot Path [{}]", absolutePath1);
+
+        Settings.Builder settings = Settings.builder()
+            .put(FsRepository.LOCATION_SETTING.getKey(), absolutePath1)
+            .put(FsRepository.COMPRESS_SETTING.getKey(), randomBoolean())
+            .put(FsRepository.CHUNK_SIZE_SETTING.getKey(), randomIntBetween(100, 1000), ByteSizeUnit.BYTES)
+            .put(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), true)
+            .put(BlobStoreRepository.SHALLOW_SNAPSHOT_V2.getKey(), true);
+        createRepository(repoName, "mock", settings);
+
+        Client client = client();
+        Settings indexSettings = getIndexSettings(20, 0).build();
+        createIndex(indexName1, indexSettings);
+
+        Settings indexSettings2 = getIndexSettings(15, 0).build();
+        createIndex(indexName2, indexSettings2);
+
+        final int numDocsInIndex1 = 10;
+        final int numDocsInIndex2 = 20;
+        indexDocuments(client, indexName1, numDocsInIndex1);
+        indexDocuments(client, indexName2, numDocsInIndex2);
+        ensureGreen(indexName1, indexName2);
+
+        String clusterManagerNode = internalCluster().getClusterManagerName();
+
+        blockClusterManagerFromFinalizingSnapshotOnIndexFile(repoName);
+        final ActionFuture<CreateSnapshotResponse> snapshotFuture = startFullSnapshot(repoName, "snapshot-queued");
+        awaitNumberOfSnapshotsInProgress(1);
+        waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
+
+        // Fail the cluster manager
+        stopNode(clusterManagerNode);
+
+        ensureGreen();
+
+        final ActionFuture<CreateSnapshotResponse> snapshotFuture2 = startFullSnapshot(repoName, "snapshot-success");
+        // Second create works out cleanly since the repo
+        CreateSnapshotResponse csr = snapshotFuture2.actionGet();
+
+        List<SnapshotInfo> snapInfo = client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots();
+        assertEquals(1, snapInfo.size());
+        assertThat(snapInfo, contains(csr.getSnapshotInfo()));
+
+    }
+
+    public void testPinnedTimestampFailSnapshot() throws Exception {
+        internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        String indexName1 = "testindex1";
+        String indexName2 = "testindex2";
+        String repoName = "test-create-snapshot-repo";
+        Path absolutePath1 = randomRepoPath().toAbsolutePath();
+        logger.info("Snapshot Path [{}]", absolutePath1);
+
+        Settings.Builder settings = Settings.builder()
+            .put(FsRepository.LOCATION_SETTING.getKey(), absolutePath1)
+            .put(FsRepository.COMPRESS_SETTING.getKey(), randomBoolean())
+            .put(FsRepository.CHUNK_SIZE_SETTING.getKey(), randomIntBetween(100, 1000), ByteSizeUnit.BYTES)
+            .put(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), true)
+            .put(BlobStoreRepository.SHALLOW_SNAPSHOT_V2.getKey(), true);
+        createRepository(repoName, "mock", settings);
+
+        Client client = client();
+        Settings indexSettings = getIndexSettings(20, 0).build();
+        createIndex(indexName1, indexSettings);
+
+        Settings indexSettings2 = getIndexSettings(15, 0).build();
+        createIndex(indexName2, indexSettings2);
+
+        final int numDocsInIndex1 = 10;
+        final int numDocsInIndex2 = 20;
+        indexDocuments(client, indexName1, numDocsInIndex1);
+        indexDocuments(client, indexName2, numDocsInIndex2);
+        ensureGreen(indexName1, indexName2);
+
+        // fail segment repo - this is to fail the timestamp pinning
+        setFailRate(BASE_REMOTE_REPO, 100);
+
+        try {
+            String snapshotName = "snapshot-fail";
+            CreateSnapshotResponse createSnapshotResponse = client().admin()
+                .cluster()
+                .prepareCreateSnapshot(repoName, snapshotName)
+                .setWaitForCompletion(true)
+                .get();
+            fail();
+        } catch (Exception e) {}
+
+        setFailRate(BASE_REMOTE_REPO, 0);
+        String snapshotName = "snapshot-success";
+        CreateSnapshotResponse createSnapshotResponse = client().admin()
+            .cluster()
+            .prepareCreateSnapshot(repoName, snapshotName)
+            .setWaitForCompletion(true)
+            .get();
+
+        List<SnapshotInfo> snapInfo = client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots();
+        assertEquals(1, snapInfo.size());
+    }
+
+    public void testConcurrentSnapshotV2CreateOperation() throws InterruptedException, ExecutionException {
+        internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        String indexName1 = "testindex1";
+        String indexName2 = "testindex2";
+        String snapshotRepoName = "test-create-snapshot-repo";
+        Path absolutePath1 = randomRepoPath().toAbsolutePath();
+        logger.info("Snapshot Path [{}]", absolutePath1);
+
+        Settings.Builder settings = Settings.builder()
+            .put(FsRepository.LOCATION_SETTING.getKey(), absolutePath1)
+            .put(FsRepository.COMPRESS_SETTING.getKey(), randomBoolean())
+            .put(FsRepository.CHUNK_SIZE_SETTING.getKey(), randomIntBetween(100, 1000), ByteSizeUnit.BYTES)
+            .put(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), true)
+            .put(BlobStoreRepository.SHALLOW_SNAPSHOT_V2.getKey(), true);
+        createRepository(snapshotRepoName, FsRepository.TYPE, settings);
+
+        Client client = client();
+        Settings indexSettings = getIndexSettings(20, 0).build();
+        createIndex(indexName1, indexSettings);
+
+        Settings indexSettings2 = getIndexSettings(15, 0).build();
+        createIndex(indexName2, indexSettings2);
+
+        final int numDocsInIndex1 = 10;
+        final int numDocsInIndex2 = 20;
+        indexDocuments(client, indexName1, numDocsInIndex1);
+        indexDocuments(client, indexName2, numDocsInIndex2);
+        ensureGreen(indexName1, indexName2);
+
+        int concurrentSnapshots = 5;
+
+        // Prepare threads for concurrent snapshot creation
+        List<Thread> threads = new ArrayList<>();
+
+        for (int i = 0; i < concurrentSnapshots; i++) {
+            int snapshotIndex = i;
+            Thread thread = new Thread(() -> {
+                try {
+                    String snapshotName = "snapshot-concurrent-" + snapshotIndex;
+                    CreateSnapshotResponse createSnapshotResponse2 = client().admin()
+                        .cluster()
+                        .prepareCreateSnapshot(snapshotRepoName, snapshotName)
+                        .setWaitForCompletion(true)
+                        .get();
+                    SnapshotInfo snapshotInfo = createSnapshotResponse2.getSnapshotInfo();
+                    assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
+                    assertThat(snapshotInfo.successfulShards(), greaterThan(0));
+                    assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
+                    assertThat(snapshotInfo.snapshotId().getName(), equalTo(snapshotName));
+                    assertThat(snapshotInfo.getPinnedTimestamp(), greaterThan(0L));
+                } catch (Exception e) {}
+            });
+            threads.add(thread);
+        }
+        // start all threads
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // Wait for all threads to complete
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // Validate that only one snapshot has been created
+        Repository repository = internalCluster().getInstance(RepositoriesService.class).repository(snapshotRepoName);
+        PlainActionFuture<RepositoryData> repositoryDataPlainActionFuture = new PlainActionFuture<>();
+        repository.getRepositoryData(repositoryDataPlainActionFuture);
+
+        RepositoryData repositoryData = repositoryDataPlainActionFuture.get();
+        assertThat(repositoryData.getSnapshotIds().size(), greaterThanOrEqualTo(1));
+    }
+
+    public void testLongRunningSnapshotDontAllowConcurrentClone() throws Exception {
+        final String clusterManagerName = internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        String indexName1 = "testindex1";
+        String indexName2 = "testindex2";
+        String repoName = "test-create-snapshot-repo";
+        Path absolutePath1 = randomRepoPath().toAbsolutePath();
+        logger.info("Snapshot Path [{}]", absolutePath1);
+
+        Settings.Builder settings = Settings.builder()
+            .put(FsRepository.LOCATION_SETTING.getKey(), absolutePath1)
+            .put(FsRepository.COMPRESS_SETTING.getKey(), randomBoolean())
+            .put(FsRepository.CHUNK_SIZE_SETTING.getKey(), randomIntBetween(100, 1000), ByteSizeUnit.BYTES)
+            .put(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), true)
+            .put(BlobStoreRepository.SHALLOW_SNAPSHOT_V2.getKey(), true);
+        createRepository(repoName, "mock", settings);
+
+        Client client = client();
+        Settings indexSettings = getIndexSettings(20, 0).build();
+        createIndex(indexName1, indexSettings);
+
+        Settings indexSettings2 = getIndexSettings(15, 0).build();
+        createIndex(indexName2, indexSettings2);
+
+        final int numDocsInIndex1 = 10;
+        final int numDocsInIndex2 = 20;
+        indexDocuments(client, indexName1, numDocsInIndex1);
+        indexDocuments(client, indexName2, numDocsInIndex2);
+        ensureGreen(indexName1, indexName2);
+
+        String sourceSnap = "snapshot-source";
+
+        final CreateSnapshotResponse csr = startFullSnapshot(repoName, sourceSnap).actionGet();
+        blockClusterManagerOnWriteIndexFile(repoName);
+
+        final ActionFuture<AcknowledgedResponse> snapshotFuture = startCloneSnapshot(repoName, sourceSnap, "snapshot-clone");
+        awaitNumberOfSnapshotsInProgress(1);
+
+        final ActionFuture<AcknowledgedResponse> snapshotFuture2 = startCloneSnapshot(repoName, sourceSnap, "snapshot-clone-2");
+        assertThrows(ConcurrentSnapshotExecutionException.class, snapshotFuture2::actionGet);
+
+        unblockNode(repoName, clusterManagerName);
+        assertThrows(SnapshotException.class, snapshotFuture2::actionGet);
+
+        snapshotFuture.get();
+
+        List<SnapshotInfo> snapInfo = client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots();
+        assertEquals(2, snapInfo.size());
+    }
+
+    public void testCloneSnapshotFailInFinalize() throws Exception {
+        final String clusterManagerNode = internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        String indexName1 = "testindex1";
+        String indexName2 = "testindex2";
+        String repoName = "test-create-snapshot-repo";
+        Path absolutePath1 = randomRepoPath().toAbsolutePath();
+        logger.info("Snapshot Path [{}]", absolutePath1);
+
+        Settings.Builder settings = Settings.builder()
+            .put(FsRepository.LOCATION_SETTING.getKey(), absolutePath1)
+            .put(FsRepository.COMPRESS_SETTING.getKey(), randomBoolean())
+            .put(FsRepository.CHUNK_SIZE_SETTING.getKey(), randomIntBetween(100, 1000), ByteSizeUnit.BYTES)
+            .put(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), true)
+            .put(BlobStoreRepository.SHALLOW_SNAPSHOT_V2.getKey(), true);
+        createRepository(repoName, "mock", settings);
+
+        Client client = client();
+        Settings indexSettings = getIndexSettings(20, 0).build();
+        createIndex(indexName1, indexSettings);
+
+        Settings indexSettings2 = getIndexSettings(15, 0).build();
+        createIndex(indexName2, indexSettings2);
+
+        final int numDocsInIndex1 = 10;
+        final int numDocsInIndex2 = 20;
+        indexDocuments(client, indexName1, numDocsInIndex1);
+        indexDocuments(client, indexName2, numDocsInIndex2);
+        ensureGreen(indexName1, indexName2);
+
+        String sourceSnap = "snapshot-source";
+        CreateSnapshotResponse sourceResp = startFullSnapshot(repoName, sourceSnap).actionGet();
+
+        blockClusterManagerFromFinalizingSnapshotOnIndexFile(repoName);
+        final ActionFuture<AcknowledgedResponse> snapshotFuture = startCloneSnapshot(repoName, sourceSnap, "snapshot-queued");
+        awaitNumberOfSnapshotsInProgress(1);
+        waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
+        unblockNode(repoName, clusterManagerNode);
+        assertThrows(SnapshotException.class, snapshotFuture::actionGet);
+
+        final ActionFuture<CreateSnapshotResponse> snapshotFuture2 = startFullSnapshot(repoName, "snapshot-success");
+        // Second create works out cleanly since the repo is cleaned up
+        CreateSnapshotResponse csr = snapshotFuture2.actionGet();
+
+        List<SnapshotInfo> snapInfo = client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots();
+        assertEquals(2, snapInfo.size());
+        assertThat(snapInfo, containsInAnyOrder(csr.getSnapshotInfo(), sourceResp.getSnapshotInfo()));
+    }
+
+    public void testCloneSnapshotV2MasterSwitch() throws Exception {
+        internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
+        internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
+        internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
+
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        String indexName1 = "testindex1";
+        String indexName2 = "testindex2";
+        String repoName = "test-create-snapshot-repo";
+        Path absolutePath1 = randomRepoPath().toAbsolutePath();
+        logger.info("Snapshot Path [{}]", absolutePath1);
+
+        Settings.Builder settings = Settings.builder()
+            .put(FsRepository.LOCATION_SETTING.getKey(), absolutePath1)
+            .put(FsRepository.COMPRESS_SETTING.getKey(), randomBoolean())
+            .put(FsRepository.CHUNK_SIZE_SETTING.getKey(), randomIntBetween(100, 1000), ByteSizeUnit.BYTES)
+            .put(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), true)
+            .put(BlobStoreRepository.SHALLOW_SNAPSHOT_V2.getKey(), true);
+        createRepository(repoName, "mock", settings);
+
+        Client client = client();
+        Settings indexSettings = getIndexSettings(20, 0).build();
+        createIndex(indexName1, indexSettings);
+
+        Settings indexSettings2 = getIndexSettings(15, 0).build();
+        createIndex(indexName2, indexSettings2);
+
+        final int numDocsInIndex1 = 10;
+        final int numDocsInIndex2 = 20;
+        indexDocuments(client, indexName1, numDocsInIndex1);
+        indexDocuments(client, indexName2, numDocsInIndex2);
+        ensureGreen(indexName1, indexName2);
+
+        String sourceSnap = "snapshot-source";
+        CreateSnapshotResponse csr = startFullSnapshot(repoName, sourceSnap).actionGet();
+
+        String clusterManagerNode = internalCluster().getClusterManagerName();
+
+        blockClusterManagerFromFinalizingSnapshotOnIndexFile(repoName);
+        final ActionFuture<AcknowledgedResponse> snapshotFuture = startCloneSnapshot(repoName, sourceSnap, "snapshot-queued");
+        awaitNumberOfSnapshotsInProgress(1);
+        waitForBlock(clusterManagerNode, repoName, TimeValue.timeValueSeconds(30L));
+
+        // Fail the cluster manager
+        stopNode(clusterManagerNode);
+
+        ensureGreen();
+
+        final ActionFuture<CreateSnapshotResponse> snapshotFuture2 = startFullSnapshot(repoName, "snapshot-success");
+        // Second create works out cleanly since the repo
+        CreateSnapshotResponse csr2 = snapshotFuture2.actionGet();
+        List<SnapshotInfo> snapInfo = client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots();
+        assertEquals(2, snapInfo.size());
+        assertThat(snapInfo, containsInAnyOrder(csr.getSnapshotInfo(), csr2.getSnapshotInfo()));
+    }
+
+    protected ActionFuture<AcknowledgedResponse> startCloneSnapshot(String repoName, String sourceSnapshotName, String snapshotName) {
+        logger.info("--> creating full snapshot [{}] to repo [{}]", snapshotName, repoName);
+        return clusterAdmin().prepareCloneSnapshot(repoName, sourceSnapshotName, snapshotName).setIndices("*").execute();
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
@@ -202,7 +202,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             Map.of(),
             false,
             false// initialising to false, will be updated in startCloning method of SnapshotsService while updating entry with
-                  // clone jobs
+                 // clone jobs
         );
     }
 
@@ -231,7 +231,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             source,
             Map.of(),
             remoteStoreIndexShallowCopyV2,
-            remoteStoreIndexShallowCopyV2// initialising to false, will be updated in startCloning method of SnapshotsService while updating entry with
+            remoteStoreIndexShallowCopyV2// initialising to false, will be updated in startCloning method of SnapshotsService while updating
+                                         // entry with
             // clone jobs
         );
     }
@@ -388,7 +389,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             }
             this.remoteStoreIndexShallowCopy = remoteStoreIndexShallowCopy;
             this.remoteStoreIndexShallowCopyV2 = remoteStoreIndexShallowCopyV2;
-            assert this.remoteStoreIndexShallowCopyV2 || assertShardsConsistent(this.source, this.state, this.indices, this.shards, this.clones);
+            assert this.remoteStoreIndexShallowCopyV2
+                || assertShardsConsistent(this.source, this.state, this.indices, this.shards, this.clones);
         }
 
         private Entry(StreamInput in) throws IOException {

--- a/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
@@ -231,9 +231,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             source,
             Map.of(),
             remoteStoreIndexShallowCopyV2,
-            remoteStoreIndexShallowCopyV2// initialising to false, will be updated in startCloning method of SnapshotsService while updating
-                                         // entry with
-            // clone jobs
+            remoteStoreIndexShallowCopyV2// initialising to false, will be updated in startCloning method of SnapshotsService
+            // while updating entry with clone jobs
         );
     }
 

--- a/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
@@ -349,7 +349,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             );
         }
 
-        public Entry(
+        private Entry(
             Snapshot snapshot,
             boolean includeGlobalState,
             boolean partial,

--- a/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/opensearch/cluster/SnapshotsInProgress.java
@@ -134,6 +134,38 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         );
     }
 
+    public static Entry startedEntry(
+        Snapshot snapshot,
+        boolean includeGlobalState,
+        boolean partial,
+        List<IndexId> indices,
+        List<String> dataStreams,
+        long startTime,
+        long repositoryStateId,
+        final Map<ShardId, ShardSnapshotStatus> shards,
+        Map<String, Object> userMetadata,
+        Version version,
+        boolean remoteStoreIndexShallowCopy,
+        boolean remoteStoreIndexShallowCopyV2
+    ) {
+        return new SnapshotsInProgress.Entry(
+            snapshot,
+            includeGlobalState,
+            partial,
+            completed(shards.values()) ? State.SUCCESS : State.STARTED,
+            indices,
+            dataStreams,
+            startTime,
+            repositoryStateId,
+            shards,
+            null,
+            userMetadata,
+            version,
+            remoteStoreIndexShallowCopy,
+            remoteStoreIndexShallowCopyV2
+        );
+    }
+
     /**
      * Creates the initial snapshot clone entry
      *
@@ -168,8 +200,39 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             version,
             source,
             Map.of(),
-            false // initialising to false, will be updated in startCloning method of SnapshotsService while updating entry with
+            false,
+            false// initialising to false, will be updated in startCloning method of SnapshotsService while updating entry with
                   // clone jobs
+        );
+    }
+
+    public static Entry startClone(
+        Snapshot snapshot,
+        SnapshotId source,
+        List<IndexId> indices,
+        long startTime,
+        long repositoryStateId,
+        Version version,
+        boolean remoteStoreIndexShallowCopyV2
+    ) {
+        return new SnapshotsInProgress.Entry(
+            snapshot,
+            true,
+            false,
+            State.STARTED,
+            indices,
+            Collections.emptyList(),
+            startTime,
+            repositoryStateId,
+            Map.of(),
+            null,
+            Collections.emptyMap(),
+            version,
+            source,
+            Map.of(),
+            remoteStoreIndexShallowCopyV2,
+            remoteStoreIndexShallowCopyV2// initialising to false, will be updated in startCloning method of SnapshotsService while updating entry with
+            // clone jobs
         );
     }
 
@@ -183,6 +246,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         private final Snapshot snapshot;
         private final boolean includeGlobalState;
         private final boolean remoteStoreIndexShallowCopy;
+
+        private final boolean remoteStoreIndexShallowCopyV2;
         private final boolean partial;
         /**
          * Map of {@link ShardId} to {@link ShardSnapshotStatus} tracking the state of each shard snapshot operation.
@@ -211,6 +276,42 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         private final Map<String, Object> userMetadata;
         @Nullable
         private final String failure;
+
+        public Entry(
+            Snapshot snapshot,
+            boolean includeGlobalState,
+            boolean partial,
+            State state,
+            List<IndexId> indices,
+            List<String> dataStreams,
+            long startTime,
+            long repositoryStateId,
+            final Map<ShardId, ShardSnapshotStatus> shards,
+            String failure,
+            Map<String, Object> userMetadata,
+            Version version,
+            boolean remoteStoreIndexShallowCopy,
+            boolean remoteStoreIndexShallowCopyV2
+        ) {
+            this(
+                snapshot,
+                includeGlobalState,
+                partial,
+                state,
+                indices,
+                dataStreams,
+                startTime,
+                repositoryStateId,
+                shards,
+                failure,
+                userMetadata,
+                version,
+                null,
+                Map.of(),
+                remoteStoreIndexShallowCopy,
+                remoteStoreIndexShallowCopyV2
+            );
+        }
 
         // visible for testing, use #startedEntry and copy constructors in production code
         public Entry(
@@ -243,11 +344,12 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                 version,
                 null,
                 Map.of(),
-                remoteStoreIndexShallowCopy
+                remoteStoreIndexShallowCopy,
+                false
             );
         }
 
-        private Entry(
+        public Entry(
             Snapshot snapshot,
             boolean includeGlobalState,
             boolean partial,
@@ -262,7 +364,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             Version version,
             @Nullable SnapshotId source,
             @Nullable final Map<RepositoryShardId, ShardSnapshotStatus> clones,
-            boolean remoteStoreIndexShallowCopy
+            boolean remoteStoreIndexShallowCopy,
+            boolean remoteStoreIndexShallowCopyV2
         ) {
             this.state = state;
             this.snapshot = snapshot;
@@ -284,7 +387,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                 this.clones = Collections.unmodifiableMap(clones);
             }
             this.remoteStoreIndexShallowCopy = remoteStoreIndexShallowCopy;
-            assert assertShardsConsistent(this.source, this.state, this.indices, this.shards, this.clones);
+            this.remoteStoreIndexShallowCopyV2 = remoteStoreIndexShallowCopyV2;
+            assert this.remoteStoreIndexShallowCopyV2 || assertShardsConsistent(this.source, this.state, this.indices, this.shards, this.clones);
         }
 
         private Entry(StreamInput in) throws IOException {
@@ -306,6 +410,11 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                 remoteStoreIndexShallowCopy = in.readBoolean();
             } else {
                 remoteStoreIndexShallowCopy = false;
+            }
+            if (in.getVersion().onOrAfter(Version.CURRENT)) {
+                remoteStoreIndexShallowCopyV2 = in.readBoolean();
+            } else {
+                remoteStoreIndexShallowCopyV2 = false;
             }
         }
 
@@ -428,7 +537,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                 version,
                 source,
                 clones,
-                remoteStoreIndexShallowCopy
+                remoteStoreIndexShallowCopy,
+                remoteStoreIndexShallowCopyV2
             );
         }
 
@@ -451,7 +561,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                 version,
                 source,
                 updatedClones,
-                remoteStoreIndexShallowCopy
+                remoteStoreIndexShallowCopy,
+                remoteStoreIndexShallowCopyV2
             );
         }
 
@@ -471,7 +582,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                 version,
                 source,
                 clones,
-                remoteStoreIndexShallowCopy
+                remoteStoreIndexShallowCopy,
+                remoteStoreIndexShallowCopyV2
             );
         }
 
@@ -527,7 +639,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                 version,
                 source,
                 clones,
-                remoteStoreIndexShallowCopy
+                remoteStoreIndexShallowCopy,
+                remoteStoreIndexShallowCopyV2
             );
         }
 
@@ -614,6 +727,10 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             return remoteStoreIndexShallowCopy;
         }
 
+        public boolean remoteStoreIndexShallowCopyV2() {
+            return remoteStoreIndexShallowCopyV2;
+        }
+
         public Map<String, Object> userMetadata() {
             return userMetadata;
         }
@@ -678,6 +795,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             if (Objects.equals(source, ((Entry) o).source) == false) return false;
             if (clones.equals(((Entry) o).clones) == false) return false;
             if (remoteStoreIndexShallowCopy != entry.remoteStoreIndexShallowCopy) return false;
+            if (remoteStoreIndexShallowCopyV2 != entry.remoteStoreIndexShallowCopyV2) return false;
             return true;
         }
 
@@ -695,6 +813,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             result = 31 * result + (source == null ? 0 : source.hashCode());
             result = 31 * result + clones.hashCode();
             result = 31 * result + (remoteStoreIndexShallowCopy ? 1 : 0);
+            result = 31 * result + (remoteStoreIndexShallowCopyV2 ? 1 : 0);
             return result;
         }
 
@@ -765,6 +884,9 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             out.writeMap(clones, (o, v) -> v.writeTo(o), (o, v) -> v.writeTo(o));
             if (out.getVersion().onOrAfter(Version.V_2_9_0)) {
                 out.writeBoolean(remoteStoreIndexShallowCopy);
+            }
+            if (out.getVersion().onOrAfter(Version.CURRENT)) {
+                out.writeBoolean(remoteStoreIndexShallowCopyV2);
             }
         }
 

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -2490,6 +2490,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 // number_of_shards) has increased.
                 Set<String> updatedIndexIds = writeNewIndexShardPaths(existingRepositoryData, updatedRepositoryData, snapshotId);
                 cleanupRedundantSnapshotShardPaths(updatedIndexIds);
+                logger.info("update repo data for {}", snapshotInfo.snapshotId());
                 writeIndexGen(
                     updatedRepositoryData,
                     repositoryStateId,
@@ -3289,6 +3290,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         + "] must be larger than latest known generation ["
                         + latestKnownRepoGen.get()
                         + "]";
+                    logger.info("Setting it to {} {}", safeGeneration, newGen);
                     return ClusterState.builder(currentState)
                         .metadata(
                             Metadata.builder(currentState.getMetadata())
@@ -3409,6 +3411,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                                     + "]"
                             );
                         }
+                        logger.info("Done Setting it to {} {}", newGen, newGen);
                         return updateRepositoryGenerationsIfNecessary(
                             stateFilter.apply(
                                 ClusterState.builder(currentState)

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -823,7 +823,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         + "] to generation ["
                         + metadata.generation()
                         + "]";
-                logger.info("Updated repository generation from [{}] to [{}]", previousBest, metadata.generation());
+                logger.debug("Updated repository generation from [{}] to [{}]", previousBest, metadata.generation());
             }
         }
     }
@@ -2490,7 +2490,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 // number_of_shards) has increased.
                 Set<String> updatedIndexIds = writeNewIndexShardPaths(existingRepositoryData, updatedRepositoryData, snapshotId);
                 cleanupRedundantSnapshotShardPaths(updatedIndexIds);
-                logger.info("update repo data for {}", snapshotInfo.snapshotId());
                 writeIndexGen(
                     updatedRepositoryData,
                     repositoryStateId,
@@ -3290,7 +3289,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         + "] must be larger than latest known generation ["
                         + latestKnownRepoGen.get()
                         + "]";
-                    logger.info("Setting it to {} {}", safeGeneration, newGen);
                     return ClusterState.builder(currentState)
                         .metadata(
                             Metadata.builder(currentState.getMetadata())

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -823,7 +823,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         + "] to generation ["
                         + metadata.generation()
                         + "]";
-                logger.debug("Updated repository generation from [{}] to [{}]", previousBest, metadata.generation());
+                logger.info("Updated repository generation from [{}] to [{}]", previousBest, metadata.generation());
             }
         }
     }
@@ -2932,6 +2932,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             return;
         }
         final Tuple<Long, BytesReference> cached = latestKnownRepositoryData.get();
+        // Fast path loading repository data directly from cache if we're in fully consistent mode and the cache matches up with
+        // Fast path loading repository data directly from cache if we're in fully consistent mode and the cache matches up with
         // Fast path loading repository data directly from cache if we're in fully consistent mode and the cache matches up with
         // the latest known repository generation
         if (bestEffortConsistency == false && cached != null && cached.v1() == latestKnownRepoGen.get()) {

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -2933,8 +2933,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
         final Tuple<Long, BytesReference> cached = latestKnownRepositoryData.get();
         // Fast path loading repository data directly from cache if we're in fully consistent mode and the cache matches up with
-        // Fast path loading repository data directly from cache if we're in fully consistent mode and the cache matches up with
-        // Fast path loading repository data directly from cache if we're in fully consistent mode and the cache matches up with
         // the latest known repository generation
         if (bestEffortConsistency == false && cached != null && cached.v1() == latestKnownRepoGen.get()) {
             try {
@@ -3413,7 +3411,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                                     + "]"
                             );
                         }
-                        logger.info("Done Setting it to {} {}", newGen, newGen);
                         return updateRepositoryGenerationsIfNecessary(
                             stateFilter.apply(
                                 ClusterState.builder(currentState)

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -639,6 +639,12 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 });
                 updateSnapshotPinnedTimestamp(repositoryData, snapshot, pinnedTimestamp, pinnedTimestampListener);
             }
+
+            @Override
+            public TimeValue timeout() {
+                return request.clusterManagerNodeTimeout();
+            }
+
         }, "create_snapshot [" + snapshotName + ']', listener::onFailure);
     }
 

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -470,6 +470,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         final String snapshotName = indexNameExpressionResolver.resolveDateMathExpression(request.snapshot());
 
         Repository repository = repositoriesService.repository(repositoryName);
+        validate(repositoryName, snapshotName);
         repository.executeConsistentStateUpdate(repositoryData -> new ClusterStateUpdateTask(Priority.URGENT) {
             private SnapshotsInProgress.Entry newEntry;
 
@@ -482,8 +483,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             @Override
             public ClusterState execute(ClusterState currentState) {
                 // move to in progress
-                validate(repositoryName, snapshotName);
-
                 snapshotId = new SnapshotId(snapshotName, UUIDs.randomBase64UUID()); // new UUID for the snapshot
                 Repository repository = repositoriesService.repository(repositoryName);
 

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotsInProgressSerializationTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotsInProgressSerializationTests.java
@@ -214,7 +214,11 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
                     assert (curr_entry.remoteStoreIndexShallowCopy() == false);
                 }
             }
-            try (StreamInput in = out.bytes().streamInput()) {
+
+            BytesStreamOutput out2 = new BytesStreamOutput();
+            out2.setVersion(Version.V_2_9_0);
+            snapshotsInProgress.writeTo(out2);
+            try (StreamInput in = out2.bytes().streamInput()) {
                 in.setVersion(Version.V_2_9_0);
                 actualSnapshotsInProgress = new SnapshotsInProgress(in);
                 assert in.available() == 0;


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

1. Adding `IN_PROGRESS` cluster state entry for shallow v2 snapshots. Associated clean up with this. This ensure whatever validations we are doing are atomic in nature. 
2. Pinning timestamp before doing finalize snapshot .
3. Blocking concurrent v2 snapshots. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
