### PR TITLE
[Flaky Test] Fix Flaky Test SearchTimeoutIT.testSimpleTimeout

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchTimeoutIT.java
@@ -82,8 +82,7 @@ public class SearchTimeoutIT extends ParameterizedStaticSettingsOpenSearchIntegT
     }
 
     public void testSimpleTimeout() throws Exception {
-        final int numDocs = 1000;
-        for (int i = 0; i < numDocs; i++) {
+        for (int i = 0; i < 32; i++) {
             client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value").get();
         }
         refresh("test");


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
When numDocs=1000:
1. The `testSimpleTimeout` will cost several  minutes, when scoring each doc, it will cost 500ms, it's a long time to iterating all the doc in `queryphase`.
https://github.com/opensearch-project/OpenSearch/blob/5aa65096ff3ca3aec8eb563a8ac52c5e42bf5009/server/src/internalClusterTest/java/org/opensearch/search/SearchTimeoutIT.java#L138
2. `ReaderContext` is created before executing `queryphase` and released after the `fetchphase`.
3. the life time of `ReaderContext` is 1min(determined by `search.keep_alive_interval`)
4. If `queryPhase` costs too much time, the `ReaderContext` may be released before `fetchphase`, so the `fetch/Id` will be failed, which hit the case.
![image](https://github.com/user-attachments/assets/05e80f1b-d99e-4043-8d00-62e0bb6c4b76)

### Related Issues
Resolves #16056 #9401
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
