### PR TITLE
[Backport 2.x] Add success and failure count OTel metrics for async shard fetch 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove identity-related feature flagged code from the RestController ([#15430](https://github.com/opensearch-project/OpenSearch/pull/15430))
 - Fallback to Remote cluster-state on Term-Version check mismatch - ([#15424](https://github.com/opensearch-project/OpenSearch/pull/15424))
 - Add support for msearch API to pass search pipeline name - ([#15923](https://github.com/opensearch-project/OpenSearch/pull/15923))
+- Add success and failure metrics for async shard fetch ([#15976](https://github.com/opensearch-project/OpenSearch/pull/15976))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.23.1 to 2.24.0 ([#15858](https://github.com/opensearch-project/OpenSearch/pull/15858))

--- a/server/src/main/java/org/opensearch/cluster/ClusterManagerMetrics.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterManagerMetrics.java
@@ -34,6 +34,8 @@ public final class ClusterManagerMetrics {
 
     public final Counter leaderCheckFailureCounter;
     public final Counter followerChecksFailureCounter;
+    public final Counter asyncFetchFailureCounter;
+    public final Counter asyncFetchSuccessCounter;
 
     public ClusterManagerMetrics(MetricsRegistry metricsRegistry) {
         clusterStateAppliersHistogram = metricsRegistry.createHistogram(
@@ -71,6 +73,17 @@ public final class ClusterManagerMetrics {
             "Counter for number of failed leader checks",
             COUNTER_METRICS_UNIT
         );
+        asyncFetchFailureCounter = metricsRegistry.createCounter(
+            "async.fetch.failure.count",
+            "Counter for number of failed async fetches",
+            COUNTER_METRICS_UNIT
+        );
+        asyncFetchSuccessCounter = metricsRegistry.createCounter(
+            "async.fetch.success.count",
+            "Counter for number of successful async fetches",
+            COUNTER_METRICS_UNIT
+        );
+
     }
 
     public void recordLatency(Histogram histogram, Double value) {

--- a/server/src/main/java/org/opensearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterModule.java
@@ -141,6 +141,7 @@ public class ClusterModule extends AbstractModule {
     // pkg private for tests
     final Collection<AllocationDecider> deciderList;
     final ShardsAllocator shardsAllocator;
+    private final ClusterManagerMetrics clusterManagerMetrics;
 
     public ClusterModule(
         Settings settings,
@@ -165,6 +166,7 @@ public class ClusterModule extends AbstractModule {
             settings,
             clusterManagerMetrics
         );
+        this.clusterManagerMetrics = clusterManagerMetrics;
     }
 
     public static List<Entry> getNamedWriteables() {
@@ -453,6 +455,7 @@ public class ClusterModule extends AbstractModule {
         bind(TaskResultsService.class).asEagerSingleton();
         bind(AllocationDeciders.class).toInstance(allocationDeciders);
         bind(ShardsAllocator.class).toInstance(shardsAllocator);
+        bind(ClusterManagerMetrics.class).toInstance(clusterManagerMetrics);
     }
 
     public void setExistingShardsAllocators(GatewayAllocator gatewayAllocator, ShardsBatchGatewayAllocator shardsBatchGatewayAllocator) {

--- a/server/src/main/java/org/opensearch/gateway/AsyncShardBatchFetch.java
+++ b/server/src/main/java/org/opensearch/gateway/AsyncShardBatchFetch.java
@@ -11,6 +11,7 @@ package org.opensearch.gateway;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterManagerMetrics;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.core.index.shard.ShardId;
@@ -48,7 +49,8 @@ public abstract class AsyncShardBatchFetch<T extends BaseNodeResponse, V> extend
         Class<V> clazz,
         V emptyShardResponse,
         Predicate<V> emptyShardResponsePredicate,
-        ShardBatchResponseFactory<T, V> responseFactory
+        ShardBatchResponseFactory<T, V> responseFactory,
+        ClusterManagerMetrics clusterManagerMetrics
     ) {
         super(
             logger,
@@ -64,7 +66,8 @@ public abstract class AsyncShardBatchFetch<T extends BaseNodeResponse, V> extend
                 clazz,
                 emptyShardResponse,
                 emptyShardResponsePredicate,
-                responseFactory
+                responseFactory,
+                clusterManagerMetrics
             )
         );
     }
@@ -116,9 +119,10 @@ public abstract class AsyncShardBatchFetch<T extends BaseNodeResponse, V> extend
             Class<V> clazz,
             V emptyResponse,
             Predicate<V> emptyShardResponsePredicate,
-            ShardBatchResponseFactory<T, V> responseFactory
+            ShardBatchResponseFactory<T, V> responseFactory,
+            ClusterManagerMetrics clusterManagerMetrics
         ) {
-            super(Loggers.getLogger(logger, "_" + logKey), type);
+            super(Loggers.getLogger(logger, "_" + logKey), type, clusterManagerMetrics);
             this.batchSize = shardAttributesMap.size();
             this.emptyShardResponsePredicate = emptyShardResponsePredicate;
             cache = new HashMap<>();

--- a/server/src/main/java/org/opensearch/gateway/AsyncShardFetch.java
+++ b/server/src/main/java/org/opensearch/gateway/AsyncShardFetch.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterManagerMetrics;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.routing.allocation.RoutingAllocation;
@@ -94,7 +95,8 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
         String type,
         ShardId shardId,
         String customDataPath,
-        Lister<? extends BaseNodesResponse<T>, T> action
+        Lister<? extends BaseNodesResponse<T>, T> action,
+        ClusterManagerMetrics clusterManagerMetrics
     ) {
         this.logger = logger;
         this.type = type;
@@ -102,7 +104,7 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
         shardAttributesMap.put(shardId, new ShardAttributes(customDataPath));
         this.action = (Lister<BaseNodesResponse<T>, T>) action;
         this.reroutingKey = "ShardId=[" + shardId.toString() + "]";
-        cache = new ShardCache<>(logger, reroutingKey, type);
+        cache = new ShardCache<>(logger, reroutingKey, type, clusterManagerMetrics);
     }
 
     /**
@@ -284,8 +286,8 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
 
         private final Map<String, NodeEntry<K>> cache;
 
-        public ShardCache(Logger logger, String logKey, String type) {
-            super(Loggers.getLogger(logger, "_" + logKey), type);
+        public ShardCache(Logger logger, String logKey, String type, ClusterManagerMetrics clusterManagerMetrics) {
+            super(Loggers.getLogger(logger, "_" + logKey), type, clusterManagerMetrics);
             cache = new HashMap<>();
         }
 

--- a/server/src/main/java/org/opensearch/gateway/AsyncShardFetchCache.java
+++ b/server/src/main/java/org/opensearch/gateway/AsyncShardFetchCache.java
@@ -14,6 +14,7 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchTimeoutException;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.cluster.ClusterManagerMetrics;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
@@ -51,10 +52,12 @@ public abstract class AsyncShardFetchCache<K extends BaseNodeResponse> {
 
     private final Logger logger;
     private final String type;
+    private final ClusterManagerMetrics clusterManagerMetrics;
 
-    protected AsyncShardFetchCache(Logger logger, String type) {
+    protected AsyncShardFetchCache(Logger logger, String type, ClusterManagerMetrics clusterManagerMetrics) {
         this.logger = logger;
         this.type = type;
+        this.clusterManagerMetrics = clusterManagerMetrics;
     }
 
     abstract void initData(DiscoveryNode node);
@@ -162,6 +165,7 @@ public abstract class AsyncShardFetchCache<K extends BaseNodeResponse> {
     }
 
     void processResponses(List<K> responses, long fetchingRound) {
+        clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchSuccessCounter, Double.valueOf(responses.size()));
         for (K response : responses) {
             BaseNodeEntry nodeEntry = getCache().get(response.getNode().getId());
             if (nodeEntry != null) {
@@ -222,6 +226,7 @@ public abstract class AsyncShardFetchCache<K extends BaseNodeResponse> {
     }
 
     void processFailures(List<FailedNodeException> failures, long fetchingRound) {
+        clusterManagerMetrics.incrementCounter(clusterManagerMetrics.asyncFetchFailureCounter, Double.valueOf(failures.size()));
         for (FailedNodeException failure : failures) {
             logger.trace("processing failure {} for [{}]", failure, type);
             BaseNodeEntry nodeEntry = getCache().get(failure.nodeId());

--- a/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java
+++ b/server/src/main/java/org/opensearch/gateway/ShardsBatchGatewayAllocator.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterManagerMetrics;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -44,6 +45,7 @@ import org.opensearch.indices.store.TransportNodesListShardStoreMetadataBatch;
 import org.opensearch.indices.store.TransportNodesListShardStoreMetadataBatch.NodeStoreFilesMetadata;
 import org.opensearch.indices.store.TransportNodesListShardStoreMetadataHelper;
 import org.opensearch.indices.store.TransportNodesListShardStoreMetadataHelper.StoreFilesMetadata;
+import org.opensearch.telemetry.metrics.noop.NoopMetricsRegistry;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -81,6 +83,7 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
     private TimeValue primaryShardsBatchGatewayAllocatorTimeout;
     private TimeValue replicaShardsBatchGatewayAllocatorTimeout;
     public static final TimeValue MIN_ALLOCATOR_TIMEOUT = TimeValue.timeValueSeconds(20);
+    private final ClusterManagerMetrics clusterManagerMetrics;
 
     /**
      * Number of shards we send in one batch to data nodes for fetching metadata
@@ -160,7 +163,8 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
         TransportNodesListGatewayStartedShardsBatch batchStartedAction,
         TransportNodesListShardStoreMetadataBatch batchStoreAction,
         Settings settings,
-        ClusterSettings clusterSettings
+        ClusterSettings clusterSettings,
+        ClusterManagerMetrics clusterManagerMetrics
     ) {
         this.rerouteService = rerouteService;
         this.primaryShardBatchAllocator = new InternalPrimaryBatchShardAllocator();
@@ -172,6 +176,7 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
         clusterSettings.addSettingsUpdateConsumer(PRIMARY_BATCH_ALLOCATOR_TIMEOUT_SETTING, this::setPrimaryBatchAllocatorTimeout);
         this.replicaShardsBatchGatewayAllocatorTimeout = REPLICA_BATCH_ALLOCATOR_TIMEOUT_SETTING.get(settings);
         clusterSettings.addSettingsUpdateConsumer(REPLICA_BATCH_ALLOCATOR_TIMEOUT_SETTING, this::setReplicaBatchAllocatorTimeout);
+        this.clusterManagerMetrics = clusterManagerMetrics;
     }
 
     @Override
@@ -187,6 +192,7 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
         this(DEFAULT_SHARD_BATCH_SIZE, null);
     }
 
+    // for tests
     protected ShardsBatchGatewayAllocator(long batchSize, RerouteService rerouteService) {
         this.rerouteService = rerouteService;
         this.batchStartedAction = null;
@@ -196,9 +202,8 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
         this.maxBatchSize = batchSize;
         this.primaryShardsBatchGatewayAllocatorTimeout = null;
         this.replicaShardsBatchGatewayAllocatorTimeout = null;
+        this.clusterManagerMetrics = new ClusterManagerMetrics(NoopMetricsRegistry.INSTANCE);
     }
-
-    // for tests
 
     @Override
     public int getNumberOfInFlightFetches() {
@@ -413,7 +418,7 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
             // add to batch if batch size full or last shard in unassigned list
             if (batchSize == 0 || iterator.hasNext() == false) {
                 String batchUUId = UUIDs.base64UUID();
-                ShardsBatch shardsBatch = new ShardsBatch(batchUUId, perBatchShards, primary);
+                ShardsBatch shardsBatch = new ShardsBatch(batchUUId, perBatchShards, primary, clusterManagerMetrics);
                 // add the batch to list of current batches
                 addBatch(shardsBatch, primary);
                 batchesToBeAssigned.add(batchUUId);
@@ -588,9 +593,21 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
             Class<V> clazz,
             V emptyShardResponse,
             Predicate<V> emptyShardResponsePredicate,
-            ShardBatchResponseFactory<T, V> responseFactory
+            ShardBatchResponseFactory<T, V> responseFactory,
+            ClusterManagerMetrics clusterManagerMetrics
         ) {
-            super(logger, type, map, action, batchUUId, clazz, emptyShardResponse, emptyShardResponsePredicate, responseFactory);
+            super(
+                logger,
+                type,
+                map,
+                action,
+                batchUUId,
+                clazz,
+                emptyShardResponse,
+                emptyShardResponsePredicate,
+                responseFactory,
+                clusterManagerMetrics
+            );
         }
 
         @Override
@@ -650,16 +667,17 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
              * It should return false if there has never been a fetch for this batch.
              * This function is currently only used in the case of replica shards when all deciders returned NO/THROTTLE, and explain mode is ON.
              * Allocation explain and manual reroute APIs try to append shard store information (matching bytes) to the allocation decision.
-             * However, these APIs do not want to trigger a new asyncFetch for these ineligible shards, unless the data from nodes is already there.
+             * However, these APIs do not want to trigger a new asyncFetch for these ineligible shards
+             * They only want to use the data if it is already available.
              * This function is used to see if a fetch has happened to decide if it is possible to append shard store info without a new async fetch.
              * In the case when shard has a batch but no fetch has happened before, it would be because it is a new batch.
              * In the case when shard has a batch, and a fetch has happened before, and no fetch is ongoing, it would be because we have already completed fetch for all nodes.
-             *
+             * <p>
              * In order to check if a fetch has ever happened, we check 2 things:
              * 1. If the shard batch cache is empty, we know that fetch has never happened so we return false.
              * 2. If we see that the list of nodes to fetch from is empty, we know that all nodes have data or are ongoing a fetch. So we return true.
              * 3. Otherwise we return false.
-             *
+             * <p>
              * see {@link AsyncShardFetchCache#findNodesToFetch()}
              */
             String batchId = getBatchId(shard, shard.primary());
@@ -669,7 +687,8 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
             logger.trace("Checking if fetching done for batch id {}", batchId);
             ShardsBatch shardsBatch = shard.primary() ? batchIdToStartedShardBatch.get(batchId) : batchIdToStoreShardBatch.get(batchId);
             // if fetchData has never been called, the per node cache will be empty and have no nodes
-            // this is because cache.fillShardCacheWithDataNodes(nodes) initialises this map and is called in AsyncShardFetch.fetchData
+            /// this is because {@link AsyncShardFetchCache#fillShardCacheWithDataNodes(DiscoveryNodes)} initialises this map
+            /// and is called in {@link AsyncShardFetch#fetchData(DiscoveryNodes, Map)}
             if (shardsBatch == null || shardsBatch.getAsyncFetcher().hasEmptyCache()) {
                 logger.trace("Batch cache is empty for batch {} ", batchId);
                 return false;
@@ -739,7 +758,12 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
 
         private final Map<ShardId, ShardEntry> batchInfo;
 
-        public ShardsBatch(String batchId, Map<ShardId, ShardEntry> shardsWithInfo, boolean primary) {
+        public ShardsBatch(
+            String batchId,
+            Map<ShardId, ShardEntry> shardsWithInfo,
+            boolean primary,
+            ClusterManagerMetrics clusterManagerMetrics
+        ) {
             this.batchId = batchId;
             this.batchInfo = new HashMap<>(shardsWithInfo);
             // create a ShardId -> customDataPath map for async fetch
@@ -757,7 +781,8 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
                     GatewayStartedShard.class,
                     new GatewayStartedShard(null, false, null, null),
                     GatewayStartedShard::isEmpty,
-                    new ShardBatchResponseFactory<>(true)
+                    new ShardBatchResponseFactory<>(true),
+                    clusterManagerMetrics
                 );
             } else {
                 asyncBatch = new InternalBatchAsyncFetch<>(
@@ -769,7 +794,8 @@ public class ShardsBatchGatewayAllocator implements ExistingShardsAllocator {
                     NodeStoreFilesMetadata.class,
                     new NodeStoreFilesMetadata(new StoreFilesMetadata(null, Store.MetadataSnapshot.EMPTY, Collections.emptyList()), null),
                     NodeStoreFilesMetadata::isEmpty,
-                    new ShardBatchResponseFactory<>(false)
+                    new ShardBatchResponseFactory<>(false),
+                    clusterManagerMetrics
                 );
             }
         }

--- a/server/src/test/java/org/opensearch/gateway/AsyncShardFetchTests.java
+++ b/server/src/test/java/org/opensearch/gateway/AsyncShardFetchTests.java
@@ -35,10 +35,13 @@ import org.apache.logging.log4j.LogManager;
 import org.opensearch.Version;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.cluster.ClusterManagerMetrics;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.telemetry.metrics.Counter;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -54,6 +57,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.anyDouble;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class AsyncShardFetchTests extends OpenSearchTestCase {
     private final DiscoveryNode node1 = new DiscoveryNode(
@@ -78,13 +87,29 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
 
     private ThreadPool threadPool;
     private TestFetch test;
+    private Counter asyncFetchSuccessCounter;
+    private Counter asyncFetchFailureCounter;
+    private Counter dummyCounter;
 
     @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
         this.threadPool = new TestThreadPool(getTestName());
-        this.test = new TestFetch(threadPool);
+        final MetricsRegistry metricsRegistry = mock(MetricsRegistry.class);
+        this.asyncFetchFailureCounter = mock(Counter.class);
+        this.asyncFetchSuccessCounter = mock(Counter.class);
+        this.dummyCounter = mock(Counter.class);
+        when(metricsRegistry.createCounter(anyString(), anyString(), anyString())).thenAnswer(invocationOnMock -> {
+            String counterName = (String) invocationOnMock.getArguments()[0];
+            if (counterName.contains("async.fetch.success.count")) {
+                return asyncFetchSuccessCounter;
+            } else if (counterName.contains("async.fetch.failure.count")) {
+                return asyncFetchFailureCounter;
+            }
+            return dummyCounter;
+        });
+        this.test = new TestFetch(threadPool, metricsRegistry);
     }
 
     @After
@@ -100,14 +125,26 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
         assertThat(test.reroute.get(), equalTo(0));
+        // counter remains 0 because fetch is ongoing
+        verify(asyncFetchSuccessCounter, times(0)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // fire a response, wait on reroute incrementing
         test.fireSimulationAndWait(node1.getId());
+        // counter goes up because fetch completed
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
+
         // verify we get back the data node
         assertThat(test.reroute.get(), equalTo(1));
         test.close();
         try {
             test.fetchData(nodes, emptyMap());
+            // counter should not go up when calling fetchData since fetch never completed
+            verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+            verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+            verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
             fail("fetch data should fail when closed");
         } catch (IllegalStateException e) {
             // all is well
@@ -125,12 +162,21 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
 
         // fire a response, wait on reroute incrementing
         test.fireSimulationAndWait(node1.getId());
+        // total counter goes up by 1 after success
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
+
         // verify we get back the data node
         assertThat(test.reroute.get(), equalTo(1));
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(1));
         assertThat(fetchData.getData().get(node1), sameInstance(response1));
+        // counter remains same because fetchData does not trigger new async fetch
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
     }
 
     public void testFullCircleSingleNodeFailure() throws Exception {
@@ -145,24 +191,47 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
 
         // fire a response, wait on reroute incrementing
         test.fireSimulationAndWait(node1.getId());
+        verify(asyncFetchSuccessCounter, times(0)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(1)).add(1.0);
+        verify(asyncFetchFailureCounter, times(1)).add(anyDouble());
+
         // failure, fetched data exists, but has no data
         assertThat(test.reroute.get(), equalTo(1));
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(0));
+        // counter remains same because fetchData does not trigger new async fetch
+        verify(asyncFetchSuccessCounter, times(0)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(1)).add(1.0);
+        verify(asyncFetchFailureCounter, times(1)).add(anyDouble());
 
         // on failure, we reset the failure on a successive call to fetchData, and try again afterwards
         test.addSimulation(node1.getId(), response1);
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
+        // No additional failure, empty data so no change in counter
+        verify(asyncFetchSuccessCounter, times(0)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(1)).add(1.0);
+        verify(asyncFetchFailureCounter, times(1)).add(anyDouble());
 
         test.fireSimulationAndWait(node1.getId());
+        // Success counter will increase
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(1)).add(1.0);
+        verify(asyncFetchFailureCounter, times(1)).add(anyDouble());
+
         // 2 reroutes, cause we have a failure that we clear
         assertThat(test.reroute.get(), equalTo(3));
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(1));
         assertThat(fetchData.getData().get(node1), sameInstance(response1));
+        // counter remains same because fetchData does not trigger new async fetch
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(1)).add(1.0);
+        verify(asyncFetchFailureCounter, times(1)).add(anyDouble());
     }
 
     public void testIgnoreResponseFromDifferentRound() throws Exception {
@@ -173,20 +242,40 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
         assertThat(test.reroute.get(), equalTo(0));
+        // counter 0 because fetchData is not completed
+        verify(asyncFetchSuccessCounter, times(0)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // handle a response with incorrect round id, wait on reroute incrementing
         test.processAsyncFetch(Collections.singletonList(response1), Collections.emptyList(), 0);
         assertThat(fetchData.hasData(), equalTo(false));
         assertThat(test.reroute.get(), equalTo(1));
+        // success counter increments to 1 because we called processAsyncFetch with a valid response, even though the round was incorrect
+        // failure counter also increments by 1 with empty list
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(1)).add(0.0);
+        verify(asyncFetchFailureCounter, times(1)).add(anyDouble());
 
         // fire a response (with correct round id), wait on reroute incrementing
         test.fireSimulationAndWait(node1.getId());
+        // success counter now goes up by 1 because fetchData completed
+        verify(asyncFetchSuccessCounter, times(2)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(2)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(1)).add(0.0);
+        verify(asyncFetchFailureCounter, times(1)).add(anyDouble());
+
         // verify we get back the data node
         assertThat(test.reroute.get(), equalTo(2));
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(1));
         assertThat(fetchData.getData().get(node1), sameInstance(response1));
+        // total counter remains same because fetchdata does not trigger new async fetch
+        verify(asyncFetchSuccessCounter, times(2)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(2)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(1)).add(0.0);
+        verify(asyncFetchFailureCounter, times(1)).add(anyDouble());
     }
 
     public void testIgnoreFailureFromDifferentRound() throws Exception {
@@ -198,6 +287,9 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
         assertThat(test.reroute.get(), equalTo(0));
+        // counter 0 because fetchData still ongoing
+        verify(asyncFetchSuccessCounter, times(0)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // handle a failure with incorrect round id, wait on reroute incrementing
         test.processAsyncFetch(
@@ -207,14 +299,30 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         );
         assertThat(fetchData.hasData(), equalTo(false));
         assertThat(test.reroute.get(), equalTo(1));
+        // success counter called with empty list
+        // failure counter goes up by 1 because of the failure
+        verify(asyncFetchSuccessCounter, times(1)).add(0.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(1)).add(1.0);
+        verify(asyncFetchFailureCounter, times(1)).add(anyDouble());
 
         // fire a response, wait on reroute incrementing
         test.fireSimulationAndWait(node1.getId());
+        // failure counter goes up by 1 because of the failure
+        verify(asyncFetchSuccessCounter, times(1)).add(0.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(2)).add(1.0);
+        verify(asyncFetchFailureCounter, times(2)).add(anyDouble());
         // failure, fetched data exists, but has no data
         assertThat(test.reroute.get(), equalTo(2));
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(0));
+        // counters remain same because fetchData does not trigger new async fetch
+        verify(asyncFetchSuccessCounter, times(1)).add(0.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(2)).add(1.0);
+        verify(asyncFetchFailureCounter, times(2)).add(anyDouble());
     }
 
     public void testTwoNodesOnSetup() throws Exception {
@@ -226,16 +334,32 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
         assertThat(test.reroute.get(), equalTo(0));
+        // counter 0 because fetch ongoing
+        verify(asyncFetchSuccessCounter, times(0)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // fire the first response, it should trigger a reroute
         test.fireSimulationAndWait(node1.getId());
+        // counter 1 because one fetch completed
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
+
         // there is still another on going request, so no data
         assertThat(test.getNumberOfInFlightFetches(), equalTo(1));
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
+        // counter still 1 because fetchData did not trigger new async fetch
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // fire the second simulation, this should allow us to get the data
         test.fireSimulationAndWait(node2.getId());
+        // counter 2 because 2 fetches completed
+        verify(asyncFetchSuccessCounter, times(2)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(2)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
         // no more ongoing requests, we should fetch the data
         assertThat(test.reroute.get(), equalTo(2));
         fetchData = test.fetchData(nodes, emptyMap());
@@ -243,6 +367,10 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         assertThat(fetchData.getData().size(), equalTo(2));
         assertThat(fetchData.getData().get(node1), sameInstance(response1));
         assertThat(fetchData.getData().get(node2), sameInstance(response2));
+        // counter still 2 because fetchData call did not trigger new async fetch
+        verify(asyncFetchSuccessCounter, times(2)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(2)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
     }
 
     public void testTwoNodesOnSetupAndFailure() throws Exception {
@@ -254,34 +382,59 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
         assertThat(test.reroute.get(), equalTo(0));
+        // counter 0 because both fetches ongoing
+        verify(asyncFetchSuccessCounter, times(0)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // fire the first response, it should trigger a reroute
         test.fireSimulationAndWait(node1.getId());
         assertThat(test.reroute.get(), equalTo(1));
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
+        // counter 1 because one fetch completed
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // fire the second simulation, this should allow us to get the data
         test.fireSimulationAndWait(node2.getId());
+        // failure counter up by 1 because one fetch failed
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(1)).add(1.0);
+        verify(asyncFetchFailureCounter, times(1)).add(anyDouble());
         assertThat(test.reroute.get(), equalTo(2));
+
         // since one of those failed, we should only have one entry
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(1));
         assertThat(fetchData.getData().get(node1), sameInstance(response1));
+        // success and failure counters same because fetchData did not trigger new async fetch
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(1)).add(1.0);
+        verify(asyncFetchFailureCounter, times(1)).add(anyDouble());
     }
 
     public void testTwoNodesAddedInBetween() throws Exception {
         DiscoveryNodes nodes = DiscoveryNodes.builder().add(node1).build();
         test.addSimulation(node1.getId(), response1);
 
-        // no fetched data, 2 requests still on going
+        // no fetched data, request still on going
         AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
         assertThat(test.reroute.get(), equalTo(0));
+        // counter 0 because both fetches ongoing
+        verify(asyncFetchSuccessCounter, times(0)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // fire the first response, it should trigger a reroute
         test.fireSimulationAndWait(node1.getId());
+        // counter 1 because fetch completed
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // now, add a second node to the nodes, it should add it to the ongoing requests
         nodes = DiscoveryNodes.builder(nodes).add(node2).build();
@@ -289,16 +442,28 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         // no fetch data, has a new node introduced
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
+        // counter still 1 because second fetch ongoing
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // fire the second simulation, this should allow us to get the data
         test.fireSimulationAndWait(node2.getId());
+        // counter now 2 because 2 fetches completed
+        verify(asyncFetchSuccessCounter, times(2)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(2)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
-        // since one of those failed, we should only have one entry
+        // since both succeeded, we should have 2 entries
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(2));
         assertThat(fetchData.getData().get(node1), sameInstance(response1));
         assertThat(fetchData.getData().get(node2), sameInstance(response2));
+        // counter still 2 because fetchData did not trigger new async fetch
+        verify(asyncFetchSuccessCounter, times(2)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(2)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
     }
 
     public void testClearCache() throws Exception {
@@ -312,21 +477,36 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
         assertThat(test.reroute.get(), equalTo(0));
+        // counter 0 because fetch ongoing
+        verify(asyncFetchSuccessCounter, times(0)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         test.fireSimulationAndWait(node1.getId());
         assertThat(test.reroute.get(), equalTo(1));
+        // counter 1 because 1 fetch completed
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // verify we get back right data from node
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(1));
         assertThat(fetchData.getData().get(node1), sameInstance(response1));
+        // counter still 1 because a new fetch is not called
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // second fetch gets same data
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(1));
         assertThat(fetchData.getData().get(node1), sameInstance(response1));
+        // counter still 1 because a new fetch is not called
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         test.clearCacheForNode(node1.getId());
 
@@ -336,15 +516,27 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         // no fetched data, new request on going
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
+        // counter still 1 because new fetch is still ongoing
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         test.fireSimulationAndWait(node1.getId());
         assertThat(test.reroute.get(), equalTo(2));
+        // counter now 2 because second fetch completed
+        verify(asyncFetchSuccessCounter, times(2)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(2)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // verify we get new data back
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(1));
         assertThat(fetchData.getData().get(node1), sameInstance(response1_2));
+        // counter still 2 because fetchData did not trigger new async fetch
+        verify(asyncFetchSuccessCounter, times(2)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(2)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
     }
 
     public void testConcurrentRequestAndClearCache() throws Exception {
@@ -355,12 +547,19 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
         assertThat(test.reroute.get(), equalTo(0));
+        // counter 0 because fetch ongoing
+        verify(asyncFetchSuccessCounter, times(0)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // clear cache while request is still on going, before it is processed
         test.clearCacheForNode(node1.getId());
 
         test.fireSimulationAndWait(node1.getId());
         assertThat(test.reroute.get(), equalTo(1));
+        // counter 1 because fetch completed, even though cache was wiped
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // prepare next request
         test.addSimulation(node1.getId(), response1_2);
@@ -368,15 +567,27 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         // verify still no fetched data, request still on going
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(false));
+        // counter unchanged because fetch ongoing
+        verify(asyncFetchSuccessCounter, times(1)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(1)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         test.fireSimulationAndWait(node1.getId());
         assertThat(test.reroute.get(), equalTo(2));
+        // counter 2 because second fetch completed
+        verify(asyncFetchSuccessCounter, times(2)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(2)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
         // verify we get new data back
         fetchData = test.fetchData(nodes, emptyMap());
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(1));
         assertThat(fetchData.getData().get(node1), sameInstance(response1_2));
+        // counter unchanged because fetchData does not trigger new async fetch
+        verify(asyncFetchSuccessCounter, times(2)).add(1.0);
+        verify(asyncFetchSuccessCounter, times(2)).add(anyDouble());
+        verify(asyncFetchFailureCounter, times(0)).add(anyDouble());
 
     }
 
@@ -398,8 +609,15 @@ public class AsyncShardFetchTests extends OpenSearchTestCase {
         private final Map<String, Entry> simulations = new ConcurrentHashMap<>();
         private AtomicInteger reroute = new AtomicInteger();
 
-        TestFetch(ThreadPool threadPool) {
-            super(LogManager.getLogger(TestFetch.class), "test", new ShardId("test", "_na_", 1), "", null);
+        TestFetch(ThreadPool threadPool, MetricsRegistry metricsRegistry) {
+            super(
+                LogManager.getLogger(TestFetch.class),
+                "test",
+                new ShardId("test", "_na_", 1),
+                "",
+                null,
+                new ClusterManagerMetrics(metricsRegistry)
+            );
             this.threadPool = threadPool;
         }
 

--- a/server/src/test/java/org/opensearch/gateway/ShardBatchCacheTests.java
+++ b/server/src/test/java/org/opensearch/gateway/ShardBatchCacheTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.gateway;
 
+import org.opensearch.cluster.ClusterManagerMetrics;
 import org.opensearch.cluster.OpenSearchAllocationTestCase;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -19,6 +20,7 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.gateway.TransportNodesGatewayStartedShardHelper.GatewayStartedShard;
 import org.opensearch.gateway.TransportNodesListGatewayStartedShardsBatch.NodeGatewayStartedShardsBatch;
 import org.opensearch.indices.store.ShardAttributes;
+import org.opensearch.telemetry.metrics.noop.NoopMetricsRegistry;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -52,7 +54,8 @@ public class ShardBatchCacheTests extends OpenSearchAllocationTestCase {
             GatewayStartedShard.class,
             new GatewayStartedShard(null, false, null, null),
             GatewayStartedShard::isEmpty,
-            new ShardBatchResponseFactory<>(true)
+            new ShardBatchResponseFactory<>(true),
+            new ClusterManagerMetrics(NoopMetricsRegistry.INSTANCE)
         );
     }
 

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -2429,7 +2429,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                             nodeEnv,
                             indicesService,
                             namedXContentRegistry
-                        )
+                        ),
+                        new ClusterManagerMetrics(NoopMetricsRegistry.INSTANCE)
                     )
                 );
                 actions.put(


### PR DESCRIPTION
Backport [`8ddb3ee`](https://github.com/opensearch-project/OpenSearch/commit/8ddb3eeee00978913fedd5aa49a84e718538ddae) from #15976 