### PR TITLE
Disallow snapshot deletion while a v2 snapshot is in progress

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/ConcurrentSnapshotsV2IT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/ConcurrentSnapshotsV2IT.java
@@ -529,14 +529,13 @@ public class ConcurrentSnapshotsV2IT extends RemoteSnapshotIT {
         awaitNumberOfSnapshotsInProgress(1);
 
         ActionFuture<AcknowledgedResponse> a = startDeleteSnapshot(repoName, "snapshot-v1");
+        expectThrows(ConcurrentSnapshotExecutionException.class, a::actionGet);
 
         unblockNode(repoName, clusterManagerName);
         CreateSnapshotResponse csr = snapshotFuture.actionGet();
         assertTrue(csr.getSnapshotInfo().getPinnedTimestamp() != 0);
-        assertTrue(a.actionGet().isAcknowledged());
         List<SnapshotInfo> snapInfo = client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots();
-        assertEquals(1, snapInfo.size());
-        assertThat(snapInfo, contains(csr.getSnapshotInfo()));
+        assertEquals(2, snapInfo.size());
     }
 
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/16205")

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -619,10 +619,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                             }
                             cleanOrphanTimestamp(repositoryName, repositoryData);
                             logger.info("created snapshot-v2 [{}] in repository [{}]", repositoryName, snapshotName);
+                            leaveRepoLoop(repositoryName);
                             listener.onResponse(snapshotInfo);
-                            // For snapshot-v2, we don't allow concurrent snapshots . But meanwhile non-v2 snapshot operations
-                            // can get queued . This is triggering them.
-                            runNextQueuedOperation(repositoryData, repositoryName, true);
                         }
 
                         @Override
@@ -1021,10 +1019,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                                         return;
                                     }
                                     logger.info("snapshot-v2 clone [{}] completed successfully", snapshot);
+                                    leaveRepoLoop(repositoryName);
                                     listener.onResponse(null);
-                                    // For snapshot-v2, we don't allow concurrent snapshots . But meanwhile non-v2 snapshot operations
-                                    // can get queued . This is triggering them.
-                                    runNextQueuedOperation(repositoryData, repositoryName, true);
                                 }
 
                                 @Override
@@ -2564,6 +2560,15 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             public ClusterState execute(ClusterState currentState) throws Exception {
                 final SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
                 final List<SnapshotsInProgress.Entry> snapshotEntries = findInProgressSnapshots(snapshots, snapshotNames, repoName);
+                boolean isSnapshotV2 = SHALLOW_SNAPSHOT_V2.get(repository.getMetadata().settings());
+                boolean remoteStoreIndexShallowCopy = remoteStoreShallowCopyEnabled(repository);
+                if (isSnapshotV2 && remoteStoreIndexShallowCopy && snapshots.entries().size() > 0) {
+                    throw new ConcurrentSnapshotExecutionException(
+                        repoName,
+                        String.join(",", snapshotNames),
+                        "cannot delete snapshots in v2 repo while a snapshot is in progress"
+                    );
+                }
                 final List<SnapshotId> snapshotIds = matchingSnapshotIds(
                     snapshotEntries.stream().map(e -> e.snapshot().getSnapshotId()).collect(Collectors.toList()),
                     repositoryData,

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotsService.java
@@ -2562,7 +2562,11 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 final List<SnapshotsInProgress.Entry> snapshotEntries = findInProgressSnapshots(snapshots, snapshotNames, repoName);
                 boolean isSnapshotV2 = SHALLOW_SNAPSHOT_V2.get(repository.getMetadata().settings());
                 boolean remoteStoreIndexShallowCopy = remoteStoreShallowCopyEnabled(repository);
-                if (isSnapshotV2 && remoteStoreIndexShallowCopy && snapshots.entries().size() > 0) {
+                List<SnapshotsInProgress.Entry> entriesForThisRepo = snapshots.entries()
+                    .stream()
+                    .filter(entry -> Objects.equals(entry.repository(), repoName))
+                    .collect(Collectors.toList());
+                if (isSnapshotV2 && remoteStoreIndexShallowCopy && entriesForThisRepo.isEmpty() == false) {
                     throw new ConcurrentSnapshotExecutionException(
                         repoName,
                         String.join(",", snapshotNames),


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Earlier we were accepting deletes while a create/clone v2 operation was going on . Post create/clone, we did a `runNextQueuedOperation` to run the queued operation . However , `runNextQueuedOperation` creates a pending task of `NORMAL` priority . In cases where pending tasks are high , this will starve. Meanwhile , the new create/clone v2 snapshots also can't start as it won't get the repo lock .

To solve for this, we are not accepting deletes when a create/clone v2 operation is going on and have now removed the `runNextQueuedOperation`. 

```
% curl localhost:9200/_cat/pending_tasks
374716  3.7s HIGH   cluster_reroute(reroute after balanced shards allocator timed out)
374646 24.1m NORMAL Run ready deletions
```


### Check List
- [x] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
