### PR TITLE
Add support to dynamically resize threadpools size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add _list/indices API as paginated alternate to _cat/indices ([#14718](https://github.com/opensearch-project/OpenSearch/pull/14718))
 - Add success and failure metrics for async shard fetch ([#15976](https://github.com/opensearch-project/OpenSearch/pull/15976))
 - Add new metric REMOTE_STORE to NodeStats API response ([#15611](https://github.com/opensearch-project/OpenSearch/pull/15611))
+- Add support to dynamically resize threadpools size. ([#16236](https://github.com/opensearch-project/OpenSearch/pull/16236))
 - [S3 Repository] Change default retry mechanism of s3 clients to Standard Mode ([#15978](https://github.com/opensearch-project/OpenSearch/pull/15978))
 - Add changes to block calls in cat shards, indices and segments based on dynamic limit settings ([#15986](https://github.com/opensearch-project/OpenSearch/pull/15986))
 - New `phone` & `phone-search` analyzer + tokenizer ([#15915](https://github.com/opensearch-project/OpenSearch/pull/15915))

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/settings/ClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/settings/ClusterSettingsIT.java
@@ -414,7 +414,7 @@ public class ClusterSettingsIT extends OpenSearchIntegTestCase {
                 .get();
             fail("bogus value");
         } catch (IllegalArgumentException ex) {
-            assertEquals(ex.getCause().getMessage(), "illegal thread_pool config : [wrong] should only have max and core");
+            assertEquals(ex.getCause().getMessage(), "illegal thread_pool config : [wrong] should only have [core, max]");
         }
 
         // Scaling threadpool - core > max
@@ -449,7 +449,7 @@ public class ClusterSettingsIT extends OpenSearchIntegTestCase {
                 .get();
             fail("bogus value");
         } catch (IllegalArgumentException ex) {
-            assertEquals(ex.getCause().getMessage(), "illegal thread_pool config : [wrong] should only have size");
+            assertEquals(ex.getCause().getMessage(), "illegal thread_pool config : [wrong] should only have [size]");
         }
 
         // Fixed threadpool - 0 value

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/settings/ClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/settings/ClusterSettingsIT.java
@@ -380,6 +380,35 @@ public class ClusterSettingsIT extends OpenSearchIntegTestCase {
         }
     }
 
+    public void testThreadPoolSettings() {
+        String key1 = "cluster.thread_pool.snapshot.max";
+        Settings transientSettings = Settings.builder().put(key1, "-1").build();
+
+        String key2 = "cluster.thread_pool.snapshot.max";
+        Settings persistentSettings = Settings.builder().put(key2, "5").build();
+
+        try {
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setTransientSettings(transientSettings)
+                .setPersistentSettings(persistentSettings)
+                .get();
+            fail("bogus value");
+        } catch (IllegalArgumentException ex) {
+            assertEquals(ex.getMessage(), "illegal value for [cluster.thread_pool.snapshot], has to be positive value");
+        }
+
+        transientSettings = Settings.builder().put(key1, "1").build();
+        persistentSettings = Settings.builder().put(key2, "5").build();
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(transientSettings)
+            .setPersistentSettings(persistentSettings)
+            .get();
+    }
+
     public void testLoggerLevelUpdate() {
         assertAcked(prepareCreate("test"));
 

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -805,7 +805,10 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 // Settings to be used for limiting rest requests
                 ResponseLimitSettings.CAT_INDICES_RESPONSE_LIMIT_SETTING,
                 ResponseLimitSettings.CAT_SHARDS_RESPONSE_LIMIT_SETTING,
-                ResponseLimitSettings.CAT_SEGMENTS_RESPONSE_LIMIT_SETTING
+                ResponseLimitSettings.CAT_SEGMENTS_RESPONSE_LIMIT_SETTING,
+
+                // Thread pool Settings
+                ThreadPool.CLUSTER_THREAD_POOL_SIZE_SETTING
             )
         )
     );

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -624,6 +624,7 @@ public class Node implements Closeable {
                 additionalSettingsFilter,
                 settingsUpgraders
             );
+            threadPool.setClusterSettings(settingsModule.getClusterSettings());
             scriptModule.registerClusterSettingsListeners(scriptService, settingsModule.getClusterSettings());
             final NetworkService networkService = new NetworkService(
                 getCustomNameResolvers(pluginsService.filterPlugins(DiscoveryPlugin.class))

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -624,7 +624,7 @@ public class Node implements Closeable {
                 additionalSettingsFilter,
                 settingsUpgraders
             );
-            threadPool.setClusterSettings(settingsModule.getClusterSettings());
+            threadPool.registerClusterSettingsListeners(settingsModule.getClusterSettings());
             scriptModule.registerClusterSettingsListeners(scriptService, settingsModule.getClusterSettings());
             final NetworkService networkService = new NetworkService(
                 getCustomNameResolvers(pluginsService.filterPlugins(DiscoveryPlugin.class))

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -218,8 +218,6 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
 
     private final ScheduledThreadPoolExecutor scheduler;
 
-    private ClusterSettings clusterSettings = null;
-
     public Collection<ExecutorBuilder> builders() {
         return Collections.unmodifiableCollection(builders.values());
     }
@@ -418,9 +416,8 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         return holder.info;
     }
 
-    public void setClusterSettings(ClusterSettings clusterSettings) {
-        this.clusterSettings = clusterSettings;
-        this.clusterSettings.addSettingsUpdateConsumer(CLUSTER_THREAD_POOL_SIZE_SETTING, this::setThreadPool, this::validateSetting);
+    public void registerClusterSettingsListeners(ClusterSettings clusterSettings) {
+        clusterSettings.addSettingsUpdateConsumer(CLUSTER_THREAD_POOL_SIZE_SETTING, this::setThreadPool, this::validateSetting);
     }
 
     /*

--- a/server/src/test/java/org/opensearch/threadpool/ThreadPoolTests.java
+++ b/server/src/test/java/org/opensearch/threadpool/ThreadPoolTests.java
@@ -191,11 +191,7 @@ public class ThreadPoolTests extends OpenSearchTestCase {
         TestThreadPool threadPool = new TestThreadPool("test");
         try {
             Settings commonSettings = Settings.builder().put("snapshot.max", "50").put("snapshot.core", "100").build();
-            threadPool.setThreadPool(commonSettings);
-            ExecutorService executorService = threadPool.executor("snapshot");
-            OpenSearchThreadPoolExecutor executor = (OpenSearchThreadPoolExecutor) executorService;
-            assertNotEquals(50, executor.getMaximumPoolSize());
-            assertNotEquals(100, executor.getCorePoolSize());
+            assertThrows(IllegalArgumentException.class, () -> threadPool.setThreadPool(commonSettings));
         } finally {
             terminate(threadPool);
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Adds capability to change thread pool sizes for all threadpools defined in core

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
