### PR TITLE
FIX Clone Index setting override for replication type

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1708,7 +1708,8 @@ public class MetadataCreateIndexService {
             .put(builder.build())
             .put(IndexMetadata.SETTING_ROUTING_PARTITION_SIZE, sourceMetadata.getRoutingPartitionSize())
             .put(IndexMetadata.INDEX_RESIZE_SOURCE_NAME.getKey(), resizeSourceIndex.getName())
-            .put(IndexMetadata.INDEX_RESIZE_SOURCE_UUID.getKey(), resizeSourceIndex.getUUID());
+            .put(IndexMetadata.INDEX_RESIZE_SOURCE_UUID.getKey(), resizeSourceIndex.getUUID())
+            .put(INDEX_REPLICATION_TYPE_SETTING.getKey(), INDEX_REPLICATION_TYPE_SETTING.get(sourceMetadata.getSettings()));
     }
 
     /**

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -611,6 +611,20 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         );
     }
 
+    public void testPrepareResizeIndexSettingsReplicationType() {
+        runPrepareResizeIndexSettingsTest(
+            Settings.builder().put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT.toString()).build(),
+            Settings.builder().put(SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT.toString()).build(),
+            emptyList(),
+            true,
+            settings -> assertThat(
+                "Segment Replication must be equal to source type",
+                settings.get(SETTING_REPLICATION_TYPE),
+                equalTo(ReplicationType.SEGMENT.toString())
+            )
+        );
+    }
+
     public void testPrepareResizeIndexSettingsAnalysisSettings() {
         // analysis settings from the request are not overwritten
         runPrepareResizeIndexSettingsTest(


### PR DESCRIPTION

### Description
- Fix index setting override for replication type clone/shrink/split indices


### Related Issues
we see there is previous pr and issues, but when we do clone/shirnk/split which is `Resize Action` it would make a Segment Replication Type  indices to Document Replication Type.

#11417 @kotwanikunal
#11230

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
