### PR TITLE
Coordinator can return partial results after the timeout when allow_partial_search_results is true

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/CoordinatorTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/CoordinatorTimeoutIT.java
@@ -1,0 +1,232 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.opensearch.action.search.MultiSearchRequest;
+import org.opensearch.action.search.MultiSearchResponse;
+import org.opensearch.action.search.SearchPhaseExecutionException;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchTransportService.CoordinatorTimeoutStrategy;
+import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginsService;
+import org.opensearch.script.Script;
+import org.opensearch.script.ScriptType;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
+import org.opensearch.transport.ReceiveTimeoutTransportException;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.index.query.QueryBuilders.scriptQuery;
+import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
+import static org.opensearch.search.SearchService.NO_TIMEOUT;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.instanceOf;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
+public class CoordinatorTimeoutIT extends ParameterizedStaticSettingsOpenSearchIntegTestCase {
+
+    private static final String INDEX = "test";
+    private static final TimeValue COORDINATOR_TIMEOUT = TimeValue.timeValueMillis(500);
+
+    private String coordinatorNode;
+
+    public CoordinatorTimeoutIT(Settings nodeSettings) {
+        super(nodeSettings);
+    }
+
+    @ParametersFactory
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(
+            new Object[] { Settings.builder().put(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), false).build() },
+            new Object[] { Settings.builder().put(CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING.getKey(), true).build() }
+        );
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singleton(ScriptedBlockPlugin.class);
+    }
+
+    @Before
+    public void startCluster() {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+        internalCluster().startDataOnlyNode();
+        coordinatorNode = internalCluster().startCoordinatingOnlyNode(Settings.EMPTY);
+
+        assertAcked(
+            prepareCreate(INDEX).setSettings(
+                Settings.builder()
+                    .put("index.number_of_shards", 2)
+                    .put("index.number_of_replicas", 0)
+                    .put("index.routing.allocation.total_shards_per_node", 1)
+            )
+        );
+        ensureGreen(INDEX);
+        ensureStableCluster(4, coordinatorNode);
+    }
+
+    public void testRequestCoordinatorTimeoutStrategyReturnsPartialResultsAfterTimeout() throws Exception {
+        indexTestData();
+        assertSearchReturnsPartialResultsAfterCoordinatorTimeout(newSearchRequest(true, true, true));
+    }
+
+    public void testFailsWhenPartialResultsAreDisallowed() throws Exception {
+        indexTestData();
+        List<ScriptedBlockPlugin> plugins = initBlockFactory();
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        try {
+            client(coordinatorNode).search(newSearchRequest(false, true, true), future);
+
+            awaitForBlock(plugins);
+            sleepForAtLeast(COORDINATOR_TIMEOUT.getMillis());
+            disableBlocks(plugins);
+
+            SearchPhaseExecutionException exception = expectThrows(
+                SearchPhaseExecutionException.class,
+                () -> future.actionGet(10, TimeUnit.SECONDS)
+            );
+            assertEquals(1, exception.shardFailures().length);
+            assertThat(exception.shardFailures()[0].getCause(), instanceOf(ReceiveTimeoutTransportException.class));
+        } finally {
+            disableBlocks(plugins);
+        }
+    }
+
+    public void testNoCoordinatorTimeoutStrategyWaitsForBlockedShard() throws Exception {
+        indexTestData();
+        assertSearchWaitsForBlockedShard(newSearchRequest(true, true, false));
+    }
+
+    public void testNoTimeoutWaitsForBlockedShard() throws Exception {
+        indexTestData();
+        assertSearchWaitsForBlockedShard(newSearchRequest(true, false, true));
+    }
+
+    public void testMultiSearchRequestCoordinatorTimeoutStrategyReturnsPartialResults() throws Exception {
+        indexTestData();
+        List<ScriptedBlockPlugin> plugins = initBlockFactory();
+        PlainActionFuture<MultiSearchResponse> future = PlainActionFuture.newFuture();
+        try {
+            client(coordinatorNode).multiSearch(new MultiSearchRequest().add(newSearchRequest(true, true, true)), future);
+
+            awaitForBlock(plugins);
+            sleepForAtLeast(COORDINATOR_TIMEOUT.getMillis());
+            disableBlocks(plugins);
+
+            MultiSearchResponse response = future.actionGet(10, TimeUnit.SECONDS);
+            assertEquals(1, response.getResponses().length);
+            assertFalse(response.getResponses()[0].isFailure());
+            SearchResponse searchResponse = response.getResponses()[0].getResponse();
+            assertEquals(2, searchResponse.getTotalShards());
+            assertEquals(1, searchResponse.getSuccessfulShards());
+            assertEquals(1, searchResponse.getFailedShards());
+            verifyFailedException(searchResponse.getShardFailures());
+        } finally {
+            disableBlocks(plugins);
+        }
+    }
+
+    private void verifyFailedException(ShardSearchFailure[] shardFailures) {
+        for (ShardSearchFailure shardFailure : shardFailures) {
+            final Throwable topFailureCause = shardFailure.getCause();
+            assertTrue(shardFailure.toString(), topFailureCause instanceof ReceiveTimeoutTransportException);
+        }
+    }
+
+    private SearchRequest newSearchRequest(boolean allowPartialResults, boolean timeoutEnabled, boolean failStrategy) {
+        TimeValue timeout = timeoutEnabled ? COORDINATOR_TIMEOUT : NO_TIMEOUT;
+        SearchRequest request = new SearchRequest(INDEX).allowPartialSearchResults(allowPartialResults)
+            .source(
+                new SearchSourceBuilder().query(
+                    scriptQuery(new Script(ScriptType.INLINE, "mockscript", ScriptedBlockPlugin.SCRIPT_NAME, Collections.emptyMap()))
+                ).timeout(timeout)
+            );
+        if (failStrategy) {
+            request.setCoordinatorTimeoutStrategy(CoordinatorTimeoutStrategy.FAIL.getType());
+        }
+        return request;
+    }
+
+    private void assertSearchReturnsPartialResultsAfterCoordinatorTimeout(SearchRequest request) throws Exception {
+        List<ScriptedBlockPlugin> plugins = initBlockFactory();
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        try {
+            client(coordinatorNode).search(request, future);
+
+            awaitForBlock(plugins);
+            sleepForAtLeast(COORDINATOR_TIMEOUT.getMillis());
+            disableBlocks(plugins);
+
+            SearchResponse searchResponse = future.actionGet(10, TimeUnit.SECONDS);
+            assertEquals(2, searchResponse.getTotalShards());
+            assertEquals(1, searchResponse.getSuccessfulShards());
+            assertEquals(1, searchResponse.getFailedShards());
+            verifyFailedException(searchResponse.getShardFailures());
+        } finally {
+            disableBlocks(plugins);
+        }
+    }
+
+    private void assertSearchWaitsForBlockedShard(SearchRequest request) throws Exception {
+        List<ScriptedBlockPlugin> plugins = initBlockFactory();
+        PlainActionFuture<SearchResponse> future = PlainActionFuture.newFuture();
+        try {
+            client(coordinatorNode).search(request, future);
+
+            awaitForBlock(plugins);
+            assertFalse(future.isDone());
+            disableBlocks(plugins);
+
+            SearchResponse searchResponse = future.actionGet(10, TimeUnit.SECONDS);
+            assertEquals(2, searchResponse.getTotalShards());
+            assertEquals(2, searchResponse.getSuccessfulShards());
+            assertEquals(0, searchResponse.getFailedShards());
+        } finally {
+            disableBlocks(plugins);
+        }
+    }
+
+    private List<ScriptedBlockPlugin> initBlockFactory() {
+        List<ScriptedBlockPlugin> plugins = new ArrayList<>();
+        boolean notBlockFirst = true;
+        for (PluginsService pluginsService : internalCluster().getDataNodeInstances(PluginsService.class)) {
+            List<ScriptedBlockPlugin> scriptedBlockPlugins = pluginsService.filterPlugins(ScriptedBlockPlugin.class);
+            for (ScriptedBlockPlugin plugin : scriptedBlockPlugins) {
+                plugin.reset();
+                // just block one data node
+                if (notBlockFirst) {
+                    notBlockFirst = false;
+                    // default is enable block
+                    plugin.disableBlock();
+                } else {
+                    plugin.enableBlock();
+                }
+            }
+            plugins.addAll(scriptedBlockPlugins);
+        }
+        return plugins;
+    }
+
+}

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
@@ -34,11 +34,9 @@ package org.opensearch.search;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.apache.logging.log4j.LogManager;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.admin.cluster.node.tasks.cancel.CancelTasksResponse;
 import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
-import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.search.MultiSearchAction;
 import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchAction;
@@ -46,8 +44,6 @@ import org.opensearch.action.search.SearchPhaseExecutionException;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchScrollAction;
 import org.opensearch.action.search.ShardSearchFailure;
-import org.opensearch.action.support.WriteRequest;
-import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -56,10 +52,8 @@ import org.opensearch.core.tasks.TaskCancelledException;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.PluginsService;
-import org.opensearch.script.MockScriptPlugin;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
-import org.opensearch.search.lookup.LeafFieldsLookup;
 import org.opensearch.tasks.TaskInfo;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
@@ -72,21 +66,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 
 import static org.opensearch.action.search.TransportSearchAction.SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING_KEY;
 import static org.opensearch.index.query.QueryBuilders.scriptQuery;
-import static org.opensearch.search.SearchCancellationIT.ScriptedBlockPlugin.SCRIPT_NAME;
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
 import static org.opensearch.search.SearchService.NO_TIMEOUT;
+import static org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase.ScriptedBlockPlugin.SCRIPT_NAME;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertFailures;
-import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -129,17 +117,6 @@ public class SearchCancellationIT extends ParameterizedStaticSettingsOpenSearchI
         client().admin().cluster().prepareUpdateSettings().setPersistentSettings(Settings.builder().putNull("*")).get();
     }
 
-    private void indexTestData() {
-        for (int i = 0; i < 5; i++) {
-            // Make sure we have a few segments
-            BulkRequestBuilder bulkRequestBuilder = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-            for (int j = 0; j < 20; j++) {
-                bulkRequestBuilder.add(client().prepareIndex("test").setId(Integer.toString(i * 5 + j)).setSource("field", "value"));
-            }
-            assertNoFailures(bulkRequestBuilder.get());
-        }
-    }
-
     private List<ScriptedBlockPlugin> initBlockFactory() {
         List<ScriptedBlockPlugin> plugins = new ArrayList<>();
         for (PluginsService pluginsService : internalCluster().getDataNodeInstances(PluginsService.class)) {
@@ -150,24 +127,6 @@ public class SearchCancellationIT extends ParameterizedStaticSettingsOpenSearchI
             plugin.enableBlock();
         }
         return plugins;
-    }
-
-    private void awaitForBlock(List<ScriptedBlockPlugin> plugins) throws Exception {
-        int numberOfShards = getNumShards("test").numPrimaries;
-        assertBusy(() -> {
-            int numberOfBlockedPlugins = 0;
-            for (ScriptedBlockPlugin plugin : plugins) {
-                numberOfBlockedPlugins += plugin.hits.get();
-            }
-            logger.info("The plugin blocked on {} out of {} shards", numberOfBlockedPlugins, numberOfShards);
-            assertThat(numberOfBlockedPlugins, greaterThan(0));
-        });
-    }
-
-    private void disableBlocks(List<ScriptedBlockPlugin> plugins) throws Exception {
-        for (ScriptedBlockPlugin plugin : plugins) {
-            plugin.disableBlock();
-        }
     }
 
     private void cancelSearch(String action) {
@@ -599,51 +558,5 @@ public class SearchCancellationIT extends ParameterizedStaticSettingsOpenSearchI
         expectedFailedRequests.add(0);
         expectedFailedRequests.add(2);
         ensureMSearchWasCancelled(mSearchResponse, expectedFailedRequests);
-    }
-
-    /**
-     * Sleeps for the specified number of milliseconds plus a 100ms buffer to account for system timer/scheduler inaccuracies.
-     *
-     * @param milliseconds The minimum time to sleep
-     * @throws InterruptedException if interrupted during sleep
-     */
-    @SuppressForbidden(reason = "Waiting longer than timeout")
-    private static void sleepForAtLeast(long milliseconds) throws InterruptedException {
-        Thread.sleep(milliseconds + 100L);
-    }
-
-    public static class ScriptedBlockPlugin extends MockScriptPlugin {
-        static final String SCRIPT_NAME = "search_block";
-
-        private final AtomicInteger hits = new AtomicInteger();
-
-        private final AtomicBoolean shouldBlock = new AtomicBoolean(true);
-
-        public void reset() {
-            hits.set(0);
-        }
-
-        public void disableBlock() {
-            shouldBlock.set(false);
-        }
-
-        public void enableBlock() {
-            shouldBlock.set(true);
-        }
-
-        @Override
-        public Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
-            return Collections.singletonMap(SCRIPT_NAME, params -> {
-                LeafFieldsLookup fieldsLookup = (LeafFieldsLookup) params.get("_fields");
-                LogManager.getLogger(SearchCancellationIT.class).info("Blocking on the document {}", fieldsLookup.get("_id"));
-                hits.incrementAndGet();
-                try {
-                    assertBusy(() -> assertFalse(shouldBlock.get()));
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-                return true;
-            });
-        }
     }
 }

--- a/server/src/main/java/org/opensearch/action/search/MultiSearchRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/MultiSearchRequest.java
@@ -64,6 +64,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.opensearch.action.ValidateActions.addValidationError;
+import static org.opensearch.action.search.SearchRequest.COORDINATOR_TIMEOUT_STRATEGY;
 import static org.opensearch.common.xcontent.support.XContentMapValues.nodeBooleanValue;
 import static org.opensearch.common.xcontent.support.XContentMapValues.nodeStringArrayValue;
 import static org.opensearch.common.xcontent.support.XContentMapValues.nodeStringValue;
@@ -281,6 +282,8 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
                                 searchRequest.setCancelAfterTimeInterval(nodeTimeValue(value, null));
                             } else if ("phase_took".equals(entry.getKey())) {
                                 searchRequest.setPhaseTook(nodeBooleanValue(value));
+                            } else if (COORDINATOR_TIMEOUT_STRATEGY.equals(entry.getKey())) {
+                                searchRequest.setCoordinatorTimeoutStrategy(nodeStringValue(value));
                             } else {
                                 throw new IllegalArgumentException("key [" + entry.getKey() + "] is not supported in the metadata section");
                             }
@@ -384,6 +387,9 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
         }
         if (request.isPhaseTook() != null) {
             xContentBuilder.field("phase_took", request.isPhaseTook());
+        }
+        if (request.coordinatorTimeoutStrategy() != null) {
+            xContentBuilder.field(COORDINATOR_TIMEOUT_STRATEGY, request.coordinatorTimeoutStrategy().getType());
         }
         xContentBuilder.endObject();
     }

--- a/server/src/main/java/org/opensearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequest.java
@@ -37,6 +37,7 @@ import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.IndicesRequest;
+import org.opensearch.action.search.SearchTransportService.CoordinatorTimeoutStrategy;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.ExperimentalApi;
@@ -85,6 +86,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
 
     public static final ToXContent.Params FORMAT_PARAMS = new ToXContent.MapParams(Collections.singletonMap("pretty", "false"));
 
+    public static final String COORDINATOR_TIMEOUT_STRATEGY = "coordinator_timeout_strategy";
     public static final int DEFAULT_PRE_FILTER_SHARD_SIZE = 128;
     public static final int DEFAULT_BATCHED_REDUCE_SIZE = 512;
 
@@ -128,6 +130,8 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
     private String pipeline;
 
     private Boolean phaseTook = null;
+
+    private CoordinatorTimeoutStrategy coordinatorTimeoutStrategy = null;
 
     public SearchRequest() {
         this.localClusterAlias = null;
@@ -234,6 +238,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         this.finalReduce = finalReduce;
         this.cancelAfterTimeInterval = searchRequest.cancelAfterTimeInterval;
         this.phaseTook = searchRequest.phaseTook;
+        this.coordinatorTimeoutStrategy = searchRequest.coordinatorTimeoutStrategy;
     }
 
     /**
@@ -281,6 +286,9 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         if (in.getVersion().onOrAfter(Version.V_2_12_0)) {
             phaseTook = in.readOptionalBoolean();
         }
+        if (in.getVersion().onOrAfter(Version.V_3_8_0)) {
+            coordinatorTimeoutStrategy = CoordinatorTimeoutStrategy.fromType(in.readOptionalString());
+        }
     }
 
     @Override
@@ -314,6 +322,9 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         }
         if (out.getVersion().onOrAfter(Version.V_2_12_0)) {
             out.writeOptionalBoolean(phaseTook);
+        }
+        if (out.getVersion().onOrAfter(Version.V_3_8_0)) {
+            out.writeOptionalString(coordinatorTimeoutStrategy != null ? coordinatorTimeoutStrategy.getType() : null);
         }
     }
 
@@ -762,9 +773,29 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         return pipeline;
     }
 
+    public void setCoordinatorTimeoutStrategy(String coordinatorTimeoutStrategy) {
+        assert coordinatorTimeoutStrategy != null;
+        this.coordinatorTimeoutStrategy = CoordinatorTimeoutStrategy.fromType(coordinatorTimeoutStrategy);
+    }
+
+    public CoordinatorTimeoutStrategy coordinatorTimeoutStrategy() {
+        return coordinatorTimeoutStrategy;
+    }
+
     @Override
     public SearchTask createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-        return new SearchTask(id, type, action, this::buildDescription, parentTaskId, headers, cancelAfterTimeInterval);
+        TimeValue timeout = source == null ? null : source.timeout();
+        return new SearchTask(
+            id,
+            type,
+            action,
+            this::buildDescription,
+            parentTaskId,
+            headers,
+            cancelAfterTimeInterval,
+            timeout,
+            coordinatorTimeoutStrategy
+        );
     }
 
     public final String buildDescription() {
@@ -816,7 +847,8 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             && ccsMinimizeRoundtrips == that.ccsMinimizeRoundtrips
             && Objects.equals(cancelAfterTimeInterval, that.cancelAfterTimeInterval)
             && Objects.equals(pipeline, that.pipeline)
-            && Objects.equals(phaseTook, that.phaseTook);
+            && Objects.equals(phaseTook, that.phaseTook)
+            && Objects.equals(coordinatorTimeoutStrategy, that.coordinatorTimeoutStrategy);
     }
 
     @Override
@@ -838,7 +870,9 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             absoluteStartMillis,
             ccsMinimizeRoundtrips,
             cancelAfterTimeInterval,
-            phaseTook
+            pipeline,
+            phaseTook,
+            coordinatorTimeoutStrategy
         );
     }
 
@@ -883,6 +917,8 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             + pipeline
             + ", phaseTook="
             + phaseTook
+            + ", coordinatorTimeoutStrategy="
+            + coordinatorTimeoutStrategy
             + "}";
     }
 }

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestBuilder.java
@@ -655,4 +655,9 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
         this.request.setCancelAfterTimeInterval(cancelAfterTimeInterval);
         return this;
     }
+
+    public SearchRequestBuilder setCoordinatorTimeoutStrategy(String coordinatorTimeoutStrategy) {
+        this.request.setCoordinatorTimeoutStrategy(coordinatorTimeoutStrategy);
+        return this;
+    }
 }

--- a/server/src/main/java/org/opensearch/action/search/SearchTask.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchTask.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.action.search;
 
+import org.opensearch.action.search.SearchTransportService.CoordinatorTimeoutStrategy;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.tasks.TaskId;
@@ -53,6 +54,8 @@ public class SearchTask extends WorkloadGroupTask implements SearchBackpressureT
     // generating description in a lazy way since source can be quite big
     private final Supplier<String> descriptionSupplier;
     private SearchProgressListener progressListener = SearchProgressListener.NOOP;
+    private final TimeValue timeout;
+    private final CoordinatorTimeoutStrategy coordinatorTimeoutStrategy;
 
     public SearchTask(
         long id,
@@ -62,9 +65,10 @@ public class SearchTask extends WorkloadGroupTask implements SearchBackpressureT
         TaskId parentTaskId,
         Map<String, String> headers
     ) {
-        this(id, type, action, descriptionSupplier, parentTaskId, headers, NO_TIMEOUT);
+        this(id, type, action, descriptionSupplier, parentTaskId, headers, NO_TIMEOUT, null, null);
     }
 
+    @Deprecated
     public SearchTask(
         long id,
         String type,
@@ -76,6 +80,25 @@ public class SearchTask extends WorkloadGroupTask implements SearchBackpressureT
     ) {
         super(id, type, action, null, parentTaskId, headers, cancelAfterTimeInterval);
         this.descriptionSupplier = descriptionSupplier;
+        this.timeout = null;
+        this.coordinatorTimeoutStrategy = null;
+    }
+
+    public SearchTask(
+        long id,
+        String type,
+        String action,
+        Supplier<String> descriptionSupplier,
+        TaskId parentTaskId,
+        Map<String, String> headers,
+        TimeValue cancelAfterTimeInterval,
+        TimeValue timeValue,
+        CoordinatorTimeoutStrategy coordinatorTimeoutStrategy
+    ) {
+        super(id, type, action, null, parentTaskId, headers, cancelAfterTimeInterval);
+        this.descriptionSupplier = descriptionSupplier;
+        this.timeout = timeValue;
+        this.coordinatorTimeoutStrategy = coordinatorTimeoutStrategy;
     }
 
     @Override
@@ -105,5 +128,16 @@ public class SearchTask extends WorkloadGroupTask implements SearchBackpressureT
     @Override
     public boolean shouldCancelChildrenOnCancellation() {
         return true;
+    }
+
+    public boolean coordinatorTimeoutEnabled() {
+        if (timeout != null && timeout.duration() > 0) {
+            return this.coordinatorTimeoutStrategy == CoordinatorTimeoutStrategy.FAIL;
+        }
+        return false;
+    }
+
+    public TimeValue timeout() {
+        return timeout;
     }
 }

--- a/server/src/main/java/org/opensearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchTransportService.java
@@ -39,6 +39,7 @@ import org.opensearch.action.support.ChannelActionListener;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -71,6 +72,7 @@ import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -188,7 +190,7 @@ public class SearchTransportService {
             QUERY_CAN_MATCH_NAME,
             request,
             task,
-            TransportRequestOptions.EMPTY,
+            getTransportRequestOptions(task),
             new ActionListenerResponseHandler<>(listener, SearchService.CanMatchResponse::new)
         );
     }
@@ -228,6 +230,7 @@ public class SearchTransportService {
             DFS_ACTION_NAME,
             request,
             task,
+            getTransportRequestOptions(task),
             new ConnectionCountingHandler<>(listener, DfsSearchResult::new, clientConnections, connection.getNode().getId())
         );
     }
@@ -249,6 +252,7 @@ public class SearchTransportService {
             QUERY_ACTION_NAME,
             request,
             task,
+            getTransportRequestOptions(task),
             new ConnectionCountingHandler<>(handler, reader, clientConnections, connection.getNode().getId())
         );
     }
@@ -264,6 +268,7 @@ public class SearchTransportService {
             QUERY_ID_ACTION_NAME,
             request,
             task,
+            getTransportRequestOptions(task),
             new ConnectionCountingHandler<>(listener, QuerySearchResult::new, clientConnections, connection.getNode().getId())
         );
     }
@@ -323,11 +328,15 @@ public class SearchTransportService {
         SearchTask task,
         final SearchActionListener<FetchSearchResult> listener
     ) {
+        // Fetch cost is relatively low and was not originally intended to be governed by
+        // coordinator_timeout. A forced coordinator_timeout is added as a safeguard against
+        // unexpected host hangs.
         transportService.sendChildRequest(
             connection,
             action,
             request,
             task,
+            getTransportRequestOptions(task),
             new ConnectionCountingHandler<>(listener, FetchSearchResult::new, clientConnections, connection.getNode().getId())
         );
     }
@@ -337,13 +346,24 @@ public class SearchTransportService {
      */
     void sendExecuteMultiSearch(final MultiSearchRequest request, SearchTask task, final ActionListener<MultiSearchResponse> listener) {
         final Transport.Connection connection = transportService.getConnection(transportService.getLocalNode());
+        // Expand and field-collapsing sub queries run as inline supplementary queries after the main top-N results are retrieved.
+        // Similar to the fetch phase, added as a safeguard against unexpected host hangs.
         transportService.sendChildRequest(
             connection,
             MultiSearchAction.NAME,
             request,
             task,
+            getTransportRequestOptions(task),
             new ConnectionCountingHandler<>(listener, MultiSearchResponse::new, clientConnections, connection.getNode().getId())
         );
+    }
+
+    static TransportRequestOptions getTransportRequestOptions(SearchTask task) {
+        if (task.coordinatorTimeoutEnabled()) {
+            return TransportRequestOptions.builder().withTimeout(task.timeout()).build();
+        } else {
+            return TransportRequestOptions.EMPTY;
+        }
     }
 
     public RemoteClusterService getRemoteClusterService() {
@@ -773,6 +793,50 @@ public class SearchTransportService {
             // Always return true, there is additional asserting here, the boolean is just so this
             // can be skipped when assertions are not enabled
             return true;
+        }
+    }
+
+    /**
+     * Coordinator timeout strategy when search coordinator timeout is enabled.
+     *
+     * @opensearch.api
+     */
+    @PublicApi(since = "3.8.0")
+    public enum CoordinatorTimeoutStrategy {
+        /** Fail the request if the coordinator times out. */
+        FAIL("fail");
+        // TODO retry strategy
+        // RETRY("retry");
+
+        private final String type;
+
+        public String getType() {
+            return type;
+        }
+
+        CoordinatorTimeoutStrategy(String type) {
+            this.type = type;
+        }
+
+        private static final Map<String, CoordinatorTimeoutStrategy> TYPE_MAP;
+
+        static {
+            Map<String, CoordinatorTimeoutStrategy> typeMap = new HashMap<>();
+            for (CoordinatorTimeoutStrategy threadPoolType : CoordinatorTimeoutStrategy.values()) {
+                typeMap.put(threadPoolType.getType(), threadPoolType);
+            }
+            TYPE_MAP = Collections.unmodifiableMap(typeMap);
+        }
+
+        public static CoordinatorTimeoutStrategy fromType(String typeString) {
+            if (typeString == null) {
+                return null;
+            }
+            CoordinatorTimeoutStrategy type = TYPE_MAP.get(typeString);
+            if (type == null) {
+                throw new IllegalArgumentException("no CoordinatorTimeoutStrategy for " + typeString);
+            }
+            return type;
         }
     }
 }

--- a/server/src/main/java/org/opensearch/rest/action/search/RestMultiSearchAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/search/RestMultiSearchAction.java
@@ -157,6 +157,7 @@ public class RestMultiSearchAction extends BaseRestHandler {
             multiRequest.add(searchRequest);
         });
         List<SearchRequest> requests = multiRequest.requests();
+        final String coordinatorTimeoutStrategy = restRequest.param(SearchRequest.COORDINATOR_TIMEOUT_STRATEGY);
         final TimeValue cancelAfterTimeInterval = restRequest.paramAsTime("cancel_after_time_interval", null);
         for (SearchRequest request : requests) {
             // preserve if it's set on the request
@@ -170,6 +171,9 @@ public class RestMultiSearchAction extends BaseRestHandler {
             // multi search request level will be used
             if (request.getCancelAfterTimeInterval() == null) {
                 request.setCancelAfterTimeInterval(cancelAfterTimeInterval);
+            }
+            if (coordinatorTimeoutStrategy != null && request.coordinatorTimeoutStrategy() == null) {
+                request.setCoordinatorTimeoutStrategy(coordinatorTimeoutStrategy);
             }
         }
         return multiRequest;

--- a/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
@@ -254,6 +254,9 @@ public class RestSearchAction extends BaseRestHandler {
         }
 
         searchRequest.setCancelAfterTimeInterval(request.paramAsTime("cancel_after_time_interval", null));
+        if (request.hasParam(SearchRequest.COORDINATOR_TIMEOUT_STRATEGY)) {
+            searchRequest.setCoordinatorTimeoutStrategy(request.param(SearchRequest.COORDINATOR_TIMEOUT_STRATEGY));
+        }
     }
 
     /**

--- a/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
@@ -36,11 +36,13 @@ import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.OriginalIndices;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.GroupShardsIterator;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.AtomicArray;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.util.set.Sets;
@@ -55,6 +57,7 @@ import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.shard.ShardNotFoundException;
 import org.opensearch.search.SearchPhaseResult;
 import org.opensearch.search.SearchShardTarget;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.internal.AliasFilter;
 import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.search.internal.ShardSearchContextId;
@@ -65,6 +68,7 @@ import org.opensearch.test.InternalAggregationTestCase;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.ReceiveTimeoutTransportException;
 import org.opensearch.transport.Transport;
 import org.junit.After;
 import org.junit.Before;
@@ -89,6 +93,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.stream.IntStream;
 
+import org.mockito.Mockito;
+
+import static org.opensearch.action.search.SearchTransportService.QUERY_ACTION_NAME;
 import static org.opensearch.tasks.TaskResourceTrackingService.TASK_RESOURCE_USAGE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -138,6 +145,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             false,
             expected,
             resourceUsage,
+            false,
             new SearchShardIterator(null, null, Collections.emptyList(), null)
         );
     }
@@ -151,6 +159,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
         final boolean catchExceptionWhenExecutePhaseOnShard,
         final AtomicLong expected,
         final TaskResourceUsage resourceUsage,
+        final boolean blockTheFirstQueryPhase,
         final SearchShardIterator... shards
     ) {
 
@@ -179,7 +188,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             .setNodeId(randomAlphaOfLengthBetween(1, 5))
             .build();
         threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, taskResourceInfo.toString());
-
+        AtomicBoolean firstShard = new AtomicBoolean(true);
         return new AbstractSearchAsyncAction<SearchPhaseResult>(
             "test",
             logger,
@@ -207,7 +216,17 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
         ) {
             @Override
             protected SearchPhase getNextPhase(final SearchPhaseResults<SearchPhaseResult> results, SearchPhaseContext context) {
-                return null;
+                if (blockTheFirstQueryPhase) {
+                    return new SearchPhase("test") {
+                        @Override
+                        public void run() {
+                            listener.onResponse(new SearchResponse(null, null, 0, 0, 0, 0, null, null));
+                            assertingListener.onPhaseEnd(context, null);
+                        }
+                    };
+                } else {
+                    return null;
+                }
             }
 
             @Override
@@ -218,6 +237,16 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             ) {
                 if (failExecutePhaseOnShard) {
                     listener.onFailure(new ShardNotFoundException(shardIt.shardId()));
+                } else if (blockTheFirstQueryPhase && firstShard.compareAndSet(true, false)) {
+                    // Sleep and throw ReceiveTimeoutTransportException to simulate node blocked
+                    try {
+                        Thread.sleep(request.source().timeout().millis());
+                    } catch (InterruptedException e) {}
+                    DiscoveryNode node = Mockito.mock(DiscoveryNode.class);
+                    Mockito.when(node.getName()).thenReturn("test_nodes");
+                    listener.onFailure(
+                        new ReceiveTimeoutTransportException(node, QUERY_ACTION_NAME, "request_id [171] timed out after [413ms]")
+                    );
                 } else {
                     if (catchExceptionWhenExecutePhaseOnShard) {
                         try {
@@ -227,6 +256,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
                         }
                     } else {
                         listener.onResponse(new QuerySearchResult());
+
                     }
                 }
             }
@@ -587,6 +617,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             false,
             new AtomicLong(),
             new TaskResourceUsage(randomLong(), randomLong()),
+            false,
             shards
         );
         action.run();
@@ -635,6 +666,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             false,
             new AtomicLong(),
             new TaskResourceUsage(randomLong(), randomLong()),
+            false,
             shards
         );
         action.run();
@@ -688,6 +720,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             catchExceptionWhenExecutePhaseOnShard,
             new AtomicLong(),
             new TaskResourceUsage(randomLong(), randomLong()),
+            false,
             shards
         );
         action.run();
@@ -792,6 +825,40 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
         );
         assertEquals(1, testListener.getPhaseTotal(searchDfsQueryThenFetchAsyncAction.getSearchPhaseNameOptional().get()));
         assertEquals(0, testListener.getPhaseCurrent(searchDfsQueryThenFetchAsyncAction.getSearchPhaseNameOptional().get()));
+    }
+
+    public void testExecutePhaseOnShardBlockAndRetrunPartialResult() {
+        // on shard is blocked in query phase
+        final Index index = new Index("test", UUID.randomUUID().toString());
+
+        final SearchShardIterator[] shards = IntStream.range(0, 2 + randomInt(4))
+            .mapToObj(i -> new SearchShardIterator(null, new ShardId(index, i), List.of("n1"), null, null, null))
+            .toArray(SearchShardIterator[]::new);
+
+        SearchRequest searchRequest = new SearchRequest().allowPartialSearchResults(true);
+        long timeoutMills = 500;
+        searchRequest.source(new SearchSourceBuilder().timeout(new TimeValue(timeoutMills, TimeUnit.MILLISECONDS)));
+        searchRequest.setCoordinatorTimeoutStrategy(SearchTransportService.CoordinatorTimeoutStrategy.FAIL.getType());
+        searchRequest.setMaxConcurrentShardRequests(shards.length);
+        final AtomicBoolean successed = new AtomicBoolean(false);
+        long current = System.currentTimeMillis();
+
+        final ArraySearchPhaseResults<SearchPhaseResult> queryResult = new ArraySearchPhaseResults<>(shards.length);
+        AbstractSearchAsyncAction<SearchPhaseResult> action = createAction(searchRequest, queryResult, new ActionListener<>() {
+            @Override
+            public void onResponse(SearchResponse response) {
+                successed.set(true);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                successed.set(false);
+            }
+        }, false, false, false, new AtomicLong(), new TaskResourceUsage(randomLong(), randomLong()), true, shards);
+        action.run();
+        long s = System.currentTimeMillis() - current;
+        assertTrue(s > timeoutMills);
+        assertTrue(successed.get());
     }
 
     private SearchDfsQueryThenFetchAsyncAction createSearchDfsQueryThenFetchAsyncAction(

--- a/server/src/test/java/org/opensearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/search/MultiSearchRequestTests.java
@@ -33,6 +33,7 @@
 package org.opensearch.action.search;
 
 import org.opensearch.Version;
+import org.opensearch.action.search.SearchTransportService.CoordinatorTimeoutStrategy;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.common.CheckedBiConsumer;
 import org.opensearch.common.CheckedRunnable;
@@ -178,6 +179,48 @@ public class MultiSearchRequestTests extends OpenSearchTestCase {
         assertThat(request.requests().size(), equalTo(1));
         assertThat(request.requests().get(0).indices()[0], equalTo("test"));
         assertEquals(new TimeValue(20, TimeUnit.SECONDS), request.requests().get(0).getCancelAfterTimeInterval());
+    }
+
+    public void testCoordinatorTimeoutStrategyAtParentAndChildRequest() throws IOException {
+        final String requestContent = "{\"index\":\"test\", \"expand_wildcards\" : \"open,closed\", "
+            + "\"coordinator_timeout_strategy\" : \"fail\"}\r\n"
+            + "{\"query\" : {\"match_all\" :{}}}\r\n {\"search_type\" : \"dfs_query_then_fetch\"}\n"
+            + "{\"query\" : {\"match_all\" :{}}}\r\n";
+        FakeRestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry()).withContent(
+            new BytesArray(requestContent),
+            XContentType.JSON
+        ).withParams(Collections.singletonMap(SearchRequest.COORDINATOR_TIMEOUT_STRATEGY, "fail")).build();
+        MultiSearchRequest request = RestMultiSearchAction.parseRequest(restRequest, null, true);
+        assertThat(request.requests().size(), equalTo(2));
+        assertEquals(CoordinatorTimeoutStrategy.FAIL, request.requests().get(0).coordinatorTimeoutStrategy());
+        assertEquals(CoordinatorTimeoutStrategy.FAIL, request.requests().get(1).coordinatorTimeoutStrategy());
+    }
+
+    public void testOnlyParentMSearchRequestWithCoordinatorTimeoutStrategyParameter() throws IOException {
+        final String requestContent = "{\"index\":\"test\", \"expand_wildcards\" : \"open,closed\"}}\r\n"
+            + "{\"query\" : {\"match_all\" :{}}}\r\n";
+        FakeRestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry()).withContent(
+            new BytesArray(requestContent),
+            XContentType.JSON
+        ).withParams(Collections.singletonMap(SearchRequest.COORDINATOR_TIMEOUT_STRATEGY, "fail")).build();
+        MultiSearchRequest request = RestMultiSearchAction.parseRequest(restRequest, null, true);
+        assertThat(request.requests().size(), equalTo(1));
+        assertThat(request.requests().get(0).indices()[0], equalTo("test"));
+        assertEquals(CoordinatorTimeoutStrategy.FAIL, request.requests().get(0).coordinatorTimeoutStrategy());
+    }
+
+    public void testWriteSearchRequestParamsWithCoordinatorTimeoutStrategy() throws IOException {
+        SearchRequest request = new SearchRequest();
+        request.setCoordinatorTimeoutStrategy(CoordinatorTimeoutStrategy.FAIL.getType());
+        try (XContentBuilder builder = JsonXContent.contentBuilder()) {
+            MultiSearchRequest.writeSearchRequestParams(request, builder);
+            Map<String, Object> map = XContentHelper.convertToMap(
+                MediaTypeRegistry.JSON.xContent(),
+                BytesReference.bytes(builder).streamInput(),
+                false
+            );
+            assertEquals("fail", map.get(SearchRequest.COORDINATOR_TIMEOUT_STRATEGY));
+        }
     }
 
     public void testDefaultIndicesOptions() throws IOException {

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
@@ -34,6 +34,7 @@ package org.opensearch.action.search;
 
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.search.SearchTransportService.CoordinatorTimeoutStrategy;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.ArrayUtils;
@@ -385,12 +386,61 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         }
     }
 
+    public void testCoordinatorTimeoutStrategyResolvesTaskTimeout() {
+        TimeValue timeout = TimeValue.timeValueMillis(100);
+        SearchRequest searchRequest = new SearchRequest().source(new SearchSourceBuilder().timeout(timeout));
+
+        SearchTask defaultTask = (SearchTask) searchRequest.createTask(0, "test", SearchAction.NAME, TaskId.EMPTY_TASK_ID, emptyMap());
+        assertFalse(defaultTask.coordinatorTimeoutEnabled());
+        assertEquals(timeout, defaultTask.timeout());
+
+        searchRequest.setCoordinatorTimeoutStrategy(CoordinatorTimeoutStrategy.FAIL.getType());
+        SearchTask failTask = (SearchTask) searchRequest.createTask(0, "test", SearchAction.NAME, TaskId.EMPTY_TASK_ID, emptyMap());
+        assertTrue(failTask.coordinatorTimeoutEnabled());
+        assertEquals(timeout, failTask.timeout());
+    }
+
     public void testCopyConstructor() throws IOException {
         SearchRequest searchRequest = createSearchRequest();
         SearchRequest deserializedRequest = copyWriteable(searchRequest, namedWriteableRegistry, SearchRequest::new);
         assertEquals(deserializedRequest, searchRequest);
         assertEquals(deserializedRequest.hashCode(), searchRequest.hashCode());
         assertNotSame(deserializedRequest, searchRequest);
+    }
+
+    public void testCoordinatorTimeoutStrategySerialization() throws IOException {
+        SearchRequest searchRequest = new SearchRequest().source(new SearchSourceBuilder().timeout(TimeValue.timeValueMillis(100)));
+        searchRequest.setCoordinatorTimeoutStrategy(CoordinatorTimeoutStrategy.FAIL.getType());
+
+        SearchRequest deserializedRequest = copyWriteable(searchRequest, namedWriteableRegistry, SearchRequest::new);
+        assertEquals(CoordinatorTimeoutStrategy.FAIL, deserializedRequest.coordinatorTimeoutStrategy());
+    }
+
+    public void testCreateTaskDisablesCoordinatorTimeoutForZeroTimeoutValue() {
+        SearchRequest searchRequest = new SearchRequest().source(new SearchSourceBuilder().timeout(TimeValue.ZERO));
+        searchRequest.setCoordinatorTimeoutStrategy("fail");
+
+        SearchTask task = searchRequest.createTask(1L, "transport", SearchAction.NAME, TaskId.EMPTY_TASK_ID, emptyMap());
+
+        assertEquals(TimeValue.ZERO, task.timeout());
+        assertFalse(task.coordinatorTimeoutEnabled());
+    }
+
+    public void testCoordinatorTimeoutSerializationAllowsUnsetStrategy() throws Exception {
+        SearchRequest searchRequest = createSearchRequest();
+        // defect-probing: an optional strategy must remain optional when serialization is enabled.
+        SearchRequest deserializedRequest = copyWriteable(searchRequest, namedWriteableRegistry, SearchRequest::new);
+        assertNull(deserializedRequest.coordinatorTimeoutStrategy());
+    }
+
+    public void testCreateTaskPropagatesCoordinatorTimeoutStrategy() {
+        SearchRequest searchRequest = new SearchRequest().source(new SearchSourceBuilder().timeout(TimeValue.timeValueMillis(100)));
+        searchRequest.setCoordinatorTimeoutStrategy("fail");
+
+        SearchTask task = (SearchTask) searchRequest.createTask(1L, "transport", SearchAction.NAME, TaskId.EMPTY_TASK_ID, emptyMap());
+
+        assertTrue(task.coordinatorTimeoutEnabled());
+        assertEquals(TimeValue.timeValueMillis(100), task.timeout());
     }
 
     public void testParseSearchRequestWithUnsupportedSearchType() throws IOException {
@@ -404,6 +454,16 @@ public class SearchRequestTests extends AbstractSearchTestCase {
             () -> RestSearchAction.parseSearchRequest(searchRequest, restRequest, null, namedWriteableRegistry, setSize)
         );
         assertEquals("Unsupported search type [query_and_fetch]", exception.getMessage());
+    }
+
+    public void testParseSearchRequestWithCoordinatorTimeoutStrategy() throws IOException {
+        RestRequest restRequest = new FakeRestRequest();
+        SearchRequest searchRequest = createSearchRequest();
+        IntConsumer setSize = mock(IntConsumer.class);
+        restRequest.params().put(SearchRequest.COORDINATOR_TIMEOUT_STRATEGY, CoordinatorTimeoutStrategy.FAIL.getType());
+
+        RestSearchAction.parseSearchRequest(searchRequest, restRequest, null, namedWriteableRegistry, setSize);
+        assertEquals(CoordinatorTimeoutStrategy.FAIL, searchRequest.coordinatorTimeoutStrategy());
     }
 
     public void testEqualsAndHashcode() throws IOException {
@@ -447,6 +507,9 @@ public class SearchRequestTests extends AbstractSearchTestCase {
                     : TimeValue.parseTimeValue(randomTimeValue(), null, "cancel_after_time_interval")
             )
         );
+        if (searchRequest.coordinatorTimeoutStrategy() == null) {
+            mutators.add(() -> mutation.setCoordinatorTimeoutStrategy(CoordinatorTimeoutStrategy.FAIL.getType()));
+        }
         randomFrom(mutators).run();
         return mutation;
     }

--- a/test/framework/src/main/java/org/opensearch/test/ParameterizedStaticSettingsOpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/ParameterizedStaticSettingsOpenSearchIntegTestCase.java
@@ -8,16 +8,29 @@
 
 package org.opensearch.test;
 
+import org.apache.logging.log4j.LogManager;
+import org.opensearch.action.bulk.BulkRequestBuilder;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.script.MockScriptPlugin;
+import org.opensearch.search.lookup.LeafFieldsLookup;
 
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_REPLICATION_TYPE_SETTING;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertNoFailures;
+import static org.hamcrest.Matchers.greaterThan;
 
 /**
  * Base class for running the tests with parameterization with static settings: the cluster will be pre-created with the settings at startup, the method
@@ -76,5 +89,80 @@ public abstract class ParameterizedStaticSettingsOpenSearchIntegTestCase extends
 
         final ParameterizedStaticSettingsOpenSearchIntegTestCase other = (ParameterizedStaticSettingsOpenSearchIntegTestCase) obj;
         return Objects.equals(settings, other.settings);
+    }
+
+    protected void indexTestData() {
+        for (int i = 0; i < 5; i++) {
+            // Make sure we have a few segments
+            BulkRequestBuilder bulkRequestBuilder = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            for (int j = 0; j < 20; j++) {
+                bulkRequestBuilder.add(client().prepareIndex("test").setId(Integer.toString(i * 5 + j)).setSource("field", "value"));
+            }
+            assertNoFailures(bulkRequestBuilder.get());
+        }
+    }
+
+    public static class ScriptedBlockPlugin extends MockScriptPlugin {
+        public static final String SCRIPT_NAME = "search_block";
+
+        private final AtomicInteger hits = new AtomicInteger();
+
+        private final AtomicBoolean shouldBlock = new AtomicBoolean(true);
+
+        public void reset() {
+            hits.set(0);
+        }
+
+        public void disableBlock() {
+            shouldBlock.set(false);
+        }
+
+        public void enableBlock() {
+            shouldBlock.set(true);
+        }
+
+        @Override
+        public Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
+            return Collections.singletonMap(SCRIPT_NAME, params -> {
+                LeafFieldsLookup fieldsLookup = (LeafFieldsLookup) params.get("_fields");
+                LogManager.getLogger(ScriptedBlockPlugin.class).info("Blocking on the document {}", fieldsLookup.get("_id"));
+                hits.incrementAndGet();
+                try {
+                    assertBusy(() -> assertFalse(shouldBlock.get()));
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                return true;
+            });
+        }
+    }
+
+    protected void awaitForBlock(List<ScriptedBlockPlugin> plugins) throws Exception {
+        int numberOfShards = getNumShards("test").numPrimaries;
+        assertBusy(() -> {
+            int numberOfBlockedPlugins = 0;
+            for (ScriptedBlockPlugin plugin : plugins) {
+                numberOfBlockedPlugins += plugin.hits.get();
+            }
+            logger.info("The plugin blocked on {} out of {} shards", numberOfBlockedPlugins, numberOfShards);
+            assertThat(numberOfBlockedPlugins, greaterThan(0));
+        });
+    }
+
+    protected void disableBlocks(List<ScriptedBlockPlugin> plugins) throws Exception {
+        for (ScriptedBlockPlugin plugin : plugins) {
+            plugin.disableBlock();
+        }
+    }
+
+    /**
+     * Sleeps for the specified number of milliseconds plus a 100ms buffer to account for system timer/scheduler inaccuracies.
+     *
+     * @param milliseconds The minimum time to sleep
+     * @throws InterruptedException if interrupted during sleep
+     */
+    @SuppressForbidden(reason = "Waiting longer than timeout")
+    protected static void sleepForAtLeast(long milliseconds) throws InterruptedException {
+        Thread.sleep(milliseconds + 100L);
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
In query phase, the coordinate concurrently search each shard, If any shard is blocked or responds very slowly, the coordination node will be stuck even if the timeout is set.

The pr supports timeout waiting, if the timeout is exceeded, the coordinator considers the shard as failed and gos on the fetch phase.

### Related Issues
Resolves #21088, https://github.com/opensearch-project/OpenSearch/issues/817#issuecomment-2039383610
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
