### PR TITLE
Ignore google-cloud-storage and google-api-client major version upgrade for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -726,6 +726,8 @@ updates:
       # For all packages, ignore all major versions to minimize breaking issues
       - dependency-name: "com.google.cloud:google-cloud-storage"
         update-types: [ "version-update:semver-major" ]
+      - dependency-name: "com.google.api-client:google-api-client"
+        update-types: [ "version-update:semver-major" ]
     schedule:
       interval: weekly
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -722,6 +722,10 @@ updates:
   - directory: /plugins/
     open-pull-requests-limit: 1
     package-ecosystem: gradle
+    ignore:
+      # For all packages, ignore all major versions to minimize breaking issues
+      - dependency-name: "com.google.cloud:google-cloud-storage"
+        update-types: [ "version-update:semver-major" ]
     schedule:
       interval: weekly
     labels:


### PR DESCRIPTION
### Description

Creating this PR to reduce some noise from dependabot. Dependabot has been making PRs that upgrade google-cloud-storage from 1.x to 2.x which cannot be merged since additional code changes need to be made to adopt 2.x.

This PR mutes dependabot to prevent it from making any more PRs on a major version upgrade for this dependency in any of the modules under the `/plugins` folder.

Example PRs which will require additional changes:

- https://github.com/opensearch-project/OpenSearch/pull/16043
- https://github.com/opensearch-project/OpenSearch/pull/15577
- https://github.com/opensearch-project/OpenSearch/pull/13938

You can find the syntax for dependabot.yml here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
