### PR TITLE
Update version check in yaml test file for the bug fix of avoid infinite loop in flat_object parsing

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/90_flat_object.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/90_flat_object.yml
@@ -76,7 +76,7 @@ teardown:
 ---
 "Invalid docs":
   - skip:
-      version: "- 2.99.99"
+      version: "- 2.17.99"
       reason: "parsing of these objects would infinite loop prior to 2.18"
   # The following documents are invalid.
   - do:


### PR DESCRIPTION
### Description

After this [PR](https://github.com/opensearch-project/OpenSearch/pull/15985) is backport to 2.x branch, we need to update the version check in the yaml test file from `2.99.99` to `2.17.99`.

Backport to 2.x is needed.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
<del>- [ ] Functionality includes testing.
<del>- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
<del>- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
