### PR TITLE
[NOCOMMIT] Approximate match all query benchmark

### DIFF
--- a/.github/benchmark-configs.json
+++ b/.github/benchmark-configs.json
@@ -221,5 +221,23 @@
       "data_instance_config": "4vCPU, 32G Mem, 16G Heap"
     },
     "baseline_cluster_config": "x64-r5.xlarge-1-shard-0-replica-snapshot-baseline"
+  },
+  "id_14": {
+    "description": "Search only test-procedure for big5, uses snapshot to restore the data for OS-3.0.0. Enables range query approximation.",
+    "supported_major_versions": ["3"],
+    "cluster-benchmark-configs": {
+      "SINGLE_NODE_CLUSTER": "true",
+      "MIN_DISTRIBUTION": "true",
+      "TEST_WORKLOAD": "big5",
+      "ADDITIONAL_CONFIG": "opensearch.experimental.feature.approximate_point_range_query.enabled:true",
+      "WORKLOAD_PARAMS": "{\"snapshot_repo_name\":\"benchmark-workloads-repo-300\",\"snapshot_bucket_name\":\"benchmark-workload-snapshots\",\"snapshot_region\":\"us-east-1\",\"snapshot_base_path\":\"workload-snapshots-300\",\"snapshot_name\":\"big5_1_shard_ordered\"}",
+      "CAPTURE_NODE_STAT": "true",
+      "TEST_PROCEDURE": "restore-from-snapshot"
+    },
+    "cluster_configuration": {
+      "size": "Single-Node",
+      "data_instance_config": "4vCPU, 32G Mem, 16G Heap"
+    },
+    "baseline_cluster_config": "x64-r5.xlarge-1-shard-0-replica-snapshot-baseline"
   }
 }

--- a/server/src/main/java/org/opensearch/index/query/MatchAllQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/MatchAllQueryBuilder.java
@@ -34,12 +34,15 @@ package org.opensearch.index.query;
 
 import org.apache.lucene.search.Query;
 import org.opensearch.common.lucene.search.Queries;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.common.ParsingException;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ObjectParser;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.search.approximate.ApproximateMatchAllQuery;
+import org.opensearch.search.approximate.ApproximateScoreQuery;
 
 import java.io.IOException;
 
@@ -88,7 +91,11 @@ public class MatchAllQueryBuilder extends AbstractQueryBuilder<MatchAllQueryBuil
 
     @Override
     protected Query doToQuery(QueryShardContext context) {
-        return Queries.newMatchAllQuery();
+        Query query = Queries.newMatchAllQuery();
+        if (FeatureFlags.isEnabled(FeatureFlags.APPROXIMATE_POINT_RANGE_QUERY_SETTING)) {
+            return new ApproximateScoreQuery(query, new ApproximateMatchAllQuery());
+        }
+        return query;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/approximate/ApproximateMatchAllQuery.java
+++ b/server/src/main/java/org/opensearch/search/approximate/ApproximateMatchAllQuery.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.approximate;
+
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.sort.FieldSortBuilder;
+
+import java.io.IOException;
+
+public class ApproximateMatchAllQuery extends ApproximateQuery {
+    private ApproximateQuery approximation = null;
+
+    @Override
+    protected boolean canApproximate(SearchContext context) {
+        if (context == null) {
+            return false;
+        }
+        if (context.aggregations() != null) {
+            return false;
+        }
+
+        if (context.request() != null && context.request().source() != null) {
+            FieldSortBuilder primarySortField = FieldSortBuilder.getPrimaryFieldSortOrNull(context.request().source());
+            if (primarySortField != null && primarySortField.missing() == null) {
+                MappedFieldType mappedFieldType = context.getQueryShardContext().fieldMapper(primarySortField.fieldName());
+                Query rangeQuery = mappedFieldType.rangeQuery(null, null, false, false, null, null, null, context.getQueryShardContext());
+                if (rangeQuery instanceof ApproximateScoreQuery) {
+                    ApproximateScoreQuery approximateScoreQuery = (ApproximateScoreQuery) rangeQuery;
+                    approximateScoreQuery.setContext(context);
+                    if (approximateScoreQuery.resolvedQuery instanceof ApproximateQuery) {
+                        approximation = (ApproximateQuery) approximateScoreQuery.resolvedQuery;
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString(String field) {
+        return "Approximate(*:*)";
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        visitor.visitLeaf(this);
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return sameClassAs(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return classHash();
+    }
+
+    @Override
+    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+        if (approximation == null) {
+            throw new IllegalStateException("rewrite called without setting context or query could not be approximated");
+        }
+        return approximation;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/approximate/ApproximateScoreQuery.java
+++ b/server/src/main/java/org/opensearch/search/approximate/ApproximateScoreQuery.java
@@ -42,7 +42,7 @@ public final class ApproximateScoreQuery extends Query {
     }
 
     @Override
-    public final Query rewrite(IndexSearcher indexSearcher) throws IOException {
+    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
         if (resolvedQuery == null) {
             throw new IllegalStateException("Cannot rewrite resolved query without setContext being called");
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR accompanies https://github.com/opensearch-project/OpenSearch/pull/16321 and adds a throwaway benchmark workload that enables range query approximation, to check if the changes there have the desired effect of reducing latency on `match_all` queries with a `sort` over a numeric field.

### Related Issues
N/A

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
