### PR TITLE
[Flaky Test] Fix Flaky Test SearchWithRandomExceptionsIT.testRandomExceptions

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomExceptionsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/basic/SearchWithRandomExceptionsIT.java
@@ -193,6 +193,11 @@ public class SearchWithRandomExceptionsIT extends ParameterizedStaticSettingsOpe
                 logger.info("expected SearchPhaseException: [{}]", ex.getMessage());
             }
         }
+
+        // as the index refresh may fail, so the translog in the index will be not flushed,
+        // and `TranslogWriter.buffer` is not null, which causes arrays not been released,
+        // so we need to close the index to release the arrays.
+        cluster().wipeIndices("test");
     }
 
     public static final String EXCEPTION_TOP_LEVEL_RATIO_KEY = "index.engine.exception.ratio.top";


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
As the index refresh may fail, so the translog in the index will be not flushed, and `TranslogWriter.buffer` is not null, which causes arrays not been released, so we need to close the index to release the arrays.

Why `TransportSearchFailuresIT.testFailedSearchWithWrongQuery` is successfully is the refreshing index is successful.

### Related Issues
Resolves #15828
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
