### PR TITLE
Bound the size of cache in deprecation logger

### DIFF
--- a/server/src/test/java/org/opensearch/common/logging/DeprecationLoggerTests.java
+++ b/server/src/test/java/org/opensearch/common/logging/DeprecationLoggerTests.java
@@ -69,4 +69,26 @@ public class DeprecationLoggerTests extends OpenSearchTestCase {
         // assert that only unique warnings are logged
         assertWarnings("Deprecated message 1", "Deprecated message 2", "Deprecated message 3");
     }
+
+    public void testMaximumSizeOfCache() {
+        final int maxEntries = DeprecatedMessage.MAX_DEDUPE_CACHE_ENTRIES;
+        // Fill up the cache, asserting every message is new
+        for (int i = 0; i < maxEntries; i++) {
+            DeprecatedMessage message = new DeprecatedMessage("key-" + i, "message-" + i, "");
+            assertFalse(message.toString(), message.isAlreadyLogged());
+        }
+        // Do the same thing except assert every message has been seen
+        for (int i = 0; i < maxEntries; i++) {
+            DeprecatedMessage message = new DeprecatedMessage("key-" + i, "message-" + i, "");
+            assertTrue(message.toString(), message.isAlreadyLogged());
+        }
+        // Add one more new entry, asserting it is new
+        DeprecatedMessage message = new DeprecatedMessage("key-new", "message-new", "");
+        assertFalse(message.toString(), message.isAlreadyLogged());
+        assertTrue(message.toString(), message.isAlreadyLogged());
+        // Check the first entry added, asserting it has been evicted and is now seen as new
+        DeprecatedMessage message2 = new DeprecatedMessage("key-0", "message-0", "");
+        assertFalse(message2.toString(), message2.isAlreadyLogged());
+        assertTrue(message2.toString(), message2.isAlreadyLogged());
+    }
 }


### PR DESCRIPTION
The current implementation of the map used to de-duplicate deprecation log messages can grow without bound. This replaces the ConcurrentHashMap implementation with an `o.o.common.cache.Cache` implementation configured for a fixed maximum size. To reduce memory overhead, this also changes to storing only a hash of the key instead of the full text since we never need to retrieve the original entry.

### Related Issues
Resolves #16702

### Check List
- [x] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
