### PR TITLE
Add pluginZip publication for plugins in the plugins folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add changes to block calls in cat shards, indices and segments based on dynamic limit settings ([#15986](https://github.com/opensearch-project/OpenSearch/pull/15986))
 - New `phone` & `phone-search` analyzer + tokenizer ([#15915](https://github.com/opensearch-project/OpenSearch/pull/15915))
 - Add _list/shards API as paginated alternate to _cat/shards ([#14641](https://github.com/opensearch-project/OpenSearch/pull/14641))
+- Add pluginZip publication for plugins in the plugins folder ([#16219](https://github.com/opensearch-project/OpenSearch/pull/16219))
 
 ### Dependencies
 - Bump `com.azure:azure-identity` from 1.13.0 to 1.13.2 ([#15578](https://github.com/opensearch-project/OpenSearch/pull/15578))

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,11 @@ subprojects {
             developer.appendNode('url', 'https://github.com/opensearch-project/OpenSearch')
           }
         }
+        pluginZip(MavenPublication) { publication ->
+          groupId = "org.opensearch.plugin"
+          artifactId = project.name
+          version = project.version
+        }
       }
       repositories {
         maven {

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -36,6 +36,7 @@ subprojects {
 configure(subprojects.findAll { it.parent.path == project.path }) {
   group = 'org.opensearch.plugin'
   apply plugin: 'opensearch.opensearchplugin'
+  apply plugin: 'opensearch.pluginzip'
 
   opensearchplugin {
     // for local ES plugins, the name of the plugin is the same as the directory


### PR DESCRIPTION
### Description

This PR adds a new publication for plugins in the `plugins/` folder to publish zip files of the artifacts.

This enables tasks like the following:

```
➜  OpenSearch git:(publish-plugin-zip) ./gradlew :plugins:mapper-size:publishPluginZipToMavenLocal

➜  OpenSearch git:(publish-plugin-zip) ✗ ls -latr ~/.m2/repository/org/opensearch/plugin/mapper-size/3.0.0-SNAPSHOT
total 328
drwxr-xr-x@ 12 cwperx  staff     384 May  6 16:32 ..
-rw-r--r--@  1 cwperx  staff    9981 Oct  1 16:51 mapper-size-3.0.0-SNAPSHOT.jar
-rw-r--r--@  1 cwperx  staff    8359 Oct  1 16:51 mapper-size-3.0.0-SNAPSHOT-sources.jar
-rw-r--r--@  1 cwperx  staff    1950 Oct  1 16:51 mapper-size-3.0.0-SNAPSHOT.module
-rw-r--r--@  1 cwperx  staff  113170 Oct  1 16:51 mapper-size-3.0.0-SNAPSHOT-javadoc.jar
drwxr-xr-x@  9 cwperx  staff     288 Oct  7 11:43 .
-rw-r--r--@  1 cwperx  staff   14238 Oct  7 11:43 mapper-size-3.0.0-SNAPSHOT.zip
-rw-r--r--@  1 cwperx  staff    1086 Oct  7 11:43 mapper-size-3.0.0-SNAPSHOT.pom
-rw-r--r--@  1 cwperx  staff     718 Oct  7 11:43 maven-metadata-local.xml
```

### Related Issues

Related to https://github.com/opensearch-project/OpenSearch/issues/16195

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
