### PR TITLE
Remove resource usages object from search response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix get index settings API doesn't show `number_of_routing_shards` setting when it was explicitly set ([#16294](https://github.com/opensearch-project/OpenSearch/pull/16294))
 - Revert changes to upload remote state manifest using minimum codec version([#16403](https://github.com/opensearch-project/OpenSearch/pull/16403))
 - Ensure index templates are not applied to system indices ([#16418](https://github.com/opensearch-project/OpenSearch/pull/16418))
+- Remove resource usages object from search response headers ([#16532](https://github.com/opensearch-project/OpenSearch/pull/16532))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/action/search/SearchTaskRequestOperationsListener.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchTaskRequestOperationsListener.java
@@ -25,6 +25,14 @@ public final class SearchTaskRequestOperationsListener extends SearchRequestOper
 
     @Override
     public void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        // Refresh the coordinator node level resource usages
         taskResourceTrackingService.refreshResourceStats(context.getTask());
+        // Remove the shard level resource usages from thread context
+        taskResourceTrackingService.removeTaskResourceUsage();
+    }
+
+    @Override
+    public void onRequestFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        taskResourceTrackingService.removeTaskResourceUsage();
     }
 }

--- a/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/ThreadContext.java
@@ -548,6 +548,15 @@ public final class ThreadContext implements Writeable {
     }
 
     /**
+     * Remove the {@code value} for the specified {@code key}.
+     *
+     * @param key         the header name
+     */
+    public void removeResponseHeader(final String key) {
+        threadLocal.get().responseHeaders.remove(key);
+    }
+
+    /**
      * Saves the current thread context and wraps command in a Runnable that restores that context before running command. If
      * <code>command</code> has already been passed through this method then it is returned unaltered rather than wrapped twice.
      */

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
@@ -329,6 +329,13 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
     }
 
     /**
+     * Remove the current task level resource usages.
+     */
+    public void removeTaskResourceUsage() {
+        threadPool.getThreadContext().removeResponseHeader(TASK_RESOURCE_USAGE);
+    }
+
+    /**
      * Get the task resource usages from {@link ThreadContext}
      *
      * @return {@link TaskResourceInfo}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR (https://github.com/opensearch-project/OpenSearch/pull/13172) introduced shard-level resource usage tracking by adding task resource usage objects to the node response headers. However, by default, all headers from the thread context are added to the response header: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/http/DefaultRestChannel.java#L156

This behavior could lead to excessive headers being sent to the client, potentially impacting latency. To address this, we now explicitly remove task-related headers before sending the response to the client.

### Testing
before the changes, run an opensearch cluster and insert some document. Do search and get response headers.
```
➜  OpenSearch git:(main) ✗ curl -v -X GET "localhost:9201/my-index-*/_search?size=1000&pretty" -H 'Content-Type: application/json' -d '{}'
* Host localhost:9201 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:9201...
* Connected to localhost (::1) port 9201
> GET /my-index-*/_search?size=1000&pretty HTTP/1.1
> Host: localhost:9201
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 2
>
* upload completely sent off: 2 bytes
< HTTP/1.1 200 OK
< TASK_RESOURCE_USAGE: {"action":"indices:data/read/search[phase/query]","taskId":898,"parentTaskId":865,"nodeId":"Ld-7uLOxQPOnDjnCnSuFRQ","taskResourceUsage":{"cpu_time_in_nanos":22979000,"memory_in_bytes":2000624}}
< X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
< content-type: application/json; charset=UTF-8
< content-length: 563
<
{
  "took" : 2064,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 1,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "my-index-0",
        "_id" : "HnDr45IBtfKEb7mfm5L1",
        "_score" : 1.0,
        "_source" : {
          "@timestamp" : "2099-11-15T13:12:00",
          "message" : "this is document 0",
          "user" : {
            "id" : "cyji"
          }
        }
      }
    ]
  }
}
```

With the change, run an opensearch cluster and insert some document. Do search and get response headers.
```
➜  OpenSearch git:(main) ✗ curl -v -X GET "localhost:9201/my-index-*/_search?size=1000&pretty" -H 'Content-Type: application/json' -d '{}'
* Host localhost:9201 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:9201...
* Connected to localhost (::1) port 9201
> GET /my-index-*/_search?size=1000&pretty HTTP/1.1
> Host: localhost:9201
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 2
>
* upload completely sent off: 2 bytes
< HTTP/1.1 200 OK
< X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
< content-type: application/json; charset=UTF-8
< content-length: 564
<
{
  "took" : 44872,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 1,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "my-index-0",
        "_id" : "v7z_45IBOxouwpmRaIKI",
        "_score" : 1.0,
        "_source" : {
          "@timestamp" : "2099-11-15T13:12:00",
          "message" : "this is document 0",
          "user" : {
            "id" : "cyji"
          }
        }
      }
    ]
  }
}
```

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
