### PR TITLE
Fix unclosed store references with SearchOnlyReplicaIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/SearchOnlyReplicaIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/SearchOnlyReplicaIT.java
@@ -126,6 +126,8 @@ public class SearchOnlyReplicaIT extends OpenSearchIntegTestCase {
                 .put(indexSettings())
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numWriterReplicas)
                 .put(IndexMetadata.SETTING_NUMBER_OF_SEARCH_REPLICAS, numSearchReplicas)
+                .put("index.refresh_interval", "40ms") // set lower interval so replica attempts replication cycles after primary is
+                                                       // removed.
                 .build()
         );
         ensureYellow(TEST_INDEX);

--- a/server/src/main/java/org/opensearch/indices/replication/PrimaryShardReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/PrimaryShardReplicationSource.java
@@ -47,6 +47,8 @@ public class PrimaryShardReplicationSource implements SegmentReplicationSource {
         RecoverySettings recoverySettings,
         DiscoveryNode sourceNode
     ) {
+        assert targetNode != null : "Target node must be set";
+        assert sourceNode != null : "Source node must be set";
         this.targetAllocationId = targetAllocationId;
         this.transportService = transportService;
         this.sourceNode = sourceNode;

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceFactory.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSourceFactory.java
@@ -53,6 +53,10 @@ public class SegmentReplicationSourceFactory {
 
     private DiscoveryNode getPrimaryNode(ShardId shardId) {
         ShardRouting primaryShard = clusterService.state().routingTable().shardRoutingTable(shardId).primaryShard();
-        return clusterService.state().nodes().get(primaryShard.currentNodeId());
+        DiscoveryNode node = clusterService.state().nodes().get(primaryShard.currentNodeId());
+        if (node == null) {
+            throw new IllegalStateException("Cannot replicate, primary shard for " + shardId + " is not allocated on any node");
+        }
+        return node;
     }
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR fixes a bug with node-node pull based replication where store refs are left open. If the replica does not know the DiscoveryNode of its primary we would fail late only after replication is started and a ref is not cleaned up. Push based replication already handled this case by catching any error and closing the SegmentReplicationTarget, which holds the ref. This update ensures the validation is done before constructing our PrimaryShardReplicationSource, before any target object is created in both cases push and pull.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/15812

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
