### PR TITLE
Fix stale index deletion in snapshots for hashed prefix path type

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
@@ -45,7 +45,7 @@ public class DeleteSnapshotIT extends AbstractSnapshotIntegTestCase {
 
     private static final String REMOTE_REPO_NAME = "remote-store-repo-name";
 
-    public void testShardBlobDeletionForHashedPrefixPathType() throws Exception {
+    public void testStaleIndexDeletion() throws Exception {
         String indexName1 = ".testindex1";
         String repoName = "test-restore-snapshot-repo";
         String snapshotName1 = "test-restore-snapshot1";

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DeleteSnapshotIT.java
@@ -45,6 +45,37 @@ public class DeleteSnapshotIT extends AbstractSnapshotIntegTestCase {
 
     private static final String REMOTE_REPO_NAME = "remote-store-repo-name";
 
+    public void testShardBlobDeletionForHashedPrefixPathType() throws Exception {
+        String indexName1 = ".testindex1";
+        String repoName = "test-restore-snapshot-repo";
+        String snapshotName1 = "test-restore-snapshot1";
+        Path absolutePath = randomRepoPath().toAbsolutePath();
+        logger.info("Path [{}]", absolutePath);
+
+        Client client = client();
+        // Write a document
+        String docId = Integer.toString(randomInt());
+        index(indexName1, "_doc", docId, "value", "expected");
+        createRepository(repoName, "fs", absolutePath);
+
+        logger.info("--> snapshot");
+        CreateSnapshotResponse createSnapshotResponse = client.admin()
+            .cluster()
+            .prepareCreateSnapshot(repoName, snapshotName1)
+            .setWaitForCompletion(true)
+            .setIndices(indexName1)
+            .get();
+        assertTrue(createSnapshotResponse.getSnapshotInfo().successfulShards() > 0);
+        assertEquals(createSnapshotResponse.getSnapshotInfo().totalShards(), createSnapshotResponse.getSnapshotInfo().successfulShards());
+        assertEquals(SnapshotState.SUCCESS, createSnapshotResponse.getSnapshotInfo().state());
+
+        assertAcked(startDeleteSnapshot(repoName, snapshotName1).get());
+        assertBusy(() -> assertEquals(0, RemoteStoreBaseIntegTestCase.getFileCount(absolutePath.resolve(BlobStoreRepository.INDICES_DIR))));
+        assertBusy(() -> assertEquals(0, RemoteStoreBaseIntegTestCase.getFileCount(absolutePath.resolve(SnapshotShardPaths.DIR))));
+        // At the end there are 2 files that exists - index-N and index.latest
+        assertBusy(() -> assertEquals(2, RemoteStoreBaseIntegTestCase.getFileCount(absolutePath)));
+    }
+
     public void testDeleteSnapshot() throws Exception {
         disableRepoConsistencyCheck("Remote store repository is being used in the test");
         final Path remoteStoreRepoPath = randomRepoPath();

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -2565,7 +2565,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             Set<String> updatedIndexIds = updatedShardPathsIndexIds.stream()
                 .map(s -> getIndexId(s.split("\\" + SnapshotShardPaths.DELIMITER)[0]))
                 .collect(Collectors.toSet());
+            logger.debug(new ParameterizedMessage("updatedIndexIds={}", updatedIndexIds));
             Set<String> indexIdShardPaths = getSnapshotShardPaths().keySet();
+            logger.debug(new ParameterizedMessage("indexIdShardPaths={}", indexIdShardPaths));
             List<String> staleShardPaths = indexIdShardPaths.stream()
                 .filter(s -> updatedShardPathsIndexIds.contains(s) == false)
                 .filter(s -> {
@@ -2573,20 +2575,17 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     return updatedIndexIds.contains(indexId);
                 })
                 .collect(Collectors.toList());
-            try {
-                deleteFromContainer(snapshotShardPathBlobContainer(), staleShardPaths);
-            } catch (IOException e) {
-                logger.warn(
-                    new ParameterizedMessage(
-                        "Repository [{}] Exception during snapshot stale index deletion {}",
-                        metadata.name(),
-                        staleShardPaths
-                    ),
-                    e
-                );
-            }
-        } catch (Exception ex) {
-            logger.error("Exception during cleanup of redundant snapshot shard paths", ex);
+            logger.debug(new ParameterizedMessage("staleShardPaths={}", staleShardPaths));
+            deleteFromContainer(snapshotShardPathBlobContainer(), staleShardPaths);
+        } catch (Exception e) {
+            logger.warn(
+                new ParameterizedMessage(
+                    "Repository [{}] Exception during snapshot stale index deletion for updatedIndexIds {}",
+                    metadata.name(),
+                    updatedShardPathsIndexIds
+                ),
+                e
+            );
         }
     }
 

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotShardPaths.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotShardPaths.java
@@ -92,18 +92,21 @@ public class SnapshotShardPaths implements ToXContent {
      * Parses a shard path string and extracts relevant shard information.
      *
      * @param shardPath The shard path string to parse. Expected format is:
-     *                  [index_id]#[index_name]#[shard_count]#[path_type_code]#[path_hash_algorithm_code]
+     *                  [index_id].[index_name].[shard_count].[path_type_code].[path_hash_algorithm_code]
      * @return A {@link ShardInfo} object containing the parsed index ID and shard count.
      * @throws IllegalArgumentException if the shard path format is invalid or cannot be parsed.
      */
     public static ShardInfo parseShardPath(String shardPath) {
         String[] parts = shardPath.split("\\" + SnapshotShardPaths.DELIMITER);
-        if (parts.length != 5) {
+        int len = parts.length;
+        if (len < 5) {
             throw new IllegalArgumentException("Invalid shard path format: " + shardPath);
         }
         try {
-            IndexId indexId = new IndexId(parts[1], getIndexId(parts[0]), Integer.parseInt(parts[3]));
-            int shardCount = Integer.parseInt(parts[2]);
+            // indexName is never used from within the ShardInfo returned
+            String indexName = len == 5 ? parts[1] : "";
+            IndexId indexId = new IndexId(indexName, getIndexId(parts[0]), Integer.parseInt(parts[len - 2]));
+            int shardCount = Integer.parseInt(parts[len - 3]);
             return new ShardInfo(indexId, shardCount);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid shard path format: " + shardPath, e);

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotShardPaths.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotShardPaths.java
@@ -92,7 +92,7 @@ public class SnapshotShardPaths implements ToXContent {
      * Parses a shard path string and extracts relevant shard information.
      *
      * @param shardPath The shard path string to parse. Expected format is:
-     *                  [index_id].[index_name].[shard_count].[path_type_code].[path_hash_algorithm_code]
+     *                  snapshot_path_[index_id].[index_name].[shard_count].[path_type_code].[path_hash_algorithm_code]
      * @return A {@link ShardInfo} object containing the parsed index ID and shard count.
      * @throws IllegalArgumentException if the shard path format is invalid or cannot be parsed.
      */
@@ -103,8 +103,12 @@ public class SnapshotShardPaths implements ToXContent {
             throw new IllegalArgumentException("Invalid shard path format: " + shardPath);
         }
         try {
-            // indexName is never used from within the ShardInfo returned
-            String indexName = len == 5 ? parts[1] : "";
+            String indexName = shardPath.substring(
+                // First separator after index id
+                shardPath.indexOf(DELIMITER) + 1,
+                // Since we know there are exactly 3 fields at the end
+                shardPath.lastIndexOf(DELIMITER, shardPath.lastIndexOf(DELIMITER, shardPath.lastIndexOf(DELIMITER) - 1) - 1)
+            );
             IndexId indexId = new IndexId(indexName, getIndexId(parts[0]), Integer.parseInt(parts[len - 2]));
             int shardCount = Integer.parseInt(parts[len - 3]);
             return new ShardInfo(indexId, shardCount);

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -2658,7 +2658,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
             builder.setTimeout(timeout);
         }
         if (finalSettings == false) {
-            settings.put(BlobStoreRepository.SHARD_PATH_TYPE.getKey(), PathType.HASHED_PREFIX.name());
+            settings.put(BlobStoreRepository.SHARD_PATH_TYPE.getKey(), randomFrom(PathType.values()));
         }
         builder.setSettings(settings);
         return builder;

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -2658,7 +2658,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
             builder.setTimeout(timeout);
         }
         if (finalSettings == false) {
-            settings.put(BlobStoreRepository.SHARD_PATH_TYPE.getKey(), randomFrom(PathType.values()));
+            settings.put(BlobStoreRepository.SHARD_PATH_TYPE.getKey(), PathType.HASHED_PREFIX.name());
         }
         builder.setSettings(settings);
         return builder;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
If the index name has `.` period in it, then the stale index deletion fails as the period character interferes with the delimiter (which is also period character) by giving more parts than expected during the `String.split(".")` operation while interpreting the snapshot shards path file. The fix is to handle the variables after the index name as relative from last than from 0. This fixes the problem.

### Check List
- [x] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
