### PR TITLE
Remove redundant force merge in rest tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
@@ -679,11 +679,6 @@ setup:
           - '{"date": "2016-03-01"}'
 
   - do:
-      indices.forcemerge:
-        index: test_2
-        max_num_segments: 1
-
-  - do:
       search:
         index: test_2
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -1103,11 +1103,6 @@ setup:
           - '{"date": "2016-03-01"}'
 
   - do:
-      indices.forcemerge:
-        index: test_2
-        max_num_segments: 1
-
-  - do:
       search:
         index: test_2
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/330_auto_date_histogram.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/330_auto_date_histogram.yml
@@ -134,11 +134,6 @@ setup:
           - '{"date": "2020-03-09", "v": 4}'
 
   - do:
-      indices.forcemerge:
-        index: test_profile
-        max_num_segments: 1
-
-  - do:
       search:
         index: test_profile
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/360_date_histogram.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/360_date_histogram.yml
@@ -141,11 +141,6 @@ setup:
           - '{"date": "2025-02-14"}'
 
   - do:
-      indices.forcemerge:
-        index: dhisto-agg-w-query
-        max_num_segments: 1
-
-  - do:
       search:
         index: dhisto-agg-w-query
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/40_range.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/40_range.yml
@@ -569,11 +569,6 @@ setup:
           - '{"double" : 50}'
 
   - do:
-      indices.forcemerge:
-        index: test_profile
-        max_num_segments: 1
-
-  - do:
       search:
         index: test_profile
         body:


### PR DESCRIPTION
### Description
Several aggregation rest tests assert on the number of optimized segments.
`  - match: { profile.shards.0.aggregations.0.debug.optimized_segments: 1 }`

For these tests to be consistent our index can only have a single segment. As such we configure out test indices with 1 shard and no refresh interval to ensure a single segment.

```
settings:
  number_of_shards: 1
  number_of_replicas: 0
  refresh_interval: -1
```

We also force merge in these cases:

```
- do:
    indices.forcemerge:
      index: <index>
      max_num_segments: 1
```

These two operations are redundant so this pr removes the force merge step for these cases.

### Related Issues
[Inciting comment
](https://github.com/opensearch-project/OpenSearch/pull/16083#discussion_r1777559595)

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
