### PR TITLE
[Backport 2.x] Mitigation for remote snapshot filecache overflow

### DIFF
--- a/release-notes/opensearch.release-notes-2.17.0.md
+++ b/release-notes/opensearch.release-notes-2.17.0.md
@@ -105,3 +105,4 @@
 - Fix unchecked cast in dynamic action map getter ([#15394](https://github.com/opensearch-project/OpenSearch/pull/15394))
 - Fix null values indexed as "null" strings in flat_object field ([#14069](https://github.com/opensearch-project/OpenSearch/pull/14069))
 - Fix terms query on wildcard field returns nothing ([#15607](https://github.com/opensearch-project/OpenSearch/pull/15607))
+- Fix remote snapshot file_cache exceeding capacity ([#15077](https://github.com/opensearch-project/OpenSearch/pull/15077))

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
@@ -95,6 +95,19 @@ public class TransferManager {
     @SuppressWarnings("removal")
     private static FileCachedIndexInput createIndexInput(FileCache fileCache, StreamReader streamReader, BlobFetchRequest request) {
         try {
+            // This local file cache is ref counted and may not strictly enforce configured capacity.
+            // If we find available capacity is exceeded, deny further BlobFetchRequests.
+            if (fileCache.capacity() < fileCache.usage().usage()) {
+                fileCache.prune();
+                throw new IOException(
+                    "Local file cache capacity ("
+                        + fileCache.capacity()
+                        + ") exceeded ("
+                        + fileCache.usage().usage()
+                        + ") - BlobFetchRequest failed: "
+                        + request.getFilePath()
+                );
+            }
             if (Files.exists(request.getFilePath()) == false) {
                 logger.trace("Fetching from Remote in createIndexInput of Transfer Manager");
                 try (


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/OpenSearch/commit/8f34ce5ca3849687d509205bfe4378e1183eb6fb from https://github.com/opensearch-project/OpenSearch/pull/15077.

### Related Issues
Mitigation for https://github.com/opensearch-project/OpenSearch/issues/11676

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
