### PR TITLE
Fix NPE in CatShardsRequestTests on version bump

### DIFF
--- a/server/src/test/java/org/opensearch/action/admin/cluster/shards/CatShardsRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/shards/CatShardsRequestTests.java
@@ -93,7 +93,11 @@ public class CatShardsRequestTests extends OpenSearchTestCase {
             new PageParams(randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10), randomIntBetween(1, 5))
         );
         catShardsRequest.setCancelAfterTimeInterval(TimeValue.timeValueMillis(randomIntBetween(1, 5)));
-        catShardsRequest.setIndices(new String[2]);
+        String[] indices = new String[2];
+        for (int i = 0; i < indices.length; i++) {
+            indices[i] = randomAlphaOfLengthBetween(3, 10);
+        }
+        catShardsRequest.setIndices(indices);
 
         Version version = VersionUtils.getPreviousVersion(Version.V_2_18_0);
         try (BytesStreamOutput out = new BytesStreamOutput()) {


### PR DESCRIPTION
### Description

Initializes the indices array with non-null values to prevent NPE.

### Related Issues
Resolves #16571

### Check List
- [X] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
