### PR TITLE
Support retrieving doc values of unsigned long field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Revert changes to upload remote state manifest using minimum codec version([#16403](https://github.com/opensearch-project/OpenSearch/pull/16403))
 - Ensure index templates are not applied to system indices ([#16418](https://github.com/opensearch-project/OpenSearch/pull/16418))
 - Remove resource usages object from search response headers ([#16532](https://github.com/opensearch-project/OpenSearch/pull/16532))
+- Support retrieving doc values of unsigned long field ([#16543](https://github.com/opensearch-project/OpenSearch/pull/16543))
 
 ### Security
 

--- a/server/src/test/java/org/opensearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/NumberFieldTypeTests.java
@@ -987,7 +987,8 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
         Document doc = new Document();
-        doc.add(new SortedNumericDocValuesField("ul", 10));
+        final BigInteger expectedValue = randomUnsignedLong();
+        doc.add(new SortedNumericDocValuesField("ul", expectedValue.longValue()));
         w.addDocument(doc);
         try (DirectoryReader reader = DirectoryReader.open(w)) {
             final NumberFieldType ft = new NumberFieldType("ul", NumberType.UNSIGNED_LONG);
@@ -1001,7 +1002,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             assertEquals(1, fetcher.docValueCount());
             final Object value = fetcher.nextValue();
             assertTrue(value instanceof BigInteger);
-            assertEquals(BigInteger.valueOf(10), value);
+            assertEquals(expectedValue, value);
         }
         IOUtils.close(w, dir);
     }

--- a/server/src/test/java/org/opensearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/NumberFieldTypeTests.java
@@ -73,6 +73,7 @@ import org.opensearch.index.mapper.MappedFieldType.Relation;
 import org.opensearch.index.mapper.NumberFieldMapper.NumberFieldType;
 import org.opensearch.index.mapper.NumberFieldMapper.NumberType;
 import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.MultiValueMode;
 import org.opensearch.search.query.BitmapDocValuesQuery;
 import org.junit.Before;
@@ -980,5 +981,28 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         ft = new NumberFieldMapper.NumberFieldType("field", type);
         NumberFieldType finalFt = ft;
         assertThrows(IllegalArgumentException.class, () -> finalFt.bitmapQuery(bitmap));
+    }
+
+    public void testFetchUnsignedLongDocValues() throws IOException {
+        Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+        Document doc = new Document();
+        doc.add(new SortedNumericDocValuesField("ul", 10));
+        w.addDocument(doc);
+        try (DirectoryReader reader = DirectoryReader.open(w)) {
+            final NumberFieldType ft = new NumberFieldType("ul", NumberType.UNSIGNED_LONG);
+            IndexNumericFieldData fielddata = (IndexNumericFieldData) ft.fielddataBuilder(
+                "index",
+                () -> { throw new UnsupportedOperationException(); }
+            ).build(null, null);
+            assertEquals(IndexNumericFieldData.NumericType.UNSIGNED_LONG, fielddata.getNumericType());
+            DocValueFetcher.Leaf fetcher = fielddata.load(reader.leaves().get(0)).getLeafValueFetcher(DocValueFormat.UNSIGNED_LONG);
+            assertTrue(fetcher.advanceExact(0));
+            assertEquals(1, fetcher.docValueCount());
+            final Object value = fetcher.nextValue();
+            assertTrue(value instanceof BigInteger);
+            assertEquals(BigInteger.valueOf(10), value);
+        }
+        IOUtils.close(w, dir);
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->


### Description
Implement the `LeafFieldData#getLeafValueFetcher` method for unsigned long field to support retrieving doc values.  Previously, attempting to use the `docvalue_fields` parameter to access doc values would result in a UOE being thrown.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
