### PR TITLE
[1.3] Force commons-io transitive dependency version

### DIFF
--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -31,6 +31,7 @@
 apply plugin: 'opensearch.java'
 
 dependencies {
+  api("commons-io:commons-io:2.16.0")
   api("org.apache.hadoop:hadoop-minicluster:3.3.5") {
     exclude module: 'websocket-client'
     exclude module: 'jettison'
@@ -41,6 +42,7 @@ dependencies {
     exclude group: "org.bouncycastle"
     exclude group: "com.squareup.okhttp3"
     exclude group: "org.xerial.snappy"
+    exclude group: "commons-io"
     exclude module: "json-io"
     exclude module: "logback-core"
     exclude module: "logback-classic"
@@ -66,7 +68,9 @@ dependencies {
   api "org.eclipse.jetty.websocket:javax-websocket-server-impl:${versions.jetty}"
   api "ch.qos.logback:logback-core:1.2.13"
   api "ch.qos.logback:logback-classic:1.2.13"
-  api 'org.apache.kerby:kerb-admin:2.0.3'
+  api("org.apache.kerby:kerb-admin:2.0.3") {
+    exclude group: "commons-io"
+  }
   runtimeOnly "com.google.guava:guava:${versions.guava}"
   runtimeOnly("com.squareup.okhttp3:okhttp:4.11.0") {
     exclude group: "com.squareup.okio"


### PR DESCRIPTION
### Description

Forces the transitive dependency on commons-io to a non-impacted version.

Fixes CVE-2024-47554

Note: as a transitive dependency, no SHAs, and the version bump (#16780) is already included in release notes for the OpenSearch bump


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
