### PR TITLE
Add method to create empty query collector context with customizable score mode

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))
 - Fix compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Don't over-allocate in HeapBufferedAsyncEntityConsumer in order to consume the response ([#9993](https://github.com/opensearch-project/OpenSearch/pull/9993))
+- Add method to create empty query collector context with customizable score mode ([#16660](https://github.com/opensearch-project/OpenSearch/pull/16660))
 
 ### Security
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -49,7 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix 'org.apache.hc.core5.http.ParseException: Invalid protocol version' under JDK 16+ ([#4827](https://github.com/opensearch-project/OpenSearch/pull/4827))
 - Fix compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Don't over-allocate in HeapBufferedAsyncEntityConsumer in order to consume the response ([#9993](https://github.com/opensearch-project/OpenSearch/pull/9993))
-- Add method to create empty query collector context with customizable score mode ([#16660](https://github.com/opensearch-project/OpenSearch/pull/16660))
+- Add empty query collector context constant with TOP_SCORES score mode ([#16660](https://github.com/opensearch-project/OpenSearch/pull/16660))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/search/query/QueryCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryCollectorContext.java
@@ -51,14 +51,10 @@ import org.opensearch.search.profile.query.InternalProfileCollectorManager;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.opensearch.search.profile.query.CollectorResult.REASON_SEARCH_MIN_SCORE;
 import static org.opensearch.search.profile.query.CollectorResult.REASON_SEARCH_MULTI;
@@ -112,29 +108,19 @@ public abstract class QueryCollectorContext {
         };
     }
 
-    private static final Map<ScoreMode, QueryCollectorContext> CONTEXTS = Arrays.stream(ScoreMode.values())
-        .collect(
-            Collectors.toMap(
-                Function.identity(),
-                scoreMode -> createEmptyContext(formatContextName(scoreMode), createEmptyCollector(scoreMode))
-            )
-        );
-
     private static String formatContextName(ScoreMode scoreMode) {
         return String.format(Locale.ROOT, "empty_with_score_mode_%s", scoreMode.toString().toLowerCase(Locale.ROOT));
     }
 
     private static final Collector EMPTY_COLLECTOR = createEmptyCollector(ScoreMode.COMPLETE_NO_SCORES);
-    public static final QueryCollectorContext EMPTY_CONTEXT = CONTEXTS.get(ScoreMode.COMPLETE_NO_SCORES);
-
-    /**
-     * Returns the {@link QueryCollectorContext} for the provided {@link ScoreMode}
-     *
-     * @param scoreMode The score mode to get the context for
-     */
-    public static QueryCollectorContext getContextForScoreMode(final ScoreMode scoreMode) {
-        return CONTEXTS.getOrDefault(scoreMode, EMPTY_CONTEXT);
-    }
+    public static final QueryCollectorContext EMPTY_CONTEXT = createEmptyContext(
+        formatContextName(ScoreMode.COMPLETE_NO_SCORES),
+        createEmptyCollector(ScoreMode.COMPLETE_NO_SCORES)
+    );
+    public static final QueryCollectorContext EMPTY_CONTEXT_TOP_SCORES_SCORE_MODE = createEmptyContext(
+        formatContextName(ScoreMode.TOP_SCORES),
+        createEmptyCollector(ScoreMode.TOP_SCORES)
+    );
 
     private String profilerName;
 

--- a/server/src/main/java/org/opensearch/search/query/QueryCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryCollectorContext.java
@@ -83,7 +83,8 @@ public abstract class QueryCollectorContext {
 
     private static final ReduceableSearchResult EMPTY_RESULT = result -> {};
 
-    private static QueryCollectorContext createEmptyContext(String name, Collector collector) {
+    private static QueryCollectorContext createEmptyContext(Collector collector) {
+        String name = String.format(Locale.ROOT, "empty_with_score_mode_%s", collector.scoreMode().toString().toLowerCase(Locale.ROOT));
         return new QueryCollectorContext(name) {
             @Override
             Collector create(Collector in) {
@@ -108,19 +109,11 @@ public abstract class QueryCollectorContext {
         };
     }
 
-    private static String formatContextName(ScoreMode scoreMode) {
-        return String.format(Locale.ROOT, "empty_with_score_mode_%s", scoreMode.toString().toLowerCase(Locale.ROOT));
-    }
-
     private static final Collector EMPTY_COLLECTOR = createEmptyCollector(ScoreMode.COMPLETE_NO_SCORES);
-    public static final QueryCollectorContext EMPTY_CONTEXT = createEmptyContext(
-        formatContextName(ScoreMode.COMPLETE_NO_SCORES),
-        createEmptyCollector(ScoreMode.COMPLETE_NO_SCORES)
-    );
-    public static final QueryCollectorContext EMPTY_CONTEXT_TOP_SCORES_SCORE_MODE = createEmptyContext(
-        formatContextName(ScoreMode.TOP_SCORES),
-        createEmptyCollector(ScoreMode.TOP_SCORES)
-    );
+    private static final Collector EMPTY_COLLECTOR_TOP_SCORES = createEmptyCollector(ScoreMode.TOP_SCORES);
+
+    public static final QueryCollectorContext EMPTY_CONTEXT = createEmptyContext(EMPTY_COLLECTOR);
+    public static final QueryCollectorContext EMPTY_CONTEXT_TOP_SCORES_SCORE_MODE = createEmptyContext(EMPTY_COLLECTOR_TOP_SCORES);
 
     private String profilerName;
 

--- a/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
@@ -1197,6 +1197,36 @@ public class QueryPhaseTests extends IndexShardTestCase {
         verifyNoMoreInteractions(mockedSearchContext);
     }
 
+    public void testQueryCollectorContextScoreModes() throws Exception {
+        // Test default empty context
+        QueryCollectorContext emptyContext = QueryCollectorContext.EMPTY_CONTEXT;
+        assertEquals(org.apache.lucene.search.ScoreMode.COMPLETE_NO_SCORES, emptyContext.create(null).scoreMode());
+
+        // Test getting context for different score modes
+        org.apache.lucene.search.ScoreMode[] scoreModes = org.apache.lucene.search.ScoreMode.values();
+        for (org.apache.lucene.search.ScoreMode scoreMode : scoreModes) {
+            QueryCollectorContext context = QueryCollectorContext.getContextForScoreMode(scoreMode);
+            assertEquals(scoreMode, context.create(null).scoreMode());
+        }
+
+        // Test that invalid score mode returns empty context
+        QueryCollectorContext defaultContext = QueryCollectorContext.getContextForScoreMode(null);
+        assertEquals(QueryCollectorContext.EMPTY_CONTEXT, defaultContext);
+        assertEquals(org.apache.lucene.search.ScoreMode.COMPLETE_NO_SCORES, defaultContext.create(null).scoreMode());
+    }
+
+    public void testQueryCollectorContextTopScores() throws Exception {
+        QueryCollectorContext topScoresContext = QueryCollectorContext.getContextForScoreMode(
+            org.apache.lucene.search.ScoreMode.TOP_SCORES
+        );
+
+        // Verify score mode
+        assertEquals(org.apache.lucene.search.ScoreMode.TOP_SCORES, topScoresContext.create(null).scoreMode());
+
+        // Verify it's a different instance than empty context
+        assertNotEquals(QueryCollectorContext.EMPTY_CONTEXT, topScoresContext);
+    }
+
     private static class TestSearchContextWithRewriteAndCancellation extends TestSearchContext {
 
         private TestSearchContextWithRewriteAndCancellation(

--- a/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
@@ -1197,28 +1197,8 @@ public class QueryPhaseTests extends IndexShardTestCase {
         verifyNoMoreInteractions(mockedSearchContext);
     }
 
-    public void testQueryCollectorContextScoreModes() throws Exception {
-        // Test default empty context
-        QueryCollectorContext emptyContext = QueryCollectorContext.EMPTY_CONTEXT;
-        assertEquals(org.apache.lucene.search.ScoreMode.COMPLETE_NO_SCORES, emptyContext.create(null).scoreMode());
-
-        // Test getting context for different score modes
-        org.apache.lucene.search.ScoreMode[] scoreModes = org.apache.lucene.search.ScoreMode.values();
-        for (org.apache.lucene.search.ScoreMode scoreMode : scoreModes) {
-            QueryCollectorContext context = QueryCollectorContext.getContextForScoreMode(scoreMode);
-            assertEquals(scoreMode, context.create(null).scoreMode());
-        }
-
-        // Test that invalid score mode returns empty context
-        QueryCollectorContext defaultContext = QueryCollectorContext.getContextForScoreMode(null);
-        assertEquals(QueryCollectorContext.EMPTY_CONTEXT, defaultContext);
-        assertEquals(org.apache.lucene.search.ScoreMode.COMPLETE_NO_SCORES, defaultContext.create(null).scoreMode());
-    }
-
-    public void testQueryCollectorContextTopScores() throws Exception {
-        QueryCollectorContext topScoresContext = QueryCollectorContext.getContextForScoreMode(
-            org.apache.lucene.search.ScoreMode.TOP_SCORES
-        );
+    public void testEmptyQueryCollectorContextAndDifferentScoreModes() throws Exception {
+        QueryCollectorContext topScoresContext = QueryCollectorContext.EMPTY_CONTEXT_TOP_SCORES_SCORE_MODE;
 
         // Verify score mode
         assertEquals(org.apache.lucene.search.ScoreMode.TOP_SCORES, topScoresContext.create(null).scoreMode());


### PR DESCRIPTION
### Description
This PR introduces a new method that allows clients to create an empty query collector context with a specified score mode. This enhancement addresses limitations in the current MultiCollector implementation where score modes can default to suboptimal values.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/16659

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
