### PR TITLE
Search dv only IP masks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support retrieving doc values of unsigned long field ([#16543](https://github.com/opensearch-project/OpenSearch/pull/16543))
 - Fix rollover alias supports restored searchable snapshot index([#16483](https://github.com/opensearch-project/OpenSearch/pull/16483))
 - Fix permissions error on scripted query against remote snapshot ([#16544](https://github.com/opensearch-project/OpenSearch/pull/16544))
+- Fix `doc_values` only (`index:false`) IP field searching for masks ([#16628](https://github.com/opensearch-project/OpenSearch/pull/16628))
 
 ### Security
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/340_doc_values_field.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/340_doc_values_field.yml
@@ -1119,10 +1119,6 @@
   - match: { hits.total: 0 }
 ---
 "search on fields with only doc_values enabled":
-  - skip:
-      features: [ "headers" ]
-      version: " - 2.99.99"
-      reason: "searching with only doc_values was added in 3.0.0"
   - do:
       indices.create:
         index: test-doc-values

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/340_doc_values_field.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/340_doc_values_field.yml
@@ -455,6 +455,28 @@
         index: test-iodvq
         body:
           query:
+            term:
+              ip_field: "192.168.0.1/24"
+
+  - match: { hits.total: 3 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test-iodvq
+        body:
+          query:
+            term:
+              ip_field: "192.168.0.1/31"
+
+  - match: { hits.total: 1 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test-iodvq
+        body:
+          query:
             range: {
               date_nanos: {
                 gte: "2018-10-29T12:12:12.123456789Z"
@@ -993,6 +1015,28 @@
         index: test-index
         body:
           query:
+            term:
+              ip_field: "192.168.0.1/24"
+
+  - match: { hits.total: 3 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test-index
+        body:
+          query:
+            term:
+              ip_field: "192.168.0.1/31"
+
+  - match: { hits.total: 1 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test-index
+        body:
+          query:
             range: {
               date_nanos: {
                 gte: "2018-10-29T12:12:12.123456789Z"
@@ -1379,6 +1423,28 @@
         body:
           query:
             terms:
+              ip_field: ["192.168.0.1", "192.168.0.2"]
+
+  - match: { hits.total: 2 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test-doc-values
+        body:
+          query:
+            terms:
+              ip_field: ["192.168.0.1/31", "192.168.0.3"]
+
+  - match: { hits.total: 2 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test-doc-values
+        body:
+          query:
+            terms:
               boolean: [true, false]
 
   - match: { hits.total: 3 }
@@ -1515,6 +1581,28 @@
                 lte: "192.168.0.2"
 
   - match: { hits.total: 2 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test-doc-values
+        body:
+          query:
+            term:
+              ip_field: "192.168.0.1/31"
+
+  - match: { hits.total: 1 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test-doc-values
+        body:
+          query:
+            term:
+              ip_field: "192.168.0.1/24"
+
+  - match: { hits.total: 3 }
 
   - do:
       search:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/340_doc_values_field.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/340_doc_values_field.yml
@@ -1119,6 +1119,10 @@
   - match: { hits.total: 0 }
 ---
 "search on fields with only doc_values enabled":
+  - skip:
+      features: [ "headers" ]
+      version: " - 2.18.99"
+      reason: "searching with only doc_values was finally added in 2.19.0"
   - do:
       indices.create:
         index: test-doc-values

--- a/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
@@ -257,15 +257,15 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
 
         private Query indexOrDvQuery(Query pointQuery, Query dvQuery) {
             if (isSearchable() && hasDocValues()) {
-                assert pointQuery!=null;
-                assert dvQuery!=null;
+                assert pointQuery != null;
+                assert dvQuery != null;
                 return new IndexOrDocValuesQuery(pointQuery, dvQuery);
             } else {
                 if (isSearchable()) {
-                    assert pointQuery!=null;
+                    assert pointQuery != null;
                     return pointQuery;
                 } else {
-                    assert dvQuery!=null;
+                    assert dvQuery != null;
                     return dvQuery;
                 }
             }

--- a/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
@@ -257,8 +257,7 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
 
         private Query indexOrDvQuery(Query pointQuery, Query dvQuery) {
             if (isSearchable() && hasDocValues()) {
-                assert pointQuery != null;
-                assert dvQuery != null;
+                assert pointQuery != null && dvQuery != null;
                 return new IndexOrDocValuesQuery(pointQuery, dvQuery);
             } else {
                 if (isSearchable()) {

--- a/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
@@ -246,22 +246,24 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
                 }
                 pointQuery = (PointRangeQuery) query;
             }
-            final Supplier<Query> dvQuery = () -> SortedSetDocValuesField.newSlowRangeQuery(
-                name(),
-                new BytesRef(pointQuery.getLowerPoint()),
-                new BytesRef(pointQuery.getUpperPoint()),
-                true,
-                true
-            );
+            Query dvQuery = null;
+            if (hasDocValues()) {
+                dvQuery = SortedSetDocValuesField.newSlowRangeQuery(
+                    name(),
+                    new BytesRef(pointQuery.getLowerPoint()),
+                    new BytesRef(pointQuery.getUpperPoint()),
+                    true,
+                    true
+                );
+            }
 
             if (isSearchable() && hasDocValues()) {
-                return new IndexOrDocValuesQuery(pointQuery, dvQuery.get());
+                return new IndexOrDocValuesQuery(pointQuery, dvQuery);
             } else {
                 if (isSearchable()) {
                     return pointQuery;
                 } else {
-                    assert hasDocValues();
-                    return dvQuery.get();
+                    return dvQuery;
                 }
             }
         }

--- a/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
@@ -257,11 +257,15 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
 
         private Query indexOrDvQuery(Query pointQuery, Query dvQuery) {
             if (isSearchable() && hasDocValues()) {
+                assert pointQuery!=null;
+                assert dvQuery!=null;
                 return new IndexOrDocValuesQuery(pointQuery, dvQuery);
             } else {
                 if (isSearchable()) {
+                    assert pointQuery!=null;
                     return pointQuery;
                 } else {
+                    assert dvQuery!=null;
                     return dvQuery;
                 }
             }

--- a/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
@@ -252,21 +252,10 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
                     true
                 );
             }
-            return indexOrDvQuery(pointQuery, dvQuery);
-        }
-
-        private Query indexOrDvQuery(Query pointQuery, Query dvQuery) {
             if (isSearchable() && hasDocValues()) {
-                assert pointQuery != null && dvQuery != null;
                 return new IndexOrDocValuesQuery(pointQuery, dvQuery);
             } else {
-                if (isSearchable()) {
-                    assert pointQuery != null;
-                    return pointQuery;
-                } else {
-                    assert dvQuery != null;
-                    return dvQuery;
-                }
+                return isSearchable() ? pointQuery : dvQuery;
             }
         }
 
@@ -305,7 +294,11 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
             if (isSearchable()) {
                 pointQuery = InetAddressPoint.newSetQuery(name(), addresses);
             }
-            return indexOrDvQuery(pointQuery, dvQuery);
+            if (isSearchable() && hasDocValues()) {
+                return new IndexOrDocValuesQuery(pointQuery, dvQuery);
+            } else {
+                return isSearchable() ? pointQuery : dvQuery;
+            }
         }
 
         @Override
@@ -323,7 +316,11 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
                         true
                     );
                 }
-                return indexOrDvQuery(pointQuery, dvQuery);
+                if (isSearchable() && hasDocValues()) {
+                    return new IndexOrDocValuesQuery(pointQuery, dvQuery);
+                } else {
+                    return isSearchable() ? pointQuery : dvQuery;
+                }
             });
         }
 

--- a/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
@@ -227,24 +227,20 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
         public Query termQuery(Object value, @Nullable QueryShardContext context) {
             failIfNotIndexedAndNoDocValues();
             final PointRangeQuery pointQuery;
-            {
-                final Query query;
-                if (value instanceof InetAddress) {
-                    query = InetAddressPoint.newExactQuery(name(), (InetAddress) value);
-                } else {
-                    if (value instanceof BytesRef) {
-                        value = ((BytesRef) value).utf8ToString();
-                    }
-                    String term = value.toString();
-                    if (term.contains("/")) {
-                        final Tuple<InetAddress, Integer> cidr = InetAddresses.parseCidr(term);
-                        query = InetAddressPoint.newPrefixQuery(name(), cidr.v1(), cidr.v2());
-                    } else {
-                        InetAddress address = InetAddresses.forString(term);
-                        query = InetAddressPoint.newExactQuery(name(), address);
-                    }
+            if (value instanceof InetAddress) {
+                pointQuery = (PointRangeQuery) InetAddressPoint.newExactQuery(name(), (InetAddress) value);
+            } else {
+                if (value instanceof BytesRef) {
+                    value = ((BytesRef) value).utf8ToString();
                 }
-                pointQuery = (PointRangeQuery) query;
+                String term = value.toString();
+                if (term.contains("/")) {
+                    final Tuple<InetAddress, Integer> cidr = InetAddresses.parseCidr(term);
+                    pointQuery = (PointRangeQuery) InetAddressPoint.newPrefixQuery(name(), cidr.v1(), cidr.v2());
+                } else {
+                    InetAddress address = InetAddresses.forString(term);
+                    pointQuery = (PointRangeQuery) InetAddressPoint.newExactQuery(name(), address);
+                }
             }
             Query dvQuery = null;
             if (hasDocValues()) {

--- a/server/src/test/java/org/opensearch/index/mapper/IpFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/IpFieldTypeTests.java
@@ -50,6 +50,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 public class IpFieldTypeTests extends FieldTypeTestCase {
 
@@ -76,7 +78,7 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testTermQuery() {
-        MappedFieldType ft = new IpFieldMapper.IpFieldType("field");
+        MappedFieldType ft = new IpFieldMapper.IpFieldType("field", true, false, true, null, Collections.emptyMap());
 
         String ip = "2001:db8::2:1";
 
@@ -104,20 +106,94 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
         String prefix = ip + "/64";
 
         query = InetAddressPoint.newPrefixQuery("field", InetAddresses.forString(ip), 64);
-        assertEquals(query, ft.termQuery(prefix, null));
+        assertEquals(
+            new IndexOrDocValuesQuery(
+                query,
+                SortedSetDocValuesField.newSlowRangeQuery(
+                    "field",
+                    ipToByteRef("2001:db8:0:0:0:0:0:0"),
+                    ipToByteRef("2001:db8:0:0:ffff:ffff:ffff:ffff"),
+                    true,
+                    true
+                )
+            ),
+            ft.termQuery(prefix, null)
+        );
 
         ip = "192.168.1.7";
         prefix = ip + "/16";
         query = InetAddressPoint.newPrefixQuery("field", InetAddresses.forString(ip), 16);
-        assertEquals(query, ft.termQuery(prefix, null));
+        assertEquals(
+            new IndexOrDocValuesQuery(
+                query,
+                SortedSetDocValuesField.newSlowRangeQuery(
+                    "field",
+                    ipToByteRef("::ffff:192.168.0.0"),
+                    ipToByteRef("::ffff:192.168.255.255"),
+                    true,
+                    true
+                )
+            ),
+            ft.termQuery(prefix, null)
+        );
 
         MappedFieldType unsearchable = new IpFieldMapper.IpFieldType("field", false, false, false, null, Collections.emptyMap());
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> unsearchable.termQuery("::1", null));
         assertEquals("Cannot search on field [field] since it is both not indexed, and does not have doc_values enabled.", e.getMessage());
     }
 
+    public void testDvOnlyTermQuery() {
+        IpFieldMapper.IpFieldType dvOnly = new IpFieldMapper.IpFieldType("field", false, false, true, null, Collections.emptyMap());
+        String ip = "2001:db8::2:1";
+
+        Query query = InetAddressPoint.newExactQuery("field", InetAddresses.forString(ip));
+
+        assertEquals(
+            SortedSetDocValuesField.newSlowExactQuery("field", new BytesRef(((PointRangeQuery) query).getLowerPoint())),
+            dvOnly.termQuery(ip, null)
+        );
+
+        ip = "192.168.1.7";
+        query = InetAddressPoint.newExactQuery("field", InetAddresses.forString(ip));
+        assertEquals(
+            SortedSetDocValuesField.newSlowExactQuery("field", new BytesRef(((PointRangeQuery) query).getLowerPoint())),
+            dvOnly.termQuery(ip, null)
+        );
+
+        ip = "2001:db8::2:1";
+        String prefix = ip + "/64";
+
+        assertEquals(
+            SortedSetDocValuesField.newSlowRangeQuery(
+                "field",
+                ipToByteRef("2001:db8:0:0:0:0:0:0"),
+                ipToByteRef("2001:db8:0:0:ffff:ffff:ffff:ffff"),
+                true,
+                true
+            ),
+            dvOnly.termQuery(prefix, null)
+        );
+
+        ip = "192.168.1.7";
+        prefix = ip + "/16";
+        assertEquals(
+            SortedSetDocValuesField.newSlowRangeQuery(
+                "field",
+                ipToByteRef("::ffff:192.168.0.0"),
+                ipToByteRef("::ffff:192.168.255.255"),
+                true,
+                true
+            ),
+            dvOnly.termQuery(prefix, null)
+        );
+    }
+
+    private static BytesRef ipToByteRef(String ipString) {
+        return new BytesRef(Objects.requireNonNull(InetAddresses.ipStringToBytes(ipString)));
+    }
+
     public void testTermsQuery() {
-        MappedFieldType ft = new IpFieldMapper.IpFieldType("field");
+        MappedFieldType ft = new IpFieldMapper.IpFieldType("field", true, false, false, null, Collections.emptyMap());
 
         assertEquals(
             InetAddressPoint.newSetQuery("field", InetAddresses.forString("::2"), InetAddresses.forString("::5")),
@@ -136,6 +212,29 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
                     .build()
             ),
             ft.termsQuery(Arrays.asList("::42", "::2/16"), null)
+        );
+    }
+
+    public void testDvOnlyTermsQuery() {
+        MappedFieldType dvOnly = new IpFieldMapper.IpFieldType("field", false, false, true, null, Collections.emptyMap());
+
+        assertEquals(
+            SortedSetDocValuesField.newSlowSetQuery("field", List.of(ipToByteRef("::2"), ipToByteRef("::5"))),
+            dvOnly.termsQuery(Arrays.asList(InetAddresses.forString("::2"), InetAddresses.forString("::5")), null)
+        );
+        assertEquals(
+            SortedSetDocValuesField.newSlowSetQuery("field", List.of(ipToByteRef("::2"), ipToByteRef("::5"))),
+            dvOnly.termsQuery(Arrays.asList("::2", "::5"), null)
+        );
+
+        // if the list includes a prefix query we fallback to a bool query
+        assertEquals(
+            new ConstantScoreQuery(
+                new BooleanQuery.Builder().add(dvOnly.termQuery("::42", null), Occur.SHOULD)
+                    .add(dvOnly.termQuery("::2/16", null), Occur.SHOULD)
+                    .build()
+            ),
+            dvOnly.termsQuery(Arrays.asList("::42", "::2/16"), null)
         );
     }
 


### PR DESCRIPTION

### Description
it fixes an edge case when docvalues-only (index:false) IP field is queried via IP mask (1.2.3.4/22 syntax). Now such query is ignored, this change makes it work. 

### Related Issues
relate #11508 

### Check List
- [v] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
