### PR TITLE
Introducing OpenSearch Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![GHA validate pull request](https://github.com/opensearch-project/OpenSearch/actions/workflows/wrapper.yml/badge.svg)](https://github.com/opensearch-project/OpenSearch/actions/workflows/wrapper.yml)
 [![GHA precommit](https://github.com/opensearch-project/OpenSearch/actions/workflows/precommit.yml/badge.svg)](https://github.com/opensearch-project/OpenSearch/actions/workflows/precommit.yml)
 [![Jenkins gradle check job](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fbuild.ci.opensearch.org%2Fjob%2Fgradle-check%2F&label=Jenkins%20Gradle%20Check)](https://build.ci.opensearch.org/job/gradle-check/)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20OpenSearch%20Guru-006BFF)](https://gurubase.io/g/opensearch)
 
 - [Welcome!](#welcome)
 - [Project Resources](#project-resources)


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [OpenSearch Guru](https://gurubase.io/g/opensearch) to Gurubase. OpenSearch Guru uses the data from this repo and data from the [docs](https://opensearch.org/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "OpenSearch Guru", which highlights that OpenSearch now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable OpenSearch Guru in Gurubase, just let me know that's totally fine.
