### PR TITLE
Fix flaky test in testApproximateRangeWithSizeOverDefault by adjusting totalHits assertion logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix missing fields in task index mapping to ensure proper task result storage ([#16201](https://github.com/opensearch-project/OpenSearch/pull/16201))
 - Fix typo super->sb in method toString() of RemoteStoreNodeAttribute ([#15362](https://github.com/opensearch-project/OpenSearch/pull/15362))
 - [Workload Management] Fixing Create/Update QueryGroup TransportActions to execute from non-cluster manager nodes ([16422](https://github.com/opensearch-project/OpenSearch/pull/16422))
+- Fix flaky test in `testApproximateRangeWithSizeOverDefault` by adjusting totalHits assertion logic ([#16434](https://github.com/opensearch-project/OpenSearch/pull/16434#pullrequestreview-2386999409))
 
 ### Security
 


### PR DESCRIPTION
### Description
This PR addresses an issue in the `testApproximateRangeWithSizeOverDefault` method of `ApproximatePointRangeQueryTests`, where the test would occasionally fail due to how Lucene handles total hits.
By default, `search()` in Lucene's `IndexSearcher` provides an accurate count for up to 1000 hits.
Beyond this threshold, Lucene may return a lower bound using GREATER_THAN_OR_EQUAL_TO for performance reasons (refer to the [Lucene IndexSearcher documentation](https://lucene.apache.org/core/9_11_0/core/org/apache/lucene/search/IndexSearcher.html).)

In `testApproximateRangeWithSizeOverDefault`, the search range includes 12,001 documents, and the test would sometimes fail when `GREATER_THAN_OR_EQUAL_TO` occurred during the search.

Changes:

- If totalHits.relation is `EQUAL_TO`, the test checks for an exact count of 11000.
- If totalHits.relation is `GREATER_THAN_OR_EQUAL_TO`, the test ensures the hits are no less than 11000 and within the upper bound (maxHits).

This issue is similar to [OpenSearch PR #4270](https://github.com/opensearch-project/OpenSearch/pull/4270). I resolved it in a similar way. Special thanks to @dbwiddis for the valuable guidance.

### Related Issues
Related #15807 

### Check List
- [X] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
