### PR TITLE
[Forwardport] [main] Add 2.17.1 release notes (#16104) (#16105)

### DIFF
--- a/release-notes/opensearch.release-notes-2.17.1.md
+++ b/release-notes/opensearch.release-notes-2.17.1.md
@@ -1,0 +1,16 @@
+## 2024-10-01 Version 2.17.1 Release Notes
+
+## [2.17.1]
+### Added
+- Add path prefix support to hashed prefix snapshots ([#15664](https://github.com/opensearch-project/OpenSearch/pull/15664))
+- Memory optimisations in _cluster/health API ([#15492](https://github.com/opensearch-project/OpenSearch/pull/15492))
+
+### Dependencies
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed


### PR DESCRIPTION
Forwardport of https://github.com/opensearch-project/OpenSearch/pull/16105 to `main`