### PR TITLE
add concurrency check to gradle-check workflow

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -8,6 +8,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read # to fetch code (actions/checkout)
 


### PR DESCRIPTION
### Description
Coming from https://github.com/opensearch-project/opensearch-build/issues/5008 the gradle-check workflow runs for every new commit that is pushed onto the pull-request. This results in multiple instances of gradle-check workfow and as well as jenkins job to run. The user is only interested in the result of the latest commit run and doesn't care about the previous commit run results. 
This results in unnecessary noise on the pull request and as well as wastage of resources. Since there can be only 30 concurrent gradle-check jobs at any given point of time, these stale runs also exhaust the job queue which can otherwise be used for legitimate runs. 

This PR adds `concurrency` feature provided with github-actions to limit the workflow to run only 1 instance and cancel all other instances of the workflow for the same PR. See https://docs.github.com/en/enterprise-cloud%40latest/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs. 

This will only cancel the github worflow and doesn't handle cancelling the jenkins job. 
The logic to cancel the jenkins job is currently handled in https://github.com/opensearch-project/opensearch-build/pull/5043. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/opensearch-build/issues/5008

### Check List
- ~[ ] Functionality includes testing.~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
