### PR TITLE
Optimize remote store GC flow with pinned timestamps

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsGarbageCollectionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsGarbageCollectionIT.java
@@ -167,7 +167,7 @@ public class RemoteStorePinnedTimestampsGarbageCollectionIT extends RemoteStoreB
 
         assertBusy(() -> {
             List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
-            assertEquals(numDocs + 1, metadataFiles.size());
+            assertTrue(metadataFiles.size() >= numDocs + 1);
 
             verifyTranslogDataFileCount(metadataFiles, translogDataPath);
         }, 30, TimeUnit.SECONDS);

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsGarbageCollectionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsGarbageCollectionIT.java
@@ -112,7 +112,7 @@ public class RemoteStorePinnedTimestampsGarbageCollectionIT extends RemoteStoreB
 
         assertBusy(() -> {
             List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
-            assertEquals(1, metadataFiles.size());
+            assertEquals(2, metadataFiles.size());
 
             verifyTranslogDataFileCount(metadataFiles, translogDataPath);
         });
@@ -222,7 +222,7 @@ public class RemoteStorePinnedTimestampsGarbageCollectionIT extends RemoteStoreB
 
         assertBusy(() -> {
             List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
-            assertEquals(4, metadataFiles.size());
+            assertEquals(5, metadataFiles.size());
 
             verifyTranslogDataFileCount(metadataFiles, translogDataPath);
         });
@@ -282,7 +282,7 @@ public class RemoteStorePinnedTimestampsGarbageCollectionIT extends RemoteStoreB
 
         assertBusy(() -> {
             List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
-            assertEquals(2, metadataFiles.size());
+            assertEquals(3, metadataFiles.size());
 
             verifyTranslogDataFileCount(metadataFiles, translogDataPath);
         });
@@ -337,7 +337,7 @@ public class RemoteStorePinnedTimestampsGarbageCollectionIT extends RemoteStoreB
 
         assertBusy(() -> {
             List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
-            assertEquals(1, metadataFiles.size());
+            assertEquals(2, metadataFiles.size());
 
             verifyTranslogDataFileCount(metadataFiles, translogDataPath);
         });
@@ -405,7 +405,7 @@ public class RemoteStorePinnedTimestampsGarbageCollectionIT extends RemoteStoreB
 
         assertBusy(() -> {
             List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
-            assertEquals(2, metadataFiles.size());
+            assertEquals(3, metadataFiles.size());
 
             verifyTranslogDataFileCount(metadataFiles, translogDataPath);
         }, 30, TimeUnit.SECONDS);

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsGarbageCollectionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsGarbageCollectionIT.java
@@ -1,0 +1,433 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotestore;
+
+import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.translog.transfer.TranslogTransferMetadata;
+import org.opensearch.indices.RemoteStoreSettings;
+import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.opensearch.index.IndexSettings.INDEX_REMOTE_TRANSLOG_KEEP_EXTRA_GEN_SETTING;
+import static org.opensearch.index.remote.RemoteStoreEnums.DataCategory.TRANSLOG;
+import static org.opensearch.index.remote.RemoteStoreEnums.DataType.DATA;
+import static org.opensearch.index.remote.RemoteStoreEnums.DataType.METADATA;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class RemoteStorePinnedTimestampsGarbageCollectionIT extends RemoteStoreBaseIntegTestCase {
+    static final String INDEX_NAME = "remote-store-test-idx-1";
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), true)
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_METADATA.getKey(), false)
+            .build();
+    }
+
+    private void keepPinnedTimestampSchedulerUpdated() throws InterruptedException {
+        long currentTime = System.currentTimeMillis();
+        int maxRetry = 10;
+        while (maxRetry > 0 && RemoteStorePinnedTimestampService.getPinnedTimestamps().v1() <= currentTime) {
+            Thread.sleep(1000);
+            maxRetry--;
+        }
+    }
+
+    ActionListener<Void> noOpActionListener = new ActionListener<>() {
+        @Override
+        public void onResponse(Void unused) {}
+
+        @Override
+        public void onFailure(Exception e) {}
+    };
+
+    public void testLiveIndexNoPinnedTimestamps() throws Exception {
+        prepareCluster(1, 1, Settings.EMPTY);
+        Settings indexSettings = Settings.builder()
+            .put(remoteStoreIndexSettings(0, 1))
+            .put(INDEX_REMOTE_TRANSLOG_KEEP_EXTRA_GEN_SETTING.getKey(), 0)
+            .build();
+        createIndex(INDEX_NAME, indexSettings);
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(
+            RemoteStorePinnedTimestampService.class,
+            primaryNodeName(INDEX_NAME)
+        );
+
+        remoteStorePinnedTimestampService.rescheduleAsyncUpdatePinnedTimestampTask(TimeValue.timeValueSeconds(1));
+
+        int numDocs = randomIntBetween(5, 10);
+        for (int i = 0; i < numDocs; i++) {
+            keepPinnedTimestampSchedulerUpdated();
+            indexSingleDoc(INDEX_NAME, true);
+        }
+
+        String translogPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.get(getNodeSettings());
+        String shardDataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            DATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogDataPath = Path.of(translogRepoPath + "/" + shardDataPath + "/1");
+        String shardMetadataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            METADATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogMetadataPath = Path.of(translogRepoPath + "/" + shardMetadataPath);
+
+        assertBusy(() -> {
+            List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
+            assertEquals(1, metadataFiles.size());
+
+            verifyTranslogDataFileCount(metadataFiles, translogDataPath);
+        });
+    }
+
+    public void testLiveIndexNoPinnedTimestampsWithExtraGenSettingWithinLimit() throws Exception {
+        prepareCluster(1, 1, Settings.EMPTY);
+        Settings indexSettings = Settings.builder()
+            .put(remoteStoreIndexSettings(0, 1))
+            .put(INDEX_REMOTE_TRANSLOG_KEEP_EXTRA_GEN_SETTING.getKey(), 10)
+            .build();
+        createIndex(INDEX_NAME, indexSettings);
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(
+            RemoteStorePinnedTimestampService.class,
+            primaryNodeName(INDEX_NAME)
+        );
+
+        remoteStorePinnedTimestampService.rescheduleAsyncUpdatePinnedTimestampTask(TimeValue.timeValueSeconds(1));
+
+        int numDocs = randomIntBetween(5, 9);
+        for (int i = 0; i < numDocs; i++) {
+            keepPinnedTimestampSchedulerUpdated();
+            indexSingleDoc(INDEX_NAME, true);
+        }
+
+        String translogPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.get(getNodeSettings());
+        String shardDataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            DATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogDataPath = Path.of(translogRepoPath + "/" + shardDataPath + "/1");
+        String shardMetadataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            METADATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogMetadataPath = Path.of(translogRepoPath + "/" + shardMetadataPath);
+
+        assertBusy(() -> {
+            List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
+            assertEquals(numDocs + 1, metadataFiles.size());
+
+            verifyTranslogDataFileCount(metadataFiles, translogDataPath);
+        });
+    }
+
+    public void testLiveIndexNoPinnedTimestampsWithExtraGenSetting() throws Exception {
+        prepareCluster(1, 1, Settings.EMPTY);
+        Settings indexSettings = Settings.builder()
+            .put(remoteStoreIndexSettings(0, 1))
+            .put(INDEX_REMOTE_TRANSLOG_KEEP_EXTRA_GEN_SETTING.getKey(), 3)
+            .build();
+        createIndex(INDEX_NAME, indexSettings);
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(
+            RemoteStorePinnedTimestampService.class,
+            primaryNodeName(INDEX_NAME)
+        );
+
+        remoteStorePinnedTimestampService.rescheduleAsyncUpdatePinnedTimestampTask(TimeValue.timeValueSeconds(1));
+
+        int numDocs = 5;
+        for (int i = 0; i < numDocs; i++) {
+            keepPinnedTimestampSchedulerUpdated();
+            indexSingleDoc(INDEX_NAME, true);
+        }
+
+        String translogPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.get(getNodeSettings());
+        String shardDataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            DATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogDataPath = Path.of(translogRepoPath + "/" + shardDataPath + "/1");
+        String shardMetadataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            METADATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogMetadataPath = Path.of(translogRepoPath + "/" + shardMetadataPath);
+
+        assertBusy(() -> {
+            List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
+            assertEquals(3, metadataFiles.size());
+
+            verifyTranslogDataFileCount(metadataFiles, translogDataPath);
+        });
+    }
+
+    public void testLiveIndexWithPinnedTimestamps() throws Exception {
+        prepareCluster(1, 1, Settings.EMPTY);
+        Settings indexSettings = Settings.builder()
+            .put(remoteStoreIndexSettings(0, 1))
+            .put(INDEX_REMOTE_TRANSLOG_KEEP_EXTRA_GEN_SETTING.getKey(), 0)
+            .build();
+        createIndex(INDEX_NAME, indexSettings);
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(
+            RemoteStorePinnedTimestampService.class,
+            primaryNodeName(INDEX_NAME)
+        );
+
+        remoteStorePinnedTimestampService.rescheduleAsyncUpdatePinnedTimestampTask(TimeValue.timeValueSeconds(1));
+
+        int numDocs = randomIntBetween(5, 10);
+        for (int i = 0; i < numDocs; i++) {
+            keepPinnedTimestampSchedulerUpdated();
+            indexSingleDoc(INDEX_NAME, true);
+            if (i == 2) {
+                RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.timeValueMinutes(1));
+                remoteStorePinnedTimestampService.pinTimestamp(System.currentTimeMillis(), "xyz", noOpActionListener);
+                RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+            }
+        }
+
+        String translogPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.get(getNodeSettings());
+        String shardDataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            DATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogDataPath = Path.of(translogRepoPath + "/" + shardDataPath + "/1");
+        String shardMetadataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            METADATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogMetadataPath = Path.of(translogRepoPath + "/" + shardMetadataPath);
+
+        assertBusy(() -> {
+            List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
+            assertEquals(2, metadataFiles.size());
+
+            verifyTranslogDataFileCount(metadataFiles, translogDataPath);
+        });
+    }
+
+    public void testIndexDeletionNoPinnedTimestamps() throws Exception {
+        prepareCluster(1, 1, Settings.EMPTY);
+        Settings indexSettings = Settings.builder()
+            .put(remoteStoreIndexSettings(0, 1))
+            .put(INDEX_REMOTE_TRANSLOG_KEEP_EXTRA_GEN_SETTING.getKey(), 0)
+            .build();
+        createIndex(INDEX_NAME, indexSettings);
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(
+            RemoteStorePinnedTimestampService.class,
+            primaryNodeName(INDEX_NAME)
+        );
+
+        remoteStorePinnedTimestampService.rescheduleAsyncUpdatePinnedTimestampTask(TimeValue.timeValueSeconds(1));
+
+        int numDocs = randomIntBetween(5, 10);
+        for (int i = 0; i < numDocs; i++) {
+            keepPinnedTimestampSchedulerUpdated();
+            indexSingleDoc(INDEX_NAME, true);
+        }
+
+        String translogPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.get(getNodeSettings());
+        String shardDataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            DATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogDataPath = Path.of(translogRepoPath + "/" + shardDataPath + "/1");
+        String shardMetadataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            METADATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogMetadataPath = Path.of(translogRepoPath + "/" + shardMetadataPath);
+
+        assertBusy(() -> {
+            List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
+            assertEquals(1, metadataFiles.size());
+
+            verifyTranslogDataFileCount(metadataFiles, translogDataPath);
+        });
+
+        keepPinnedTimestampSchedulerUpdated();
+        client().admin().indices().prepareDelete(INDEX_NAME).get();
+
+        assertBusy(() -> {
+            assertEquals(0, Files.list(translogMetadataPath).collect(Collectors.toList()).size());
+            assertEquals(0, Files.list(translogDataPath).collect(Collectors.toList()).size());
+        });
+    }
+
+    public void testIndexDeletionWithPinnedTimestamps() throws Exception {
+        prepareCluster(1, 1, Settings.EMPTY);
+        Settings indexSettings = Settings.builder()
+            .put(remoteStoreIndexSettings(0, 1))
+            .put(INDEX_REMOTE_TRANSLOG_KEEP_EXTRA_GEN_SETTING.getKey(), 0)
+            .build();
+        createIndex(INDEX_NAME, indexSettings);
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(
+            RemoteStorePinnedTimestampService.class,
+            primaryNodeName(INDEX_NAME)
+        );
+
+        remoteStorePinnedTimestampService.rescheduleAsyncUpdatePinnedTimestampTask(TimeValue.timeValueSeconds(1));
+
+        int numDocs = randomIntBetween(5, 10);
+        for (int i = 0; i < numDocs; i++) {
+            keepPinnedTimestampSchedulerUpdated();
+            indexSingleDoc(INDEX_NAME, true);
+            if (i == 2) {
+                RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.timeValueMinutes(1));
+                remoteStorePinnedTimestampService.pinTimestamp(System.currentTimeMillis(), "xyz", noOpActionListener);
+                RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+            }
+        }
+
+        String translogPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.get(getNodeSettings());
+        String shardDataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            DATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogDataPath = Path.of(translogRepoPath + "/" + shardDataPath + "/1");
+        String shardMetadataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            METADATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogMetadataPath = Path.of(translogRepoPath + "/" + shardMetadataPath);
+
+        assertBusy(() -> {
+            List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
+            assertEquals(2, metadataFiles.size());
+
+            verifyTranslogDataFileCount(metadataFiles, translogDataPath);
+        }, 30, TimeUnit.SECONDS);
+
+        keepPinnedTimestampSchedulerUpdated();
+        client().admin().indices().prepareDelete(INDEX_NAME).get();
+
+        assertBusy(() -> {
+            List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
+            assertEquals(1, metadataFiles.size());
+
+            verifyTranslogDataFileCount(metadataFiles, translogDataPath);
+        });
+    }
+
+    private void verifyTranslogDataFileCount(List<Path> metadataFiles, Path translogDataPath) throws IOException {
+        List<String> mdFiles = metadataFiles.stream().map(p -> p.getFileName().toString()).collect(Collectors.toList());
+        Set<Long> generations = new HashSet<>();
+        for (String mdFile : mdFiles) {
+            Tuple<Long, Long> minMaxGen = TranslogTransferMetadata.getMinMaxTranslogGenerationFromFilename(mdFile);
+            generations.addAll(LongStream.rangeClosed(minMaxGen.v1(), minMaxGen.v2()).boxed().collect(Collectors.toList()));
+        }
+        assertEquals(generations.size() * 2, Files.list(translogDataPath).collect(Collectors.toList()).size());
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsGarbageCollectionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsGarbageCollectionIT.java
@@ -170,7 +170,7 @@ public class RemoteStorePinnedTimestampsGarbageCollectionIT extends RemoteStoreB
             assertEquals(numDocs + 1, metadataFiles.size());
 
             verifyTranslogDataFileCount(metadataFiles, translogDataPath);
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     public void testLiveIndexNoPinnedTimestampsWithExtraGenSetting() throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsGarbageCollectionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsGarbageCollectionIT.java
@@ -118,15 +118,17 @@ public class RemoteStorePinnedTimestampsGarbageCollectionIT extends RemoteStoreB
         });
     }
 
-    public void testLiveIndexNoPinnedTimestampsWithMetadataSkippedOnLastDeletionCheck() throws Exception {
+    public void testLiveIndexNoPinnedTimestampsWithExtraGenSettingWithinLimit() throws Exception {
         prepareCluster(1, 1, Settings.EMPTY);
-        Settings indexSettings = Settings.builder().put(remoteStoreIndexSettings(0, 1)).build();
+        Settings indexSettings = Settings.builder()
+            .put(remoteStoreIndexSettings(0, 1))
+            .put(INDEX_REMOTE_TRANSLOG_KEEP_EXTRA_GEN_SETTING.getKey(), 10)
+            .build();
         createIndex(INDEX_NAME, indexSettings);
         ensureYellowAndNoInitializingShards(INDEX_NAME);
         ensureGreen(INDEX_NAME);
 
-        // We don't set look-back interval to 0 as we want GC to skip based on last deletion check
-        // RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
 
         RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(
             RemoteStorePinnedTimestampService.class,
@@ -166,6 +168,61 @@ public class RemoteStorePinnedTimestampsGarbageCollectionIT extends RemoteStoreB
         assertBusy(() -> {
             List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
             assertEquals(numDocs + 1, metadataFiles.size());
+
+            verifyTranslogDataFileCount(metadataFiles, translogDataPath);
+        });
+    }
+
+    public void testLiveIndexNoPinnedTimestampsWithExtraGenSetting() throws Exception {
+        prepareCluster(1, 1, Settings.EMPTY);
+        Settings indexSettings = Settings.builder()
+            .put(remoteStoreIndexSettings(0, 1))
+            .put(INDEX_REMOTE_TRANSLOG_KEEP_EXTRA_GEN_SETTING.getKey(), 3)
+            .build();
+        createIndex(INDEX_NAME, indexSettings);
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(
+            RemoteStorePinnedTimestampService.class,
+            primaryNodeName(INDEX_NAME)
+        );
+
+        remoteStorePinnedTimestampService.rescheduleAsyncUpdatePinnedTimestampTask(TimeValue.timeValueSeconds(1));
+
+        int numDocs = 5;
+        for (int i = 0; i < numDocs; i++) {
+            keepPinnedTimestampSchedulerUpdated();
+            indexSingleDoc(INDEX_NAME, true);
+        }
+
+        String translogPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_PATH_PREFIX.get(getNodeSettings());
+        String shardDataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            DATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogDataPath = Path.of(translogRepoPath + "/" + shardDataPath + "/1");
+        String shardMetadataPath = getShardLevelBlobPath(
+            client(),
+            INDEX_NAME,
+            BlobPath.cleanPath(),
+            "0",
+            TRANSLOG,
+            METADATA,
+            translogPathFixedPrefix
+        ).buildAsString();
+        Path translogMetadataPath = Path.of(translogRepoPath + "/" + shardMetadataPath);
+
+        assertBusy(() -> {
+            List<Path> metadataFiles = Files.list(translogMetadataPath).collect(Collectors.toList());
+            assertEquals(4, metadataFiles.size());
 
             verifyTranslogDataFileCount(metadataFiles, translogDataPath);
         });

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotV2IT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotV2IT.java
@@ -23,18 +23,30 @@ import org.opensearch.repositories.blobstore.BlobStoreRepository;
 import org.opensearch.repositories.fs.FsRepository;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class DeleteSnapshotV2IT extends AbstractSnapshotIntegTestCase {
 
     private static final String REMOTE_REPO_NAME = "remote-store-repo-name";
+
+    private void keepPinnedTimestampSchedulerUpdated() throws InterruptedException {
+        long currentTime = System.currentTimeMillis();
+        int maxRetry = 10;
+        while (maxRetry > 0 && RemoteStorePinnedTimestampService.getPinnedTimestamps().v1() <= currentTime) {
+            Thread.sleep(1000);
+            maxRetry--;
+        }
+    }
 
     public void testDeleteShallowCopyV2() throws Exception {
         disableRepoConsistencyCheck("Remote store repository is being used in the test");
@@ -74,8 +86,8 @@ public class DeleteSnapshotV2IT extends AbstractSnapshotIntegTestCase {
         createIndex(indexName1, getRemoteStoreBackedIndexSettings());
         createIndex(indexName2, getRemoteStoreBackedIndexSettings());
 
-        final int numDocsInIndex1 = 10;
-        final int numDocsInIndex2 = 20;
+        final int numDocsInIndex1 = 1;
+        final int numDocsInIndex2 = 2;
         indexRandomDocs(indexName1, numDocsInIndex1);
         indexRandomDocs(indexName2, numDocsInIndex2);
         ensureGreen(indexName1, indexName2);
@@ -92,7 +104,7 @@ public class DeleteSnapshotV2IT extends AbstractSnapshotIntegTestCase {
         assertThat(snapshotInfo.snapshotId().getName(), equalTo(snapshotName1));
 
         createIndex(indexName3, getRemoteStoreBackedIndexSettings());
-        indexRandomDocs(indexName3, 10);
+        indexRandomDocs(indexName3, 1);
         CreateSnapshotResponse createSnapshotResponse2 = client().admin()
             .cluster()
             .prepareCreateSnapshot(snapshotRepoName, snapshotName2)
@@ -105,109 +117,101 @@ public class DeleteSnapshotV2IT extends AbstractSnapshotIntegTestCase {
         assertThat(snapshotInfo.snapshotId().getName(), equalTo(snapshotName2));
 
         assertAcked(client().admin().indices().prepareDelete(indexName1));
-        Thread.sleep(100);
 
-        AcknowledgedResponse deleteResponse = client().admin()
-            .cluster()
-            .prepareDeleteSnapshot(snapshotRepoName, snapshotName2)
-            .setSnapshots(snapshotName2)
-            .get();
+        AcknowledgedResponse deleteResponse = client().admin().cluster().prepareDeleteSnapshot(snapshotRepoName, snapshotName2).get();
         assertTrue(deleteResponse.isAcknowledged());
 
         // test delete non-existent snapshot
         assertThrows(
             SnapshotMissingException.class,
-            () -> client().admin().cluster().prepareDeleteSnapshot(snapshotRepoName, "random-snapshot").setSnapshots(snapshotName2).get()
+            () -> client().admin().cluster().prepareDeleteSnapshot(snapshotRepoName, "random-snapshot").get()
         );
-
     }
 
-    public void testDeleteShallowCopyV2MultipleSnapshots() throws Exception {
+    public void testRemoteStoreCleanupForDeletedIndexForSnapshotV2() throws Exception {
         disableRepoConsistencyCheck("Remote store repository is being used in the test");
         final Path remoteStoreRepoPath = randomRepoPath();
+        Settings settings = remoteStoreClusterSettings(REMOTE_REPO_NAME, remoteStoreRepoPath);
+        settings = Settings.builder()
+            .put(settings)
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), true)
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), RemoteStoreEnums.PathType.FIXED.toString())
+            .build();
+        String clusterManagerName = internalCluster().startClusterManagerOnlyNode(settings);
+        internalCluster().startDataOnlyNode(settings);
+        final Client clusterManagerClient = internalCluster().clusterManagerClient();
+        ensureStableCluster(2);
 
-        internalCluster().startClusterManagerOnlyNode(snapshotV2Settings(remoteStoreRepoPath));
-        internalCluster().startDataOnlyNode(snapshotV2Settings(remoteStoreRepoPath));
-        internalCluster().startDataOnlyNode(snapshotV2Settings(remoteStoreRepoPath));
-
-        String indexName1 = "testindex1";
-        String indexName2 = "testindex2";
-        String indexName3 = "testindex3";
-        String snapshotRepoName = "test-create-snapshot-repo";
-        String snapshotName1 = "test-create-snapshot1";
-        String snapshotName2 = "test-create-snapshot2";
-        Path absolutePath1 = randomRepoPath().toAbsolutePath();
-        logger.info("Snapshot Path [{}]", absolutePath1);
-
-        Client client = client();
-
-        assertAcked(
-            client.admin()
-                .cluster()
-                .preparePutRepository(snapshotRepoName)
-                .setType(FsRepository.TYPE)
-                .setSettings(
-                    Settings.builder()
-                        .put(FsRepository.LOCATION_SETTING.getKey(), absolutePath1)
-                        .put(FsRepository.COMPRESS_SETTING.getKey(), randomBoolean())
-                        .put(FsRepository.CHUNK_SIZE_SETTING.getKey(), randomIntBetween(100, 1000), ByteSizeUnit.BYTES)
-                        .put(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), true)
-                        .put(BlobStoreRepository.SHALLOW_SNAPSHOT_V2.getKey(), true)
-                )
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(
+            RemoteStorePinnedTimestampService.class,
+            clusterManagerName
         );
 
-        createIndex(indexName1, getRemoteStoreBackedIndexSettings());
+        final String snapshotRepoName = "snapshot-repo-name";
+        final Path snapshotRepoPath = randomRepoPath();
+        createRepository(snapshotRepoName, "mock", snapshotRepoSettingsForShallowV2(snapshotRepoPath));
 
-        createIndex(indexName2, getRemoteStoreBackedIndexSettings());
+        final String remoteStoreEnabledIndexName = "remote-index-1";
+        final Settings remoteStoreEnabledIndexSettings = getRemoteStoreBackedIndexSettings();
+        createIndex(remoteStoreEnabledIndexName, remoteStoreEnabledIndexSettings);
+        indexRandomDocs(remoteStoreEnabledIndexName, 25);
 
-        final int numDocsInIndex1 = 10;
-        final int numDocsInIndex2 = 20;
-        indexRandomDocs(indexName1, numDocsInIndex1);
-        indexRandomDocs(indexName2, numDocsInIndex2);
-        ensureGreen(indexName1, indexName2);
+        String indexUUID = client().admin()
+            .indices()
+            .prepareGetSettings(remoteStoreEnabledIndexName)
+            .get()
+            .getSetting(remoteStoreEnabledIndexName, IndexMetadata.SETTING_INDEX_UUID);
 
+        logger.info("--> create two remote index shallow snapshots");
         CreateSnapshotResponse createSnapshotResponse = client().admin()
             .cluster()
-            .prepareCreateSnapshot(snapshotRepoName, snapshotName1)
+            .prepareCreateSnapshot(snapshotRepoName, "snap1")
             .setWaitForCompletion(true)
             .get();
-        SnapshotInfo snapshotInfo = createSnapshotResponse.getSnapshotInfo();
-        assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
-        assertThat(snapshotInfo.successfulShards(), greaterThan(0));
-        assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
-        assertThat(snapshotInfo.snapshotId().getName(), equalTo(snapshotName1));
+        SnapshotInfo snapshotInfo1 = createSnapshotResponse.getSnapshotInfo();
 
-        createIndex(indexName3, getRemoteStoreBackedIndexSettings());
-        indexRandomDocs(indexName3, 10);
+        Path indexPath = Path.of(String.valueOf(remoteStoreRepoPath), indexUUID);
+        Path shardPath = Path.of(String.valueOf(indexPath), "0");
 
-        CreateSnapshotResponse createSnapshotResponse2 = client().admin()
+        // delete remote store index
+        assertAcked(client().admin().indices().prepareDelete(remoteStoreEnabledIndexName));
+
+        logger.info("--> delete snapshot 1");
+
+        Path segmentsPath = Path.of(String.valueOf(shardPath), "segments");
+        Path translogPath = Path.of(String.valueOf(shardPath), "translog");
+
+        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+
+        remoteStorePinnedTimestampService.rescheduleAsyncUpdatePinnedTimestampTask(TimeValue.timeValueSeconds(1));
+
+        keepPinnedTimestampSchedulerUpdated();
+
+        AcknowledgedResponse deleteSnapshotResponse = clusterManagerClient.admin()
             .cluster()
-            .prepareCreateSnapshot(snapshotRepoName, snapshotName2)
-            .setWaitForCompletion(true)
+            .prepareDeleteSnapshot(snapshotRepoName, snapshotInfo1.snapshotId().getName())
             .get();
-        snapshotInfo = createSnapshotResponse2.getSnapshotInfo();
-        assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
-        assertThat(snapshotInfo.successfulShards(), greaterThan(0));
-        assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
-        assertThat(snapshotInfo.snapshotId().getName(), equalTo(snapshotName2));
+        assertAcked(deleteSnapshotResponse);
 
-        AcknowledgedResponse deleteResponse = client().admin()
-            .cluster()
-            .prepareDeleteSnapshot(snapshotRepoName, snapshotName1, snapshotName2)
-            .setSnapshots(snapshotName2)
-            .get();
-        assertTrue(deleteResponse.isAcknowledged());
+        // Delete is async. Give time for it
+        assertBusy(() -> {
+            try {
+                assertEquals(0, RemoteStoreBaseIntegTestCase.getFileCount(segmentsPath));
+            } catch (NoSuchFileException e) {
+                fail();
+            }
+        }, 60, TimeUnit.SECONDS);
 
-        // test delete non-existent snapshot
-        assertThrows(
-            SnapshotMissingException.class,
-            () -> client().admin().cluster().prepareDeleteSnapshot(snapshotRepoName, "random-snapshot").setSnapshots(snapshotName2).get()
-        );
-
+        assertBusy(() -> {
+            try {
+                assertEquals(0, RemoteStoreBaseIntegTestCase.getFileCount(translogPath));
+            } catch (NoSuchFileException e) {
+                fail();
+            }
+        }, 60, TimeUnit.SECONDS);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/15692")
-    public void testRemoteStoreCleanupForDeletedIndexForSnapshotV2() throws Exception {
+    public void testRemoteStoreCleanupForDeletedIndexForSnapshotV2MultipleSnapshots() throws Exception {
         disableRepoConsistencyCheck("Remote store repository is being used in the test");
         final Path remoteStoreRepoPath = randomRepoPath();
         Settings settings = remoteStoreClusterSettings(REMOTE_REPO_NAME, remoteStoreRepoPath);
@@ -242,11 +246,11 @@ public class DeleteSnapshotV2IT extends AbstractSnapshotIntegTestCase {
             .get()
             .getSetting(remoteStoreEnabledIndexName, IndexMetadata.SETTING_INDEX_UUID);
 
-        String numShards = client().admin()
-            .indices()
-            .prepareGetSettings(remoteStoreEnabledIndexName)
-            .get()
-            .getSetting(remoteStoreEnabledIndexName, IndexMetadata.SETTING_NUMBER_OF_SHARDS);
+        Path indexPath = Path.of(String.valueOf(remoteStoreRepoPath), indexUUID);
+        Path shardPath = Path.of(String.valueOf(indexPath), "0");
+
+        Path segmentsPath = Path.of(String.valueOf(shardPath), "segments", "data");
+        Path translogPath = Path.of(String.valueOf(shardPath), "translog", "data", "1");
 
         logger.info("--> create two remote index shallow snapshots");
         CreateSnapshotResponse createSnapshotResponse = client().admin()
@@ -256,6 +260,10 @@ public class DeleteSnapshotV2IT extends AbstractSnapshotIntegTestCase {
             .get();
         SnapshotInfo snapshotInfo1 = createSnapshotResponse.getSnapshotInfo();
 
+        List<Path> segmentsPostSnapshot1 = Files.list(segmentsPath).collect(Collectors.toList());
+        List<Path> translogPostSnapshot1 = Files.list(translogPath).collect(Collectors.toList());
+
+        forceMerge(1);
         indexRandomDocs(remoteStoreEnabledIndexName, 25);
 
         CreateSnapshotResponse createSnapshotResponse2 = client().admin()
@@ -264,70 +272,47 @@ public class DeleteSnapshotV2IT extends AbstractSnapshotIntegTestCase {
             .setWaitForCompletion(true)
             .get();
         SnapshotInfo snapshotInfo2 = createSnapshotResponse2.getSnapshotInfo();
+
+        List<Path> segmentsPostSnapshot2 = Files.list(segmentsPath).collect(Collectors.toList());
+        List<Path> translogPostSnapshot2 = Files.list(translogPath).collect(Collectors.toList());
+
         assertThat(snapshotInfo2.state(), equalTo(SnapshotState.SUCCESS));
         assertThat(snapshotInfo2.successfulShards(), greaterThan(0));
         assertThat(snapshotInfo2.successfulShards(), equalTo(snapshotInfo2.totalShards()));
         assertThat(snapshotInfo2.snapshotId().getName(), equalTo("snap2"));
 
+        assertBusy(() -> assertTrue(translogPostSnapshot2.size() > translogPostSnapshot1.size()), 60, TimeUnit.SECONDS);
+        assertBusy(() -> assertTrue(segmentsPostSnapshot2.size() > segmentsPostSnapshot1.size()), 60, TimeUnit.SECONDS);
+
+        remoteStorePinnedTimestampService.rescheduleAsyncUpdatePinnedTimestampTask(TimeValue.timeValueSeconds(1));
+        keepPinnedTimestampSchedulerUpdated();
+
         // delete remote store index
         assertAcked(client().admin().indices().prepareDelete(remoteStoreEnabledIndexName));
 
-        logger.info("--> delete snapshot 2");
-
-        Path indexPath = Path.of(String.valueOf(remoteStoreRepoPath), indexUUID);
-        Path shardPath = Path.of(String.valueOf(indexPath), "0");
-        Path segmentsPath = Path.of(String.valueOf(shardPath), "segments");
-        Path translogPath = Path.of(String.valueOf(shardPath), "translog");
-
-        // Get total segments remote store directory file count for deleted index and shard 0
-        int segmentFilesCountBeforeDeletingSnapshot1 = RemoteStoreBaseIntegTestCase.getFileCount(segmentsPath);
-        int translogFilesCountBeforeDeletingSnapshot1 = RemoteStoreBaseIntegTestCase.getFileCount(translogPath);
-
-        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
-
-        AcknowledgedResponse deleteSnapshotResponse = clusterManagerClient.admin()
-            .cluster()
-            .prepareDeleteSnapshot(snapshotRepoName, snapshotInfo2.snapshotId().getName())
-            .get();
-        assertAcked(deleteSnapshotResponse);
-
-        Thread.sleep(5000);
-
-        assertBusy(() -> {
-            try {
-                assertThat(RemoteStoreBaseIntegTestCase.getFileCount(segmentsPath), lessThan(segmentFilesCountBeforeDeletingSnapshot1));
-            } catch (Exception e) {}
-        }, 30, TimeUnit.SECONDS);
-        int segmentFilesCountAfterDeletingSnapshot1 = RemoteStoreBaseIntegTestCase.getFileCount(segmentsPath);
-
         logger.info("--> delete snapshot 1");
         RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.ZERO);
+        keepPinnedTimestampSchedulerUpdated();
         // on snapshot deletion, remote store segment files should get cleaned up for deleted index - `remote-index-1`
-        deleteSnapshotResponse = clusterManagerClient.admin()
+        AcknowledgedResponse deleteSnapshotResponse = clusterManagerClient.admin()
             .cluster()
             .prepareDeleteSnapshot(snapshotRepoName, snapshotInfo1.snapshotId().getName())
             .get();
         assertAcked(deleteSnapshotResponse);
 
+        List<Path> segmentsPostDeletionOfSnapshot1 = Files.list(segmentsPath).collect(Collectors.toList());
+        List<Path> translogPostDeletionOfSnapshot1 = Files.list(translogPath).collect(Collectors.toList());
+
         // Delete is async. Give time for it
-        assertBusy(() -> {
-            try {
-                assertThat(RemoteStoreBaseIntegTestCase.getFileCount(segmentsPath), lessThan(segmentFilesCountAfterDeletingSnapshot1));
-            } catch (Exception e) {}
-        }, 60, TimeUnit.SECONDS);
-
-        assertBusy(() -> {
-            try {
-                assertThat(RemoteStoreBaseIntegTestCase.getFileCount(translogPath), lessThan(translogFilesCountBeforeDeletingSnapshot1));
-            } catch (Exception e) {}
-        }, 60, TimeUnit.SECONDS);
-
+        assertBusy(() -> assertEquals(translogPostSnapshot2.size(), translogPostDeletionOfSnapshot1.size()), 60, TimeUnit.SECONDS);
+        assertBusy(() -> assertEquals(segmentsPostSnapshot2.size(), segmentsPostDeletionOfSnapshot1.size()), 60, TimeUnit.SECONDS);
     }
 
     private Settings snapshotV2Settings(Path remoteStoreRepoPath) {
         Settings settings = Settings.builder()
             .put(remoteStoreClusterSettings(REMOTE_REPO_NAME, remoteStoreRepoPath))
             .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), true)
+            .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_TRANSLOG_METADATA.getKey(), false)
             .build();
         return settings;
     }

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
@@ -136,7 +136,7 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
 
         // This is to ensure that after the permits are acquired during primary relocation, there are no further modification on remote
         // store.
-        if ((indexDeleted == false && startedPrimarySupplier.getAsBoolean() == false) || pauseSync.get()) {
+        if (indexDeleted == false && (startedPrimarySupplier.getAsBoolean() == false || pauseSync.get())) {
             return;
         }
 
@@ -505,7 +505,7 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
         }
     }
 
-    public static void cleanup(TranslogTransferManager translogTransferManager, boolean forceClean) throws IOException {
+    public static void cleanupOfDeletedIndex(TranslogTransferManager translogTransferManager, boolean forceClean) throws IOException {
         if (forceClean) {
             translogTransferManager.delete();
         } else {
@@ -523,7 +523,7 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
                             metadataFiles,
                             new HashMap<>(),
                             Long.MAX_VALUE,
-                            true,
+                            true,  // This method gets called when the index is no longer present
                             staticLogger
                         );
                         if (metadataFilesToBeDeleted.isEmpty()) {

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -683,7 +683,11 @@ public class RemoteFsTranslog extends Translog {
         @Override
         public void onUploadComplete(TransferSnapshot transferSnapshot) throws IOException {
             maxRemoteTranslogGenerationUploaded = generation;
+            long previousMinRemoteGenReferenced = minRemoteGenReferenced;
             minRemoteGenReferenced = getMinFileGeneration();
+            if (previousMinRemoteGenReferenced != minRemoteGenReferenced) {
+                onMinRemoteGenReferencedChange();
+            }
             logger.debug(
                 "Successfully uploaded translog for primary term = {}, generation = {}, maxSeqNo = {}, minRemoteGenReferenced = {}",
                 primaryTerm,
@@ -701,6 +705,10 @@ public class RemoteFsTranslog extends Translog {
                 throw (RuntimeException) ex;
             }
         }
+    }
+
+    protected void onMinRemoteGenReferencedChange() {
+
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -685,10 +685,11 @@ public class RemoteFsTranslog extends Translog {
             maxRemoteTranslogGenerationUploaded = generation;
             minRemoteGenReferenced = getMinFileGeneration();
             logger.debug(
-                "Successfully uploaded translog for primary term = {}, generation = {}, maxSeqNo = {}",
+                "Successfully uploaded translog for primary term = {}, generation = {}, maxSeqNo = {}, minRemoteGenReferenced = {}",
                 primaryTerm,
                 generation,
-                maxSeqNo
+                maxSeqNo,
+                minRemoteGenReferenced
             );
         }
 

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -170,6 +170,16 @@ public class TranslogTransferMetadata {
         }
     }
 
+    public static long getMaxGenerationFromFileName(String filename) {
+        String[] tokens = filename.split(METADATA_SEPARATOR);
+        try {
+            return RemoteStoreUtils.invertLong(tokens[2]);
+        } catch (Exception e) {
+            logger.error(() -> new ParameterizedMessage("Exception while getting max generation from: {}", filename), e);
+            return -1;
+        }
+    }
+
     public static Tuple<Long, Long> getMinMaxPrimaryTermFromFilename(String filename) {
         String[] tokens = filename.split(METADATA_SEPARATOR);
         if (tokens.length < 7) {

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -37,7 +37,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * Service for managing pinned timestamps in a remote store.
@@ -48,7 +47,8 @@ import java.util.stream.Collectors;
 @ExperimentalApi
 public class RemoteStorePinnedTimestampService implements Closeable {
     private static final Logger logger = LogManager.getLogger(RemoteStorePinnedTimestampService.class);
-    private static Tuple<Long, Set<Long>> pinnedTimestampsSet = new Tuple<>(-1L, Set.of());
+    private static Tuple<Long, Map<String, Set<Long>>> pinningEntityTimestampMap = new Tuple<>(-1L, Map.of());
+
     public static final String PINNED_TIMESTAMPS_PATH_TOKEN = "pinned_timestamps";
     public static final String PINNED_TIMESTAMPS_FILENAME_SEPARATOR = "__";
 
@@ -199,21 +199,23 @@ public class RemoteStorePinnedTimestampService implements Closeable {
         }
     }
 
-    private String getBlobName(long timestamp, String pinningEntity) {
+    public static String getBlobName(long timestamp, String pinningEntity) {
         return String.join(PINNED_TIMESTAMPS_FILENAME_SEPARATOR, pinningEntity, String.valueOf(timestamp));
     }
 
-    private long getTimestampFromBlobName(String blobName) {
+    public static Tuple<String, Long> getPinningEntityTimestampFromBlobName(String blobName) {
         String[] blobNameTokens = blobName.split(PINNED_TIMESTAMPS_FILENAME_SEPARATOR);
         if (blobNameTokens.length < 2) {
             logger.error("Pinned timestamps blob name contains invalid format: {}", blobName);
         }
         try {
-            return Long.parseLong(blobNameTokens[blobNameTokens.length - 1]);
+            String pinningEntity = blobName.substring(blobName.lastIndexOf(PINNED_TIMESTAMPS_FILENAME_SEPARATOR));
+            Long timestamp = Long.parseLong(blobNameTokens[blobNameTokens.length - 1]);
+            return new Tuple<>(pinningEntity, timestamp);
         } catch (NumberFormatException e) {
             logger.error(() -> new ParameterizedMessage("Pinned timestamps blob name contains invalid format: {}", blobName), e);
         }
-        return -1;
+        return null;
     }
 
     /**
@@ -248,14 +250,32 @@ public class RemoteStorePinnedTimestampService implements Closeable {
     // Used in integ tests
     public void rescheduleAsyncUpdatePinnedTimestampTask(TimeValue pinnedTimestampsSchedulerInterval) {
         if (pinnedTimestampsSchedulerInterval != null) {
-            pinnedTimestampsSet = new Tuple<>(-1L, Set.of());
+            pinningEntityTimestampMap = new Tuple<>(-1L, Map.of());
             asyncUpdatePinnedTimestampTask.close();
             startAsyncUpdateTask(pinnedTimestampsSchedulerInterval);
         }
     }
 
     public static Tuple<Long, Set<Long>> getPinnedTimestamps() {
-        return pinnedTimestampsSet;
+        return getPinnedTimestamps(null);
+    }
+
+    public static Tuple<Long, Set<Long>> getPinnedTimestamps(Map<String, Long> pinnedTimestampsToSkip) {
+        Set<Long> allPinnedTimestamps = new HashSet<>();
+        if (pinnedTimestampsToSkip == null || pinnedTimestampsToSkip.isEmpty()) {
+            pinningEntityTimestampMap.v2().values().forEach(allPinnedTimestamps::addAll);
+        } else {
+            for (String pinningEntity : pinningEntityTimestampMap.v2().keySet()) {
+                if (pinnedTimestampsToSkip.containsKey(pinningEntity)) {
+                    Set<Long> timestamps = new HashSet<>(pinningEntityTimestampMap.v2().get(pinningEntity));
+                    timestamps.remove(pinnedTimestampsToSkip.get(pinningEntity));
+                    allPinnedTimestamps.addAll(timestamps);
+                } else {
+                    allPinnedTimestamps.addAll(pinningEntityTimestampMap.v2().get(pinningEntity));
+                }
+            }
+        }
+        return new Tuple<>(pinningEntityTimestampMap.v1(), allPinnedTimestamps);
     }
 
     /**
@@ -278,16 +298,22 @@ public class RemoteStorePinnedTimestampService implements Closeable {
             try {
                 Map<String, BlobMetadata> pinnedTimestampList = blobContainer.listBlobs();
                 if (pinnedTimestampList.isEmpty()) {
-                    pinnedTimestampsSet = new Tuple<>(triggerTimestamp, Set.of());
+                    logger.debug("Fetched empty pinned timestamps from remote store: {}", triggerTimestamp);
+                    pinningEntityTimestampMap = new Tuple<>(triggerTimestamp, Map.of());
                     return;
                 }
-                Set<Long> pinnedTimestamps = pinnedTimestampList.keySet()
-                    .stream()
-                    .map(RemoteStorePinnedTimestampService.this::getTimestampFromBlobName)
-                    .filter(timestamp -> timestamp != -1)
-                    .collect(Collectors.toSet());
+                Map<String, Set<Long>> pinnedTimestamps = new HashMap<>();
+                for (String blobName : pinnedTimestampList.keySet()) {
+                    Tuple<String, Long> pinningEntityTimestamp = getPinningEntityTimestampFromBlobName(blobName);
+                    if (pinningEntityTimestamp != null) {
+                        if (pinnedTimestamps.containsKey(pinningEntityTimestamp.v1()) == false) {
+                            pinnedTimestamps.put(pinningEntityTimestamp.v1(), new HashSet<>());
+                        }
+                        pinnedTimestamps.get(pinningEntityTimestamp.v1()).add(pinningEntityTimestamp.v2());
+                    }
+                }
                 logger.debug("Fetched pinned timestamps from remote store: {} - {}", triggerTimestamp, pinnedTimestamps);
-                pinnedTimestampsSet = new Tuple<>(triggerTimestamp, pinnedTimestamps);
+                pinningEntityTimestampMap = new Tuple<>(triggerTimestamp, pinnedTimestamps);
             } catch (Throwable t) {
                 logger.error("Exception while fetching pinned timestamp details", t);
             }

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -199,7 +199,6 @@ import java.util.stream.Stream;
 import static org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm.FNV_1A_COMPOSITE_1;
 import static org.opensearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo.canonicalName;
 import static org.opensearch.repositories.blobstore.ChecksumBlobStoreFormat.SNAPSHOT_ONLY_FORMAT_PARAMS;
-import static org.opensearch.snapshots.SnapshotsService.SNAPSHOT_PINNED_TIMESTAMP_DELIMITER;
 
 /**
  * BlobStore - based implementation of Snapshot Repository
@@ -1281,7 +1280,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     snapshotIds,
                     writeShardMetaDataAndComputeDeletesStep.result(),
                     remoteSegmentStoreDirectoryFactory,
-                    afterCleanupsListener
+                    afterCleanupsListener,
+                    snapshotIdPinnedTimestampMap
                 );
             } else {
                 asyncCleanupUnlinkedShardLevelBlobs(
@@ -1300,7 +1300,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         Collection<SnapshotId> snapshotIds,
         Collection<ShardSnapshotMetaDeleteResult> result,
         RemoteSegmentStoreDirectoryFactory remoteSegmentStoreDirectoryFactory,
-        ActionListener<Void> afterCleanupsListener
+        ActionListener<Void> afterCleanupsListener,
+        Map<SnapshotId, Long> snapshotIdPinnedTimestampMap
     ) {
         try {
             Set<String> uniqueIndexIds = new HashSet<>();
@@ -1309,7 +1310,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             }
             // iterate through all the indices and trigger remote store directory cleanup for deleted index segments
             for (String indexId : uniqueIndexIds) {
-                cleanRemoteStoreDirectoryIfNeeded(snapshotIds, indexId, repositoryData, remoteSegmentStoreDirectoryFactory);
+                cleanRemoteStoreDirectoryIfNeeded(
+                    snapshotIds,
+                    indexId,
+                    repositoryData,
+                    remoteSegmentStoreDirectoryFactory,
+                    snapshotIdPinnedTimestampMap,
+                    false
+                );
             }
             afterCleanupsListener.onResponse(null);
         } catch (Exception e) {
@@ -1357,7 +1365,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     ) {
         remoteStorePinnedTimestampService.unpinTimestamp(
             timestampToUnpin,
-            repository + SNAPSHOT_PINNED_TIMESTAMP_DELIMITER + snapshotId.getUUID(),
+            SnapshotsService.getPinningEntity(repository, snapshotId.getUUID()),
             new ActionListener<Void>() {
                 @Override
                 public void onResponse(Void unused) {
@@ -1466,7 +1474,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         String indexUUID,
         ShardId shardId,
         String threadPoolName,
-        RemoteStorePathStrategy pathStrategy
+        RemoteStorePathStrategy pathStrategy,
+        boolean forceClean,
+        Map<String, Long> pinnedTimestampsToSkip
     ) {
         threadpool.executor(threadPoolName)
             .execute(
@@ -1476,7 +1486,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         remoteStoreRepoForIndex,
                         indexUUID,
                         shardId,
-                        pathStrategy
+                        pathStrategy,
+                        forceClean,
+                        pinnedTimestampsToSkip
                     ),
                     indexUUID,
                     shardId
@@ -1532,7 +1544,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 indexUUID,
                 new ShardId(Index.UNKNOWN_INDEX_NAME, indexUUID, Integer.parseInt(shardId)),
                 ThreadPool.Names.REMOTE_PURGE,
-                remoteStoreShardShallowCopySnapshot.getRemoteStorePathStrategy()
+                remoteStoreShardShallowCopySnapshot.getRemoteStorePathStrategy(),
+                false,
+                null
             );
         }
     }
@@ -2095,7 +2109,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 deleteResult = deleteResult.add(cleanUpStaleSnapshotShardPathsFile(matchingShardPaths, snapshotShardPaths));
 
                 if (remoteSegmentStoreDirectoryFactory != null) {
-                    cleanRemoteStoreDirectoryIfNeeded(deletedSnapshots, indexSnId, oldRepoData, remoteSegmentStoreDirectoryFactory);
+                    cleanRemoteStoreDirectoryIfNeeded(
+                        deletedSnapshots,
+                        indexSnId,
+                        oldRepoData,
+                        remoteSegmentStoreDirectoryFactory,
+                        new HashMap<>(),
+                        true
+                    );
                 }
 
                 // Finally, we delete the [base_path]/indexId folder
@@ -2167,7 +2188,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         Collection<SnapshotId> deletedSnapshots,
         String indexSnId,
         RepositoryData oldRepoData,
-        RemoteSegmentStoreDirectoryFactory remoteSegmentStoreDirectoryFactory
+        RemoteSegmentStoreDirectoryFactory remoteSegmentStoreDirectoryFactory,
+        Map<SnapshotId, Long> snapshotIdPinnedTimestampMap,
+        boolean forceClean
     ) {
         assert (indexSnId != null);
 
@@ -2210,6 +2233,12 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                             prevIndexMetadata
                         );
 
+                        String pinningEntity = SnapshotsService.getPinningEntity(getMetadata().name(), snapshotId.getUUID());
+                        Map<String, Long> pinnedTimestampsToSkip = new HashMap<>();
+                        if (snapshotIdPinnedTimestampMap.get(snapshotId) != null) {
+                            pinnedTimestampsToSkip.put(pinningEntity, snapshotIdPinnedTimestampMap.get(snapshotId));
+                        }
+
                         for (int shardId = 0; shardId < prevIndexMetadata.getNumberOfShards(); shardId++) {
                             ShardId shard = new ShardId(Index.UNKNOWN_INDEX_NAME, prevIndexMetadata.getIndexUUID(), shardId);
                             remoteDirectoryCleanupAsync(
@@ -2219,9 +2248,18 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                                 prevIndexMetadata.getIndexUUID(),
                                 shard,
                                 ThreadPool.Names.REMOTE_PURGE,
-                                remoteStorePathStrategy
+                                remoteStorePathStrategy,
+                                forceClean,
+                                pinnedTimestampsToSkip
                             );
-                            remoteTranslogCleanupAsync(remoteTranslogRepository, shard, remoteStorePathStrategy, prevIndexMetadata);
+                            remoteTranslogCleanupAsync(
+                                remoteTranslogRepository,
+                                shard,
+                                remoteStorePathStrategy,
+                                prevIndexMetadata,
+                                forceClean,
+                                pinnedTimestampsToSkip
+                            );
                         }
                     }
                 } catch (Exception e) {
@@ -2245,7 +2283,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         Repository remoteTranslogRepository,
         ShardId shardId,
         RemoteStorePathStrategy remoteStorePathStrategy,
-        IndexMetadata prevIndexMetadata
+        IndexMetadata prevIndexMetadata,
+        boolean forceClean,
+        Map<String, Long> pinnedTimestampsToSkip
     ) {
         assert remoteTranslogRepository instanceof BlobStoreRepository;
         boolean indexMetadataEnabled = RemoteStoreUtils.determineTranslogMetadataEnabled(prevIndexMetadata);
@@ -2262,7 +2302,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             indexMetadataEnabled
         );
         try {
-            RemoteFsTimestampAwareTranslog.cleanup(translogTransferManager);
+            RemoteFsTimestampAwareTranslog.cleanup(translogTransferManager, forceClean, pinnedTimestampsToSkip);
         } catch (IOException e) {
             logger.error("Exception while cleaning up remote translog for shard: " + shardId, e);
         }

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -2279,7 +2279,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             indexMetadataEnabled
         );
         try {
-            RemoteFsTimestampAwareTranslog.cleanup(translogTransferManager, forceClean);
+            RemoteFsTimestampAwareTranslog.cleanupOfDeletedIndex(translogTransferManager, forceClean);
         } catch (IOException e) {
             logger.error("Exception while cleaning up remote translog for shard: " + shardId, e);
         }

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -613,7 +613,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     ) {
         remoteStorePinnedTimestampService.pinTimestamp(
             timestampToPin,
-            snapshot.getRepository() + SNAPSHOT_PINNED_TIMESTAMP_DELIMITER + snapshot.getSnapshotId().getUUID(),
+            getPinningEntity(snapshot.getRepository(), snapshot.getSnapshotId().getUUID()),
             new ActionListener<Void>() {
                 @Override
                 public void onResponse(Void unused) {
@@ -631,6 +631,10 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         );
     }
 
+    public static String getPinningEntity(String repositoryName, String snapshotUUID) {
+        return repositoryName + SNAPSHOT_PINNED_TIMESTAMP_DELIMITER + snapshotUUID;
+    }
+
     private void cloneSnapshotPinnedTimestamp(
         RepositoryData repositoryData,
         SnapshotId sourceSnapshot,
@@ -640,8 +644,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     ) {
         remoteStorePinnedTimestampService.cloneTimestamp(
             timestampToPin,
-            snapshot.getRepository() + SNAPSHOT_PINNED_TIMESTAMP_DELIMITER + sourceSnapshot.getUUID(),
-            snapshot.getRepository() + SNAPSHOT_PINNED_TIMESTAMP_DELIMITER + snapshot.getSnapshotId().getUUID(),
+            getPinningEntity(snapshot.getRepository(), sourceSnapshot.getUUID()),
+            getPinningEntity(snapshot.getRepository(), snapshot.getSnapshotId().getUUID()),
             new ActionListener<Void>() {
                 @Override
                 public void onResponse(Void unused) {

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -566,8 +566,7 @@ public class RemoteSegmentStoreDirectoryTests extends BaseRemoteSegmentStoreDire
             indexUUID,
             shardId,
             pathStrategy,
-            false,
-            Map.of()
+            false
         );
         verify(remoteSegmentStoreDirectoryFactory).newDirectory(repositoryName, indexUUID, shardId, pathStrategy);
         verify(threadPool, times(0)).executor(ThreadPool.Names.REMOTE_PURGE);

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryTests.java
@@ -565,7 +565,9 @@ public class RemoteSegmentStoreDirectoryTests extends BaseRemoteSegmentStoreDire
             repositoryName,
             indexUUID,
             shardId,
-            pathStrategy
+            pathStrategy,
+            false,
+            Map.of()
         );
         verify(remoteSegmentStoreDirectoryFactory).newDirectory(repositoryName, indexUUID, shardId, pathStrategy);
         verify(threadPool, times(0)).executor(ThreadPool.Names.REMOTE_PURGE);

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslogTests.java
@@ -783,7 +783,7 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
 
     public void testGetMetadataFilesToBeDeletedExclusionBasedOnAgeAndPinning() throws IOException {
         long currentTimeInMillis = System.currentTimeMillis();
-        String md1Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 200000);
+        String md1Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis + 100000);
         String md2Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 300000);
         String md3Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 600000);
 

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslogTests.java
@@ -402,7 +402,7 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
         );
         updatePinnedTimstampTask.run();
         translog.trimUnreferencedReaders();
-        assertBusy(() -> { assertEquals(2, blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR)).size()); });
+        assertBusy(() -> { assertEquals(3, blobStoreTransferService.listAll(getTranslogDirectory().add(METADATA_DIR)).size()); });
     }
 
     public void testMetadataFileDeletionWithPinnedTimestamps() throws Exception {
@@ -715,14 +715,7 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
 
         assertEquals(
             metadataFiles,
-            RemoteFsTimestampAwareTranslog.getMetadataFilesToBeDeleted(
-                metadataFiles,
-                new HashMap<>(),
-                Long.MAX_VALUE,
-                Map.of(),
-                false,
-                logger
-            )
+            RemoteFsTimestampAwareTranslog.getMetadataFilesToBeDeleted(metadataFiles, new HashMap<>(), Long.MAX_VALUE, false, logger)
         );
     }
 
@@ -743,7 +736,6 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
             metadataFiles,
             new HashMap<>(),
             Long.MAX_VALUE,
-            Map.of(),
             false,
             logger
         );
@@ -772,7 +764,6 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
             metadataFiles,
             new HashMap<>(),
             Long.MAX_VALUE,
-            Map.of(),
             false,
             logger
         );
@@ -802,7 +793,6 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
             metadataFiles,
             new HashMap<>(),
             Long.MAX_VALUE,
-            Map.of(),
             false,
             logger
         );
@@ -833,7 +823,6 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
             metadataFiles,
             new HashMap<>(),
             10L,
-            Map.of(),
             false,
             logger
         );
@@ -865,7 +854,6 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
             metadataFiles,
             new HashMap<>(),
             10L,
-            Map.of(),
             true,
             logger
         );


### PR DESCRIPTION
### Description
- Added a bunch of optimisations in remote store garbage collection flow to work with pinned timestamps
  - If index is deleted and a snapshot containing the index is getting deleted:
    - If this is the last snapshot containing the index, delete remote store data (segments + translog)
    - else pass pinning entity for the snapshot that is getting deleted. This is required to delete the data specific to snapshot even if pinned timestamp scheduler runs later.
  - For remote translog, avoid calling list metadata files if `minRemoteGenReferenced - indexSettings().getRemoteTranslogExtraKeep() <= maxDeletedGenerationOnRemote`
  - For remote translog, make sure to keep metadata and generation deletion in sync. With this, if metadata file is present, we can ensure that generations corresponding to it are not deleted.
  - Added integ tests around these scenarios.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
