### PR TITLE
Add success and failure count OTel metrics for async shard fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove identity-related feature flagged code from the RestController ([#15430](https://github.com/opensearch-project/OpenSearch/pull/15430))
 - Add support for msearch API to pass search pipeline name - ([#15923](https://github.com/opensearch-project/OpenSearch/pull/15923))
 - Add _list/indices API as paginated alternate to _cat/indices ([#14718](https://github.com/opensearch-project/OpenSearch/pull/14718))
+- Add success and failure metrics for async shard fetch ([#15976](https://github.com/opensearch-project/OpenSearch/pull/15976))
 
 ### Dependencies
 - Bump `com.azure:azure-identity` from 1.13.0 to 1.13.2 ([#15578](https://github.com/opensearch-project/OpenSearch/pull/15578))

--- a/server/src/main/java/org/opensearch/cluster/ClusterManagerMetrics.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterManagerMetrics.java
@@ -35,7 +35,7 @@ public final class ClusterManagerMetrics {
     public final Counter leaderCheckFailureCounter;
     public final Counter followerChecksFailureCounter;
     public final Counter asyncFetchFailureCounter;
-    public final Counter asyncFetchTotalFetchesCounter;
+    public final Counter asyncFetchTotalCounter;
 
     public ClusterManagerMetrics(MetricsRegistry metricsRegistry) {
         clusterStateAppliersHistogram = metricsRegistry.createHistogram(
@@ -74,12 +74,12 @@ public final class ClusterManagerMetrics {
             COUNTER_METRICS_UNIT
         );
         asyncFetchFailureCounter = metricsRegistry.createCounter(
-            "allocation.reroute.async.fetch.failure.count",
+            "async.fetch.failure.count",
             "Counter for number of failed async fetches",
             COUNTER_METRICS_UNIT
         );
-        asyncFetchTotalFetchesCounter = metricsRegistry.createCounter(
-            "allocation.reroute.async.fetch.total.count",
+        asyncFetchTotalCounter = metricsRegistry.createCounter(
+            "async.fetch.total.count",
             "Counter for total number of async fetches",
             COUNTER_METRICS_UNIT
         );

--- a/server/src/main/java/org/opensearch/cluster/ClusterManagerMetrics.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterManagerMetrics.java
@@ -34,6 +34,8 @@ public final class ClusterManagerMetrics {
 
     public final Counter leaderCheckFailureCounter;
     public final Counter followerChecksFailureCounter;
+    public final Counter asyncFetchFailureCounter;
+    public final Counter asyncFetchTotalFetchesCounter;
 
     public ClusterManagerMetrics(MetricsRegistry metricsRegistry) {
         clusterStateAppliersHistogram = metricsRegistry.createHistogram(
@@ -71,6 +73,17 @@ public final class ClusterManagerMetrics {
             "Counter for number of failed leader checks",
             COUNTER_METRICS_UNIT
         );
+        asyncFetchFailureCounter = metricsRegistry.createCounter(
+            "allocation.reroute.async.fetch.failure.count",
+            "Counter for number of failed async fetches",
+            COUNTER_METRICS_UNIT
+        );
+        asyncFetchTotalFetchesCounter = metricsRegistry.createCounter(
+            "allocation.reroute.async.fetch.total.count",
+            "Counter for total number of async fetches",
+            COUNTER_METRICS_UNIT
+        );
+
     }
 
     public void recordLatency(Histogram histogram, Double value) {

--- a/server/src/main/java/org/opensearch/cluster/ClusterManagerMetrics.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterManagerMetrics.java
@@ -35,7 +35,7 @@ public final class ClusterManagerMetrics {
     public final Counter leaderCheckFailureCounter;
     public final Counter followerChecksFailureCounter;
     public final Counter asyncFetchFailureCounter;
-    public final Counter asyncFetchTotalCounter;
+    public final Counter asyncFetchSuccessCounter;
 
     public ClusterManagerMetrics(MetricsRegistry metricsRegistry) {
         clusterStateAppliersHistogram = metricsRegistry.createHistogram(
@@ -78,8 +78,8 @@ public final class ClusterManagerMetrics {
             "Counter for number of failed async fetches",
             COUNTER_METRICS_UNIT
         );
-        asyncFetchTotalCounter = metricsRegistry.createCounter(
-            "async.fetch.total.count",
+        asyncFetchSuccessCounter = metricsRegistry.createCounter(
+            "async.fetch.success.count",
             "Counter for total number of async fetches",
             COUNTER_METRICS_UNIT
         );

--- a/server/src/main/java/org/opensearch/cluster/ClusterManagerMetrics.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterManagerMetrics.java
@@ -80,7 +80,7 @@ public final class ClusterManagerMetrics {
         );
         asyncFetchSuccessCounter = metricsRegistry.createCounter(
             "async.fetch.success.count",
-            "Counter for total number of async fetches",
+            "Counter for number of successful async fetches",
             COUNTER_METRICS_UNIT
         );
 

--- a/server/src/main/java/org/opensearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterModule.java
@@ -142,6 +142,7 @@ public class ClusterModule extends AbstractModule {
     // pkg private for tests
     final Collection<AllocationDecider> deciderList;
     final ShardsAllocator shardsAllocator;
+    private final ClusterManagerMetrics clusterManagerMetrics;
 
     public ClusterModule(
         Settings settings,
@@ -166,6 +167,7 @@ public class ClusterModule extends AbstractModule {
             settings,
             clusterManagerMetrics
         );
+        this.clusterManagerMetrics = clusterManagerMetrics;
     }
 
     public static List<Entry> getNamedWriteables() {
@@ -456,6 +458,7 @@ public class ClusterModule extends AbstractModule {
         bind(TaskResultsService.class).asEagerSingleton();
         bind(AllocationDeciders.class).toInstance(allocationDeciders);
         bind(ShardsAllocator.class).toInstance(shardsAllocator);
+        bind(ClusterManagerMetrics.class).toInstance(clusterManagerMetrics);
     }
 
     public void setExistingShardsAllocators(GatewayAllocator gatewayAllocator, ShardsBatchGatewayAllocator shardsBatchGatewayAllocator) {

--- a/server/src/main/java/org/opensearch/gateway/AsyncShardBatchFetch.java
+++ b/server/src/main/java/org/opensearch/gateway/AsyncShardBatchFetch.java
@@ -11,6 +11,7 @@ package org.opensearch.gateway;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterManagerMetrics;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.core.index.shard.ShardId;
@@ -48,7 +49,8 @@ public abstract class AsyncShardBatchFetch<T extends BaseNodeResponse, V> extend
         Class<V> clazz,
         V emptyShardResponse,
         Predicate<V> emptyShardResponsePredicate,
-        ShardBatchResponseFactory<T, V> responseFactory
+        ShardBatchResponseFactory<T, V> responseFactory,
+        ClusterManagerMetrics clusterManagerMetrics
     ) {
         super(
             logger,
@@ -64,7 +66,8 @@ public abstract class AsyncShardBatchFetch<T extends BaseNodeResponse, V> extend
                 clazz,
                 emptyShardResponse,
                 emptyShardResponsePredicate,
-                responseFactory
+                responseFactory,
+                clusterManagerMetrics
             )
         );
     }
@@ -116,9 +119,10 @@ public abstract class AsyncShardBatchFetch<T extends BaseNodeResponse, V> extend
             Class<V> clazz,
             V emptyResponse,
             Predicate<V> emptyShardResponsePredicate,
-            ShardBatchResponseFactory<T, V> responseFactory
+            ShardBatchResponseFactory<T, V> responseFactory,
+            ClusterManagerMetrics clusterManagerMetrics
         ) {
-            super(Loggers.getLogger(logger, "_" + logKey), type);
+            super(Loggers.getLogger(logger, "_" + logKey), type, clusterManagerMetrics);
             this.batchSize = shardAttributesMap.size();
             this.emptyShardResponsePredicate = emptyShardResponsePredicate;
             cache = new HashMap<>();

--- a/server/src/main/java/org/opensearch/gateway/AsyncShardFetch.java
+++ b/server/src/main/java/org/opensearch/gateway/AsyncShardFetch.java
@@ -225,7 +225,7 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
             logger.trace("{} ignoring fetched [{}] results, already closed", reroutingKey, type);
             return;
         }
-        logger.info("{} processing fetched [{}] results", reroutingKey, type);
+        logger.trace("{} processing fetched [{}] results", reroutingKey, type);
 
         if (responses != null) {
             cache.processResponses(responses, fetchingRound);

--- a/server/src/main/java/org/opensearch/gateway/AsyncShardFetch.java
+++ b/server/src/main/java/org/opensearch/gateway/AsyncShardFetch.java
@@ -266,7 +266,6 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
 
             @Override
             public void onFailure(Exception e) {
-                // TODO: add failure metrics here
                 List<FailedNodeException> failures = new ArrayList<>(nodes.length);
                 for (final DiscoveryNode node : nodes) {
                     failures.add(new FailedNodeException(node.getId(), "total failure in fetching", e));

--- a/server/src/main/java/org/opensearch/gateway/AsyncShardFetchCache.java
+++ b/server/src/main/java/org/opensearch/gateway/AsyncShardFetchCache.java
@@ -167,7 +167,7 @@ public abstract class AsyncShardFetchCache<K extends BaseNodeResponse> {
     void processResponses(List<K> responses, long fetchingRound) {
         for (K response : responses) {
             BaseNodeEntry nodeEntry = getCache().get(response.getNode().getId());
-            clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchTotalFetchesCounter, 1.0);
+            clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchTotalCounter, 1.0);
             if (nodeEntry != null) {
                 if (validateNodeResponse(nodeEntry, fetchingRound)) {
                     // if the entry is there, for the right fetching round and not marked as failed already, process it
@@ -197,7 +197,7 @@ public abstract class AsyncShardFetchCache<K extends BaseNodeResponse> {
     }
 
     private void handleNodeFailure(BaseNodeEntry nodeEntry, FailedNodeException failure, long fetchingRound) {
-        clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchTotalFetchesCounter, 1.0);
+        clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchTotalCounter, 1.0);
         clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchFailureCounter, 1.0);
         if (nodeEntry.getFetchingRound() != fetchingRound) {
             assert nodeEntry.getFetchingRound() > fetchingRound : "node entries only replaced by newer rounds";

--- a/server/src/main/java/org/opensearch/gateway/AsyncShardFetchCache.java
+++ b/server/src/main/java/org/opensearch/gateway/AsyncShardFetchCache.java
@@ -165,9 +165,9 @@ public abstract class AsyncShardFetchCache<K extends BaseNodeResponse> {
     }
 
     void processResponses(List<K> responses, long fetchingRound) {
+        clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchSuccessCounter, Double.valueOf(responses.size()));
         for (K response : responses) {
             BaseNodeEntry nodeEntry = getCache().get(response.getNode().getId());
-            clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchSuccessCounter, 1.0);
             if (nodeEntry != null) {
                 if (validateNodeResponse(nodeEntry, fetchingRound)) {
                     // if the entry is there, for the right fetching round and not marked as failed already, process it
@@ -226,9 +226,9 @@ public abstract class AsyncShardFetchCache<K extends BaseNodeResponse> {
     }
 
     void processFailures(List<FailedNodeException> failures, long fetchingRound) {
+        clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchFailureCounter, Double.valueOf(failures.size()));
         for (FailedNodeException failure : failures) {
             logger.trace("processing failure {} for [{}]", failure, type);
-            clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchFailureCounter, 1.0);
             BaseNodeEntry nodeEntry = getCache().get(failure.nodeId());
             if (nodeEntry != null) {
                 handleNodeFailure(nodeEntry, failure, fetchingRound);

--- a/server/src/main/java/org/opensearch/gateway/AsyncShardFetchCache.java
+++ b/server/src/main/java/org/opensearch/gateway/AsyncShardFetchCache.java
@@ -167,7 +167,7 @@ public abstract class AsyncShardFetchCache<K extends BaseNodeResponse> {
     void processResponses(List<K> responses, long fetchingRound) {
         for (K response : responses) {
             BaseNodeEntry nodeEntry = getCache().get(response.getNode().getId());
-            clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchTotalCounter, 1.0);
+            clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchSuccessCounter, 1.0);
             if (nodeEntry != null) {
                 if (validateNodeResponse(nodeEntry, fetchingRound)) {
                     // if the entry is there, for the right fetching round and not marked as failed already, process it
@@ -197,8 +197,6 @@ public abstract class AsyncShardFetchCache<K extends BaseNodeResponse> {
     }
 
     private void handleNodeFailure(BaseNodeEntry nodeEntry, FailedNodeException failure, long fetchingRound) {
-        clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchTotalCounter, 1.0);
-        clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchFailureCounter, 1.0);
         if (nodeEntry.getFetchingRound() != fetchingRound) {
             assert nodeEntry.getFetchingRound() > fetchingRound : "node entries only replaced by newer rounds";
             logger.trace(
@@ -230,6 +228,7 @@ public abstract class AsyncShardFetchCache<K extends BaseNodeResponse> {
     void processFailures(List<FailedNodeException> failures, long fetchingRound) {
         for (FailedNodeException failure : failures) {
             logger.trace("processing failure {} for [{}]", failure, type);
+            clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchFailureCounter, 1.0);
             BaseNodeEntry nodeEntry = getCache().get(failure.nodeId());
             if (nodeEntry != null) {
                 handleNodeFailure(nodeEntry, failure, fetchingRound);

--- a/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java
+++ b/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java
@@ -83,7 +83,7 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
     private TimeValue primaryShardsBatchGatewayAllocatorTimeout;
     private TimeValue replicaShardsBatchGatewayAllocatorTimeout;
     public static final TimeValue MIN_ALLOCATOR_TIMEOUT = TimeValue.timeValueSeconds(20);
-    private ClusterManagerMetrics clusterManagerMetrics;
+    private final ClusterManagerMetrics clusterManagerMetrics;
 
     /**
      * Number of shards we send in one batch to data nodes for fetching metadata

--- a/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java
+++ b/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterManagerMetrics;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -44,6 +45,7 @@ import org.opensearch.indices.store.TransportNodesListShardStoreMetadataBatch;
 import org.opensearch.indices.store.TransportNodesListShardStoreMetadataBatch.NodeStoreFilesMetadata;
 import org.opensearch.indices.store.TransportNodesListShardStoreMetadataHelper;
 import org.opensearch.indices.store.TransportNodesListShardStoreMetadataHelper.StoreFilesMetadata;
+import org.opensearch.telemetry.metrics.noop.NoopMetricsRegistry;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -81,6 +83,7 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
     private TimeValue primaryShardsBatchGatewayAllocatorTimeout;
     private TimeValue replicaShardsBatchGatewayAllocatorTimeout;
     public static final TimeValue MIN_ALLOCATOR_TIMEOUT = TimeValue.timeValueSeconds(20);
+    private ClusterManagerMetrics clusterManagerMetrics;
 
     /**
      * Number of shards we send in one batch to data nodes for fetching metadata
@@ -160,7 +163,8 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
         TransportNodesListGatewayStartedShardsBatch batchStartedAction,
         TransportNodesListShardStoreMetadataBatch batchStoreAction,
         Settings settings,
-        ClusterSettings clusterSettings
+        ClusterSettings clusterSettings,
+        ClusterManagerMetrics clusterManagerMetrics
     ) {
         this.rerouteService = rerouteService;
         this.primaryShardBatchAllocator = new InternalPrimaryBatchShardAllocator();
@@ -172,6 +176,7 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
         clusterSettings.addSettingsUpdateConsumer(PRIMARY_BATCH_ALLOCATOR_TIMEOUT_SETTING, this::setPrimaryBatchAllocatorTimeout);
         this.replicaShardsBatchGatewayAllocatorTimeout = REPLICA_BATCH_ALLOCATOR_TIMEOUT_SETTING.get(settings);
         clusterSettings.addSettingsUpdateConsumer(REPLICA_BATCH_ALLOCATOR_TIMEOUT_SETTING, this::setReplicaBatchAllocatorTimeout);
+        this.clusterManagerMetrics = clusterManagerMetrics;
     }
 
     @Override
@@ -187,6 +192,7 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
         this(DEFAULT_SHARD_BATCH_SIZE, null);
     }
 
+    // for tests
     protected ShardsBatchGatewayAllocator(long batchSize, RerouteService rerouteService) {
         this.rerouteService = rerouteService;
         this.batchStartedAction = null;
@@ -196,9 +202,8 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
         this.maxBatchSize = batchSize;
         this.primaryShardsBatchGatewayAllocatorTimeout = null;
         this.replicaShardsBatchGatewayAllocatorTimeout = null;
+        this.clusterManagerMetrics = new ClusterManagerMetrics(NoopMetricsRegistry.INSTANCE);
     }
-
-    // for tests
 
     @Override
     public int getNumberOfInFlightFetches() {
@@ -413,7 +418,7 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
             // add to batch if batch size full or last shard in unassigned list
             if (batchSize == 0 || iterator.hasNext() == false) {
                 String batchUUId = UUIDs.base64UUID();
-                ShardsBatch shardsBatch = new ShardsBatch(batchUUId, perBatchShards, primary);
+                ShardsBatch shardsBatch = new ShardsBatch(batchUUId, perBatchShards, primary, clusterManagerMetrics);
                 // add the batch to list of current batches
                 addBatch(shardsBatch, primary);
                 batchesToBeAssigned.add(batchUUId);
@@ -588,9 +593,21 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
             Class<V> clazz,
             V emptyShardResponse,
             Predicate<V> emptyShardResponsePredicate,
-            ShardBatchResponseFactory<T, V> responseFactory
+            ShardBatchResponseFactory<T, V> responseFactory,
+            ClusterManagerMetrics clusterManagerMetrics
         ) {
-            super(logger, type, map, action, batchUUId, clazz, emptyShardResponse, emptyShardResponsePredicate, responseFactory);
+            super(
+                logger,
+                type,
+                map,
+                action,
+                batchUUId,
+                clazz,
+                emptyShardResponse,
+                emptyShardResponsePredicate,
+                responseFactory,
+                clusterManagerMetrics
+            );
         }
 
         @Override
@@ -650,16 +667,17 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
              * It should return false if there has never been a fetch for this batch.
              * This function is currently only used in the case of replica shards when all deciders returned NO/THROTTLE, and explain mode is ON.
              * Allocation explain and manual reroute APIs try to append shard store information (matching bytes) to the allocation decision.
-             * However, these APIs do not want to trigger a new asyncFetch for these ineligible shards, unless the data from nodes is already there.
+             * However, these APIs do not want to trigger a new asyncFetch for these ineligible shards
+             * They only want to use the data if it is already available.
              * This function is used to see if a fetch has happened to decide if it is possible to append shard store info without a new async fetch.
              * In the case when shard has a batch but no fetch has happened before, it would be because it is a new batch.
              * In the case when shard has a batch, and a fetch has happened before, and no fetch is ongoing, it would be because we have already completed fetch for all nodes.
-             *
+             * <p>
              * In order to check if a fetch has ever happened, we check 2 things:
              * 1. If the shard batch cache is empty, we know that fetch has never happened so we return false.
              * 2. If we see that the list of nodes to fetch from is empty, we know that all nodes have data or are ongoing a fetch. So we return true.
              * 3. Otherwise we return false.
-             *
+             * <p>
              * see {@link AsyncShardFetchCache#findNodesToFetch()}
              */
             String batchId = getBatchId(shard, shard.primary());
@@ -669,7 +687,8 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
             logger.trace("Checking if fetching done for batch id {}", batchId);
             ShardsBatch shardsBatch = shard.primary() ? batchIdToStartedShardBatch.get(batchId) : batchIdToStoreShardBatch.get(batchId);
             // if fetchData has never been called, the per node cache will be empty and have no nodes
-            // this is because cache.fillShardCacheWithDataNodes(nodes) initialises this map and is called in AsyncShardFetch.fetchData
+            /// this is because {@link AsyncShardFetchCache#fillShardCacheWithDataNodes(DiscoveryNodes)} initialises this map
+            /// and is called in {@link AsyncShardFetch#fetchData(DiscoveryNodes, Map)}
             if (shardsBatch == null || shardsBatch.getAsyncFetcher().hasEmptyCache()) {
                 logger.trace("Batch cache is empty for batch {} ", batchId);
                 return false;
@@ -739,7 +758,12 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
 
         private final Map<ShardId, ShardEntry> batchInfo;
 
-        public ShardsBatch(String batchId, Map<ShardId, ShardEntry> shardsWithInfo, boolean primary) {
+        public ShardsBatch(
+            String batchId,
+            Map<ShardId, ShardEntry> shardsWithInfo,
+            boolean primary,
+            ClusterManagerMetrics clusterManagerMetrics
+        ) {
             this.batchId = batchId;
             this.batchInfo = new HashMap<>(shardsWithInfo);
             // create a ShardId -> customDataPath map for async fetch
@@ -757,7 +781,8 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
                     GatewayStartedShard.class,
                     new GatewayStartedShard(null, false, null, null),
                     GatewayStartedShard::isEmpty,
-                    new ShardBatchResponseFactory<>(true)
+                    new ShardBatchResponseFactory<>(true),
+                    clusterManagerMetrics
                 );
             } else {
                 asyncBatch = new InternalBatchAsyncFetch<>(
@@ -769,7 +794,8 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
                     NodeStoreFilesMetadata.class,
                     new NodeStoreFilesMetadata(new StoreFilesMetadata(null, Store.MetadataSnapshot.EMPTY, Collections.emptyList()), null),
                     NodeStoreFilesMetadata::isEmpty,
-                    new ShardBatchResponseFactory<>(false)
+                    new ShardBatchResponseFactory<>(false),
+                    clusterManagerMetrics
                 );
             }
         }

--- a/server/src/test/java/org/opensearch/gateway/AsyncShardFetchTests.java
+++ b/server/src/test/java/org/opensearch/gateway/AsyncShardFetchTests.java
@@ -102,9 +102,9 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         this.dummyCounter = mock(Counter.class);
         when(metricsRegistry.createCounter(anyString(), anyString(), anyString())).thenAnswer(invocationOnMock -> {
             String counterName = (String) invocationOnMock.getArguments()[0];
-            if (counterName.contains("allocation.reroute.async.fetch.total.count")) {
+            if (counterName.contains("async.fetch.total.count")) {
                 return asyncFetchTotalCounter;
-            } else if (counterName.contains("allocation.reroute.async.fetch.failure.count")) {
+            } else if (counterName.contains("async.fetch.failure.count")) {
                 return asyncFetchFailureCounter;
             }
             return dummyCounter;

--- a/server/src/test/java/org/opensearch/gateway/AsyncShardFetchTests.java
+++ b/server/src/test/java/org/opensearch/gateway/AsyncShardFetchTests.java
@@ -35,10 +35,12 @@ import org.apache.logging.log4j.LogManager;
 import org.opensearch.Version;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.cluster.ClusterManagerMetrics;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.telemetry.metrics.noop.NoopMetricsRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -399,7 +401,14 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         private AtomicInteger reroute = new AtomicInteger();
 
         TestFetch(ThreadPool threadPool) {
-            super(LogManager.getLogger(TestFetch.class), "test", new ShardId("test", "_na_", 1), "", null);
+            super(
+                LogManager.getLogger(TestFetch.class),
+                "test",
+                new ShardId("test", "_na_", 1),
+                "",
+                null,
+                new ClusterManagerMetrics(NoopMetricsRegistry.INSTANCE)
+            );
             this.threadPool = threadPool;
         }
 

--- a/server/src/test/java/org/opensearch/gateway/ShardBatchCacheTests.java
+++ b/server/src/test/java/org/opensearch/gateway/ShardBatchCacheTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.gateway;
 
+import org.opensearch.cluster.ClusterManagerMetrics;
 import org.opensearch.cluster.OpenSearchAllocationTestCase;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -19,6 +20,7 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.gateway.TransportNodesGatewayStartedShardHelper.GatewayStartedShard;
 import org.opensearch.gateway.TransportNodesListGatewayStartedShardsBatch.NodeGatewayStartedShardsBatch;
 import org.opensearch.indices.store.ShardAttributes;
+import org.opensearch.telemetry.metrics.noop.NoopMetricsRegistry;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -52,7 +54,8 @@ public class ShardBatchCacheTests extends OpenSearchAllocationTestCase {
             GatewayStartedShard.class,
             new GatewayStartedShard(null, false, null, null),
             GatewayStartedShard::isEmpty,
-            new ShardBatchResponseFactory<>(true)
+            new ShardBatchResponseFactory<>(true),
+            new ClusterManagerMetrics(NoopMetricsRegistry.INSTANCE)
         );
     }
 

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -2429,7 +2429,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                             nodeEnv,
                             indicesService,
                             namedXContentRegistry
-                        )
+                        ),
+                        new ClusterManagerMetrics(NoopMetricsRegistry.INSTANCE)
                     )
                 );
                 actions.put(

--- a/test/fixtures/azure-fixture/docker-compose.yml
+++ b/test/fixtures/azure-fixture/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   azure-fixture:
     build:

--- a/test/fixtures/azure-fixture/docker-compose.yml
+++ b/test/fixtures/azure-fixture/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3'
 services:
   azure-fixture:
     build:


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change adds failure count and success count OTel metrics for async shard fetch

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
