### PR TITLE
[Star tree] Support for keyword changes as part of star tree mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add _list/shards API as paginated alternate to _cat/shards ([#14641](https://github.com/opensearch-project/OpenSearch/pull/14641))
 - Latency and Memory allocation improvements to Multi Term Aggregation queries ([#14993](https://github.com/opensearch-project/OpenSearch/pull/14993))
 - Flat object field use IndexOrDocValuesQuery to optimize query ([#14383](https://github.com/opensearch-project/OpenSearch/issues/14383))
-
+- [Star tree] Adding date field rounding support in star tree ([#15249](https://github.com/opensearch-project/OpenSearch/issues/15249))
+- [Star tree] Support for keyword changes as part of star tree mapper ([#16103](https://github.com/opensearch-project/OpenSearch/issues/16103))
 ### Dependencies
 - Bump `com.azure:azure-identity` from 1.13.0 to 1.13.2 ([#15578](https://github.com/opensearch-project/OpenSearch/pull/15578))
 - Bump `protobuf` from 3.22.3 to 3.25.4 ([#15684](https://github.com/opensearch-project/OpenSearch/pull/15684))

--- a/server/src/main/java/org/opensearch/index/codec/composite/composite912/Composite912DocValuesWriter.java
+++ b/server/src/main/java/org/opensearch/index/codec/composite/composite912/Composite912DocValuesWriter.java
@@ -21,7 +21,6 @@ import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.IndexOutput;
 import org.opensearch.common.annotation.ExperimentalApi;
@@ -35,7 +34,6 @@ import org.opensearch.index.compositeindex.datacube.startree.index.CompositeInde
 import org.opensearch.index.compositeindex.datacube.startree.index.StarTreeValues;
 import org.opensearch.index.mapper.CompositeMappedFieldType;
 import org.opensearch.index.mapper.DocCountFieldMapper;
-import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.StarTreeMapper;
 
@@ -84,7 +82,14 @@ public class Composite912DocValuesWriter extends DocValuesConsumer {
         this.compositeMappedFieldTypes = mapperService.getCompositeFieldTypes();
         compositeFieldSet = new HashSet<>();
         segmentFieldSet = new HashSet<>();
-        addStarTreeSupportedFieldsFromSegment();
+        // TODO : add integ test for this
+        for (FieldInfo fi : this.state.fieldInfos) {
+            if (DocValuesType.SORTED_NUMERIC.equals(fi.getDocValuesType())) {
+                segmentFieldSet.add(fi.name);
+            } else if (fi.name.equals(DocCountFieldMapper.NAME)) {
+                segmentFieldSet.add(fi.name);
+            }
+        }
         for (CompositeMappedFieldType type : compositeMappedFieldTypes) {
             compositeFieldSet.addAll(type.fields());
         }
@@ -143,19 +148,6 @@ public class Composite912DocValuesWriter extends DocValuesConsumer {
         segmentHasCompositeFields = Collections.disjoint(segmentFieldSet, compositeFieldSet) == false;
     }
 
-    private void addStarTreeSupportedFieldsFromSegment() {
-        // TODO : add integ test for this
-        for (FieldInfo fi : this.state.fieldInfos) {
-            if (DocValuesType.SORTED_NUMERIC.equals(fi.getDocValuesType())) {
-                segmentFieldSet.add(fi.name);
-            } else if (DocValuesType.SORTED_SET.equals(fi.getDocValuesType())) {
-                segmentFieldSet.add(fi.name);
-            } else if (fi.name.equals(DocCountFieldMapper.NAME)) {
-                segmentFieldSet.add(fi.name);
-            }
-        }
-    }
-
     @Override
     public void addNumericField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
         delegate.addNumericField(field, valuesProducer);
@@ -187,10 +179,6 @@ public class Composite912DocValuesWriter extends DocValuesConsumer {
     @Override
     public void addSortedSetField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
         delegate.addSortedSetField(field, valuesProducer);
-        // Perform this only during flush flow
-        if (mergeState.get() == null && segmentHasCompositeFields) {
-            createCompositeIndicesIfPossible(valuesProducer, field);
-        }
     }
 
     @Override
@@ -247,7 +235,6 @@ public class Composite912DocValuesWriter extends DocValuesConsumer {
      * Add empty doc values for fields not present in segment
      */
     private void addDocValuesForEmptyField(String compositeField) {
-        // special case for doc count
         if (compositeField.equals(DocCountFieldMapper.NAME)) {
             fieldProducerMap.put(compositeField, new EmptyDocValuesProducer() {
                 @Override
@@ -256,27 +243,14 @@ public class Composite912DocValuesWriter extends DocValuesConsumer {
                 }
             });
         } else {
-            if (isSortedSetField(compositeField)) {
-                fieldProducerMap.put(compositeField, new EmptyDocValuesProducer() {
-                    @Override
-                    public SortedSetDocValues getSortedSet(FieldInfo field) {
-                        return DocValues.emptySortedSet();
-                    }
-                });
-            } else {
-                fieldProducerMap.put(compositeField, new EmptyDocValuesProducer() {
-                    @Override
-                    public SortedNumericDocValues getSortedNumeric(FieldInfo field) {
-                        return DocValues.emptySortedNumeric();
-                    }
-                });
-            }
+            fieldProducerMap.put(compositeField, new EmptyDocValuesProducer() {
+                @Override
+                public SortedNumericDocValues getSortedNumeric(FieldInfo field) {
+                    return DocValues.emptySortedNumeric();
+                }
+            });
         }
         compositeFieldSet.remove(compositeField);
-    }
-
-    private boolean isSortedSetField(String field) {
-        return mapperService.fieldType(field) instanceof KeywordFieldMapper.KeywordFieldType;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/codec/composite/composite912/Composite912DocValuesWriter.java
+++ b/server/src/main/java/org/opensearch/index/codec/composite/composite912/Composite912DocValuesWriter.java
@@ -21,6 +21,7 @@ import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.IndexOutput;
 import org.opensearch.common.annotation.ExperimentalApi;
@@ -34,6 +35,7 @@ import org.opensearch.index.compositeindex.datacube.startree.index.CompositeInde
 import org.opensearch.index.compositeindex.datacube.startree.index.StarTreeValues;
 import org.opensearch.index.mapper.CompositeMappedFieldType;
 import org.opensearch.index.mapper.DocCountFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.StarTreeMapper;
 
@@ -82,14 +84,7 @@ public class Composite912DocValuesWriter extends DocValuesConsumer {
         this.compositeMappedFieldTypes = mapperService.getCompositeFieldTypes();
         compositeFieldSet = new HashSet<>();
         segmentFieldSet = new HashSet<>();
-        // TODO : add integ test for this
-        for (FieldInfo fi : this.state.fieldInfos) {
-            if (DocValuesType.SORTED_NUMERIC.equals(fi.getDocValuesType())) {
-                segmentFieldSet.add(fi.name);
-            } else if (fi.name.equals(DocCountFieldMapper.NAME)) {
-                segmentFieldSet.add(fi.name);
-            }
-        }
+        addStarTreeSupportedFieldsFromSegment();
         for (CompositeMappedFieldType type : compositeMappedFieldTypes) {
             compositeFieldSet.addAll(type.fields());
         }
@@ -148,6 +143,19 @@ public class Composite912DocValuesWriter extends DocValuesConsumer {
         segmentHasCompositeFields = Collections.disjoint(segmentFieldSet, compositeFieldSet) == false;
     }
 
+    private void addStarTreeSupportedFieldsFromSegment() {
+        // TODO : add integ test for this
+        for (FieldInfo fi : this.state.fieldInfos) {
+            if (DocValuesType.SORTED_NUMERIC.equals(fi.getDocValuesType())) {
+                segmentFieldSet.add(fi.name);
+            } else if (DocValuesType.SORTED_SET.equals(fi.getDocValuesType())) {
+                segmentFieldSet.add(fi.name);
+            } else if (fi.name.equals(DocCountFieldMapper.NAME)) {
+                segmentFieldSet.add(fi.name);
+            }
+        }
+    }
+
     @Override
     public void addNumericField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
         delegate.addNumericField(field, valuesProducer);
@@ -179,6 +187,10 @@ public class Composite912DocValuesWriter extends DocValuesConsumer {
     @Override
     public void addSortedSetField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
         delegate.addSortedSetField(field, valuesProducer);
+        // Perform this only during flush flow
+        if (mergeState.get() == null && segmentHasCompositeFields) {
+            createCompositeIndicesIfPossible(valuesProducer, field);
+        }
     }
 
     @Override
@@ -235,6 +247,7 @@ public class Composite912DocValuesWriter extends DocValuesConsumer {
      * Add empty doc values for fields not present in segment
      */
     private void addDocValuesForEmptyField(String compositeField) {
+        // special case for doc count
         if (compositeField.equals(DocCountFieldMapper.NAME)) {
             fieldProducerMap.put(compositeField, new EmptyDocValuesProducer() {
                 @Override
@@ -243,14 +256,27 @@ public class Composite912DocValuesWriter extends DocValuesConsumer {
                 }
             });
         } else {
-            fieldProducerMap.put(compositeField, new EmptyDocValuesProducer() {
-                @Override
-                public SortedNumericDocValues getSortedNumeric(FieldInfo field) {
-                    return DocValues.emptySortedNumeric();
-                }
-            });
+            if (isSortedSetField(compositeField)) {
+                fieldProducerMap.put(compositeField, new EmptyDocValuesProducer() {
+                    @Override
+                    public SortedSetDocValues getSortedSet(FieldInfo field) {
+                        return DocValues.emptySortedSet();
+                    }
+                });
+            } else {
+                fieldProducerMap.put(compositeField, new EmptyDocValuesProducer() {
+                    @Override
+                    public SortedNumericDocValues getSortedNumeric(FieldInfo field) {
+                        return DocValues.emptySortedNumeric();
+                    }
+                });
+            }
         }
         compositeFieldSet.remove(compositeField);
+    }
+
+    private boolean isSortedSetField(String field) {
+        return mapperService.fieldType(field) instanceof KeywordFieldMapper.KeywordFieldType;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/DimensionFactory.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/DimensionFactory.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.opensearch.index.compositeindex.datacube.DateDimension.CALENDAR_INTERVALS;
+import static org.opensearch.index.compositeindex.datacube.KeywordDimension.KEYWORD;
 
 /**
  * Dimension factory class mainly used to parse and create dimension from the mappings
@@ -43,6 +44,8 @@ public class DimensionFactory {
                 return parseAndCreateDateDimension(name, dimensionMap, c);
             case NumericDimension.NUMERIC:
                 return new NumericDimension(name);
+            case KEYWORD:
+                return new KeywordDimension(name);
             default:
                 throw new IllegalArgumentException(
                     String.format(Locale.ROOT, "unsupported field type associated with dimension [%s] as part of star tree field", name)
@@ -56,16 +59,23 @@ public class DimensionFactory {
         Map<String, Object> dimensionMap,
         Mapper.TypeParser.ParserContext c
     ) {
-        if (builder.getSupportedDataCubeDimensionType().isPresent()
-            && builder.getSupportedDataCubeDimensionType().get().equals(DimensionType.DATE)) {
-            return parseAndCreateDateDimension(name, dimensionMap, c);
-        } else if (builder.getSupportedDataCubeDimensionType().isPresent()
-            && builder.getSupportedDataCubeDimensionType().get().equals(DimensionType.NUMERIC)) {
+        if (builder.getSupportedDataCubeDimensionType().isEmpty()) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "unsupported field type associated with star tree dimension [%s]", name)
+            );
+        }
+        switch (builder.getSupportedDataCubeDimensionType().get()) {
+            case DATE:
+                return parseAndCreateDateDimension(name, dimensionMap, c);
+            case NUMERIC:
                 return new NumericDimension(name);
-            }
-        throw new IllegalArgumentException(
-            String.format(Locale.ROOT, "unsupported field type associated with star tree dimension [%s]", name)
-        );
+            case KEYWORD:
+                return new KeywordDimension(name);
+            default:
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "unsupported field type associated with star tree dimension [%s]", name)
+                );
+        }
     }
 
     private static DateDimension parseAndCreateDateDimension(

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/DimensionType.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/DimensionType.java
@@ -27,5 +27,11 @@ public enum DimensionType {
      * Represents a date dimension type.
      * This is used for dimensions that contain date or timestamp values.
      */
-    DATE
+    DATE,
+
+    /**
+     * Represents a keyword dimension type.
+     * This is used for dimensions that contain keyword ordinals.
+     */
+    KEYWORD
 }

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/KeywordDimension.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/KeywordDimension.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.compositeindex.datacube;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.mapper.CompositeDataCubeFieldType;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Composite index keyword dimension class
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class KeywordDimension implements Dimension {
+    public static final String KEYWORD = "keyword";
+    private final String field;
+
+    public KeywordDimension(String field) {
+        this.field = field;
+    }
+
+    @Override
+    public String getField() {
+        return field;
+    }
+
+    @Override
+    public int getNumSubDimensions() {
+        return 1;
+    }
+
+    @Override
+    public int setDimensionValues(Long value, Long[] dims, int index) {
+        dims[index++] = value;
+        return index;
+    }
+
+    @Override
+    public List<String> getDimensionFieldsNames() {
+        return List.of(field);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(CompositeDataCubeFieldType.NAME, field);
+        builder.field(CompositeDataCubeFieldType.TYPE, KEYWORD);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        KeywordDimension dimension = (KeywordDimension) o;
+        return Objects.equals(field, dimension.getField());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/KeywordDimension.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/KeywordDimension.java
@@ -15,6 +15,7 @@ import org.opensearch.index.mapper.CompositeDataCubeFieldType;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * Composite index keyword dimension class
@@ -41,13 +42,12 @@ public class KeywordDimension implements Dimension {
     }
 
     @Override
-    public int setDimensionValues(Long value, Long[] dims, int index) {
-        dims[index++] = value;
-        return index;
+    public void setDimensionValues(Long value, Consumer<Long> dimSetter) {
+        dimSetter.accept(value);
     }
 
     @Override
-    public List<String> getDimensionFieldsNames() {
+    public List<String> getSubDimensionNames() {
         return List.of(field);
     }
 

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeDocsFileManager.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeDocsFileManager.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.RandomAccessInput;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeDocument;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeField;
@@ -45,7 +46,9 @@ import java.util.Map;
  * <p>The set of 'star-tree.documents' files is maintained, and a tracker array is used to keep track of the start document ID for each file.
  * Once the number of files reaches a set threshold, the files are merged.
  *
+ * @opensearch.experimental
  */
+@ExperimentalApi
 public class StarTreeDocsFileManager extends AbstractDocumentsFileManager implements Closeable {
     private static final Logger logger = LogManager.getLogger(StarTreeDocsFileManager.class);
     private static final String STAR_TREE_DOC_FILE_NAME = "star-tree.documents";

--- a/server/src/main/java/org/opensearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/KeywordFieldMapper.java
@@ -59,6 +59,7 @@ import org.opensearch.common.unit.Fuzziness;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.analysis.IndexAnalyzers;
 import org.opensearch.index.analysis.NamedAnalyzer;
+import org.opensearch.index.compositeindex.datacube.DimensionType;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.opensearch.index.query.QueryShardContext;
@@ -73,6 +74,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.opensearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
@@ -253,6 +255,11 @@ public final class KeywordFieldMapper extends ParametrizedFieldMapper {
                 copyTo.build(),
                 this
             );
+        }
+
+        @Override
+        public Optional<DimensionType> getSupportedDataCubeDimensionType() {
+            return Optional.of(DimensionType.KEYWORD);
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/compositeindex/datacube/DimensionFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/compositeindex/datacube/DimensionFactoryTests.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.compositeindex.datacube;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.mapper.Mapper;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DimensionFactoryTests extends OpenSearchTestCase {
+
+    public void testParseAndCreateDateDimension() {
+        String name = "dateDimension";
+        Map<String, Object> dimensionMap = new HashMap<>();
+        List<String> calendarIntervals = Arrays.asList("day", "month");
+        dimensionMap.put("calendar_intervals", calendarIntervals);
+
+        Mapper.TypeParser.ParserContext mockContext = mock(Mapper.TypeParser.ParserContext.class);
+        when(mockContext.getSettings()).thenReturn(Settings.EMPTY);
+
+        Dimension dimension = DimensionFactory.parseAndCreateDimension(name, DateDimension.DATE, dimensionMap, mockContext);
+
+        assertTrue(dimension instanceof DateDimension);
+        assertEquals(2, dimension.getNumSubDimensions());
+        for (String interval : calendarIntervals) {
+            assertTrue(dimension.getSubDimensionNames().contains(name + "_" + interval));
+        }
+        assertEquals(name, dimension.getField());
+        DateDimension dateDimension = (DateDimension) dimension;
+        assertEquals(2, dateDimension.getIntervals().size());
+    }
+
+    public void testParseAndCreateNumericDimension() {
+        String name = "numericDimension";
+        Dimension dimension = DimensionFactory.parseAndCreateDimension(name, NumericDimension.NUMERIC, new HashMap<>(), null);
+
+        assertTrue(dimension instanceof NumericDimension);
+        assertEquals(1, dimension.getNumSubDimensions());
+        assertTrue(dimension.getSubDimensionNames().contains(name));
+        assertEquals(name, dimension.getField());
+    }
+
+    public void testParseAndCreateKeywordDimension() {
+        String name = "keywordDimension";
+        Dimension dimension = DimensionFactory.parseAndCreateDimension(name, KeywordDimension.KEYWORD, new HashMap<>(), null);
+        KeywordDimension kd = new KeywordDimension(name);
+        assertTrue(dimension instanceof KeywordDimension);
+        assertEquals(1, dimension.getNumSubDimensions());
+        assertTrue(dimension.getSubDimensionNames().contains(name));
+        assertEquals(dimension, kd);
+        assertEquals(name, dimension.getField());
+        List<Long> dimValue = new ArrayList<>();
+        kd.setDimensionValues(1L, dimValue::add);
+        assertEquals((Long) 1L, dimValue.get(0));
+    }
+
+    public void testParseAndCreateDimensionWithUnsupportedType() {
+        String name = "unsupportedDimension";
+        String unsupportedType = "unsupported";
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> DimensionFactory.parseAndCreateDimension(name, unsupportedType, new HashMap<>(), null)
+        );
+        assertTrue(exception.getMessage().contains("unsupported field type"));
+    }
+
+    public void testParseAndCreateDimensionWithBuilder() {
+        String name = "builderDimension";
+        Mapper.Builder mockBuilder = mock(Mapper.Builder.class);
+        when(mockBuilder.getSupportedDataCubeDimensionType()).thenReturn(java.util.Optional.of(DimensionType.KEYWORD));
+
+        Dimension dimension = DimensionFactory.parseAndCreateDimension(name, mockBuilder, new HashMap<>(), null);
+
+        assertTrue(dimension instanceof KeywordDimension);
+        assertEquals(name, dimension.getField());
+    }
+
+    public void testParseAndCreateDimensionWithUnsupportedBuilder() {
+        String name = "unsupportedBuilderDimension";
+        Mapper.Builder mockBuilder = mock(Mapper.Builder.class);
+        when(mockBuilder.getSupportedDataCubeDimensionType()).thenReturn(java.util.Optional.empty());
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> DimensionFactory.parseAndCreateDimension(name, mockBuilder, new HashMap<>(), null)
+        );
+        assertTrue(exception.getMessage().contains("unsupported field type"));
+    }
+}

--- a/server/src/test/java/org/opensearch/index/mapper/StarTreeMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/StarTreeMapperTests.java
@@ -672,6 +672,9 @@ public class StarTreeMapperTests extends MapperTestCase {
             b.startObject("size");
             b.field("type", "integer");
             b.endObject();
+            b.startObject("keyword1");
+            b.field("type", "keyword");
+            b.endObject();
             b.endObject();
         });
     }
@@ -718,6 +721,7 @@ public class StarTreeMapperTests extends MapperTestCase {
                 .field("type", "integer")
                 .field("doc_values", true)
                 .endObject()
+
                 .endObject()
                 .endObject();
         } catch (IOException e) {
@@ -772,6 +776,9 @@ public class StarTreeMapperTests extends MapperTestCase {
             b.startObject("size");
             b.field("type", "integer");
             b.endObject();
+            b.startObject("keyword1");
+            b.field("type", "keyword");
+            b.endObject();
             b.endObject();
         });
     }
@@ -823,6 +830,9 @@ public class StarTreeMapperTests extends MapperTestCase {
             b.startObject("size");
             b.field("type", "integer");
             b.endObject();
+            b.startObject("keyword1");
+            b.field("type", "keyword");
+            b.endObject();
             b.endObject();
         });
     }
@@ -866,6 +876,9 @@ public class StarTreeMapperTests extends MapperTestCase {
                 b.startObject();
                 b.field("name", "metric_field");
                 b.endObject();
+                b.startObject();
+                b.field("name", "keyword1");
+                b.endObject();
             }
             b.endArray();
 
@@ -895,6 +908,9 @@ public class StarTreeMapperTests extends MapperTestCase {
             b.startObject("metric_field");
             b.field("type", "integer");
             b.endObject();
+            b.startObject("keyword1");
+            b.field("type", "keyword");
+            b.endObject();
 
             b.endObject();
         });
@@ -919,6 +935,9 @@ public class StarTreeMapperTests extends MapperTestCase {
                 b.startArray("ordered_dimensions");
                 b.startObject();
                 b.field("name", "status");
+                b.endObject();
+                b.startObject();
+                b.field("name", "keyword1");
                 b.endObject();
                 b.endArray();
             }
@@ -951,6 +970,9 @@ public class StarTreeMapperTests extends MapperTestCase {
                 b.field("type", "integer");
                 b.endObject();
             }
+            b.startObject("keyword1");
+            b.field("type", "keyword");
+            b.endObject();
             b.endObject();
         });
     }
@@ -1018,7 +1040,9 @@ public class StarTreeMapperTests extends MapperTestCase {
             b.startObject("metric_field");
             b.field("type", "integer");
             b.endObject();
-
+            b.startObject("keyword1");
+            b.field("type", "keyword");
+            b.endObject();
             b.endObject();
         });
     }
@@ -1058,6 +1082,9 @@ public class StarTreeMapperTests extends MapperTestCase {
                 b.startObject();
                 b.field("name", "status");
                 b.endObject();
+                b.startObject();
+                b.field("name", "keyword1");
+                b.endObject();
             }
             b.endArray();
             b.startArray("metrics");
@@ -1090,7 +1117,7 @@ public class StarTreeMapperTests extends MapperTestCase {
             if (!invalidDimType) {
                 b.field("type", "integer");
             } else {
-                b.field("type", "keyword");
+                b.field("type", "ip");
             }
             b.endObject();
             b.startObject("metric_field");
@@ -1099,6 +1126,9 @@ public class StarTreeMapperTests extends MapperTestCase {
             } else {
                 b.field("type", "integer");
             }
+            b.endObject();
+            b.startObject("keyword1");
+            b.field("type", "keyword");
             b.endObject();
             b.endObject();
         });
@@ -1131,6 +1161,9 @@ public class StarTreeMapperTests extends MapperTestCase {
             if (!singleDim) {
                 b.startObject();
                 b.field("name", "status");
+                b.endObject();
+                b.startObject();
+                b.field("name", "keyword1");
                 b.endObject();
             }
             b.endArray();
@@ -1167,6 +1200,9 @@ public class StarTreeMapperTests extends MapperTestCase {
                 b.field("type", "integer");
                 b.field("doc_values", "true");
             }
+            b.endObject();
+            b.startObject("keyword1");
+            b.field("type", "keyword");
             b.endObject();
             b.endObject();
         });
@@ -1223,6 +1259,9 @@ public class StarTreeMapperTests extends MapperTestCase {
             b.endObject();
             b.startObject("status");
             b.field("type", "integer");
+            b.endObject();
+            b.startObject("keyword1");
+            b.field("type", "keyword");
             b.endObject();
             b.endObject();
         })));


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR supports keyword fields as part of the star tree mapping.

This is built on top of date mapping PR.

As part of "ordered_dimensions" as part of star tree mapping , users can provide keyword fields as well now. [ Metrics are not supported for keyword, its still "numeric-only" supported for star tree]

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/16232
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
