### PR TITLE
Fix warnings from SLF4J on startup when repository-s3 is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix infinite loop in nested agg ([#15931](https://github.com/opensearch-project/OpenSearch/pull/15931))
 - Fix race condition in node-join and node-left ([#15521](https://github.com/opensearch-project/OpenSearch/pull/15521))
 - Streaming bulk request hangs ([#16158](https://github.com/opensearch-project/OpenSearch/pull/16158))
+- Fix warnings from SLF4J on startup when repository-s3 is installed ([#16194](https://github.com/opensearch-project/OpenSearch/pull/16194))
 
 ### Security
 

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -82,6 +82,8 @@ dependencies {
   api "joda-time:joda-time:${versions.joda}"
   api "org.slf4j:slf4j-api:${versions.slf4j}"
 
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
+
   // network stack
   api "io.netty:netty-buffer:${versions.netty}"
   api "io.netty:netty-codec:${versions.netty}"

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -113,6 +113,7 @@ tasks.named("dependencyLicenses").configure {
   mapping from: /jackson-.*/, to: 'jackson'
   mapping from: /jaxb-.*/, to: 'jaxb'
   mapping from: /netty-.*/, to: 'netty'
+  mapping from: /log4j-.*/, to: 'log4j'
 }
 
 bundlePlugin {
@@ -512,9 +513,7 @@ thirdPartyAudit {
     'org.jboss.marshalling.MarshallingConfiguration',
     'org.jboss.marshalling.Unmarshaller',
 
-    'org.slf4j.impl.StaticLoggerBinder',
-    'org.slf4j.impl.StaticMDCBinder',
-    'org.slf4j.impl.StaticMarkerBinder',
+    'org.slf4j.ext.EventData',
     'reactor.blockhound.BlockHound$Builder',
     'reactor.blockhound.integration.BlockHoundIntegration',
 

--- a/plugins/repository-s3/licenses/log4j-slf4j-impl-2.21.0.jar.sha1
+++ b/plugins/repository-s3/licenses/log4j-slf4j-impl-2.21.0.jar.sha1
@@ -1,0 +1,1 @@
+911fdb5b1a1df36719c579ecc6f2957b88bce1ab


### PR DESCRIPTION
### Description

Fixes an issue in the repository-s3 plugin which prints warnings on startup related to slf4j:

```
[2024-10-01T14:20:57,070][WARN ][stderr                   ] SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
[2024-10-01T14:20:57,071][WARN ][stderr                   ] SLF4J: Defaulting to no-operation (NOP) logger implementation
[2024-10-01T14:20:57,071][WARN ][stderr                   ] SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

This PR is based on a similar PR done in the security plugin: https://github.com/opensearch-project/security/pull/2564

Verified that the messages appear w/o this change and disappear on startup after this change.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/16152

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
