### PR TITLE
Treat last fetch timestamp of pinned timestamp as one of the pinned timestamps

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
@@ -189,7 +189,7 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
                     List<String> metadataFilesToBeDeleted = getMetadataFilesToBeDeleted(metadataFiles, indexDeleted);
 
                     // If index is not deleted, make sure to keep latest metadata file
-                    if (indexDeleted == false || RemoteStoreSettings.isPinnedTimestampsEnabled()) {
+                    if (indexDeleted == false) {
                         metadataFilesToBeDeleted.remove(metadataFiles.get(0));
                     }
 
@@ -345,9 +345,11 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
         );
 
         // Get md files matching pinned timestamps
+        Set<Long> pinnedTimestamps = new HashSet<>(pinnedTimestampsState.v2());
+        pinnedTimestamps.add(pinnedTimestampsState.v1());
         Set<String> implicitLockedFiles = RemoteStoreUtils.getPinnedTimestampLockedFiles(
             metadataFilesToBeDeleted,
-            pinnedTimestampsState.v2(),
+            pinnedTimestamps,
             metadataFilePinnedTimestampMap,
             file -> RemoteStoreUtils.invertLong(file.split(METADATA_SEPARATOR)[3]),
             TranslogTransferMetadata::getNodeIdByPrimaryTermAndGen

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslogTests.java
@@ -755,17 +755,21 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
         assertTrue(generations.isEmpty());
     }
 
-    public void testGetMetadataFilesToBeDeletedNoExclusion() {
+    public void testGetMetadataFilesToBeDeletedExclusionDueToRefreshTimestamp() {
         updatePinnedTimstampTask.run();
 
-        List<String> metadataFiles = List.of(
-            "metadata__9223372036438563903__9223372036854774799__9223370311919910393__31__9223372036854775106__1",
-            "metadata__9223372036438563903__9223372036854775800__9223370311919910398__31__9223372036854775803__1",
-            "metadata__9223372036438563903__9223372036854775701__9223370311919910403__31__9223372036854775701__1"
-        );
+        List<String> metadataFiles = new ArrayList<>();
+        metadataFiles.add("metadata__9223372036438563903__9223372036854774799__9223370311919910393__31__9223372036854775106__1");
+        metadataFiles.add("metadata__9223372036438563903__9223372036854775701__9223370311919910403__31__9223372036854775701__1");
+        metadataFiles.add("metadata__9223372036438563903__9223372036854775800__9223370311919910398__31__9223372036854775803__1");
 
+        // Removing file that is pinned by latest refresh timestamp
+        List<String> metadataFilesToBeDeleted = new ArrayList<>(metadataFiles);
+        metadataFilesToBeDeleted.remove(
+            "metadata__9223372036438563903__9223372036854774799__9223370311919910393__31__9223372036854775106__1"
+        );
         assertEquals(
-            metadataFiles,
+            metadataFilesToBeDeleted,
             RemoteFsTimestampAwareTranslog.getMetadataFilesToBeDeleted(metadataFiles, new HashMap<>(), Long.MAX_VALUE, false, logger)
         );
     }
@@ -774,13 +778,15 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
         updatePinnedTimstampTask.run();
         long currentTimeInMillis = System.currentTimeMillis();
         String md1Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 200000);
-        String md2Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis + 30000);
-        String md3Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis + 60000);
+        String md2Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 400000);
+        String md3Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis + 30000);
+        String md4Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis + 60000);
 
         List<String> metadataFiles = List.of(
-            "metadata__9223372036438563903__9223372036854774799__" + md1Timestamp + "__31__9223372036854775106__1",
-            "metadata__9223372036438563903__9223372036854775800__" + md2Timestamp + "__31__9223372036854775803__1",
-            "metadata__9223372036438563903__9223372036854775701__" + md3Timestamp + "__31__9223372036854775701__1"
+            "metadata__9223372036438563903__9223372036854774500__" + md1Timestamp + "__31__9223372036854775106__1",
+            "metadata__9223372036438563903__9223372036854774799__" + md2Timestamp + "__31__9223372036854775106__1",
+            "metadata__9223372036438563903__9223372036854775800__" + md3Timestamp + "__31__9223372036854775803__1",
+            "metadata__9223372036438563903__9223372036854775701__" + md4Timestamp + "__31__9223372036854775701__1"
         );
 
         List<String> metadataFilesToBeDeleted = RemoteFsTimestampAwareTranslog.getMetadataFilesToBeDeleted(
@@ -791,24 +797,26 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
             logger
         );
         assertEquals(1, metadataFilesToBeDeleted.size());
-        assertEquals(metadataFiles.get(0), metadataFilesToBeDeleted.get(0));
+        assertEquals(metadataFiles.get(1), metadataFilesToBeDeleted.get(0));
     }
 
     public void testGetMetadataFilesToBeDeletedExclusionBasedOnPinningOnly() throws IOException {
         long currentTimeInMillis = System.currentTimeMillis();
-        String md1Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 200000);
-        String md2Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 300000);
-        String md3Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 600000);
+        String md1Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 190000);
+        String md2Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 200000);
+        String md3Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 300000);
+        String md4Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 600000);
 
-        long pinnedTimestamp = RemoteStoreUtils.invertLong(md2Timestamp) + 10000;
+        long pinnedTimestamp = RemoteStoreUtils.invertLong(md3Timestamp) + 10000;
         when(blobContainer.listBlobs()).thenReturn(Map.of(randomInt(100) + "__" + pinnedTimestamp, new PlainBlobMetadata("xyz", 100)));
 
         updatePinnedTimstampTask.run();
 
         List<String> metadataFiles = List.of(
-            "metadata__9223372036438563903__9223372036854774799__" + md1Timestamp + "__31__9223372036854775106__1",
-            "metadata__9223372036438563903__9223372036854775600__" + md2Timestamp + "__31__9223372036854775803__1",
-            "metadata__9223372036438563903__9223372036854775701__" + md3Timestamp + "__31__9223372036854775701__1"
+            "metadata__9223372036438563903__9223372036854774500__" + md1Timestamp + "__31__9223372036854775701__1",
+            "metadata__9223372036438563903__9223372036854774799__" + md2Timestamp + "__31__9223372036854775106__1",
+            "metadata__9223372036438563903__9223372036854775600__" + md3Timestamp + "__31__9223372036854775803__1",
+            "metadata__9223372036438563903__9223372036854775701__" + md4Timestamp + "__31__9223372036854775701__1"
         );
 
         List<String> metadataFilesToBeDeleted = RemoteFsTimestampAwareTranslog.getMetadataFilesToBeDeleted(
@@ -819,8 +827,8 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
             logger
         );
         assertEquals(2, metadataFilesToBeDeleted.size());
-        assertEquals(metadataFiles.get(0), metadataFilesToBeDeleted.get(0));
-        assertEquals(metadataFiles.get(2), metadataFilesToBeDeleted.get(1));
+        assertEquals(metadataFiles.get(1), metadataFilesToBeDeleted.get(0));
+        assertEquals(metadataFiles.get(3), metadataFilesToBeDeleted.get(1));
     }
 
     public void testGetMetadataFilesToBeDeletedExclusionBasedOnAgeAndPinning() throws IOException {
@@ -856,6 +864,7 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
         String md1Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 200000);
         String md2Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 300000);
         String md3Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 600000);
+        String md4Timestamp = RemoteStoreUtils.invertLong(currentTimeInMillis - 800000);
 
         when(blobContainer.listBlobs()).thenReturn(Map.of());
 
@@ -866,8 +875,10 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
             "metadata__9223372036438563903__9223372036854775800__" + md1Timestamp + "__31__9223372036854775106__1",
             // MaxGen 12
             "metadata__9223372036438563903__9223372036854775795__" + md2Timestamp + "__31__9223372036854775803__1",
+            // MaxGen 9
+            "metadata__9223372036438563903__9223372036854775798__" + md3Timestamp + "__31__9223372036854775701__1",
             // MaxGen 10
-            "metadata__9223372036438563903__9223372036854775798__" + md3Timestamp + "__31__9223372036854775701__1"
+            "metadata__9223372036438563903__9223372036854775797__" + md4Timestamp + "__31__9223372036854775701__1"
         );
 
         List<String> metadataFilesToBeDeleted = RemoteFsTimestampAwareTranslog.getMetadataFilesToBeDeleted(
@@ -878,8 +889,8 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
             logger
         );
         assertEquals(2, metadataFilesToBeDeleted.size());
-        assertEquals(metadataFiles.get(0), metadataFilesToBeDeleted.get(0));
-        assertEquals(metadataFiles.get(2), metadataFilesToBeDeleted.get(1));
+        assertEquals(metadataFiles.get(2), metadataFilesToBeDeleted.get(0));
+        assertEquals(metadataFiles.get(0), metadataFilesToBeDeleted.get(1));
     }
 
     public void testGetMetadataFilesToBeDeletedExclusionBasedOnGenerationDeleteIndex() throws IOException {
@@ -892,13 +903,15 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
 
         updatePinnedTimstampTask.run();
 
-        List<String> metadataFiles = List.of(
-            // MaxGen 7
-            "metadata__9223372036438563903__9223372036854775800__" + md1Timestamp + "__31__9223372036854775106__1",
-            // MaxGen 12
-            "metadata__9223372036438563903__9223372036854775795__" + md2Timestamp + "__31__9223372036854775803__1",
-            // MaxGen 17
-            "metadata__9223372036438563903__9223372036854775790__" + md3Timestamp + "__31__9223372036854775701__1"
+        List<String> metadataFiles = new ArrayList<>(
+            List.of(
+                // MaxGen 12
+                "metadata__9223372036438563903__9223372036854775795__" + md2Timestamp + "__31__9223372036854775803__1",
+                // MaxGen 7
+                "metadata__9223372036438563903__9223372036854775800__" + md1Timestamp + "__31__9223372036854775106__1",
+                // MaxGen 17
+                "metadata__9223372036438563903__9223372036854775790__" + md3Timestamp + "__31__9223372036854775701__1"
+            )
         );
 
         List<String> metadataFilesToBeDeleted = RemoteFsTimestampAwareTranslog.getMetadataFilesToBeDeleted(
@@ -908,6 +921,10 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
             true,
             logger
         );
+
+        // Metadata file corresponding to latest pinned timestamp fetch is always considered pinned
+        metadataFiles.remove(metadataFiles.get(2));
+
         assertEquals(metadataFiles, metadataFilesToBeDeleted);
     }
 


### PR DESCRIPTION
### Description
- In https://github.com/opensearch-project/OpenSearch/pull/16332, we provided a solution to always keep last metadata file even if index is deleted.
- But this still does not solve a problem with following scenario:
```
Metadata 1 - 10:30
Pin Timestamp Fetch - 11:00
Snapshot 1 - 11:30
Snapshot 2 - 12:30
Metadata 2 - 13:10
Snapshot 3 - 13:30
DELETE INDEX
```
- In this case, with the existing solution, we will make sure not to delete `Metadata 2` but Metadata 1 will be deleted creating data loss issues for `Snapshot 1` and `Snapshot 2`.
- To solve this problem completely, we need to understand which metadata files need to be kept based on timestamp of pinned timestamps fetch and snapshot timestamp.
- We have following three scenarios:
```
// Scenario 1
Pin Timestamp Fetch
Metadata 1
Snapshot 1
Metadata 2
Delete Index
// Here, as both the metadata file are created post pin timestamp fetch, we do not delete them. This logic already exists.

// Scenario 2
Metadata 1 - 10:30
Pin Timestamp Fetch - 11:00
Snapshot 1
Metadata 2
Delete Index
// Here, Snapshot 1 refers to Metadata 1 but while deleting index, we delete Metadata 1. This creates data loss issue for Snapshot 1. Need to fix this.

// Scenario 3
Metadata 1
Snapshot 1
Pin Timestamp Fetch
Metadata 2
Delete Index
// Here, pin timestamp fetch already has snapshot 1 and metadata 1 info. So, while deleting the index, we do not delete metadata 1 as it is pinned and we do not delete metadata 2 as it was created post pin timestamp fetch. This logic already exists.

// Scenario 4
Metadata 1
Snapshot 1
Metadata 2
Pin Timestamp Fetch
Delete Index
// Here, pin timestamp fetch has a knowledge of metadata 1 referred by snapshot 1. While deleting index, we keep last metadata file, so metadata 2 is not deleted. And metadata 1 is not deleted as it is pinned. We have added metadata 2 not deleting logic as part of https://github.com/opensearch-project/OpenSearch/pull/16332.
```
- So, we need to fix Scenario 2. In this scenario, we need to keep the last metadata file before the pin timestamp fetch. Only keeping last md file is sufficient as any snapshot that is created will only refer to the last md file.
- In this PR, we add last fetch timestamp to the pinned timestamp list to avoid deletion of last metadata file created prior to last fetch.

- With change in this PR, we don't need changes  done in https://github.com/opensearch-project/OpenSearch/pull/16332 to always keep last deleted file. This improves stale data deletion as well.


### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
