### PR TITLE
Change remote store restore cluster state priority to URGENT

### DIFF
--- a/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
+++ b/server/src/main/java/org/opensearch/index/recovery/RemoteStoreRestoreService.java
@@ -27,6 +27,7 @@ import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.Priority;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
@@ -95,7 +96,7 @@ public class RemoteStoreRestoreService {
      * @param listener restore listener
      */
     public void restore(RestoreRemoteStoreRequest request, final ActionListener<RestoreService.RestoreCompletionResponse> listener) {
-        clusterService.submitStateUpdateTask("restore[remote_store]", new ClusterStateUpdateTask() {
+        clusterService.submitStateUpdateTask("restore[remote_store]", new ClusterStateUpdateTask(Priority.URGENT) {
             String restoreUUID;
             RestoreInfo restoreInfo = null;
 


### PR DESCRIPTION
### Description
- Currently, remote store restore cluster state update has NORMAL priority.
- Given that remote store restore is triggered when cluster has unassigned shards, it becomes important to trigger restore as soon as possible.
- Due to NORMAL priority, it is possible that other HIGH/URGENT priority tasks will delay the restore process.
- In this PR, we are changing the remote store restore cluster state update priority from NORMAL to URGENT.

### Check List
- ~[ ] Functionality includes testing.~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
