### PR TITLE
[Forwardport] [main] Fix japicmp configuration by treating abstract-to-default method changes as non-breaking

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -407,6 +407,8 @@ tasks.named("sourcesJar").configure {
 /** Compares the current build against a laltest released version or the version supplied through 'japicmp.compare.version' system property */
 tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
     logger.info("Comparing public APIs from ${version} to ${japicmpCompareTarget}")
+    // See please https://github.com/siom79/japicmp/issues/201
+    compatibilityChangeExcludes = [ "METHOD_ABSTRACT_NOW_DEFAULT" ]
     oldClasspath.from(files("${buildDir}/japicmp-target/opensearch-${japicmpCompareTarget}.jar"))
     newClasspath.from(tasks.named('jar'))
     onlyModified = true


### PR DESCRIPTION
Forwardport of https://github.com/opensearch-project/OpenSearch/pull/16141 to `main`