### PR TITLE
Add support for incremental download of translog files

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/Translog.java
+++ b/server/src/main/java/org/opensearch/index/translog/Translog.java
@@ -134,6 +134,8 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
     public static final String CHECKPOINT_SUFFIX = ".ckp";
     public static final String CHECKPOINT_FILE_NAME = "translog" + CHECKPOINT_SUFFIX;
 
+    // STRICT_TLOG_OR_CKP_PATTERN is the strict pattern for Translog or Checkpoint file.
+    static final Pattern STRICT_TLOG_OR_CKP_PATTERN = Pattern.compile("^" + TRANSLOG_FILE_PREFIX + "(\\d+)(\\.ckp|\\.tlog)$");
     static final Pattern PARSE_STRICT_ID_PATTERN = Pattern.compile("^" + TRANSLOG_FILE_PREFIX + "(\\d+)(\\.tlog)$");
     public static final int DEFAULT_HEADER_SIZE_IN_BYTES = TranslogHeader.headerSizeInBytes(UUIDs.randomBase64UUID());
 
@@ -320,14 +322,18 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
         return parseIdFromFileName(fileName);
     }
 
-    public static long parseIdFromFileName(String fileName) {
-        final Matcher matcher = PARSE_STRICT_ID_PATTERN.matcher(fileName);
+    public static long parseIdFromFileName(String translogFile) {
+        return parseIdFromFileName(translogFile, PARSE_STRICT_ID_PATTERN);
+    }
+
+    public static long parseIdFromFileName(String fileName, Pattern pattern) {
+        final Matcher matcher = pattern.matcher(fileName);
         if (matcher.matches()) {
             try {
                 return Long.parseLong(matcher.group(1));
             } catch (NumberFormatException e) {
                 throw new IllegalStateException(
-                    "number formatting issue in a file that passed PARSE_STRICT_ID_PATTERN: " + fileName + "]",
+                    "number formatting issue in a file that passed " + pattern.pattern() + ": " + fileName + "]",
                     e
                 );
             }

--- a/server/src/main/java/org/opensearch/index/translog/TranslogFooter.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogFooter.java
@@ -1,0 +1,148 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.index.translog;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.store.OutputStreamDataOutput;
+import org.opensearch.common.io.Channels;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Handles the writing and reading of the translog footer, which contains the checksum of the translog data.
+ *
+ * Each translog file is structured as follows:
+ *
+ * 1. Translog header
+ * 2. Translog operations
+ * 3. Translog footer
+ *
+ * The footer contains the following information:
+ *
+ * - Magic number (int): A constant value that identifies the start of the footer.
+ * - Algorithm ID (int): The identifier of the checksum algorithm used. Currently, this is always 0.
+ * - Checksum (long): The checksum of the entire translog data, calculated using the specified algorithm.
+ */
+public class TranslogFooter {
+
+    /**
+     * FOOTER_LENGTH is the length of the present footer added to translog files.
+     * We write 4 bytes for the magic number, 4 bytes for algorithm ID and 8 bytes for the checksum.
+     * Therefore, the footer length as 16.
+     * */
+    private static final int FOOTER_LENGTH = 16;
+
+    /**
+     * Returns the length of the translog footer in bytes.
+     *
+     * @return the length of the translog footer in bytes
+     */
+    static int footerLength() {
+        return FOOTER_LENGTH;
+    }
+
+    /**
+     * Writes the translog footer to the provided `FileChannel`.
+     *
+     * @param channel  the `FileChannel` to write the footer to
+     * @param checksum the checksum value to be written in the footer
+     * @param toSync   whether to force a sync of the written data to the underlying storage
+     * @return the byte array containing the written footer data
+     * @throws IOException if an I/O error occurs while writing the footer
+     */
+    static byte[] write(FileChannel channel, long checksum, boolean toSync) throws IOException {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        final OutputStreamDataOutput out = new OutputStreamDataOutput(new OutputStreamStreamOutput(byteArrayOutputStream));
+
+        CodecUtil.writeBEInt(out, CodecUtil.FOOTER_MAGIC);
+        CodecUtil.writeBEInt(out, 0);
+        CodecUtil.writeBELong(out, checksum);
+
+        Channels.writeToChannel(byteArrayOutputStream.toByteArray(), channel);
+        if (toSync) {
+            channel.force(false);
+        }
+
+        return byteArrayOutputStream.toByteArray();
+    }
+
+    /**
+     * Reads the checksum value from the footer of the translog file located at the provided `Path`.
+     *
+     * If the translog file is of an older version and does not have a footer, this method returns `null`.
+     *
+     * @param path the `Path` to the translog file
+     * @return the checksum value from the translog footer, or `null` if the footer is not present
+     * @throws IOException if an I/O error occurs while reading the footer
+     */
+    static Long readChecksum(Path path) throws IOException {
+        try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+            // Read the header and find out if the footer is supported.
+            final TranslogHeader header = TranslogHeader.read(path, channel);
+            if (header.getTranslogHeaderVersion() < TranslogHeader.VERSION_WITH_FOOTER) {
+                return null;
+            }
+
+            // Read the footer.
+            final long fileSize = channel.size();
+            final long footerStart = fileSize - TranslogFooter.footerLength();
+            ByteBuffer footer = ByteBuffer.allocate(TranslogFooter.footerLength());
+            int bytesRead = Channels.readFromFileChannel(channel, footerStart, footer);
+            if (bytesRead != TranslogFooter.footerLength()) {
+                throw new IOException(
+                    "Read " + bytesRead + " bytes from footer instead of expected " + TranslogFooter.footerLength() + " bytes"
+                );
+            }
+            footer.flip();
+
+            // Validate the footer and return the checksum.
+            int magic = footer.getInt();
+            if (magic != CodecUtil.FOOTER_MAGIC) {
+                throw new IOException("Invalid footer magic number: " + magic);
+            }
+
+            int algorithmId = footer.getInt();
+            if (algorithmId != 0) {
+                throw new IOException("Unsupported checksum algorithm ID: " + algorithmId);
+            }
+
+            return footer.getLong();
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/translog/TranslogReader.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogReader.java
@@ -64,8 +64,13 @@ public class TranslogReader extends BaseTranslogReader implements Closeable {
 
     @Nullable
     private final Long translogChecksum;
+
+    // fullTranslogChecksum is the checksum for translog which includes header, content, and footer.
+    @Nullable
+    private final Long fullTranslogChecksum;
     @Nullable
     private final Long checkpointChecksum;
+    private final Boolean hasFooter;
 
     /**
      * Create a translog writer against the specified translog file channel.
@@ -80,14 +85,18 @@ public class TranslogReader extends BaseTranslogReader implements Closeable {
         final FileChannel channel,
         final Path path,
         final TranslogHeader header,
-        final Long translogChecksum
+        final Long translogChecksum,
+        final Long fullTranslogChecksum,
+        final Boolean hasFooter
     ) throws IOException {
         super(checkpoint.generation, channel, path, header);
         this.length = checkpoint.offset;
         this.totalOperations = checkpoint.numOps;
         this.checkpoint = checkpoint;
         this.translogChecksum = translogChecksum;
+        this.fullTranslogChecksum = fullTranslogChecksum;
         this.checkpointChecksum = (translogChecksum != null) ? calculateCheckpointChecksum(checkpoint, path) : null;
+        this.hasFooter = hasFooter;
     }
 
     private static Long calculateCheckpointChecksum(Checkpoint checkpoint, Path path) throws IOException {
@@ -99,6 +108,14 @@ public class TranslogReader extends BaseTranslogReader implements Closeable {
 
     public Long getTranslogChecksum() {
         return translogChecksum;
+    }
+
+    /**
+     * getFullTranslogChecksum returns the complete checksum of the translog which includes
+     * header, content and footer.
+     * */
+    public Long getFullTranslogChecksum() {
+        return fullTranslogChecksum;
     }
 
     public Long getCheckpointChecksum() {
@@ -118,7 +135,18 @@ public class TranslogReader extends BaseTranslogReader implements Closeable {
     public static TranslogReader open(final FileChannel channel, final Path path, final Checkpoint checkpoint, final String translogUUID)
         throws IOException {
         final TranslogHeader header = TranslogHeader.read(translogUUID, path, channel);
-        return new TranslogReader(checkpoint, channel, path, header, null);
+
+        // When we open a reader to Translog from a path, we want to fetch the checksum
+        // as that would be needed later on while creating the metadata map for
+        // generation to checksum.
+        Long translogChecksum = null;
+        try {
+            translogChecksum = TranslogFooter.readChecksum(path);
+        } catch (IOException ignored) {}
+
+        boolean hasFooter = translogChecksum != null;
+
+        return new TranslogReader(checkpoint, channel, path, header, translogChecksum, null, hasFooter);
     }
 
     /**
@@ -146,9 +174,9 @@ public class TranslogReader extends BaseTranslogReader implements Closeable {
 
                     IOUtils.fsync(checkpointFile.getParent(), true);
 
-                    newReader = new TranslogReader(newCheckpoint, channel, path, header, translogChecksum);
+                    newReader = new TranslogReader(newCheckpoint, channel, path, header, translogChecksum, fullTranslogChecksum, hasFooter);
                 } else {
-                    newReader = new TranslogReader(checkpoint, channel, path, header, translogChecksum);
+                    newReader = new TranslogReader(checkpoint, channel, path, header, translogChecksum, fullTranslogChecksum, hasFooter);
                 }
                 toCloseOnFailure = null;
                 return newReader;
@@ -177,6 +205,23 @@ public class TranslogReader extends BaseTranslogReader implements Closeable {
      * reads an operation at the given position into the given buffer.
      */
     protected void readBytes(ByteBuffer buffer, long position) throws IOException {
+        if (hasFooter && header.getTranslogHeaderVersion() == TranslogHeader.VERSION_WITH_FOOTER) {
+            // Ensure that the read request does not overlap with footer.
+            long translogLengthWithoutFooter = length - TranslogFooter.footerLength();
+            if (position >= translogLengthWithoutFooter && position < length) {
+                throw new EOFException(
+                    "read requested past last ops into footer. pos [" + position + "] end: [" + translogLengthWithoutFooter + "]"
+                );
+            }
+            // If we are trying to read beyond the last Ops, we need to return EOF error.
+            long lastPositionToRead = position + buffer.limit();
+            if (lastPositionToRead > translogLengthWithoutFooter) {
+                throw new EOFException(
+                    "trying to read past last ops into footer. pos [" + lastPositionToRead + "] end: [" + translogLengthWithoutFooter + "]"
+                );
+            }
+        }
+
         if (position >= length) {
             throw new EOFException("read requested past EOF. pos [" + position + "] end: [" + length + "]");
         }

--- a/server/src/main/java/org/opensearch/index/translog/transfer/FileSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/FileSnapshot.java
@@ -163,14 +163,28 @@ public class FileSnapshot implements Closeable {
     public static final class TranslogFileSnapshot extends TransferFileSnapshot {
 
         private final long generation;
+        // translogContentChecksum is the checksum of Translog which does not include footer.
+        // In contrast, the checksum class variable has the checksum of Translog which includes footer.
+        private Long translogContentChecksum;
 
         public TranslogFileSnapshot(long primaryTerm, long generation, Path path, Long checksum) throws IOException {
             super(path, primaryTerm, checksum);
             this.generation = generation;
+            this.translogContentChecksum = checksum;
+        }
+
+        public TranslogFileSnapshot(long primaryTerm, long generation, Path path, Long checksum, Long fullTranslogChecksum)
+            throws IOException {
+            this(primaryTerm, generation, path, fullTranslogChecksum);
+            this.translogContentChecksum = checksum;
         }
 
         public long getGeneration() {
             return generation;
+        }
+
+        public Long getTranslogContentChecksum() {
+            return translogContentChecksum;
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogCheckpointTransferSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogCheckpointTransferSnapshot.java
@@ -168,7 +168,13 @@ public class TranslogCheckpointTransferSnapshot implements TransferSnapshot, Clo
                 Path checkpointPath = location.resolve(checkpointGenFileNameMapper.apply(readerGeneration));
                 generations.add(readerGeneration);
                 translogTransferSnapshot.add(
-                    new TranslogFileSnapshot(readerPrimaryTerm, readerGeneration, translogPath, reader.getTranslogChecksum()),
+                    new TranslogFileSnapshot(
+                        readerPrimaryTerm,
+                        readerGeneration,
+                        translogPath,
+                        reader.getTranslogChecksum(),
+                        reader.getFullTranslogChecksum()
+                    ),
                     new CheckpointFileSnapshot(
                         readerPrimaryTerm,
                         checkpointGeneration,

--- a/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
+++ b/server/src/main/java/org/opensearch/index/translog/transfer/TranslogTransferMetadata.java
@@ -42,6 +42,9 @@ public class TranslogTransferMetadata {
 
     private final SetOnce<Map<String, String>> generationToPrimaryTermMapper = new SetOnce<>();
 
+    // generationToChecksumMapper is the mapping between the generation and the checksum of associated translog file.
+    private final SetOnce<Map<String, String>> generationToChecksumMapper = new SetOnce<>();
+
     public static final String METADATA_SEPARATOR = "__";
 
     public static final String METADATA_PREFIX = "metadata";
@@ -94,6 +97,20 @@ public class TranslogTransferMetadata {
 
     public Map<String, String> getGenerationToPrimaryTermMapper() {
         return generationToPrimaryTermMapper.get();
+    }
+
+    /*
+    * setGenerationToChecksumMapper sets the mapping between the generation and the checksum of associated translog file.
+    * */
+    public void setGenerationToChecksumMapper(Map<String, String> generationToChecksumMap) {
+        generationToChecksumMapper.set(generationToChecksumMap);
+    }
+
+    /*
+    * getGenerationToChecksumMapper gets the mapping between the generation and the checksum of associated translog file.
+    * */
+    public Map<String, String> getGenerationToChecksumMapper() {
+        return generationToChecksumMapper.get();
     }
 
     /*

--- a/server/src/test/java/org/opensearch/index/translog/LocalTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/LocalTranslogTests.java
@@ -501,9 +501,9 @@ public class LocalTranslogTests extends OpenSearchTestCase {
         {
             final TranslogStats stats = stats();
             assertThat(stats.estimatedNumberOfOperations(), equalTo(4));
-            assertThat(stats.getTranslogSizeInBytes(), equalTo(326L));
+            assertThat(stats.getTranslogSizeInBytes(), equalTo(342L));
             assertThat(stats.getUncommittedOperations(), equalTo(4));
-            assertThat(stats.getUncommittedSizeInBytes(), equalTo(271L));
+            assertThat(stats.getUncommittedSizeInBytes(), equalTo(287L));
             assertThat(stats.getEarliestLastModifiedAge(), greaterThan(0L));
         }
 
@@ -513,7 +513,7 @@ public class LocalTranslogTests extends OpenSearchTestCase {
             stats.writeTo(out);
             final TranslogStats copy = new TranslogStats(out.bytes().streamInput());
             assertThat(copy.estimatedNumberOfOperations(), equalTo(4));
-            assertThat(copy.getTranslogSizeInBytes(), equalTo(326L));
+            assertThat(copy.getTranslogSizeInBytes(), equalTo(342L));
 
             try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
                 builder.startObject();
@@ -521,9 +521,9 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 builder.endObject();
                 assertEquals(
                     "{\"translog\":{\"operations\":4,\"size_in_bytes\":"
-                        + 326
+                        + 342
                         + ",\"uncommitted_operations\":4,\"uncommitted_size_in_bytes\":"
-                        + 271
+                        + 287
                         + ",\"earliest_last_modified_age\":"
                         + stats.getEarliestLastModifiedAge()
                         + ",\"remote_store\":{\"upload\":{"
@@ -540,7 +540,7 @@ public class LocalTranslogTests extends OpenSearchTestCase {
             long lastModifiedAge = System.currentTimeMillis() - translog.getCurrent().getLastModifiedTime();
             final TranslogStats stats = stats();
             assertThat(stats.estimatedNumberOfOperations(), equalTo(4));
-            assertThat(stats.getTranslogSizeInBytes(), equalTo(326L));
+            assertThat(stats.getTranslogSizeInBytes(), equalTo(342L));
             assertThat(stats.getUncommittedOperations(), equalTo(0));
             assertThat(stats.getUncommittedSizeInBytes(), equalTo(firstOperationPosition));
             assertThat(stats.getEarliestLastModifiedAge(), greaterThanOrEqualTo(lastModifiedAge));
@@ -1754,8 +1754,10 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 writer.add(ReleasableBytesReference.wrap(new BytesArray(bytes)), randomNonNegativeLong());
             }
             writer.sync();
-            final Checkpoint writerCheckpoint = writer.getCheckpoint();
             TranslogReader reader = writer.closeIntoReader();
+            // We need to find checkpoint only after the reader has been closed.
+            // This is so that the added footer is taken care of.
+            final Checkpoint writerCheckpoint = writer.getCheckpoint();
             try {
                 if (randomBoolean()) {
                     reader.close();

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
@@ -1663,8 +1663,10 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
                 writer.add(ReleasableBytesReference.wrap(new BytesArray(bytes)), randomNonNegativeLong());
             }
             writer.sync();
-            final Checkpoint writerCheckpoint = writer.getCheckpoint();
             TranslogReader reader = writer.closeIntoReader();
+            // We need to find checkpoint only after the reader has been closed.
+            // This is so that the added footer is taken care of.
+            final Checkpoint writerCheckpoint = writer.getCheckpoint();
             try {
                 if (randomBoolean()) {
                     reader.close();
@@ -1690,8 +1692,10 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
         Path location = createTempDir();
         TranslogTransferMetadata translogTransferMetadata = new TranslogTransferMetadata(primaryTerm, generation, generation, 1);
         Map<String, String> generationToPrimaryTermMapper = new HashMap<>();
+        Map<String, String> generationToChecksumMapper = new HashMap<>();
         generationToPrimaryTermMapper.put(String.valueOf(generation), String.valueOf(primaryTerm));
         translogTransferMetadata.setGenerationToPrimaryTermMapper(generationToPrimaryTermMapper);
+        translogTransferMetadata.setGenerationToChecksumMapper(generationToChecksumMapper);
 
         TranslogTransferManager mockTransfer = mock(TranslogTransferManager.class);
         RemoteTranslogTransferTracker remoteTranslogTransferTracker = mock(RemoteTranslogTransferTracker.class);

--- a/server/src/test/java/org/opensearch/index/translog/TranslogFooterTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/TranslogFooterTests.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.index.translog;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.opensearch.common.UUIDs;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+public class TranslogFooterTests extends OpenSearchTestCase {
+
+    /**
+     * testTranslogFooterWrite verifies the functionality of TranslogFooter.write() method
+     * wherein we write the footer to the translog file.
+     * */
+    public void testTranslogFooterWrite() throws IOException {
+        Path translogPath = createTempFile();
+        try (FileChannel channel = FileChannel.open(translogPath, StandardOpenOption.WRITE)) {
+            // Write a translog header
+            TranslogHeader header = new TranslogHeader(UUIDs.randomBase64UUID(), randomNonNegativeLong());
+            header.write(channel, true);
+
+            // Write some translog operations
+            byte[] operationBytes = new byte[] { 1, 2, 3, 4 };
+            channel.write(ByteBuffer.wrap(operationBytes));
+
+            // Write the translog footer
+            long expectedChecksum = 0x1234567890ABCDEFL;
+            byte[] footer = TranslogFooter.write(channel, expectedChecksum, true);
+
+            // Verify the footer contents
+            ByteBuffer footerBuffer = ByteBuffer.wrap(footer);
+            assertEquals(CodecUtil.FOOTER_MAGIC, footerBuffer.getInt());
+            assertEquals(0, footerBuffer.getInt());
+            assertEquals(expectedChecksum, footerBuffer.getLong());
+
+            // Verify that the footer was written to the channel
+            assertEquals(footer.length, channel.size() - (header.sizeInBytes() + operationBytes.length));
+        }
+    }
+
+    /**
+     * testTranslogFooterReadChecksum verifies the behavior of the TranslogFooter.readChecksum() method,
+     * which reads the checksum from the footer of a translog file.
+     * */
+    public void testTranslogFooterReadChecksum() throws IOException {
+        long expectedChecksum = 0x1234567890ABCDEFL;
+        Path translogPath = createTempFile();
+        try (FileChannel channel = FileChannel.open(translogPath, StandardOpenOption.WRITE)) {
+            // Write a translog header
+            TranslogHeader header = new TranslogHeader(UUIDs.randomBase64UUID(), randomNonNegativeLong());
+            header.write(channel, true);
+
+            // Write some translog operations
+            byte[] operationBytes = new byte[] { 1, 2, 3, 4 };
+            channel.write(ByteBuffer.wrap(operationBytes));
+
+            // Write the translog footer.
+            TranslogFooter.write(channel, expectedChecksum, true);
+        }
+
+        // Verify that the checksum can be read correctly
+        Long actualChecksum = TranslogFooter.readChecksum(translogPath);
+        assert actualChecksum != null;
+        assertEquals(expectedChecksum, actualChecksum.longValue());
+    }
+}

--- a/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferMetadataHandlerTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/transfer/TranslogTransferMetadataHandlerTests.java
@@ -29,20 +29,69 @@ public class TranslogTransferMetadataHandlerTests extends OpenSearchTestCase {
         handler = new TranslogTransferMetadataHandler();
     }
 
+    /**
+     * Tests the readContent method of the TranslogTransferMetadataHandler, which reads the TranslogTransferMetadata
+     * from the provided IndexInput.
+     *
+     * @throws IOException if there is an error reading the metadata from the IndexInput
+     */
     public void testReadContent() throws IOException {
         TranslogTransferMetadata expectedMetadata = getTestMetadata();
 
         // Operation: Read expected metadata from source input stream.
-        IndexInput indexInput = new ByteArrayIndexInput("metadata file", getTestMetadataBytes());
+        IndexInput indexInput = new ByteArrayIndexInput("metadata file", getTestMetadataBytes(expectedMetadata));
         TranslogTransferMetadata actualMetadata = handler.readContent(indexInput);
 
         // Verification: Compare actual metadata read from the source input stream.
         assertEquals(expectedMetadata, actualMetadata);
     }
 
-    public void testWriteContent() throws IOException {
-        TranslogTransferMetadata expectedMetadata = getTestMetadata();
+    /**
+     * Tests the readContent method of the TranslogTransferMetadataHandler, which reads the TranslogTransferMetadata
+     * that includes the generation-to-checksum map from the provided IndexInput.
+     *
+     * @throws IOException if there is an error reading the metadata from the IndexInput
+     */
+    public void testReadContentForMetadataWithgenerationToChecksumMap() throws IOException {
+        TranslogTransferMetadata expectedMetadata = getTestMetadataWithGenerationToChecksumMap();
 
+        // Operation: Read expected metadata from source input stream.
+        IndexInput indexInput = new ByteArrayIndexInput("metadata file", getTestMetadataBytes(expectedMetadata));
+        TranslogTransferMetadata actualMetadata = handler.readContent(indexInput);
+
+        // Verification: Compare actual metadata read from the source input stream.
+        assertEquals(expectedMetadata, actualMetadata);
+    }
+
+    /**
+     * Tests the writeContent method of the TranslogTransferMetadataHandler, which writes the provided
+     * TranslogTransferMetadata to the OutputStreamIndexOutput.
+     *
+     * @throws IOException if there is an error writing the metadata to the OutputStreamIndexOutput
+     */
+    public void testWriteContent() throws IOException {
+        verifyWriteContent(getTestMetadata());
+    }
+
+    /**
+     * Tests the writeContent method of the TranslogTransferMetadataHandler, which writes the provided
+     * TranslogTransferMetadata that includes the generation-to-checksum map to the OutputStreamIndexOutput.
+     *
+     * @throws IOException if there is an error writing the metadata to the OutputStreamIndexOutput
+     */
+    public void testWriteContentWithGeneratonToChecksumMap() throws IOException {
+        verifyWriteContent(getTestMetadataWithGenerationToChecksumMap());
+    }
+
+    /**
+     * Verifies the writeContent method of the TranslogTransferMetadataHandler by writing the provided
+     * TranslogTransferMetadata to an OutputStreamIndexOutput, and then reading it back and comparing it
+     * to the original metadata.
+     *
+     * @param expectedMetadata the expected TranslogTransferMetadata to be written and verified
+     * @throws IOException if there is an error writing or reading the metadata
+     */
+    private void verifyWriteContent(TranslogTransferMetadata expectedMetadata) throws IOException {
         // Operation: Write expected metadata to the target output stream.
         BytesStreamOutput output = new BytesStreamOutput();
         OutputStreamIndexOutput actualMetadataStream = new OutputStreamIndexOutput("dummy bytes", "dummy stream", output, 4096);
@@ -55,9 +104,11 @@ public class TranslogTransferMetadataHandlerTests extends OpenSearchTestCase {
         long generation = indexInput.readLong();
         long minTranslogGeneration = indexInput.readLong();
         Map<String, String> generationToPrimaryTermMapper = indexInput.readMapOfStrings();
+        Map<String, String> generationToChecksumMapper = indexInput.readMapOfStrings();
         int count = generationToPrimaryTermMapper.size();
         TranslogTransferMetadata actualMetadata = new TranslogTransferMetadata(primaryTerm, generation, minTranslogGeneration, count);
         actualMetadata.setGenerationToPrimaryTermMapper(generationToPrimaryTermMapper);
+        actualMetadata.setGenerationToChecksumMapper(generationToChecksumMapper);
         assertEquals(expectedMetadata, actualMetadata);
     }
 
@@ -76,18 +127,36 @@ public class TranslogTransferMetadataHandlerTests extends OpenSearchTestCase {
         return metadata;
     }
 
-    private byte[] getTestMetadataBytes() throws IOException {
+    private TranslogTransferMetadata getTestMetadataWithGenerationToChecksumMap() {
         TranslogTransferMetadata metadata = getTestMetadata();
+        Map<String, String> generationToChecksumMapper = Map.of(
+            String.valueOf(300),
+            String.valueOf(1234),
+            String.valueOf(400),
+            String.valueOf(4567)
+        );
+        metadata.setGenerationToChecksumMapper(generationToChecksumMapper);
+        return metadata;
+    }
 
+    /**
+     * Creates a byte array representation of the provided TranslogTransferMetadata instance, which includes
+     * the primary term, generation, minimum translog generation, generation-to-primary term mapping, and
+     * generation-to-checksum mapping (if available).
+     *
+     * @param metadata the TranslogTransferMetadata instance to be converted to a byte array
+     * @return the byte array representation of the TranslogTransferMetadata
+     * @throws IOException if there is an error writing the metadata to the byte array
+     */
+    private byte[] getTestMetadataBytes(TranslogTransferMetadata metadata) throws IOException {
         BytesStreamOutput output = new BytesStreamOutput();
-        OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("dummy bytes", "dummy stream", output, 4096);
-        indexOutput.writeLong(metadata.getPrimaryTerm());
-        indexOutput.writeLong(metadata.getGeneration());
-        indexOutput.writeLong(metadata.getMinTranslogGeneration());
-        Map<String, String> generationToPrimaryTermMapper = metadata.getGenerationToPrimaryTermMapper();
-        indexOutput.writeMapOfStrings(generationToPrimaryTermMapper);
-        indexOutput.close();
-
+        try (OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput("dummy bytes", "dummy stream", output, 4096)) {
+            indexOutput.writeLong(metadata.getPrimaryTerm());
+            indexOutput.writeLong(metadata.getGeneration());
+            indexOutput.writeLong(metadata.getMinTranslogGeneration());
+            indexOutput.writeMapOfStrings(metadata.getGenerationToPrimaryTermMapper());
+            if (metadata.getGenerationToChecksumMapper() != null) indexOutput.writeMapOfStrings(metadata.getGenerationToChecksumMapper());
+        }
         return BytesReference.toBytes(output.bytes());
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Presently, the download workflow for remote backed storage works in a manner that causes the download of the same translog files multiple times, each time deleting all the older files before downloading them again. This causes significant wasted network bandwidth, along with the time taken for the shard to become active.

This change adds support for downloading the translog files incrementally and omitting the same if they are present locally. 

### Implementation
The key changes include-
#### Incremental Download Logic in RemoteFsTranslog:

- The download logic now checks if the local translog files are present and have the same checksum as the remote files.
    - If the local and remote checksums match, the download is skipped for that generation.
    - If the checksums do not match, the download is performed for that generation.

#### Translog Footer Handling:
- The TranslogFooter class has been added to handle the writing and reading of the translog footer, which contains the checksum of the translog data.
- The footer is written when the TranslogWriter is closed, and the checksum is stored in the TranslogReader.
- The TranslogReader is updated to handle reading the footer and ensuring that read requests do not overlap with the footer.

#### Generation-to-Checksum Mapping in TranslogTransferMetadata:
- The TranslogTransferMetadata now includes a mapping between the translog generation and the corresponding checksum.
- This mapping is used to compare the local and remote checksums during the incremental download process.
- The TranslogTransferMetadataHandler is updated to read and write this generation-to-checksum mapping.

### Testing

#### Manual Testing
Manually tested failover and restore workflow on a 3-node EC2 cluster.
Also, tested backward compatibility wherein initial cluster was created and indexed with older OpenSearch process. It was then switched to incremental download.

#### Newly added tests

- The `RemoteFsTranslogTests` class has been updated to include new test cases for the incremental download logic:
    - `testIncrementalDownloadWithMatchingChecksum` tests the scenario where the local and remote translog files have the same checksum, and the download is skipped.
    - `testIncrementalDownloadWithDifferentChecksum` tests the scenario where the local and remote translog files have different checksums, and only the missing generation is downloaded.
- The `TranslogFooterTests` class has been added to verify the functionality of the `TranslogFooter` class, including writing and reading the footer.
- The `TranslogTransferMetadataHandlerTests` class has been updated to include test cases for handling the generation-to-checksum map in the `TranslogTransferMetadata`.



### Related Issues
<!-- List any other related issues here -->
One of the optimisations for https://github.com/opensearch-project/OpenSearch/issues/15277

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
