### PR TITLE
[2.18] Fix NPE in CatShardsRequestTests on version bump

### DIFF
--- a/server/src/test/java/org/opensearch/action/admin/cluster/shards/CatShardsRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/shards/CatShardsRequestTests.java
@@ -95,7 +95,7 @@ public class CatShardsRequestTests extends OpenSearchTestCase {
         catShardsRequest.setCancelAfterTimeInterval(TimeValue.timeValueMillis(randomIntBetween(1, 5)));
         catShardsRequest.setIndices(new String[2]);
 
-        Version version = VersionUtils.getPreviousVersion(Version.CURRENT);
+        Version version = VersionUtils.getPreviousVersion(Version.V_2_18_0);
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.setVersion(version);
             catShardsRequest.writeTo(out);


### PR DESCRIPTION
### Description

One of the version changes from https://github.com/opensearch-project/OpenSearch/pull/16455/files was missed when it was manually backported in https://github.com/opensearch-project/OpenSearch/pull/16396.

The test in question is intended to check for a previous version that does not read the array of null strings.  By leaving it at `Version.CURRENT` it bumped to 2.18.1 where 2.18.0 was the previous version and incorrectly tried to read that array.

### Related Issues
Resolves #16580

### Check List
- [x] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
