### PR TITLE
Removed unneeded calls of String.format.

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteManifestManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteManifestManager.java
@@ -145,7 +145,7 @@ public class RemoteManifestManager {
         CountDownLatch latch = new CountDownLatch(1);
 
         LatchedActionListener completionListener = new LatchedActionListener<>(ActionListener.wrap(resp -> {
-            logger.trace(String.format(Locale.ROOT, "Manifest file uploaded successfully."));
+            logger.trace("Manifest file uploaded successfully.");
         }, ex -> { exceptionReference.set(ex); }), latch);
 
         RemoteClusterMetadataManifest remoteClusterMetadataManifest = new RemoteClusterMetadataManifest(
@@ -159,13 +159,13 @@ public class RemoteManifestManager {
         try {
             if (latch.await(getMetadataManifestUploadTimeout().millis(), TimeUnit.MILLISECONDS) == false) {
                 RemoteStateTransferException ex = new RemoteStateTransferException(
-                    String.format(Locale.ROOT, "Timed out waiting for transfer of manifest file to complete")
+                    "Timed out waiting for transfer of manifest file to complete"
                 );
                 throw ex;
             }
         } catch (InterruptedException ex) {
             RemoteStateTransferException exception = new RemoteStateTransferException(
-                String.format(Locale.ROOT, "Timed out waiting for transfer of manifest file to complete - %s"),
+                "Timed out waiting for transfer of manifest file to complete",
                 ex
             );
             Thread.currentThread().interrupt();

--- a/server/src/main/java/org/opensearch/index/compositeindex/CompositeIndexValidator.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/CompositeIndexValidator.java
@@ -35,10 +35,8 @@ public class CompositeIndexValidator {
     ) {
         if (!isCompositeFieldPresent && mapperService.isCompositeIndexPresent()) {
             throw new IllegalArgumentException(
-                String.format(
-                    Locale.ROOT,
-                    "Composite fields must be specified during index creation, addition of new composite fields during update is not supported"
-                )
+                Locale.ROOT,
+                "Composite fields must be specified during index creation, addition of new composite fields during update is not supported"
             );
         }
         StarTreeValidator.validate(mapperService, compositeIndexSettings, indexSettings);

--- a/server/src/main/java/org/opensearch/index/compositeindex/CompositeIndexValidator.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/CompositeIndexValidator.java
@@ -35,7 +35,6 @@ public class CompositeIndexValidator {
     ) {
         if (!isCompositeFieldPresent && mapperService.isCompositeIndexPresent()) {
             throw new IllegalArgumentException(
-                Locale.ROOT,
                 "Composite fields must be specified during index creation, addition of new composite fields during update is not supported"
             );
         }

--- a/server/src/test/java/org/opensearch/cluster/routing/remote/RemoteRoutingTableServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/remote/RemoteRoutingTableServiceTests.java
@@ -567,7 +567,7 @@ public class RemoteRoutingTableServiceTests extends OpenSearchTestCase {
     public void testGetAsyncIndexRoutingReadAction() throws Exception {
         String indexName = randomAlphaOfLength(randomIntBetween(1, 50));
         ClusterState clusterState = createClusterState(indexName);
-        String uploadedFileName = String.format(Locale.ROOT, "index-routing/" + indexName);
+        String uploadedFileName = "index-routing/" + indexName;
         when(blobContainer.readBlob(indexName)).thenReturn(
             INDEX_ROUTING_TABLE_FORMAT.serialize(
                 clusterState.getRoutingTable().getIndicesRouting().get(indexName),
@@ -598,7 +598,7 @@ public class RemoteRoutingTableServiceTests extends OpenSearchTestCase {
 
         RoutingTableIncrementalDiff diff = new RoutingTableIncrementalDiff(previousState.getRoutingTable(), currentState.getRoutingTable());
 
-        String uploadedFileName = String.format(Locale.ROOT, "routing-table-diff/" + indexName);
+        String uploadedFileName = "routing-table-diff/" + indexName;
         when(blobContainer.readBlob(indexName)).thenReturn(
             REMOTE_ROUTING_TABLE_DIFF_FORMAT.serialize(diff, uploadedFileName, compressor).streamInput()
         );


### PR DESCRIPTION
Why do I think that they aren't needed?
No args provided for the string literal or there are no placeholders like %s in the string literal.