### PR TITLE
[Backport 2.x] Bound the size of cache in deprecation logger (#16724)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix permissions error on scripted query against remote snapshot ([#16544](https://github.com/opensearch-project/OpenSearch/pull/16544))
 - Fix `doc_values` only (`index:false`) IP field searching for masks ([#16628](https://github.com/opensearch-project/OpenSearch/pull/16628))
 - Fix stale cluster state custom file deletion ([#16670](https://github.com/opensearch-project/OpenSearch/pull/16670))
+- Bound the size of cache in deprecation logger ([16702](https://github.com/opensearch-project/OpenSearch/issues/16702))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/common/logging/DeprecationLogger.java
+++ b/server/src/main/java/org/opensearch/common/logging/DeprecationLogger.java
@@ -116,9 +116,12 @@ public class DeprecationLogger {
     public class DeprecationLoggerBuilder {
 
         public DeprecationLoggerBuilder withDeprecation(String key, String msg, Object[] params) {
-            DeprecatedMessage deprecationMessage = new DeprecatedMessage(key, HeaderWarning.getXOpaqueId(), msg, params);
-            if (!deprecationMessage.isAlreadyLogged()) {
-                logger.log(DEPRECATION, deprecationMessage);
+            // Check if the logger is enabled to skip the overhead of deduplicating messages if the logger is disabled
+            if (logger.isEnabled(DEPRECATION)) {
+                DeprecatedMessage deprecationMessage = new DeprecatedMessage(key, HeaderWarning.getXOpaqueId(), msg, params);
+                if (!deprecationMessage.isAlreadyLogged()) {
+                    logger.log(DEPRECATION, deprecationMessage);
+                }
             }
             return this;
         }

--- a/server/src/test/java/org/opensearch/common/logging/DeprecationLoggerTests.java
+++ b/server/src/test/java/org/opensearch/common/logging/DeprecationLoggerTests.java
@@ -69,4 +69,22 @@ public class DeprecationLoggerTests extends OpenSearchTestCase {
         // assert that only unique warnings are logged
         assertWarnings("Deprecated message 1", "Deprecated message 2", "Deprecated message 3");
     }
+
+    public void testMaximumSizeOfCache() {
+        final int maxEntries = DeprecatedMessage.MAX_DEDUPE_CACHE_ENTRIES;
+        // Fill up the cache, asserting every message is new
+        for (int i = 0; i < maxEntries; i++) {
+            DeprecatedMessage message = new DeprecatedMessage("key-" + i, "message-" + i, "");
+            assertFalse(message.toString(), message.isAlreadyLogged());
+        }
+        // Do the same thing except assert every message has been seen
+        for (int i = 0; i < maxEntries; i++) {
+            DeprecatedMessage message = new DeprecatedMessage("key-" + i, "message-" + i, "");
+            assertTrue(message.toString(), message.isAlreadyLogged());
+        }
+        // Add one more new entry, asserting it will forever been seen as already logged (cache is full)
+        DeprecatedMessage message = new DeprecatedMessage("key-new", "message-new", "");
+        assertTrue(message.toString(), message.isAlreadyLogged());
+        assertTrue(message.toString(), message.isAlreadyLogged());
+    }
 }


### PR DESCRIPTION
Backports b1bf72f26e2681e4dbe726bc9605209675f6ab38 from #16724