### PR TITLE
Fix allowed_warnings takes no effect for the yaml test in 75_update.yml

### DIFF
--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/75_update.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/75_update.yml
@@ -44,7 +44,7 @@ teardown:
   - skip:
       version:  " - 2.18.99"
       reason:   "this change is added in 2.19.0"
-      features: allowed_warnings
+      features: [warnings, headers]
   - do:
       index:
         index: test_1
@@ -57,7 +57,8 @@ teardown:
   - match: { result:        created }
 
   - do:
-      allowed_warnings:
+      headers: { "X-Opaque-Id": "default_pipeline_request" }
+      warnings:
         - "the index [test_1] has a default ingest pipeline or a final ingest pipeline, the support of the ingest pipelines for update operation causes unexpected result and will be removed in 3.0.0"
       update:
         index:            test_1
@@ -85,7 +86,8 @@ teardown:
   - match: { result:        created }
 
   - do:
-      allowed_warnings:
+      headers: { "X-Opaque-Id": "final_pipeline_request" }
+      warnings:
         - "the index [test_2] has a default ingest pipeline or a final ingest pipeline, the support of the ingest pipelines for update operation causes unexpected result and will be removed in 3.0.0"
       update:
         index:            test_2


### PR DESCRIPTION
### Description

In this [PR](https://github.com/opensearch-project/OpenSearch/pull/16712), we have some yaml tests to verify that the update API can return deprecation warning header under some condition, but by accident, I found that the [`allowed_warnings` command in the second test case](https://github.com/opensearch-project/OpenSearch/blob/ac456430d6159a21a8899a95bc64208f6f4c9eb5/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/75_update.yml#L89) in 75_update.yml takes no effect, change  the warning message to a random string and even remove the `allowed_warnings`, the test case still passes, after diving deep into this, I found the reason is that we only log the deprecation log and return the warning header [once](https://github.com/opensearch-project/OpenSearch/blob/ac456430d6159a21a8899a95bc64208f6f4c9eb5/server/src/main/java/org/opensearch/common/logging/DeprecationLogger.java#L120) for every single `X-Opaque-Id`, both the first update request and second update request in the yaml test file have empty `X-Opaque-Id` header, so the second update request receives no warning header.

This PR fixes this test bug by specifying different `X-Opaque-Id` header for the two update requests and changing the `allowed_warning` command to `warnings` which can verify that the API request really returns warning header.

### Related Issues
No issue.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
