### PR TITLE
Skip unnecessary string format in RemoteStoreMigrationAllocationDecider when not in debug mode

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/RemoteStoreMigrationAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/RemoteStoreMigrationAllocationDecider.java
@@ -186,8 +186,8 @@ public class RemoteStoreMigrationAllocationDecider extends AllocationDecider {
         String reason,
         RoutingAllocation allocation
     ) {
-        if (allocation.debugDecision()) {
-            return "";
+        if (allocation.debugDecision() == false) {
+            return null;
         }
         return new StringBuilder("[").append(migrationDirection.direction)
             .append(" migration_direction]: ")


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Skip unnecessary string format in RemoteStoreMigrationAllocationDecider when not in debug mode

### Related Issues
Master hot thread - 
```
app//org.opensearch.cluster.routing.allocation.decider.RemoteStoreMigrationAllocationDecider.getDecisionDetails(RemoteStoreMigrationAllocationDecider.java:196)
       app//org.opensearch.cluster.routing.allocation.decider.RemoteStoreMigrationAllocationDecider.canAllocate(RemoteStoreMigrationAllocationDecider.java:94)
       app//org.opensearch.cluster.routing.allocation.decider.AllocationDeciders.canAllocate(AllocationDeciders.java:94)
       app//org.opensearch.cluster.routing.allocation.allocator.LocalShardsBalancer.decideAllocateUnassigned(LocalShardsBalancer.java:980)
       app//org.opensearch.cluster.routing.allocation.allocator.LocalShardsBalancer.allocateUnassigned(LocalShardsBalancer.java:866)
       app//org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.allocate(BalancedShardsAllocator.java:353)
       app//org.opensearch.cluster.routing.allocation.AllocationService.reroute(AllocationService.java:575)
       app//org.opensearch.cluster.routing.allocation.AllocationService.reroute(AllocationService.java:542)
       app//org.opensearch.cluster.routing.allocation.AllocationService.disassociateDeadNodes(AllocationService.java:353)
       app//org.opensearch.cluster.coordination.NodeRemovalClusterStateTaskExecutor.getTaskClusterTasksResult(NodeRemovalClusterStateTaskExecutor.java:123)
       app//org.opensearch.cluster.coordination.NodeRemovalClusterStateTaskExecutor.execute(NodeRemovalClusterStateTaskExecutor.java:113)
       app//org.opensearch.cluster.service.MasterService.executeTasks(MasterService.java:912)
       app//org.opensearch.cluster.service.MasterService.calculateTaskOutputs(MasterService.java:464)
       app//org.opensearch.cluster.service.MasterService.runTasks(MasterService.java:324)
       app//org.opensearch.cluster.service.MasterService$Batcher.run(MasterService.java:228)
       app//org.opensearch.cluster.service.TaskBatcher.runIfNotProcessed(TaskBatcher.java:215)
       app//org.opensearch.cluster.service.TaskBatcher$BatchedTask.run(TaskBatcher.java:257)
       app//org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:891)
       
```

### Check List
- ~[ ] Functionality includes testing.~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
