### PR TITLE
Implementing pagination for _cat/indices API (#14718)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [S3 Repository] Change default retry mechanism of s3 clients to Standard Mode ([#15978](https://github.com/opensearch-project/OpenSearch/pull/15978))
 - Add new metric REMOTE_STORE to NodeStats API response ([#15611](https://github.com/opensearch-project/OpenSearch/pull/15611))
 - New `phone` & `phone-search` analyzer + tokenizer ([#15915](https://github.com/opensearch-project/OpenSearch/pull/15915))
+- Add _list/indices API as paginated alternate to _cat/indices ([#14718](https://github.com/opensearch-project/OpenSearch/pull/14718))
 
 ### Dependencies
 - Bump `org.apache.logging.log4j:log4j-core` from 2.23.1 to 2.24.0 ([#15858](https://github.com/opensearch-project/OpenSearch/pull/15858))

--- a/server/src/main/java/org/opensearch/action/ActionModule.java
+++ b/server/src/main/java/org/opensearch/action/ActionModule.java
@@ -454,6 +454,9 @@ import org.opensearch.rest.action.ingest.RestDeletePipelineAction;
 import org.opensearch.rest.action.ingest.RestGetPipelineAction;
 import org.opensearch.rest.action.ingest.RestPutPipelineAction;
 import org.opensearch.rest.action.ingest.RestSimulatePipelineAction;
+import org.opensearch.rest.action.list.AbstractListAction;
+import org.opensearch.rest.action.list.RestIndicesListAction;
+import org.opensearch.rest.action.list.RestListAction;
 import org.opensearch.rest.action.search.RestClearScrollAction;
 import org.opensearch.rest.action.search.RestCountAction;
 import org.opensearch.rest.action.search.RestCreatePitAction;
@@ -787,9 +790,14 @@ public class ActionModule extends AbstractModule {
 
     public void initRestHandlers(Supplier<DiscoveryNodes> nodesInCluster) {
         List<AbstractCatAction> catActions = new ArrayList<>();
+        List<AbstractListAction> listActions = new ArrayList<>();
         Consumer<RestHandler> registerHandler = handler -> {
             if (handler instanceof AbstractCatAction) {
-                catActions.add((AbstractCatAction) handler);
+                if (handler instanceof AbstractListAction && ((AbstractListAction) handler).isActionPaginated()) {
+                    listActions.add((AbstractListAction) handler);
+                } else {
+                    catActions.add((AbstractCatAction) handler);
+                }
             }
             restController.registerHandler(handler);
         };
@@ -957,6 +965,9 @@ public class ActionModule extends AbstractModule {
         }
         registerHandler.accept(new RestTemplatesAction());
 
+        // LIST API
+        registerHandler.accept(new RestIndicesListAction());
+
         // Point in time API
         registerHandler.accept(new RestCreatePitAction());
         registerHandler.accept(new RestDeletePitAction());
@@ -988,6 +999,7 @@ public class ActionModule extends AbstractModule {
             }
         }
         registerHandler.accept(new RestCatAction(catActions));
+        registerHandler.accept(new RestListAction(listActions));
         registerHandler.accept(new RestDecommissionAction());
         registerHandler.accept(new RestGetDecommissionStateAction());
         registerHandler.accept(new RestRemoteStoreStatsAction());

--- a/server/src/main/java/org/opensearch/common/Table.java
+++ b/server/src/main/java/org/opensearch/common/Table.java
@@ -34,6 +34,7 @@ package org.opensearch.common;
 
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.core.common.Strings;
+import org.opensearch.rest.pagination.PageToken;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -59,8 +60,18 @@ public class Table {
     private List<Cell> currentCells;
     private boolean inHeaders = false;
     private boolean withTime = false;
+    /**
+     * paginatedQueryResponse if null will imply the Table response is not paginated.
+     */
+    private PageToken pageToken;
     public static final String EPOCH = "epoch";
     public static final String TIMESTAMP = "timestamp";
+
+    public Table() {}
+
+    public Table(@Nullable PageToken pageToken) {
+        this.pageToken = pageToken;
+    }
 
     public Table startHeaders() {
         inHeaders = true;
@@ -228,6 +239,10 @@ public class Table {
             headerAliasMap.put(headerName, headerName);
         }
         return headerAliasMap;
+    }
+
+    public PageToken getPageToken() {
+        return pageToken;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -125,6 +125,13 @@ public interface RestHandler {
         return false;
     }
 
+    /**
+     * Denotes whether the RestHandler will output paginated responses or not.
+     */
+    default boolean isActionPaginated() {
+        return false;
+    }
+
     static RestHandler wrapper(RestHandler delegate) {
         return new Wrapper(delegate);
     }

--- a/server/src/main/java/org/opensearch/rest/RestHandler.java
+++ b/server/src/main/java/org/opensearch/rest/RestHandler.java
@@ -194,6 +194,11 @@ public interface RestHandler {
         }
 
         @Override
+        public boolean isActionPaginated() {
+            return delegate.isActionPaginated();
+        }
+
+        @Override
         public boolean supportsStreaming() {
             return delegate.supportsStreaming();
         }

--- a/server/src/main/java/org/opensearch/rest/RestRequest.java
+++ b/server/src/main/java/org/opensearch/rest/RestRequest.java
@@ -51,6 +51,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.http.HttpChannel;
 import org.opensearch.http.HttpRequest;
+import org.opensearch.rest.pagination.PageParams;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -67,6 +68,9 @@ import java.util.stream.Collectors;
 
 import static org.opensearch.common.unit.TimeValue.parseTimeValue;
 import static org.opensearch.core.common.unit.ByteSizeValue.parseBytesSizeValue;
+import static org.opensearch.rest.pagination.PageParams.PARAM_NEXT_TOKEN;
+import static org.opensearch.rest.pagination.PageParams.PARAM_SIZE;
+import static org.opensearch.rest.pagination.PageParams.PARAM_SORT;
 
 /**
  * REST Request
@@ -589,6 +593,10 @@ public class RestRequest implements ToXContent.Params {
             }
         }
         throw new IllegalArgumentException("empty Content-Type header");
+    }
+
+    public PageParams parsePaginatedQueryParams(String defaultSortOrder, int defaultPageSize) {
+        return new PageParams(param(PARAM_NEXT_TOKEN), param(PARAM_SORT, defaultSortOrder), paramAsInt(PARAM_SIZE, defaultPageSize));
     }
 
     /**

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
@@ -50,6 +50,7 @@ import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.health.ClusterIndexHealth;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Table;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.unit.TimeValue;
@@ -60,6 +61,9 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestResponse;
 import org.opensearch.rest.action.RestResponseListener;
+import org.opensearch.rest.action.list.AbstractListAction;
+import org.opensearch.rest.pagination.IndexPaginationStrategy;
+import org.opensearch.rest.pagination.PageToken;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -67,9 +71,11 @@ import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Spliterators;
 import java.util.function.Function;
@@ -86,7 +92,7 @@ import static org.opensearch.rest.RestRequest.Method.GET;
  *
  * @opensearch.api
  */
-public class RestIndicesAction extends AbstractCatAction {
+public class RestIndicesAction extends AbstractListAction {
 
     private static final DateFormatter STRICT_DATE_TIME_FORMATTER = DateFormatter.forPattern("strict_date_time");
 
@@ -144,48 +150,70 @@ public class RestIndicesAction extends AbstractCatAction {
                 new ActionListener<GetSettingsResponse>() {
                     @Override
                     public void onResponse(final GetSettingsResponse getSettingsResponse) {
-                        final GroupedActionListener<ActionResponse> groupedListener = createGroupedListener(request, 4, listener);
-                        groupedListener.onResponse(getSettingsResponse);
-
                         // The list of indices that will be returned is determined by the indices returned from the Get Settings call.
                         // All the other requests just provide additional detail, and wildcards may be resolved differently depending on the
                         // type of request in the presence of security plugins (looking at you, ClusterHealthRequest), so
                         // force the IndicesOptions for all the sub-requests to be as inclusive as possible.
                         final IndicesOptions subRequestIndicesOptions = IndicesOptions.lenientExpandHidden();
 
-                        // Indices that were successfully resolved during the get settings request might be deleted when the subsequent
-                        // cluster
-                        // state, cluster health and indices stats requests execute. We have to distinguish two cases:
-                        // 1) the deleted index was explicitly passed as parameter to the /_cat/indices request. In this case we want the
-                        // subsequent requests to fail.
-                        // 2) the deleted index was resolved as part of a wildcard or _all. In this case, we want the subsequent requests
-                        // not to
-                        // fail on the deleted index (as we want to ignore wildcards that cannot be resolved).
-                        // This behavior can be ensured by letting the cluster state, cluster health and indices stats requests re-resolve
-                        // the
-                        // index names with the same indices options that we used for the initial cluster state request (strictExpand).
-                        sendIndicesStatsRequest(
-                            indices,
-                            subRequestIndicesOptions,
-                            includeUnloadedSegments,
-                            client,
-                            ActionListener.wrap(groupedListener::onResponse, groupedListener::onFailure)
-                        );
+                        // Indices that were successfully resolved during the get settings request might be deleted when the
+                        // subsequent cluster state, cluster health and indices stats requests execute. We have to distinguish two cases:
+                        // 1) the deleted index was explicitly passed as parameter to the /_cat/indices request. In this case we
+                        // want the subsequent requests to fail.
+                        // 2) the deleted index was resolved as part of a wildcard or _all. In this case, we want the subsequent
+                        // requests not to fail on the deleted index (as we want to ignore wildcards that cannot be resolved).
+                        // This behavior can be ensured by letting the cluster state, cluster health and indices stats requests
+                        // re-resolve the index names with the same indices options that we used for the initial cluster state
+                        // request (strictExpand).
                         sendClusterStateRequest(
                             indices,
                             subRequestIndicesOptions,
                             local,
                             clusterManagerNodeTimeout,
                             client,
-                            ActionListener.wrap(groupedListener::onResponse, groupedListener::onFailure)
-                        );
-                        sendClusterHealthRequest(
-                            indices,
-                            subRequestIndicesOptions,
-                            local,
-                            clusterManagerNodeTimeout,
-                            client,
-                            ActionListener.wrap(groupedListener::onResponse, groupedListener::onFailure)
+                            new ActionListener<ClusterStateResponse>() {
+                                @Override
+                                public void onResponse(ClusterStateResponse clusterStateResponse) {
+                                    IndexPaginationStrategy paginationStrategy = getPaginationStrategy(clusterStateResponse);
+                                    // For non-paginated queries, indicesToBeQueried would be same as indices retrieved from
+                                    // rest request and unresolved, while for paginated queries, it would be a list of indices
+                                    // already resolved by ClusterStateRequest and to be displayed in a page.
+                                    final String[] indicesToBeQueried = Objects.isNull(paginationStrategy)
+                                        ? indices
+                                        : paginationStrategy.getRequestedEntities().toArray(new String[0]);
+                                    final GroupedActionListener<ActionResponse> groupedListener = createGroupedListener(
+                                        request,
+                                        4,
+                                        listener,
+                                        indicesToBeQueried,
+                                        Objects.isNull(paginationStrategy) ? null : paginationStrategy.getResponseToken()
+                                    );
+                                    groupedListener.onResponse(getSettingsResponse);
+                                    groupedListener.onResponse(clusterStateResponse);
+
+                                    sendIndicesStatsRequest(
+                                        indicesToBeQueried,
+                                        subRequestIndicesOptions,
+                                        includeUnloadedSegments,
+                                        client,
+                                        ActionListener.wrap(groupedListener::onResponse, groupedListener::onFailure)
+                                    );
+
+                                    sendClusterHealthRequest(
+                                        indicesToBeQueried,
+                                        subRequestIndicesOptions,
+                                        local,
+                                        clusterManagerNodeTimeout,
+                                        client,
+                                        ActionListener.wrap(groupedListener::onResponse, groupedListener::onFailure)
+                                    );
+                                }
+
+                                @Override
+                                public void onFailure(Exception e) {
+                                    listener.onFailure(e);
+                                }
+                            }
                         );
                     }
 
@@ -196,6 +224,7 @@ public class RestIndicesAction extends AbstractCatAction {
                 }
             );
         };
+
     }
 
     /**
@@ -280,7 +309,9 @@ public class RestIndicesAction extends AbstractCatAction {
     private GroupedActionListener<ActionResponse> createGroupedListener(
         final RestRequest request,
         final int size,
-        final ActionListener<Table> listener
+        final ActionListener<Table> listener,
+        final String[] indicesToBeQueried,
+        final PageToken pageToken
     ) {
         return new GroupedActionListener<>(new ActionListener<Collection<ActionResponse>>() {
             @Override
@@ -304,7 +335,15 @@ public class RestIndicesAction extends AbstractCatAction {
                     IndicesStatsResponse statsResponse = extractResponse(responses, IndicesStatsResponse.class);
                     Map<String, IndexStats> indicesStats = statsResponse.getIndices();
 
-                    Table responseTable = buildTable(request, indicesSettings, indicesHealths, indicesStats, indicesStates);
+                    Table responseTable = buildTable(
+                        request,
+                        indicesSettings,
+                        indicesHealths,
+                        indicesStats,
+                        indicesStates,
+                        getTableIterator(indicesToBeQueried, indicesSettings),
+                        pageToken
+                    );
                     listener.onResponse(responseTable);
                 } catch (Exception e) {
                     onFailure(e);
@@ -333,7 +372,11 @@ public class RestIndicesAction extends AbstractCatAction {
 
     @Override
     protected Table getTableWithHeader(final RestRequest request) {
-        Table table = new Table();
+        return getTableWithHeader(request, null);
+    }
+
+    protected Table getTableWithHeader(final RestRequest request, final PageToken pageToken) {
+        Table table = new Table(pageToken);
         table.startHeaders();
         table.addCell("health", "alias:h;desc:current health status");
         table.addCell("status", "alias:s;desc:open/close status");
@@ -697,22 +740,27 @@ public class RestIndicesAction extends AbstractCatAction {
     }
 
     // package private for testing
-    Table buildTable(
+    protected Table buildTable(
         final RestRequest request,
         final Map<String, Settings> indicesSettings,
         final Map<String, ClusterIndexHealth> indicesHealths,
         final Map<String, IndexStats> indicesStats,
-        final Map<String, IndexMetadata> indicesMetadatas
+        final Map<String, IndexMetadata> indicesMetadatas,
+        final Iterator<Tuple<String, Settings>> tableIterator,
+        final PageToken pageToken
     ) {
-
         final String healthParam = request.param("health");
-        final Table table = getTableWithHeader(request);
+        final Table table = getTableWithHeader(request, pageToken);
 
-        indicesSettings.forEach((indexName, settings) -> {
+        while (tableIterator.hasNext()) {
+            final Tuple<String, Settings> tuple = tableIterator.next();
+            String indexName = tuple.v1();
+            Settings settings = tuple.v2();
+
             if (indicesMetadatas.containsKey(indexName) == false) {
                 // the index exists in the Get Indices response but is not present in the cluster state:
                 // it is likely that the index was deleted in the meanwhile, so we ignore it.
-                return;
+                continue;
             }
 
             final IndexMetadata indexMetadata = indicesMetadatas.get(indexName);
@@ -741,7 +789,7 @@ public class RestIndicesAction extends AbstractCatAction {
                     skip = ClusterHealthStatus.RED != healthStatusFilter;
                 }
                 if (skip) {
-                    return;
+                    continue;
                 }
             }
 
@@ -975,7 +1023,8 @@ public class RestIndicesAction extends AbstractCatAction {
             table.addCell(searchThrottled);
 
             table.endRow();
-        });
+
+        }
 
         return table;
     }
@@ -984,4 +1033,34 @@ public class RestIndicesAction extends AbstractCatAction {
     private static <A extends ActionResponse> A extractResponse(final Collection<? extends ActionResponse> responses, Class<A> c) {
         return (A) responses.stream().filter(c::isInstance).findFirst().get();
     }
+
+    @Override
+    public boolean isActionPaginated() {
+        return false;
+    }
+
+    protected IndexPaginationStrategy getPaginationStrategy(ClusterStateResponse clusterStateResponse) {
+        return null;
+    }
+
+    /**
+     * Provides the iterator to be used for building the response table.
+     */
+    protected Iterator<Tuple<String, Settings>> getTableIterator(String[] indices, Map<String, Settings> indexSettingsMap) {
+        return new Iterator<>() {
+            final Iterator<String> settingsMapIter = indexSettingsMap.keySet().iterator();
+
+            @Override
+            public boolean hasNext() {
+                return settingsMapIter.hasNext();
+            }
+
+            @Override
+            public Tuple<String, Settings> next() {
+                String index = settingsMapIter.next();
+                return new Tuple<>(index, indexSettingsMap.get(index));
+            }
+        };
+    }
+
 }

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestTable.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestTable.java
@@ -58,7 +58,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+
+import static org.opensearch.rest.pagination.PageToken.PAGINATED_RESPONSE_NEXT_TOKEN_KEY;
 
 /**
  * a REST table
@@ -87,8 +90,37 @@ public class RestTable {
         RestRequest request = channel.request();
         XContentBuilder builder = channel.newBuilder();
         List<DisplayHeader> displayHeaders = buildDisplayHeaders(table, request);
+        if (Objects.nonNull(table.getPageToken())) {
+            buildPaginatedXContentBuilder(table, request, builder, displayHeaders);
+        } else {
+            builder.startArray();
+            addRowsToXContentBuilder(table, request, builder, displayHeaders);
+            builder.endArray();
+        }
+        return new BytesRestResponse(RestStatus.OK, builder);
+    }
 
-        builder.startArray();
+    private static void buildPaginatedXContentBuilder(
+        Table table,
+        RestRequest request,
+        XContentBuilder builder,
+        List<DisplayHeader> displayHeaders
+    ) throws Exception {
+        assert Objects.nonNull(table.getPageToken().getPaginatedEntity()) : "Paginated element is required in-case of paginated responses";
+        builder.startObject();
+        builder.field(PAGINATED_RESPONSE_NEXT_TOKEN_KEY, table.getPageToken().getNextToken());
+        builder.startArray(table.getPageToken().getPaginatedEntity());
+        addRowsToXContentBuilder(table, request, builder, displayHeaders);
+        builder.endArray();
+        builder.endObject();
+    }
+
+    private static void addRowsToXContentBuilder(
+        Table table,
+        RestRequest request,
+        XContentBuilder builder,
+        List<DisplayHeader> displayHeaders
+    ) throws Exception {
         List<Integer> rowOrder = getRowOrder(table, request);
         for (Integer row : rowOrder) {
             builder.startObject();
@@ -97,8 +129,6 @@ public class RestTable {
             }
             builder.endObject();
         }
-        builder.endArray();
-        return new BytesRestResponse(RestStatus.OK, builder);
     }
 
     public static RestResponse buildTextPlainResponse(Table table, RestChannel channel) throws IOException {
@@ -134,6 +164,11 @@ public class RestTable {
                     out.append(" ");
                 }
             }
+            out.append("\n");
+        }
+        // Adding a new row for next_token, in the response if the table is paginated.
+        if (Objects.nonNull(table.getPageToken())) {
+            out.append("next_token" + " " + table.getPageToken().getNextToken());
             out.append("\n");
         }
         out.close();

--- a/server/src/main/java/org/opensearch/rest/action/list/AbstractListAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/list/AbstractListAction.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest.action.list;
+
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.cat.AbstractCatAction;
+import org.opensearch.rest.pagination.PageParams;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.opensearch.rest.pagination.PageParams.PARAM_ASC_SORT_VALUE;
+import static org.opensearch.rest.pagination.PageParams.PARAM_DESC_SORT_VALUE;
+
+/**
+ * Base Transport action class for _list API.
+ * Serves as a base class for APIs wanting to support pagination.
+ * Existing _cat APIs can refer {@link org.opensearch.rest.action.cat.RestIndicesAction}.
+ * @opensearch.api
+ */
+public abstract class AbstractListAction extends AbstractCatAction {
+
+    private static final int DEFAULT_PAGE_SIZE = 100;
+    protected PageParams pageParams;
+
+    protected abstract void documentation(StringBuilder sb);
+
+    @Override
+    public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        boolean helpWanted = request.paramAsBoolean("help", false);
+        if (helpWanted || isActionPaginated() == false) {
+            return super.prepareRequest(request, client);
+        }
+        this.pageParams = validateAndGetPageParams(request);
+        assert Objects.nonNull(pageParams) : "pageParams can not be null for paginated queries";
+        return doCatRequest(request, client);
+    }
+
+    @Override
+    public boolean isActionPaginated() {
+        return true;
+    }
+
+    /**
+     *
+     * @return Metadata that can be extracted out from the rest request. Query params supported by the action specific
+     * to pagination along with any respective validations to be added here.
+     */
+    protected PageParams validateAndGetPageParams(RestRequest restRequest) {
+        PageParams pageParams = restRequest.parsePaginatedQueryParams(defaultSort(), defaultPageSize());
+        // validating pageSize
+        if (pageParams.getSize() <= 0) {
+            throw new IllegalArgumentException("size must be greater than zero");
+        }
+        // Validating sort order
+        if (!(PARAM_ASC_SORT_VALUE.equals(pageParams.getSort()) || PARAM_DESC_SORT_VALUE.equals(pageParams.getSort()))) {
+            throw new IllegalArgumentException("value of sort can either be asc or desc");
+        }
+        return pageParams;
+    }
+
+    protected int defaultPageSize() {
+        return DEFAULT_PAGE_SIZE;
+    }
+
+    protected String defaultSort() {
+        return PARAM_ASC_SORT_VALUE;
+    }
+
+}

--- a/server/src/main/java/org/opensearch/rest/action/list/RestIndicesListAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/list/RestIndicesListAction.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest.action.list;
+
+import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.cat.RestIndicesAction;
+import org.opensearch.rest.pagination.IndexPaginationStrategy;
+import org.opensearch.rest.pagination.PageParams;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static org.opensearch.rest.RestRequest.Method.GET;
+
+/**
+ * _list API action to output indices in pages.
+ *
+ * @opensearch.api
+ */
+public class RestIndicesListAction extends RestIndicesAction {
+
+    private static final int MAX_SUPPORTED_LIST_INDICES_PAGE_SIZE = 5000;
+    private static final int DEFAULT_LIST_INDICES_PAGE_SIZE = 500;
+
+    @Override
+    public List<Route> routes() {
+        return unmodifiableList(asList(new Route(GET, "/_list/indices"), new Route(GET, "/_list/indices/{index}")));
+    }
+
+    @Override
+    public String getName() {
+        return "list_indices_action";
+    }
+
+    @Override
+    protected void documentation(StringBuilder sb) {
+        sb.append("/_list/indices\n");
+        sb.append("/_list/indices/{index}\n");
+    }
+
+    @Override
+    public boolean isActionPaginated() {
+        return true;
+    }
+
+    @Override
+    protected PageParams validateAndGetPageParams(RestRequest restRequest) {
+        PageParams pageParams = super.validateAndGetPageParams(restRequest);
+        // validate max supported pageSize
+        if (pageParams.getSize() > MAX_SUPPORTED_LIST_INDICES_PAGE_SIZE) {
+            throw new IllegalArgumentException("size should be less than [" + MAX_SUPPORTED_LIST_INDICES_PAGE_SIZE + "]");
+        }
+        // Next Token in the request will be validated by the IndexStrategyToken itself.
+        if (Objects.nonNull(pageParams.getRequestedToken())) {
+            IndexPaginationStrategy.IndexStrategyToken.validateIndexStrategyToken(pageParams.getRequestedToken());
+        }
+        return pageParams;
+    }
+
+    protected int defaultPageSize() {
+        return DEFAULT_LIST_INDICES_PAGE_SIZE;
+    }
+
+    @Override
+    protected IndexPaginationStrategy getPaginationStrategy(ClusterStateResponse clusterStateResponse) {
+        return new IndexPaginationStrategy(pageParams, clusterStateResponse.getState());
+    }
+
+    // Public for testing
+    @Override
+    public Iterator<Tuple<String, Settings>> getTableIterator(String[] indices, Map<String, Settings> indexSettingsMap) {
+        return new Iterator<>() {
+            int indexPos = 0;
+
+            @Override
+            public boolean hasNext() {
+                while (indexPos < indices.length && indexSettingsMap.containsKey(indices[indexPos]) == false) {
+                    indexPos++;
+                }
+                return indexPos < indices.length;
+            }
+
+            @Override
+            public Tuple<String, Settings> next() {
+                Tuple<String, Settings> tuple = new Tuple<>(indices[indexPos], indexSettingsMap.get(indices[indexPos]));
+                indexPos++;
+                return tuple;
+            }
+        };
+    }
+}

--- a/server/src/main/java/org/opensearch/rest/action/list/RestListAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/list/RestListAction.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest.action.list;
+
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+
+import java.io.IOException;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.opensearch.rest.RestRequest.Method.GET;
+
+/**
+ * Base _list API endpoint
+ *
+ * @opensearch.api
+ */
+public class RestListAction extends BaseRestHandler {
+
+    private static final String LIST = ":‑|";
+    private static final String LIST_NL = LIST + "\n";
+    private final String HELP;
+
+    public RestListAction(List<AbstractListAction> listActions) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(LIST_NL);
+        for (AbstractListAction listAction : listActions) {
+            listAction.documentation(sb);
+        }
+        HELP = sb.toString();
+    }
+
+    @Override
+    public List<Route> routes() {
+        return singletonList(new Route(GET, "/_list"));
+    }
+
+    @Override
+    public String getName() {
+        return "list_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.OK, HELP));
+    }
+
+}

--- a/server/src/main/java/org/opensearch/rest/action/list/package-info.java
+++ b/server/src/main/java/org/opensearch/rest/action/list/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * {@link org.opensearch.rest.RestHandler}s for actions that list out results in chunks of pages.
+ */
+package org.opensearch.rest.action.list;

--- a/server/src/main/java/org/opensearch/rest/pagination/IndexPaginationStrategy.java
+++ b/server/src/main/java/org/opensearch/rest/pagination/IndexPaginationStrategy.java
@@ -1,0 +1,185 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest.pagination;
+
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.Nullable;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static org.opensearch.rest.pagination.PageParams.PARAM_ASC_SORT_VALUE;
+
+/**
+ * This strategy can be used by the Rest APIs wanting to paginate the responses based on Indices.
+ * The strategy considers create timestamps of indices as the keys to iterate over pages.
+ *
+ * @opensearch.internal
+ */
+public class IndexPaginationStrategy implements PaginationStrategy<String> {
+    private static final String DEFAULT_INDICES_PAGINATED_ENTITY = "indices";
+
+    private static final Comparator<IndexMetadata> ASC_COMPARATOR = (metadata1, metadata2) -> {
+        if (metadata1.getCreationDate() == metadata2.getCreationDate()) {
+            return metadata1.getIndex().getName().compareTo(metadata2.getIndex().getName());
+        }
+        return Long.compare(metadata1.getCreationDate(), metadata2.getCreationDate());
+    };
+    private static final Comparator<IndexMetadata> DESC_COMPARATOR = (metadata1, metadata2) -> {
+        if (metadata1.getCreationDate() == metadata2.getCreationDate()) {
+            return metadata2.getIndex().getName().compareTo(metadata1.getIndex().getName());
+        }
+        return Long.compare(metadata2.getCreationDate(), metadata1.getCreationDate());
+    };
+
+    private final PageToken pageToken;
+    private final List<String> requestedIndices;
+
+    public IndexPaginationStrategy(PageParams pageParams, ClusterState clusterState) {
+        // Get list of indices metadata sorted by their creation time and filtered by the last sent index
+        List<IndexMetadata> sortedIndices = PaginationStrategy.getSortedIndexMetadata(
+            clusterState,
+            getMetadataFilter(pageParams.getRequestedToken(), pageParams.getSort()),
+            PARAM_ASC_SORT_VALUE.equals(pageParams.getSort()) ? ASC_COMPARATOR : DESC_COMPARATOR
+        );
+        // Trim sortedIndicesList to get the list of indices metadata to be sent as response
+        List<IndexMetadata> metadataSublist = getMetadataSubList(sortedIndices, pageParams.getSize());
+        // Get list of index names from the trimmed metadataSublist
+        this.requestedIndices = metadataSublist.stream().map(metadata -> metadata.getIndex().getName()).collect(Collectors.toList());
+        this.pageToken = getResponseToken(
+            pageParams.getSize(),
+            sortedIndices.size(),
+            metadataSublist.isEmpty() ? null : metadataSublist.get(metadataSublist.size() - 1)
+        );
+    }
+
+    private static Predicate<IndexMetadata> getMetadataFilter(String requestedTokenStr, String sortOrder) {
+        boolean isAscendingSort = sortOrder.equals(PARAM_ASC_SORT_VALUE);
+        IndexStrategyToken requestedToken = Objects.isNull(requestedTokenStr) || requestedTokenStr.isEmpty()
+            ? null
+            : new IndexStrategyToken(requestedTokenStr);
+        if (Objects.isNull(requestedToken)) {
+            return indexMetadata -> true;
+        }
+        return metadata -> {
+            if (metadata.getIndex().getName().equals(requestedToken.lastIndexName)) {
+                return false;
+            } else if (metadata.getCreationDate() == requestedToken.lastIndexCreationTime) {
+                return isAscendingSort
+                    ? metadata.getIndex().getName().compareTo(requestedToken.lastIndexName) > 0
+                    : metadata.getIndex().getName().compareTo(requestedToken.lastIndexName) < 0;
+            }
+            return isAscendingSort
+                ? metadata.getCreationDate() > requestedToken.lastIndexCreationTime
+                : metadata.getCreationDate() < requestedToken.lastIndexCreationTime;
+        };
+    }
+
+    private List<IndexMetadata> getMetadataSubList(List<IndexMetadata> sortedIndices, final int pageSize) {
+        if (sortedIndices.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return sortedIndices.subList(0, Math.min(pageSize, sortedIndices.size()));
+    }
+
+    private PageToken getResponseToken(final int pageSize, final int totalIndices, IndexMetadata lastIndex) {
+        if (totalIndices <= pageSize) {
+            return new PageToken(null, DEFAULT_INDICES_PAGINATED_ENTITY);
+        }
+        return new PageToken(
+            new IndexStrategyToken(lastIndex.getCreationDate(), lastIndex.getIndex().getName()).generateEncryptedToken(),
+            DEFAULT_INDICES_PAGINATED_ENTITY
+        );
+    }
+
+    @Override
+    @Nullable
+    public PageToken getResponseToken() {
+        return pageToken;
+    }
+
+    @Override
+    public List<String> getRequestedEntities() {
+        return Objects.isNull(requestedIndices) ? new ArrayList<>() : requestedIndices;
+    }
+
+    /**
+     * TokenParser to be used by {@link IndexPaginationStrategy}.
+     * Token would look like: CreationTimeOfLastRespondedIndex + | + NameOfLastRespondedIndex
+     */
+    public static class IndexStrategyToken {
+
+        private static final String JOIN_DELIMITER = "|";
+        private static final String SPLIT_REGEX = "\\|";
+        private static final int CREATE_TIME_POS_IN_TOKEN = 0;
+        private static final int INDEX_NAME_POS_IN_TOKEN = 1;
+
+        /**
+         * Represents creation times of last index which was displayed in the page.
+         * Used to identify the new start point in case the indices get created/deleted while queries are executed.
+         */
+        private final long lastIndexCreationTime;
+
+        /**
+         * Represents name of the last index which was displayed in the page.
+         * Used to identify whether the sorted list of indices has changed or not.
+         */
+        private final String lastIndexName;
+
+        public IndexStrategyToken(String requestedTokenString) {
+            // TODO: Avoid validating the requested token multiple times while calling from Rest and/or Transport layer.
+            validateIndexStrategyToken(requestedTokenString);
+            String decryptedToken = PaginationStrategy.decryptStringToken(requestedTokenString);
+            final String[] decryptedTokenElements = decryptedToken.split(SPLIT_REGEX);
+            this.lastIndexCreationTime = Long.parseLong(decryptedTokenElements[CREATE_TIME_POS_IN_TOKEN]);
+            this.lastIndexName = decryptedTokenElements[INDEX_NAME_POS_IN_TOKEN];
+        }
+
+        public IndexStrategyToken(long creationTimeOfLastRespondedIndex, String nameOfLastRespondedIndex) {
+            Objects.requireNonNull(nameOfLastRespondedIndex, "index name should be provided");
+            this.lastIndexCreationTime = creationTimeOfLastRespondedIndex;
+            this.lastIndexName = nameOfLastRespondedIndex;
+        }
+
+        public String generateEncryptedToken() {
+            return PaginationStrategy.encryptStringToken(String.join(JOIN_DELIMITER, String.valueOf(lastIndexCreationTime), lastIndexName));
+        }
+
+        /**
+         * Will perform simple validations on token received in the request.
+         * Token should be base64 encoded, and should contain the expected number of elements separated by "|".
+         * Timestamps should also be a valid long.
+         *
+         * @param requestedTokenStr string denoting the encoded token requested by the user.
+         */
+        public static void validateIndexStrategyToken(String requestedTokenStr) {
+            Objects.requireNonNull(requestedTokenStr, "requestedTokenString can not be null");
+            String decryptedToken = PaginationStrategy.decryptStringToken(requestedTokenStr);
+            final String[] decryptedTokenElements = decryptedToken.split(SPLIT_REGEX);
+            if (decryptedTokenElements.length != 2) {
+                throw new OpenSearchParseException(INCORRECT_TAINTED_NEXT_TOKEN_ERROR_MESSAGE);
+            }
+            try {
+                long creationTimeOfLastRespondedIndex = Long.parseLong(decryptedTokenElements[CREATE_TIME_POS_IN_TOKEN]);
+                if (creationTimeOfLastRespondedIndex <= 0) {
+                    throw new OpenSearchParseException(INCORRECT_TAINTED_NEXT_TOKEN_ERROR_MESSAGE);
+                }
+            } catch (NumberFormatException exception) {
+                throw new OpenSearchParseException(INCORRECT_TAINTED_NEXT_TOKEN_ERROR_MESSAGE);
+            }
+        }
+    }
+
+}

--- a/server/src/main/java/org/opensearch/rest/pagination/PageParams.java
+++ b/server/src/main/java/org/opensearch/rest/pagination/PageParams.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest.pagination;
+
+import org.opensearch.common.annotation.PublicApi;
+
+/**
+ *
+ * Class specific to paginated queries, which will contain common query params required by a paginated API.
+ */
+@PublicApi(since = "3.0.0")
+public class PageParams {
+
+    public static final String PARAM_SORT = "sort";
+    public static final String PARAM_NEXT_TOKEN = "next_token";
+    public static final String PARAM_SIZE = "size";
+    public static final String PARAM_ASC_SORT_VALUE = "asc";
+    public static final String PARAM_DESC_SORT_VALUE = "desc";
+
+    private final String requestedTokenStr;
+    private final String sort;
+    private final int size;
+
+    public PageParams(String requestedToken, String sort, int size) {
+        this.requestedTokenStr = requestedToken;
+        this.sort = sort;
+        this.size = size;
+    }
+
+    public String getSort() {
+        return sort;
+    }
+
+    public String getRequestedToken() {
+        return requestedTokenStr;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+}

--- a/server/src/main/java/org/opensearch/rest/pagination/PageToken.java
+++ b/server/src/main/java/org/opensearch/rest/pagination/PageToken.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest.pagination;
+
+/**
+ * Pagination response metadata for a paginated query.
+ * @opensearch.internal
+ */
+public class PageToken {
+
+    public static final String PAGINATED_RESPONSE_NEXT_TOKEN_KEY = "next_token";
+
+    /**
+     * String denoting the next_token of paginated response, which will be used to fetch next page (if any).
+     */
+    private final String nextToken;
+
+    /**
+     * String denoting the element which is being paginated (for e.g. shards, indices..).
+     */
+    private final String paginatedEntity;
+
+    public PageToken(String nextToken, String paginatedElement) {
+        assert paginatedElement != null : "paginatedElement must be specified for a paginated response";
+        this.nextToken = nextToken;
+        this.paginatedEntity = paginatedElement;
+    }
+
+    public String getNextToken() {
+        return nextToken;
+    }
+
+    public String getPaginatedEntity() {
+        return paginatedEntity;
+    }
+}

--- a/server/src/main/java/org/opensearch/rest/pagination/PaginationStrategy.java
+++ b/server/src/main/java/org/opensearch/rest/pagination/PaginationStrategy.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest.pagination;
+
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Interface to be implemented by any strategy getting used for paginating rest responses.
+ *
+ * @opensearch.internal
+ */
+public interface PaginationStrategy<T> {
+
+    String INCORRECT_TAINTED_NEXT_TOKEN_ERROR_MESSAGE =
+        "Parameter [next_token] has been tainted and is incorrect. Please provide a valid [next_token].";
+
+    /**
+     *
+     * @return Base64 encoded string, which can be used to fetch next page of response.
+     */
+    PageToken getResponseToken();
+
+    /**
+     *
+     * @return List of elements fetched corresponding to the store and token received by the strategy.
+     */
+    List<T> getRequestedEntities();
+
+    /**
+     *
+     * Utility method to get list of indices filtered as per {@param filterPredicate} and the sorted according to {@param comparator}.
+     */
+    static List<IndexMetadata> getSortedIndexMetadata(
+        final ClusterState clusterState,
+        Predicate<IndexMetadata> filterPredicate,
+        Comparator<IndexMetadata> comparator
+    ) {
+        return clusterState.metadata().indices().values().stream().filter(filterPredicate).sorted(comparator).collect(Collectors.toList());
+    }
+
+    static String encryptStringToken(String tokenString) {
+        if (Objects.isNull(tokenString)) {
+            return null;
+        }
+        return Base64.getEncoder().encodeToString(tokenString.getBytes(UTF_8));
+    }
+
+    static String decryptStringToken(String encTokenString) {
+        if (Objects.isNull(encTokenString)) {
+            return null;
+        }
+        try {
+            return new String(Base64.getDecoder().decode(encTokenString), UTF_8);
+        } catch (IllegalArgumentException exception) {
+            throw new OpenSearchParseException(INCORRECT_TAINTED_NEXT_TOKEN_ERROR_MESSAGE);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/rest/pagination/package-info.java
+++ b/server/src/main/java/org/opensearch/rest/pagination/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Exposes utilities for Rest actions to paginate responses.
+ */
+package org.opensearch.rest.pagination;

--- a/server/src/test/java/org/opensearch/rest/action/cat/RestIndicesActionTests.java
+++ b/server/src/test/java/org/opensearch/rest/action/cat/RestIndicesActionTests.java
@@ -47,9 +47,13 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.rest.action.list.RestIndicesListAction;
+import org.opensearch.rest.pagination.PageToken;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.rest.FakeRestRequest;
+import org.junit.Before;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -63,13 +67,14 @@ import static org.mockito.Mockito.when;
 
 public class RestIndicesActionTests extends OpenSearchTestCase {
 
-    public void testBuildTable() {
-        final int numIndices = randomIntBetween(3, 20);
-        final Map<String, Settings> indicesSettings = new LinkedHashMap<>();
-        final Map<String, IndexMetadata> indicesMetadatas = new LinkedHashMap<>();
-        final Map<String, ClusterIndexHealth> indicesHealths = new LinkedHashMap<>();
-        final Map<String, IndexStats> indicesStats = new LinkedHashMap<>();
+    final Map<String, Settings> indicesSettings = new LinkedHashMap<>();
+    final Map<String, IndexMetadata> indicesMetadatas = new LinkedHashMap<>();
+    final Map<String, ClusterIndexHealth> indicesHealths = new LinkedHashMap<>();
+    final Map<String, IndexStats> indicesStats = new LinkedHashMap<>();
 
+    @Before
+    public void setup() {
+        final int numIndices = randomIntBetween(3, 20);
         for (int i = 0; i < numIndices; i++) {
             String indexName = "index-" + i;
 
@@ -136,11 +141,59 @@ public class RestIndicesActionTests extends OpenSearchTestCase {
                 }
             }
         }
+    }
 
+    public void testBuildTable() {
         final RestIndicesAction action = new RestIndicesAction();
-        final Table table = action.buildTable(new FakeRestRequest(), indicesSettings, indicesHealths, indicesStats, indicesMetadatas);
+        final Table table = action.buildTable(
+            new FakeRestRequest(),
+            indicesSettings,
+            indicesHealths,
+            indicesStats,
+            indicesMetadatas,
+            action.getTableIterator(new String[0], indicesSettings),
+            null
+        );
 
         // now, verify the table is correct
+        assertNotNull(table);
+
+        assertTableHeaders(table);
+
+        assertThat(table.getRows().size(), equalTo(indicesMetadatas.size()));
+        assertTableRows(table);
+    }
+
+    public void testBuildPaginatedTable() {
+        final RestIndicesAction action = new RestIndicesAction();
+        final RestIndicesListAction indicesListAction = new RestIndicesListAction();
+        List<String> indicesList = new ArrayList<>(indicesMetadatas.keySet());
+        // Using half of the indices from metadata list for a page
+        String[] indicesToBeQueried = indicesList.subList(0, indicesMetadatas.size() / 2).toArray(new String[0]);
+        PageToken pageToken = new PageToken("foo", "indices");
+        final Table table = action.buildTable(
+            new FakeRestRequest(),
+            indicesSettings,
+            indicesHealths,
+            indicesStats,
+            indicesMetadatas,
+            indicesListAction.getTableIterator(indicesToBeQueried, indicesSettings),
+            pageToken
+        );
+
+        // verifying table
+        assertNotNull(table);
+        assertTableHeaders(table);
+        assertNotNull(table.getPageToken());
+        assertEquals(pageToken.getNextToken(), table.getPageToken().getNextToken());
+        assertEquals(pageToken.getPaginatedEntity(), table.getPageToken().getPaginatedEntity());
+
+        // Table should only contain the indices present in indicesToBeQueried
+        assertThat(table.getRows().size(), equalTo(indicesMetadatas.size() / 2));
+        assertTableRows(table);
+    }
+
+    private void assertTableHeaders(Table table) {
         List<Table.Cell> headers = table.getHeaders();
         assertThat(headers.get(0).value, equalTo("health"));
         assertThat(headers.get(1).value, equalTo("status"));
@@ -148,9 +201,10 @@ public class RestIndicesActionTests extends OpenSearchTestCase {
         assertThat(headers.get(3).value, equalTo("uuid"));
         assertThat(headers.get(4).value, equalTo("pri"));
         assertThat(headers.get(5).value, equalTo("rep"));
+    }
 
+    private void assertTableRows(Table table) {
         final List<List<Table.Cell>> rows = table.getRows();
-        assertThat(rows.size(), equalTo(indicesMetadatas.size()));
 
         for (final List<Table.Cell> row : rows) {
             final String indexName = (String) row.get(2).value;

--- a/server/src/test/java/org/opensearch/rest/action/cat/RestTableTests.java
+++ b/server/src/test/java/org/opensearch/rest/action/cat/RestTableTests.java
@@ -37,6 +37,7 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.rest.AbstractRestChannel;
 import org.opensearch.rest.RestResponse;
+import org.opensearch.rest.pagination.PageToken;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.rest.FakeRestRequest;
 import org.junit.Before;
@@ -64,10 +65,26 @@ public class RestTableTests extends OpenSearchTestCase {
     private static final String ACCEPT = "Accept";
     private static final String TEXT_PLAIN = "text/plain; charset=UTF-8";
     private static final String TEXT_TABLE_BODY = "foo foo foo foo foo foo foo foo\n";
+    private static final String PAGINATED_TEXT_TABLE_BODY = "foo foo foo foo foo foo foo foo\nnext_token foo\n";
     private static final String JSON_TABLE_BODY = "[{\"bulk.foo\":\"foo\",\"bulk.bar\":\"foo\",\"aliasedBulk\":\"foo\","
         + "\"aliasedSecondBulk\":\"foo\",\"unmatched\":\"foo\","
         + "\"invalidAliasesBulk\":\"foo\",\"timestamp\":\"foo\",\"epoch\":\"foo\"}]";
+    private static final String PAGINATED_JSON_TABLE_BODY =
+        "{\"next_token\":\"foo\",\"entities\":[{\"bulk.foo\":\"foo\",\"bulk.bar\":\"foo\",\"aliasedBulk\":\"foo\","
+            + "\"aliasedSecondBulk\":\"foo\",\"unmatched\":\"foo\","
+            + "\"invalidAliasesBulk\":\"foo\",\"timestamp\":\"foo\",\"epoch\":\"foo\"}]}";
     private static final String YAML_TABLE_BODY = "---\n"
+        + "- bulk.foo: \"foo\"\n"
+        + "  bulk.bar: \"foo\"\n"
+        + "  aliasedBulk: \"foo\"\n"
+        + "  aliasedSecondBulk: \"foo\"\n"
+        + "  unmatched: \"foo\"\n"
+        + "  invalidAliasesBulk: \"foo\"\n"
+        + "  timestamp: \"foo\"\n"
+        + "  epoch: \"foo\"\n";
+    private static final String PAGINATED_YAML_TABLE_BODY = "---\n"
+        + "next_token: \"foo\"\n"
+        + "entities:\n"
         + "- bulk.foo: \"foo\"\n"
         + "  bulk.bar: \"foo\"\n"
         + "  aliasedBulk: \"foo\"\n"
@@ -83,20 +100,7 @@ public class RestTableTests extends OpenSearchTestCase {
     public void setup() {
         restRequest = new FakeRestRequest();
         table = new Table();
-        table.startHeaders();
-        table.addCell("bulk.foo", "alias:f;desc:foo");
-        table.addCell("bulk.bar", "alias:b;desc:bar");
-        // should be matched as well due to the aliases
-        table.addCell("aliasedBulk", "alias:bulkWhatever;desc:bar");
-        table.addCell("aliasedSecondBulk", "alias:foobar,bulkolicious,bulkotastic;desc:bar");
-        // no match
-        table.addCell("unmatched", "alias:un.matched;desc:bar");
-        // invalid alias
-        table.addCell("invalidAliasesBulk", "alias:,,,;desc:bar");
-        // timestamp
-        table.addCell("timestamp", "alias:ts");
-        table.addCell("epoch", "alias:t");
-        table.endHeaders();
+        addHeaders(table);
     }
 
     public void testThatDisplayHeadersSupportWildcards() throws Exception {
@@ -121,8 +125,26 @@ public class RestTableTests extends OpenSearchTestCase {
         assertResponse(Collections.singletonMap(ACCEPT, Collections.singletonList(APPLICATION_JSON)), APPLICATION_JSON, JSON_TABLE_BODY);
     }
 
+    public void testThatWeUseTheAcceptHeaderJsonForPaginatedTable() throws Exception {
+        assertResponse(
+            Collections.singletonMap(ACCEPT, Collections.singletonList(APPLICATION_JSON)),
+            APPLICATION_JSON,
+            PAGINATED_JSON_TABLE_BODY,
+            getPaginatedTable()
+        );
+    }
+
     public void testThatWeUseTheAcceptHeaderYaml() throws Exception {
         assertResponse(Collections.singletonMap(ACCEPT, Collections.singletonList(APPLICATION_YAML)), APPLICATION_YAML, YAML_TABLE_BODY);
+    }
+
+    public void testThatWeUseTheAcceptHeaderYamlForPaginatedTable() throws Exception {
+        assertResponse(
+            Collections.singletonMap(ACCEPT, Collections.singletonList(APPLICATION_YAML)),
+            APPLICATION_YAML,
+            PAGINATED_YAML_TABLE_BODY,
+            getPaginatedTable()
+        );
     }
 
     public void testThatWeUseTheAcceptHeaderSmile() throws Exception {
@@ -135,6 +157,15 @@ public class RestTableTests extends OpenSearchTestCase {
 
     public void testThatWeUseTheAcceptHeaderText() throws Exception {
         assertResponse(Collections.singletonMap(ACCEPT, Collections.singletonList(TEXT_PLAIN)), TEXT_PLAIN, TEXT_TABLE_BODY);
+    }
+
+    public void testThatWeUseTheAcceptHeaderTextForPaginatedTable() throws Exception {
+        assertResponse(
+            Collections.singletonMap(ACCEPT, Collections.singletonList(TEXT_PLAIN)),
+            TEXT_PLAIN,
+            PAGINATED_TEXT_TABLE_BODY,
+            getPaginatedTable()
+        );
     }
 
     public void testIgnoreContentType() throws Exception {
@@ -261,6 +292,10 @@ public class RestTableTests extends OpenSearchTestCase {
     }
 
     private RestResponse assertResponseContentType(Map<String, List<String>> headers, String mediaType) throws Exception {
+        return assertResponseContentType(headers, mediaType, table);
+    }
+
+    private RestResponse assertResponseContentType(Map<String, List<String>> headers, String mediaType, Table table) throws Exception {
         FakeRestRequest requestWithAcceptHeader = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(headers).build();
         table.startRow();
         table.addCell("foo");
@@ -282,7 +317,11 @@ public class RestTableTests extends OpenSearchTestCase {
     }
 
     private void assertResponse(Map<String, List<String>> headers, String mediaType, String body) throws Exception {
-        RestResponse response = assertResponseContentType(headers, mediaType);
+        assertResponse(headers, mediaType, body, table);
+    }
+
+    private void assertResponse(Map<String, List<String>> headers, String mediaType, String body, Table table) throws Exception {
+        RestResponse response = assertResponseContentType(headers, mediaType, table);
         assertThat(response.content().utf8ToString(), equalTo(body));
     }
 
@@ -293,5 +332,29 @@ public class RestTableTests extends OpenSearchTestCase {
         }
 
         return headerNames;
+    }
+
+    private Table getPaginatedTable() {
+        PageToken pageToken = new PageToken("foo", "entities");
+        Table paginatedTable = new Table(pageToken);
+        addHeaders(paginatedTable);
+        return paginatedTable;
+    }
+
+    private void addHeaders(Table table) {
+        table.startHeaders();
+        table.addCell("bulk.foo", "alias:f;desc:foo");
+        table.addCell("bulk.bar", "alias:b;desc:bar");
+        // should be matched as well due to the aliases
+        table.addCell("aliasedBulk", "alias:bulkWhatever;desc:bar");
+        table.addCell("aliasedSecondBulk", "alias:foobar,bulkolicious,bulkotastic;desc:bar");
+        // no match
+        table.addCell("unmatched", "alias:un.matched;desc:bar");
+        // invalid alias
+        table.addCell("invalidAliasesBulk", "alias:,,,;desc:bar");
+        // timestamp
+        table.addCell("timestamp", "alias:ts");
+        table.addCell("epoch", "alias:t");
+        table.endHeaders();
     }
 }

--- a/server/src/test/java/org/opensearch/rest/pagination/IndexPaginationStrategyTests.java
+++ b/server/src/test/java/org/opensearch/rest/pagination/IndexPaginationStrategyTests.java
@@ -1,0 +1,399 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest.pagination;
+
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.routing.IndexRoutingTable;
+import org.opensearch.cluster.routing.RoutingTable;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
+import static org.opensearch.rest.pagination.PageParams.PARAM_ASC_SORT_VALUE;
+import static org.opensearch.rest.pagination.PageParams.PARAM_DESC_SORT_VALUE;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.getRandom;
+
+public class IndexPaginationStrategyTests extends OpenSearchTestCase {
+
+    public void testRetrieveAllIndicesWithVaryingPageSize() {
+        List<Integer> indexNumberList = new ArrayList<>();
+        final int totalIndices = 100;
+        for (int indexNumber = 1; indexNumber <= 100; indexNumber++) {
+            indexNumberList.add(indexNumber);
+        }
+        // creating a cluster state with 100 indices
+        Collections.shuffle(indexNumberList, getRandom());
+        ClusterState clusterState = getRandomClusterState(indexNumberList);
+
+        // Checking pagination response for different pageSizes, which has a mix of even and odd numbers
+        // to ensure number of indices in last page is not always equal to pageSize.
+        List<Integer> pageSizeList = List.of(1, 6, 10, 13);
+        List<String> sortOrderList = List.of(PARAM_ASC_SORT_VALUE, PARAM_DESC_SORT_VALUE);
+        for (String sortOrder : sortOrderList) {
+            for (int pageSize : pageSizeList) {
+                String requestedToken = null;
+                int totalPagesToFetch = (int) Math.ceil(totalIndices / (pageSize * 1.0));
+                int indicesRemaining = totalIndices;
+                for (int pageNumber = 1; pageNumber <= totalPagesToFetch; pageNumber++) {
+                    PageParams pageParams = new PageParams(requestedToken, sortOrder, pageSize);
+                    IndexPaginationStrategy paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+                    if (pageNumber < totalPagesToFetch) {
+                        assertNotNull(paginationStrategy.getResponseToken().getNextToken());
+                    } else {
+                        assertNull(paginationStrategy.getResponseToken().getNextToken());
+                    }
+                    requestedToken = paginationStrategy.getResponseToken().getNextToken();
+                    // Asserting all the indices received
+                    int responseItr = 0;
+                    if (PARAM_ASC_SORT_VALUE.equals(sortOrder)) {
+                        for (int indexNumber = (pageNumber - 1) * pageSize; indexNumber < Math.min(
+                            100,
+                            pageNumber * pageSize
+                        ); indexNumber++) {
+                            assertEquals("test-index-" + (indexNumber + 1), paginationStrategy.getRequestedEntities().get(responseItr));
+                            responseItr++;
+                        }
+                    } else {
+                        int endIndexNumberForPage = Math.max(indicesRemaining - pageSize, 0);
+                        for (; indicesRemaining > endIndexNumberForPage; indicesRemaining--) {
+                            assertEquals("test-index-" + indicesRemaining, paginationStrategy.getRequestedEntities().get(responseItr));
+                            responseItr++;
+                        }
+                    }
+                    assertEquals(responseItr, paginationStrategy.getRequestedEntities().size());
+                }
+            }
+        }
+    }
+
+    public void testRetrieveAllIndicesInAscOrderWhileIndicesGetCreatedAndDeleted() {
+        List<Integer> indexNumberList = new ArrayList<>();
+        List<Integer> deletedIndices = new ArrayList<>();
+        final int totalIndices = 100;
+        final int numIndicesToDelete = 10;
+        final int numIndicesToCreate = 5;
+        List<String> indicesFetched = new ArrayList<>();
+        for (int indexNumber = 1; indexNumber <= 100; indexNumber++) {
+            indexNumberList.add(indexNumber);
+        }
+        ClusterState clusterState = getRandomClusterState(indexNumberList);
+
+        int pageSize = 6;
+        String requestedToken = null;
+        int numPages = 0;
+        do {
+            numPages++;
+            PageParams pageParams = new PageParams(requestedToken, PARAM_ASC_SORT_VALUE, pageSize);
+            IndexPaginationStrategy paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+            assertNotNull(paginationStrategy);
+            assertNotNull(paginationStrategy.getResponseToken());
+            requestedToken = paginationStrategy.getResponseToken().getNextToken();
+            // randomly deleting 10 indices after 3rd call
+            if (numPages == 3) {
+                deletedIndices = indexNumberList.subList(20, indexNumberList.size());
+                Collections.shuffle(deletedIndices, getRandom());
+                for (int pos = 0; pos < numIndicesToDelete; pos++) {
+                    clusterState = deleteIndexFromClusterState(clusterState, deletedIndices.get(pos));
+                }
+            }
+            // creating 5 indices after 5th call
+            if (numPages == 5) {
+                for (int indexNumber = totalIndices + 1; indexNumber <= totalIndices + numIndicesToCreate; indexNumber++) {
+                    clusterState = addIndexToClusterState(clusterState, indexNumber);
+                }
+            }
+            if (requestedToken == null) {
+                assertEquals(paginationStrategy.getRequestedEntities().size(), 5);
+            } else {
+                assertEquals(paginationStrategy.getRequestedEntities().size(), pageSize);
+            }
+
+            indicesFetched.addAll(paginationStrategy.getRequestedEntities());
+        } while (Objects.nonNull(requestedToken));
+
+        assertEquals((int) Math.ceil((double) (totalIndices + numIndicesToCreate - numIndicesToDelete) / pageSize), numPages);
+        assertEquals(totalIndices + numIndicesToCreate - numIndicesToDelete, indicesFetched.size());
+
+        // none of the deleted index should appear in the list of fetched indices
+        for (int deletedIndexPos = 0; deletedIndexPos < numIndicesToDelete; deletedIndexPos++) {
+            assertFalse(indicesFetched.contains("test-index-" + deletedIndices.get(deletedIndexPos)));
+        }
+
+        // all the newly created indices should be present in the list of fetched indices
+        for (int indexNumber = totalIndices + 1; indexNumber <= totalIndices + numIndicesToCreate; indexNumber++) {
+            assertTrue(indicesFetched.contains("test-index-" + indexNumber));
+        }
+    }
+
+    public void testRetrieveAllIndicesInDescOrderWhileIndicesGetCreatedAndDeleted() {
+        List<Integer> indexNumberList = new ArrayList<>();
+        List<Integer> deletedIndices = new ArrayList<>();
+        final int totalIndices = 100;
+        final int numIndicesToDelete = 9;
+        final int numIndicesToCreate = 5;
+        List<String> indicesFetched = new ArrayList<>();
+        for (int indexNumber = 1; indexNumber <= 100; indexNumber++) {
+            indexNumberList.add(indexNumber);
+        }
+        ClusterState clusterState = getRandomClusterState(indexNumberList);
+
+        int pageSize = 6;
+        String requestedToken = null;
+        int numPages = 0;
+        do {
+            numPages++;
+            PageParams pageParams = new PageParams(requestedToken, PARAM_DESC_SORT_VALUE, pageSize);
+            IndexPaginationStrategy paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+            assertNotNull(paginationStrategy);
+            assertNotNull(paginationStrategy.getResponseToken());
+            requestedToken = paginationStrategy.getResponseToken().getNextToken();
+            // randomly deleting 10 indices after 3rd call
+            if (numPages == 3) {
+                deletedIndices = indexNumberList.subList(0, 80);
+                Collections.shuffle(deletedIndices, getRandom());
+                for (int pos = 0; pos < numIndicesToDelete; pos++) {
+                    clusterState = deleteIndexFromClusterState(clusterState, deletedIndices.get(pos));
+                }
+            }
+            // creating 5 indices after 5th call
+            if (numPages == 5) {
+                for (int indexNumber = totalIndices + 1; indexNumber <= totalIndices + numIndicesToCreate; indexNumber++) {
+                    clusterState = addIndexToClusterState(clusterState, indexNumber);
+                }
+            }
+            if (requestedToken == null) {
+                assertEquals(paginationStrategy.getRequestedEntities().size(), (totalIndices - numIndicesToDelete) % pageSize);
+            } else {
+                assertEquals(paginationStrategy.getRequestedEntities().size(), pageSize);
+            }
+
+            indicesFetched.addAll(paginationStrategy.getRequestedEntities());
+        } while (Objects.nonNull(requestedToken));
+
+        assertEquals((int) Math.ceil((double) (totalIndices - numIndicesToDelete) / pageSize), numPages);
+        assertEquals(totalIndices - numIndicesToDelete, indicesFetched.size());
+
+        // none of the deleted index should appear in the list of fetched indices
+        for (int deletedIndexPos = 0; deletedIndexPos < numIndicesToDelete; deletedIndexPos++) {
+            assertFalse(indicesFetched.contains("test-index-" + deletedIndices.get(deletedIndexPos)));
+        }
+
+        // none of the newly created indices should be present in the list of fetched indices
+        for (int indexNumber = totalIndices + 1; indexNumber <= totalIndices + numIndicesToCreate; indexNumber++) {
+            assertFalse(indicesFetched.contains("test-index-" + indexNumber));
+        }
+    }
+
+    public void testRetrieveIndicesWithSizeOneAndCurrentIndexGetsDeletedAscOrder() {
+        // Query1 with 4 indices in clusterState (test-index1,2,3,4)
+        ClusterState clusterState = getRandomClusterState(List.of(1, 2, 3, 4));
+        PageParams pageParams = new PageParams(null, PARAM_ASC_SORT_VALUE, 1);
+        IndexPaginationStrategy paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertPaginationResult(paginationStrategy, 1, true);
+        assertEquals("test-index-1", paginationStrategy.getRequestedEntities().get(0));
+
+        // Adding index5 to clusterState, before executing next query.
+        clusterState = addIndexToClusterState(clusterState, 5);
+        pageParams = new PageParams(paginationStrategy.getResponseToken().getNextToken(), PARAM_ASC_SORT_VALUE, 1);
+        paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertPaginationResult(paginationStrategy, 1, true);
+        assertEquals("test-index-2", paginationStrategy.getRequestedEntities().get(0));
+
+        // Deleting test-index-2 which has already been displayed, still test-index-3 should get displayed
+        clusterState = deleteIndexFromClusterState(clusterState, 2);
+        pageParams = new PageParams(paginationStrategy.getResponseToken().getNextToken(), PARAM_ASC_SORT_VALUE, 1);
+        paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertPaginationResult(paginationStrategy, 1, true);
+        assertEquals("test-index-3", paginationStrategy.getRequestedEntities().get(0));
+
+        // Deleting test-index-4 which is not yet displayed which otherwise should have been displayed in the following query
+        // instead test-index-5 should now get displayed.
+        clusterState = deleteIndexFromClusterState(clusterState, 4);
+        pageParams = new PageParams(paginationStrategy.getResponseToken().getNextToken(), PARAM_ASC_SORT_VALUE, 1);
+        paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertPaginationResult(paginationStrategy, 1, false);
+        assertEquals("test-index-5", paginationStrategy.getRequestedEntities().get(0));
+
+    }
+
+    public void testRetrieveIndicesWithSizeOneAndCurrentIndexGetsDeletedDescOrder() {
+        // Query1 with 4 indices in clusterState (test-index1,2,3,4).
+        ClusterState clusterState = getRandomClusterState(List.of(1, 2, 3, 4));
+        PageParams pageParams = new PageParams(null, PARAM_DESC_SORT_VALUE, 1);
+        IndexPaginationStrategy paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertPaginationResult(paginationStrategy, 1, true);
+        assertEquals("test-index-4", paginationStrategy.getRequestedEntities().get(0));
+
+        // adding test-index-5 to clusterState, before executing next query.
+        clusterState = addIndexToClusterState(clusterState, 5);
+        pageParams = new PageParams(paginationStrategy.getResponseToken().getNextToken(), PARAM_DESC_SORT_VALUE, 1);
+        paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertPaginationResult(paginationStrategy, 1, true);
+        assertEquals("test-index-3", paginationStrategy.getRequestedEntities().get(0));
+
+        // Deleting test-index-3 which has already been displayed, still index2 should get displayed.
+        clusterState = deleteIndexFromClusterState(clusterState, 3);
+        pageParams = new PageParams(paginationStrategy.getResponseToken().getNextToken(), PARAM_DESC_SORT_VALUE, 1);
+        paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertPaginationResult(paginationStrategy, 1, true);
+        assertEquals("test-index-2", paginationStrategy.getRequestedEntities().get(0));
+
+        // Deleting test-index-1 which is not yet displayed which otherwise should have been displayed in the following query.
+        clusterState = deleteIndexFromClusterState(clusterState, 1);
+        pageParams = new PageParams(paginationStrategy.getResponseToken().getNextToken(), PARAM_DESC_SORT_VALUE, 1);
+        paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertPaginationResult(paginationStrategy, 0, false);
+    }
+
+    public void testRetrieveIndicesWithMultipleDeletionsAtOnceAscOrder() {
+        // Query1 with 5 indices in clusterState (test-index1,2,3,4,5).
+        ClusterState clusterState = getRandomClusterState(List.of(1, 2, 3, 4, 5));
+        PageParams pageParams = new PageParams(null, PARAM_ASC_SORT_VALUE, 1);
+        IndexPaginationStrategy paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertEquals(1, paginationStrategy.getRequestedEntities().size());
+        assertEquals("test-index-1", paginationStrategy.getRequestedEntities().get(0));
+        assertNotNull(paginationStrategy.getResponseToken().getNextToken());
+
+        // executing next query without any changes to clusterState
+        pageParams = new PageParams(paginationStrategy.getResponseToken().getNextToken(), PARAM_ASC_SORT_VALUE, 1);
+        paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertEquals(1, paginationStrategy.getRequestedEntities().size());
+        assertEquals("test-index-2", paginationStrategy.getRequestedEntities().get(0));
+        assertNotNull(paginationStrategy.getResponseToken().getNextToken());
+
+        // Deleting test-index-1, test-index-2 & test-index-3 and executing next query. test-index-4 should get displayed.
+        clusterState = deleteIndexFromClusterState(clusterState, 1);
+        clusterState = deleteIndexFromClusterState(clusterState, 2);
+        clusterState = deleteIndexFromClusterState(clusterState, 3);
+        pageParams = new PageParams(paginationStrategy.getResponseToken().getNextToken(), PARAM_ASC_SORT_VALUE, 1);
+        paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertEquals(1, paginationStrategy.getRequestedEntities().size());
+        assertEquals("test-index-4", paginationStrategy.getRequestedEntities().get(0));
+        assertNotNull(paginationStrategy.getResponseToken().getNextToken());
+
+        // Executing the last query without any further change. Should result in test-index-5 and nextToken as null.
+        pageParams = new PageParams(paginationStrategy.getResponseToken().getNextToken(), PARAM_ASC_SORT_VALUE, 1);
+        paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertEquals(1, paginationStrategy.getRequestedEntities().size());
+        assertEquals("test-index-5", paginationStrategy.getRequestedEntities().get(0));
+        assertNull(paginationStrategy.getResponseToken().getNextToken());
+    }
+
+    public void testRetrieveIndicesWithTokenModifiedToQueryBeyondTotal() {
+        ClusterState clusterState = getRandomClusterState(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        PageParams pageParams = new PageParams(null, PARAM_ASC_SORT_VALUE, 10);
+        IndexPaginationStrategy paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertEquals(10, paginationStrategy.getRequestedEntities().size());
+        assertNull(paginationStrategy.getResponseToken().getNextToken());
+        // creating a token with last sent index as test-index-10
+        String token = clusterState.metadata().indices().get("test-index-10").getCreationDate() + "|" + "test-index-10";
+        pageParams = new PageParams(Base64.getEncoder().encodeToString(token.getBytes(UTF_8)), PARAM_ASC_SORT_VALUE, 10);
+        paginationStrategy = new IndexPaginationStrategy(pageParams, clusterState);
+        assertEquals(0, paginationStrategy.getRequestedEntities().size());
+        assertNull(paginationStrategy.getResponseToken().getNextToken());
+    }
+
+    public void testCreatingIndexStrategyPageTokenWithRequestedTokenNull() {
+        try {
+            new IndexPaginationStrategy.IndexStrategyToken(null);
+            fail("expected exception");
+        } catch (Exception e) {
+            assert e.getMessage().contains("requestedTokenString can not be null");
+        }
+    }
+
+    public void testIndexStrategyPageTokenWithWronglyEncryptedRequestToken() {
+        assertThrows(OpenSearchParseException.class, () -> new IndexPaginationStrategy.IndexStrategyToken("3%4%5"));
+    }
+
+    public void testIndexStrategyPageTokenWithIncorrectNumberOfElementsInRequestedToken() {
+        assertThrows(
+            OpenSearchParseException.class,
+            () -> new IndexPaginationStrategy.IndexStrategyToken(PaginationStrategy.encryptStringToken("1725361543"))
+        );
+        assertThrows(
+            OpenSearchParseException.class,
+            () -> new IndexPaginationStrategy.IndexStrategyToken(PaginationStrategy.encryptStringToken("1|1725361543|index|12345"))
+        );
+    }
+
+    public void testIndexStrategyPageTokenWithInvalidValuesInRequestedToken() {
+        assertThrows(
+            OpenSearchParseException.class,
+            () -> new IndexPaginationStrategy.IndexStrategyToken(PaginationStrategy.encryptStringToken("-1725361543|index"))
+        );
+    }
+
+    public void testCreatingIndexStrategyPageTokenWithNameOfLastRespondedIndexNull() {
+        try {
+            new IndexPaginationStrategy.IndexStrategyToken(1234l, null);
+            fail("expected exception");
+        } catch (Exception e) {
+            assert e.getMessage().contains("index name should be provided");
+        }
+    }
+
+    /**
+     * @param indexNumbers would be used to create indices having names with integer appended after foo, like foo1, foo2.
+     * @return random clusterState consisting of indices having their creation times set to the integer used to name them.
+     */
+    private ClusterState getRandomClusterState(List<Integer> indexNumbers) {
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().build())
+            .routingTable(RoutingTable.builder().build())
+            .build();
+        for (Integer indexNumber : indexNumbers) {
+            clusterState = addIndexToClusterState(clusterState, indexNumber);
+        }
+        return clusterState;
+    }
+
+    private ClusterState addIndexToClusterState(ClusterState clusterState, int indexNumber) {
+        IndexMetadata indexMetadata = IndexMetadata.builder("test-index-" + indexNumber)
+            .settings(
+                settings(Version.CURRENT).put(SETTING_CREATION_DATE, Instant.now().plus(indexNumber, ChronoUnit.SECONDS).toEpochMilli())
+            )
+            .numberOfShards(between(1, 10))
+            .numberOfReplicas(randomInt(20))
+            .build();
+        IndexRoutingTable.Builder indexRoutingTableBuilder = new IndexRoutingTable.Builder(indexMetadata.getIndex());
+        return ClusterState.builder(clusterState)
+            .metadata(Metadata.builder(clusterState.metadata()).put(indexMetadata, true).build())
+            .routingTable(RoutingTable.builder(clusterState.routingTable()).add(indexRoutingTableBuilder).build())
+            .build();
+    }
+
+    private ClusterState deleteIndexFromClusterState(ClusterState clusterState, int indexNumber) {
+        return ClusterState.builder(clusterState)
+            .metadata(Metadata.builder(clusterState.metadata()).remove("test-index-" + indexNumber))
+            .routingTable(RoutingTable.builder(clusterState.routingTable()).remove("test-index-" + indexNumber).build())
+            .build();
+    }
+
+    private void assertPaginationResult(IndexPaginationStrategy paginationStrategy, int expectedEntities, boolean tokenExpected) {
+        assertNotNull(paginationStrategy);
+        assertEquals(expectedEntities, paginationStrategy.getRequestedEntities().size());
+        assertNotNull(paginationStrategy.getResponseToken());
+        assertEquals(tokenExpected, Objects.nonNull(paginationStrategy.getResponseToken().getNextToken()));
+    }
+
+}


### PR DESCRIPTION
* Implementing pagination for _cat/indices

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

Backporting https://github.com/opensearch-project/OpenSearch/pull/14718

Additionally also fixed the RestHandlerWrapper, which was backported as part of this https://github.com/opensearch-project/OpenSearch/pull/16161 but since this PR is getting merged later in 2.x, added this explicitly:

```

@Override
        public boolean isActionPaginated() {
            return delegate.isActionPaginated();
        }

```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
