### PR TITLE
Fix stale cluster state custom file deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix rollover alias supports restored searchable snapshot index([#16483](https://github.com/opensearch-project/OpenSearch/pull/16483))
 - Fix permissions error on scripted query against remote snapshot ([#16544](https://github.com/opensearch-project/OpenSearch/pull/16544))
 - Fix `doc_values` only (`index:false`) IP field searching for masks ([#16628](https://github.com/opensearch-project/OpenSearch/pull/16628))
+- Fix stale cluster state custom file deletion ([#16670](https://github.com/opensearch-project/OpenSearch/pull/16670))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateCleanupManager.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateCleanupManager.java
@@ -306,7 +306,7 @@ public class RemoteClusterStateCleanupManager implements Closeable {
                     staleEphemeralAttributePaths.add(clusterMetadataManifest.getHashesOfConsistentSettings().getUploadedFilename());
                 }
                 if (clusterMetadataManifest.getClusterStateCustomMap() != null) {
-                    clusterMetadataManifest.getCustomMetadataMap()
+                    clusterMetadataManifest.getClusterStateCustomMap()
                         .values()
                         .stream()
                         .filter(u -> !filesToKeep.contains(u.getUploadedFilename()))

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateCleanupManagerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateCleanupManagerTests.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -200,6 +201,7 @@ public class RemoteClusterStateCleanupManagerTests extends OpenSearchTestCase {
             .nodeId("nodeA")
             .opensearchVersion(VersionUtils.randomOpenSearchVersion(random()))
             .previousClusterUUID(ClusterState.UNKNOWN_UUID)
+            .clusterStateCustomMetadataMap(Map.of("snapshots", new UploadedMetadataAttribute("snapshots", "snapshot_file1")))
             .committed(true)
             .build();
         ClusterMetadataManifest manifest2 = ClusterMetadataManifest.builder(manifest1)
@@ -209,10 +211,12 @@ public class RemoteClusterStateCleanupManagerTests extends OpenSearchTestCase {
             .coordinationMetadata(coordinationMetadata)
             .templatesMetadata(templateMetadata)
             .settingMetadata(settingMetadata)
+            .clusterStateCustomMetadataMap(Map.of("restore", new UploadedMetadataAttribute("restore", "restore_file1")))
             .build();
         ClusterMetadataManifest manifest3 = ClusterMetadataManifest.builder(manifest2)
             .indices(List.of(index1UpdatedMetadata, index2Metadata))
             .settingMetadata(settingMetadataUpdated)
+            .clusterStateCustomMetadataMap(Map.of())
             .build();
 
         UploadedIndexMetadata index3Metadata = new UploadedIndexMetadata("index3", "indexUUID3", "index_metadata3__2");
@@ -286,6 +290,7 @@ public class RemoteClusterStateCleanupManagerTests extends OpenSearchTestCase {
             )
         );
         verify(container).deleteBlobsIgnoringIfNotExists(List.of(getFormattedIndexFileName(index1Metadata.getUploadedFilePath())));
+        verify(container).deleteBlobsIgnoringIfNotExists(List.of("restore_file1", "snapshot_file1"));
         Set<String> staleManifest = new HashSet<>();
         inactiveBlobs.forEach(
             blob -> staleManifest.add(


### PR DESCRIPTION
### Description
When remote cluster state publication is enabled, cluster state custom objects get uploaded to remote store. The stale file deletion logic deletes stale remote state files. But the cluster state custom files are not getting deleted.
This PR fixes the logic for stale cluster state custom file deletion.

### Related Issues
NA

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
