### PR TITLE
[Snapshot V2] Remove orphan timestamps post create snapshot completion

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
@@ -796,6 +796,8 @@ public class RemoteRestoreSnapshotIT extends RemoteSnapshotIT {
             RemoteStorePinnedTimestampService.class,
             internalCluster().getClusterManagerName()
         );
+        forceSyncPinnedTimestamps();
+
         long pinnedTimestamp = System.currentTimeMillis();
         final CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<Void> latchedActionListener = new LatchedActionListener<>(new ActionListener<>() {
@@ -819,7 +821,6 @@ public class RemoteRestoreSnapshotIT extends RemoteSnapshotIT {
         assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
         assertThat(snapshotInfo.getPinnedTimestamp(), greaterThan(0L));
 
-        forceSyncPinnedTimestamps();
         waitUntil(() -> 1 == RemoteStorePinnedTimestampService.getPinnedEntities().size());
     }
 
@@ -1106,7 +1107,7 @@ public class RemoteRestoreSnapshotIT extends RemoteSnapshotIT {
             .get()
             .status();
         assertEquals(RestStatus.ACCEPTED, createSnapshotResponseStatus);
-
+        forceSyncPinnedTimestamps();
         assertEquals(2, RemoteStorePinnedTimestampService.getPinnedEntities().size());
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
@@ -9,6 +9,7 @@
 package org.opensearch.remotestore;
 
 import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStoreRequest;
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
@@ -29,6 +30,7 @@ import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.rest.RestStatus;
@@ -41,6 +43,7 @@ import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.RepositoryData;
@@ -62,8 +65,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -73,6 +78,7 @@ import static org.opensearch.index.remote.RemoteStoreEnums.DataCategory.TRANSLOG
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.DATA;
 import static org.opensearch.index.remote.RemoteStoreEnums.DataType.METADATA;
 import static org.opensearch.indices.RemoteStoreSettings.CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING;
+import static org.opensearch.snapshots.SnapshotsService.getPinningEntity;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -753,17 +759,15 @@ public class RemoteRestoreSnapshotIT extends RemoteSnapshotIT {
         assertTrue(exception.getMessage().contains("cannot remove setting [index.remote_store.segment.repository]" + " on restore"));
     }
 
-    public void testCreateSnapshotV2() throws Exception {
+    public void testCreateSnapshotV2_Orphan_Timestamp_Cleanup() throws Exception {
         internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
         internalCluster().startDataOnlyNode(pinnedTimestampSettings());
         internalCluster().startDataOnlyNode(pinnedTimestampSettings());
         String indexName1 = "testindex1";
         String indexName2 = "testindex2";
-        String indexName3 = "testindex3";
         String snapshotRepoName = "test-create-snapshot-repo";
         String snapshotName1 = "test-create-snapshot1";
         Path absolutePath1 = randomRepoPath().toAbsolutePath();
-        logger.info("Snapshot Path [{}]", absolutePath1);
 
         Settings.Builder settings = Settings.builder()
             .put(FsRepository.LOCATION_SETTING.getKey(), absolutePath1)
@@ -787,27 +791,36 @@ public class RemoteRestoreSnapshotIT extends RemoteSnapshotIT {
         indexDocuments(client, indexName2, numDocsInIndex2);
         ensureGreen(indexName1, indexName2);
 
+        // create an orphan timestamp related to this repo
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(
+            RemoteStorePinnedTimestampService.class,
+            internalCluster().getClusterManagerName()
+        );
+        long pinnedTimestamp = System.currentTimeMillis();
+        final CountDownLatch latch = new CountDownLatch(1);
+        LatchedActionListener<Void> latchedActionListener = new LatchedActionListener<>(new ActionListener<>() {
+            @Override
+            public void onResponse(Void unused) {}
+
+            @Override
+            public void onFailure(Exception e) {}
+        }, latch);
+
+        remoteStorePinnedTimestampService.pinTimestamp(
+            pinnedTimestamp,
+            getPinningEntity(snapshotRepoName, "some_uuid"),
+            latchedActionListener
+        );
+        latch.await();
+
         SnapshotInfo snapshotInfo = createSnapshot(snapshotRepoName, snapshotName1, Collections.emptyList());
         assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
         assertThat(snapshotInfo.successfulShards(), greaterThan(0));
         assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
         assertThat(snapshotInfo.getPinnedTimestamp(), greaterThan(0L));
 
-        indexDocuments(client, indexName1, 10);
-        indexDocuments(client, indexName2, 20);
-
-        createIndex(indexName3, indexSettings);
-        indexDocuments(client, indexName3, 10);
-
-        String snapshotName2 = "test-create-snapshot2";
-
-        // verify response status if waitForCompletion is not true
-        RestStatus createSnapshotResponseStatus = client().admin()
-            .cluster()
-            .prepareCreateSnapshot(snapshotRepoName, snapshotName2)
-            .get()
-            .status();
-        assertEquals(RestStatus.ACCEPTED, createSnapshotResponseStatus);
+        forceSyncPinnedTimestamps();
+        waitUntil(() -> 1 == RemoteStorePinnedTimestampService.getPinnedEntities().size());
     }
 
     public void testMixedSnapshotCreationWithV2RepositorySetting() throws Exception {
@@ -879,6 +892,7 @@ public class RemoteRestoreSnapshotIT extends RemoteSnapshotIT {
         assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
         assertThat(snapshotInfo.snapshotId().getName(), equalTo(snapshotName2));
         assertThat(snapshotInfo.getPinnedTimestamp(), greaterThan(0L));
+        assertEquals(RemoteStorePinnedTimestampService.getPinnedEntities().size(), 1);
 
     }
 
@@ -955,6 +969,7 @@ public class RemoteRestoreSnapshotIT extends RemoteSnapshotIT {
 
         RepositoryData repositoryData = repositoryDataPlainActionFuture.get();
         assertThat(repositoryData.getSnapshotIds().size(), greaterThanOrEqualTo(1));
+        assertEquals(RemoteStorePinnedTimestampService.getPinnedEntities().size(), repositoryData.getSnapshotIds().size());
     }
 
     public void testConcurrentSnapshotV2CreateOperation_MasterChange() throws Exception {
@@ -1017,13 +1032,93 @@ public class RemoteRestoreSnapshotIT extends RemoteSnapshotIT {
             logger.info("Exception while creating new-snapshot", e);
         }
 
+        AtomicLong totalSnaps = new AtomicLong();
+
         // Validate that snapshot is present in repository data
         assertBusy(() -> {
             GetSnapshotsRequest request = new GetSnapshotsRequest(snapshotRepoName);
             GetSnapshotsResponse response2 = client().admin().cluster().getSnapshots(request).actionGet();
             assertThat(response2.getSnapshots().size(), greaterThanOrEqualTo(1));
+            totalSnaps.set(response2.getSnapshots().size());
+
         }, 30, TimeUnit.SECONDS);
         thread.join();
+        RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(
+            RemoteStorePinnedTimestampService.class,
+            internalCluster().getClusterManagerName()
+        );
+        forceSyncPinnedTimestamps();
+        assertEquals(RemoteStorePinnedTimestampService.getPinnedEntities().size(), totalSnaps.intValue());
+    }
+
+    public void testCreateSnapshotV2() throws Exception {
+        internalCluster().startClusterManagerOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        internalCluster().startDataOnlyNode(pinnedTimestampSettings());
+        String indexName1 = "testindex1";
+        String indexName2 = "testindex2";
+        String indexName3 = "testindex3";
+        String snapshotRepoName = "test-create-snapshot-repo";
+        String snapshotName1 = "test-create-snapshot1";
+        Path absolutePath1 = randomRepoPath().toAbsolutePath();
+        logger.info("Snapshot Path [{}]", absolutePath1);
+
+        Settings.Builder settings = Settings.builder()
+            .put(FsRepository.LOCATION_SETTING.getKey(), absolutePath1)
+            .put(FsRepository.COMPRESS_SETTING.getKey(), randomBoolean())
+            .put(FsRepository.CHUNK_SIZE_SETTING.getKey(), randomIntBetween(100, 1000), ByteSizeUnit.BYTES)
+            .put(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), true)
+            .put(BlobStoreRepository.SHALLOW_SNAPSHOT_V2.getKey(), true);
+
+        createRepository(snapshotRepoName, FsRepository.TYPE, settings);
+
+        Client client = client();
+        Settings indexSettings = getIndexSettings(20, 0).build();
+        createIndex(indexName1, indexSettings);
+
+        Settings indexSettings2 = getIndexSettings(15, 0).build();
+        createIndex(indexName2, indexSettings2);
+
+        final int numDocsInIndex1 = 10;
+        final int numDocsInIndex2 = 20;
+        indexDocuments(client, indexName1, numDocsInIndex1);
+        indexDocuments(client, indexName2, numDocsInIndex2);
+        ensureGreen(indexName1, indexName2);
+
+        SnapshotInfo snapshotInfo = createSnapshot(snapshotRepoName, snapshotName1, Collections.emptyList());
+        assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
+        assertThat(snapshotInfo.successfulShards(), greaterThan(0));
+        assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
+        assertThat(snapshotInfo.getPinnedTimestamp(), greaterThan(0L));
+
+        indexDocuments(client, indexName1, 10);
+        indexDocuments(client, indexName2, 20);
+
+        createIndex(indexName3, indexSettings);
+        indexDocuments(client, indexName3, 10);
+
+        String snapshotName2 = "test-create-snapshot2";
+
+        // verify response status if waitForCompletion is not true
+        RestStatus createSnapshotResponseStatus = client().admin()
+            .cluster()
+            .prepareCreateSnapshot(snapshotRepoName, snapshotName2)
+            .get()
+            .status();
+        assertEquals(RestStatus.ACCEPTED, createSnapshotResponseStatus);
+
+        assertEquals(2, RemoteStorePinnedTimestampService.getPinnedEntities().size());
+    }
+
+    public void forceSyncPinnedTimestamps() {
+        // for all nodes , run forceSyncPinnedTimestamps()
+        for (String node : internalCluster().getNodeNames()) {
+            RemoteStorePinnedTimestampService remoteStorePinnedTimestampService = internalCluster().getInstance(
+                RemoteStorePinnedTimestampService.class,
+                node
+            );
+            remoteStorePinnedTimestampService.forceSyncPinnedTimestamps();
+        }
     }
 
     public void testCreateSnapshotV2WithRedIndex() throws Exception {

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -301,6 +301,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
                 Map<String, BlobMetadata> pinnedTimestampList = blobContainer.listBlobs();
                 if (pinnedTimestampList.isEmpty()) {
                     pinnedTimestampsSet = new Tuple<>(triggerTimestamp, Set.of());
+                    pinnedEntityToTimestampsMap = new HashMap<>();
                     return;
                 }
                 Set<Long> pinnedTimestamps = pinnedTimestampList.keySet()

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
 public class RemoteStorePinnedTimestampService implements Closeable {
     private static final Logger logger = LogManager.getLogger(RemoteStorePinnedTimestampService.class);
     private static Tuple<Long, Set<Long>> pinnedTimestampsSet = new Tuple<>(-1L, Set.of());
-    private static HashMap<String, List<Long>> pinnedEntityToTimestampsMap = new HashMap<>();
+    private static Map<String, List<Long>> pinnedEntityToTimestampsMap = new HashMap<>();
     public static final String PINNED_TIMESTAMPS_PATH_TOKEN = "pinned_timestamps";
     public static final String PINNED_TIMESTAMPS_FILENAME_SEPARATOR = "__";
 
@@ -276,7 +276,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
         return pinnedTimestampsSet;
     }
 
-    public static HashMap<String, List<Long>> getPinnedEntities() {
+    public static Map<String, List<Long>> getPinnedEntities() {
         return pinnedEntityToTimestampsMap;
     }
 
@@ -311,20 +311,16 @@ public class RemoteStorePinnedTimestampService implements Closeable {
 
                 logger.debug("Fetched pinned timestamps from remote store: {} - {}", triggerTimestamp, pinnedTimestamps);
                 pinnedTimestampsSet = new Tuple<>(triggerTimestamp, pinnedTimestamps);
-
-                pinnedEntityToTimestampsMap = new HashMap<>();
-                pinnedEntityToTimestampsMap.putAll(
-                    pinnedTimestampList.keySet()
-                        .stream()
-                        .collect(Collectors.toMap(RemoteStorePinnedTimestampService.this::getEntityFromBlobName, blobName -> {
-                            long timestamp = RemoteStorePinnedTimestampService.this.getTimestampFromBlobName(blobName);
-                            return Collections.singletonList(timestamp);
-                        }, (existingList, newList) -> {
-                            List<Long> mergedList = new ArrayList<>(existingList);
-                            mergedList.addAll(newList);
-                            return mergedList;
-                        }))
-                );
+                pinnedEntityToTimestampsMap = pinnedTimestampList.keySet()
+                    .stream()
+                    .collect(Collectors.toMap(RemoteStorePinnedTimestampService.this::getEntityFromBlobName, blobName -> {
+                        long timestamp = RemoteStorePinnedTimestampService.this.getTimestampFromBlobName(blobName);
+                        return Collections.singletonList(timestamp);
+                    }, (existingList, newList) -> {
+                        List<Long> mergedList = new ArrayList<>(existingList);
+                        mergedList.addAll(newList);
+                        return mergedList;
+                    }));
             } catch (Throwable t) {
                 logger.error("Exception while fetching pinned timestamp details", t);
             }

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.Version;
 import org.opensearch.action.ActionRunnable;
+import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.StepListener;
 import org.opensearch.action.admin.cluster.snapshots.clone.CloneSnapshotRequest;
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
@@ -621,6 +622,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                                     return;
                                 }
                                 listener.onResponse(snapshotInfo);
+                                cleanOrphanTimestamp(repositoryName, repositoryData);
                             }
 
                             @Override
@@ -649,6 +651,60 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             }
 
         }, "create_snapshot [" + snapshotName + ']', listener::onFailure);
+    }
+
+    private void cleanOrphanTimestamp(String repoName, RepositoryData repositoryData) {
+        Collection<String> snapshotUUIDs = repositoryData.getSnapshotIds().stream().map(SnapshotId::getUUID).collect(Collectors.toList());
+        remoteStorePinnedTimestampService.forceSyncPinnedTimestamps();
+
+        HashMap<String, List<Long>> pinnedEntities = RemoteStorePinnedTimestampService.getPinnedEntities();
+
+        List<String> orphanPinnedEntities = pinnedEntities.keySet()
+            .stream()
+            .filter(pinnedEntity -> isOrphanPinnedEntity(repoName, snapshotUUIDs, pinnedEntity))
+            .collect(Collectors.toList());
+
+        if (orphanPinnedEntities.isEmpty()) {
+            return;
+        }
+
+        logger.info("Found {} orphan timestamps. Cleaning it up now", orphanPinnedEntities.size());
+        if (tryEnterRepoLoop(repoName)) {
+            deleteOrphanTimestamps(pinnedEntities, orphanPinnedEntities);
+            leaveRepoLoop(repoName);
+        } else {
+            logger.info("Concurrent snapshot create/delete is happening. Skipping clean up of orphan timestamps");
+        }
+    }
+
+    private boolean isOrphanPinnedEntity(String repoName, Collection<String> snapshotUUIDs, String pinnedEntity) {
+        Tuple<String, String> tokens = getRepoSnapshotUUIDTuple(pinnedEntity);
+        return Objects.equals(tokens.v1(), repoName) && snapshotUUIDs.contains(tokens.v2()) == false;
+    }
+
+    private void deleteOrphanTimestamps(HashMap<String, List<Long>> pinnedEntities, List<String> orphanPinnedEntities) {
+        final CountDownLatch latch = new CountDownLatch(orphanPinnedEntities.size());
+        for (String pinnedEntity : orphanPinnedEntities) {
+            assert pinnedEntities.get(pinnedEntity).size() == 1 : "Multiple timestamps for same repo-snapshot uuid found";
+            long orphanTimestamp = pinnedEntities.get(pinnedEntity).get(0);
+            String pinningEntity = getPinningEntity(pinnedEntity);
+            remoteStorePinnedTimestampService.unpinTimestamp(
+                orphanTimestamp,
+                pinningEntity,
+                new LatchedActionListener<>(new ActionListener<>() {
+                    @Override
+                    public void onResponse(Void unused) {}
+
+                    @Override
+                    public void onFailure(Exception e) {}
+                }, latch)
+            );
+        }
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private void createSnapshotPreValidations(
@@ -705,6 +761,16 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
     public static String getPinningEntity(String repositoryName, String snapshotUUID) {
         return repositoryName + SNAPSHOT_PINNED_TIMESTAMP_DELIMITER + snapshotUUID;
+    }
+
+    public static String getPinningEntity(String blobname) {
+        String[] tokens = blobname.split(SNAPSHOT_PINNED_TIMESTAMP_DELIMITER);
+        return tokens[0] + SNAPSHOT_PINNED_TIMESTAMP_DELIMITER + tokens[1];
+    }
+
+    public static Tuple<String, String> getRepoSnapshotUUIDTuple(String pinningEntity) {
+        String[] tokens = pinningEntity.split(SNAPSHOT_PINNED_TIMESTAMP_DELIMITER);
+        return new Tuple<>(tokens[0], tokens[1]);
     }
 
     private void cloneSnapshotPinnedTimestamp(


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

We update pinned timestamps before finalizing the snapshot . In case post pinning timestamp, finalizing snapshot can fail . This leads to orphan pinned timestamps. This will leak data in remote store. 

In this change, post every create snapshot operation, we find the orphan pinned timestamps and then unpin it . 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
