### PR TITLE
Fixing inline javadocs usage in PaginationStrategy

### DIFF
--- a/server/src/main/java/org/opensearch/action/pagination/PaginationStrategy.java
+++ b/server/src/main/java/org/opensearch/action/pagination/PaginationStrategy.java
@@ -44,8 +44,11 @@ public interface PaginationStrategy<T> {
     List<T> getRequestedEntities();
 
     /**
-     *
-     * Utility method to get list of indices filtered as per {@param filterPredicate} and the sorted according to {@param comparator}.
+     * Utility method to get list of indices filtered and sorted as per the provided parameters.
+     * @param clusterState state consisting of all the indices to be filtered and sorted.
+     * @param filterPredicate predicate to be used for filtering out the required indices.
+     * @param comparator comparator to be used for sorting the already filtered list of indices.
+     * @return list of filtered and sorted IndexMetadata.
      */
     static List<IndexMetadata> getSortedIndexMetadata(
         final ClusterState clusterState,
@@ -56,8 +59,10 @@ public interface PaginationStrategy<T> {
     }
 
     /**
-     *
-     * Utility method to get list of indices sorted as per {@param comparator}.
+     * Utility method to get list of sorted indices.
+     * @param clusterState state consisting of indices to be sorted.
+     * @param comparator comparator to be used for sorting the list of indices.
+     * @return list of sorted IndexMetadata.
      */
     static List<IndexMetadata> getSortedIndexMetadata(final ClusterState clusterState, Comparator<IndexMetadata> comparator) {
         return clusterState.metadata().indices().values().stream().sorted(comparator).collect(Collectors.toList());


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixes the usage of inline javadocs in paginationStrategy interface causing build failures on older jdk versions.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/16374
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
