### PR TITLE
IP field via MultrangeQuery fix #16200

### DIFF
--- a/server/src/test/java/org/opensearch/index/mapper/IpFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/IpFieldTypeTests.java
@@ -117,7 +117,7 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testTermsQuery() {
-        MappedFieldType ft = new IpFieldMapper.IpFieldType("field");
+        MappedFieldType ft = new IpFieldMapper.IpFieldType("field", true, false, false, null, Collections.emptyMap());
 
         assertEquals(
             InetAddressPoint.newSetQuery("field", InetAddresses.forString("::2"), InetAddresses.forString("::5")),
@@ -131,8 +131,8 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
         // if the list includes a prefix query we fallback to a bool query
         assertEquals(
             new ConstantScoreQuery(
-                new BooleanQuery.Builder().add(ft.termQuery("::42", null), Occur.SHOULD)
-                    .add(ft.termQuery("::2/16", null), Occur.SHOULD)
+                new BooleanQuery.Builder().add(ft.termQuery("::2/16", null), Occur.SHOULD)
+                    .add(ft.termQuery("::42", null), Occur.SHOULD)
                     .build()
             ),
             ft.termsQuery(Arrays.asList("::42", "::2/16"), null)

--- a/server/src/test/java/org/opensearch/search/SearchIpFieldTermsTest.java
+++ b/server/src/test/java/org/opensearch/search/SearchIpFieldTermsTest.java
@@ -131,10 +131,13 @@ public class SearchIpFieldTermsTest extends OpenSearchSingleNodeTestCase {
 
     // Generate a random IPv4 address
     private String generateRandomIPv4() {
-        return String.join(".", String.valueOf(random().nextInt(256)),
+        return String.join(
+            ".",
             String.valueOf(random().nextInt(256)),
             String.valueOf(random().nextInt(256)),
-            String.valueOf(random().nextInt(256)));
+            String.valueOf(random().nextInt(256)),
+            String.valueOf(random().nextInt(256))
+        );
     }
 
     // Generate a random IPv6 address

--- a/server/src/test/java/org/opensearch/search/SearchIpFieldTermsTest.java
+++ b/server/src/test/java/org/opensearch/search/SearchIpFieldTermsTest.java
@@ -1,0 +1,169 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search;
+
+import org.opensearch.action.bulk.BulkRequestBuilder;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.network.InetAddresses;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+import org.hamcrest.MatcherAssert;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.hamcrest.Matchers.equalTo;
+
+public class SearchIpFieldTermsTest extends OpenSearchSingleNodeTestCase {
+
+    public static final boolean IPv4_ONLY = true;
+    static String defaultIndexName = "test";
+
+    public void testMassive() throws Exception {
+        XContentBuilder xcb = createMapping();
+        client().admin().indices().prepareCreate(defaultIndexName).setMapping(xcb).get();
+        ensureGreen();
+
+        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
+
+        int cidrs = 0;
+        int ips = 0;
+        List<String> toQuery = new ArrayList<>();
+        for (int i = 0; ips <= 1024 && i < 1000000; i++) {
+            final String ip;
+            final int prefix;
+            if (IPv4_ONLY) {
+                ip = generateRandomIPv4();
+                prefix = 8 + random().nextInt(24); // CIDR prefix for IPv4
+            } else {
+                ip = generateRandomIPv6();
+                prefix = 32 + random().nextInt(97); // CIDR prefix for IPv6
+            }
+
+            bulkRequestBuilder.add(client().prepareIndex(defaultIndexName).setSource(Map.of("addr", ip)));
+
+            final String termToQuery;
+            if (cidrs < 1024 - 1 && random().nextBoolean()) {
+                termToQuery = ip + "/" + prefix;
+                cidrs++;
+            } else {
+                termToQuery = ip;
+                ips++;
+            }
+            toQuery.add(termToQuery);
+        }
+        int addMatches = 0;
+        for (int i = 0; i < atLeast(100); i++) {
+            final String ip;
+            if (IPv4_ONLY) {
+                ip = generateRandomIPv4();
+            } else {
+                ip = generateRandomIPv6();
+            }
+            bulkRequestBuilder.add(client().prepareIndex(defaultIndexName).setSource(Map.of("addr", ip)));
+            boolean match = false;
+            for (String termQ : toQuery) {
+                boolean isCidr = termQ.contains("/");
+                if ((isCidr && isIPInCIDR(ip, termQ)) || (!isCidr && termQ.equals(ip))) {
+                    match = true;
+                    break;
+                }
+            }
+            if (match) {
+                addMatches++;
+            } else {
+                break; // single mismatch is enough.
+            }
+        }
+
+        bulkRequestBuilder.setRefreshPolicy(IMMEDIATE).get();
+        SearchResponse result = client().prepareSearch(defaultIndexName).setQuery(QueryBuilders.termsQuery("addr", toQuery)).get();
+        MatcherAssert.assertThat(Objects.requireNonNull(result.getHits().getTotalHits()).value, equalTo((long) cidrs + ips + addMatches));
+    }
+
+    // Converts an IP string (either IPv4 or IPv6) to a byte array
+    private static byte[] ipToBytes(String ip) {
+        InetAddress inetAddress = InetAddresses.forString(ip);
+        return inetAddress.getAddress();
+    }
+
+    // Checks if an IP is within a given CIDR (works for both IPv4 and IPv6)
+    private static boolean isIPInCIDR(String ip, String cidr) {
+        String[] cidrParts = cidr.split("/");
+        String cidrIp = cidrParts[0];
+        int prefixLength = Integer.parseInt(cidrParts[1]);
+
+        byte[] ipBytes = ipToBytes(ip);
+        byte[] cidrIpBytes = ipToBytes(cidrIp);
+
+        // Calculate how many full bytes and how many bits are in the mask
+        int fullBytes = prefixLength / 8;
+        int extraBits = prefixLength % 8;
+
+        // Compare full bytes
+        for (int i = 0; i < fullBytes; i++) {
+            if (ipBytes[i] != cidrIpBytes[i]) {
+                return false;
+            }
+        }
+
+        // Compare extra bits (if any)
+        if (extraBits > 0) {
+            int mask = 0xFF << (8 - extraBits);
+            return (ipBytes[fullBytes] & mask) == (cidrIpBytes[fullBytes] & mask);
+        }
+
+        return true;
+    }
+
+    // Generate a random IPv4 address
+    private static String generateRandomIPv4() {
+        return String.format("%d.%d.%d.%d", random().nextInt(256), random().nextInt(256), random().nextInt(256), random().nextInt(256));
+    }
+
+    // Generate a random IPv6 address
+    private static String generateRandomIPv6() {
+        StringBuilder ipv6 = new StringBuilder();
+        for (int i = 0; i < 8; i++) {
+            ipv6.append(Integer.toHexString(random().nextInt(0xFFFF + 1)));
+            if (i < 7) {
+                ipv6.append(":");
+            }
+        }
+        return ipv6.toString();
+    }
+
+    private XContentBuilder createMapping() throws IOException {
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject("addr")
+            .field("type", "ip")
+            .startObject("fields")
+            .startObject("idx")
+            .field("type", "ip")
+            .field("doc_values", false)
+            .endObject()
+            .startObject("dv")
+            .field("type", "ip")
+            .field("index", false)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+    }
+}

--- a/server/src/test/java/org/opensearch/search/SearchIpFieldTermsTest.java
+++ b/server/src/test/java/org/opensearch/search/SearchIpFieldTermsTest.java
@@ -130,8 +130,11 @@ public class SearchIpFieldTermsTest extends OpenSearchSingleNodeTestCase {
     }
 
     // Generate a random IPv4 address
-    private static String generateRandomIPv4() {
-        return String.format("%d.%d.%d.%d", random().nextInt(256), random().nextInt(256), random().nextInt(256), random().nextInt(256));
+    private String generateRandomIPv4() {
+        return String.join(".", String.valueOf(random().nextInt(256)),
+            String.valueOf(random().nextInt(256)),
+            String.valueOf(random().nextInt(256)),
+            String.valueOf(random().nextInt(256)));
     }
 
     // Generate a random IPv6 address

--- a/server/src/test/java/org/opensearch/search/SearchIpFieldTermsTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchIpFieldTermsTests.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.hamcrest.Matchers.equalTo;
 
-public class SearchIpFieldTermsTest extends OpenSearchSingleNodeTestCase {
+public class SearchIpFieldTermsTests extends OpenSearchSingleNodeTestCase {
 
     public static final boolean IPv4_ONLY = true;
     static String defaultIndexName = "test";

--- a/server/src/test/java/org/opensearch/search/SearchIpFieldTermsTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchIpFieldTermsTests.java
@@ -42,7 +42,7 @@ public class SearchIpFieldTermsTests extends OpenSearchSingleNodeTestCase {
         int cidrs = 0;
         int ips = 0;
         List<String> toQuery = new ArrayList<>();
-        for (int i = 0; ips <= 1024 && i < 1000000; i++) {
+        for (int i = 0; ips <= 10240 && cidrs <= 1024 && i < 1000000; i++) {
             final String ip;
             final int prefix;
             if (IPv4_ONLY) {
@@ -56,7 +56,7 @@ public class SearchIpFieldTermsTests extends OpenSearchSingleNodeTestCase {
             bulkRequestBuilder.add(client().prepareIndex(defaultIndexName).setSource(Map.of("addr", ip)));
 
             final String termToQuery;
-            if (cidrs < 1024 - 1 && random().nextBoolean()) {
+            if (random().nextBoolean()) {
                 termToQuery = ip + "/" + prefix;
                 cidrs++;
             } else {


### PR DESCRIPTION

### Description
Combines a many concrete IPs and CIRR masks into set when querying IP field

### Related Issues
Resolves #16200
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
