### PR TITLE
Fix version check in yml test file for double range profiler shows filter rewrite info

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -535,8 +535,8 @@ setup:
 ---
 "Double range profiler shows filter rewrite info":
   - skip:
-      version: " - 2.99.99"
-      reason: debug info for filter rewrite added in 3.0.0 (to be backported to 2.15.0)
+      version: " - 2.15.99"
+      reason: debug info for filter rewrite was added in 2.16.0
 
   - do:
       indices.create:


### PR DESCRIPTION

### Description

This is a follow-up PR of https://github.com/opensearch-project/OpenSearch/pull/13865, which added filter rewrite info for the double range profiler, we need to update the version check in yaml test file to 2.16.0 because the original PR was released in 2.16.0.

Backport to 2.x is needed.

### Related Issues
No issue.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
