### PR TITLE
Make timezone in "strict_date_time" format optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support prefix list for remote repository attributes([#16271](https://github.com/opensearch-project/OpenSearch/pull/16271))
 - Add new configuration setting `synonym_analyzer`, to the `synonym` and `synonym_graph` filters, enabling the specification of a custom analyzer for reading the synonym file ([#16488](https://github.com/opensearch-project/OpenSearch/pull/16488)).
 - Add stats for remote publication failure and move download failure stats to remote methods([#16682](https://github.com/opensearch-project/OpenSearch/pull/16682/))
+- Make timezone optional for strict_date_time format ([#16701](https://github.com/opensearch-project/OpenSearch/pull/16701))
 
 ### Dependencies
 - Bump `com.google.cloud:google-cloud-core-http` from 2.23.0 to 2.47.0 ([#16504](https://github.com/opensearch-project/OpenSearch/pull/16504))

--- a/server/src/main/java/org/opensearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/opensearch/common/time/DateFormatters.java
@@ -732,6 +732,8 @@ public class DateFormatters {
     /*
      * Returns a formatter that combines a full date and time, separated by a 'T'
      * (uuuu-MM-dd'T'HH:mm:ss.SSSZZ).
+     * Timezone is optional and defaults to UTC,
+     * as Python's isoformat() can outputs ISO 8601-compliant dates that lack a timezone.
      */
     private static final DateFormatter STRICT_DATE_TIME = new JavaDateFormatter(
         "strict_date_time",
@@ -741,7 +743,9 @@ public class DateFormatters {
             .toFormatter(Locale.ROOT)
             .withResolverStyle(ResolverStyle.STRICT),
         new DateTimeFormatterBuilder().append(STRICT_DATE_FORMATTER)
+            .optionalStart()
             .append(TIME_ZONE_FORMATTER_NO_COLON)
+            .optionalEnd()
             .toFormatter(Locale.ROOT)
             .withResolverStyle(ResolverStyle.STRICT)
     );

--- a/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
@@ -828,6 +828,22 @@ public class DateFormattersTests extends OpenSearchTestCase {
         }
     }
 
+    public void testStrictDateTimeDefaultsToUTC() {
+        DateFormatter dateFormatter = DateFormatter.forPattern("strict_date_time");
+        // "strict_date_time" formatter should be able to parse with and without a timezone specified, as both are valid in ISO 8601
+        // See https://github.com/opensearch-project/OpenSearch/issues/16673
+        assertEquals(
+            ZonedDateTime.of(2024, 11, 21, 0, 0, 0, 0, ZoneOffset.UTC),
+            DateFormatters.from(dateFormatter.parse("2024-11-21T00:00:00Z"))
+        );
+
+        // Should default to UTC without a timezone specified
+        assertEquals(
+            ZonedDateTime.of(2024, 11, 21, 0, 0, 0, 0, ZoneOffset.UTC),
+            DateFormatters.from(dateFormatter.parse("2024-11-21T00:00:00"))
+        );
+    }
+
     void assertDateTimeEquals(String toTest, DateFormatter candidateParser, DateFormatter baselineParser) {
         Instant gotInstant = DateFormatters.from(candidateParser.parse(toTest)).toInstant();
         Instant expectedInstant = DateFormatters.from(baselineParser.parse(toTest)).toInstant();


### PR DESCRIPTION
### Description
Changes `"strict_date_time"` format to make the timezone optional. For example, `2024-06-01T13:38:18.280` was not previously allowed, only `2024-06-01T13:38:18.280Z` or `2024-06-01T13:38:18.280Z+00:00`. If there's no timezone, it defaults to UTC. This is useful as Python's `isoformat()` can output times like this, and they are ISO 8601 compliant. 

Adds UT. Also tested manually with the mapping: 

```
"timestamp":    { 
    "type" : "date", 
    "format":"strict_date_time" 
} 
```
and indexing two documents, one with timestamp "2023-01-01T14:14:14Z" and one with "2023-01-01T14:14:14". In the existing code, the second one failed with `RequestError(400, 'mapper_parsing_exception', "failed to parse field [timestamp] of type [date] in document with id '2'. Preview of field's value: '2023-02-02T14:14:14'")`. 

After this change, both are accepted. 

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/16673

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
