### PR TITLE
Bump mockito from 5.14.1 to 5.14.2, objenesis from 3.2 to 3.3 and bytebuddy from 1.15.4 to 1.15.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `com.nimbusds:nimbus-jose-jwt` from 9.41.1 to 9.46 ([#16611](https://github.com/opensearch-project/OpenSearch/pull/16611))
 - Bump `lycheeverse/lychee-action` from 2.0.2 to 2.1.0 ([#16610](https://github.com/opensearch-project/OpenSearch/pull/16610))
 - Bump `me.champeau.gradle.japicmp` from 0.4.4 to 0.4.5 ([#16614](https://github.com/opensearch-project/OpenSearch/pull/16614))
+- Bump `mockito` from 5.14.1 to 5.14.2 and `objenesis` from 3.2 to 3.3 ([#16655](https://github.com/opensearch-project/OpenSearch/pull/16655))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `com.nimbusds:nimbus-jose-jwt` from 9.41.1 to 9.46 ([#16611](https://github.com/opensearch-project/OpenSearch/pull/16611))
 - Bump `lycheeverse/lychee-action` from 2.0.2 to 2.1.0 ([#16610](https://github.com/opensearch-project/OpenSearch/pull/16610))
 - Bump `me.champeau.gradle.japicmp` from 0.4.4 to 0.4.5 ([#16614](https://github.com/opensearch-project/OpenSearch/pull/16614))
-- Bump `mockito` from 5.14.1 to 5.14.2 and `objenesis` from 3.2 to 3.3 ([#16655](https://github.com/opensearch-project/OpenSearch/pull/16655))
+- Bump `mockito` from 5.14.1 to 5.14.2, `objenesis` from 3.2 to 3.3 and `bytebuddy` from 1.15.4 to 1.15.10 ([#16655](https://github.com/opensearch-project/OpenSearch/pull/16655))
 
 ### Changed
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,7 @@ randomizedrunner  = "2.7.1"
 junit             = "4.13.2"
 hamcrest          = "2.1"
 mockito           = "5.14.2"
-objenesis         = "3.2"
+objenesis         = "3.3"
 bytebuddy         = "1.15.4"
 
 # benchmark dependencies

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,7 +62,7 @@ bouncycastle="1.78"
 randomizedrunner  = "2.7.1"
 junit             = "4.13.2"
 hamcrest          = "2.1"
-mockito           = "5.14.1"
+mockito           = "5.14.2"
 objenesis         = "3.2"
 bytebuddy         = "1.15.4"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ junit             = "4.13.2"
 hamcrest          = "2.1"
 mockito           = "5.14.2"
 objenesis         = "3.3"
-bytebuddy         = "1.15.4"
+bytebuddy         = "1.15.10"
 
 # benchmark dependencies
 jmh               = "1.35"

--- a/server/src/main/resources/org/opensearch/bootstrap/test-framework.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/test-framework.policy
@@ -45,7 +45,13 @@ grant codeBase "${codebase.mockito-core}" {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   permission java.lang.RuntimePermission "getClassLoader";
+
   permission java.lang.RuntimePermission "createClassLoader";
+  permission java.lang.RuntimePermission "net.bytebuddy.createJavaDispatcher";
+  permission java.lang.reflect.ReflectPermission "newProxyInPackage.net.bytebuddy.utility";
+  permission java.lang.reflect.ReflectPermission "newProxyInPackage.net.bytebuddy.dynamic.loading";
+  permission java.lang.reflect.ReflectPermission "newProxyInPackage.net.bytebuddy.description.type";
+  permission java.lang.reflect.ReflectPermission "newProxyInPackage.net.bytebuddy.description.method";
 };
 
 grant codeBase "${codebase.objenesis}" {

--- a/server/src/main/resources/org/opensearch/bootstrap/test-framework.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/test-framework.policy
@@ -45,6 +45,7 @@ grant codeBase "${codebase.mockito-core}" {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   permission java.lang.RuntimePermission "getClassLoader";
+  permission java.lang.RuntimePermission "createClassLoader";
 };
 
 grant codeBase "${codebase.objenesis}" {

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -80,7 +80,8 @@ thirdPartyAudit.ignoreMissingClasses(
   'org.apache.log4j.Priority',
   'org.mockito.internal.creation.bytebuddy.inject.MockMethodDispatcher',
   'org.opentest4j.AssertionFailedError',
-  'net.bytebuddy.agent.ByteBuddyAgent'
+  'net.bytebuddy.agent.ByteBuddyAgent',
+  'net.bytebuddy.agent.Installer'
 )
 // TODO - OpenSearch remove this violation. Issue: https://github.com/opensearch-project/OpenSearch/issues/420
 thirdPartyAudit.ignoreViolations(


### PR DESCRIPTION
### Description

Bumps the version of mockito from 5.14.1 to 5.14.2, objenesis from 3.2 to 3.3 and bytebuddy from 1.15.4 to 1.15.10

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
