### PR TITLE
Add new parameters to snapshot restore to rename the restored aliases…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Latency and Memory allocation improvements to Multi Term Aggregation queries ([#14993](https://github.com/opensearch-project/OpenSearch/pull/14993))
 - Flat object field use IndexOrDocValuesQuery to optimize query ([#14383](https://github.com/opensearch-project/OpenSearch/issues/14383))
 - Add method to return dynamic SecureTransportParameters from SecureTransportSettingsProvider interface ([#16387](https://github.com/opensearch-project/OpenSearch/pull/16387)
-- Add support for renaming aliases during snapshot restore ([XXXX](https://github.com/opensearch-project/OpenSearch/pull/XXXX))
+- Add support for renaming aliases during snapshot restore ([#16292](https://github.com/opensearch-project/OpenSearch/pull/16292))
 
 ### Dependencies
 - Bump `com.azure:azure-identity` from 1.13.0 to 1.13.2 ([#15578](https://github.com/opensearch-project/OpenSearch/pull/15578))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Latency and Memory allocation improvements to Multi Term Aggregation queries ([#14993](https://github.com/opensearch-project/OpenSearch/pull/14993))
 - Flat object field use IndexOrDocValuesQuery to optimize query ([#14383](https://github.com/opensearch-project/OpenSearch/issues/14383))
 - Add method to return dynamic SecureTransportParameters from SecureTransportSettingsProvider interface ([#16387](https://github.com/opensearch-project/OpenSearch/pull/16387)
-- [Star Tree - Search] Add support for metric aggregations with/without term query ([15289](https://github.com/opensearch-project/OpenSearch/pull/15289))
+- Add support for renaming aliases during snapshot restore ([XXXX](https://github.com/opensearch-project/OpenSearch/pull/XXXX))
 
 ### Dependencies
 - Bump `com.azure:azure-identity` from 1.13.0 to 1.13.2 ([#15578](https://github.com/opensearch-project/OpenSearch/pull/15578))

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -112,6 +112,8 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
     private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
     private String renamePattern;
     private String renameReplacement;
+    private String renameAliasPattern;
+    private String renameAliasReplacement;
     private boolean waitForCompletion;
     private boolean includeGlobalState = false;
     private boolean partial = false;
@@ -148,6 +150,8 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         renamePattern = in.readOptionalString();
         renameReplacement = in.readOptionalString();
+        renameAliasPattern = in.readOptionalString();
+        renameAliasReplacement = in.readOptionalString();
         waitForCompletion = in.readBoolean();
         includeGlobalState = in.readBoolean();
         partial = in.readBoolean();
@@ -175,6 +179,8 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         indicesOptions.writeIndicesOptions(out);
         out.writeOptionalString(renamePattern);
         out.writeOptionalString(renameReplacement);
+        out.writeOptionalString(renameAliasPattern);
+        out.writeOptionalString(renameAliasReplacement);
         out.writeBoolean(waitForCompletion);
         out.writeBoolean(includeGlobalState);
         out.writeBoolean(partial);
@@ -359,6 +365,51 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
      */
     public String renameReplacement() {
         return renameReplacement;
+    }
+
+    /**
+     * Sets rename pattern that should be applied to restored indices' alias.
+     * <p>
+     * Alias that match the rename pattern will be renamed according to {@link #renameAliasReplacement(String)}. The
+     * rename pattern is applied according to the {@link java.util.regex.Matcher#appendReplacement(StringBuffer, String)}
+     * The request will fail if two or more alias will be renamed into the same name.
+     *
+     * @param renameAliasPattern rename pattern
+     * @return this request
+     */
+    public RestoreSnapshotRequest renameAliasPattern(String renameAliasPattern) {
+        this.renameAliasPattern = renameAliasPattern;
+        return this;
+    }
+
+    /**
+     * Returns rename alias pattern
+     *
+     * @return rename alias pattern
+     */
+    public String renameAliasPattern() {
+        return renameAliasPattern;
+    }
+
+    /**
+     * Sets rename alias replacement
+     * <p>
+     * See {@link #renameAliasPattern(String)} for more information.
+     *
+     * @param renameAliasReplacement rename replacement
+     */
+    public RestoreSnapshotRequest renameAliasReplacement(String renameAliasReplacement) {
+        this.renameAliasReplacement = renameAliasReplacement;
+        return this;
+    }
+
+    /**
+     * Returns rename alias replacement
+     *
+     * @return rename alias replacement
+     */
+    public String renameAliasReplacement() {
+        return renameAliasReplacement;
     }
 
     /**
@@ -625,6 +676,18 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
                 } else {
                     throw new IllegalArgumentException("malformed rename_replacement");
                 }
+            } else if (name.equals("rename_alias_pattern")) {
+                if (entry.getValue() instanceof String) {
+                    renameAliasPattern((String) entry.getValue());
+                } else {
+                    throw new IllegalArgumentException("malformed rename_alias_pattern");
+                }
+            } else if (name.equals("rename_alias_replacement")) {
+                if (entry.getValue() instanceof String) {
+                    renameAliasReplacement((String) entry.getValue());
+                } else {
+                    throw new IllegalArgumentException("malformed rename_alias_replacement");
+                }
             } else if (name.equals("index_settings")) {
                 if (!(entry.getValue() instanceof Map)) {
                     throw new IllegalArgumentException("malformed index_settings section");
@@ -684,6 +747,12 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         }
         if (renameReplacement != null) {
             builder.field("rename_replacement", renameReplacement);
+        }
+        if (renameAliasPattern != null) {
+            builder.field("rename_alias_pattern", renameAliasPattern);
+        }
+        if (renameAliasReplacement != null) {
+            builder.field("rename_alias_replacement", renameAliasReplacement);
         }
         builder.field("include_global_state", includeGlobalState);
         builder.field("partial", partial);

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -150,8 +150,6 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         renamePattern = in.readOptionalString();
         renameReplacement = in.readOptionalString();
-        renameAliasPattern = in.readOptionalString();
-        renameAliasReplacement = in.readOptionalString();
         waitForCompletion = in.readBoolean();
         includeGlobalState = in.readBoolean();
         partial = in.readBoolean();
@@ -168,6 +166,12 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         if (in.getVersion().onOrAfter(Version.V_2_17_0)) {
             sourceRemoteTranslogRepository = in.readOptionalString();
         }
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            renameAliasPattern = in.readOptionalString();
+        }
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            renameAliasReplacement = in.readOptionalString();
+        }
     }
 
     @Override
@@ -179,8 +183,6 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         indicesOptions.writeIndicesOptions(out);
         out.writeOptionalString(renamePattern);
         out.writeOptionalString(renameReplacement);
-        out.writeOptionalString(renameAliasPattern);
-        out.writeOptionalString(renameAliasReplacement);
         out.writeBoolean(waitForCompletion);
         out.writeBoolean(includeGlobalState);
         out.writeBoolean(partial);
@@ -196,6 +198,12 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         }
         if (out.getVersion().onOrAfter(Version.V_2_17_0)) {
             out.writeOptionalString(sourceRemoteTranslogRepository);
+        }
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeOptionalString(renameAliasPattern);
+        }
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeOptionalString(renameAliasReplacement);
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -372,7 +372,7 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
      * <p>
      * Alias that match the rename pattern will be renamed according to {@link #renameAliasReplacement(String)}. The
      * rename pattern is applied according to the {@link java.util.regex.Matcher#appendReplacement(StringBuffer, String)}
-     * The request will fail if two or more alias will be renamed into the same name.
+     * If two or more aliases are renamed into the same name, they will be merged.
      *
      * @param renameAliasPattern rename pattern
      * @return this request

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -166,10 +166,11 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         if (in.getVersion().onOrAfter(Version.V_2_17_0)) {
             sourceRemoteTranslogRepository = in.readOptionalString();
         }
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+        // TODO: change to V_2_18_0 once this is backported into that version
+        if (in.getVersion().onOrAfter(Version.CURRENT)) {
             renameAliasPattern = in.readOptionalString();
         }
-        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (in.getVersion().onOrAfter(Version.CURRENT)) {
             renameAliasReplacement = in.readOptionalString();
         }
     }
@@ -199,10 +200,11 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
         if (out.getVersion().onOrAfter(Version.V_2_17_0)) {
             out.writeOptionalString(sourceRemoteTranslogRepository);
         }
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+        // TODO: change to V_2_18_0 once this is backported into that version
+        if (out.getVersion().onOrAfter(Version.CURRENT)) {
             out.writeOptionalString(renameAliasPattern);
         }
-        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+        if (out.getVersion().onOrAfter(Version.CURRENT)) {
             out.writeOptionalString(renameAliasReplacement);
         }
     }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -810,6 +810,8 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
             && Objects.equals(indicesOptions, that.indicesOptions)
             && Objects.equals(renamePattern, that.renamePattern)
             && Objects.equals(renameReplacement, that.renameReplacement)
+            && Objects.equals(renameAliasPattern, that.renameAliasPattern)
+            && Objects.equals(renameAliasReplacement, that.renameAliasReplacement)
             && Objects.equals(indexSettings, that.indexSettings)
             && Arrays.equals(ignoreIndexSettings, that.ignoreIndexSettings)
             && Objects.equals(snapshotUuid, that.snapshotUuid)
@@ -828,6 +830,8 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
             indicesOptions,
             renamePattern,
             renameReplacement,
+            renameAliasPattern,
+            renameAliasReplacement,
             waitForCompletion,
             includeGlobalState,
             partial,

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestBuilder.java
@@ -145,6 +145,34 @@ public class RestoreSnapshotRequestBuilder extends ClusterManagerNodeOperationRe
     }
 
     /**
+     * Sets rename pattern that should be applied to restored indices' aliases.
+     * <p>
+     * Aliases that match the rename pattern will be renamed according to {@link #setRenameAliasReplacement(String)}. The
+     * rename pattern is applied according to the {@link java.util.regex.Matcher#appendReplacement(StringBuffer, String)}
+     * The request will fail if two or more alias will be renamed into the same name.
+     *
+     * @param renameAliasPattern rename alias pattern
+     * @return this builder
+     */
+    public RestoreSnapshotRequestBuilder setRenameAliasPattern(String renameAliasPattern) {
+        request.renameAliasPattern(renameAliasPattern);
+        return this;
+    }
+
+    /**
+     * Sets rename replacement
+     * <p>
+     * See {@link #setRenameAliasPattern(String)} for more information.
+     *
+     * @param renameAliasReplacement rename alias replacement
+     * @return this builder
+     */
+    public RestoreSnapshotRequestBuilder setRenameAliasReplacement(String renameAliasReplacement) {
+        request.renameAliasReplacement(renameAliasReplacement);
+        return this;
+    }
+
+    /**
      * If this parameter is set to true the operation will wait for completion of restore process before returning.
      *
      * @param waitForCompletion if true the operation will wait for completion

--- a/server/src/main/java/org/opensearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/opensearch/snapshots/RestoreService.java
@@ -486,8 +486,18 @@ public class RestoreService implements ClusterStateApplier {
                                         // Remove all aliases - they shouldn't be restored
                                         indexMdBuilder.removeAllAliases();
                                     } else {
-                                        for (final String alias : snapshotIndexMetadata.getAliases().keySet()) {
-                                            aliases.add(alias);
+                                        for (final Map.Entry<String, AliasMetadata> alias : snapshotIndexMetadata.getAliases().entrySet()) {
+                                            String aliasName = alias.getKey();
+                                            if (request.renameAliasPattern() != null && request.renameAliasReplacement() != null) {
+                                                indexMdBuilder.removeAlias(aliasName);
+                                                aliasName = aliasName.replaceAll(
+                                                    request.renameAliasPattern(),
+                                                    request.renameAliasReplacement()
+                                                );
+                                                AliasMetadata newAlias = AliasMetadata.newAliasMetadata(alias.getValue(), aliasName);
+                                                indexMdBuilder.putAlias(newAlias);
+                                            }
+                                            aliases.add(aliasName);
                                         }
                                     }
                                     IndexMetadata updatedIndexMetadata = indexMdBuilder.build();
@@ -533,8 +543,18 @@ public class RestoreService implements ClusterStateApplier {
                                             indexMdBuilder.putAlias(alias);
                                         }
                                     } else {
-                                        for (final String alias : snapshotIndexMetadata.getAliases().keySet()) {
-                                            aliases.add(alias);
+                                        for (final Map.Entry<String, AliasMetadata> alias : snapshotIndexMetadata.getAliases().entrySet()) {
+                                            String aliasName = alias.getKey();
+                                            if (request.renameAliasPattern() != null && request.renameAliasReplacement() != null) {
+                                                indexMdBuilder.removeAlias(aliasName);
+                                                aliasName = aliasName.replaceAll(
+                                                    request.renameAliasPattern(),
+                                                    request.renameAliasReplacement()
+                                                );
+                                                AliasMetadata newAlias = AliasMetadata.newAliasMetadata(alias.getValue(), aliasName);
+                                                indexMdBuilder.putAlias(newAlias);
+                                            }
+                                            aliases.add(aliasName);
                                         }
                                     }
                                     final Settings.Builder indexSettingsBuilder = Settings.builder()

--- a/server/src/test/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
@@ -71,6 +71,12 @@ public class RestoreSnapshotRequestTests extends AbstractWireSerializingTestCase
         if (randomBoolean()) {
             instance.renameReplacement(randomUnicodeOfLengthBetween(1, 100));
         }
+        if (randomBoolean()) {
+            instance.renameAliasPattern(randomUnicodeOfLengthBetween(1, 100));
+        }
+        if (randomBoolean()) {
+            instance.renameAliasReplacement(randomUnicodeOfLengthBetween(1, 100));
+        }
         instance.partial(randomBoolean());
         instance.includeAliases(randomBoolean());
 

--- a/server/src/test/java/org/opensearch/snapshots/RestoreServiceIntegTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/RestoreServiceIntegTests.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.snapshots;
+
+import org.opensearch.action.StepListener;
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
+import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.opensearch.common.CheckedConsumer;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.repositories.fs.FsRepository;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+//import static org.opensearch.node.Node.NODE_NAME_SETTING;
+
+public class RestoreServiceIntegTests extends OpenSearchSingleNodeTestCase {
+    // private DeterministicTaskQueue deterministicTaskQueue;
+
+    // @Before
+    // public void createServices() {
+    // deterministicTaskQueue = new DeterministicTaskQueue(Settings.builder().put(NODE_NAME_SETTING.getKey(), "shared").build(), random());
+    // }
+
+    // TODO there is certainly a better way to do this, but I don't know what it is....
+    public void testRestoreWithAliasAndRename() {
+        __testRestoreWithRename(false, true, true, true);
+    }
+
+    public void testRestoreWithoutAliasAndWithRename() {
+        __testRestoreWithRename(false, false, true, true);
+    }
+
+    public void testRestoreWithoutAliasAndRename() {
+        __testRestoreWithRename(false, false, false, false);
+    }
+
+    public void testRestoreWithAliasAndWithoutRename() {
+        __testRestoreWithRename(false, true, false, false);
+    }
+
+    public void __testRestoreWithRename(boolean closed, boolean includeAlias, boolean renameAlias, boolean renameIndexes) {
+        final String indexName = "index_1";
+        final String aliasName = "alias_1";
+        final String repoName = "repo_1";
+        final String snapShotName = "snap_1";
+        this.createIndex(indexName);
+        client().admin()
+            .indices()
+            .aliases(
+                new IndicesAliasesRequest().addAliasAction(IndicesAliasesRequest.AliasActions.add().alias(aliasName).index(indexName))
+            );
+
+        final boolean expectFailure = !renameIndexes || (includeAlias && !renameAlias);
+
+        Settings.Builder settings = Settings.builder().put("location", randomAlphaOfLength(10));
+        OpenSearchIntegTestCase.putRepository(client().admin().cluster(), repoName, FsRepository.TYPE, settings);
+
+        final StepListener<CreateSnapshotResponse> createSnapshotResponseStepListener = new StepListener<>();
+
+        client().admin()
+            .cluster()
+            .prepareCreateSnapshot(repoName, snapShotName)
+            .setWaitForCompletion(true)
+            .setPartial(true)
+            .execute(createSnapshotResponseStepListener);
+
+        final StepListener<RestoreSnapshotResponse> restoreSnapshotResponseStepListener = new StepListener<>();
+
+        final AtomicBoolean isFinished = new AtomicBoolean(false);
+        continueOrDie(createSnapshotResponseStepListener, r -> {
+            assert r.getSnapshotInfo().state() == SnapshotState.SUCCESS;
+            RestoreSnapshotRequest restoreSnapshotRequest = new RestoreSnapshotRequest(repoName, snapShotName).includeAliases(includeAlias);
+            if (renameAlias) {
+                restoreSnapshotRequest = restoreSnapshotRequest.renameAliasPattern("1").renameAliasReplacement("2");
+            }
+            if (renameIndexes) {
+                restoreSnapshotRequest = restoreSnapshotRequest.renamePattern("1").renameReplacement("2");
+            }
+            client().admin().cluster().restoreSnapshot(restoreSnapshotRequest, restoreSnapshotResponseStepListener);
+        });
+
+        restoreSnapshotResponseStepListener.whenComplete(r -> {
+            assertFalse("unexpected sucesssful restore", expectFailure);
+            isFinished.set(true);
+        }, e -> {
+            if (expectFailure) {
+                // expected failed - ignore
+                isFinished.set(true);
+            } else {
+                throw new RuntimeException(e);
+            }
+        });
+
+        runUntil(isFinished::get, TimeUnit.MINUTES.toMillis(1L));
+    }
+
+    private static <T> void continueOrDie(StepListener<T> listener, CheckedConsumer<T, Exception> onResponse) {
+        listener.whenComplete(onResponse, e -> { throw new AssertionError(e); });
+    }
+
+    // TODO there is certainly a better way to do this, but I don't know what it is....
+    private void runUntil(Supplier<Boolean> fulfilled, long timeout) {
+        // final long start = deterministicTaskQueue.getCurrentTimeMillis();
+        // while (timeout > deterministicTaskQueue.getCurrentTimeMillis() - start) {
+        final long start = System.currentTimeMillis();
+        while (timeout > System.currentTimeMillis() - start) {
+            if (fulfilled.get()) {
+                return;
+            }
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {}
+            // deterministicTaskQueue.runAllRunnableTasks();
+            // deterministicTaskQueue.advanceTime();
+        }
+        fail("Condition wasn't fulfilled.");
+    }
+}

--- a/server/src/test/java/org/opensearch/snapshots/RestoreServiceIntegTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/RestoreServiceIntegTests.java
@@ -40,56 +40,57 @@ import java.util.concurrent.TimeUnit;
 public class RestoreServiceIntegTests extends OpenSearchSingleNodeTestCase {
     // TODO there is certainly a better way to do this, but I don't know what it is....
     public void testRestoreToNewWithAliasAndRename() throws Exception {
-        __testRestoreWithRename(false, false, true, true, true);
+        testRestoreWithRename(false, false, true, true, true);
     }
 
     public void testRestoreToNewWithoutAliasAndWithRename() throws Exception {
-        __testRestoreWithRename(false, false, false, true, true);
+        testRestoreWithRename(false, false, false, true, true);
     }
 
     public void testRestoreToNewWithAliasAndWithoutRename() throws Exception {
-        __testRestoreWithRename(false, false, true, false, false);
+        testRestoreWithRename(false, false, true, false, false);
     }
 
     public void testRestoreToNewWithoutAliasAndRename() throws Exception {
-        __testRestoreWithRename(false, false, false, false, false);
+        testRestoreWithRename(false, false, false, false, false);
     }
 
     public void testRestoreOverExistingOpenWithAliasAndRename() throws Exception {
-        __testRestoreWithRename(true, false, true, true, true);
+        testRestoreWithRename(true, false, true, true, true);
     }
 
     public void testRestoreOverExistingOpenWithoutAliasAndWithRename() throws Exception {
-        __testRestoreWithRename(true, false, false, true, true);
+        testRestoreWithRename(true, false, false, true, true);
     }
 
     public void testRestoreOverExistingClosedWithAliasAndRename() throws Exception {
-        __testRestoreWithRename(true, true, true, true, true);
+        testRestoreWithRename(true, true, true, true, true);
     }
 
     public void testRestoreOverExistingClosedWithoutAliasAndWithRename() throws Exception {
-        __testRestoreWithRename(true, true, false, true, true);
+        testRestoreWithRename(true, true, false, true, true);
     }
 
     public void testRestoreOverExistingOpenWithoutAliasAndRename() throws Exception {
-        __testRestoreWithRename(true, false, false, false, false);
+        testRestoreWithRename(true, false, false, false, false);
     }
 
     public void testRestoreOverExistingOpenWithAliasAndWithoutRename() throws Exception {
-        __testRestoreWithRename(true, false, true, false, false);
+        testRestoreWithRename(true, false, true, false, false);
     }
 
     public void testRestoreOverExistingClosedWithoutAliasAndRename() throws Exception {
-        __testRestoreWithRename(true, true, false, false, false);
+        testRestoreWithRename(true, true, false, false, false);
     }
 
     public void testRestoreOverExistingClosedWithAliasAndWithoutRename() throws Exception {
-        __testRestoreWithRename(true, true, true, false, false);
+        testRestoreWithRename(true, true, true, false, false);
     }
 
-    private void __testRestoreWithRename(boolean exists, boolean closed, boolean includeAlias, boolean renameAliases, boolean renameIndexes)
+    private void testRestoreWithRename(boolean exists, boolean closed, boolean includeAlias, boolean renameAliases, boolean renameIndexes)
         throws Exception {
-        assert exists || !closed;
+        assert exists || !closed; // index close state doesn't exist when the index doesn't exist - so only permit one value of closed to
+                                  // avoid pointless duplicate tests
         final String indexName = "index_1";
         final String renamedIndexName = "index_2";
         final String aliasName = "alias_1";

--- a/server/src/test/java/org/opensearch/snapshots/RestoreServiceIntegTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/RestoreServiceIntegTests.java
@@ -13,14 +13,29 @@ import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotRespon
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.opensearch.action.admin.indices.close.CloseIndexRequest;
+import org.opensearch.action.admin.indices.close.CloseIndexResponse;
+import org.opensearch.action.admin.indices.open.OpenIndexRequest;
+import org.opensearch.action.admin.indices.open.OpenIndexResponse;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.repositories.fs.FsRepository;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
+import java.util.Collections;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 //import static org.opensearch.node.Node.NODE_NAME_SETTING;
 
@@ -33,38 +48,105 @@ public class RestoreServiceIntegTests extends OpenSearchSingleNodeTestCase {
     // }
 
     // TODO there is certainly a better way to do this, but I don't know what it is....
-    public void testRestoreWithAliasAndRename() {
-        __testRestoreWithRename(false, true, true, true);
+    public void testRestoreToNewWithAliasAndRename() {
+        __testRestoreWithRename(false, false, true, true, true);
     }
 
-    public void testRestoreWithoutAliasAndWithRename() {
-        __testRestoreWithRename(false, false, true, true);
+    public void testRestoreToNewWithoutAliasAndWithRename() {
+        __testRestoreWithRename(false, false, false, true, true);
     }
 
-    public void testRestoreWithoutAliasAndRename() {
-        __testRestoreWithRename(false, false, false, false);
+    public void testRestoreOverExistingOpenWithAliasAndRename() {
+        __testRestoreWithRename(true, false, true, true, true);
     }
 
-    public void testRestoreWithAliasAndWithoutRename() {
-        __testRestoreWithRename(false, true, false, false);
+    public void testRestoreOverExistingOpenWithoutAliasAndWithRename() {
+        __testRestoreWithRename(true, false, false, true, true);
     }
 
-    public void __testRestoreWithRename(boolean closed, boolean includeAlias, boolean renameAlias, boolean renameIndexes) {
+    public void testRestoreOverExistingClosedWithAliasAndRename() {
+        __testRestoreWithRename(true, true, true, true, true);
+    }
+
+    public void testRestoreOverExistingClosedWithoutAliasAndWithRename() {
+        __testRestoreWithRename(true, true, false, true, true);
+    }
+
+    public void testRestoreOverExistingOpenWithoutAliasAndRename() {
+        __testRestoreWithRename(true, false, false, false, false);
+    }
+
+    public void testRestoreOverExistingOpenWithAliasAndWithoutRename() {
+        __testRestoreWithRename(true, false, true, false, false);
+    }
+
+    public void testRestoreOverExistingClosedWithoutAliasAndRename() {
+        __testRestoreWithRename(true, true, false, false, false);
+    }
+
+    public void testRestoreOverExistingClosedWithAliasAndWithoutRename() {
+        __testRestoreWithRename(true, true, true, false, false);
+    }
+
+    public void __testRestoreWithRename(
+        boolean exists,
+        boolean closed,
+        boolean includeAlias,
+        boolean renameAliases,
+        boolean renameIndexes
+    ) {
+        assert exists || renameIndexes;
         final String indexName = "index_1";
+        final String renamedIndexName = "index_2";
         final String aliasName = "alias_1";
+        final String renamedAliasName = "alias_2";
         final String repoName = "repo_1";
         final String snapShotName = "snap_1";
+        final boolean expectSuccess = !exists || closed;
+        final int documents = randomIntBetween(1, 100);
+
         this.createIndex(indexName);
+        if (exists && renameIndexes) {
+            this.createIndex(renamedIndexName);
+        }
+
+        final StepListener<AcknowledgedResponse> createAliasResponseStepListener = new StepListener<>();
         client().admin()
             .indices()
             .aliases(
-                new IndicesAliasesRequest().addAliasAction(IndicesAliasesRequest.AliasActions.add().alias(aliasName).index(indexName))
+                new IndicesAliasesRequest().addAliasAction(IndicesAliasesRequest.AliasActions.add().alias(aliasName).index(indexName)),
+                createAliasResponseStepListener
             );
 
-        final boolean expectFailure = !renameIndexes || (includeAlias && !renameAlias);
+        final AtomicBoolean isDocumentFinished = new AtomicBoolean(false);
+        continueOrDie(createAliasResponseStepListener, ignored -> {
+            final BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            for (int i = 0; i < documents; ++i) {
+                bulkRequest.add(new IndexRequest(indexName).source(Collections.singletonMap("foo", "bar" + i)));
+            }
+            final StepListener<BulkResponse> bulkResponseStepListener = new StepListener<>();
+            client().bulk(bulkRequest, bulkResponseStepListener);
+            continueOrDie(bulkResponseStepListener, bulkResponse -> {
+                assertFalse("Failures in bulk response: " + bulkResponse.buildFailureMessage(), bulkResponse.hasFailures());
+                assertEquals(documents, bulkResponse.getItems().length);
+                isDocumentFinished.set(true);
+            });
+        });
 
         Settings.Builder settings = Settings.builder().put("location", randomAlphaOfLength(10));
         OpenSearchIntegTestCase.putRepository(client().admin().cluster(), repoName, FsRepository.TYPE, settings);
+
+        runUntil(isDocumentFinished::get, TimeUnit.MINUTES.toMillis(1L));
+
+        if (closed) {
+            final AtomicBoolean isReady = new AtomicBoolean(false);
+            final StepListener<CloseIndexResponse> closeIndexResponseStepListener = new StepListener<>();
+            final String indexToClose = renameIndexes ? renamedIndexName : indexName;
+            client().admin().indices().close(new CloseIndexRequest(indexToClose), closeIndexResponseStepListener);
+
+            continueOrDie(closeIndexResponseStepListener, ignored -> { isReady.set(true); });
+            runUntil(isReady::get, TimeUnit.MINUTES.toMillis(1L));
+        }
 
         final StepListener<CreateSnapshotResponse> createSnapshotResponseStepListener = new StepListener<>();
 
@@ -80,8 +162,9 @@ public class RestoreServiceIntegTests extends OpenSearchSingleNodeTestCase {
         final AtomicBoolean isFinished = new AtomicBoolean(false);
         continueOrDie(createSnapshotResponseStepListener, r -> {
             assert r.getSnapshotInfo().state() == SnapshotState.SUCCESS;
-            RestoreSnapshotRequest restoreSnapshotRequest = new RestoreSnapshotRequest(repoName, snapShotName).includeAliases(includeAlias);
-            if (renameAlias) {
+            RestoreSnapshotRequest restoreSnapshotRequest = new RestoreSnapshotRequest(repoName, snapShotName).includeAliases(includeAlias)
+                .waitForCompletion(true);
+            if (renameAliases) {
                 restoreSnapshotRequest = restoreSnapshotRequest.renameAliasPattern("1").renameAliasReplacement("2");
             }
             if (renameIndexes) {
@@ -91,18 +174,54 @@ public class RestoreServiceIntegTests extends OpenSearchSingleNodeTestCase {
         });
 
         restoreSnapshotResponseStepListener.whenComplete(r -> {
-            assertFalse("unexpected sucesssful restore", expectFailure);
             isFinished.set(true);
+            assertTrue("unexpected sucesssful restore", expectSuccess);
         }, e -> {
-            if (expectFailure) {
-                // expected failed - ignore
-                isFinished.set(true);
-            } else {
+            isFinished.set(true);
+            if (expectSuccess) {
                 throw new RuntimeException(e);
             }
         });
 
-        runUntil(isFinished::get, TimeUnit.MINUTES.toMillis(1L));
+        runUntil(isFinished::get, TimeUnit.SECONDS.toMillis(10L));
+
+        if (expectSuccess) {
+            // assertEquals(shards, restoreSnapshotResponse.getRestoreInfo().totalShards());
+            final String indexToSearch = renameIndexes ? renamedIndexName : indexName;
+            final String aliasToSearch = renameAliases ? renamedAliasName : aliasName;
+
+            if (closed) {
+                final AtomicBoolean isReady = new AtomicBoolean(false);
+                final StepListener<OpenIndexResponse> openIndexResponseStepListener = new StepListener<>();
+                client().admin().indices().open(new OpenIndexRequest(indexToSearch).waitForActiveShards(1), openIndexResponseStepListener);
+                continueOrDie(openIndexResponseStepListener, ignored -> { isReady.set(true); });
+                runUntil(isReady::get, TimeUnit.MINUTES.toMillis(1L));
+            }
+
+            final StepListener<SearchResponse> searchIndexResponseListener = new StepListener<>();
+            final StepListener<SearchResponse> searchAliasResponseListener = new StepListener<>();
+            final int expectedCount = includeAlias ? 2 : 1;
+            final AtomicInteger isSearchDone = new AtomicInteger(0);
+            client().search(
+                new SearchRequest(indexToSearch).source(new SearchSourceBuilder().size(0).trackTotalHits(true)),
+                searchIndexResponseListener
+            );
+            continueOrDie(searchIndexResponseListener, ignored -> { isSearchDone.addAndGet(1); });
+            if (includeAlias) {
+                client().search(
+                    new SearchRequest(aliasToSearch).source(new SearchSourceBuilder().size(0).trackTotalHits(true)),
+                    searchAliasResponseListener
+                );
+                continueOrDie(searchAliasResponseListener, ignored -> { isSearchDone.addAndGet(1); });
+            }
+
+            runUntil(() -> { return isSearchDone.get() >= expectedCount; }, TimeUnit.SECONDS.toMillis(10L));
+
+            assertEquals(documents, Objects.requireNonNull(searchIndexResponseListener.result().getHits().getTotalHits()).value);
+            if (includeAlias) {
+                assertEquals(documents, Objects.requireNonNull(searchAliasResponseListener.result().getHits().getTotalHits()).value);
+            }
+        }
     }
 
     private static <T> void continueOrDie(StepListener<T> listener, CheckedConsumer<T, Exception> onResponse) {

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotRequestsTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotRequestsTests.java
@@ -77,6 +77,8 @@ public class SnapshotRequestsTests extends OpenSearchTestCase {
         builder.field("allow_no_indices", indicesOptions.allowNoIndices());
         builder.field("rename_pattern", "rename-from");
         builder.field("rename_replacement", "rename-to");
+        builder.field("rename_alias_pattern", "alias-rename-from");
+        builder.field("rename_alias_replacement", "alias-rename-to");
         boolean partial = randomBoolean();
         builder.field("partial", partial);
         builder.startObject("settings").field("set1", "val1").endObject();
@@ -103,6 +105,8 @@ public class SnapshotRequestsTests extends OpenSearchTestCase {
         assertArrayEquals(request.indices(), new String[] { "foo", "bar", "baz" });
         assertEquals("rename-from", request.renamePattern());
         assertEquals("rename-to", request.renameReplacement());
+        assertEquals("alias-rename-from", request.renameAliasPattern());
+        assertEquals("alias-rename-to", request.renameAliasReplacement());
         assertEquals(partial, request.partial());
         assertArrayEquals(request.ignoreIndexSettings(), new String[] { "set2", "set3" });
         boolean expectedIgnoreAvailable = includeIgnoreUnavailable


### PR DESCRIPTION
### Description
Add new parameters to snapshot restore to rename the restored aliases similar to how you can currently rename the restored indexes.

### Related Issues
Resolves #15632

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable. - [PR 615](https://github.com/opensearch-project/opensearch-api-specification/pull/615)
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. - [PR 8544](https://github.com/opensearch-project/documentation-website/pull/8544)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
