### PR TITLE
Add opensearch version info while deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Stop processing search requests when _msearch request is cancelled ([#17005](https://github.com/opensearch-project/OpenSearch/pull/17005))
 - Fix GRPC AUX_TRANSPORT_PORT and SETTING_GRPC_PORT settings and remove lingering HTTP terminology ([#17037](https://github.com/opensearch-project/OpenSearch/pull/17037))
 - Fix exists queries on nested flat_object fields throws exception ([#16803](https://github.com/opensearch-project/OpenSearch/pull/16803))
+- Use OpenSearch version to deserializat remote custom metadata([#16494](https://github.com/opensearch-project/OpenSearch/pull/16494))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Stop processing search requests when _msearch request is cancelled ([#17005](https://github.com/opensearch-project/OpenSearch/pull/17005))
 - Fix GRPC AUX_TRANSPORT_PORT and SETTING_GRPC_PORT settings and remove lingering HTTP terminology ([#17037](https://github.com/opensearch-project/OpenSearch/pull/17037))
 - Fix exists queries on nested flat_object fields throws exception ([#16803](https://github.com/opensearch-project/OpenSearch/pull/16803))
-- Use OpenSearch version to deserializat remote custom metadata([#16494](https://github.com/opensearch-project/OpenSearch/pull/16494))
+- Use OpenSearch version to deserialize remote custom metadata([#16494](https://github.com/opensearch-project/OpenSearch/pull/16494))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -1281,7 +1281,8 @@ public class RemoteClusterStateService implements Closeable {
                     entry.getKey(),
                     clusterUUID,
                     blobStoreRepository.getCompressor(),
-                    namedWriteableRegistry
+                    namedWriteableRegistry,
+                    manifest.getOpensearchVersion()
                 ),
                 listener
             );

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManager.java
@@ -242,7 +242,8 @@ public class RemoteGlobalMetadataManager extends AbstractRemoteWritableEntityMan
                             key,
                             clusterUUID,
                             compressor,
-                            namedWriteableRegistry
+                            namedWriteableRegistry,
+                            clusterMetadataManifest.getOpensearchVersion()
                         );
                         builder.putCustom(key, (Custom) getStore(remoteCustomMetadata).read(remoteCustomMetadata));
                     } catch (IOException e) {

--- a/server/src/main/java/org/opensearch/gateway/remote/model/RemoteCustomMetadata.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/model/RemoteCustomMetadata.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.gateway.remote.model;
 
+import org.opensearch.Version;
 import org.opensearch.cluster.metadata.Metadata.Custom;
 import org.opensearch.common.io.Streams;
 import org.opensearch.common.remote.AbstractClusterMetadataWriteableBlobEntity;
@@ -67,16 +68,17 @@ public class RemoteCustomMetadata extends AbstractClusterMetadataWriteableBlobEn
         final String customType,
         final String clusterUUID,
         final Compressor compressor,
-        final NamedWriteableRegistry namedWriteableRegistry
+        final NamedWriteableRegistry namedWriteableRegistry,
+        final Version version
     ) {
         super(clusterUUID, compressor, null);
         this.blobName = blobName;
         this.customType = customType;
         this.namedWriteableRegistry = namedWriteableRegistry;
-        this.customBlobStoreFormat = new ChecksumWritableBlobStoreFormat<>(
-            "custom",
-            is -> readFrom(is, namedWriteableRegistry, customType)
-        );
+        this.customBlobStoreFormat = new ChecksumWritableBlobStoreFormat<>("custom", is -> {
+            is.setVersion(version);
+            return readFrom(is, namedWriteableRegistry, customType);
+        });
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.gateway.remote;
 
+import org.opensearch.Version;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.cluster.ClusterModule;
 import org.opensearch.cluster.ClusterName;
@@ -487,7 +488,8 @@ public class RemoteGlobalMetadataManagerTests extends OpenSearchTestCase {
             IndexGraveyard.TYPE,
             CLUSTER_UUID,
             compressor,
-            namedWriteableRegistry
+            namedWriteableRegistry,
+            Version.CURRENT
         );
         when(blobStoreTransferService.downloadBlob(anyIterable(), anyString())).thenReturn(
             customMetadataForDownload.customBlobStoreFormat.serialize(customMetadata, fileName, compressor).streamInput()

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteGlobalMetadataManagerTests.java
@@ -481,6 +481,12 @@ public class RemoteGlobalMetadataManagerTests extends OpenSearchTestCase {
     }
 
     public void testGetAsyncReadRunnable_CustomMetadata() throws Exception {
+        for (Version version : List.of(Version.CURRENT, Version.V_2_15_0, Version.V_2_13_0)) {
+            verifyCustomMetadataReadForVersion(version);
+        }
+    }
+
+    private void verifyCustomMetadataReadForVersion(Version version) throws Exception {
         Metadata.Custom customMetadata = getCustomMetadata();
         String fileName = randomAlphaOfLength(10);
         RemoteCustomMetadata customMetadataForDownload = new RemoteCustomMetadata(
@@ -489,7 +495,7 @@ public class RemoteGlobalMetadataManagerTests extends OpenSearchTestCase {
             CLUSTER_UUID,
             compressor,
             namedWriteableRegistry,
-            Version.CURRENT
+            version
         );
         when(blobStoreTransferService.downloadBlob(anyIterable(), anyString())).thenReturn(
             customMetadataForDownload.customBlobStoreFormat.serialize(customMetadata, fileName, compressor).streamInput()
@@ -697,4 +703,5 @@ public class RemoteGlobalMetadataManagerTests extends OpenSearchTestCase {
         assertThat(customsDiff.getUpserts(), is(expectedUpserts));
         assertThat(customsDiff.getDeletes(), is(List.of(CustomMetadata1.TYPE)));
     }
+
 }

--- a/server/src/test/java/org/opensearch/gateway/remote/model/RemoteCustomMetadataTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/model/RemoteCustomMetadataTests.java
@@ -106,7 +106,8 @@ public class RemoteCustomMetadataTests extends OpenSearchTestCase {
             "test-custom",
             clusterUUID,
             compressor,
-            namedWriteableRegistry
+            namedWriteableRegistry,
+            Version.CURRENT
         );
         assertThat(remoteObjectForDownload.clusterUUID(), is(clusterUUID));
     }
@@ -128,7 +129,8 @@ public class RemoteCustomMetadataTests extends OpenSearchTestCase {
             "test-custom",
             clusterUUID,
             compressor,
-            namedWriteableRegistry
+            namedWriteableRegistry,
+            Version.CURRENT
         );
         assertThat(remoteObjectForDownload.getFullBlobName(), is(TEST_BLOB_NAME));
     }
@@ -150,7 +152,8 @@ public class RemoteCustomMetadataTests extends OpenSearchTestCase {
             "test-custom",
             clusterUUID,
             compressor,
-            namedWriteableRegistry
+            namedWriteableRegistry,
+            Version.CURRENT
         );
         assertThat(remoteObjectForDownload.getBlobFileName(), is(TEST_BLOB_FILE_NAME));
     }
@@ -162,7 +165,8 @@ public class RemoteCustomMetadataTests extends OpenSearchTestCase {
             "test-custom",
             clusterUUID,
             compressor,
-            namedWriteableRegistry
+            namedWriteableRegistry,
+            Version.CURRENT
         );
         assertThat(remoteObjectForDownload.getBlobPathTokens(), is(new String[] { "user", "local", "opensearch", "customMetadata" }));
     }


### PR DESCRIPTION
### Description
Custom Metadata is serialized `writeTo` and deserialized using the `readFrom` method or a constructor with stream input.
For example - `ComposableIndexTemplate` is serialized using [ComposableIndexTemplate.writeTo](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplate.java#L238-L254) and deserialized using the [stream input constructor](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplate.java#L175-L192).
Consider a case where a new attribute is added in a version. For example `context` is [added](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/metadata/ComposableIndexTemplate.java#L252) in ComposableIndexTemplate from 2.16 onwards. When it serialized from cluster manager of 2.15 version, the context field will not be present. But when the 2.16 cluster manager deserializes the object, it expects `context` field to be present and breaks.
The fix is to set the opensearch version in the stream input so that the deserialization will not look for new fields.

### Related Issues
NA

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
