### PR TITLE
Update version check in yaml test file for allowing composite aggregation to run under a parent filter aggregation

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -512,8 +512,8 @@ setup:
 ---
 "Composite aggregation with filtered nested parent":
   - skip:
-      version: " - 2.99.99"
-      reason:  fixed in 3.0.0
+      version: " - 2.12.99"
+      reason:  fixed in 2.13.0
   - do:
       search:
         rest_total_hits_as_int: true
@@ -582,8 +582,8 @@ setup:
 ---
 "Composite aggregation with filtered reverse nested parent":
   - skip:
-      version: " - 2.99.99"
-      reason:  fixed in 3.0.0
+      version: " - 2.12.99"
+      reason:  fixed in 2.13.0
   - do:
       search:
         rest_total_hits_as_int: true


### PR DESCRIPTION
### Description

Update the version check from `3.0.0` to `2.13.0` as the change in this  [PR](https://github.com/opensearch-project/OpenSearch/pull/11499) was released in 2.13.0.

Change log is not needed, backport to 2.x is needed.


### Related Issues
No issue.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
