### PR TITLE
Add default implementation to new finalizeSnapshot() in Repository

### DIFF
--- a/server/src/main/java/org/opensearch/repositories/Repository.java
+++ b/server/src/main/java/org/opensearch/repositories/Repository.java
@@ -180,7 +180,7 @@ public interface Repository extends LifecycleComponent {
      * @param repositoryUpdatePriority  priority for the cluster state update task
      * @param listener              listener to be invoked with the new {@link RepositoryData} after completing the snapshot
      */
-    void finalizeSnapshot(
+    default void finalizeSnapshot(
         ShardGenerations shardGenerations,
         long repositoryStateId,
         Metadata clusterMetadata,
@@ -189,7 +189,9 @@ public interface Repository extends LifecycleComponent {
         Function<ClusterState, ClusterState> stateTransformer,
         Priority repositoryUpdatePriority,
         ActionListener<RepositoryData> listener
-    );
+    ) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Deletes snapshots


### PR DESCRIPTION
### Description
- With snapshot V2 changes, create flow introduced a new overloaded method of `Repository.finalizeSnapshot`
- But this new method does not have default implementation. Due to this, external repository implementations can fail with compiler error.
- In this PR, we provided a default implementation for the new method.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
