### PR TITLE
[Backport] [2.x] Bump io.grpc:grpc-api from 1.57.2 to 1.68.0 in /plugins/discovery-gce (#16213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `netty` from 4.1.112.Final to 4.1.114.Final ([#16182](https://github.com/opensearch-project/OpenSearch/pull/16182))
 - Bump `com.azure:azure-json` from 1.1.0 to 1.3.0 ([#16217](https://github.com/opensearch-project/OpenSearch/pull/16217))
 - Bump `org.jline:jline` from 3.26.3 to 3.27.0 ([#16135](https://github.com/opensearch-project/OpenSearch/pull/16135))
+- Bump `io.grpc:grpc-api` from 1.57.2 to 1.68.0 ([#16213](https://github.com/opensearch-project/OpenSearch/pull/16213))
 
 ### Changed
 - Add support for docker compose v2 in TestFixturesPlugin ([#16049](https://github.com/opensearch-project/OpenSearch/pull/16049))

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -25,6 +25,7 @@ jakarta_annotation = 1.3.5
 google_http_client = 1.44.1
 tdigest           = 3.2
 hdrhistogram      = 2.2.2
+grpc              = 1.68.0
 
 # when updating the JNA version, also update the version in buildSrc/build.gradle
 jna               = 5.13.0

--- a/plugins/discovery-gce/build.gradle
+++ b/plugins/discovery-gce/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   api "commons-logging:commons-logging:${versions.commonslogging}"
   api "org.apache.logging.log4j:log4j-1.2-api:${versions.log4j}"
   api "commons-codec:commons-codec:${versions.commonscodec}"
-  api 'io.grpc:grpc-api:1.57.2'
+  api "io.grpc:grpc-api:${versions.grpc}"
   api 'io.opencensus:opencensus-api:0.31.1'
   api 'io.opencensus:opencensus-contrib-http-util:0.31.1'
   runtimeOnly "com.google.guava:guava:${versions.guava}"

--- a/plugins/discovery-gce/licenses/grpc-api-1.57.2.jar.sha1
+++ b/plugins/discovery-gce/licenses/grpc-api-1.57.2.jar.sha1
@@ -1,1 +1,0 @@
-c71a006b81ddae7bc4b7cb1d2da78c1b173761f4

--- a/plugins/discovery-gce/licenses/grpc-api-1.68.0.jar.sha1
+++ b/plugins/discovery-gce/licenses/grpc-api-1.68.0.jar.sha1
@@ -1,0 +1,1 @@
+9a9f25c58d8d5b0fcf37ae889a50fec87e34ac08

--- a/plugins/repository-gcs/build.gradle
+++ b/plugins/repository-gcs/build.gradle
@@ -86,7 +86,7 @@ dependencies {
   api "org.apache.logging.log4j:log4j-1.2-api:${versions.log4j}"
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api 'org.threeten:threetenbp:1.4.4'
-  api 'io.grpc:grpc-api:1.57.2'
+  api "io.grpc:grpc-api:${versions.grpc}"
   api 'io.opencensus:opencensus-api:0.31.1'
   api 'io.opencensus:opencensus-contrib-http-util:0.31.1'
 

--- a/plugins/repository-gcs/licenses/grpc-api-1.57.2.jar.sha1
+++ b/plugins/repository-gcs/licenses/grpc-api-1.57.2.jar.sha1
@@ -1,1 +1,0 @@
-c71a006b81ddae7bc4b7cb1d2da78c1b173761f4

--- a/plugins/repository-gcs/licenses/grpc-api-1.68.0.jar.sha1
+++ b/plugins/repository-gcs/licenses/grpc-api-1.68.0.jar.sha1
@@ -1,0 +1,1 @@
+9a9f25c58d8d5b0fcf37ae889a50fec87e34ac08


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/16213 to `2.x`