### PR TITLE
[Backport 2.x] Call 'toArray()' with an empty array instead of a pre-sized array

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
@@ -176,7 +176,7 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
 
         project.getRepositories().exclusiveContent(exclusiveContentRepository -> {
             exclusiveContentRepository.filter(config -> config.includeGroup(group));
-            exclusiveContentRepository.forRepositories(repos.toArray(new IvyArtifactRepository[repos.size()]));
+            exclusiveContentRepository.forRepositories(repos.toArray(new IvyArtifactRepository[0]));
         });
     }
 

--- a/client/rest-high-level/src/main/java/org/opensearch/client/core/CountResponse.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/core/CountResponse.java
@@ -233,7 +233,7 @@ public final class CountResponse {
                     parser.skipChildren();
                 }
             }
-            return new ShardStats(successfulShards, totalShards, skippedShards, failures.toArray(new ShardSearchFailure[failures.size()]));
+            return new ShardStats(successfulShards, totalShards, skippedShards, failures.toArray(new ShardSearchFailure[0]));
         }
 
         @Override

--- a/client/rest-high-level/src/main/java/org/opensearch/client/indices/PutIndexTemplateRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/indices/PutIndexTemplateRequest.java
@@ -478,7 +478,7 @@ public class PutIndexTemplateRequest extends ClusterManagerNodeRequest<PutIndexT
 
     @Override
     public String[] indices() {
-        return indexPatterns.toArray(new String[indexPatterns.size()]);
+        return indexPatterns.toArray(new String[0]);
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/opensearch/client/RestHighLevelClientExtTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/RestHighLevelClientExtTests.java
@@ -153,7 +153,7 @@ public class RestHighLevelClientExtTests extends OpenSearchTestCase {
                 values.add(parser.text());
             }
             assertEquals(XContentParser.Token.END_ARRAY, parser.currentToken());
-            CustomResponseSection2 responseSection2 = new CustomResponseSection2(values.toArray(new String[values.size()]));
+            CustomResponseSection2 responseSection2 = new CustomResponseSection2(values.toArray(new String[0]));
             assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
             return responseSection2;
         }

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/InstallPluginCommand.java
@@ -1027,7 +1027,7 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
 
     @Override
     public void close() throws IOException {
-        IOUtils.rm(pathsToDeleteOnShutdown.toArray(new Path[pathsToDeleteOnShutdown.size()]));
+        IOUtils.rm(pathsToDeleteOnShutdown.toArray(new Path[0]));
     }
 
 }

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/RemovePluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/plugins/RemovePluginCommand.java
@@ -215,7 +215,7 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
         // finally, add the marker file
         pluginPaths.add(removing);
 
-        IOUtils.rm(pluginPaths.toArray(new Path[pluginPaths.size()]));
+        IOUtils.rm(pluginPaths.toArray(new Path[0]));
     }
 
 }

--- a/libs/common/src/test/java/org/opensearch/common/collect/IteratorsTests.java
+++ b/libs/common/src/test/java/org/opensearch/common/collect/IteratorsTests.java
@@ -106,7 +106,7 @@ public class IteratorsTests extends OpenSearchTestCase {
             }
             iterators[i] = theseValues.iterator();
         }
-        assertContainsInOrder(Iterators.concat(iterators), values.toArray(new Integer[values.size()]));
+        assertContainsInOrder(Iterators.concat(iterators), values.toArray(new Integer[0]));
     }
 
     public void testTwoEntries() {

--- a/libs/core/src/main/java/org/opensearch/core/ParseField.java
+++ b/libs/core/src/main/java/org/opensearch/core/ParseField.java
@@ -73,12 +73,12 @@ public class ParseField {
         } else {
             final HashSet<String> set = new HashSet<>();
             Collections.addAll(set, deprecatedNames);
-            this.deprecatedNames = set.toArray(new String[set.size()]);
+            this.deprecatedNames = set.toArray(new String[0]);
         }
         Set<String> allNames = new HashSet<>();
         allNames.add(name);
         Collections.addAll(allNames, this.deprecatedNames);
-        this.allNames = allNames.toArray(new String[allNames.size()]);
+        this.allNames = allNames.toArray(new String[0]);
     }
 
     /**

--- a/libs/core/src/main/java/org/opensearch/core/common/Strings.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/Strings.java
@@ -343,7 +343,7 @@ public class Strings {
         if (collection == null) {
             return null;
         }
-        return collection.toArray(new String[collection.size()]);
+        return collection.toArray(new String[0]);
     }
 
     /**

--- a/libs/core/src/main/java/org/opensearch/core/common/bytes/BytesReference.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/bytes/BytesReference.java
@@ -98,7 +98,7 @@ public interface BytesReference extends Comparable<BytesReference>, ToXContentFr
             while ((r = byteRefIterator.next()) != null) {
                 buffers.add(ByteBuffer.wrap(r.bytes, r.offset, r.length));
             }
-            return buffers.toArray(new ByteBuffer[buffers.size()]);
+            return buffers.toArray(new ByteBuffer[0]);
 
         } catch (IOException e) {
             // this is really an error since we don't do IO in our bytesreferences

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/filtering/FilterPath.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/filtering/FilterPath.java
@@ -105,7 +105,7 @@ public class FilterPath {
                 }
             }
         }
-        return paths.toArray(new FilterPath[paths.size()]);
+        return paths.toArray(new FilterPath[0]);
     }
 
     private static FilterPath parse(final String filter) {

--- a/libs/core/src/main/java/org/opensearch/core/xcontent/filtering/FilterPathBasedFilter.java
+++ b/libs/core/src/main/java/org/opensearch/core/xcontent/filtering/FilterPathBasedFilter.java
@@ -100,7 +100,7 @@ public class FilterPathBasedFilter extends TokenFilter {
             }
 
             if ((nextFilters != null) && (nextFilters.isEmpty() == false)) {
-                return new FilterPathBasedFilter(nextFilters.toArray(new FilterPath[nextFilters.size()]), inclusive);
+                return new FilterPathBasedFilter(nextFilters.toArray(new FilterPath[0]), inclusive);
             }
         }
         return NO_MATCHING;

--- a/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/ChildQuerySearchIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/opensearch/join/query/ChildQuerySearchIT.java
@@ -327,7 +327,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
             }
             assertThat(parentToChildren.get(previousParentId).add(childId), is(true));
         }
-        indexRandom(true, builders.toArray(new IndexRequestBuilder[builders.size()]));
+        indexRandom(true, builders.toArray(new IndexRequestBuilder[0]));
 
         assertThat(parentToChildren.isEmpty(), equalTo(false));
         for (Map.Entry<String, Set<String>> parentToChildrenEntry : parentToChildren.entrySet()) {

--- a/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/TransportRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/TransportRankEvalAction.java
@@ -148,7 +148,7 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
             if (summaryFields.isEmpty()) {
                 evaluationRequest.fetchSource(false);
             } else {
-                evaluationRequest.fetchSource(summaryFields.toArray(new String[summaryFields.size()]), new String[0]);
+                evaluationRequest.fetchSource(summaryFields.toArray(new String[0]), new String[0]);
             }
             SearchRequest searchRequest = new SearchRequest(request.indices(), evaluationRequest);
             searchRequest.indicesOptions(request.indicesOptions());
@@ -158,12 +158,7 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
         assert ratedRequestsInSearch.size() == msearchRequest.requests().size();
         client.multiSearch(
             msearchRequest,
-            new RankEvalActionListener(
-                listener,
-                metric,
-                ratedRequestsInSearch.toArray(new RatedRequest[ratedRequestsInSearch.size()]),
-                errors
-            )
+            new RankEvalActionListener(listener, metric, ratedRequestsInSearch.toArray(new RatedRequest[0]), errors)
         );
     }
 

--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/AbstractAsyncBulkByScrollAction.java
@@ -516,7 +516,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
             return;
         }
         RefreshRequest refresh = new RefreshRequest();
-        refresh.indices(destinationIndices.toArray(new String[destinationIndices.size()]));
+        refresh.indices(destinationIndices.toArray(new String[0]));
         logger.debug("[{}]: refreshing", task.getId());
         client.admin().indices().refresh(refresh, new ActionListener<RefreshResponse>() {
             @Override

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/DeleteByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/DeleteByQueryBasicTests.java
@@ -362,7 +362,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
         int slices = randomSlices(1, 10);
         int expectedSlices = expectedSliceStatuses(slices, docs.keySet());
 
-        String[] sourceIndexNames = docs.keySet().toArray(new String[docs.size()]);
+        String[] sourceIndexNames = docs.keySet().toArray(new String[0]);
 
         assertThat(
             deleteByQuery().source(sourceIndexNames).filter(QueryBuilders.matchAllQuery()).refresh(true).setSlices(slices).get(),

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexBasicTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexBasicTests.java
@@ -161,7 +161,7 @@ public class ReindexBasicTests extends ReindexTestCase {
         int slices = randomSlices(1, 10);
         int expectedSlices = expectedSliceStatuses(slices, docs.keySet());
 
-        String[] sourceIndexNames = docs.keySet().toArray(new String[docs.size()]);
+        String[] sourceIndexNames = docs.keySet().toArray(new String[0]);
         ReindexRequestBuilder request = reindex().source(sourceIndexNames).destination("dest").refresh(true).setSlices(slices);
 
         BulkByScrollResponse response = request.get();

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/UpdateByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/UpdateByQueryBasicTests.java
@@ -151,7 +151,7 @@ public class UpdateByQueryBasicTests extends ReindexTestCase {
         int slices = randomSlices(1, 10);
         int expectedSlices = expectedSliceStatuses(slices, docs.keySet());
 
-        String[] sourceIndexNames = docs.keySet().toArray(new String[docs.size()]);
+        String[] sourceIndexNames = docs.keySet().toArray(new String[0]);
         BulkByScrollResponse response = updateByQuery().source(sourceIndexNames).refresh(true).setSlices(slices).get();
         assertThat(response, matcher().updated(allDocs.size()).slices(hasSize(expectedSlices)));
 

--- a/plugins/mapper-annotated-text/src/main/java/org/opensearch/search/fetch/subphase/highlight/AnnotatedPassageFormatter.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/opensearch/search/fetch/subphase/highlight/AnnotatedPassageFormatter.java
@@ -237,7 +237,7 @@ public class AnnotatedPassageFormatter extends PassageFormatter {
             // add 1 for the fieldvalue separator character
             fieldValueOffset += fieldValueAnnotations.textMinusMarkup.length() + 1;
         }
-        return intersectingAnnotations.toArray(new AnnotationToken[intersectingAnnotations.size()]);
+        return intersectingAnnotations.toArray(new AnnotationToken[0]);
     }
 
     private void append(StringBuilder dest, String content, int start, int end) {

--- a/server/src/internalClusterTest/java/org/opensearch/action/IndicesRequestIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/IndicesRequestIT.java
@@ -739,7 +739,7 @@ public class IndicesRequestIT extends OpenSearchIntegTestCase {
         while (uniqueIndices.size() < count) {
             uniqueIndices.add(randomFrom(this.indices));
         }
-        return uniqueIndices.toArray(new String[uniqueIndices.size()]);
+        return uniqueIndices.toArray(new String[0]);
     }
 
     private static void assertAllRequestsHaveBeenConsumed() {

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/get/GetIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/get/GetIndexIT.java
@@ -162,7 +162,7 @@ public class GetIndexIT extends OpenSearchIntegTestCase {
         }
         GetIndexResponse response = runWithRandomFeatureMethod(
             client().admin().indices().prepareGetIndex().addIndices("idx"),
-            features.toArray(new Feature[features.size()])
+            features.toArray(new Feature[0])
         );
         String[] indices = response.indices();
         assertThat(indices, notNullValue());
@@ -193,7 +193,7 @@ public class GetIndexIT extends OpenSearchIntegTestCase {
         }
         GetIndexResponse response = runWithRandomFeatureMethod(
             client().admin().indices().prepareGetIndex().addIndices("empty_idx"),
-            features.toArray(new Feature[features.size()])
+            features.toArray(new Feature[0])
         );
         String[] indices = response.indices();
         assertThat(indices, notNullValue());

--- a/server/src/internalClusterTest/java/org/opensearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/recovery/RelocationIT.java
@@ -601,7 +601,7 @@ public class RelocationIT extends ParameterizedStaticSettingsOpenSearchIntegTest
             logger.info(" --> checking iteration {}", i);
             SearchResponse afterRelocation = client().prepareSearch().setSize(ids.size()).get();
             assertNoFailures(afterRelocation);
-            assertSearchHits(afterRelocation, ids.toArray(new String[ids.size()]));
+            assertSearchHits(afterRelocation, ids.toArray(new String[0]));
         }
         stopped.set(true);
         for (Thread searchThread : searchThreads) {

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/GeoDistanceIT.java
@@ -164,7 +164,7 @@ public class GeoDistanceIT extends ParameterizedStaticSettingsOpenSearchIntegTes
                     .setSource(jsonBuilder().startObject().field("value", i * 2).field("location", "52.0945, 5.116").endObject())
             );
         }
-        indexRandom(true, builders.toArray(new IndexRequestBuilder[builders.size()]));
+        indexRandom(true, builders.toArray(new IndexRequestBuilder[0]));
         ensureSearchable();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/LongTermsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/LongTermsIT.java
@@ -180,7 +180,7 @@ public class LongTermsIT extends AbstractTermsTestCase {
 
         getMultiSortDocs(builders);
 
-        indexRandom(true, builders.toArray(new IndexRequestBuilder[builders.size()]));
+        indexRandom(true, builders.toArray(new IndexRequestBuilder[0]));
         ensureSearchable();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MaxBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MaxBucketIT.java
@@ -188,7 +188,7 @@ public class MaxBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
         assertThat(maxBucketValue, notNullValue());
         assertThat(maxBucketValue.getName(), equalTo("max_bucket"));
         assertThat(maxBucketValue.value(), equalTo(maxValue));
-        assertThat(maxBucketValue.keys(), equalTo(maxKeys.toArray(new String[maxKeys.size()])));
+        assertThat(maxBucketValue.keys(), equalTo(maxKeys.toArray(new String[0])));
     }
 
     public void testDocCountAsSubAgg() throws Exception {
@@ -240,7 +240,7 @@ public class MaxBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
             assertThat(maxBucketValue, notNullValue());
             assertThat(maxBucketValue.getName(), equalTo("max_bucket"));
             assertThat(maxBucketValue.value(), equalTo(maxValue));
-            assertThat(maxBucketValue.keys(), equalTo(maxKeys.toArray(new String[maxKeys.size()])));
+            assertThat(maxBucketValue.keys(), equalTo(maxKeys.toArray(new String[0])));
         }
     }
 
@@ -280,7 +280,7 @@ public class MaxBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
         assertThat(maxBucketValue, notNullValue());
         assertThat(maxBucketValue.getName(), equalTo("max_bucket"));
         assertThat(maxBucketValue.value(), equalTo(maxValue));
-        assertThat(maxBucketValue.keys(), equalTo(maxKeys.toArray(new String[maxKeys.size()])));
+        assertThat(maxBucketValue.keys(), equalTo(maxKeys.toArray(new String[0])));
     }
 
     public void testMetricAsSubAgg() throws Exception {
@@ -339,7 +339,7 @@ public class MaxBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
             assertThat(maxBucketValue, notNullValue());
             assertThat(maxBucketValue.getName(), equalTo("max_bucket"));
             assertThat(maxBucketValue.value(), equalTo(maxValue));
-            assertThat(maxBucketValue.keys(), equalTo(maxKeys.toArray(new String[maxKeys.size()])));
+            assertThat(maxBucketValue.keys(), equalTo(maxKeys.toArray(new String[0])));
         }
     }
 
@@ -388,7 +388,7 @@ public class MaxBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
         assertThat(maxBucketValue, notNullValue());
         assertThat(maxBucketValue.getName(), equalTo("max_bucket"));
         assertThat(maxBucketValue.value(), equalTo(maxValue));
-        assertThat(maxBucketValue.keys(), equalTo(maxKeys.toArray(new String[maxKeys.size()])));
+        assertThat(maxBucketValue.keys(), equalTo(maxKeys.toArray(new String[0])));
     }
 
     public void testMetricAsSubAggWithInsertZeros() throws Exception {
@@ -445,7 +445,7 @@ public class MaxBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
             assertThat(maxBucketValue, notNullValue());
             assertThat(maxBucketValue.getName(), equalTo("max_bucket"));
             assertThat(maxBucketValue.value(), equalTo(maxValue));
-            assertThat(maxBucketValue.keys(), equalTo(maxKeys.toArray(new String[maxKeys.size()])));
+            assertThat(maxBucketValue.keys(), equalTo(maxKeys.toArray(new String[0])));
         }
     }
 
@@ -526,7 +526,7 @@ public class MaxBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
             assertThat(maxBucketValue, notNullValue());
             assertThat(maxBucketValue.getName(), equalTo("max_histo_bucket"));
             assertThat(maxBucketValue.value(), equalTo(maxHistoValue));
-            assertThat(maxBucketValue.keys(), equalTo(maxHistoKeys.toArray(new String[maxHistoKeys.size()])));
+            assertThat(maxBucketValue.keys(), equalTo(maxHistoKeys.toArray(new String[0])));
             if (maxHistoValue > maxTermsValue) {
                 maxTermsValue = maxHistoValue;
                 maxTermsKeys = new ArrayList<>();
@@ -540,7 +540,7 @@ public class MaxBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
         assertThat(maxBucketValue, notNullValue());
         assertThat(maxBucketValue.getName(), equalTo("max_terms_bucket"));
         assertThat(maxBucketValue.value(), equalTo(maxTermsValue));
-        assertThat(maxBucketValue.keys(), equalTo(maxTermsKeys.toArray(new String[maxTermsKeys.size()])));
+        assertThat(maxBucketValue.keys(), equalTo(maxTermsKeys.toArray(new String[0])));
     }
 
     /**

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MinBucketIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/pipeline/MinBucketIT.java
@@ -174,7 +174,7 @@ public class MinBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
         assertThat(minBucketValue, notNullValue());
         assertThat(minBucketValue.getName(), equalTo("min_bucket"));
         assertThat(minBucketValue.value(), equalTo(minValue));
-        assertThat(minBucketValue.keys(), equalTo(minKeys.toArray(new String[minKeys.size()])));
+        assertThat(minBucketValue.keys(), equalTo(minKeys.toArray(new String[0])));
     }
 
     public void testDocCountAsSubAgg() throws Exception {
@@ -226,7 +226,7 @@ public class MinBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
             assertThat(minBucketValue, notNullValue());
             assertThat(minBucketValue.getName(), equalTo("min_bucket"));
             assertThat(minBucketValue.value(), equalTo(minValue));
-            assertThat(minBucketValue.keys(), equalTo(minKeys.toArray(new String[minKeys.size()])));
+            assertThat(minBucketValue.keys(), equalTo(minKeys.toArray(new String[0])));
         }
     }
 
@@ -266,7 +266,7 @@ public class MinBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
         assertThat(minBucketValue, notNullValue());
         assertThat(minBucketValue.getName(), equalTo("min_bucket"));
         assertThat(minBucketValue.value(), equalTo(minValue));
-        assertThat(minBucketValue.keys(), equalTo(minKeys.toArray(new String[minKeys.size()])));
+        assertThat(minBucketValue.keys(), equalTo(minKeys.toArray(new String[0])));
     }
 
     public void testMetricAsSubAgg() throws Exception {
@@ -325,7 +325,7 @@ public class MinBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
             assertThat(minBucketValue, notNullValue());
             assertThat(minBucketValue.getName(), equalTo("min_bucket"));
             assertThat(minBucketValue.value(), equalTo(minValue));
-            assertThat(minBucketValue.keys(), equalTo(minKeys.toArray(new String[minKeys.size()])));
+            assertThat(minBucketValue.keys(), equalTo(minKeys.toArray(new String[0])));
         }
     }
 
@@ -383,7 +383,7 @@ public class MinBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
             assertThat(minBucketValue, notNullValue());
             assertThat(minBucketValue.getName(), equalTo("min_bucket"));
             assertThat(minBucketValue.value(), equalTo(minValue));
-            assertThat(minBucketValue.keys(), equalTo(minKeys.toArray(new String[minKeys.size()])));
+            assertThat(minBucketValue.keys(), equalTo(minKeys.toArray(new String[0])));
         }
     }
 
@@ -464,7 +464,7 @@ public class MinBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
             assertThat(minBucketValue, notNullValue());
             assertThat(minBucketValue.getName(), equalTo("min_histo_bucket"));
             assertThat(minBucketValue.value(), equalTo(minHistoValue));
-            assertThat(minBucketValue.keys(), equalTo(minHistoKeys.toArray(new String[minHistoKeys.size()])));
+            assertThat(minBucketValue.keys(), equalTo(minHistoKeys.toArray(new String[0])));
             if (minHistoValue < minTermsValue) {
                 minTermsValue = minHistoValue;
                 minTermsKeys = new ArrayList<>();
@@ -478,6 +478,6 @@ public class MinBucketIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
         assertThat(minBucketValue, notNullValue());
         assertThat(minBucketValue.getName(), equalTo("min_terms_bucket"));
         assertThat(minBucketValue.value(), equalTo(minTermsValue));
-        assertThat(minBucketValue.keys(), equalTo(minTermsKeys.toArray(new String[minTermsKeys.size()])));
+        assertThat(minBucketValue.keys(), equalTo(minTermsKeys.toArray(new String[0])));
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWhileRelocatingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWhileRelocatingIT.java
@@ -103,7 +103,7 @@ public class SearchWhileRelocatingIT extends ParameterizedStaticSettingsOpenSear
                     )
             );
         }
-        indexRandom(true, indexBuilders.toArray(new IndexRequestBuilder[indexBuilders.size()]));
+        indexRandom(true, indexBuilders.toArray(new IndexRequestBuilder[0]));
         assertHitCount(client().prepareSearch().get(), (numDocs));
         final int numIters = scaledRandomIntBetween(5, 20);
         for (int i = 0; i < numIters; i++) {

--- a/server/src/internalClusterTest/java/org/opensearch/search/morelikethis/MoreLikeThisIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/morelikethis/MoreLikeThisIT.java
@@ -793,7 +793,7 @@ public class MoreLikeThisIT extends ParameterizedStaticSettingsOpenSearchIntegTe
         List<Item> docs = new ArrayList<>(numFields);
         for (int i = 0; i < numFields; i++) {
             docs.add(new Item("test", i + ""));
-            mltQuery = moreLikeThisQuery(null, new Item[] { new Item("test", doc) }).unlike(docs.toArray(new Item[docs.size()]))
+            mltQuery = moreLikeThisQuery(null, new Item[] { new Item("test", doc) }).unlike(docs.toArray(new Item[0]))
                 .minTermFreq(0)
                 .minDocFreq(0)
                 .maxQueryTerms(100)

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -149,7 +149,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 }
             }
             if (!indicesToFlush.isEmpty()) {
-                String[] indices = indicesToFlush.toArray(new String[indicesToFlush.size()]);
+                String[] indices = indicesToFlush.toArray(new String[0]);
                 logger.info("--> starting asynchronous flush for indices {}", Arrays.toString(indices));
                 flushResponseFuture = client().admin().indices().prepareFlush(indices).execute();
             }
@@ -1785,7 +1785,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(snapshotInfos.get(0).state(), equalTo(SnapshotState.SUCCESS));
         assertThat(snapshotInfos.get(0).snapshotId().getName(), equalTo("test-snap"));
 
-        assertAcked(client().admin().indices().prepareDelete(nbDocsPerIndex.keySet().toArray(new String[nbDocsPerIndex.size()])));
+        assertAcked(client().admin().indices().prepareDelete(nbDocsPerIndex.keySet().toArray(new String[0])));
 
         Predicate<String> isRestorableIndex = index -> corruptedIndex.getName().equals(index) == false;
 

--- a/server/src/main/java/org/apache/lucene/search/uhighlight/CustomFieldHighlighter.java
+++ b/server/src/main/java/org/apache/lucene/search/uhighlight/CustomFieldHighlighter.java
@@ -174,7 +174,7 @@ class CustomFieldHighlighter extends FieldHighlighter {
         } while (off.nextPosition());
         maybeAddPassage(passageQueue, passageScorer, passage, contentLength);
 
-        Passage[] passages = passageQueue.toArray(new Passage[passageQueue.size()]);
+        Passage[] passages = passageQueue.toArray(new Passage[0]);
         // sort in ascending order
         Arrays.sort(passages, Comparator.comparingInt(Passage::getStartOffset));
         return passages;

--- a/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreRequest.java
@@ -92,7 +92,7 @@ public class RestoreRemoteStoreRequest extends ClusterManagerNodeRequest<Restore
      * @return this request
      */
     public RestoreRemoteStoreRequest indices(List<String> indices) {
-        this.indices = indices.toArray(new String[indices.size()]);
+        this.indices = indices.toArray(new String[0]);
         return this;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -261,7 +261,7 @@ public class CreateSnapshotRequest extends ClusterManagerNodeRequest<CreateSnaps
      * @return this request
      */
     public CreateSnapshotRequest indices(List<String> indices) {
-        this.indices = indices.toArray(new String[indices.size()]);
+        this.indices = indices.toArray(new String[0]);
         return this;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -312,7 +312,7 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
      * @return this request
      */
     public RestoreSnapshotRequest indices(List<String> indices) {
-        this.indices = indices.toArray(new String[indices.size()]);
+        this.indices = indices.toArray(new String[0]);
         return this;
     }
 
@@ -487,7 +487,7 @@ public class RestoreSnapshotRequest extends ClusterManagerNodeRequest<RestoreSna
      * Sets the list of index settings and index settings groups that shouldn't be restored from snapshot
      */
     public RestoreSnapshotRequest ignoreIndexSettings(List<String> ignoreIndexSettings) {
-        this.ignoreIndexSettings = ignoreIndexSettings.toArray(new String[ignoreIndexSettings.size()]);
+        this.ignoreIndexSettings = ignoreIndexSettings.toArray(new String[0]);
         return this;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -123,7 +123,7 @@ public class TransportIndicesAliasesAction extends TransportClusterManagerNodeAc
         for (IndicesAliasesRequest.AliasActions aliasAction : request.aliasActions()) {
             Collections.addAll(indices, aliasAction.indices());
         }
-        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indices.toArray(new String[indices.size()]));
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indices.toArray(new String[0]));
     }
 
     @Override
@@ -196,7 +196,7 @@ public class TransportIndicesAliasesAction extends TransportClusterManagerNodeAc
             }
         }
         if (finalActions.isEmpty() && false == actions.isEmpty()) {
-            throw new AliasesNotFoundException(aliases.toArray(new String[aliases.size()]));
+            throw new AliasesNotFoundException(aliases.toArray(new String[0]));
         }
         request.aliasActions().clear();
         IndicesAliasesClusterStateUpdateRequest updateRequest = new IndicesAliasesClusterStateUpdateRequest(unmodifiableList(finalActions))

--- a/server/src/main/java/org/opensearch/action/admin/indices/delete/TransportDeleteIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/delete/TransportDeleteIndexAction.java
@@ -128,7 +128,7 @@ public class TransportDeleteIndexAction extends TransportClusterManagerNodeActio
 
         DeleteIndexClusterStateUpdateRequest deleteRequest = new DeleteIndexClusterStateUpdateRequest().ackTimeout(request.timeout())
             .masterNodeTimeout(request.clusterManagerNodeTimeout())
-            .indices(concreteIndices.toArray(new Index[concreteIndices.size()]));
+            .indices(concreteIndices.toArray(new Index[0]));
 
         deleteIndexService.deleteIndices(deleteRequest, new ActionListener<ClusterStateUpdateResponse>() {
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/segments/IndexSegments.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/segments/IndexSegments.java
@@ -68,10 +68,7 @@ public class IndexSegments implements Iterable<IndexShardSegments> {
         for (Map.Entry<Integer, List<ShardSegments>> entry : tmpIndexShards.entrySet()) {
             indexShards.put(
                 entry.getKey(),
-                new IndexShardSegments(
-                    entry.getValue().get(0).getShardRouting().shardId(),
-                    entry.getValue().toArray(new ShardSegments[entry.getValue().size()])
-                )
+                new IndexShardSegments(entry.getValue().get(0).getShardRouting().shardId(), entry.getValue().toArray(new ShardSegments[0]))
             );
         }
     }

--- a/server/src/main/java/org/opensearch/action/admin/indices/segments/PitSegmentsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/segments/PitSegmentsRequest.java
@@ -68,7 +68,7 @@ public class PitSegmentsRequest extends BroadcastRequest<PitSegmentsRequest> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeStringArrayNullable((pitIds == null) ? null : pitIds.toArray(new String[pitIds.size()]));
+        out.writeStringArrayNullable((pitIds == null) ? null : pitIds.toArray(new String[0]));
         out.writeBoolean(verbose);
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/segments/TransportIndicesSegmentsAction.java
@@ -119,7 +119,7 @@ public class TransportIndicesSegmentsAction extends TransportBroadcastByNodeActi
         ClusterState clusterState
     ) {
         return new IndicesSegmentResponse(
-            results.toArray(new ShardSegments[results.size()]),
+            results.toArray(new ShardSegments[0]),
             totalShards,
             successfulShards,
             failedShards,

--- a/server/src/main/java/org/opensearch/action/admin/indices/segments/TransportPitSegmentsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/segments/TransportPitSegmentsAction.java
@@ -170,7 +170,7 @@ public class TransportPitSegmentsAction extends TransportBroadcastByNodeAction<P
         ClusterState clusterState
     ) {
         return new IndicesSegmentResponse(
-            results.toArray(new ShardSegments[results.size()]),
+            results.toArray(new ShardSegments[0]),
             totalShards,
             successfulShards,
             failedShards,

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -183,7 +183,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
     }
 
     public Flag[] getFlags() {
-        return flags.toArray(new Flag[flags.size()]);
+        return flags.toArray(new Flag[0]);
     }
 
     public Set<CacheType> getIncludeCaches() {

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/IndexStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/IndexStats.java
@@ -91,10 +91,7 @@ public class IndexStats implements Iterable<IndexShardStats> {
         for (Map.Entry<Integer, List<ShardStats>> entry : tmpIndexShards.entrySet()) {
             indexShards.put(
                 entry.getKey(),
-                new IndexShardStats(
-                    entry.getValue().get(0).getShardRouting().shardId(),
-                    entry.getValue().toArray(new ShardStats[entry.getValue().size()])
-                )
+                new IndexShardStats(entry.getValue().get(0).getShardRouting().shardId(), entry.getValue().toArray(new ShardStats[0]))
             );
         }
         return indexShards;
@@ -156,7 +153,7 @@ public class IndexStats implements Iterable<IndexShardStats> {
         }
 
         public IndexStats build() {
-            return new IndexStats(indexName, uuid, shards.toArray(new ShardStats[shards.size()]));
+            return new IndexStats(indexName, uuid, shards.toArray(new ShardStats[0]));
         }
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -120,13 +120,7 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
         List<DefaultShardOperationFailedException> shardFailures,
         ClusterState clusterState
     ) {
-        return new IndicesStatsResponse(
-            responses.toArray(new ShardStats[responses.size()]),
-            totalShards,
-            successfulShards,
-            failedShards,
-            shardFailures
-        );
+        return new IndicesStatsResponse(responses.toArray(new ShardStats[0]), totalShards, successfulShards, failedShards, shardFailures);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -478,7 +478,7 @@ public class PutIndexTemplateRequest extends ClusterManagerNodeRequest<PutIndexT
 
     @Override
     public String[] indices() {
-        return indexPatterns.toArray(new String[indexPatterns.size()]);
+        return indexPatterns.toArray(new String[0]);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/upgrade/get/IndexUpgradeStatus.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/upgrade/get/IndexUpgradeStatus.java
@@ -70,7 +70,7 @@ public class IndexUpgradeStatus implements Iterable<IndexShardUpgradeStatus> {
                 entry.getKey(),
                 new IndexShardUpgradeStatus(
                     entry.getValue().get(0).getShardRouting().shardId(),
-                    entry.getValue().toArray(new ShardUpgradeStatus[entry.getValue().size()])
+                    entry.getValue().toArray(new ShardUpgradeStatus[0])
                 )
             );
         }

--- a/server/src/main/java/org/opensearch/action/admin/indices/upgrade/get/TransportUpgradeStatusAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/upgrade/get/TransportUpgradeStatusAction.java
@@ -121,7 +121,7 @@ public class TransportUpgradeStatusAction extends TransportBroadcastByNodeAction
         ClusterState clusterState
     ) {
         return new UpgradeStatusResponse(
-            responses.toArray(new ShardUpgradeStatus[responses.size()]),
+            responses.toArray(new ShardUpgradeStatus[0]),
             totalShards,
             successfulShards,
             failedShards,

--- a/server/src/main/java/org/opensearch/action/admin/indices/upgrade/get/UpgradeStatusResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/upgrade/get/UpgradeStatusResponse.java
@@ -96,7 +96,7 @@ public class UpgradeStatusResponse extends BroadcastResponse {
                     shards.add(shard);
                 }
             }
-            indicesUpgradeStats.put(indexName, new IndexUpgradeStatus(indexName, shards.toArray(new ShardUpgradeStatus[shards.size()])));
+            indicesUpgradeStats.put(indexName, new IndexUpgradeStatus(indexName, shards.toArray(new ShardUpgradeStatus[0])));
         }
         this.indicesUpgradeStatus = indicesUpgradeStats;
         return indicesUpgradeStats;

--- a/server/src/main/java/org/opensearch/action/bulk/BulkResponse.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BulkResponse.java
@@ -216,6 +216,6 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
                 throwUnknownToken(token, parser.getTokenLocation());
             }
         }
-        return new BulkResponse(items.toArray(new BulkItemResponse[items.size()]), took, ingestTook);
+        return new BulkResponse(items.toArray(new BulkItemResponse[0]), took, ingestTook);
     }
 }

--- a/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
@@ -642,7 +642,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                 BulkShardRequest bulkShardRequest = new BulkShardRequest(
                     shardId,
                     bulkRequest.getRefreshPolicy(),
-                    requests.toArray(new BulkItemRequest[requests.size()])
+                    requests.toArray(new BulkItemRequest[0])
                 );
                 bulkShardRequest.waitForActiveShards(bulkRequest.waitForActiveShards());
                 bulkShardRequest.timeout(bulkRequest.timeout());

--- a/server/src/main/java/org/opensearch/action/get/MultiGetRequest.java
+++ b/server/src/main/java/org/opensearch/action/get/MultiGetRequest.java
@@ -521,15 +521,15 @@ public class MultiGetRequest extends ActionRequest
 
                         fetchSourceContext = new FetchSourceContext(
                             fetchSourceContext.fetchSource(),
-                            includes == null ? Strings.EMPTY_ARRAY : includes.toArray(new String[includes.size()]),
-                            excludes == null ? Strings.EMPTY_ARRAY : excludes.toArray(new String[excludes.size()])
+                            includes == null ? Strings.EMPTY_ARRAY : includes.toArray(new String[0]),
+                            excludes == null ? Strings.EMPTY_ARRAY : excludes.toArray(new String[0])
                         );
                     }
                 }
             }
             String[] aFields;
             if (storedFields != null) {
-                aFields = storedFields.toArray(new String[storedFields.size()]);
+                aFields = storedFields.toArray(new String[0]);
             } else {
                 aFields = defaultFields;
             }

--- a/server/src/main/java/org/opensearch/action/search/ClearScrollRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/ClearScrollRequest.java
@@ -103,7 +103,7 @@ public class ClearScrollRequest extends ActionRequest implements ToXContentObjec
         if (scrollIds == null) {
             out.writeVInt(0);
         } else {
-            out.writeStringArray(scrollIds.toArray(new String[scrollIds.size()]));
+            out.writeStringArray(scrollIds.toArray(new String[0]));
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/search/DeletePitRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/DeletePitRequest.java
@@ -78,7 +78,7 @@ public class DeletePitRequest extends ActionRequest implements ToXContentObject 
         if (pitIds == null) {
             out.writeVInt(0);
         } else {
-            out.writeStringArray(pitIds.toArray(new String[pitIds.size()]));
+            out.writeStringArray(pitIds.toArray(new String[0]));
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/search/PitService.java
+++ b/server/src/main/java/org/opensearch/action/search/PitService.java
@@ -175,7 +175,7 @@ public class PitService {
         for (final DiscoveryNode node : clusterService.state().nodes().getDataNodes().values()) {
             nodes.add(node);
         }
-        DiscoveryNode[] disNodesArr = nodes.toArray(new DiscoveryNode[nodes.size()]);
+        DiscoveryNode[] disNodesArr = nodes.toArray(new DiscoveryNode[0]);
         GetAllPitNodesRequest getAllPitNodesRequest = new GetAllPitNodesRequest(disNodesArr);
         transportService.sendRequest(
             transportService.getLocalNode(),

--- a/server/src/main/java/org/opensearch/action/search/SearchScrollAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchScrollAsyncAction.java
@@ -243,7 +243,7 @@ abstract class SearchScrollAsyncAction<T extends SearchPhaseResult> implements R
         if (shardFailures.isEmpty()) {
             return ShardSearchFailure.EMPTY_ARRAY;
         }
-        return shardFailures.toArray(new ShardSearchFailure[shardFailures.size()]);
+        return shardFailures.toArray(new ShardSearchFailure[0]);
     }
 
     // we do our best to return the shard failures, but its ok if its not fully concurrently safe

--- a/server/src/main/java/org/opensearch/action/support/ActionFilters.java
+++ b/server/src/main/java/org/opensearch/action/support/ActionFilters.java
@@ -46,7 +46,7 @@ public class ActionFilters {
     private final ActionFilter[] filters;
 
     public ActionFilters(Set<ActionFilter> actionFilters) {
-        this.filters = actionFilters.toArray(new ActionFilter[actionFilters.size()]);
+        this.filters = actionFilters.toArray(new ActionFilter[0]);
         Arrays.sort(filters, new Comparator<ActionFilter>() {
             @Override
             public int compare(ActionFilter o1, ActionFilter o2) {

--- a/server/src/main/java/org/opensearch/action/support/broadcast/BroadcastResponse.java
+++ b/server/src/main/java/org/opensearch/action/support/broadcast/BroadcastResponse.java
@@ -114,7 +114,7 @@ public class BroadcastResponse extends ActionResponse implements ToXContentObjec
         if (shardFailures == null) {
             this.shardFailures = EMPTY;
         } else {
-            this.shardFailures = shardFailures.toArray(new DefaultShardOperationFailedException[shardFailures.size()]);
+            this.shardFailures = shardFailures.toArray(new DefaultShardOperationFailedException[0]);
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/support/replication/ReplicationResponse.java
+++ b/server/src/main/java/org/opensearch/action/support/replication/ReplicationResponse.java
@@ -225,7 +225,7 @@ public class ReplicationResponse extends ActionResponse {
             }
             Failure[] failures = EMPTY;
             if (failuresList != null) {
-                failures = failuresList.toArray(new Failure[failuresList.size()]);
+                failures = failuresList.toArray(new Failure[0]);
             }
             return new ShardInfo(total, successful, failures);
         }

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -356,7 +356,7 @@ public class IndexNameExpressionResolver {
             throw infe;
         }
         checkSystemIndexAccess(context, metadata, concreteIndices, indexExpressions);
-        return concreteIndices.toArray(new Index[concreteIndices.size()]);
+        return concreteIndices.toArray(new Index[0]);
     }
 
     private void checkSystemIndexAccess(Context context, Metadata metadata, Set<Index> concreteIndices, String[] originalPatterns) {
@@ -604,7 +604,7 @@ public class IndexNameExpressionResolver {
         if (aliases == null) {
             return null;
         }
-        return aliases.toArray(new String[aliases.size()]);
+        return aliases.toArray(new String[0]);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingNodes.java
@@ -1179,7 +1179,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
          */
         public ShardRouting[] drain() {
             nodes.ensureMutable();
-            ShardRouting[] mutableShardRoutings = unassigned.toArray(new ShardRouting[unassigned.size()]);
+            ShardRouting[] mutableShardRoutings = unassigned.toArray(new ShardRouting[0]);
             unassigned.clear();
             primaries = 0;
             return mutableShardRoutings;
@@ -1191,7 +1191,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
          */
         public ShardRouting[] drainIgnored() {
             nodes.ensureMutable();
-            ShardRouting[] mutableShardRoutings = ignored.toArray(new ShardRouting[ignored.size()]);
+            ShardRouting[] mutableShardRoutings = ignored.toArray(new ShardRouting[0]);
             ignored.clear();
             ignoredPrimaries = 0;
             return mutableShardRoutings;

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationService.java
@@ -380,7 +380,7 @@ public class AllocationService {
             final Metadata.Builder metadataBuilder = Metadata.builder(clusterState.metadata());
             for (Map.Entry<Integer, List<String>> entry : autoExpandReplicaChanges.entrySet()) {
                 final int numberOfReplicas = entry.getKey();
-                final String[] indices = entry.getValue().toArray(new String[entry.getValue().size()]);
+                final String[] indices = entry.getValue().toArray(new String[0]);
                 // we do *not* update the in sync allocation ids as they will be removed upon the first index
                 // operation which make these copies stale
                 routingTableBuilder.updateNumberOfReplicas(numberOfReplicas, indices);

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -111,7 +111,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
      * Returns an array view on the nodes in the balancer. Nodes should not be removed from this list.
      */
     private BalancedShardsAllocator.ModelNode[] nodesArray() {
-        return nodes.values().toArray(new BalancedShardsAllocator.ModelNode[nodes.size()]);
+        return nodes.values().toArray(new BalancedShardsAllocator.ModelNode[0]);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/blobstore/BlobPath.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/BlobPath.java
@@ -71,7 +71,7 @@ public class BlobPath implements Iterable<String> {
     }
 
     public String[] toArray() {
-        return paths.toArray(new String[paths.size()]);
+        return paths.toArray(new String[0]);
     }
 
     public BlobPath add(String path) {

--- a/server/src/main/java/org/opensearch/common/geo/GeoPolygonDecomposer.java
+++ b/server/src/main/java/org/opensearch/common/geo/GeoPolygonDecomposer.java
@@ -464,7 +464,7 @@ public class GeoPolygonDecomposer {
             }
         }
 
-        return mainEdges.toArray(new Edge[mainEdges.size()]);
+        return mainEdges.toArray(new Edge[0]);
     }
 
     private static void compose(Edge[] edges, Edge[] holes, int numHoles, List<Polygon> collector) {

--- a/server/src/main/java/org/opensearch/common/geo/builders/LineStringBuilder.java
+++ b/server/src/main/java/org/opensearch/common/geo/builders/LineStringBuilder.java
@@ -122,7 +122,7 @@ public class LineStringBuilder extends ShapeBuilder<JtsGeometry, org.opensearch.
 
     @Override
     public JtsGeometry buildS4J() {
-        Coordinate[] coordinates = this.coordinates.toArray(new Coordinate[this.coordinates.size()]);
+        Coordinate[] coordinates = this.coordinates.toArray(new Coordinate[0]);
         Geometry geometry;
         if (wrapdateline) {
             ArrayList<LineString> strings = decomposeS4J(FACTORY, coordinates, new ArrayList<LineString>());
@@ -130,7 +130,7 @@ public class LineStringBuilder extends ShapeBuilder<JtsGeometry, org.opensearch.
             if (strings.size() == 1) {
                 geometry = strings.get(0);
             } else {
-                LineString[] linestrings = strings.toArray(new LineString[strings.size()]);
+                LineString[] linestrings = strings.toArray(new LineString[0]);
                 geometry = FACTORY.createMultiLineString(linestrings);
             }
 

--- a/server/src/main/java/org/opensearch/common/geo/builders/MultiLineStringBuilder.java
+++ b/server/src/main/java/org/opensearch/common/geo/builders/MultiLineStringBuilder.java
@@ -154,7 +154,7 @@ public class MultiLineStringBuilder extends ShapeBuilder<JtsGeometry, org.opense
             if (parts.size() == 1) {
                 geometry = parts.get(0);
             } else {
-                LineString[] lineStrings = parts.toArray(new LineString[parts.size()]);
+                LineString[] lineStrings = parts.toArray(new LineString[0]);
                 geometry = FACTORY.createMultiLineString(lineStrings);
             }
         } else {

--- a/server/src/main/java/org/opensearch/common/geo/builders/PolygonBuilder.java
+++ b/server/src/main/java/org/opensearch/common/geo/builders/PolygonBuilder.java
@@ -309,7 +309,7 @@ public class PolygonBuilder extends ShapeBuilder<JtsGeometry, org.opensearch.geo
     }
 
     protected static LinearRing linearRingS4J(GeometryFactory factory, List<Coordinate> coordinates) {
-        return factory.createLinearRing(coordinates.toArray(new Coordinate[coordinates.size()]));
+        return factory.createLinearRing(coordinates.toArray(new Coordinate[0]));
     }
 
     @Override
@@ -507,7 +507,7 @@ public class PolygonBuilder extends ShapeBuilder<JtsGeometry, org.opensearch.geo
             }
         }
 
-        return mainEdges.toArray(new Edge[mainEdges.size()]);
+        return mainEdges.toArray(new Edge[0]);
     }
 
     private static Coordinate[][][] compose(Edge[] edges, Edge[] holes, int numHoles) {

--- a/server/src/main/java/org/opensearch/common/lucene/index/FilterableTermsEnum.java
+++ b/server/src/main/java/org/opensearch/common/lucene/index/FilterableTermsEnum.java
@@ -140,7 +140,7 @@ public class FilterableTermsEnum extends TermsEnum {
             }
             enums.add(new Holder(termsEnum, bits));
         }
-        this.enums = enums.toArray(new Holder[enums.size()]);
+        this.enums = enums.toArray(new Holder[0]);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/common/lucene/search/XMoreLikeThis.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/XMoreLikeThis.java
@@ -621,7 +621,7 @@ public final class XMoreLikeThis {
         if (fieldNames == null) {
             // gather list of valid fields from lucene
             Collection<String> fields = FieldInfos.getIndexedFields(ir);
-            fieldNames = fields.toArray(new String[fields.size()]);
+            fieldNames = fields.toArray(new String[0]);
         }
 
         return createQuery(retrieveTerms(docNum));

--- a/server/src/main/java/org/opensearch/common/network/NetworkService.java
+++ b/server/src/main/java/org/opensearch/common/network/NetworkService.java
@@ -205,7 +205,7 @@ public final class NetworkService {
         // 1. single wildcard address, probably set by network.host: expand to all interface addresses.
         if (addresses.length == 1 && addresses[0].isAnyLocalAddress()) {
             HashSet<InetAddress> all = new HashSet<>(Arrays.asList(NetworkUtils.getAllAddresses()));
-            addresses = all.toArray(new InetAddress[all.size()]);
+            addresses = all.toArray(new InetAddress[0]);
         }
 
         // 2. try to deal with some (mis)configuration
@@ -248,7 +248,7 @@ public final class NetworkService {
         for (String host : hosts) {
             set.addAll(Arrays.asList(resolveInternal(host)));
         }
-        return set.toArray(new InetAddress[set.size()]);
+        return set.toArray(new InetAddress[0]);
     }
 
     /** resolves a single host specification */

--- a/server/src/main/java/org/opensearch/common/network/NetworkUtils.java
+++ b/server/src/main/java/org/opensearch/common/network/NetworkUtils.java
@@ -239,7 +239,7 @@ public abstract class NetworkUtils {
         if (list.isEmpty()) {
             throw new IllegalArgumentException("Interface '" + name + "' has no internet addresses");
         }
-        return list.toArray(new InetAddress[list.size()]);
+        return list.toArray(new InetAddress[0]);
     }
 
     /** Returns only the IPV4 addresses in {@code addresses} */
@@ -253,7 +253,7 @@ public abstract class NetworkUtils {
         if (list.isEmpty()) {
             throw new IllegalArgumentException("No ipv4 addresses found in " + Arrays.toString(addresses));
         }
-        return list.toArray(new InetAddress[list.size()]);
+        return list.toArray(new InetAddress[0]);
     }
 
     /** Returns only the IPV6 addresses in {@code addresses} */
@@ -267,6 +267,6 @@ public abstract class NetworkUtils {
         if (list.isEmpty()) {
             throw new IllegalArgumentException("No ipv6 addresses found in " + Arrays.toString(addresses));
         }
-        return list.toArray(new InetAddress[list.size()]);
+        return list.toArray(new InetAddress[0]);
     }
 }

--- a/server/src/main/java/org/opensearch/common/settings/Settings.java
+++ b/server/src/main/java/org/opensearch/common/settings/Settings.java
@@ -1046,7 +1046,7 @@ public final class Settings implements ToXContentFragment {
         }
 
         private void processLegacyLists(Map<String, Object> map) {
-            String[] array = map.keySet().toArray(new String[map.size()]);
+            String[] array = map.keySet().toArray(new String[0]);
             for (String key : array) {
                 if (key.endsWith(".0")) { // let's only look at the head of the list and convert in order starting there.
                     int counter = 0;

--- a/server/src/main/java/org/opensearch/common/settings/SettingsFilter.java
+++ b/server/src/main/java/org/opensearch/common/settings/SettingsFilter.java
@@ -117,7 +117,7 @@ public final class SettingsFilter {
             }
         }
         if (!simpleMatchPatternList.isEmpty()) {
-            String[] simpleMatchPatterns = simpleMatchPatternList.toArray(new String[simpleMatchPatternList.size()]);
+            String[] simpleMatchPatterns = simpleMatchPatternList.toArray(new String[0]);
             builder.keys().removeIf(key -> Regex.simpleMatch(simpleMatchPatterns, key));
         }
         return builder.build();

--- a/server/src/main/java/org/opensearch/common/util/concurrent/PrioritizedOpenSearchThreadPoolExecutor.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/PrioritizedOpenSearchThreadPoolExecutor.java
@@ -81,7 +81,7 @@ public class PrioritizedOpenSearchThreadPoolExecutor extends OpenSearchThreadPoo
         List<Pending> pending = new ArrayList<>();
         addPending(new ArrayList<>(current), pending, true);
         addPending(new ArrayList<>(getQueue()), pending, false);
-        return pending.toArray(new Pending[pending.size()]);
+        return pending.toArray(new Pending[0]);
     }
 
     public int getNumberOfPendingTasks() {

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -1062,7 +1062,7 @@ public final class NodeEnvironment implements Closeable {
                 paths.add(indexFolder);
             }
         }
-        return paths.toArray(new Path[paths.size()]);
+        return paths.toArray(new Path[0]);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/opensearch/gateway/LocalAllocateDangledIndices.java
@@ -113,10 +113,7 @@ public class LocalAllocateDangledIndices {
             listener.onFailure(new ClusterManagerNotDiscoveredException("no cluster-manager to send allocate dangled request"));
             return;
         }
-        AllocateDangledRequest request = new AllocateDangledRequest(
-            clusterService.localNode(),
-            indices.toArray(new IndexMetadata[indices.size()])
-        );
+        AllocateDangledRequest request = new AllocateDangledRequest(clusterService.localNode(), indices.toArray(new IndexMetadata[0]));
         transportService.sendRequest(
             clusterManagerNode,
             ACTION_NAME,

--- a/server/src/main/java/org/opensearch/index/analysis/AnalyzerComponents.java
+++ b/server/src/main/java/org/opensearch/index/analysis/AnalyzerComponents.java
@@ -109,8 +109,8 @@ public final class AnalyzerComponents {
 
         return new AnalyzerComponents(
             tokenizer,
-            charFiltersList.toArray(new CharFilterFactory[charFiltersList.size()]),
-            tokenFilterList.toArray(new TokenFilterFactory[tokenFilterList.size()])
+            charFiltersList.toArray(new CharFilterFactory[0]),
+            tokenFilterList.toArray(new TokenFilterFactory[0])
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/analysis/CustomNormalizerProvider.java
+++ b/server/src/main/java/org/opensearch/index/analysis/CustomNormalizerProvider.java
@@ -98,8 +98,8 @@ public final class CustomNormalizerProvider extends AbstractIndexAnalyzerProvide
 
         this.customAnalyzer = new CustomAnalyzer(
             tokenizerFactory,
-            charFiltersList.toArray(new CharFilterFactory[charFiltersList.size()]),
-            tokenFilterList.toArray(new TokenFilterFactory[tokenFilterList.size()])
+            charFiltersList.toArray(new CharFilterFactory[0]),
+            tokenFilterList.toArray(new TokenFilterFactory[0])
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -1148,7 +1148,7 @@ public abstract class Engine implements Closeable {
             }
         }
 
-        Segment[] segmentsArr = segments.values().toArray(new Segment[segments.values().size()]);
+        Segment[] segmentsArr = segments.values().toArray(new Segment[0]);
         Arrays.sort(segmentsArr, Comparator.comparingLong(Segment::getGeneration));
         return segmentsArr;
     }

--- a/server/src/main/java/org/opensearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParseContext.java
@@ -147,7 +147,7 @@ public abstract class ParseContext implements Iterable<ParseContext.Document> {
                     f.add(field);
                 }
             }
-            return f.toArray(new IndexableField[f.size()]);
+            return f.toArray(new IndexableField[0]);
         }
 
         public IndexableField getField(String name) {

--- a/server/src/main/java/org/opensearch/index/query/IdsQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/IdsQueryBuilder.java
@@ -99,7 +99,7 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
             // types not supported so send an empty array to previous versions
             out.writeStringArray(Strings.EMPTY_ARRAY);
         }
-        out.writeStringArray(ids.toArray(new String[ids.size()]));
+        out.writeStringArray(ids.toArray(new String[0]));
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/MoreLikeThisQueryBuilder.java
@@ -390,7 +390,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
                             while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                                 fields.add(parser.text());
                             }
-                            item.fields(fields.toArray(new String[fields.size()]));
+                            item.fields(fields.toArray(new String[0]));
                         } else {
                             throw new OpenSearchParseException("failed to parse More Like This item. field [fields] must be an array");
                         }
@@ -690,7 +690,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         if (stopWords == null) {
             throw new IllegalArgumentException("requires stopwords to be non-null");
         }
-        this.stopWords = stopWords.toArray(new String[stopWords.size()]);
+        this.stopWords = stopWords.toArray(new String[0]);
         return this;
     }
 
@@ -899,11 +899,11 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
             throw new ParsingException(parser.getTokenLocation(), "more_like_this requires 'fields' to be non-empty");
         }
 
-        String[] fieldsArray = fields == null ? null : fields.toArray(new String[fields.size()]);
-        String[] likeTextsArray = likeTexts.isEmpty() ? null : likeTexts.toArray(new String[likeTexts.size()]);
-        String[] unlikeTextsArray = unlikeTexts.isEmpty() ? null : unlikeTexts.toArray(new String[unlikeTexts.size()]);
-        Item[] likeItemsArray = likeItems.isEmpty() ? null : likeItems.toArray(new Item[likeItems.size()]);
-        Item[] unlikeItemsArray = unlikeItems.isEmpty() ? null : unlikeItems.toArray(new Item[unlikeItems.size()]);
+        String[] fieldsArray = fields == null ? null : fields.toArray(new String[0]);
+        String[] likeTextsArray = likeTexts.isEmpty() ? null : likeTexts.toArray(new String[0]);
+        String[] unlikeTextsArray = unlikeTexts.isEmpty() ? null : unlikeTexts.toArray(new String[0]);
+        Item[] likeItemsArray = likeItems.isEmpty() ? null : likeItems.toArray(new Item[0]);
+        Item[] unlikeItemsArray = unlikeItems.isEmpty() ? null : unlikeItems.toArray(new Item[0]);
 
         MoreLikeThisQueryBuilder moreLikeThisQueryBuilder = new MoreLikeThisQueryBuilder(fieldsArray, likeTextsArray, likeItemsArray)
             .unlike(unlikeTextsArray)
@@ -1027,7 +1027,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         if (moreLikeFields.isEmpty()) {
             return null;
         }
-        mltQuery.setMoreLikeFields(moreLikeFields.toArray(new String[moreLikeFields.size()]));
+        mltQuery.setMoreLikeFields(moreLikeFields.toArray(new String[0]));
 
         // handle like texts
         if (likeTexts.length > 0) {
@@ -1100,7 +1100,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
             if (useDefaultField) {
                 item.fields("*");
             } else {
-                item.fields(moreLikeFields.toArray(new String[moreLikeFields.size()]));
+                item.fields(moreLikeFields.toArray(new String[0]));
             }
         }
     }

--- a/server/src/main/java/org/opensearch/index/query/VectorGeoShapeQueryProcessor.java
+++ b/server/src/main/java/org/opensearch/index/query/VectorGeoShapeQueryProcessor.java
@@ -81,11 +81,7 @@ public class VectorGeoShapeQueryProcessor {
         if (geometries.size() == 0) {
             return new MatchNoDocsQuery();
         }
-        return LatLonShape.newGeometryQuery(
-            fieldName,
-            relation.getLuceneRelation(),
-            geometries.toArray(new LatLonGeometry[geometries.size()])
-        );
+        return LatLonShape.newGeometryQuery(fieldName, relation.getLuceneRelation(), geometries.toArray(new LatLonGeometry[0]));
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -602,7 +602,7 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
 
         FunctionScoreQueryBuilder functionScoreQueryBuilder = new FunctionScoreQueryBuilder(
             query,
-            filterFunctionBuilders.toArray(new FunctionScoreQueryBuilder.FilterFunctionBuilder[filterFunctionBuilders.size()])
+            filterFunctionBuilders.toArray(new FilterFunctionBuilder[0])
         );
         if (combineFunction != null) {
             functionScoreQueryBuilder.boostMode(combineFunction);

--- a/server/src/main/java/org/opensearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/opensearch/index/reindex/ReindexRequest.java
@@ -400,7 +400,7 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
         if (value instanceof List) {
             @SuppressWarnings("unchecked")
             List<String> list = (List<String>) value;
-            return list.toArray(new String[list.size()]);
+            return list.toArray(new String[0]);
         } else if (value instanceof String) {
             return Strings.splitStringByCommaToArray((String) value);
         } else {

--- a/server/src/main/java/org/opensearch/index/shard/LocalShardSnapshot.java
+++ b/server/src/main/java/org/opensearch/index/shard/LocalShardSnapshot.java
@@ -96,7 +96,7 @@ final class LocalShardSnapshot implements Closeable {
             @Override
             public String[] listAll() throws IOException {
                 Collection<String> fileNames = wrappedIndexCommit.get().getFileNames();
-                final String[] fileNameArray = fileNames.toArray(new String[fileNames.size()]);
+                final String[] fileNameArray = fileNames.toArray(new String[0]);
                 return fileNameArray;
             }
 

--- a/server/src/main/java/org/opensearch/monitor/fs/FsProbe.java
+++ b/server/src/main/java/org/opensearch/monitor/fs/FsProbe.java
@@ -174,7 +174,7 @@ public class FsProbe {
                 }
             }
 
-            return new FsInfo.IoStats(devicesStats.toArray(new FsInfo.DeviceStats[devicesStats.size()]));
+            return new FsInfo.IoStats(devicesStats.toArray(new FsInfo.DeviceStats[0]));
         } catch (Exception e) {
             // do not fail Elasticsearch if something unexpected
             // happens here

--- a/server/src/main/java/org/opensearch/monitor/jvm/DeadlockAnalyzer.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/DeadlockAnalyzer.java
@@ -81,7 +81,7 @@ public class DeadlockAnalyzer {
         Deadlock result[] = new Deadlock[cycles.size()];
         int count = 0;
         for (LinkedHashSet<ThreadInfo> cycle : cycles) {
-            ThreadInfo asArray[] = cycle.toArray(new ThreadInfo[cycle.size()]);
+            ThreadInfo asArray[] = cycle.toArray(new ThreadInfo[0]);
             Deadlock d = new Deadlock(asArray);
             result[count++] = d;
         }

--- a/server/src/main/java/org/opensearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/JvmInfo.java
@@ -81,7 +81,7 @@ public class JvmInfo implements ReportingService.Info {
         } catch (Exception t) {
             // ignore
         }
-        String[] inputArguments = runtimeMXBean.getInputArguments().toArray(new String[runtimeMXBean.getInputArguments().size()]);
+        String[] inputArguments = runtimeMXBean.getInputArguments().toArray(new String[0]);
         Mem mem = new Mem(heapInit, heapMax, nonHeapInit, nonHeapMax, directMemoryMax);
 
         String bootClassPath;

--- a/server/src/main/java/org/opensearch/rest/action/document/RestTermVectorsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/document/RestTermVectorsAction.java
@@ -123,7 +123,7 @@ public class RestTermVectorsAction extends BaseRestHandler {
             }
         }
         if (selectedFields != null) {
-            termVectorsRequest.selectedFields(selectedFields.toArray(new String[selectedFields.size()]));
+            termVectorsRequest.selectedFields(selectedFields.toArray(new String[0]));
         }
     }
 

--- a/server/src/main/java/org/opensearch/rest/action/search/RestGetAllPitsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/search/RestGetAllPitsAction.java
@@ -54,7 +54,7 @@ public class RestGetAllPitsAction extends BaseRestHandler {
         for (DiscoveryNode node : nodesInCluster.get()) {
             nodes.add(node);
         }
-        DiscoveryNode[] disNodesArr = nodes.toArray(new DiscoveryNode[nodes.size()]);
+        DiscoveryNode[] disNodesArr = nodes.toArray(new DiscoveryNode[0]);
         GetAllPitNodesRequest getAllPitNodesRequest = new GetAllPitNodesRequest(disNodesArr);
         return channel -> client.getAllPits(getAllPitNodesRequest, new RestBuilderListener<GetAllPitNodesResponse>(channel) {
             @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/MultiBucketCollector.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/MultiBucketCollector.java
@@ -192,7 +192,7 @@ public class MultiBucketCollector extends BucketCollector {
         private int numCollectors;
 
         private MultiLeafBucketCollector(List<LeafBucketCollector> collectors, boolean cacheScores) {
-            this.collectors = collectors.toArray(new LeafBucketCollector[collectors.size()]);
+            this.collectors = collectors.toArray(new LeafBucketCollector[0]);
             this.cacheScores = cacheScores;
             this.numCollectors = this.collectors.length;
         }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantTextAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantTextAggregationBuilder.java
@@ -216,7 +216,7 @@ public class SignificantTextAggregationBuilder extends AbstractAggregationBuilde
      * to also be the name of the JSON field holding the value
      */
     public SignificantTextAggregationBuilder sourceFieldNames(List<String> names) {
-        this.sourceFieldNames = names.toArray(new String[names.size()]);
+        this.sourceFieldNames = names.toArray(new String[0]);
         return this;
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/BucketMetricsParser.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/BucketMetricsParser.java
@@ -85,7 +85,7 @@ public abstract class BucketMetricsParser implements PipelineAggregator.Parser {
                         String path = parser.text();
                         paths.add(path);
                     }
-                    bucketsPaths = paths.toArray(new String[paths.size()]);
+                    bucketsPaths = paths.toArray(new String[0]);
                 } else {
                     parseToken(pipelineAggregatorName, parser, currentFieldName, token, params);
                 }

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/DerivativePipelineAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/DerivativePipelineAggregationBuilder.java
@@ -223,7 +223,7 @@ public class DerivativePipelineAggregationBuilder extends AbstractPipelineAggreg
                         String path = parser.text();
                         paths.add(path);
                     }
-                    bucketsPaths = paths.toArray(new String[paths.size()]);
+                    bucketsPaths = paths.toArray(new String[0]);
                 } else {
                     throw new ParsingException(
                         parser.getTokenLocation(),

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/MaxBucketPipelineAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/MaxBucketPipelineAggregator.java
@@ -92,7 +92,7 @@ public class MaxBucketPipelineAggregator extends BucketMetricsPipelineAggregator
 
     @Override
     protected InternalAggregation buildAggregation(Map<String, Object> metadata) {
-        String[] keys = maxBucketKeys.toArray(new String[maxBucketKeys.size()]);
+        String[] keys = maxBucketKeys.toArray(new String[0]);
         return new InternalBucketMetricValue(name(), keys, maxValue, format, metadata());
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/MovAvgPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/MovAvgPipelineAggregationBuilder.java
@@ -386,7 +386,7 @@ public class MovAvgPipelineAggregationBuilder extends AbstractPipelineAggregatio
                         String path = parser.text();
                         paths.add(path);
                     }
-                    bucketsPaths = paths.toArray(new String[paths.size()]);
+                    bucketsPaths = paths.toArray(new String[0]);
                 } else {
                     throw new ParsingException(
                         parser.getTokenLocation(),

--- a/server/src/main/java/org/opensearch/search/aggregations/pipeline/SerialDiffPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/pipeline/SerialDiffPipelineAggregationBuilder.java
@@ -220,7 +220,7 @@ public class SerialDiffPipelineAggregationBuilder extends AbstractPipelineAggreg
                         String path = parser.text();
                         paths.add(path);
                     }
-                    bucketsPaths = paths.toArray(new String[paths.size()]);
+                    bucketsPaths = paths.toArray(new String[0]);
                 } else {
                     throw new ParsingException(
                         parser.getTokenLocation(),

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
@@ -152,7 +152,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
             while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                 list.add(parser.text());
             }
-            includes = list.toArray(new String[list.size()]);
+            includes = list.toArray(new String[0]);
         } else if (token == XContentParser.Token.START_OBJECT) {
             String currentFieldName = null;
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -172,7 +172,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                                 );
                             }
                         }
-                        includes = includesList.toArray(new String[includesList.size()]);
+                        includes = includesList.toArray(new String[0]);
                     } else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                         List<String> excludesList = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
@@ -186,7 +186,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                                 );
                             }
                         }
-                        excludes = excludesList.toArray(new String[excludesList.size()]);
+                        excludes = excludesList.toArray(new String[0]);
                     } else {
                         throw new ParsingException(
                             parser.getTokenLocation(),

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/HighlightField.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/highlight/HighlightField.java
@@ -139,7 +139,7 @@ public class HighlightField implements ToXContentFragment, Writeable {
             while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                 values.add(new Text(parser.text()));
             }
-            fragments = values.toArray(new Text[values.size()]);
+            fragments = values.toArray(new Text[0]);
         } else if (token == XContentParser.Token.VALUE_NULL) {
             fragments = null;
         } else {

--- a/server/src/main/java/org/opensearch/search/sort/GeoDistanceSortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/GeoDistanceSortBuilder.java
@@ -241,7 +241,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
      * Returns the points to create the range distance facets from.
      */
     public GeoPoint[] points() {
-        return this.points.toArray(new GeoPoint[this.points.size()]);
+        return this.points.toArray(new GeoPoint[0]);
     }
 
     /**
@@ -576,7 +576,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
             }
         }
 
-        GeoDistanceSortBuilder result = new GeoDistanceSortBuilder(fieldName, geoPoints.toArray(new GeoPoint[geoPoints.size()]));
+        GeoDistanceSortBuilder result = new GeoDistanceSortBuilder(fieldName, geoPoints.toArray(new GeoPoint[0]));
         result.geoDistance(geoDistance);
         result.unit(unit);
         result.order(order);
@@ -644,7 +644,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
     private GeoPoint[] localPoints() {
         // validation was not available prior to 2.x, so to support bwc percolation queries we only ignore_malformed
         // on 2.x created indexes
-        GeoPoint[] localPoints = points.toArray(new GeoPoint[points.size()]);
+        GeoPoint[] localPoints = points.toArray(new GeoPoint[0]);
         if (GeoValidationMethod.isIgnoreMalformed(validation) == false) {
             for (GeoPoint point : localPoints) {
                 if (GeoUtils.isValidLatitude(point.lat()) == false) {

--- a/server/src/main/java/org/opensearch/search/sort/SortBuilder.java
+++ b/server/src/main/java/org/opensearch/search/sort/SortBuilder.java
@@ -185,10 +185,7 @@ public abstract class SortBuilder<T extends SortBuilder<T>> implements NamedWrit
             }
             if (sort) {
                 return Optional.of(
-                    new SortAndFormats(
-                        new Sort(sortFields.toArray(new SortField[sortFields.size()])),
-                        sortFormats.toArray(new DocValueFormat[sortFormats.size()])
-                    )
+                    new SortAndFormats(new Sort(sortFields.toArray(new SortField[0])), sortFormats.toArray(new DocValueFormat[0]))
                 );
             }
         }

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/DirectCandidateGenerator.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/DirectCandidateGenerator.java
@@ -324,7 +324,7 @@ public final class DirectCandidateGenerator extends CandidateGenerator {
             final Set<Candidate> set = new HashSet<>(candidates);
             Collections.addAll(set, this.candidates);
 
-            this.candidates = set.toArray(new Candidate[set.size()]);
+            this.candidates = set.toArray(new Candidate[0]);
             // Sort strongest to weakest:
             Arrays.sort(this.candidates, Collections.reverseOrder());
         }

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/NoisyChannelSpellChecker.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/NoisyChannelSpellChecker.java
@@ -129,7 +129,7 @@ final class NoisyChannelSpellChecker {
         }
         double cutoffScore = Double.MIN_VALUE;
         CandidateScorer scorer = new CandidateScorer(wordScorer, numCorrections, gramSize);
-        CandidateSet[] candidateSets = candidateSetsList.toArray(new CandidateSet[candidateSetsList.size()]);
+        CandidateSet[] candidateSets = candidateSetsList.toArray(new CandidateSet[0]);
         if (confidence > 0.0) {
             Candidate[] candidates = new Candidate[candidateSets.length];
             for (int i = 0; i < candidates.length; i++) {

--- a/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggester.java
+++ b/server/src/main/java/org/opensearch/search/suggest/phrase/PhraseSuggester.java
@@ -133,7 +133,7 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
             try (TokenStream stream = tokenStream(suggestion.getAnalyzer(), suggestion.getText(), spare, suggestion.getField())) {
                 checkerResult = checker.getCorrections(
                     stream,
-                    new MultiCandidateGeneratorWrapper(suggestion.getShardSize(), gens.toArray(new CandidateGenerator[gens.size()])),
+                    new MultiCandidateGeneratorWrapper(suggestion.getShardSize(), gens.toArray(new CandidateGenerator[0])),
                     suggestion.maxErrors(),
                     suggestion.getShardSize(),
                     wordScorer,

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotInfo.java
@@ -688,11 +688,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContent,
         if (shardFailures.size() == 0) {
             return RestStatus.OK;
         }
-        return RestStatus.status(
-            successfulShards,
-            totalShards,
-            shardFailures.toArray(new ShardOperationFailedException[shardFailures.size()])
-        );
+        return RestStatus.status(successfulShards, totalShards, shardFailures.toArray(new ShardOperationFailedException[0]));
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -684,7 +684,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
                             filteredNodes.add(node);
                         }
                     }
-                    return filteredNodes.toArray(new String[filteredNodes.size()]);
+                    return filteredNodes.toArray(new String[0]);
                 }
 
                 @Override

--- a/server/src/test/java/org/opensearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
@@ -88,7 +88,7 @@ public class ClusterSearchShardsResponseTests extends OpenSearchTestCase {
         }
         ClusterSearchShardsResponse clusterSearchShardsResponse = new ClusterSearchShardsResponse(
             clusterSearchShardsGroups,
-            nodes.toArray(new DiscoveryNode[nodes.size()]),
+            nodes.toArray(new DiscoveryNode[0]),
             indicesAndFilters
         );
 

--- a/server/src/test/java/org/opensearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -426,7 +426,7 @@ public class TransportRolloverActionTests extends OpenSearchTestCase {
             }
         }
         return IndicesStatsTests.newIndicesStatsResponse(
-            shardStats.toArray(new ShardStats[shardStats.size()]),
+            shardStats.toArray(new ShardStats[0]),
             shardStats.size(),
             shardStats.size(),
             0,

--- a/server/src/test/java/org/opensearch/action/admin/indices/stats/IndicesStatsResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/stats/IndicesStatsResponseTests.java
@@ -100,13 +100,7 @@ public class IndicesStatsResponseTests extends OpenSearchTestCase {
                 shardsCounter.incrementAndGet();
             }
         }
-        final IndicesStatsResponse indicesStatsResponse = new IndicesStatsResponse(
-            shards.toArray(new ShardStats[shards.size()]),
-            0,
-            0,
-            0,
-            null
-        );
+        final IndicesStatsResponse indicesStatsResponse = new IndicesStatsResponse(shards.toArray(new ShardStats[0]), 0, 0, 0, null);
         Map<String, IndexStats> indexStats = indicesStatsResponse.getIndices();
 
         assertThat(indexStats.size(), is(noOfIndexes));

--- a/server/src/test/java/org/opensearch/action/bulk/BulkRequestModifierTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/BulkRequestModifierTests.java
@@ -130,7 +130,7 @@ public class BulkRequestModifierTests extends OpenSearchTestCase {
             IndexResponse indexResponse = new IndexResponse(new ShardId("index", "_na_", 0), indexRequest.id(), 1, 17, 1, true);
             originalResponses.add(new BulkItemResponse(Integer.parseInt(indexRequest.id()), indexRequest.opType(), indexResponse));
         }
-        bulkResponseListener.onResponse(new BulkResponse(originalResponses.toArray(new BulkItemResponse[originalResponses.size()]), 0));
+        bulkResponseListener.onResponse(new BulkResponse(originalResponses.toArray(new BulkItemResponse[0]), 0));
 
         assertThat(responses.size(), Matchers.equalTo(32));
         for (int i = 0; i < 32; i++) {

--- a/server/src/test/java/org/opensearch/action/support/nodes/TransportNodesActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/nodes/TransportNodesActionTests.java
@@ -110,7 +110,7 @@ public class TransportNodesActionTests extends OpenSearchTestCase {
             String nodeId = randomFrom(nodeIds);
             nodeSelectors.add(nodeId);
         }
-        String[] finalNodesIds = nodeSelectors.toArray(new String[nodeSelectors.size()]);
+        String[] finalNodesIds = nodeSelectors.toArray(new String[0]);
         TestNodesRequest request = new TestNodesRequest(finalNodesIds);
         action.new AsyncAction(null, request, new PlainActionFuture<>()).start();
         Map<String, List<CapturingTransport.CapturedRequest>> capturedRequests = transport.getCapturedRequestsByTargetNodeAndClear();

--- a/server/src/test/java/org/opensearch/action/termvectors/AbstractTermVectorsTestCase.java
+++ b/server/src/test/java/org/opensearch/action/termvectors/AbstractTermVectorsTestCase.java
@@ -325,7 +325,7 @@ public abstract class AbstractTermVectorsTestCase extends ParameterizedStaticSet
 
         refresh();
 
-        return configs.toArray(new TestConfig[configs.size()]);
+        return configs.toArray(new TestConfig[0]);
     }
 
     protected TestFieldSetting[] getFieldSettings() {

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodesTests.java
@@ -170,9 +170,9 @@ public class DiscoveryNodesTests extends OpenSearchTestCase {
             expectedNodeIdsSet.add(discoveryNode.getId());
         }
 
-        String[] resolvedNodesIds = discoveryNodes.resolveNodes(nodeSelectors.toArray(new String[nodeSelectors.size()]));
+        String[] resolvedNodesIds = discoveryNodes.resolveNodes(nodeSelectors.toArray(new String[0]));
         Arrays.sort(resolvedNodesIds);
-        String[] expectedNodesIds = expectedNodeIdsSet.toArray(new String[expectedNodeIdsSet.size()]);
+        String[] expectedNodesIds = expectedNodeIdsSet.toArray(new String[0]);
         Arrays.sort(expectedNodesIds);
         assertThat(resolvedNodesIds, equalTo(expectedNodesIds));
     }

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/FailedNodeRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/FailedNodeRoutingTests.java
@@ -261,7 +261,7 @@ public class FailedNodeRoutingTests extends OpenSearchAllocationTestCase {
         for (int i = 0; i < randomIntBetween(2, 5); i++) {
             allNodes.add(createNode());
         }
-        ClusterState state = ClusterStateCreationUtils.state(localNode, localNode, allNodes.toArray(new DiscoveryNode[allNodes.size()]));
+        ClusterState state = ClusterStateCreationUtils.state(localNode, localNode, allNodes.toArray(new DiscoveryNode[0]));
         return state;
     }
 

--- a/server/src/test/java/org/opensearch/cluster/serialization/DiffableTests.java
+++ b/server/src/test/java/org/opensearch/cluster/serialization/DiffableTests.java
@@ -114,10 +114,7 @@ public class DiffableTests extends OpenSearchTestCase {
         protected final Set<Integer> keysToRemove = new HashSet<>(randomSubsetOf(randomInt(keys.size()), keys.toArray(new Integer[0])));
         protected final Set<Integer> keysThatAreNotRemoved = Sets.difference(keys, keysToRemove);
         protected final Set<Integer> keysToOverride = new HashSet<>(
-            randomSubsetOf(
-                randomInt(keysThatAreNotRemoved.size()),
-                keysThatAreNotRemoved.toArray(new Integer[keysThatAreNotRemoved.size()])
-            )
+            randomSubsetOf(randomInt(keysThatAreNotRemoved.size()), keysThatAreNotRemoved.toArray(new Integer[0]))
         );
         // make sure keysToAdd does not contain elements in keys
         protected final Set<Integer> keysToAdd = Sets.difference(randomPositiveIntSet(), keys);

--- a/server/src/test/java/org/opensearch/common/geo/GeoJsonShapeParserTests.java
+++ b/server/src/test/java/org/opensearch/common/geo/GeoJsonShapeParserTests.java
@@ -352,7 +352,7 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
         shellCoordinates.add(new Coordinate(101, 1));
         shellCoordinates.add(new Coordinate(100, 1));
         shellCoordinates.add(new Coordinate(100, 0));
-        Coordinate[] coordinates = shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]);
+        Coordinate[] coordinates = shellCoordinates.toArray(new Coordinate[0]);
         LinearRing shell = GEOMETRY_FACTORY.createLinearRing(coordinates);
         Polygon expected = GEOMETRY_FACTORY.createPolygon(shell, null);
         assertGeometryEquals(jtsGeom(expected), polygonGeoJson, true);
@@ -404,7 +404,7 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
         shellCoordinates.add(new Coordinate(101, 1, 10));
         shellCoordinates.add(new Coordinate(100, 1, 10));
         shellCoordinates.add(new Coordinate(100, 0, 10));
-        Coordinate[] coordinates = shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]);
+        Coordinate[] coordinates = shellCoordinates.toArray(new Coordinate[0]);
 
         Version randomVersion = VersionUtils.randomIndexCompatibleVersion(random());
         Settings indexSettings = Settings.builder()
@@ -414,7 +414,7 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
             .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
             .build();
 
-        LinearRing shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]));
+        LinearRing shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[0]));
         Polygon expected = GEOMETRY_FACTORY.createPolygon(shell, null);
         Mapper.BuilderContext mockBuilderContext = new Mapper.BuilderContext(indexSettings, new ContentPath());
         final LegacyGeoShapeFieldMapper mapperBuilder = (LegacyGeoShapeFieldMapper) (new LegacyGeoShapeFieldMapper.Builder("test")
@@ -1377,9 +1377,9 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
         holeCoordinates.add(new Coordinate(100.2, 0.8));
         holeCoordinates.add(new Coordinate(100.2, 0.2));
 
-        LinearRing shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]));
+        LinearRing shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[0]));
         LinearRing[] holes = new LinearRing[1];
-        holes[0] = GEOMETRY_FACTORY.createLinearRing(holeCoordinates.toArray(new Coordinate[holeCoordinates.size()]));
+        holes[0] = GEOMETRY_FACTORY.createLinearRing(holeCoordinates.toArray(new Coordinate[0]));
         Polygon expected = GEOMETRY_FACTORY.createPolygon(shell, holes);
         assertGeometryEquals(jtsGeom(expected), polygonGeoJson, true);
 
@@ -1561,9 +1561,9 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
         holeCoordinates.add(new Coordinate(100.2, 0.8));
         holeCoordinates.add(new Coordinate(100.2, 0.2));
 
-        LinearRing shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]));
+        LinearRing shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[0]));
         LinearRing[] holes = new LinearRing[1];
-        holes[0] = GEOMETRY_FACTORY.createLinearRing(holeCoordinates.toArray(new Coordinate[holeCoordinates.size()]));
+        holes[0] = GEOMETRY_FACTORY.createLinearRing(holeCoordinates.toArray(new Coordinate[0]));
         Polygon withHoles = GEOMETRY_FACTORY.createPolygon(shell, holes);
 
         shellCoordinates = new ArrayList<>();
@@ -1573,7 +1573,7 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
         shellCoordinates.add(new Coordinate(102, 2));
         shellCoordinates.add(new Coordinate(102, 3));
 
-        shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]));
+        shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[0]));
         Polygon withoutHoles = GEOMETRY_FACTORY.createPolygon(shell, null);
 
         Shape expected = shapeCollection(withoutHoles, withHoles);
@@ -1675,9 +1675,9 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
         holeCoordinates.add(new Coordinate(100.8, 0.8));
         holeCoordinates.add(new Coordinate(100.2, 0.8));
 
-        shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]));
+        shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[0]));
         holes = new LinearRing[1];
-        holes[0] = GEOMETRY_FACTORY.createLinearRing(holeCoordinates.toArray(new Coordinate[holeCoordinates.size()]));
+        holes[0] = GEOMETRY_FACTORY.createLinearRing(holeCoordinates.toArray(new Coordinate[0]));
         withHoles = GEOMETRY_FACTORY.createPolygon(shell, holes);
 
         assertGeometryEquals(jtsGeom(withHoles), multiPolygonGeoJson, true);
@@ -1776,8 +1776,8 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
         expected[0] = jtsGeom(expectedLineString);
         Point expectedPoint = GEOMETRY_FACTORY.createPoint(new Coordinate(102.0, 2.0));
         expected[1] = new JtsPoint(expectedPoint, SPATIAL_CONTEXT);
-        LinearRing shell1 = GEOMETRY_FACTORY.createLinearRing(shellCoordinates1.toArray(new Coordinate[shellCoordinates1.size()]));
-        LinearRing shell2 = GEOMETRY_FACTORY.createLinearRing(shellCoordinates2.toArray(new Coordinate[shellCoordinates2.size()]));
+        LinearRing shell1 = GEOMETRY_FACTORY.createLinearRing(shellCoordinates1.toArray(new Coordinate[0]));
+        LinearRing shell2 = GEOMETRY_FACTORY.createLinearRing(shellCoordinates2.toArray(new Coordinate[0]));
         MultiPolygon expectedMultiPoly = GEOMETRY_FACTORY.createMultiPolygon(
             new Polygon[] { GEOMETRY_FACTORY.createPolygon(shell1), GEOMETRY_FACTORY.createPolygon(shell2) }
         );

--- a/server/src/test/java/org/opensearch/common/geo/GeoWKTShapeParserTests.java
+++ b/server/src/test/java/org/opensearch/common/geo/GeoWKTShapeParserTests.java
@@ -181,7 +181,7 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
     @Override
     public void testParseLineString() throws IOException, ParseException {
         List<Coordinate> coordinates = randomLineStringCoords();
-        LineString expected = GEOMETRY_FACTORY.createLineString(coordinates.toArray(new Coordinate[coordinates.size()]));
+        LineString expected = GEOMETRY_FACTORY.createLineString(coordinates.toArray(new Coordinate[0]));
         assertExpected(jtsGeom(expected), new LineStringBuilder(coordinates), true);
 
         double[] lats = new double[coordinates.size()];
@@ -200,7 +200,7 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
         MultiLineStringBuilder builder = new MultiLineStringBuilder();
         for (int j = 0; j < numLineStrings; ++j) {
             List<Coordinate> lsc = randomLineStringCoords();
-            Coordinate[] coords = lsc.toArray(new Coordinate[lsc.size()]);
+            Coordinate[] coords = lsc.toArray(new Coordinate[0]);
             lineStrings.add(GEOMETRY_FACTORY.createLineString(coords));
             builder.linestring(new LineStringBuilder(lsc));
         }
@@ -221,7 +221,7 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
         assertExpected(expectedGeom, builder, false);
         assertMalformed(builder);
 
-        MultiLineString expected = GEOMETRY_FACTORY.createMultiLineString(lineStrings.toArray(new LineString[lineStrings.size()]));
+        MultiLineString expected = GEOMETRY_FACTORY.createMultiLineString(lineStrings.toArray(new LineString[0]));
         assumeTrue("JTS test path cannot handle empty multilinestrings", numLineStrings > 1);
         assertExpected(jtsGeom(expected), builder, true);
     }
@@ -279,9 +279,9 @@ public class GeoWKTShapeParserTests extends BaseGeoParsingTestCase {
         PolygonBuilder polygonWithHole = new PolygonBuilder(new CoordinatesBuilder().coordinates(shellCoordinates));
         polygonWithHole.hole(new LineStringBuilder(holeCoordinates));
 
-        LinearRing shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[shellCoordinates.size()]));
+        LinearRing shell = GEOMETRY_FACTORY.createLinearRing(shellCoordinates.toArray(new Coordinate[0]));
         LinearRing[] holes = new LinearRing[1];
-        holes[0] = GEOMETRY_FACTORY.createLinearRing(holeCoordinates.toArray(new Coordinate[holeCoordinates.size()]));
+        holes[0] = GEOMETRY_FACTORY.createLinearRing(holeCoordinates.toArray(new Coordinate[0]));
         Polygon expected = GEOMETRY_FACTORY.createPolygon(shell, holes);
         assertExpected(jtsGeom(expected), polygonWithHole, true);
 

--- a/server/src/test/java/org/opensearch/common/xcontent/support/XContentMapValuesTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/support/XContentMapValuesTests.java
@@ -74,13 +74,13 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         if (includes == null) {
             sourceIncludes = randomBoolean() ? Strings.EMPTY_ARRAY : null;
         } else {
-            sourceIncludes = includes.toArray(new String[includes.size()]);
+            sourceIncludes = includes.toArray(new String[0]);
         }
         String[] sourceExcludes;
         if (excludes == null) {
             sourceExcludes = randomBoolean() ? Strings.EMPTY_ARRAY : null;
         } else {
-            sourceExcludes = excludes.toArray(new String[excludes.size()]);
+            sourceExcludes = excludes.toArray(new String[0]);
         }
 
         assertEquals(

--- a/server/src/test/java/org/opensearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/opensearch/env/NodeEnvironmentTests.java
@@ -266,7 +266,7 @@ public class NodeEnvironmentTests extends OpenSearchTestCase {
         }
         for (Map.Entry<String, List<Path>> actualIndexDataPathEntry : actualIndexDataPaths.entrySet()) {
             List<Path> actual = actualIndexDataPathEntry.getValue();
-            Path[] actualPaths = actual.toArray(new Path[actual.size()]);
+            Path[] actualPaths = actual.toArray(new Path[0]);
             assertThat(actualPaths, equalTo(env.resolveIndexFolder(actualIndexDataPathEntry.getKey())));
         }
         assertTrue("LockedShards: " + env.lockedShards(), env.lockedShards().isEmpty());

--- a/server/src/test/java/org/opensearch/index/query/MoreLikeThisQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/MoreLikeThisQueryBuilderTests.java
@@ -245,10 +245,7 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
                 if (request.doc() != null) {
                     generatedFields = generateFields(randomFields, request.doc().utf8ToString());
                 } else {
-                    generatedFields = generateFields(
-                        request.selectedFields().toArray(new String[request.selectedFields().size()]),
-                        request.id()
-                    );
+                    generatedFields = generateFields(request.selectedFields().toArray(new String[0]), request.id());
                 }
                 EnumSet<TermVectorsRequest.Flag> flags = EnumSet.of(TermVectorsRequest.Flag.Positions, TermVectorsRequest.Flag.Offsets);
                 response.setFields(generatedFields, request.selectedFields(), flags, generatedFields);

--- a/server/src/test/java/org/opensearch/index/query/RegexpQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/RegexpQueryBuilderTests.java
@@ -57,7 +57,7 @@ public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBu
             for (int i = 0; i < iter; i++) {
                 flags.add(randomFrom(RegexpFlag.values()));
             }
-            query.flags(flags.toArray(new RegexpFlag[flags.size()]));
+            query.flags(flags.toArray(new RegexpFlag[0]));
         }
         if (randomBoolean()) {
             query.caseInsensitive(true);

--- a/server/src/test/java/org/opensearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/SimpleQueryStringBuilderTests.java
@@ -109,7 +109,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
                 flagSet.add(randomFrom(SimpleQueryStringFlag.values()));
             }
             if (flagSet.size() > 0) {
-                result.flags(flagSet.toArray(new SimpleQueryStringFlag[flagSet.size()]));
+                result.flags(flagSet.toArray(new SimpleQueryStringFlag[0]));
             }
         }
 

--- a/server/src/test/java/org/opensearch/index/query/TermsQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/TermsQueryBuilderTests.java
@@ -244,7 +244,7 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
             builder.startObject();
-            builder.array(termsPath, randomTerms.toArray(new Object[randomTerms.size()]));
+            builder.array(termsPath, randomTerms.toArray(new Object[0]));
             builder.endObject();
             json = builder.toString();
         } catch (IOException ex) {

--- a/server/src/test/java/org/opensearch/index/seqno/LocalCheckpointTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/seqno/LocalCheckpointTrackerTests.java
@@ -235,7 +235,7 @@ public class LocalCheckpointTrackerTests extends OpenSearchTestCase {
             seqNoPerThread[t] = randomSubsetOf(size, seqNos).toArray(new Integer[size]);
             seqNos.removeAll(Arrays.asList(seqNoPerThread[t]));
         }
-        seqNoPerThread[threads.length - 1] = seqNos.toArray(new Integer[seqNos.size()]);
+        seqNoPerThread[threads.length - 1] = seqNos.toArray(new Integer[0]);
         logger.info("--> will run [{}] threads, maxOps [{}], unfinished seq no [{}]", threads.length, maxOps, unFinishedSeq);
         final CyclicBarrier barrier = new CyclicBarrier(threads.length);
         for (int t = 0; t < threads.length; t++) {

--- a/server/src/test/java/org/opensearch/index/translog/SnapshotMatchers.java
+++ b/server/src/test/java/org/opensearch/index/translog/SnapshotMatchers.java
@@ -68,7 +68,7 @@ public final class SnapshotMatchers {
      * Consumes a snapshot and make sure it's content is as expected
      */
     public static Matcher<Translog.Snapshot> equalsTo(List<Translog.Operation> ops) {
-        return new EqualMatcher(ops.toArray(new Translog.Operation[ops.size()]));
+        return new EqualMatcher(ops.toArray(new Translog.Operation[0]));
     }
 
     public static Matcher<Translog.Snapshot> containsOperationsInAnyOrder(Collection<Translog.Operation> expectedOperations) {

--- a/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -339,7 +339,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
         for (int i = 0; i < randomIntBetween(2, 5); i++) {
             allNodes.add(createNode());
         }
-        ClusterState state = ClusterStateCreationUtils.state(localNode, localNode, allNodes.toArray(new DiscoveryNode[allNodes.size()]));
+        ClusterState state = ClusterStateCreationUtils.state(localNode, localNode, allNodes.toArray(new DiscoveryNode[0]));
         // add nodes to clusterStateServiceMap
         updateNodes(state, clusterStateServiceMap, indicesServiceSupplier);
         return state;
@@ -421,7 +421,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
             indicesToDelete.add(state.metadata().index(index).getIndex().getName());
         }
         if (indicesToDelete.isEmpty() == false) {
-            DeleteIndexRequest deleteRequest = new DeleteIndexRequest(indicesToDelete.toArray(new String[indicesToDelete.size()]));
+            DeleteIndexRequest deleteRequest = new DeleteIndexRequest(indicesToDelete.toArray(new String[0]));
             state = cluster.deleteIndices(state, deleteRequest);
             for (String index : indicesToDelete) {
                 assertFalse(state.metadata().hasIndex(index));
@@ -453,9 +453,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
             }
         }
         if (indicesToUpdate.isEmpty() == false) {
-            UpdateSettingsRequest updateSettingsRequest = new UpdateSettingsRequest(
-                indicesToUpdate.toArray(new String[indicesToUpdate.size()])
-            );
+            UpdateSettingsRequest updateSettingsRequest = new UpdateSettingsRequest(indicesToUpdate.toArray(new String[0]));
             Settings.Builder settings = Settings.builder();
             if (containsClosedIndex == false) {
                 settings.put(SETTING_NUMBER_OF_REPLICAS, randomInt(2));

--- a/server/src/test/java/org/opensearch/indices/store/IndicesStoreTests.java
+++ b/server/src/test/java/org/opensearch/indices/store/IndicesStoreTests.java
@@ -56,7 +56,7 @@ public class IndicesStoreTests extends OpenSearchTestCase {
         Set<ShardRoutingState> set = new HashSet<>();
         set.addAll(Arrays.asList(ShardRoutingState.values()));
         set.remove(ShardRoutingState.STARTED);
-        NOT_STARTED_STATES = set.toArray(new ShardRoutingState[set.size()]);
+        NOT_STARTED_STATES = set.toArray(new ShardRoutingState[0]);
     }
 
     private DiscoveryNode localNode;

--- a/server/src/test/java/org/opensearch/search/CreatePitSingleNodeTests.java
+++ b/server/src/test/java/org/opensearch/search/CreatePitSingleNodeTests.java
@@ -319,7 +319,7 @@ public class CreatePitSingleNodeTests extends OpenSearchSingleNodeTestCase {
         final int maxPitContexts = SearchService.MAX_OPEN_PIT_CONTEXT.get(Settings.EMPTY);
         validatePitStats("index", maxPitContexts, 0, 0);
         // deleteall
-        DeletePitRequest deletePITRequest = new DeletePitRequest(pitIds.toArray(new String[pitIds.size()]));
+        DeletePitRequest deletePITRequest = new DeletePitRequest(pitIds.toArray(new String[0]));
 
         /*
           When we invoke delete again, returns success after clearing the remaining readers. Asserting reader context

--- a/server/src/test/java/org/opensearch/search/aggregations/support/AggregationPathTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/support/AggregationPathTests.java
@@ -99,7 +99,7 @@ public class AggregationPathTests extends OpenSearchTestCase {
         }
 
         AggregationPath.PathElement[] toArray() {
-            return tokens.toArray(new AggregationPath.PathElement[tokens.size()]);
+            return tokens.toArray(new AggregationPath.PathElement[0]);
         }
     }
 }

--- a/server/src/test/java/org/opensearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -760,7 +760,7 @@ public class HighlightBuilderTests extends OpenSearchTestCase {
         for (int f = 0; f < size; f++) {
             randomStrings.add(randomAlphaOfLengthBetween(3, 10));
         }
-        return randomStrings.toArray(new String[randomStrings.size()]);
+        return randomStrings.toArray(new String[0]);
     }
 
     /**

--- a/server/src/test/java/org/opensearch/search/sort/FieldSortBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/sort/FieldSortBuilderTests.java
@@ -717,7 +717,7 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
             expectedWarnings.add(nestedPathDeprecationWarning);
         }
         if (expectedWarnings.isEmpty() == false) {
-            assertWarnings(expectedWarnings.toArray(new String[expectedWarnings.size()]));
+            assertWarnings(expectedWarnings.toArray(new String[0]));
             assertedWarnings.addAll(expectedWarnings);
         }
     }

--- a/server/src/test/java/org/opensearch/search/sort/GeoDistanceSortBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/sort/GeoDistanceSortBuilderTests.java
@@ -419,7 +419,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
             expectedWarnings.add(nestedPathDeprecationWarning);
         }
         if (expectedWarnings.isEmpty() == false) {
-            assertWarnings(expectedWarnings.toArray(new String[expectedWarnings.size()]));
+            assertWarnings(expectedWarnings.toArray(new String[0]));
             assertedWarnings.addAll(expectedWarnings);
         }
     }

--- a/server/src/test/java/org/opensearch/search/sort/SortBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/sort/SortBuilderTests.java
@@ -201,7 +201,7 @@ public class SortBuilderTests extends OpenSearchTestCase {
                 assertEquals(iterator.next(), parsedBuilder);
             }
             if (expectedWarningHeaders.size() > 0) {
-                assertWarnings(expectedWarningHeaders.toArray(new String[expectedWarningHeaders.size()]));
+                assertWarnings(expectedWarningHeaders.toArray(new String[0]));
                 assertedWarnings.addAll(expectedWarningHeaders);
             }
         }

--- a/server/src/test/java/org/opensearch/test/hamcrest/OpenSearchGeoAssertions.java
+++ b/server/src/test/java/org/opensearch/test/hamcrest/OpenSearchGeoAssertions.java
@@ -100,7 +100,7 @@ public class OpenSearchGeoAssertions {
     }
 
     private static Coordinate[] fixedOrderedRing(List<Coordinate> coordinates, boolean direction) {
-        return fixedOrderedRing(coordinates.toArray(new Coordinate[coordinates.size()]), direction);
+        return fixedOrderedRing(coordinates.toArray(new Coordinate[0]), direction);
     }
 
     private static Coordinate[] fixedOrderedRing(Coordinate[] points, boolean direction) {

--- a/server/src/test/java/org/opensearch/threadpool/UpdateThreadPoolSettingsTests.java
+++ b/server/src/test/java/org/opensearch/threadpool/UpdateThreadPoolSettingsTests.java
@@ -248,7 +248,7 @@ public class UpdateThreadPoolSettingsTests extends OpenSearchThreadPoolTestCase 
 
     private String randomThreadPoolName() {
         Set<String> threadPoolNames = ThreadPool.THREAD_POOL_TYPES.keySet();
-        return randomFrom(threadPoolNames.toArray(new String[threadPoolNames.size()]));
+        return randomFrom(threadPoolNames.toArray(new String[0]));
     }
 
 }

--- a/test/framework/src/main/java/org/opensearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/test/framework/src/main/java/org/opensearch/action/support/replication/ClusterStateCreationUtils.java
@@ -525,7 +525,7 @@ public class ClusterStateCreationUtils {
     }
 
     private static String selectAndRemove(Set<String> strings) {
-        String selection = randomFrom(strings.toArray(new String[strings.size()]));
+        String selection = randomFrom(strings.toArray(new String[0]));
         strings.remove(selection);
         return selection;
     }

--- a/test/framework/src/main/java/org/opensearch/repositories/blobstore/OpenSearchBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/repositories/blobstore/OpenSearchBlobStoreRepositoryIntegTestCase.java
@@ -335,7 +335,7 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
         List<String> deleteIndices = randomSubsetOf(randomIntBetween(0, indexCount), indexNames);
         if (deleteIndices.size() > 0) {
             logger.info("-->  delete indices {}", deleteIndices);
-            assertAcked(client().admin().indices().prepareDelete(deleteIndices.toArray(new String[deleteIndices.size()])));
+            assertAcked(client().admin().indices().prepareDelete(deleteIndices.toArray(new String[0])));
         }
 
         Set<String> closeIndices = new HashSet<>(Arrays.asList(indexNames));
@@ -361,7 +361,7 @@ public abstract class OpenSearchBlobStoreRepositoryIntegTestCase extends OpenSea
             // Wait for green so the close does not fail in the edge case of coinciding with a shard recovery that hasn't fully synced yet
             ensureGreen();
             logger.info("-->  close indices {}", closeIndices);
-            assertAcked(client().admin().indices().prepareClose(closeIndices.toArray(new String[closeIndices.size()])));
+            assertAcked(client().admin().indices().prepareClose(closeIndices.toArray(new String[0])));
         }
 
         logger.info("--> restore all indices from the snapshot");

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -1749,7 +1749,7 @@ public final class InternalTestCluster extends TestCluster {
         for (HttpServerTransport httpServerTransport : getInstances(HttpServerTransport.class)) {
             addresses.add(httpServerTransport.boundAddress().publishAddress().address());
         }
-        return addresses.toArray(new InetSocketAddress[addresses.size()]);
+        return addresses.toArray(new InetSocketAddress[0]);
     }
 
     /**

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -757,7 +757,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
                 success = true;
             } finally {
                 if (!success && !created.isEmpty()) {
-                    cluster().wipeIndices(created.toArray(new String[created.size()]));
+                    cluster().wipeIndices(created.toArray(new String[0]));
                 }
             }
         }

--- a/test/framework/src/main/java/org/opensearch/test/XContentTestUtils.java
+++ b/test/framework/src/main/java/org/opensearch/test/XContentTestUtils.java
@@ -295,7 +295,7 @@ public final class XContentTestUtils {
             currentPath.push(parser.currentName().replaceAll("\\.", "\\\\."));
         }
         if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
-            validPaths.add(String.join(".", currentPath.toArray(new String[currentPath.size()])));
+            validPaths.add(String.join(".", currentPath.toArray(new String[0])));
             while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
                 if (parser.currentToken() == XContentParser.Token.START_OBJECT
                     || parser.currentToken() == XContentParser.Token.START_ARRAY) {

--- a/test/framework/src/main/java/org/opensearch/test/hamcrest/OpenSearchAssertions.java
+++ b/test/framework/src/main/java/org/opensearch/test/hamcrest/OpenSearchAssertions.java
@@ -272,10 +272,7 @@ public class OpenSearchAssertions {
             );
         }
         assertThat(
-            "Some expected ids were not found in search results: "
-                + Arrays.toString(idsSet.toArray(new String[idsSet.size()]))
-                + "."
-                + shardStatus,
+            "Some expected ids were not found in search results: " + Arrays.toString(idsSet.toArray(new String[0])) + "." + shardStatus,
             idsSet.size(),
             equalTo(0)
         );

--- a/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/rest/OpenSearchRestTestCase.java
@@ -202,8 +202,8 @@ public abstract class OpenSearchRestTestCase extends OpenSearchTestCase {
             }
             clusterHosts = unmodifiableList(hosts);
             logger.info("initializing REST clients against {}", clusterHosts);
-            client = buildClient(restClientSettings(), clusterHosts.toArray(new HttpHost[clusterHosts.size()]));
-            adminClient = buildClient(restAdminSettings(), clusterHosts.toArray(new HttpHost[clusterHosts.size()]));
+            client = buildClient(restClientSettings(), clusterHosts.toArray(new HttpHost[0]));
+            adminClient = buildClient(restAdminSettings(), clusterHosts.toArray(new HttpHost[0]));
 
             nodeVersions = new TreeSet<>();
             Map<?, ?> response = entityAsMap(adminClient.performRequest(new Request("GET", "_nodes/plugins")));

--- a/test/framework/src/main/java/org/opensearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/opensearch/test/transport/MockTransportService.java
@@ -269,7 +269,7 @@ public final class MockTransportService extends TransportService {
         BoundTransportAddress boundTransportAddress = transportService.boundAddress();
         transportAddresses.addAll(Arrays.asList(boundTransportAddress.boundAddresses()));
         transportAddresses.add(boundTransportAddress.publishAddress());
-        return transportAddresses.toArray(new TransportAddress[transportAddresses.size()]);
+        return transportAddresses.toArray(new TransportAddress[0]);
     }
 
     @Override


### PR DESCRIPTION
Backports 9fc3f4096958159ec9b53012fc7ced19fd793e1b from #5277 to `2.x`

### Check List
- [x] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
