### PR TITLE
Fix flaky date histo rest test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/360_date_histogram.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/360_date_histogram.yml
@@ -110,6 +110,19 @@ setup:
 ---
 "Date histogram aggregation w/ shared field range test":
   - do:
+      indices.create:
+        index: dhisto-agg-w-query
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+            refresh_interval: -1
+          mappings:
+            properties:
+              date:
+                type: date
+
+  - do:
       bulk:
         refresh: true
         index: dhisto-agg-w-query
@@ -126,6 +139,11 @@ setup:
           - '{"date": "2025-01-01"}'
           - '{"index": {}}'
           - '{"date": "2025-02-14"}'
+
+  - do:
+      indices.forcemerge:
+        index: dhisto-agg-w-query
+        max_num_segments: 1
 
   - do:
       search:


### PR DESCRIPTION
### Description
`yaml=search.aggregation/360_date_histogram/Date histogram aggregation w/ shared field range test` is flaky because it assumes there will only be a single segment created for the test index.

Previously fixed for other similar tests but this test is missing changes which guarantee a single segment: 
https://github.com/opensearch-project/OpenSearch/pull/14486

### Related Issues
#14408

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
