### PR TITLE
BugFix: call listener.onFailure on failure to pin the timestamp

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsIT.java
@@ -76,8 +76,6 @@ public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase 
         );
 
         Tuple<Long, Set<Long>> pinnedTimestampWithFetchTimestamp = RemoteStorePinnedTimestampService.getPinnedTimestamps();
-        long lastFetchTimestamp = pinnedTimestampWithFetchTimestamp.v1();
-        assertEquals(-1L, lastFetchTimestamp);
         assertEquals(Set.of(), pinnedTimestampWithFetchTimestamp.v2());
 
         long timestamp1 = System.currentTimeMillis() + 30000L;

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStorePinnedTimestampsIT.java
@@ -11,21 +11,29 @@ package org.opensearch.remotestore;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.admin.cluster.node.stats.NodeStats;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesRequest;
+import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
+import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.node.remotestore.RemoteStorePinnedTimestampService;
+import org.opensearch.repositories.fs.ReloadableFsRepository;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 
 import static org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest.Metric.REMOTE_STORE;
+import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT;
+import static org.opensearch.repositories.fs.ReloadableFsRepository.REPOSITORIES_SLOWDOWN_SETTING;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase {
@@ -33,8 +41,15 @@ public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase 
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
+        String segmentRepoTypeAttributeKey = String.format(
+            Locale.getDefault(),
+            "node.attr." + REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT,
+            REPOSITORY_NAME
+        );
+
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
+            .put(segmentRepoTypeAttributeKey, ReloadableFsRepository.TYPE)
             .put(RemoteStoreSettings.CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), true)
             .build();
     }
@@ -222,10 +237,7 @@ public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase 
         latch.await();
     }
 
-    // This test fails as we can't control actual upload of pinned timestamp file. We ideally need a BlobStoreRepository
-    // which can control the speed of upload.
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/16246")
-    public void testPinExceptionsRemoteStoreCallTakeTime() throws InterruptedException {
+    public void testPinExceptionsRemoteStoreCallTakeTime() throws InterruptedException, ExecutionException {
         prepareCluster(1, 1, INDEX_NAME, 0, 2);
         ensureGreen(INDEX_NAME);
 
@@ -234,10 +246,10 @@ public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase 
             primaryNodeName(INDEX_NAME)
         );
 
-        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.timeValueNanos(50000));
-
         CountDownLatch latch = new CountDownLatch(1);
-        long timestampToBePinned = System.currentTimeMillis();
+        slowDownRepo(REPOSITORY_NAME, 10);
+        RemoteStoreSettings.setPinnedTimestampsLookbackInterval(TimeValue.timeValueSeconds(1));
+        long timestampToBePinned = System.currentTimeMillis() + 600000;
         remoteStorePinnedTimestampService.pinTimestamp(timestampToBePinned, "ss1", new LatchedActionListener<>(new ActionListener<>() {
             @Override
             public void onResponse(Void unused) {
@@ -258,6 +270,16 @@ public class RemoteStorePinnedTimestampsIT extends RemoteStoreBaseIntegTestCase 
         }, latch));
 
         latch.await();
+    }
+
+    protected void slowDownRepo(String repoName, int value) throws ExecutionException, InterruptedException {
+        GetRepositoriesRequest gr = new GetRepositoriesRequest(new String[] { repoName });
+        GetRepositoriesResponse res = client().admin().cluster().getRepositories(gr).get();
+        RepositoryMetadata rmd = res.repositories().get(0);
+        Settings.Builder settings = Settings.builder()
+            .put("location", rmd.settings().get("location"))
+            .put(REPOSITORIES_SLOWDOWN_SETTING.getKey(), value);
+        createRepository(repoName, rmd.type(), settings);
     }
 
     public void testUnpinException() throws InterruptedException {

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java
@@ -130,16 +130,16 @@ public class RemoteStorePinnedTimestampService implements Closeable {
      * @throws IllegalArgumentException If the timestamp is less than the current time minus one second
      */
     public void pinTimestamp(long timestamp, String pinningEntity, ActionListener<Void> listener) {
-        // If a caller uses current system time to pin the timestamp, following check will almost always fail.
-        // So, we allow pinning timestamp in the past upto some buffer
-        long lookbackIntervalInMills = RemoteStoreSettings.getPinnedTimestampsLookbackInterval().millis();
-        if (timestamp < (System.currentTimeMillis() - lookbackIntervalInMills)) {
-            throw new IllegalArgumentException(
-                "Timestamp to be pinned is less than current timestamp - value of cluster.remote_store.pinned_timestamps.lookback_interval"
-            );
-        }
-        long startTime = System.nanoTime();
         try {
+            // If a caller uses current system time to pin the timestamp, following check will almost always fail.
+            // So, we allow pinning timestamp in the past upto some buffer
+            long lookbackIntervalInMills = RemoteStoreSettings.getPinnedTimestampsLookbackInterval().millis();
+            if (timestamp < (System.currentTimeMillis() - lookbackIntervalInMills)) {
+                throw new IllegalArgumentException(
+                    "Timestamp to be pinned is less than current timestamp - value of cluster.remote_store.pinned_timestamps.lookback_interval"
+                );
+            }
+            long startTime = System.nanoTime();
             logger.debug("Pinning timestamp = {} against entity = {}", timestamp, pinningEntity);
             blobContainer.writeBlob(getBlobName(timestamp, pinningEntity), new ByteArrayInputStream(new byte[0]), 0, true);
             long elapsedTime = System.nanoTime() - startTime;
@@ -155,7 +155,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
             } else {
                 listener.onResponse(null);
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             listener.onFailure(e);
         }
     }
@@ -198,7 +198,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
                 logger.error(errorMessage);
                 listener.onFailure(new IllegalArgumentException(errorMessage));
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             listener.onFailure(e);
         }
     }
@@ -249,7 +249,7 @@ public class RemoteStorePinnedTimestampService implements Closeable {
                 logger.error(errorMessage);
                 listener.onFailure(new IllegalArgumentException(errorMessage));
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             listener.onFailure(e);
         }
     }


### PR DESCRIPTION
### Description
- Today, if we try to pin the timestamp that is older than `now() - Lookbak Interval`, we throw `IllegalArgumentException`
- But as `RemoteStorePinnedTimestampService.pinTimestamp` is async, on any failure, `listener.onFailure()` should be called.
https://github.com/opensearch-project/OpenSearch/blob/acf209fc2a23d4f7220b1480c9e407e6cf3d8c55/server/src/main/java/org/opensearch/node/remotestore/RemoteStorePinnedTimestampService.java#L132-L140
- Due to this, caller will keep waiting on listener.
- In this PR, we make sure to call listener.onFailure on each type of failure

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/16247

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
