### PR TITLE
[Snapshot V2] Do orphan timestamp cleanup before completing the snapshot

### DIFF
--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -617,12 +617,12 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                                 );
                                 return;
                             }
-                            listener.onResponse(snapshotInfo);
+                            cleanOrphanTimestamp(repositoryName, repositoryData);
                             logger.info("created snapshot-v2 [{}] in repository [{}]", repositoryName, snapshotName);
+                            listener.onResponse(snapshotInfo);
                             // For snapshot-v2, we don't allow concurrent snapshots . But meanwhile non-v2 snapshot operations
                             // can get queued . This is triggering them.
                             runNextQueuedOperation(repositoryData, repositoryName, true);
-                            cleanOrphanTimestamp(repositoryName, repositoryData);
                         }
 
                         @Override
@@ -657,14 +657,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         if (orphanPinnedEntities.isEmpty()) {
             return;
         }
-
         logger.info("Found {} orphan timestamps. Cleaning it up now", orphanPinnedEntities.size());
-        if (tryEnterRepoLoop(repoName)) {
-            deleteOrphanTimestamps(pinnedEntities, orphanPinnedEntities);
-            leaveRepoLoop(repoName);
-        } else {
-            logger.info("Concurrent snapshot create/delete is happening. Skipping clean up of orphan timestamps");
-        }
+        deleteOrphanTimestamps(pinnedEntities, orphanPinnedEntities);
     }
 
     private boolean isOrphanPinnedEntity(String repoName, Collection<String> snapshotUUIDs, String pinnedEntity) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Currently we do orphan timestamp clean up after sending ack to the client . In between leaving  the repo loop and entering the loop again , if there is a snapshot , we delete the non-orphan time stamp as well . This is because the `repositoryData` which `cleanOrphanTimestamp` has becomes stale.

To simplify this, I intend to do  `cleanOrphanTimestamp`  when we are still in the `repo loop` which means that `repositoryData`  will not change during this . 



### Check List
- [x] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
