### PR TITLE
[Bugfix] Fix unknown parameter `source_remote_translog_repository` bug

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -652,6 +652,12 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
                 } else {
                     throw new IllegalArgumentException("malformed source_remote_store_repository");
                 }
+            } else if (name.equals("source_remote_translog_repository")) {
+                if (entry.getValue() instanceof String) {
+                    setSourceRemoteTranslogRepository((String) entry.getValue());
+                } else {
+                    throw new IllegalArgumentException("malformed source_remote_translog_repository");
+                }
             } else {
                 if (IndicesOptions.isIndicesOptions(name) == false) {
                     throw new IllegalArgumentException("Unknown parameter " + name);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestBuilder.java
@@ -266,4 +266,12 @@ public class RestoreSnapshotRequestBuilder extends ClusterManagerNodeOperationRe
         request.setSourceRemoteStoreRepository(repositoryName);
         return this;
     }
+
+    /**
+     * Sets the source remote translog repository name
+     */
+    public RestoreSnapshotRequestBuilder setSourceRemoteTranslogRepository(String repositoryName) {
+        request.setSourceRemoteTranslogRepository(repositoryName);
+        return this;
+    }
 }


### PR DESCRIPTION
### Description
- As part of shallow snapshot V2 restore, we introduced `source_remote_translog_repository` field in the `RestoreSnapshotRequest` in order to restore snapshot from one cluster to another.
- But using `source_remote_translog_repository` fails with unknown parameter error:
```
% curl -X POST "localhost:9200/_snapshot/backup-snapshot/S_1/_restore?pretty" -H 'Content-Type: application/json' -d'
{
  "indices": "my-index-1",
  "source_remote_store_repository": "backup-segment",
  "source_remote_translog_repository": "backup-translog"
}
'
{
  "error" : {
    "root_cause" : [
      {
        "type" : "illegal_argument_exception",
        "reason" : "Unknown parameter source_remote_translog_repository"
      }
    ],
    "type" : "illegal_argument_exception",
    "reason" : "Unknown parameter source_remote_translog_repository"
  },
  "status" : 400
}
```
- This was a miss while constructing `RestoreSnapshotRequest` that is fixed in this PR.

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/16188

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
