### PR TITLE
Add snapshot_path prefix to snapshot shards path file on remote store

### DIFF
--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -199,6 +199,7 @@ import java.util.stream.Stream;
 import static org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm.FNV_1A_COMPOSITE_1;
 import static org.opensearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo.canonicalName;
 import static org.opensearch.repositories.blobstore.ChecksumBlobStoreFormat.SNAPSHOT_ONLY_FORMAT_PARAMS;
+import static org.opensearch.snapshots.SnapshotShardPaths.getIndexId;
 
 /**
  * BlobStore - based implementation of Snapshot Repository
@@ -2293,7 +2294,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      * @return List of matching shard paths
      */
     private List<String> findMatchingShardPaths(String indexId, Map<String, BlobMetadata> snapshotShardPaths) {
-        return snapshotShardPaths.keySet().stream().filter(s -> s.startsWith(indexId)).collect(Collectors.toList());
+        return snapshotShardPaths.keySet()
+            .stream()
+            .filter(s -> (s.startsWith(indexId) || s.startsWith(SnapshotShardPaths.FILE_PREFIX + indexId)))
+            .collect(Collectors.toList());
     }
 
     /**
@@ -2546,11 +2550,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      */
     private void cleanupRedundantSnapshotShardPaths(Set<String> updatedShardPathsIndexIds) {
         Set<String> updatedIndexIds = updatedShardPathsIndexIds.stream()
-            .map(s -> s.split("\\" + SnapshotShardPaths.DELIMITER)[0])
+            .map(s -> getIndexId(s.split("\\" + SnapshotShardPaths.DELIMITER)[0]))
             .collect(Collectors.toSet());
         Set<String> indexIdShardPaths = getSnapshotShardPaths().keySet();
         List<String> staleShardPaths = indexIdShardPaths.stream().filter(s -> updatedShardPathsIndexIds.contains(s) == false).filter(s -> {
-            String indexId = s.split("\\" + SnapshotShardPaths.DELIMITER)[0];
+            String indexId = getIndexId(s.split("\\" + SnapshotShardPaths.DELIMITER)[0]);
             return updatedIndexIds.contains(indexId);
         }).collect(Collectors.toList());
         try {
@@ -2595,7 +2599,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             List<String> paths = getShardPaths(indexId, shardCount);
             int pathType = indexId.getShardPathType();
             int pathHashAlgorithm = FNV_1A_COMPOSITE_1.getCode();
-            String blobName = String.join(
+            String name = String.join(
                 SnapshotShardPaths.DELIMITER,
                 indexId.getId(),
                 indexId.getName(),
@@ -2611,9 +2615,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 PathType.fromCode(pathType),
                 PathHashAlgorithm.fromCode(pathHashAlgorithm)
             );
-            SNAPSHOT_SHARD_PATHS_FORMAT.write(shardPaths, snapshotShardPathBlobContainer(), blobName);
+            SNAPSHOT_SHARD_PATHS_FORMAT.write(shardPaths, snapshotShardPathBlobContainer(), name);
             logShardPathsOperationSuccess(indexId, snapshotId);
-            return blobName;
+            return SnapshotShardPaths.FILE_PREFIX + name;
         } catch (IOException e) {
             logShardPathsOperationWarning(indexId, snapshotId, e);
         }

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotShardPaths.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotShardPaths.java
@@ -29,7 +29,8 @@ public class SnapshotShardPaths implements ToXContent {
 
     public static final String DELIMITER = ".";
 
-    public static final String FILE_NAME_FORMAT = "%s";
+    public static final String FILE_PREFIX = "snapshot_path_";
+    public static final String FILE_NAME_FORMAT = FILE_PREFIX + "%s";
 
     private static final String PATHS_FIELD = "paths";
     private static final String INDEX_ID_FIELD = "indexId";
@@ -101,12 +102,19 @@ public class SnapshotShardPaths implements ToXContent {
             throw new IllegalArgumentException("Invalid shard path format: " + shardPath);
         }
         try {
-            IndexId indexId = new IndexId(parts[1], parts[0], Integer.parseInt(parts[3]));
+            IndexId indexId = new IndexId(parts[1], getIndexId(parts[0]), Integer.parseInt(parts[3]));
             int shardCount = Integer.parseInt(parts[2]);
             return new ShardInfo(indexId, shardCount);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid shard path format: " + shardPath, e);
         }
+    }
+
+    public static String getIndexId(String indexIdField) {
+        if (indexIdField.startsWith(FILE_PREFIX)) {
+            return indexIdField.substring(FILE_PREFIX.length());
+        }
+        return indexIdField;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/opensearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -382,6 +382,7 @@ public class BlobStoreRepositoryTests extends BlobStoreRepositoryHelperTests {
         IndexId indexId = repoData.getIndices().values().iterator().next();
         int shardCount = repoData.shardGenerations().getGens(indexId).size();
 
+        // Version 2.17 has file name starting with indexId
         String shardPath = String.join(
             SnapshotShardPaths.DELIMITER,
             indexId.getId(),
@@ -391,7 +392,19 @@ public class BlobStoreRepositoryTests extends BlobStoreRepositoryHelperTests {
             "1"
         );
         ShardInfo shardInfo = SnapshotShardPaths.parseShardPath(shardPath);
+        assertEquals(shardInfo.getIndexId(), indexId);
+        assertEquals(shardInfo.getShardCount(), shardCount);
 
+        // Version 2.17 has file name starting with snapshot_path_
+        shardPath = String.join(
+            SnapshotShardPaths.DELIMITER,
+            SnapshotShardPaths.FILE_PREFIX + indexId.getId(),
+            indexId.getName(),
+            String.valueOf(shardCount),
+            String.valueOf(indexId.getShardPathType()),
+            "1"
+        );
+        shardInfo = SnapshotShardPaths.parseShardPath(shardPath);
         assertEquals(shardInfo.getIndexId(), indexId);
         assertEquals(shardInfo.getShardCount(), shardCount);
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
In this PR, we are changing the name pattern of the file where we keep the paths for shard blobs for snapshots. This is done to align with the naming pattern we have followed with remote store index shard paths file as well. 

### Check List
- [x] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
