### PR TITLE
[Bugfix] Remote translog does not honour pinned timestamp for low value of indexSettings().getRemoteTranslogExtraKeep()

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
@@ -121,7 +121,7 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
     protected void trimUnreferencedReaders(boolean indexDeleted, boolean trimLocal) throws IOException {
         if (trimLocal) {
             // clean up local translog files and updates readers
-            super.trimUnreferencedReaders();
+            super.trimUnreferencedReaders(true);
         }
 
         // Update file tracker to reflect local translog state

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -549,8 +549,16 @@ public class RemoteFsTranslog extends Translog {
 
     @Override
     public void trimUnreferencedReaders() throws IOException {
+        trimUnreferencedReaders(false);
+    }
+
+    protected void trimUnreferencedReaders(boolean onlyTrimLocal) throws IOException {
         // clean up local translog files and updates readers
         super.trimUnreferencedReaders();
+
+        if (onlyTrimLocal) {
+            return;
+        }
 
         // This is to ensure that after the permits are acquired during primary relocation, there are no further modification on remote
         // store.


### PR DESCRIPTION
### Description
- `RemoteFsTimestampAwareTranslog` has different logic for `trimUnreferencedReaders()` when compared to that of `RemoteFsTranslog`. It considers pinned timestamps and makes sure data against pinned timestamp is not deleted from remote translog.
- `RemoteFsTimestampAwareTranslog.trimUnreferencedReaders()` calls `super.trimUnreferencedReaders()` with the intention of cleaning up local translog files.
- But as `RemoteFsTimestampAwareTranslog` extends `RemoteFsTranslog`, this call to super goes to RemoteFsTranslog which is not aware of pinned timestamps.
- In this PR, we make sure to call `Translog.trimUnreferencedReaders()` from `RemoteFsTimestampAwareTranslog`.

#### Why is it not failing always?
- Even though `RemoteFsTimestampAwareTranslog` is inadvertently calling `RemoteFsTranslog.trimUnreferencedReaders` the super method becomes a no-op in most of the cases.
- This is due to the following condition in `RemoteFsTranslog.trimUnreferencedReaders`

https://github.com/opensearch-project/OpenSearch/blob/f1acc7aad7db4c3c9ce2e0ac331b02105ddc85f5/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java#L575-L590

- The for loop makes sure to keep `indexSettings().getRemoteTranslogExtraKeep()` generations always. So, initial calls to 
`trimUnreferencedReaders` would be a no-op.
- After calling `RemoteFsTranslog.trimUnreferencedReaders`, RemoteFsTimestampAwareTranslog removes entries for translog files from fileTracker that are no longer present in the local. 
- As fileTracker is now having only entries that are present on local, even after entering the for loop, `RemoteFsTranslog.trimUnreferencedReaders` becomes a no-op and breaks out of the loop.
- The issue occurs specifically when `indexSettings().getRemoteTranslogExtraKeep()` is set to low value.


### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/16079

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
