### PR TITLE
Fixing flaky test testRemoteIndexPathFileExistsAfterMigration

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemoteMigrationIndexMetadataUpdateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemoteMigrationIndexMetadataUpdateIT.java
@@ -533,17 +533,18 @@ public class RemoteMigrationIndexMetadataUpdateIT extends MigrationBaseTestCase 
 
         // validate remote index path file exists
         logger.info("---> Asserting remote index path file exists");
-        String fileNamePrefix = String.join(RemoteIndexPathUploader.DELIMITER, indexUUID, "7", RemoteIndexPath.DEFAULT_VERSION);
 
         assertTrue(FileSystemUtils.exists(translogRepoPath.resolve(RemoteIndexPath.DIR)));
         Path[] files = FileSystemUtils.files(translogRepoPath.resolve(RemoteIndexPath.DIR));
         assertEquals(1, files.length);
-        assertTrue(Arrays.stream(files).anyMatch(file -> file.toString().contains(fileNamePrefix)));
+        logger.info(files[0].toString());
+        assertTrue(Arrays.stream(files).anyMatch(file -> file.toString().contains(indexUUID)));
 
         assertTrue(FileSystemUtils.exists(segmentRepoPath.resolve(RemoteIndexPath.DIR)));
         files = FileSystemUtils.files(segmentRepoPath.resolve(RemoteIndexPath.DIR));
         assertEquals(1, files.length);
-        assertTrue(Arrays.stream(files).anyMatch(file -> file.toString().contains(fileNamePrefix)));
+        logger.info(files[0].toString());
+        assertTrue(Arrays.stream(files).anyMatch(file -> file.toString().contains(indexUUID)));
     }
 
     /**

--- a/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemoteMigrationIndexMetadataUpdateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemoteMigrationIndexMetadataUpdateIT.java
@@ -19,7 +19,6 @@ import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.util.FileSystemUtils;
 import org.opensearch.index.remote.RemoteIndexPath;
-import org.opensearch.index.remote.RemoteIndexPathUploader;
 import org.opensearch.index.remote.RemoteStoreEnums;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.InternalTestCluster;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixing flaky testRemoteIndexPathFileExistsAfterMigration IT. We currently have a hard check on remote-index-path file, and this is resulting into flakiness when indexMetadata changes across runs. We can have a bit lighter check and we can check if `indexUUID` exists in path file name instead of `indexUUID#indexMetadataVersion#RemoteIndexPathVersion`. Sample file name : `remote_path_0kxx2-Y3RqGi9KfxXzqd9A#6#1#zB8i07rPTIWMbYZCgHp0Kg`

### Related Issues
Resolves [#14295]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
