### PR TITLE
Close RemoteStorePinnedTimestampService on Node.close()

### DIFF
--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -1837,6 +1837,7 @@ public class Node implements Closeable {
         toClose.add(() -> stopWatch.stop().start("transport"));
         toClose.add(injector.getInstance(TransportService.class));
         toClose.add(nodeService.getTaskCancellationMonitoringService());
+        toClose.add(injector.getInstance(RemoteStorePinnedTimestampService.class));
 
         for (LifecycleComponent plugin : pluginLifecycleComponents) {
             toClose.add(() -> stopWatch.stop().start("plugin(" + plugin.getClass().getName() + ")"));
@@ -1867,6 +1868,7 @@ public class Node implements Closeable {
         if (logger.isTraceEnabled()) {
             toClose.add(() -> logger.trace("Close times for each service:\n{}", stopWatch.prettyPrint()));
         }
+
         IOUtils.close(toClose);
         logger.info("closed");
     }


### PR DESCRIPTION
### Description
- `RemoteStorePinnedTimestampService` internally manages an async scheduler.
- If not closed properly, integ tests sometimes fail with following exception:

```
com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=6639, name=opensearch[node_t1][scheduler][T#1], state=RUNNABLE, group=TGRP-RemoteStorePinnedTimestampsGarbageCollectionIT]
	at __randomizedtesting.SeedInfo.seed([401E5CF6CD0D4727:9C0BCAD1CF20D2F6]:0)
Caused by: org.opensearch.core.concurrency.OpenSearchRejectedExecutionException: rejected execution of java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@143262f2[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@2866748[Wrapped task = org.opensearch.node.remotestore.RemoteStorePinnedTimestampService$AsyncUpdatePinnedTimestampTask@7794b6fc]] on org.opensearch.threadpool.Scheduler$SafeScheduledThreadPoolExecutor@16dc01db[Shutting down, pool size = 1, active threads = 1, queued tasks = 0, completed tasks = 124]
	at __randomizedtesting.SeedInfo.seed([401E5CF6CD0D4727]:0)
```

- Even though this does not have direct impact on live clusters as Node.close() closes threadpool, integ tests became flaky due to this.
- In this PR, we explicitly close `RemoteStorePinnedTimestampService` on Node.close()

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/16088

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
