### PR TITLE
Fix the arithmetic long overflow exception with null date values.

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-    <component name="IssueNavigationConfiguration">
-        <option name="links">
-            <list>
-                <IssueNavigationLink>
-                    <option name="issueRegexp" value="#(\d+)" />
-                    <option name="linkRegexp" value="https://github.com/opensearch-project/OpenSearch/pulls/$1" />
-                </IssueNavigationLink>
-                <IssueNavigationLink>
-                    <option name="issueRegexp" value="#(\d+)" />
-                    <option name="linkRegexp" value="https://github.com/opensearch-project/OpenSearch/issues/$1" />
-                </IssueNavigationLink>
-            </list>
-        </option>
-    </component>
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/opensearch-project/OpenSearch/pulls/$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/opensearch-project/OpenSearch/issues/$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/server/src/main/java/org/opensearch/common/time/DateUtils.java
+++ b/server/src/main/java/org/opensearch/common/time/DateUtils.java
@@ -272,6 +272,16 @@ public class DateUtils {
         return instant;
     }
 
+    public static Instant clampToMillisRange(Instant instant) {
+        if (instant.isBefore(Instant.ofEpochMilli(Long.MIN_VALUE))) {
+            return Instant.ofEpochMilli(Long.MIN_VALUE);
+        }
+        if (instant.isAfter(Instant.ofEpochMilli(Long.MAX_VALUE))) {
+            return Instant.ofEpochMilli(Long.MAX_VALUE);
+        }
+        return instant;
+    }
+
     /**
      * convert a long value to a java time instant
      * the long value resembles the nanoseconds since the epoch

--- a/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
@@ -123,7 +123,7 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
         MILLISECONDS(CONTENT_TYPE, NumericType.DATE) {
             @Override
             public long convert(Instant instant) {
-                return instant.toEpochMilli();
+                return clampToValidRange(instant).toEpochMilli();
             }
 
             @Override
@@ -133,7 +133,7 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
 
             @Override
             public Instant clampToValidRange(Instant instant) {
-                return instant;
+                return DateUtils.clampToMillisRange(instant);
             }
 
             @Override
@@ -612,6 +612,7 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
             if (isSearchable() == false && hasDocValues()) {
                 return Relation.INTERSECTS;
             }
+
             if (dateParser == null) {
                 dateParser = this.dateMathParser;
             }


### PR DESCRIPTION
### Description

- Early termination by checking `PointValues.size()` before any date parsing, If there are no points in the segment, we return DISJOINT immediately.
- Avoid attempting to parse dates when there's no data.
- This prevents the arithmetic overflow that would occur when trying to parse null/empty dates.

**Pending to add unit tests.**

### Related Issues
Related Issue https://github.com/opensearch-project/OpenSearch/issues/16709 and coming from https://github.com/opensearch-project/OpenSearch/issues/16709#issuecomment-2518868424

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
