### PR TITLE
Fix: Update field names in /index/_recovery API response to snake_case for consistency

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
@@ -415,10 +415,10 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
                 .field("version", version.toString())
                 .field("index", index.getName())
                 .field("restoreUUID", restoreUUID)
-                .field("isSearchableSnapshot", isSearchableSnapshot)
-                .field("remoteStoreIndexShallowCopy", remoteStoreIndexShallowCopy)
-                .field("sourceRemoteStoreRepository", sourceRemoteStoreRepository)
-                .field("sourceRemoteTranslogRepository", sourceRemoteTranslogRepository);
+                .field("is_searchable_snapshot", isSearchableSnapshot)
+                .field("remote_store_index_shallow_copy", remoteStoreIndexShallowCopy)
+                .field("source_remote_store_repository", sourceRemoteStoreRepository)
+                .field("source_remote_translog_repository", sourceRemoteTranslogRepository);
         }
 
         @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

This PR updates field names in the ```SnapshotRecoverySource``` response to follow snake_case, ensuring consistency across OpenSearch API responses. Specifically, it modifies the following fields:
- ```isSearchableSnapshot``` -> ```is_searchable_snapshot```
- ```remoteStoreIndexShallowCopy``` -> ```remote_store_index_shallow_copy```
- ```sourceRemoteStoreRepository``` -> ```source_remote_store_repository```
- ```sourceRemoteTranslogRepository``` -> ```source_remote_translog_repository```

This update aligns the naming conventions within the API, addressing an inconsistency in the ```/{index}/_recovery``` API response format.

### Related Issues
Resolves #16334 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
