### PR TITLE
Fix flaky test in testApproximateRangeWithSizeOverDefault by adjusting totalHits assertion logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Workload Management] Make query groups persistent across process restarts [#16370](https://github.com/opensearch-project/OpenSearch/pull/16370)
 - Fix inefficient Stream API call chains ending with count() ([#15386](https://github.com/opensearch-project/OpenSearch/pull/15386))
 - Fix array hashCode calculation in ResyncReplicationRequest ([#16378](https://github.com/opensearch-project/OpenSearch/pull/16378))
+- Fix missing fields in task index mapping to ensure proper task result storage ([#16201](https://github.com/opensearch-project/OpenSearch/pull/16201))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/tasks/TaskResultsService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResultsService.java
@@ -85,7 +85,7 @@ public class TaskResultsService {
 
     public static final String TASK_RESULT_MAPPING_VERSION_META_FIELD = "version";
 
-    public static final int TASK_RESULT_MAPPING_VERSION = 4; // must match version in task-index-mapping.json
+    public static final int TASK_RESULT_MAPPING_VERSION = 5; // must match version in task-index-mapping.json
 
     /**
      * The backoff policy to use when saving a task result fails. The total wait

--- a/server/src/test/resources/org/opensearch/tasks/missing-fields-task-index-mapping.json
+++ b/server/src/test/resources/org/opensearch/tasks/missing-fields-task-index-mapping.json
@@ -34,9 +34,6 @@
           "start_time_in_millis": {
             "type": "long"
           },
-          "cancellation_time_millis": {
-            "type": "long"
-          },
           "type": {
             "type": "keyword"
           },
@@ -48,10 +45,6 @@
             "type": "text"
           },
           "headers": {
-            "type" : "object",
-            "enabled" : false
-          },
-          "resource_stats": {
             "type" : "object",
             "enabled" : false
           }


### PR DESCRIPTION
### Description
This PR addresses an issue in the `testApproximateRangeWithSizeOverDefault` method of `ApproximatePointRangeQueryTests`, where the test would occasionally fail due to how Lucene handles total hits.
By default, `search()` in Lucene's `IndexSearcher` provides an accurate count for up to 1000 hits.
Beyond this threshold, Lucene may return a lower bound using GREATER_THAN_OR_EQUAL_TO for performance reasons (refer to the [Lucene IndexSearcher documentation](https://lucene.apache.org/core/9_11_0/core/org/apache/lucene/search/IndexSearcher.html).)

In `testApproximateRangeWithSizeOverDefault`, the search range includes 12,001 documents, and the test would sometimes fail when `GREATER_THAN_OR_EQUAL_TO` occurred during the search.

Changes:

- If totalHits.relation is `EQUAL_TO`, the test checks for an exact count of 11000.
- If totalHits.relation is `GREATER_THAN_OR_EQUAL_TO`, the test ensures the hits are no less than 11000 and within the upper bound (maxHits).

This issue is similar to [OpenSearch PR #4270](https://github.com/opensearch-project/OpenSearch/pull/4270). I resolved it in a similar way. Special thanks to @dbwiddis for the valuable guidance.

### Related Issues
Related #15807 

### Check List
- [X] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
