### PR TITLE
Separating remote download and publication stats

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/PublicationTransportHandler.java
@@ -298,9 +298,9 @@ public class PublicationTransportHandler {
             }
         } catch (Exception e) {
             if (applyFullState) {
-                remoteClusterStateService.fullDownloadFailed();
+                remoteClusterStateService.fullIncomingPublicationFailed();
             } else {
-                remoteClusterStateService.diffDownloadFailed();
+                remoteClusterStateService.diffIncomingPublicationFailed();
             }
             throw e;
         }

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -1460,7 +1460,6 @@ public class RemoteClusterStateService implements Closeable {
             newRoutingTable = routingTableDiff.apply(previousState.getRoutingTable());
         }
         clusterStateBuilder.routingTable(newRoutingTable);
-
         return clusterStateBuilder.build();
     }
 
@@ -1470,173 +1469,191 @@ public class RemoteClusterStateService implements Closeable {
         String localNodeId,
         boolean includeEphemeral
     ) throws IOException {
-        ClusterState stateFromCache = remoteClusterStateCache.getState(clusterName, manifest);
-        if (stateFromCache != null) {
-            return stateFromCache;
-        }
-
-        final ClusterState clusterState;
-        final long startTimeNanos = relativeTimeNanosSupplier.getAsLong();
-        if (manifest.onOrAfterCodecVersion(CODEC_V2)) {
-            clusterState = readClusterStateInParallel(
-                ClusterState.builder(new ClusterName(clusterName)).build(),
-                manifest,
-                manifest.getClusterUUID(),
-                localNodeId,
-                manifest.getIndices(),
-                manifest.getCustomMetadataMap(),
-                manifest.getCoordinationMetadata() != null,
-                manifest.getSettingsMetadata() != null,
-                includeEphemeral && manifest.getTransientSettingsMetadata() != null,
-                manifest.getTemplatesMetadata() != null,
-                includeEphemeral && manifest.getDiscoveryNodesMetadata() != null,
-                includeEphemeral && manifest.getClusterBlocksMetadata() != null,
-                includeEphemeral ? manifest.getIndicesRouting() : emptyList(),
-                includeEphemeral && manifest.getHashesOfConsistentSettings() != null,
-                includeEphemeral ? manifest.getClusterStateCustomMap() : emptyMap(),
-                false,
-                includeEphemeral
-            );
-
-            if (includeEphemeral
-                && !remoteClusterStateValidationMode.equals(RemoteClusterStateValidationMode.NONE)
-                && manifest.getClusterStateChecksum() != null) {
-                validateClusterStateFromChecksum(manifest, clusterState, clusterName, localNodeId, true);
+        try {
+            ClusterState stateFromCache = remoteClusterStateCache.getState(clusterName, manifest);
+            if (stateFromCache != null) {
+                return stateFromCache;
             }
-        } else {
-            ClusterState state = readClusterStateInParallel(
-                ClusterState.builder(new ClusterName(clusterName)).build(),
-                manifest,
-                manifest.getClusterUUID(),
-                localNodeId,
-                manifest.getIndices(),
-                // for manifest codec V1, we don't have the following objects to read, so not passing anything
-                emptyMap(),
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                emptyList(),
-                false,
-                emptyMap(),
-                false,
-                false
-            );
-            Metadata.Builder mb = Metadata.builder(remoteGlobalMetadataManager.getGlobalMetadata(manifest.getClusterUUID(), manifest));
-            mb.indices(state.metadata().indices());
-            clusterState = ClusterState.builder(state).metadata(mb).build();
+
+            final ClusterState clusterState;
+            final long startTimeNanos = relativeTimeNanosSupplier.getAsLong();
+            if (manifest.onOrAfterCodecVersion(CODEC_V2)) {
+                clusterState = readClusterStateInParallel(
+                    ClusterState.builder(new ClusterName(clusterName)).build(),
+                    manifest,
+                    manifest.getClusterUUID(),
+                    localNodeId,
+                    manifest.getIndices(),
+                    manifest.getCustomMetadataMap(),
+                    manifest.getCoordinationMetadata() != null,
+                    manifest.getSettingsMetadata() != null,
+                    includeEphemeral && manifest.getTransientSettingsMetadata() != null,
+                    manifest.getTemplatesMetadata() != null,
+                    includeEphemeral && manifest.getDiscoveryNodesMetadata() != null,
+                    includeEphemeral && manifest.getClusterBlocksMetadata() != null,
+                    includeEphemeral ? manifest.getIndicesRouting() : emptyList(),
+                    includeEphemeral && manifest.getHashesOfConsistentSettings() != null,
+                    includeEphemeral ? manifest.getClusterStateCustomMap() : emptyMap(),
+                    false,
+                    includeEphemeral
+                );
+
+                if (includeEphemeral
+                    && !remoteClusterStateValidationMode.equals(RemoteClusterStateValidationMode.NONE)
+                    && manifest.getClusterStateChecksum() != null) {
+                    validateClusterStateFromChecksum(manifest, clusterState, clusterName, localNodeId, true);
+                }
+            } else {
+                ClusterState state = readClusterStateInParallel(
+                    ClusterState.builder(new ClusterName(clusterName)).build(),
+                    manifest,
+                    manifest.getClusterUUID(),
+                    localNodeId,
+                    manifest.getIndices(),
+                    // for manifest codec V1, we don't have the following objects to read, so not passing anything
+                    emptyMap(),
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    emptyList(),
+                    false,
+                    emptyMap(),
+                    false,
+                    false
+                );
+                Metadata.Builder mb = Metadata.builder(remoteGlobalMetadataManager.getGlobalMetadata(manifest.getClusterUUID(), manifest));
+                mb.indices(state.metadata().indices());
+                clusterState = ClusterState.builder(state).metadata(mb).build();
+            }
+            final long durationMillis = TimeValue.nsecToMSec(relativeTimeNanosSupplier.getAsLong() - startTimeNanos);
+            remoteStateStats.stateFullDownloadSucceeded();
+            remoteStateStats.stateFullDownloadTook(durationMillis);
+            if (includeEphemeral) {
+                // cache only if the entire cluster-state is present
+                remoteClusterStateCache.putState(clusterState);
+            }
+            return clusterState;
+        } catch (Exception e) {
+            logger.error("Failure in downloading full cluster state. ", e);
+            remoteStateStats.stateFullDownloadFailed();
+            throw e;
         }
-        final long durationMillis = TimeValue.nsecToMSec(relativeTimeNanosSupplier.getAsLong() - startTimeNanos);
-        remoteStateStats.stateFullDownloadSucceeded();
-        remoteStateStats.stateFullDownloadTook(durationMillis);
-        if (includeEphemeral) {
-            // cache only if the entire cluster-state is present
-            remoteClusterStateCache.putState(clusterState);
-        }
-        return clusterState;
     }
 
     public ClusterState getClusterStateUsingDiff(ClusterMetadataManifest manifest, ClusterState previousState, String localNodeId) {
-        assert manifest.getDiffManifest() != null : "Diff manifest null which is required for downloading cluster state";
-        final long startTimeNanos = relativeTimeNanosSupplier.getAsLong();
-        ClusterStateDiffManifest diff = manifest.getDiffManifest();
-        boolean includeEphemeral = true;
+        try {
+            assert manifest.getDiffManifest() != null : "Diff manifest null which is required for downloading cluster state";
+            final long startTimeNanos = relativeTimeNanosSupplier.getAsLong();
+            ClusterStateDiffManifest diff = manifest.getDiffManifest();
+            boolean includeEphemeral = true;
 
-        List<UploadedIndexMetadata> updatedIndices = diff.getIndicesUpdated().stream().map(idx -> {
-            Optional<UploadedIndexMetadata> uploadedIndexMetadataOptional = manifest.getIndices()
-                .stream()
-                .filter(idx2 -> idx2.getIndexName().equals(idx))
-                .findFirst();
-            assert uploadedIndexMetadataOptional.isPresent() == true;
-            return uploadedIndexMetadataOptional.get();
-        }).collect(Collectors.toList());
+            List<UploadedIndexMetadata> updatedIndices = diff.getIndicesUpdated().stream().map(idx -> {
+                Optional<UploadedIndexMetadata> uploadedIndexMetadataOptional = manifest.getIndices()
+                    .stream()
+                    .filter(idx2 -> idx2.getIndexName().equals(idx))
+                    .findFirst();
+                assert uploadedIndexMetadataOptional.isPresent() == true;
+                return uploadedIndexMetadataOptional.get();
+            }).collect(Collectors.toList());
 
-        Map<String, UploadedMetadataAttribute> updatedCustomMetadata = new HashMap<>();
-        if (diff.getCustomMetadataUpdated() != null) {
-            for (String customType : diff.getCustomMetadataUpdated()) {
-                updatedCustomMetadata.put(customType, manifest.getCustomMetadataMap().get(customType));
+            Map<String, UploadedMetadataAttribute> updatedCustomMetadata = new HashMap<>();
+            if (diff.getCustomMetadataUpdated() != null) {
+                for (String customType : diff.getCustomMetadataUpdated()) {
+                    updatedCustomMetadata.put(customType, manifest.getCustomMetadataMap().get(customType));
+                }
             }
-        }
-        Map<String, UploadedMetadataAttribute> updatedClusterStateCustom = new HashMap<>();
-        if (diff.getClusterStateCustomUpdated() != null) {
-            for (String customType : diff.getClusterStateCustomUpdated()) {
-                updatedClusterStateCustom.put(customType, manifest.getClusterStateCustomMap().get(customType));
+            Map<String, UploadedMetadataAttribute> updatedClusterStateCustom = new HashMap<>();
+            if (diff.getClusterStateCustomUpdated() != null) {
+                for (String customType : diff.getClusterStateCustomUpdated()) {
+                    updatedClusterStateCustom.put(customType, manifest.getClusterStateCustomMap().get(customType));
+                }
             }
-        }
 
-        List<UploadedIndexMetadata> updatedIndexRouting = new ArrayList<>();
-        if (manifest.getCodecVersion() == CODEC_V2 || manifest.getCodecVersion() == CODEC_V3) {
-            updatedIndexRouting.addAll(
-                remoteRoutingTableService.getUpdatedIndexRoutingTableMetadata(diff.getIndicesRoutingUpdated(), manifest.getIndicesRouting())
+            List<UploadedIndexMetadata> updatedIndexRouting = new ArrayList<>();
+            if (manifest.getCodecVersion() == CODEC_V2 || manifest.getCodecVersion() == CODEC_V3) {
+                updatedIndexRouting.addAll(
+                    remoteRoutingTableService.getUpdatedIndexRoutingTableMetadata(
+                        diff.getIndicesRoutingUpdated(),
+                        manifest.getIndicesRouting()
+                    )
+                );
+            }
+
+            ClusterState updatedClusterState = readClusterStateInParallel(
+                previousState,
+                manifest,
+                manifest.getClusterUUID(),
+                localNodeId,
+                updatedIndices,
+                updatedCustomMetadata,
+                diff.isCoordinationMetadataUpdated(),
+                diff.isSettingsMetadataUpdated(),
+                diff.isTransientSettingsMetadataUpdated(),
+                diff.isTemplatesMetadataUpdated(),
+                diff.isDiscoveryNodesUpdated(),
+                diff.isClusterBlocksUpdated(),
+                updatedIndexRouting,
+                diff.isHashesOfConsistentSettingsUpdated(),
+                updatedClusterStateCustom,
+                manifest.getDiffManifest() != null
+                    && manifest.getDiffManifest().getIndicesRoutingDiffPath() != null
+                    && !manifest.getDiffManifest().getIndicesRoutingDiffPath().isEmpty(),
+                includeEphemeral
             );
-        }
-
-        ClusterState updatedClusterState = readClusterStateInParallel(
-            previousState,
-            manifest,
-            manifest.getClusterUUID(),
-            localNodeId,
-            updatedIndices,
-            updatedCustomMetadata,
-            diff.isCoordinationMetadataUpdated(),
-            diff.isSettingsMetadataUpdated(),
-            diff.isTransientSettingsMetadataUpdated(),
-            diff.isTemplatesMetadataUpdated(),
-            diff.isDiscoveryNodesUpdated(),
-            diff.isClusterBlocksUpdated(),
-            updatedIndexRouting,
-            diff.isHashesOfConsistentSettingsUpdated(),
-            updatedClusterStateCustom,
-            manifest.getDiffManifest() != null
-                && manifest.getDiffManifest().getIndicesRoutingDiffPath() != null
-                && !manifest.getDiffManifest().getIndicesRoutingDiffPath().isEmpty(),
-            includeEphemeral
-        );
-        ClusterState.Builder clusterStateBuilder = ClusterState.builder(updatedClusterState);
-        Metadata.Builder metadataBuilder = Metadata.builder(updatedClusterState.metadata());
-        // remove the deleted indices from the metadata
-        for (String index : diff.getIndicesDeleted()) {
-            metadataBuilder.remove(index);
-        }
-        // remove the deleted metadata customs from the metadata
-        if (diff.getCustomMetadataDeleted() != null) {
-            for (String customType : diff.getCustomMetadataDeleted()) {
-                metadataBuilder.removeCustom(customType);
+            ClusterState.Builder clusterStateBuilder = ClusterState.builder(updatedClusterState);
+            Metadata.Builder metadataBuilder = Metadata.builder(updatedClusterState.metadata());
+            // remove the deleted indices from the metadata
+            for (String index : diff.getIndicesDeleted()) {
+                metadataBuilder.remove(index);
             }
-        }
-
-        // remove the deleted cluster state customs from the metadata
-        if (diff.getClusterStateCustomDeleted() != null) {
-            for (String customType : diff.getClusterStateCustomDeleted()) {
-                clusterStateBuilder.removeCustom(customType);
+            // remove the deleted metadata customs from the metadata
+            if (diff.getCustomMetadataDeleted() != null) {
+                for (String customType : diff.getCustomMetadataDeleted()) {
+                    metadataBuilder.removeCustom(customType);
+                }
             }
-        }
 
-        HashMap<String, IndexRoutingTable> indexRoutingTables = new HashMap<>(updatedClusterState.getRoutingTable().getIndicesRouting());
-        if (manifest.getCodecVersion() == CODEC_V2 || manifest.getCodecVersion() == CODEC_V3) {
-            for (String indexName : diff.getIndicesRoutingDeleted()) {
-                indexRoutingTables.remove(indexName);
+            // remove the deleted cluster state customs from the metadata
+            if (diff.getClusterStateCustomDeleted() != null) {
+                for (String customType : diff.getClusterStateCustomDeleted()) {
+                    clusterStateBuilder.removeCustom(customType);
+                }
             }
-        }
 
-        ClusterState clusterState = clusterStateBuilder.stateUUID(manifest.getStateUUID())
-            .version(manifest.getStateVersion())
-            .metadata(metadataBuilder)
-            .routingTable(new RoutingTable(manifest.getRoutingTableVersion(), indexRoutingTables))
-            .build();
-        if (!remoteClusterStateValidationMode.equals(RemoteClusterStateValidationMode.NONE) && manifest.getClusterStateChecksum() != null) {
-            validateClusterStateFromChecksum(manifest, clusterState, previousState.getClusterName().value(), localNodeId, false);
-        }
-        final long durationMillis = TimeValue.nsecToMSec(relativeTimeNanosSupplier.getAsLong() - startTimeNanos);
-        remoteStateStats.stateDiffDownloadSucceeded();
-        remoteStateStats.stateDiffDownloadTook(durationMillis);
+            HashMap<String, IndexRoutingTable> indexRoutingTables = new HashMap<>(
+                updatedClusterState.getRoutingTable().getIndicesRouting()
+            );
+            if (manifest.getCodecVersion() == CODEC_V2 || manifest.getCodecVersion() == CODEC_V3) {
+                for (String indexName : diff.getIndicesRoutingDeleted()) {
+                    indexRoutingTables.remove(indexName);
+                }
+            }
 
-        assert includeEphemeral == true;
-        // newState includes all the fields of cluster-state (includeEphemeral=true always)
-        remoteClusterStateCache.putState(clusterState);
-        return clusterState;
+            ClusterState clusterState = clusterStateBuilder.stateUUID(manifest.getStateUUID())
+                .version(manifest.getStateVersion())
+                .metadata(metadataBuilder)
+                .routingTable(new RoutingTable(manifest.getRoutingTableVersion(), indexRoutingTables))
+                .build();
+            if (!remoteClusterStateValidationMode.equals(RemoteClusterStateValidationMode.NONE)
+                && manifest.getClusterStateChecksum() != null) {
+                validateClusterStateFromChecksum(manifest, clusterState, previousState.getClusterName().value(), localNodeId, false);
+            }
+            final long durationMillis = TimeValue.nsecToMSec(relativeTimeNanosSupplier.getAsLong() - startTimeNanos);
+            remoteStateStats.stateDiffDownloadSucceeded();
+            remoteStateStats.stateDiffDownloadTook(durationMillis);
+
+            assert includeEphemeral == true;
+            // newState includes all the fields of cluster-state (includeEphemeral=true always)
+            remoteClusterStateCache.putState(clusterState);
+            return clusterState;
+        } catch (Exception e) {
+            logger.error("Failure in downloading diff cluster state. ", e);
+            remoteStateStats.stateDiffDownloadFailed();
+            throw e;
+        }
     }
 
     void validateClusterStateFromChecksum(
@@ -2034,6 +2051,14 @@ public class RemoteClusterStateService implements Closeable {
 
     public void diffDownloadFailed() {
         remoteStateStats.stateDiffDownloadFailed();
+    }
+
+    public void fullIncomingPublicationFailed() {
+        remoteStateStats.stateFullIncomingPublicationFailed();
+    }
+
+    public void diffIncomingPublicationFailed() {
+        remoteStateStats.stateDiffIncomingPublicationFailed();
     }
 
     RemoteClusterStateCache getRemoteClusterStateCache() {

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteDownloadStats.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteDownloadStats.java
@@ -20,10 +20,13 @@ import java.util.concurrent.atomic.AtomicLong;
 public class RemoteDownloadStats extends PersistedStateStats {
     static final String CHECKSUM_VALIDATION_FAILED_COUNT = "checksum_validation_failed_count";
     private AtomicLong checksumValidationFailedCount = new AtomicLong(0);
+    static final String INCOMING_PUBLICATION_FAILED_COUNT = "incoming_publication_failed_count";
+    private AtomicLong incomingPublicationFailedCount = new AtomicLong(0);
 
     public RemoteDownloadStats(String statsName) {
         super(statsName);
         addToExtendedFields(CHECKSUM_VALIDATION_FAILED_COUNT, checksumValidationFailedCount);
+        addToExtendedFields(INCOMING_PUBLICATION_FAILED_COUNT, incomingPublicationFailedCount);
     }
 
     public void checksumValidationFailedCount() {
@@ -32,5 +35,13 @@ public class RemoteDownloadStats extends PersistedStateStats {
 
     public long getChecksumValidationFailedCount() {
         return checksumValidationFailedCount.get();
+    }
+
+    public void incomingPublicationFailedCount() {
+        incomingPublicationFailedCount.incrementAndGet();
+    }
+
+    public long getIncomingPublicationFailedCount() {
+        return incomingPublicationFailedCount.get();
     }
 }

--- a/server/src/main/java/org/opensearch/gateway/remote/RemotePersistenceStats.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemotePersistenceStats.java
@@ -106,6 +106,14 @@ public class RemotePersistenceStats {
         return remoteFullDownloadStats.getChecksumValidationFailedCount();
     }
 
+    public void stateDiffIncomingPublicationFailed() {
+        remoteDiffDownloadStats.incomingPublicationFailedCount();
+    }
+
+    public void stateFullIncomingPublicationFailed() {
+        remoteFullDownloadStats.incomingPublicationFailedCount();
+    }
+
     public PersistedStateStats getUploadStats() {
         return remoteUploadStats;
     }


### PR DESCRIPTION
### Description
- Moved remote download failure stat to the RemoteClusterStateService download methods.
-  Added new stat for remote publication failure during download.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
