### PR TITLE
Fix flaky terminaton conditions for org.opensearch.rest.ReactorNetty4StreamingStressIT.testCloseClientStreamingRequest test case (#15959)

### DIFF
--- a/plugins/transport-reactor-netty4/src/javaRestTest/java/org/opensearch/rest/ReactorNetty4StreamingStressIT.java
+++ b/plugins/transport-reactor-netty4/src/javaRestTest/java/org/opensearch/rest/ReactorNetty4StreamingStressIT.java
@@ -17,6 +17,7 @@ import org.opensearch.test.rest.OpenSearchRestTestCase;
 import org.junit.After;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -75,7 +76,7 @@ public class ReactorNetty4StreamingStressIT extends OpenSearchRestTestCase {
                 }
             })
             .then(() -> scheduler.advanceTimeBy(delay))
-            .expectErrorMatches(t -> t instanceof ConnectionClosedException)
+            .expectErrorMatches(t -> t instanceof InterruptedIOException || t instanceof ConnectionClosedException)
             .verify();
     }
 }


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/15959 to `2.x`