### PR TITLE
Add more unit tests for RemoteStoreUtils and RemoteFsTimestampAwareTranslog

### DIFF
--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
@@ -476,7 +476,8 @@ public class RemoteStoreUtils {
         Set<Long> newPinnedTimestamps = new TreeSet<>(Collections.reverseOrder());
         for (Long pinnedTimestamp : pinnedTimestampSet) {
             String cachedFile = metadataFilePinnedTimestampMap.get(pinnedTimestamp);
-            if (cachedFile != null && metadataFiles.contains(cachedFile)) {
+            if (cachedFile != null) {
+                assert metadataFiles.contains(cachedFile) : "Metadata files should contain [" + cachedFile + "]";
                 implicitLockedFiles.add(cachedFile);
             } else {
                 newPinnedTimestamps.add(pinnedTimestamp);

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreUtils.java
@@ -476,7 +476,7 @@ public class RemoteStoreUtils {
         Set<Long> newPinnedTimestamps = new TreeSet<>(Collections.reverseOrder());
         for (Long pinnedTimestamp : pinnedTimestampSet) {
             String cachedFile = metadataFilePinnedTimestampMap.get(pinnedTimestamp);
-            if (cachedFile != null) {
+            if (cachedFile != null && metadataFiles.contains(cachedFile)) {
                 implicitLockedFiles.add(cachedFile);
             } else {
                 newPinnedTimestamps.add(pinnedTimestamp);

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
@@ -460,7 +460,7 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
         }
     }
 
-    private static Long getMinPrimaryTermInRemote(
+    protected static Long getMinPrimaryTermInRemote(
         AtomicLong minPrimaryTermInRemote,
         TranslogTransferManager translogTransferManager,
         Logger logger

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
@@ -1162,6 +1162,15 @@ public class RemoteStoreUtilsTests extends OpenSearchTestCase {
         assertEquals(0, implicitLockedFiles.size());
         assertEquals(3, metadataFilePinnedTimestampCache.size());
 
+        assertThrows(
+            AssertionError.class,
+            () -> testGetPinnedTimestampLockedFilesWithPinnedTimestamps(
+                List.of(2000L, 2200L, 3001L, 4200L, 4600L, 5010L),
+                Set.of(3000L, 4000L, 5000L, 6000L),
+                metadataFilePinnedTimestampCache
+            )
+        );
+
         metadataAndLocks = testGetPinnedTimestampLockedFilesWithPinnedTimestamps(
             List.of(2000L, 2200L, 2500L, 3001L, 4200L, 4600L, 5010L),
             Set.of(),


### PR DESCRIPTION
### Description
- Add more unit tests for code flows that are missing test coverage.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
