### PR TITLE
[BUGFIX] Fix missing fields to resolve Strict Dynamic Mapping issue when saving task result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Workload Management] Make query groups persistent across process restarts [#16370](https://github.com/opensearch-project/OpenSearch/pull/16370)
 - Fix inefficient Stream API call chains ending with count() ([#15386](https://github.com/opensearch-project/OpenSearch/pull/15386))
 - Fix array hashCode calculation in ResyncReplicationRequest ([#16378](https://github.com/opensearch-project/OpenSearch/pull/16378))
+- Fix missing fields in task index mapping to ensure proper task result storage ([#16201](https://github.com/opensearch-project/OpenSearch/pull/16201))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/tasks/TaskResultsService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResultsService.java
@@ -85,7 +85,7 @@ public class TaskResultsService {
 
     public static final String TASK_RESULT_MAPPING_VERSION_META_FIELD = "version";
 
-    public static final int TASK_RESULT_MAPPING_VERSION = 4; // must match version in task-index-mapping.json
+    public static final int TASK_RESULT_MAPPING_VERSION = 5; // must match version in task-index-mapping.json
 
     /**
      * The backoff policy to use when saving a task result fails. The total wait

--- a/server/src/test/resources/org/opensearch/tasks/missing-fields-task-index-mapping.json
+++ b/server/src/test/resources/org/opensearch/tasks/missing-fields-task-index-mapping.json
@@ -34,9 +34,6 @@
           "start_time_in_millis": {
             "type": "long"
           },
-          "cancellation_time_millis": {
-            "type": "long"
-          },
           "type": {
             "type": "keyword"
           },
@@ -48,10 +45,6 @@
             "type": "text"
           },
           "headers": {
-            "type" : "object",
-            "enabled" : false
-          },
-          "resource_stats": {
             "type" : "object",
             "enabled" : false
           }


### PR DESCRIPTION
### Related Issues
Resolves #16060
<br>

### Description

#### [The result of the execution]
* Click the image to view it in full size.

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/be929930-24f2-4175-988e-3cebec6b22a4) | ![after](https://github.com/user-attachments/assets/efe95b8c-85a6-4681-b6c7-881454bd2e5c) |
|`StrictDynamicMappingException` occurred|not occurred|

- When applying and then deleting the auto follow rule in the `CCR Plugin`(cross-cluster-replication), the `.tasks` index is properly updated without `StrictDynamicMappingException`.

#### [Background]
- OpenSearch allows a Follower Cluster to replicate indexes from a Leader Cluster through the [Opensearch CCR Plugin](https://github.com/opensearch-project/cross-cluster-replication).
- However, when cancelling the `auto follow` rule in the CCR Plugin, a `StrictDynamicMappingException` was previously encountered:
```
[2024-09-28T12:01:16,819][WARN ][o.o.r.t.a.AutoFollowTask ] [5460424aac92][my-connection-alias] Error storing result StrictDynamicMappingException[mapping set to strict, dynamic introduction of [cancellation_time_millis] within [task] is not allowed]
2024-09-28 21:01:16     at org.opensearch.index.mapper.DocumentParser.parseDynamicValue(DocumentParser.java:876)
2024-09-28 21:01:16     at org.opensearch.index.mapper.DocumentParser.parseValue(DocumentParser.java:722)
2024-09-28 21:01:16     at org.opensearch.index.mapper.DocumentParser.innerParseObject(DocumentParser.java:461)
2024-09-28 21:01:16     at org.opensearch.index.mapper.DocumentParser.parseObjectOrNested(DocumentParser.java:419)
2024-09-28 21:01:16     at org.opensearch.index.mapper.DocumentParser.parseObjectOrField(DocumentParser.java:524)
2024-09-28 21:01:16     at org.opensearch.index.mapper.DocumentParser.parseObject(DocumentParser.java:545)
2024-09-28 21:01:16     at org.opensearch.index.mapper.DocumentParser.innerParseObject(DocumentParser.java:447)
2024-09-28 21:01:16     at org.opensearch.index.mapper.DocumentParser.parseObjectOrNested(DocumentParser.java:419)
2024-09-28 21:01:16     at org.opensearch.index.mapper.DocumentParser.internalParseDocument(DocumentParser.java:138)
2024-09-28 21:01:16     at org.opensearch.index.mapper.DocumentParser.parseDocument(DocumentParser.java:93)
2024-09-28 21:01:16     at org.opensearch.index.mapper.DocumentMapper.parse(DocumentMapper.java:256)
2024-09-28 21:01:16     at org.opensearch.index.shard.IndexShard.prepareIndex(IndexShard.java:1178)
2024-09-28 21:01:16     at org.opensearch.index.shard.IndexShard.applyIndexOperation(IndexShard.java:1135)
2024-09-28 21:01:16     at org.opensearch.index.shard.IndexShard.applyIndexOperationOnPrimary(IndexShard.java:1052)
2024-09-28 21:01:16     at org.opensearch.action.bulk.TransportShardBulkAction.executeBulkItemRequest(TransportShardBulkAction.java:625)
2024-09-28 21:01:16     at org.opensearch.action.bulk.TransportShardBulkAction$2.doRun(TransportShardBulkAction.java:471)
2024-09-28 21:01:16     at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
2024-09-28 21:01:16     at org.opensearch.action.bulk.TransportShardBulkAction.performOnPrimary(TransportShardBulkAction.java:535)
2024-09-28 21:01:16     at org.opensearch.action.bulk.TransportShardBulkAction.dispatchedShardOperationOnPrimary(TransportShardBulkAction.java:416)
2024-09-28 21:01:16     at org.opensearch.action.bulk.TransportShardBulkAction.dispatchedShardOperationOnPrimary(TransportShardBulkAction.java:125)
2024-09-28 21:01:16     at org.opensearch.action.support.replication.TransportWriteAction$1.doRun(TransportWriteAction.java:275)
2024-09-28 21:01:16     at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1005)
2024-09-28 21:01:16     at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
2024-09-28 21:01:16     at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
2024-09-28 21:01:16     at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
2024-09-28 21:01:16     at java.base/java.lang.Thread.run(Thread.java:1583)
```
- When a task is stored, OpenSearch’s `TaskResultsService.storeResult(TaskResult taskResult, ActionListener<Void> listener)` is called.
- This method extracts a `TaskInfo` object from the`TaskResult` parameter. `TaskInfo` defines the necessary fields for a task, which are mapped to the `.tasks` index via `task-index-mapping.json`.
- So, when a task is cancelled, the `.tasks` index should be updated
- Also, the `.tasks` index has **strict dynamic mapping** enabled.
- However, `cancellation_time_millis` and `resource_stats` were present in `TaskInfo` but missing from the mapping JSON.
- As a result, this was causing a `StrictDynamicMappingException`.


#### [PR contents]  
1. Added the `cancellation_time_millis` and `resource_stats` fields to `task-index-mapping.json`:
```
...
          "cancellation_time_millis": {
            "type": "long"
          },
          "resource_stats": {
            "type" : "object",
            "enabled" : false
          }
...
```

2. Updated the mapping `version` in both `task-index-mapping.json` and `TaskResultsService` from 4 to 5.
These versions must match for the mapping to apply correctly. When updating a mapping, increment the version so future operations can detect and apply changes.


#### [Test]
I conducted two types of tests:
- Writing a test in OpenSearch
- Running local end-to-end (e2e) tests

##### Writing a test in OpenSearch

TaskInfo has two constructors: one that includes `cancellation_time_millis` (a) and one that does not (b).
In the existing `TasksIT`, the `resultsService.storeResult()` test did not include the appropriate `resource_stats` and `cancellation_time_millis` in the `TaskInfo`.
So, I added `testStoreResultWithAllFields`, using constructor (b) to create a test that only passes with the updated `task-index-mapping.json`.


##### Local End-to-End (e2e) Testing

- To perform the e2e test, I needed a setup with two custom OpenSearch 3.0.0v clusters and the CCR Plugin 3.0.0v installed. 

1. I set up two clusters with the CCR Plugin installed. I cloned the [OpenSearch GitHub repository](https://github.com/opensearch-project/OpenSearch) and modified the task-index-mapping.json.
2. After modifying OpenSearch, I `assemble` it, generating the `opensearch-min-3.0.0-SNAPSHOT-linux-arm64.tar.gz file`.
5. I then cloned and assembled the [OpenSearch CCR GitHub repository](https://github.com/opensearch-project/cross-cluster-replication), which generated opensearch-cross-cluster-replication-3.0.0.0-SNAPSHOT.zip.
6. Using a `Dockerfile`, I built a `Docker image`. In the same directory as the Dockerfile, I included the following files:
`opensearch-min-3.0.0-SNAPSHOT-linux-arm64.tar.gz`, `opensearch-cross-cluster-replication-3.0.0.0-SNAPSHOT.zip`, `opensearch.yml`,  `opensearch-docker-entrypoint.sh`, `opensearch-onetime-setup.sh`
<img width="492" alt="image" src="https://github.com/user-attachments/assets/afd151a4-4233-4446-81c8-856cf05360ee">       

7. I used `Docker Compose` to create two clusters.
8. Finally, I installed the CCR plugin on each cluster:
```
docker exec -it [container] /bin/bash
/usr/share/opensearch/bin/opensearch-plugin install file:/usr/share/opensearch/opensearch-cross-cluster-replication-3.0.0.0-SNAPSHOT.zip
```

9. I registered an `auto follow` rule and then canceled it to verify the behavior. [Set up a cross-cluster connection](https://opensearch.org/docs/latest/tuning-your-cluster/replication-plugin/getting-started/#set-up-a-cross-cluster-connection), [get-started-with-auto-follow](https://opensearch.org/docs/latest/tuning-your-cluster/replication-plugin/auto-follow/#get-started-with-auto-follow):
```
curl -XPUT -k -H 'Content-Type: application/json'  'http://localhost:9200/_cluster/settings?pretty' -d '
{
  "persistent": {
    "cluster": {
      "remote": {
        "my-connection-alias": {
          "seeds": ["localhost:9300"]
        }
      }
    }
  }
}'
```
```
curl -XPUT -k -H 'Content-Type: application/json'  'http://localhost:9201/leader-01?pretty'
```
```
curl -XPOST -k -H 'Content-Type: application/json' -u 'admin:Yhj99!009' 'https://localhost:9200/_plugins/_replication/_autofollow?pretty' -d '
{
   "leader_alias" : "my-connection-alias",
   "name": "my-replication-rule",
   "pattern": "movies*",
   "use_roles":{
      "leader_cluster_role": "all_access",
      "follower_cluster_role": "all_access"
   }
}'
```
```
curl -XDELETE -k -H 'Content-Type: application/json'  'http://localhost:9200/_plugins/_replication/_autofollow?pretty' -d '
{
   "leader_alias" : "my-connection-alias",
   "name": "my-replication-rule"
}'
```

10. I checked the logs to confirm if `StrictDynamicMappingException` occurred. After modifying the `task-index-mapping.json` correctly, I observed that instead of the previous `StrictDynamicMappingException`, the task status was successfully updated.
```
replication-node22-orin: {"type": "server", "timestamp": "2024-10-05T04:37:02,764Z", "level": "INFO", "component": "o.o.r.t.a.AutoFollowTask", "cluster.name": "follower-cluster", "node.name": "6b9ce94a6ee6", "message": "[my-connection-alias] Going to mark AutoFollowTask:97 task as completed", "cluster.uuid": "6afNBEthSgaKVY55dxNk8Q", "node.id": "0Zrg1aZFS_Sov4YAJjCDAg"  }
replication-node22-orin: {"type": "server", "timestamp": "2024-10-05T04:37:02,766Z", "level": "INFO", "component": "o.o.r.t.a.AutoFollowTask", "cluster.name": "follower-cluster", "node.name": "6b9ce94a6ee6", "message": "[my-connection-alias] Completed the task with id:97", "cluster.uuid": "6afNBEthSgaKVY55dxNk8Q", "node.id": "0Zrg1aZFS_Sov4YAJjCDAg"  }
replication-node22-orin: {"type": "server", "timestamp": "2024-10-05T04:37:02,770Z", "level": "INFO", "component": "o.o.r.t.a.AutoFollowTask", "cluster.name": "follower-cluster", "node.name": "6b9ce94a6ee6", "message": "[my-connection-alias] Successfully persisted task status", "cluster.uuid": "6afNBEthSgaKVY55dxNk8Q", "node.id": "0Zrg1aZFS_Sov4YAJjCDAg"  }
```



Below are the files I used for testing, along with their sources:
| Name | File | Source |
|--------|-------|---------|
| DockerFile | [link](https://github.com/inpink/opensearch-test/blob/main/Dockerfile) | ["opensearch-build" al2023.dockerfile](https://github.com/opensearch-project/opensearch-build/blob/89ccd0936fc4d2f813aa876ffda3e7f04a7793b8/docker/release/dockerfiles/opensearch.al2023.dockerfile) |
| docker-compose | [link](https://github.com/inpink/opensearch-test/blob/main/docker-compose.yml) | ["opensearch" distribution docker-compose](https://github.com/opensearch-project/OpenSearch/blob/421a1cc2270ef02f02fc7621895f8b15ec7282f1/distribution/docker/docker-compose.yml) |
| log4j2.properties |  [link](https://github.com/inpink/opensearch-test/blob/main/log4j2.properties) | ["opensearch-build" log4j2.properties](https://github.com/opensearch-project/OpenSearch/blob/421a1cc2270ef02f02fc7621895f8b15ec7282f1/distribution/docker/src/docker/config/log4j2.properties) | 
| opensearch-docker-entrypoint-default.x.sh | [link](https://github.com/inpink/opensearch-test/blob/main/opensearch-docker-entrypoint-default.x.sh) | ["opensearch-build" entrypoint](https://github.com/opensearch-project/opensearch-build/blob/89ccd0936fc4d2f813aa876ffda3e7f04a7793b8/docker/release/config/opensearch/opensearch-docker-entrypoint-default.x.sh)
| opensearch-onetime-setup.sh | [link](https://github.com/inpink/opensearch-test/blob/main/opensearch-onetime-setup.sh) | ["opensearch-build" onetime](https://github.com/opensearch-project/opensearch-build/blob/89ccd0936fc4d2f813aa876ffda3e7f04a7793b8/scripts/opensearch-onetime-setup.sh)
| opensearch.yml | [link](https://github.com/inpink/opensearch-test/blob/main/opensearch.yml) | ["opensearch" distribution yml](https://github.com/opensearch-project/OpenSearch/blob/421a1cc2270ef02f02fc7621895f8b15ec7282f1/distribution/docker/src/docker/config/opensearch.yml) |
| opensearch-min-3.0.0-SNAPSHOT-linux-arm64.tar.gz | [link](https://github.com/inpink/opensearch-test/blob/main/opensearch-min-3.0.0-SNAPSHOT-linux-arm64.tar.gz) | Generated by cloning the [OpenSearch repository](https://github.com/opensearch-project/OpenSearch) and assembling the project. |
| opensearch-cross-cluster-replication-3.0.0.0-SNAPSHOT.zip | [link](https://github.com/inpink/opensearch-test/blob/main/opensearch-cross-cluster-replication-3.0.0.0-SNAPSHOT.zip) |  Generated by cloning the [OpenSearch CCR Plugin repository](https://github.com/opensearch-project/cross-cluster-replication) and assembling the project. |

My test environment was `Mac OS M2`. If you are using a different operating system, replace the `.tar.gz` file with the version that matches your system.

If needed, I am happy to provide the `Docker image` used in my test. Please feel free to request it if required.



### Check List
- [X] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
