### PR TITLE
Update version check in yaml test file for bitmap filtering

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/370_bitmap_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/370_bitmap_filtering.yml
@@ -1,7 +1,7 @@
 ---
 setup:
   - skip:
-      version: " - 2.99.99"
+      version: " - 2.16.99"
       reason: The bitmap filtering feature is available in 2.17 and later.
   - do:
       indices.create:


### PR DESCRIPTION
### Description

The bitmap filtering feature is released in 2.17.0, we need to update the supported version to `2.17.0` in the yaml test file.

Backport 2.x is needed.

### Related Issues
No issue.

### Check List
<del>- [ ] Functionality includes testing.
<del>- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
<del>- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
