### PR TITLE
Change setting allowing size > 0 queries in request cache to be an int threshold

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -519,7 +519,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 IndicesRequestCache.INDICES_CACHE_QUERY_EXPIRE,
                 IndicesRequestCache.INDICES_REQUEST_CACHE_CLEANUP_INTERVAL_SETTING,
                 IndicesRequestCache.INDICES_REQUEST_CACHE_STALENESS_THRESHOLD_SETTING,
-                IndicesRequestCache.INDICES_REQUEST_CACHE_ENABLE_FOR_ALL_REQUESTS_SETTING,
+                IndicesRequestCache.INDICES_REQUEST_CACHE_MAX_SIZE_ALLOWED_IN_CACHE_SETTING,
                 HunspellService.HUNSPELL_LAZY_LOAD,
                 HunspellService.HUNSPELL_IGNORE_CASE,
                 HunspellService.HUNSPELL_DICTIONARY_OPTIONS,

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -148,13 +148,17 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
     );
 
     /**
-     * If enabled, allows caching all cacheable queries. For now, this means also allowing size > 0 queries.
-     * If enabled, fundamentally non-cacheable queries like DFS queries, queries using the `now` keyword, and
-     * scroll requests are still not cached.
+     * Sets the maximum size of a query which is allowed in the request cache.
+     * This refers to the number of documents returned, not the size in bytes.
+     * Default value of 0 only allows size == 0 queries, matching earlier behavior.
+     * Fundamentally non-cacheable queries like DFS queries, queries using the `now` keyword, and
+     * scroll requests are never cached, regardless of this setting.
      */
-    public static final Setting<Boolean> INDICES_REQUEST_CACHE_ENABLE_FOR_ALL_REQUESTS_SETTING = Setting.boolSetting(
-        "indices.requests.cache.enable_for_all_requests",
-        false,
+    public static final Setting<Integer> INDICES_REQUEST_CACHE_MAX_SIZE_ALLOWED_IN_CACHE_SETTING = Setting.intSetting(
+        "indices.requests.cache.maximum_cacheable_size",
+        0,
+        0,
+        10_000,
         Property.NodeScope,
         Property.Dynamic
     );


### PR DESCRIPTION
### Description
Followup to https://github.com/opensearch-project/OpenSearch/pull/16484. @kkhatua pointed out we may want to set some maximum size for a query to enter the cache, rather than just allowing or not allowing all size > 0 queries. For example, sizes as large as 10,000 are sometimes used, and letting them in may take up too much cache space. Also, queries with extremely large sizes spend more time in the fetch phase, so they benefit less from the request cache. 

This PR changes the new setting to be an int, which is the maximum size allowed into the cache. The default value is 0, so the earlier behavior is still maintained. 

Based on benchmarking so far, a reasonable non-zero value for this setting might be around 200, but benchmarks of very large sizes are still ongoing. 

Since the original PR is not in any release, I think it's safe to rename the setting, but please let me know if this isn't true. We also shouldn't have to update the changelog as its original entry was not specific about the setting name/values. 

Related doc PR: https://github.com/opensearch-project/documentation-website/pull/8684

Tested in UT/IT and manually. 

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/16485

### Check List
- [x] Functionality includes testing.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
