### PR TITLE
[Star tree] Performance optimizations during flush flow

### DIFF
--- a/server/src/main/java/org/opensearch/common/util/ByteArrayBackedBitset.java
+++ b/server/src/main/java/org/opensearch/common/util/ByteArrayBackedBitset.java
@@ -8,11 +8,10 @@
 
 package org.opensearch.common.util;
 
-import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.RandomAccessInput;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 /**
  * A bitset backed by a byte array. This will initialize and set bits in the byte array based on the index.
@@ -40,18 +39,6 @@ public class ByteArrayBackedBitset {
     }
 
     /**
-     * Constructor which set the Lucene's IndexInput to read the bitset into a read-only buffer.
-     */
-    public ByteArrayBackedBitset(IndexInput in, int length) throws IOException {
-        byteArray = new byte[length];
-        int i = 0;
-        while (i < length) {
-            byteArray[i] = in.readByte();
-            i++;
-        }
-    }
-
-    /**
      * Sets the bit at the given index to 1.
      * Each byte can indicate 8 bits, so the index is divided by 8 to get the byte array index.
      * @param index the index to set the bit
@@ -61,10 +48,10 @@ public class ByteArrayBackedBitset {
         byteArray[byteArrIndex] |= (byte) (1 << (index & 7));
     }
 
-    public int write(IndexOutput output) throws IOException {
+    public int write(ByteBuffer output) throws IOException {
         int numBytes = 0;
         for (Byte bitSet : byteArray) {
-            output.writeByte(bitSet);
+            output.put(bitSet);
             numBytes += Byte.BYTES;
         }
         return numBytes;

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/AbstractDocumentsFileManager.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/AbstractDocumentsFileManager.java
@@ -16,6 +16,8 @@ import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.store.TrackingDirectoryWrapper;
 import org.apache.lucene.util.NumericUtils;
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.index.compositeindex.datacube.Metric;
+import org.opensearch.index.compositeindex.datacube.MetricStat;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeDocument;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeField;
 import org.opensearch.index.compositeindex.datacube.startree.aggregators.MetricAggregatorInfo;
@@ -71,7 +73,11 @@ public abstract class AbstractDocumentsFileManager implements Closeable {
      */
     protected int writeStarTreeDocument(StarTreeDocument starTreeDocument, IndexOutput output, boolean isAggregatedDoc) throws IOException {
         int numBytes = writeDimensions(starTreeDocument, output);
-        numBytes += writeMetrics(starTreeDocument, output, isAggregatedDoc);
+        if (isAggregatedDoc == false) {
+            numBytes += writeMetrics(starTreeDocument, output);
+        } else {
+            numBytes += writeMetrics(starTreeDocument, output, isAggregatedDoc);
+        }
         setDocSizeInBytes(numBytes);
         return numBytes;
     }
@@ -86,6 +92,20 @@ public abstract class AbstractDocumentsFileManager implements Closeable {
             numBytes += Long.BYTES;
         }
         numBytes += StarTreeDocumentBitSetUtil.writeBitSet(starTreeDocument.dimensions, output);
+        return numBytes;
+    }
+
+    /**
+     * Write star tree document metrics to file. Here we only write the metric field values. [ we avoid writing duplicate
+     * values for each of the stats ]
+     */
+    protected int writeMetrics(StarTreeDocument starTreeDocument, IndexOutput output) throws IOException {
+        int numBytes = 0;
+        for (int i = 0; i < starTreeDocument.metrics.length; i++) {
+            output.writeLong(starTreeDocument.metrics[i] == null ? 0L : (Long) starTreeDocument.metrics[i]);
+            numBytes += Long.BYTES;
+        }
+        numBytes += StarTreeDocumentBitSetUtil.writeBitSet(starTreeDocument.metrics, output);
         return numBytes;
     }
 
@@ -132,7 +152,11 @@ public abstract class AbstractDocumentsFileManager implements Closeable {
         offset = readDimensions(dimensions, input, offset);
 
         Object[] metrics = new Object[numMetrics];
-        offset = readMetrics(input, offset, numMetrics, metrics, isAggregatedDoc);
+        if (isAggregatedDoc == false) {
+            offset = readMetrics(input, offset, metrics);
+        } else {
+            offset = readMetrics(input, offset, numMetrics, metrics, isAggregatedDoc);
+        }
         assert (offset - initialOffset) == docSizeInBytes;
         return new StarTreeDocument(dimensions, metrics);
     }
@@ -155,9 +179,31 @@ public abstract class AbstractDocumentsFileManager implements Closeable {
     }
 
     /**
+     * Read metrics based on metric field values. Then we reuse the metric field values to each of the metric stats.
+     */
+    private long readMetrics(RandomAccessInput input, long offset, Object[] metrics) throws IOException {
+        Object[] fieldMetrics = new Object[starTreeField.getMetrics().size()];
+        for (int i = 0; i < starTreeField.getMetrics().size(); i++) {
+            fieldMetrics[i] = input.readLong(offset);
+            offset += Long.BYTES;
+        }
+        offset += StarTreeDocumentBitSetUtil.readBitSet(input, offset, fieldMetrics, index -> null);
+        int fieldIndex = 0;
+        int numMetrics = 0;
+        for (Metric metric : starTreeField.getMetrics()) {
+            for (MetricStat stat : metric.getBaseMetrics()) {
+                metrics[numMetrics] = fieldMetrics[fieldIndex];
+                numMetrics++;
+            }
+            fieldIndex++;
+        }
+        return offset;
+    }
+
+    /**
      * Read star tree metrics from file
      */
-    protected long readMetrics(RandomAccessInput input, long offset, int numMetrics, Object[] metrics, boolean isAggregatedDoc)
+    private long readMetrics(RandomAccessInput input, long offset, int numMetrics, Object[] metrics, boolean isAggregatedDoc)
         throws IOException {
         for (int i = 0; i < numMetrics; i++) {
             FieldValueConverter aggregatedValueType = metricAggregatorInfos.get(i).getValueAggregators().getAggregatedValueType();

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/OffHeapStarTreeBuilder.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/OffHeapStarTreeBuilder.java
@@ -144,8 +144,7 @@ public class OffHeapStarTreeBuilder extends BaseStarTreeBuilder {
     /**
      * Returns the metric field values for the star-tree document from the segment based on the current doc id
      */
-    private Object[] getStarTreeMetricFieldValuesFromSegment(int currentDocId, List<SequentialDocValuesIterator> metricReaders)
-        throws IOException {
+    private Object[] getStarTreeMetricFieldValuesFromSegment(int currentDocId, List<SequentialDocValuesIterator> metricReaders) {
         Object[] metricValues = new Object[starTreeField.getMetrics().size()];
         for (int i = 0; i < starTreeField.getMetrics().size(); i++) {
             if (starTreeField.getMetrics().get(i).getBaseMetrics().isEmpty()) continue;

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/StarTreeDocumentBitSetUtil.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/StarTreeDocumentBitSetUtil.java
@@ -8,34 +8,17 @@
 
 package org.opensearch.index.compositeindex.datacube.startree.utils;
 
-import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.RandomAccessInput;
 import org.opensearch.common.util.ByteArrayBackedBitset;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.function.Function;
 
 /**
  * Helper class to read/write bitset for null values and identity values.
  */
 public class StarTreeDocumentBitSetUtil {
-    /**
-     * Write bitset for null values.
-     *
-     * @param array array of objects
-     * @param output output stream
-     * @return number of bytes written
-     * @throws IOException if an I/O error occurs while writing to the output stream
-     */
-    public static int writeBitSet(Object[] array, IndexOutput output) throws IOException {
-        ByteArrayBackedBitset bitset = new ByteArrayBackedBitset(getLength(array));
-        for (int i = 0; i < array.length; i++) {
-            if (array[i] == null) {
-                bitset.set(i);
-            }
-        }
-        return bitset.write(output);
-    }
 
     /**
      * Set identity values based on bitset.
@@ -49,6 +32,19 @@ public class StarTreeDocumentBitSetUtil {
             }
         }
         return bitset.getCurrBytesRead();
+    }
+
+    /**
+     * Write the bitset for the given array to the ByteBuffer
+     */
+    public static void writeBitSet(Object[] array, ByteBuffer buffer) throws IOException {
+        ByteArrayBackedBitset bitset = new ByteArrayBackedBitset(getLength(array));
+        for (int i = 0; i < array.length; i++) {
+            if (array[i] == null) {
+                bitset.set(i);
+            }
+        }
+        bitset.write(buffer);
     }
 
     private static int getLength(Object[] array) {

--- a/server/src/test/java/org/opensearch/common/util/ByteArrayBackedBitsetTests.java
+++ b/server/src/test/java/org/opensearch/common/util/ByteArrayBackedBitsetTests.java
@@ -16,6 +16,8 @@ import org.apache.lucene.store.RandomAccessInput;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.file.Path;
 
 /**
@@ -39,7 +41,10 @@ public class ByteArrayBackedBitsetTests extends OpenSearchTestCase {
         IndexOutput indexOutput = fsDirectory.createOutput(TEST_FILE, IOContext.DEFAULT);
         bitset.set(randomIndex1);
         bitset.set(randomIndex2);
-        bitset.write(indexOutput);
+        byte[] bytes = new byte[randomArraySize];
+        ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.nativeOrder());
+        bitset.write(buffer);
+        indexOutput.writeBytes(bytes, bytes.length);
         indexOutput.close();
 
         IndexInput in = fsDirectory.openInput(TEST_FILE, IOContext.DEFAULT);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
1. Optimize metrics in off heap

Currently we initialize metric readers for all metric stats, thereby duplicating field value for each of the stats, when we write star tree document in off heap method.

If we initialize metric readers per metric field instead, we can write and read only the actual field values and when we read and initialize the star tree document, we can set the field's value to all metric stats.

2. Buffer complete star tree document instead of writing individual dimension / metrics to IndexOutput

We can buffer each starTreeDocument in memory and write bytes to indexOutput.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/16218

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
