### PR TITLE
[Backport 2.x] Fix array hashCode calculation in ResyncReplicationRequest (#16378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Streaming Indexing] Fix intermittent 'The bulk request must be terminated by a newline [\n]' failures [#16337](https://github.com/opensearch-project/OpenSearch/pull/16337))
 - Fix wrong default value when setting `index.number_of_routing_shards` to null on index creation ([#16331](https://github.com/opensearch-project/OpenSearch/pull/16331))
 - [Workload Management] Make query groups persistent across process restarts [#16370](https://github.com/opensearch-project/OpenSearch/pull/16370)
+- Fix array hashCode calculation in ResyncReplicationRequest ([#16378](https://github.com/opensearch-project/OpenSearch/pull/16378))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/action/resync/ResyncReplicationRequest.java
+++ b/server/src/main/java/org/opensearch/action/resync/ResyncReplicationRequest.java
@@ -103,7 +103,7 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
 
     @Override
     public int hashCode() {
-        return Objects.hash(trimAboveSeqNo, maxSeenAutoIdTimestampOnPrimary, operations);
+        return Objects.hash(trimAboveSeqNo, maxSeenAutoIdTimestampOnPrimary, Arrays.hashCode(operations));
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/action/resync/ResyncReplicationRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/resync/ResyncReplicationRequestTests.java
@@ -40,14 +40,14 @@ import org.opensearch.index.translog.Translog;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class ResyncReplicationRequestTests extends OpenSearchTestCase {
 
     public void testSerialization() throws IOException {
-        final byte[] bytes = "{}".getBytes(Charset.forName("UTF-8"));
+        final byte[] bytes = "{}".getBytes(StandardCharsets.UTF_8);
         final Translog.Index index = new Translog.Index("id", 0, randomNonNegativeLong(), randomNonNegativeLong(), bytes, null, -1);
         final ShardId shardId = new ShardId(new Index("index", "uuid"), 0);
         final ResyncReplicationRequest before = new ResyncReplicationRequest(shardId, 42L, 100, new Translog.Operation[] { index });
@@ -59,6 +59,20 @@ public class ResyncReplicationRequestTests extends OpenSearchTestCase {
         final ResyncReplicationRequest after = new ResyncReplicationRequest(in);
 
         assertThat(after, equalTo(before));
+    }
+
+    public void testContractBetweenEqualsAndHashCode() {
+        final byte[] bytes = "{}".getBytes(StandardCharsets.UTF_8);
+        final Translog.Index index = new Translog.Index("id", 0, 123L, -123L, bytes, null, -1);
+        final ShardId shardId = new ShardId(new Index("index", "uuid"), 0);
+        // Both created requests have arrays `operations` with the same content, and we want to verify that
+        // equals() and hashCode() are following the contract:
+        // If objects are equal, they have the same hash code
+        final ResyncReplicationRequest request1 = new ResyncReplicationRequest(shardId, 42L, 100, new Translog.Operation[] { index });
+        final ResyncReplicationRequest request2 = new ResyncReplicationRequest(shardId, 42L, 100, new Translog.Operation[] { index });
+
+        assertEquals(request1, request2);
+        assertEquals(request1.hashCode(), request2.hashCode());
     }
 
 }


### PR DESCRIPTION
Backport 0f7d572da1d2dec4c2b83c6ae2c9e47ce38edd00 from #16378