### PR TITLE
Add method to return dynamic SecureTransportParameters from SecureTransportSettingsProvider interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add _list/shards API as paginated alternate to _cat/shards ([#14641](https://github.com/opensearch-project/OpenSearch/pull/14641))
 - Latency and Memory allocation improvements to Multi Term Aggregation queries ([#14993](https://github.com/opensearch-project/OpenSearch/pull/14993))
 - Flat object field use IndexOrDocValuesQuery to optimize query ([#14383](https://github.com/opensearch-project/OpenSearch/issues/14383))
+- Add method to return dynamic SecureTransportParameters from SecureTransportSettingsProvider interface ([#16387](https://github.com/opensearch-project/OpenSearch/pull/16387)
 
 ### Dependencies
 - Bump `com.azure:azure-identity` from 1.13.0 to 1.13.2 ([#15578](https://github.com/opensearch-project/OpenSearch/pull/15578))

--- a/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/ssl/SecureNetty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/ssl/SecureNetty4Transport.java
@@ -57,6 +57,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Optional;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
@@ -142,9 +143,14 @@ public class SecureNetty4Transport extends Netty4Transport {
         protected void initChannel(Channel ch) throws Exception {
             super.initChannel(ch);
 
-            final boolean dualModeEnabled = secureTransportSettingsProvider.isDualModeEnabled(settings);
+            boolean dualModeEnabled = false;
+            Optional<SecureTransportSettingsProvider.SecureTransportParameters> parameters = secureTransportSettingsProvider.parameters(
+                settings
+            );
+            if (parameters.isPresent()) {
+                dualModeEnabled = parameters.get().dualModeEnabled();
+            }
             if (dualModeEnabled) {
-                logger.info("SSL Dual mode enabled, using port unification handler");
                 final ChannelHandler portUnificationHandler = new DualModeSslHandler(
                     settings,
                     secureTransportSettingsProvider,
@@ -258,7 +264,13 @@ public class SecureNetty4Transport extends Netty4Transport {
         public SSLClientChannelInitializer(DiscoveryNode node) {
             this.node = node;
 
-            final boolean dualModeEnabled = secureTransportSettingsProvider.isDualModeEnabled(settings);
+            boolean dualModeEnabled = false;
+            Optional<SecureTransportSettingsProvider.SecureTransportParameters> parameters = secureTransportSettingsProvider.parameters(
+                settings
+            );
+            if (parameters.isPresent()) {
+                dualModeEnabled = parameters.get().dualModeEnabled();
+            }
             hostnameVerificationEnabled = NetworkModule.TRANSPORT_SSL_ENFORCE_HOSTNAME_VERIFICATION.get(settings);
             hostnameVerificationResolveHostName = NetworkModule.TRANSPORT_SSL_ENFORCE_HOSTNAME_VERIFICATION_RESOLVE_HOST_NAME.get(settings);
 

--- a/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/ssl/SecureNetty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/ssl/SecureNetty4Transport.java
@@ -57,7 +57,6 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Optional;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
@@ -143,13 +142,9 @@ public class SecureNetty4Transport extends Netty4Transport {
         protected void initChannel(Channel ch) throws Exception {
             super.initChannel(ch);
 
-            boolean dualModeEnabled = false;
-            Optional<SecureTransportSettingsProvider.SecureTransportParameters> parameters = secureTransportSettingsProvider.parameters(
-                settings
-            );
-            if (parameters.isPresent()) {
-                dualModeEnabled = parameters.get().dualModeEnabled();
-            }
+            final boolean dualModeEnabled = secureTransportSettingsProvider.parameters(settings)
+                .map(SecureTransportSettingsProvider.SecureTransportParameters::dualModeEnabled)
+                .orElse(false);
             if (dualModeEnabled) {
                 final ChannelHandler portUnificationHandler = new DualModeSslHandler(
                     settings,
@@ -264,13 +259,9 @@ public class SecureNetty4Transport extends Netty4Transport {
         public SSLClientChannelInitializer(DiscoveryNode node) {
             this.node = node;
 
-            boolean dualModeEnabled = false;
-            Optional<SecureTransportSettingsProvider.SecureTransportParameters> parameters = secureTransportSettingsProvider.parameters(
-                settings
-            );
-            if (parameters.isPresent()) {
-                dualModeEnabled = parameters.get().dualModeEnabled();
-            }
+            final boolean dualModeEnabled = secureTransportSettingsProvider.parameters(settings)
+                .map(SecureTransportSettingsProvider.SecureTransportParameters::dualModeEnabled)
+                .orElse(false);
             hostnameVerificationEnabled = NetworkModule.TRANSPORT_SSL_ENFORCE_HOSTNAME_VERIFICATION.get(settings);
             hostnameVerificationResolveHostName = NetworkModule.TRANSPORT_SSL_ENFORCE_HOSTNAME_VERIFICATION_RESOLVE_HOST_NAME.get(settings);
 

--- a/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/ssl/SecureNetty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/ssl/SecureNetty4Transport.java
@@ -142,7 +142,7 @@ public class SecureNetty4Transport extends Netty4Transport {
         protected void initChannel(Channel ch) throws Exception {
             super.initChannel(ch);
 
-            final boolean dualModeEnabled = NetworkModule.TRANSPORT_SSL_DUAL_MODE_ENABLED.get(settings);
+            final boolean dualModeEnabled = secureTransportSettingsProvider.isDualModeEnabled(settings);
             if (dualModeEnabled) {
                 logger.info("SSL Dual mode enabled, using port unification handler");
                 final ChannelHandler portUnificationHandler = new DualModeSslHandler(
@@ -258,7 +258,7 @@ public class SecureNetty4Transport extends Netty4Transport {
         public SSLClientChannelInitializer(DiscoveryNode node) {
             this.node = node;
 
-            final boolean dualModeEnabled = NetworkModule.TRANSPORT_SSL_DUAL_MODE_ENABLED.get(settings);
+            final boolean dualModeEnabled = secureTransportSettingsProvider.isDualModeEnabled(settings);
             hostnameVerificationEnabled = NetworkModule.TRANSPORT_SSL_ENFORCE_HOSTNAME_VERIFICATION.get(settings);
             hostnameVerificationResolveHostName = NetworkModule.TRANSPORT_SSL_ENFORCE_HOSTNAME_VERIFICATION_RESOLVE_HOST_NAME.get(settings);
 

--- a/server/src/main/java/org/opensearch/plugins/DefaultSecureTransportParameters.java
+++ b/server/src/main/java/org/opensearch/plugins/DefaultSecureTransportParameters.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+import org.opensearch.common.network.NetworkModule;
+import org.opensearch.common.settings.Settings;
+
+/**
+ * Default implementation of {@link SecureTransportSettingsProvider.SecureTransportParameters}.
+ */
+class DefaultSecureTransportParameters implements SecureTransportSettingsProvider.SecureTransportParameters {
+    private final Settings settings;
+
+    DefaultSecureTransportParameters(Settings settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    public boolean dualModeEnabled() {
+        return NetworkModule.TRANSPORT_SSL_DUAL_MODE_ENABLED.get(settings);
+    }
+}

--- a/server/src/main/java/org/opensearch/plugins/SecureTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureTransportSettingsProvider.java
@@ -38,12 +38,30 @@ public interface SecureTransportSettingsProvider {
     }
 
     /**
-     * Returns true if dual mode is enabled. Dual mode domains support both encrypted and non-encrypted traffic
+     * Returns parameters that can be dynamically provided by a plugin providing a {@link SecureTransportSettingsProvider}
+     * implementation
      * @param settings settings
-     * @return a boolean indicating if dual mode is enabled
+     * @return an instance of {@link SecureTransportParameters}
      */
-    default boolean isDualModeEnabled(Settings settings) {
-        return NetworkModule.TRANSPORT_SSL_DUAL_MODE_ENABLED.get(settings);
+    default Optional<SecureTransportParameters> parameters(Settings settings) {
+        return Optional.of(new DefaultSecureTransportParameters(settings));
+    }
+
+    interface SecureTransportParameters {
+        boolean dualModeEnabled();
+    }
+
+    class DefaultSecureTransportParameters implements SecureTransportParameters {
+        private final Settings settings;
+
+        DefaultSecureTransportParameters(Settings settings) {
+            this.settings = settings;
+        }
+
+        @Override
+        public boolean dualModeEnabled() {
+            return NetworkModule.TRANSPORT_SSL_DUAL_MODE_ENABLED.get(settings);
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/plugins/SecureTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureTransportSettingsProvider.java
@@ -47,6 +47,7 @@ public interface SecureTransportSettingsProvider {
         return Optional.of(new DefaultSecureTransportParameters(settings));
     }
 
+    @ExperimentalApi
     interface SecureTransportParameters {
         boolean dualModeEnabled();
     }

--- a/server/src/main/java/org/opensearch/plugins/SecureTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureTransportSettingsProvider.java
@@ -9,7 +9,6 @@
 package org.opensearch.plugins;
 
 import org.opensearch.common.annotation.ExperimentalApi;
-import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportAdapterProvider;
@@ -47,22 +46,12 @@ public interface SecureTransportSettingsProvider {
         return Optional.of(new DefaultSecureTransportParameters(settings));
     }
 
+    /**
+     * Dynamic parameters that can be provided by the {@link SecureTransportSettingsProvider}
+     */
     @ExperimentalApi
     interface SecureTransportParameters {
         boolean dualModeEnabled();
-    }
-
-    class DefaultSecureTransportParameters implements SecureTransportParameters {
-        private final Settings settings;
-
-        DefaultSecureTransportParameters(Settings settings) {
-            this.settings = settings;
-        }
-
-        @Override
-        public boolean dualModeEnabled() {
-            return NetworkModule.TRANSPORT_SSL_DUAL_MODE_ENABLED.get(settings);
-        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/plugins/SecureTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureTransportSettingsProvider.java
@@ -9,6 +9,7 @@
 package org.opensearch.plugins;
 
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportAdapterProvider;
@@ -34,6 +35,15 @@ public interface SecureTransportSettingsProvider {
      */
     default Collection<TransportAdapterProvider<Transport>> getTransportAdapterProviders(Settings settings) {
         return Collections.emptyList();
+    }
+
+    /**
+     * Returns true if dual mode is enabled. Dual mode domains support both encrypted and non-encrypted traffic
+     * @param settings settings
+     * @return a boolean indicating if dual mode is enabled
+     */
+    default boolean isDualModeEnabled(Settings settings) {
+
     }
 
     /**

--- a/server/src/main/java/org/opensearch/plugins/SecureTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureTransportSettingsProvider.java
@@ -43,7 +43,7 @@ public interface SecureTransportSettingsProvider {
      * @return a boolean indicating if dual mode is enabled
      */
     default boolean isDualModeEnabled(Settings settings) {
-
+        return NetworkModule.TRANSPORT_SSL_DUAL_MODE_ENABLED.get(settings);
     }
 
     /**


### PR DESCRIPTION
### Description

Companion PR in the Security plugin: https://github.com/opensearch-project/security/pull/4820

Fixes an issue with SSL Dual mode where the settings provider relies on the static node settings without taking dynamic cluster settings into account. This PR and companion Security PR fixes a regression introduced in https://github.com/opensearch-project/security/pull/4119

Before 2.14, this setting was coming from the Security plugins [SSLConfig class](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/ssl/transport/SSLConfig.java#L35-L47) which originally gets the value from the node settings, but also registers a cluster settings listener to listen for dynamic updates to this setting.

For instance an operator can run:

```
curl -XPUT https://localhost:9200/_cluster/settings -k -H "Content-Type: application/json" -d '{"persistent": {"plugins.security_config.ssl_dual_mode_enabled": false}}'
``` 

To update this setting, but since 2.14 the dynamic value is not getting propagated. 

This PR adds a new method to the SecureTransportSettingsProvider interface to allow a plugin that implements the provider to feed this value to core instead of relying on the static node settings.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
