### PR TITLE
[Backport 2.x] Fix multi-search with template doesn't return status code (#16265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Streaming bulk request hangs ([#16158](https://github.com/opensearch-project/OpenSearch/pull/16158))
 - Fix warnings from SLF4J on startup when repository-s3 is installed ([#16194](https://github.com/opensearch-project/OpenSearch/pull/16194))
 - Fix protobuf-java leak through client library dependencies ([#16254](https://github.com/opensearch-project/OpenSearch/pull/16254))
+- Fix multi-search with template doesn't return status code ([#16265](https://github.com/opensearch-project/OpenSearch/pull/16265))
 
 ### Security
 

--- a/modules/lang-mustache/src/main/java/org/opensearch/script/mustache/MultiSearchTemplateResponse.java
+++ b/modules/lang-mustache/src/main/java/org/opensearch/script/mustache/MultiSearchTemplateResponse.java
@@ -33,6 +33,7 @@
 package org.opensearch.script.mustache;
 
 import org.opensearch.LegacyESVersion;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.common.Nullable;
@@ -174,6 +175,7 @@ public class MultiSearchTemplateResponse extends ActionResponse implements Itera
             if (item.isFailure()) {
                 builder.startObject();
                 OpenSearchException.generateFailureXContent(builder, params, item.getFailure(), true);
+                builder.field(Fields.STATUS, ExceptionsHelper.status(item.getFailure()).getStatus());
                 builder.endObject();
             } else {
                 item.getResponse().toXContent(builder, params);
@@ -186,6 +188,7 @@ public class MultiSearchTemplateResponse extends ActionResponse implements Itera
 
     static final class Fields {
         static final String RESPONSES = "responses";
+        static final String STATUS = "status";
     }
 
     public static MultiSearchTemplateResponse fromXContext(XContentParser parser) {

--- a/modules/lang-mustache/src/main/java/org/opensearch/script/mustache/MultiSearchTemplateResponse.java
+++ b/modules/lang-mustache/src/main/java/org/opensearch/script/mustache/MultiSearchTemplateResponse.java
@@ -32,8 +32,8 @@
 
 package org.opensearch.script.mustache;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.common.Nullable;

--- a/modules/lang-mustache/src/main/java/org/opensearch/script/mustache/SearchTemplateResponse.java
+++ b/modules/lang-mustache/src/main/java/org/opensearch/script/mustache/SearchTemplateResponse.java
@@ -120,7 +120,10 @@ public class SearchTemplateResponse extends ActionResponse implements StatusToXC
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         if (hasResponse()) {
-            response.toXContent(builder, params);
+            builder.startObject();
+            response.innerToXContent(builder, params);
+            builder.field(MultiSearchTemplateResponse.Fields.STATUS, response.status().getStatus());
+            builder.endObject();
         } else {
             builder.startObject();
             // we can assume the template is always json as we convert it before compiling it

--- a/modules/lang-mustache/src/test/java/org/opensearch/script/mustache/SearchTemplateResponseTests.java
+++ b/modules/lang-mustache/src/test/java/org/opensearch/script/mustache/SearchTemplateResponseTests.java
@@ -234,6 +234,7 @@ public class SearchTemplateResponseTests extends AbstractXContentTestCase<Search
             .endObject()
             .endArray()
             .endObject()
+            .field("status", 200)
             .endObject();
 
         XContentBuilder actualResponse = MediaTypeRegistry.contentBuilder(contentType);

--- a/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/50_multi_search_template.yml
+++ b/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/50_multi_search_template.yml
@@ -205,3 +205,51 @@ setup:
   - match:  { responses.1.hits.total.relation:  eq }
   - match:  { responses.2.hits.total.value:     1  }
   - match:  { responses.1.hits.total.relation:  eq }
+
+---
+"Test multi-search template returns status code":
+  - skip:
+      version: " - 2.17.99"
+      reason: Fixed in 2.18.0.
+  - do:
+      msearch_template:
+        rest_total_hits_as_int: true
+        body:
+          # Search 0 is OK
+          - index: index_*
+          - source: '{"query": {"match": {"foo": "{{value}}"} } }'
+            params:
+              value: "foo"
+          # Search 1 has an unclosed JSON template
+          - index: index_*
+          - source: '{"query": {"match": {'
+            params:
+              field: "foo"
+              value: "bar"
+          # Search 2 is OK
+          - index: _all
+          - source:
+              query:
+                match: {foo: "{{text}}"}
+            params:
+              text: "baz"
+          # Search 3 has an unknown query type
+          - index: index_*
+          - source: '{"query": {"{{query_type}}": {} }' # Unknown query type
+            params:
+              query_type: "unknown"
+          # Search 4 has an unsupported track_total_hits
+          - index: index_*
+          - source: '{"query": {"match_all": {} }, "track_total_hits": "{{trackTotalHits}}" }'
+            params:
+              trackTotalHits: 1
+          # Search 5 has an unknown index
+          - index: unknown_index
+          - source: '{"query": {"match_all": {} } }'
+
+  - match:  { responses.0.status:     200  }
+  - match:  { responses.1.status:     400  }
+  - match:  { responses.2.status:     200  }
+  - match:  { responses.3.status:     400  }
+  - match:  { responses.4.status:     400  }
+  - match:  { responses.5.status:     404  }


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/OpenSearch/pull/16265 to 2.x.

### Related Issues

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
