### PR TITLE
[Forwardport][main] Deprecate performing update operation with default pipeline or final pipeline

### DIFF
--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/75_update.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/75_update.yml
@@ -42,8 +42,8 @@ teardown:
 ---
 "update operation with predefined default or final pipeline returns warning header":
   - skip:
-      version:  " - 2.99.99"
-      reason:   "this change is added in 3.0.0"
+      version:  " - 2.18.99"
+      reason:   "this change is added in 2.19.0"
       features: allowed_warnings
   - do:
       index:


### PR DESCRIPTION
Forwardport of https://github.com/opensearch-project/OpenSearch/pull/16756 to `main`