### PR TITLE
Add verbose pipeline parameter to output each processor's execution details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add stats for remote publication failure and move download failure stats to remote methods([#16682](https://github.com/opensearch-project/OpenSearch/pull/16682/))
 - Update script supports java.lang.String.sha1() and java.lang.String.sha256() methods ([#16923](https://github.com/opensearch-project/OpenSearch/pull/16923))
 - Added a precaution to handle extreme date values during sorting to prevent `arithmetic_exception: long overflow` ([#16812](https://github.com/opensearch-project/OpenSearch/pull/16812)).
+- Add `verbose_pipeline` parameter to output each processor's execution details ([#14745](https://github.com/opensearch-project/OpenSearch/pull/14745)).
 - Add search replica stats to segment replication stats API ([#16678](https://github.com/opensearch-project/OpenSearch/pull/16678))
 - Introduce a setting to disable download of full cluster state from remote on term mismatch([#16798](https://github.com/opensearch-project/OpenSearch/pull/16798/))
 - Added ability to retrieve value from DocValues in a flat_object filed([#16802](https://github.com/opensearch-project/OpenSearch/pull/16802))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add stats for remote publication failure and move download failure stats to remote methods([#16682](https://github.com/opensearch-project/OpenSearch/pull/16682/))
 - Update script supports java.lang.String.sha1() and java.lang.String.sha256() methods ([#16923](https://github.com/opensearch-project/OpenSearch/pull/16923))
 - Added a precaution to handle extreme date values during sorting to prevent `arithmetic_exception: long overflow` ([#16812](https://github.com/opensearch-project/OpenSearch/pull/16812)).
-- Add `verbose_pipeline` parameter to output each processor's execution details ([#14745](https://github.com/opensearch-project/OpenSearch/pull/14745)).
+- Add `verbose_pipeline` parameter to output each processor's execution details ([#16843](https://github.com/opensearch-project/OpenSearch/pull/16843)).
 - Add search replica stats to segment replication stats API ([#16678](https://github.com/opensearch-project/OpenSearch/pull/16678))
 - Introduce a setting to disable download of full cluster state from remote on term mismatch([#16798](https://github.com/opensearch-project/OpenSearch/pull/16798/))
 - Added ability to retrieve value from DocValues in a flat_object filed([#16802](https://github.com/opensearch-project/OpenSearch/pull/16802))

--- a/server/src/main/java/org/opensearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchResponse.java
@@ -74,6 +74,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import static org.opensearch.action.search.SearchResponseSections.EXT_FIELD;
+import static org.opensearch.action.search.SearchResponseSections.PROCESSOR_RESULT_FIELD;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 
 /**
@@ -518,6 +519,11 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
                             }
                             extBuilders.add(searchExtBuilder);
                         }
+                    }
+                } else if (PROCESSOR_RESULT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    while ((token = parser.nextToken()) != Token.END_ARRAY) {
+                        ProcessorExecutionDetail detail = ProcessorExecutionDetail.fromXContent(parser);
+                        processorResult.add(detail);
                     }
                 } else {
                     parser.skipChildren();

--- a/server/src/main/java/org/opensearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchResponse.java
@@ -59,6 +59,7 @@ import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.Aggregations;
 import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.internal.InternalSearchResponse;
+import org.opensearch.search.pipeline.ProcessorExecutionDetail;
 import org.opensearch.search.profile.ProfileShardResult;
 import org.opensearch.search.profile.SearchProfileShardResults;
 import org.opensearch.search.suggest.Suggest;
@@ -394,6 +395,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
         List<ShardSearchFailure> failures = new ArrayList<>();
         Clusters clusters = Clusters.EMPTY;
         List<SearchExtBuilder> extBuilders = new ArrayList<>();
+        List<ProcessorExecutionDetail> processorResult = new ArrayList<>();
         for (Token token = parser.nextToken(); token != Token.END_OBJECT; token = parser.nextToken()) {
             if (token == Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -530,7 +532,8 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
             terminatedEarly,
             profile,
             numReducePhases,
-            extBuilders
+            extBuilders,
+            processorResult
         );
         return new SearchResponse(
             searchResponseSections,

--- a/server/src/main/java/org/opensearch/action/search/SearchResponseSections.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchResponseSections.java
@@ -66,6 +66,7 @@ import java.util.Objects;
 public class SearchResponseSections implements ToXContentFragment {
 
     public static final ParseField EXT_FIELD = new ParseField("ext");
+    public static final ParseField PROCESSOR_RESULT_FIELD = new ParseField("processor_results");
     protected final SearchHits hits;
     protected final Aggregations aggregations;
     protected final Suggest suggest;
@@ -181,7 +182,7 @@ public class SearchResponseSections implements ToXContentFragment {
         }
 
         if (!processorResult.isEmpty()) {
-            builder.field("processor_result", processorResult);
+            builder.field(PROCESSOR_RESULT_FIELD.getPreferredName(), processorResult);
         }
         return builder;
     }

--- a/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
@@ -256,6 +256,9 @@ public class RestSearchAction extends BaseRestHandler {
         if (request.hasParam("timeout")) {
             searchSourceBuilder.timeout(request.paramAsTime("timeout", null));
         }
+        if (request.hasParam("verbose_pipeline")) {
+            searchSourceBuilder.verbosePipeline(request.paramAsBoolean("verbose_pipeline", false));
+        }
         if (request.hasParam("terminate_after")) {
             int terminateAfter = request.paramAsInt("terminate_after", SearchContext.DEFAULT_TERMINATE_AFTER);
             if (terminateAfter < 0) {

--- a/server/src/main/java/org/opensearch/search/SearchHits.java
+++ b/server/src/main/java/org/opensearch/search/SearchHits.java
@@ -37,6 +37,7 @@ import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.TotalHits.Relation;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -164,6 +165,22 @@ public final class SearchHits implements Writeable, ToXContentFragment, Iterable
      */
     public SearchHit[] getHits() {
         return this.hits;
+    }
+
+    /**
+     * Creates a deep copy of this SearchHits instance.
+     *
+     * @return a deep copy of the current SearchHits object
+     * @throws IOException if an I/O exception occurs during serialization or deserialization
+     */
+    public SearchHits deepCopy() throws IOException {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            this.writeTo(out);
+
+            try (StreamInput in = out.bytes().streamInput()) {
+                return new SearchHits(in);
+            }
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -227,7 +227,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
     private String searchPipeline;
 
-    private boolean verbosePipeline = false;
+    private Boolean verbosePipeline = false;
 
     /**
      * Constructs a new search source builder.
@@ -306,8 +306,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             searchPipeline = in.readOptionalString();
         }
         // Todo: change version to 2_19_0
-        if (in.getVersion().onOrAfter(Version.CURRENT)) {
-            verbosePipeline = in.readBoolean();
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            verbosePipeline = in.readOptionalBoolean();
         }
     }
 
@@ -393,8 +393,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             out.writeOptionalString(searchPipeline);
         }
         // Todo: change version to 2_19_0
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {
-            out.writeBoolean(verbosePipeline);
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeOptionalBoolean(verbosePipeline);
         }
     }
 

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -305,6 +305,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         if (in.getVersion().onOrAfter(Version.V_2_18_0)) {
             searchPipeline = in.readOptionalString();
         }
+        // Todo: change version to 2_19_0
         if (in.getVersion().onOrAfter(Version.CURRENT)) {
             verbosePipeline = in.readBoolean();
         }
@@ -391,6 +392,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         if (out.getVersion().onOrAfter(Version.V_2_18_0)) {
             out.writeOptionalString(searchPipeline);
         }
+        // Todo: change version to 2_19_0
         if (out.getVersion().onOrAfter(Version.CURRENT)) {
             out.writeOptionalBoolean(verbosePipeline);
         }

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -227,7 +227,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
     private String searchPipeline;
 
-    private Boolean verbosePipeline;
+    private boolean verbosePipeline = false;
 
     /**
      * Constructs a new search source builder.
@@ -306,7 +306,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             searchPipeline = in.readOptionalString();
         }
         if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
-            verbosePipeline = in.readOptionalBoolean();
+            verbosePipeline = in.readBoolean();
         }
     }
 
@@ -392,7 +392,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             out.writeOptionalString(searchPipeline);
         }
         if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
-            out.writeOptionalBoolean(verbosePipeline);
+            out.writeBoolean(verbosePipeline);
         }
     }
 
@@ -1162,7 +1162,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
      * to track how data flows and transforms through the search pipeline.
      *
      */
-    public SearchSourceBuilder verbosePipeline(boolean verbosePipeline) {
+    public SearchSourceBuilder verbosePipeline(Boolean verbosePipeline) {
         this.verbosePipeline = verbosePipeline;
         return this;
     }
@@ -1674,7 +1674,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             builder.field(SEARCH_PIPELINE.getPreferredName(), searchPipeline);
         }
 
-        if (verbosePipeline != null) {
+        if (verbosePipeline) {
             builder.field(VERBOSE_SEARCH_PIPELINE.getPreferredName(), verbosePipeline);
         }
 

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -227,7 +227,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
     private String searchPipeline;
 
-    private Boolean verbosePipeline = false;
+    private Boolean verbosePipeline;
 
     /**
      * Constructs a new search source builder.
@@ -1167,7 +1167,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         return this;
     }
 
-    public boolean verbosePipeline() {
+    public Boolean verbosePipeline() {
         return verbosePipeline;
     }
 

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -304,6 +304,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         }
         if (in.getVersion().onOrAfter(Version.V_2_18_0)) {
             searchPipeline = in.readOptionalString();
+        }
+        if (in.getVersion().onOrAfter(Version.CURRENT)) {
             verbosePipeline = in.readBoolean();
         }
     }
@@ -388,6 +390,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         }
         if (out.getVersion().onOrAfter(Version.V_2_18_0)) {
             out.writeOptionalString(searchPipeline);
+        }
+        if (out.getVersion().onOrAfter(Version.CURRENT)) {
             out.writeOptionalBoolean(verbosePipeline);
         }
     }

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -136,6 +136,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     public static final ParseField SLICE = new ParseField("slice");
     public static final ParseField POINT_IN_TIME = new ParseField("pit");
     public static final ParseField SEARCH_PIPELINE = new ParseField("search_pipeline");
+    public static final ParseField VERBOSE_SEARCH_PIPELINE = new ParseField("verbose_pipeline");
 
     public static SearchSourceBuilder fromXContent(XContentParser parser) throws IOException {
         return fromXContent(parser, true);
@@ -226,6 +227,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
     private String searchPipeline;
 
+    private boolean verbosePipeline;
+
     /**
      * Constructs a new search source builder.
      */
@@ -301,6 +304,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         }
         if (in.getVersion().onOrAfter(Version.V_2_18_0)) {
             searchPipeline = in.readOptionalString();
+            verbosePipeline = in.readBoolean();
         }
     }
 
@@ -384,6 +388,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         }
         if (out.getVersion().onOrAfter(Version.V_2_18_0)) {
             out.writeOptionalString(searchPipeline);
+            out.writeOptionalBoolean(verbosePipeline);
         }
     }
 
@@ -1143,6 +1148,26 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     }
 
     /**
+     * Enables or disables verbose mode for the search pipeline.
+     *
+     * When verbose mode is enabled, detailed information about each processor
+     * in the search pipeline is included in the search response. This includes
+     * the processor name, execution status, input, output, and time taken for processing.
+     *
+     * This parameter is primarily intended for debugging purposes, allowing users
+     * to track how data flows and transforms through the search pipeline.
+     *
+     */
+    public SearchSourceBuilder verbosePipeline(boolean verbosePipeline) {
+        this.verbosePipeline = verbosePipeline;
+        return this;
+    }
+
+    public Boolean verbosePipeline() {
+        return verbosePipeline;
+    }
+
+    /**
      * Rewrites this search source builder into its primitive form. e.g. by
      * rewriting the QueryBuilder. If the builder did not change the identity
      * reference must be returned otherwise the builder will be rewritten
@@ -1240,6 +1265,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         rewrittenBuilder.derivedFieldsObject = derivedFieldsObject;
         rewrittenBuilder.derivedFields = derivedFields;
         rewrittenBuilder.searchPipeline = searchPipeline;
+        rewrittenBuilder.verbosePipeline = verbosePipeline;
         return rewrittenBuilder;
     }
 
@@ -1309,6 +1335,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                     profile = parser.booleanValue();
                 } else if (SEARCH_PIPELINE.match(currentFieldName, parser.getDeprecationHandler())) {
                     searchPipeline = parser.text();
+                } else if (VERBOSE_SEARCH_PIPELINE.match(currentFieldName, parser.getDeprecationHandler())) {
+                    verbosePipeline = parser.booleanValue();
                 } else {
                     throw new ParsingException(
                         parser.getTokenLocation(),
@@ -1920,7 +1948,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             pointInTimeBuilder,
             derivedFieldsObject,
             derivedFields,
-            searchPipeline
+            searchPipeline,
+            verbosePipeline
         );
     }
 
@@ -1966,7 +1995,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             && Objects.equals(pointInTimeBuilder, other.pointInTimeBuilder)
             && Objects.equals(derivedFieldsObject, other.derivedFieldsObject)
             && Objects.equals(derivedFields, other.derivedFields)
-            && Objects.equals(searchPipeline, other.searchPipeline);
+            && Objects.equals(searchPipeline, other.searchPipeline)
+            && Objects.equals(verbosePipeline, other.verbosePipeline);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -305,7 +305,6 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         if (in.getVersion().onOrAfter(Version.V_2_18_0)) {
             searchPipeline = in.readOptionalString();
         }
-        // Todo: change version to 2_19_0
         if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
             verbosePipeline = in.readOptionalBoolean();
         }
@@ -392,7 +391,6 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         if (out.getVersion().onOrAfter(Version.V_2_18_0)) {
             out.writeOptionalString(searchPipeline);
         }
-        // Todo: change version to 2_19_0
         if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
             out.writeOptionalBoolean(verbosePipeline);
         }
@@ -1674,6 +1672,10 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
         if (searchPipeline != null) {
             builder.field(SEARCH_PIPELINE.getPreferredName(), searchPipeline);
+        }
+
+        if (verbosePipeline != null) {
+            builder.field(VERBOSE_SEARCH_PIPELINE.getPreferredName(), verbosePipeline);
         }
 
         return builder;

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -1167,7 +1167,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         return this;
     }
 
-    public Boolean verbosePipeline() {
+    public boolean verbosePipeline() {
         return verbosePipeline;
     }
 

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -227,7 +227,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
     private String searchPipeline;
 
-    private boolean verbosePipeline;
+    private boolean verbosePipeline = false;
 
     /**
      * Constructs a new search source builder.
@@ -394,7 +394,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         }
         // Todo: change version to 2_19_0
         if (out.getVersion().onOrAfter(Version.CURRENT)) {
-            out.writeOptionalBoolean(verbosePipeline);
+            out.writeBoolean(verbosePipeline);
         }
     }
 

--- a/server/src/main/java/org/opensearch/search/internal/InternalSearchResponse.java
+++ b/server/src/main/java/org/opensearch/search/internal/InternalSearchResponse.java
@@ -149,12 +149,12 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
     }
 
     private static List<ProcessorExecutionDetail> readProcessorResultOnOrAfter(StreamInput in) throws IOException {
-        return (in.getVersion().onOrAfter(Version.V_2_18_0)) ? in.readList(ProcessorExecutionDetail::new) : Collections.emptyList();
+        return (in.getVersion().onOrAfter(Version.CURRENT)) ? in.readList(ProcessorExecutionDetail::new) : Collections.emptyList();
     }
 
     private static void writeProcessorResultOnOrAfter(StreamOutput out, List<ProcessorExecutionDetail> processorResult) throws IOException {
-        if (out.getVersion().onOrAfter(Version.V_2_18_0)) {
-            out.writeCollection(processorResult, (o, detail) -> detail.writeTo(o));
+        if (out.getVersion().onOrAfter(Version.CURRENT)) {
+            out.writeList(processorResult);
         }
     }
 

--- a/server/src/main/java/org/opensearch/search/internal/InternalSearchResponse.java
+++ b/server/src/main/java/org/opensearch/search/internal/InternalSearchResponse.java
@@ -149,10 +149,12 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
     }
 
     private static List<ProcessorExecutionDetail> readProcessorResultOnOrAfter(StreamInput in) throws IOException {
+        // Todo: change to 2.19
         return (in.getVersion().onOrAfter(Version.CURRENT)) ? in.readList(ProcessorExecutionDetail::new) : Collections.emptyList();
     }
 
     private static void writeProcessorResultOnOrAfter(StreamOutput out, List<ProcessorExecutionDetail> processorResult) throws IOException {
+        // Todo: change to 2.19
         if (out.getVersion().onOrAfter(Version.CURRENT)) {
             out.writeList(processorResult);
         }

--- a/server/src/main/java/org/opensearch/search/internal/InternalSearchResponse.java
+++ b/server/src/main/java/org/opensearch/search/internal/InternalSearchResponse.java
@@ -149,13 +149,11 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
     }
 
     private static List<ProcessorExecutionDetail> readProcessorResultOnOrAfter(StreamInput in) throws IOException {
-        // Todo: change to 2.19
-        return (in.getVersion().onOrAfter(Version.CURRENT)) ? in.readList(ProcessorExecutionDetail::new) : Collections.emptyList();
+        return (in.getVersion().onOrAfter(Version.V_3_0_0)) ? in.readList(ProcessorExecutionDetail::new) : Collections.emptyList();
     }
 
     private static void writeProcessorResultOnOrAfter(StreamOutput out, List<ProcessorExecutionDetail> processorResult) throws IOException {
-        // Todo: change to 2.19
-        if (out.getVersion().onOrAfter(Version.CURRENT)) {
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
             out.writeList(processorResult);
         }
     }

--- a/server/src/main/java/org/opensearch/search/internal/InternalSearchResponse.java
+++ b/server/src/main/java/org/opensearch/search/internal/InternalSearchResponse.java
@@ -42,6 +42,7 @@ import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.search.SearchExtBuilder;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.pipeline.ProcessorExecutionDetail;
 import org.opensearch.search.profile.SearchProfileShardResults;
 import org.opensearch.search.suggest.Suggest;
 
@@ -73,7 +74,17 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
         Boolean terminatedEarly,
         int numReducePhases
     ) {
-        this(hits, aggregations, suggest, profileResults, timedOut, terminatedEarly, numReducePhases, Collections.emptyList());
+        this(
+            hits,
+            aggregations,
+            suggest,
+            profileResults,
+            timedOut,
+            terminatedEarly,
+            numReducePhases,
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
     }
 
     public InternalSearchResponse(
@@ -84,9 +95,20 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
         boolean timedOut,
         Boolean terminatedEarly,
         int numReducePhases,
-        List<SearchExtBuilder> searchExtBuilderList
+        List<SearchExtBuilder> searchExtBuilderList,
+        List<ProcessorExecutionDetail> processorResult
     ) {
-        super(hits, aggregations, suggest, timedOut, terminatedEarly, profileResults, numReducePhases, searchExtBuilderList);
+        super(
+            hits,
+            aggregations,
+            suggest,
+            timedOut,
+            terminatedEarly,
+            profileResults,
+            numReducePhases,
+            searchExtBuilderList,
+            processorResult
+        );
     }
 
     public InternalSearchResponse(StreamInput in) throws IOException {
@@ -98,7 +120,8 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
             in.readOptionalBoolean(),
             in.readOptionalWriteable(SearchProfileShardResults::new),
             in.readVInt(),
-            readSearchExtBuildersOnOrAfter(in)
+            readSearchExtBuildersOnOrAfter(in),
+            readProcessorResultOnOrAfter(in)
         );
     }
 
@@ -112,6 +135,7 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
         out.writeOptionalWriteable(profileResults);
         out.writeVInt(numReducePhases);
         writeSearchExtBuildersOnOrAfter(out, searchExtBuilders);
+        writeProcessorResultOnOrAfter(out, processorResult);
     }
 
     private static List<SearchExtBuilder> readSearchExtBuildersOnOrAfter(StreamInput in) throws IOException {
@@ -123,4 +147,15 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
             out.writeNamedWriteableList(searchExtBuilders);
         }
     }
+
+    private static List<ProcessorExecutionDetail> readProcessorResultOnOrAfter(StreamInput in) throws IOException {
+        return (in.getVersion().onOrAfter(Version.V_2_18_0)) ? in.readList(ProcessorExecutionDetail::new) : Collections.emptyList();
+    }
+
+    private static void writeProcessorResultOnOrAfter(StreamOutput out, List<ProcessorExecutionDetail> processorResult) throws IOException {
+        if (out.getVersion().onOrAfter(Version.V_2_18_0)) {
+            out.writeCollection(processorResult, (o, detail) -> detail.writeTo(o));
+        }
+    }
+
 }

--- a/server/src/main/java/org/opensearch/search/pipeline/Pipeline.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/Pipeline.java
@@ -160,6 +160,8 @@ class Pipeline {
                     long took = TimeUnit.NANOSECONDS.toMillis(relativeTimeSupplier.getAsLong() - start);
                     afterRequestProcessor(processor, took);
                     onRequestProcessorFailed(processor);
+                    // When verbosePipeline is enabled, all processor failures are ignored to ensure the execution chain continues without
+                    // interruption.TrackingSearchResponseProcessorWrapper will log all errors in detail for debugging purposes
                     if (processor.isIgnoreFailure() || r.source().verbosePipeline()) {
                         logger.warn(
                             "The exception from request processor ["
@@ -239,7 +241,8 @@ class Pipeline {
                     onResponseProcessorFailed(processor);
                     long took = TimeUnit.NANOSECONDS.toMillis(relativeTimeSupplier.getAsLong() - start);
                     afterResponseProcessor(processor, took);
-                    // If an error occurs and the pipeline is in verbose mode, the processor will not terminate the execution chain.
+                    // When verbosePipeline is enabled, all processor failures are ignored to ensure the execution chain continues without
+                    // interruption.TrackingSearchResponseProcessorWrapper will log all errors in detail for debugging purposes
                     if (processor.isIgnoreFailure() || request.source().verbosePipeline()) {
                         logger.warn(
                             "The exception from response processor ["

--- a/server/src/main/java/org/opensearch/search/pipeline/Pipeline.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/Pipeline.java
@@ -167,13 +167,7 @@ class Pipeline {
                     afterRequestProcessor(processor, took);
                     onRequestProcessorFailed(processor);
                     if (r.source().verbosePipeline()) {
-                        String errorMessage = "An error occurred in the request processor ["
-                            + processor.getType()
-                            + "] while executing in the search pipeline ["
-                            + id
-                            + "]: "
-                            + e.getMessage();
-                        detail.markProcessorAsFailed(ProcessorExecutionDetail.ProcessorStatus.FAIL, errorMessage);
+                        detail.markProcessorAsFailed(ProcessorExecutionDetail.ProcessorStatus.FAIL, e.getMessage());
                         requestContext.addProcessorExecutionDetail(detail);
                         nextListener.onResponse(r);
                     } else if (processor.isIgnoreFailure()) {
@@ -275,13 +269,7 @@ class Pipeline {
                     afterResponseProcessor(processor, took);
                     // If an error occurs and the pipeline is in verbose mode, the processor will not terminate the execution chain.
                     if (request.source().verbosePipeline()) {
-                        String errorMessage = "An error occurred in the response processor ["
-                            + processor.getType()
-                            + "] while executing in the search pipeline ["
-                            + id
-                            + "]: "
-                            + e.getMessage();
-                        detail.markProcessorAsFailed(ProcessorExecutionDetail.ProcessorStatus.FAIL, errorMessage);
+                        detail.markProcessorAsFailed(ProcessorExecutionDetail.ProcessorStatus.FAIL, e.getMessage());
                         requestContext.addProcessorExecutionDetail(detail);
                         r.getInternalResponse().getProcessorResult().add(detail);
                         currentFinalListener.onResponse(r);

--- a/server/src/main/java/org/opensearch/search/pipeline/Pipeline.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/Pipeline.java
@@ -167,11 +167,12 @@ class Pipeline {
                     afterRequestProcessor(processor, took);
                     onRequestProcessorFailed(processor);
                     if (r.source().verbosePipeline()) {
-                        String errorMessage = "The request processor ["
+                        String errorMessage = "An error occurred in the request processor ["
                             + processor.getType()
-                            + "] encountered an error while executing in the search pipeline ["
+                            + "] while executing in the search pipeline ["
                             + id
-                            + "].";
+                            + "]: "
+                            + e.getMessage();
                         detail.markProcessorAsFailed(ProcessorExecutionDetail.ProcessorStatus.FAIL, errorMessage);
                         requestContext.addProcessorExecutionDetail(detail);
                         nextListener.onResponse(r);
@@ -274,11 +275,12 @@ class Pipeline {
                     afterResponseProcessor(processor, took);
                     // If an error occurs and the pipeline is in verbose mode, the processor will not terminate the execution chain.
                     if (request.source().verbosePipeline()) {
-                        String errorMessage = "The response processor ["
+                        String errorMessage = "An error occurred in the response processor ["
                             + processor.getType()
-                            + "] encountered an error while executing in the search pipeline ["
+                            + "] while executing in the search pipeline ["
                             + id
-                            + "].";
+                            + "]: "
+                            + e.getMessage();
                         detail.markProcessorAsFailed(ProcessorExecutionDetail.ProcessorStatus.FAIL, errorMessage);
                         requestContext.addProcessorExecutionDetail(detail);
                         r.getInternalResponse().getProcessorResult().add(detail);

--- a/server/src/main/java/org/opensearch/search/pipeline/Pipeline.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/Pipeline.java
@@ -204,7 +204,6 @@ class Pipeline {
         ActionListener<SearchResponse> responseListener,
         PipelineProcessingContext requestContext
     ) {
-        // If there are no response processors, directly check requestContext for execution details
         if (searchResponseProcessors.isEmpty()) {
             return responseListener;
         }

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelineProcessingContext.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelineProcessingContext.java
@@ -14,13 +14,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.opensearch.search.pipeline.ProcessorExecutionDetail.PROCESSOR_EXECUTION_DETAILS_KEY;
-
 /**
  * A holder for state that is passed through each processor in the pipeline.
  */
 public class PipelineProcessingContext {
     private final Map<String, Object> attributes = new HashMap<>();
+    private final List<ProcessorExecutionDetail> processorExecutionDetails = new ArrayList<>();
 
     /**
      * Set a generic attribute in the state for this request. Overwrites any existing value.
@@ -47,12 +46,7 @@ public class PipelineProcessingContext {
      * @param detail the ProcessorExecutionDetail to add
      */
     public void addProcessorExecutionDetail(ProcessorExecutionDetail detail) {
-        @SuppressWarnings("unchecked")
-        List<ProcessorExecutionDetail> details = (List<ProcessorExecutionDetail>) attributes.computeIfAbsent(
-            PROCESSOR_EXECUTION_DETAILS_KEY,
-            k -> new ArrayList<>()
-        );
-        details.add(detail);
+        processorExecutionDetails.add(detail);
     }
 
     /**
@@ -60,8 +54,7 @@ public class PipelineProcessingContext {
      *
      * @return a list of ProcessorExecutionDetails
      */
-    @SuppressWarnings("unchecked")
     public List<ProcessorExecutionDetail> getProcessorExecutionDetails() {
-        return (List<ProcessorExecutionDetail>) attributes.getOrDefault(PROCESSOR_EXECUTION_DETAILS_KEY, Collections.emptyList());
+        return Collections.unmodifiableList(processorExecutionDetails);
     }
 }

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelineProcessingContext.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelineProcessingContext.java
@@ -47,10 +47,12 @@ public class PipelineProcessingContext {
      *
      * @param detail the ProcessorExecutionDetail to add
      */
-    @SuppressWarnings("unchecked")
     public void addProcessorExecutionDetail(ProcessorExecutionDetail detail) {
-        attributes.computeIfAbsent(PROCESSOR_EXECUTION_DETAILS_KEY, k -> new ArrayList<ProcessorExecutionDetail>());
-        List<ProcessorExecutionDetail> details = (List<ProcessorExecutionDetail>) attributes.get(PROCESSOR_EXECUTION_DETAILS_KEY);
+        @SuppressWarnings("unchecked")
+        List<ProcessorExecutionDetail> details = (List<ProcessorExecutionDetail>) attributes.computeIfAbsent(
+            PROCESSOR_EXECUTION_DETAILS_KEY,
+            k -> new ArrayList<>()
+        );
         details.add(detail);
     }
 

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelineProcessingContext.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelineProcessingContext.java
@@ -14,14 +14,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.opensearch.search.pipeline.ProcessorExecutionDetail.PROCESSOR_EXECUTION_DETAILS_KEY;
+
 /**
  * A holder for state that is passed through each processor in the pipeline.
  */
 public class PipelineProcessingContext {
     private final Map<String, Object> attributes = new HashMap<>();
-
-    // Key for processor execution details
-    private static final String PROCESSOR_EXECUTION_DETAILS_KEY = "processorExecutionDetails";
 
     /**
      * Set a generic attribute in the state for this request. Overwrites any existing value.

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelineProcessingContext.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelineProcessingContext.java
@@ -58,15 +58,10 @@ public class PipelineProcessingContext {
     /**
      * Get all ProcessorExecutionDetails recorded in this context.
      *
-     * @return an unmodifiable list of ProcessorExecutionDetails
+     * @return a list of ProcessorExecutionDetails
      */
     @SuppressWarnings("unchecked")
     public List<ProcessorExecutionDetail> getProcessorExecutionDetails() {
-        Object details = attributes.get(PROCESSOR_EXECUTION_DETAILS_KEY);
-        if (details instanceof List) {
-            return Collections.unmodifiableList((List<ProcessorExecutionDetail>) details);
-        }
-        return Collections.emptyList();
+        return (List<ProcessorExecutionDetail>) attributes.getOrDefault(PROCESSOR_EXECUTION_DETAILS_KEY, Collections.emptyList());
     }
-
 }

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelineProcessingContext.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelineProcessingContext.java
@@ -8,7 +8,10 @@
 
 package org.opensearch.search.pipeline;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -16,6 +19,9 @@ import java.util.Map;
  */
 public class PipelineProcessingContext {
     private final Map<String, Object> attributes = new HashMap<>();
+
+    // Key for processor execution details
+    private static final String PROCESSOR_EXECUTION_DETAILS_KEY = "processorExecutionDetails";
 
     /**
      * Set a generic attribute in the state for this request. Overwrites any existing value.
@@ -35,4 +41,31 @@ public class PipelineProcessingContext {
     public Object getAttribute(String name) {
         return attributes.get(name);
     }
+
+    /**
+     * Add a ProcessorExecutionDetail to the list of execution details.
+     *
+     * @param detail the ProcessorExecutionDetail to add
+     */
+    @SuppressWarnings("unchecked")
+    public void addProcessorExecutionDetail(ProcessorExecutionDetail detail) {
+        attributes.computeIfAbsent(PROCESSOR_EXECUTION_DETAILS_KEY, k -> new ArrayList<ProcessorExecutionDetail>());
+        List<ProcessorExecutionDetail> details = (List<ProcessorExecutionDetail>) attributes.get(PROCESSOR_EXECUTION_DETAILS_KEY);
+        details.add(detail);
+    }
+
+    /**
+     * Get all ProcessorExecutionDetails recorded in this context.
+     *
+     * @return an unmodifiable list of ProcessorExecutionDetails
+     */
+    @SuppressWarnings("unchecked")
+    public List<ProcessorExecutionDetail> getProcessorExecutionDetails() {
+        Object details = attributes.get(PROCESSOR_EXECUTION_DETAILS_KEY);
+        if (details instanceof List) {
+            return Collections.unmodifiableList((List<ProcessorExecutionDetail>) details);
+        }
+        return Collections.emptyList();
+    }
+
 }

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
@@ -8,8 +8,6 @@
 
 package org.opensearch.search.pipeline;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.action.search.SearchPhaseContext;
 import org.opensearch.action.search.SearchPhaseResults;
 import org.opensearch.action.search.SearchRequest;
@@ -27,7 +25,6 @@ import java.util.List;
 public final class PipelinedRequest extends SearchRequest {
     private final Pipeline pipeline;
     private final PipelineProcessingContext requestContext;
-    private static final Logger logger = LogManager.getLogger(Pipeline.class);
 
     PipelinedRequest(Pipeline pipeline, SearchRequest transformedRequest, PipelineProcessingContext requestContext) {
         super(transformedRequest);

--- a/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/PipelinedRequest.java
@@ -43,13 +43,10 @@ public final class PipelinedRequest extends SearchRequest {
         return pipeline.transformResponseListener(this, ActionListener.wrap(response -> {
             // Extract processor execution details
             List<ProcessorExecutionDetail> details = requestContext.getProcessorExecutionDetails();
-            logger.info("it is going to be executed in [{}]", details);
             // Add details to the response's InternalResponse if available
             if (!details.isEmpty() && response.getInternalResponse() != null) {
                 response.getInternalResponse().getProcessorResult().addAll(details);
             }
-
-            // Pass the modified response to the original listener
             responseListener.onResponse(response);
         }, responseListener::onFailure), requestContext);
     }

--- a/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
@@ -290,13 +290,10 @@ public class ProcessorExecutionDetail implements Writeable, ToXContentObject {
      * or encountered a failure during its execution. It helps in categorizing the
      * execution result of processors within a pipeline.
      *
-     * @opensearch.internal
-     * @since 2.19.0
      */
     @PublicApi(since = "2.19.0")
     public enum ProcessorStatus {
         SUCCESS,
         FAIL
     }
-
 }

--- a/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
 /**
  * Detailed information about a processor execution in a search pipeline.
  *
@@ -167,7 +169,10 @@ public class ProcessorExecutionDetail implements Writeable, ToXContentObject {
         long durationMillis = 0;
         Object inputData = null;
         Object outputData = null;
-
+        if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
+            parser.nextToken();
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        }
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
             String fieldName = parser.currentName();
             parser.nextToken();

--- a/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
@@ -1,0 +1,183 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Detailed information about a processor execution in a search pipeline.
+ *
+ * @opensearch.internal
+ */
+@PublicApi(since = "1.0.0")
+public class ProcessorExecutionDetail implements Writeable, ToXContentObject {
+
+    private final String processorName;
+    private long durationMillis;
+    private Object inputData;
+    private Object outputData;
+    private static final Logger logger = LogManager.getLogger(ProcessorExecutionDetail.class);
+
+    /**
+     * Constructor for ProcessorExecutionDetail
+     */
+    public ProcessorExecutionDetail(String processorName, long durationMillis, Object inputData, Object outputData) {
+        this.processorName = processorName;
+        this.durationMillis = durationMillis;
+        this.inputData = inputData;
+        this.outputData = outputData;
+    }
+
+    public ProcessorExecutionDetail(String processorName) {
+        this(processorName, 0, null, null);
+
+    }
+
+    public ProcessorExecutionDetail(StreamInput in) throws IOException {
+        this.processorName = in.readString();
+        this.durationMillis = in.readLong();
+        this.inputData = in.readGenericValue();
+        this.outputData = in.readGenericValue();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(processorName);
+        out.writeLong(durationMillis);
+        out.writeGenericValue(inputData);
+        out.writeGenericValue(outputData);
+    }
+
+    public String getProcessorName() {
+        return processorName;
+    }
+
+    public long getDurationMillis() {
+        return durationMillis;
+    }
+
+    public Object getInputData() {
+        return inputData;
+    }
+
+    public Object getOutputData() {
+        return outputData;
+    }
+
+    /**
+     * Adds or updates the input data for this processor execution detail.
+     *
+     * @param inputData the new input data
+     */
+    public void addInput(Object inputData) {
+        this.inputData = inputData;
+    }
+
+    /**
+     * Adds or updates the output data for this processor execution detail.
+     *
+     * @param outputData the new output data
+     */
+    public void addOutput(Object outputData) {
+        this.outputData = outputData;
+    }
+
+    /**
+     * Adds or updates the duration of the processor execution.
+     *
+     * @param durationMillis the new duration in milliseconds
+     */
+    public void addTook(long durationMillis) {
+        this.durationMillis = durationMillis;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("processor_name", processorName);
+        builder.field("duration_millis", durationMillis);
+
+        addFieldToXContent(builder, "input_data", inputData, params);
+
+        addFieldToXContent(builder, "output_data", outputData, params);
+
+        builder.endObject();
+        return builder;
+    }
+
+    private void addFieldToXContent(XContentBuilder builder, String fieldName, Object data, Params params) throws IOException {
+        if (data == null) {
+            builder.nullField(fieldName);
+            return;
+        }
+
+        if (data instanceof List) {
+            builder.startArray(fieldName);
+            for (Object item : (List<?>) data) {
+                writeItemToXContent(builder, item, params);
+            }
+            builder.endArray();
+        } else if (data instanceof ToXContentObject) {
+            builder.field(fieldName);
+            ((ToXContentObject) data).toXContent(builder, params);
+        } else {
+            builder.field(fieldName, data);
+        }
+    }
+
+    private void writeItemToXContent(XContentBuilder builder, Object item, Params params) throws IOException {
+        if (item instanceof ToXContentObject) {
+            ((ToXContentObject) item).toXContent(builder, params);
+        } else {
+            builder.value(item);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProcessorExecutionDetail that = (ProcessorExecutionDetail) o;
+        return durationMillis == that.durationMillis
+            && Objects.equals(processorName, that.processorName)
+            && Objects.equals(inputData, that.inputData)
+            && Objects.equals(outputData, that.outputData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(processorName, durationMillis, inputData, outputData);
+    }
+
+    @Override
+    public String toString() {
+        return "ProcessorExecutionDetail{"
+            + "processorName='"
+            + processorName
+            + '\''
+            + ", durationMillis="
+            + durationMillis
+            + ", inputData="
+            + inputData
+            + ", outputData="
+            + outputData
+            + '}';
+    }
+}

--- a/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
@@ -32,7 +32,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 /**
  * Detailed information about a processor execution in a search pipeline.
  *
- * @opensearch.internal
+ * @opensearch.api
  */
 @PublicApi(since = "2.19.0")
 public class ProcessorExecutionDetail implements Writeable, ToXContentObject {

--- a/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
@@ -273,7 +273,16 @@ public class ProcessorExecutionDetail implements Writeable, ToXContentObject {
             + '\''
             + '}';
     }
-
+    /**
+     * Represents the status of a processor in the search pipeline.
+     *
+     * <p>This enum is used to indicate whether a processor has executed successfully
+     * or encountered a failure during its execution. It helps in categorizing the
+     * execution result of processors within a pipeline.
+     *
+     * @opensearch.internal
+     * @since 2.19.0
+     */
     @PublicApi(since = "2.19.0")
     public enum ProcessorStatus {
         SUCCESS,

--- a/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
@@ -8,16 +8,17 @@
 
 package org.opensearch.search.pipeline;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.core.ParseField;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -33,7 +34,10 @@ public class ProcessorExecutionDetail implements Writeable, ToXContentObject {
     private long durationMillis;
     private Object inputData;
     private Object outputData;
-    private static final Logger logger = LogManager.getLogger(ProcessorExecutionDetail.class);
+    public static final ParseField PROCESSOR_NAME_FIELD = new ParseField("processor_name");
+    public static final ParseField DURATION_MILLIS_FIELD = new ParseField("duration_millis");
+    public static final ParseField INPUT_DATA_FIELD = new ParseField("input_data");
+    public static final ParseField OUTPUT_DATA_FIELD = new ParseField("output_data");
 
     /**
      * Constructor for ProcessorExecutionDetail
@@ -111,13 +115,10 @@ public class ProcessorExecutionDetail implements Writeable, ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field("processor_name", processorName);
-        builder.field("duration_millis", durationMillis);
-
-        addFieldToXContent(builder, "input_data", inputData, params);
-
-        addFieldToXContent(builder, "output_data", outputData, params);
-
+        builder.field(PROCESSOR_NAME_FIELD.getPreferredName(), processorName);
+        builder.field(DURATION_MILLIS_FIELD.getPreferredName(), durationMillis);
+        addFieldToXContent(builder, INPUT_DATA_FIELD.getPreferredName(), inputData, params);
+        addFieldToXContent(builder, OUTPUT_DATA_FIELD.getPreferredName(), outputData, params);
         builder.endObject();
         return builder;
     }
@@ -159,6 +160,63 @@ public class ProcessorExecutionDetail implements Writeable, ToXContentObject {
             && Objects.equals(processorName, that.processorName)
             && Objects.equals(inputData, that.inputData)
             && Objects.equals(outputData, that.outputData);
+    }
+
+    public static ProcessorExecutionDetail fromXContent(XContentParser parser) throws IOException {
+        String processorName = null;
+        long durationMillis = 0;
+        Object inputData = null;
+        Object outputData = null;
+
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            if (PROCESSOR_NAME_FIELD.match(fieldName, parser.getDeprecationHandler())) {
+                processorName = parser.text();
+            } else if (DURATION_MILLIS_FIELD.match(fieldName, parser.getDeprecationHandler())) {
+                durationMillis = parser.longValue();
+            } else if (INPUT_DATA_FIELD.match(fieldName, parser.getDeprecationHandler())) {
+                inputData = parseFieldFromXContent(parser);
+            } else if (OUTPUT_DATA_FIELD.match(fieldName, parser.getDeprecationHandler())) {
+                outputData = parseFieldFromXContent(parser);
+            } else {
+                parser.skipChildren();
+            }
+        }
+
+        if (processorName == null) {
+            throw new IllegalArgumentException("Processor name is required");
+        }
+
+        return new ProcessorExecutionDetail(processorName, durationMillis, inputData, outputData);
+    }
+
+    private static Object parseFieldFromXContent(XContentParser parser) throws IOException {
+        XContentParser.Token token = parser.currentToken();
+        if (token == XContentParser.Token.VALUE_NULL) {
+            return null;
+        } else if (token == XContentParser.Token.START_ARRAY) {
+            return parseArrayFromXContent(parser);
+        } else if (token == XContentParser.Token.START_OBJECT) {
+            return parser.map();
+        } else {
+            return parser.textOrNull();
+        }
+    }
+
+    private static List<Object> parseArrayFromXContent(XContentParser parser) throws IOException {
+        List<Object> list = new ArrayList<>();
+        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+            if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
+                list.add(parser.map());
+            } else if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
+                list.add(parseArrayFromXContent(parser));
+            } else {
+                list.add(parser.textOrNull());
+            }
+        }
+        return list;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
@@ -20,6 +20,7 @@ import org.opensearch.core.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
@@ -36,10 +37,10 @@ public class ProcessorExecutionDetail implements Writeable, ToXContentObject {
     private long durationMillis;
     private Object inputData;
     private Object outputData;
-    public static final ParseField PROCESSOR_NAME_FIELD = new ParseField("processor_name");
-    public static final ParseField DURATION_MILLIS_FIELD = new ParseField("duration_millis");
-    public static final ParseField INPUT_DATA_FIELD = new ParseField("input_data");
-    public static final ParseField OUTPUT_DATA_FIELD = new ParseField("output_data");
+    private static final ParseField PROCESSOR_NAME_FIELD = new ParseField("processor_name");
+    private static final ParseField DURATION_MILLIS_FIELD = new ParseField("duration_millis");
+    private static final ParseField INPUT_DATA_FIELD = new ParseField("input_data");
+    private static final ParseField OUTPUT_DATA_FIELD = new ParseField("output_data");
     // Key for processor execution details
     public static final String PROCESSOR_EXECUTION_DETAILS_KEY = "processorExecutionDetails";
 
@@ -83,6 +84,7 @@ public class ProcessorExecutionDetail implements Writeable, ToXContentObject {
 
     public Object getInputData() {
         return inputData;
+
     }
 
     public Object getOutputData() {
@@ -139,6 +141,12 @@ public class ProcessorExecutionDetail implements Writeable, ToXContentObject {
                 writeItemToXContent(builder, item, params);
             }
             builder.endArray();
+        } else if (data instanceof Map) {
+            builder.startObject(fieldName);
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) data).entrySet()) {
+                addFieldToXContent(builder, entry.getKey().toString(), entry.getValue(), params);
+            }
+            builder.endObject();
         } else if (data instanceof ToXContentObject) {
             builder.field(fieldName);
             ((ToXContentObject) data).toXContent(builder, params);

--- a/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/ProcessorExecutionDetail.java
@@ -273,6 +273,7 @@ public class ProcessorExecutionDetail implements Writeable, ToXContentObject {
             + '\''
             + '}';
     }
+
     /**
      * Represents the status of a processor in the search pipeline.
      *

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -367,7 +367,6 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
 
     public PipelinedRequest resolvePipeline(SearchRequest searchRequest, IndexNameExpressionResolver indexNameExpressionResolver) {
         Pipeline pipeline = Pipeline.NO_OP_PIPELINE;
-
         if (searchRequest.source() != null && searchRequest.source().searchPipelineSource() != null) {
             // Pipeline defined in search request (ad hoc pipeline).
             if (searchRequest.pipeline() != null) {
@@ -425,6 +424,9 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
                 }
                 pipeline = pipelineHolder.pipeline;
             }
+        }
+        if (searchRequest.source().verbosePipeline() && pipeline.getId().equals(NOOP_PIPELINE_ID)) {
+            throw new IllegalArgumentException("The 'verbose pipelines' option requires a search pipeline to be defined.");
         }
         PipelineProcessingContext requestContext = new PipelineProcessingContext();
         return new PipelinedRequest(pipeline, searchRequest, requestContext);

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -425,7 +425,7 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
                 pipeline = pipelineHolder.pipeline;
             }
         }
-        if (searchRequest.source().verbosePipeline() && pipeline.getId().equals(NOOP_PIPELINE_ID)) {
+        if (searchRequest.source() != null && searchRequest.source().verbosePipeline() && pipeline.getId().equals(NOOP_PIPELINE_ID)) {
             throw new IllegalArgumentException("The 'verbose pipelines' option requires a search pipeline to be defined.");
         }
         PipelineProcessingContext requestContext = new PipelineProcessingContext();

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -425,9 +425,7 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
                 pipeline = pipelineHolder.pipeline;
             }
         }
-        if (searchRequest.source() != null
-            && searchRequest.source().verbosePipeline()
-            && NOOP_PIPELINE_ID.equals(pipeline.getId()) == true) {
+        if (searchRequest.source() != null && searchRequest.source().verbosePipeline() && pipeline.equals(Pipeline.NO_OP_PIPELINE)) {
             throw new IllegalArgumentException("The 'verbose pipeline' option requires a search pipeline to be defined.");
         }
         PipelineProcessingContext requestContext = new PipelineProcessingContext();

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -425,8 +425,10 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
                 pipeline = pipelineHolder.pipeline;
             }
         }
-        if (searchRequest.source() != null && searchRequest.source().verbosePipeline() && pipeline.getId().equals(NOOP_PIPELINE_ID)) {
-            throw new IllegalArgumentException("The 'verbose pipelines' option requires a search pipeline to be defined.");
+        if (searchRequest.source() != null
+            && searchRequest.source().verbosePipeline()
+            && NOOP_PIPELINE_ID.equals(pipeline.getId()) == true) {
+            throw new IllegalArgumentException("The 'verbose pipeline' option requires a search pipeline to be defined.");
         }
         PipelineProcessingContext requestContext = new PipelineProcessingContext();
         return new PipelinedRequest(pipeline, searchRequest, requestContext);

--- a/server/src/main/java/org/opensearch/search/pipeline/TrackingSearchRequestProcessorWrapper.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/TrackingSearchRequestProcessorWrapper.java
@@ -13,6 +13,8 @@ import org.opensearch.core.action.ActionListener;
 
 /**
  * Wrapper for SearchRequestProcessor to track execution details.
+ *
+ *  @opensearch.internal
  */
 public class TrackingSearchRequestProcessorWrapper implements SearchRequestProcessor {
 

--- a/server/src/main/java/org/opensearch/search/pipeline/TrackingSearchRequestProcessorWrapper.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/TrackingSearchRequestProcessorWrapper.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.core.action.ActionListener;
+
+/**
+ * Wrapper for SearchRequestProcessor to track execution details.
+ */
+public class TrackingSearchRequestProcessorWrapper implements SearchRequestProcessor {
+
+    private final SearchRequestProcessor wrappedProcessor;
+
+    /**
+     * Constructor for the wrapper.
+     *
+     * @param wrappedProcessor the actual processor to be wrapped
+     */
+    public TrackingSearchRequestProcessorWrapper(SearchRequestProcessor wrappedProcessor) {
+        this.wrappedProcessor = wrappedProcessor;
+    }
+
+    @Override
+    public String getType() {
+        return wrappedProcessor.getType();
+    }
+
+    @Override
+    public String getTag() {
+        return wrappedProcessor.getTag();
+    }
+
+    @Override
+    public String getDescription() {
+        return wrappedProcessor.getDescription();
+    }
+
+    @Override
+    public boolean isIgnoreFailure() {
+        return wrappedProcessor.isIgnoreFailure();
+    }
+
+    @Override
+    public SearchRequest processRequest(SearchRequest request) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SearchRequest processRequest(SearchRequest request, PipelineProcessingContext requestContext) throws Exception {
+        ProcessorExecutionDetail detail = new ProcessorExecutionDetail(getType(), getTag());
+
+        long start = System.nanoTime();
+        try {
+            detail.addInput(request.source().toString());
+            SearchRequest result = wrappedProcessor.processRequest(request, requestContext);
+            detail.addOutput(result.source().toString());
+            long took = System.nanoTime() - start;
+            detail.addTook(took);
+            requestContext.addProcessorExecutionDetail(detail);
+            return result;
+        } catch (Exception e) {
+            detail.markProcessorAsFailed(ProcessorExecutionDetail.ProcessorStatus.FAIL, e.getMessage());
+            requestContext.addProcessorExecutionDetail(detail);
+            throw e;
+        }
+    }
+
+    @Override
+    public void processRequestAsync(
+        SearchRequest request,
+        PipelineProcessingContext requestContext,
+        ActionListener<SearchRequest> requestListener
+    ) {
+        ProcessorExecutionDetail detail = new ProcessorExecutionDetail(getType(), getTag());
+
+        long start = System.nanoTime();
+        try {
+            detail.addInput(request.source().toString());
+            wrappedProcessor.processRequestAsync(request, requestContext, ActionListener.wrap(result -> {
+                detail.addOutput(result.source().toString());
+                long took = System.nanoTime() - start;
+                detail.addTook(took);
+                requestContext.addProcessorExecutionDetail(detail);
+                requestListener.onResponse(result);
+            }, e -> {
+                detail.markProcessorAsFailed(ProcessorExecutionDetail.ProcessorStatus.FAIL, e.getMessage());
+                requestContext.addProcessorExecutionDetail(detail);
+                requestListener.onFailure(e);
+            }));
+        } catch (Exception e) {
+            detail.markProcessorAsFailed(ProcessorExecutionDetail.ProcessorStatus.FAIL, e.getMessage());
+            requestContext.addProcessorExecutionDetail(detail);
+            requestListener.onFailure(e);
+        }
+    }
+
+}

--- a/server/src/main/java/org/opensearch/search/pipeline/TrackingSearchRequestProcessorWrapper.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/TrackingSearchRequestProcessorWrapper.java
@@ -56,11 +56,7 @@ public class TrackingSearchRequestProcessorWrapper implements SearchRequestProce
 
     @Override
     public SearchRequest processRequest(SearchRequest request, PipelineProcessingContext requestContext) throws Exception {
-        try {
-            return wrappedProcessor.processRequest(request, requestContext);
-        } catch (UnsupportedOperationException e) {
-            throw e;
-        }
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapper.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapper.java
@@ -8,8 +8,6 @@
 
 package org.opensearch.search.pipeline;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.core.action.ActionListener;
@@ -18,11 +16,12 @@ import java.util.Arrays;
 
 /**
  * Wrapper for SearchResponseProcessor to track execution details.
+ *
+ *  @opensearch.internal
  */
 public class TrackingSearchResponseProcessorWrapper implements SearchResponseProcessor {
 
     private final SearchResponseProcessor wrappedProcessor;
-    private static final Logger logger = LogManager.getLogger(TrackingSearchResponseProcessorWrapper.class);
 
     /**
      * Constructor for the wrapper.

--- a/server/src/main/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapper.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapper.java
@@ -62,13 +62,8 @@ public class TrackingSearchResponseProcessorWrapper implements SearchResponsePro
     }
 
     @Override
-    public SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelineProcessingContext requestContext)
-        throws Exception {
-        try {
-            return wrappedProcessor.processResponse(request, response, requestContext);
-        } catch (UnsupportedOperationException e) {
-            throw e;
-        }
+    public SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelineProcessingContext requestContext) {
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -83,7 +78,8 @@ public class TrackingSearchResponseProcessorWrapper implements SearchResponsePro
         try {
             detail.addInput(Arrays.asList(response.getHits().deepCopy().getHits()));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            responseListener.onFailure(e);
+            return;
         }
         wrappedProcessor.processResponseAsync(request, response, requestContext, ActionListener.wrap(result -> {
             detail.addOutput(Arrays.asList(result.getHits().deepCopy().getHits()));

--- a/server/src/main/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapper.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapper.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.core.action.ActionListener;
+
+import java.util.Arrays;
+
+/**
+ * Wrapper for SearchResponseProcessor to track execution details.
+ */
+public class TrackingSearchResponseProcessorWrapper implements SearchResponseProcessor {
+
+    private final SearchResponseProcessor wrappedProcessor;
+    private static final Logger logger = LogManager.getLogger(TrackingSearchResponseProcessorWrapper.class);
+
+    /**
+     * Constructor for the wrapper.
+     *
+     * @param wrappedProcessor the actual processor to be wrapped
+     */
+    public TrackingSearchResponseProcessorWrapper(SearchResponseProcessor wrappedProcessor) {
+        if (wrappedProcessor == null) {
+            throw new IllegalArgumentException("Wrapped processor cannot be null.");
+        }
+        this.wrappedProcessor = wrappedProcessor;
+    }
+
+    @Override
+    public String getType() {
+        return wrappedProcessor.getType();
+    }
+
+    @Override
+    public String getTag() {
+        return wrappedProcessor.getTag();
+    }
+
+    @Override
+    public String getDescription() {
+        return wrappedProcessor.getDescription();
+    }
+
+    @Override
+    public boolean isIgnoreFailure() {
+        return wrappedProcessor.isIgnoreFailure();
+    }
+
+    @Override
+    public SearchResponse processResponse(SearchRequest request, SearchResponse response) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SearchResponse processResponse(SearchRequest request, SearchResponse response, PipelineProcessingContext requestContext)
+        throws Exception {
+        ProcessorExecutionDetail detail = new ProcessorExecutionDetail(getType(), getTag());
+
+        long start = System.nanoTime();
+        try {
+            detail.addInput(Arrays.asList(response.getHits().deepCopy().getHits()));
+            SearchResponse result = wrappedProcessor.processResponse(request, response, requestContext);
+            detail.addOutput(Arrays.asList(result.getHits().deepCopy().getHits()));
+            long took = System.nanoTime() - start;
+            detail.addTook(took);
+            requestContext.addProcessorExecutionDetail(detail);
+            return result;
+        } catch (Exception e) {
+            detail.markProcessorAsFailed(ProcessorExecutionDetail.ProcessorStatus.FAIL, e.getMessage());
+            requestContext.addProcessorExecutionDetail(detail);
+            throw e;
+        }
+    }
+
+    @Override
+    public void processResponseAsync(
+        SearchRequest request,
+        SearchResponse response,
+        PipelineProcessingContext requestContext,
+        ActionListener<SearchResponse> responseListener
+    ) {
+        ProcessorExecutionDetail detail = new ProcessorExecutionDetail(getType(), getTag());
+
+        long start = System.nanoTime();
+        try {
+            detail.addInput(Arrays.asList(response.getHits().deepCopy().getHits()));
+            wrappedProcessor.processResponseAsync(request, response, requestContext, ActionListener.wrap(result -> {
+                detail.addOutput(Arrays.asList(result.getHits().deepCopy().getHits()));
+                long took = System.nanoTime() - start;
+                detail.addTook(took);
+                requestContext.addProcessorExecutionDetail(detail);
+                responseListener.onResponse(result);
+            }, e -> {
+                detail.markProcessorAsFailed(ProcessorExecutionDetail.ProcessorStatus.FAIL, e.getMessage());
+                requestContext.addProcessorExecutionDetail(detail);
+                responseListener.onFailure(e);
+            }));
+        } catch (Exception e) {
+            detail.markProcessorAsFailed(ProcessorExecutionDetail.ProcessorStatus.FAIL, e.getMessage());
+            requestContext.addProcessorExecutionDetail(detail);
+            responseListener.onFailure(e);
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
@@ -314,8 +314,8 @@ public class SearchResponseTests extends OpenSearchTestCase {
         SearchHit[] hits = new SearchHit[] { hit };
         String dummyId = UUID.randomUUID().toString();
         List<ProcessorExecutionDetail> processorResults = List.of(
-            new ProcessorExecutionDetail("processor1", 50, List.of(1), List.of(1)),
-            new ProcessorExecutionDetail("processor2", 30, List.of(3), List.of(3))
+            new ProcessorExecutionDetail("processor1", 50, List.of(1), List.of(1), ProcessorExecutionDetail.ProcessorStatus.SUCCESS, ""),
+            new ProcessorExecutionDetail("processor2", 30, List.of(3), List.of(3), ProcessorExecutionDetail.ProcessorStatus.SUCCESS, "")
         );
         {
             SearchResponse response = new SearchResponse(

--- a/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
@@ -77,6 +77,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -314,8 +315,24 @@ public class SearchResponseTests extends OpenSearchTestCase {
         SearchHit[] hits = new SearchHit[] { hit };
         String dummyId = UUID.randomUUID().toString();
         List<ProcessorExecutionDetail> processorResults = List.of(
-            new ProcessorExecutionDetail("processor1", 50, List.of(1), List.of(1), ProcessorExecutionDetail.ProcessorStatus.SUCCESS, ""),
-            new ProcessorExecutionDetail("processor2", 30, List.of(3), List.of(3), ProcessorExecutionDetail.ProcessorStatus.SUCCESS, "")
+            new ProcessorExecutionDetail(
+                "processor1",
+                50,
+                List.of(1),
+                List.of(1),
+                ProcessorExecutionDetail.ProcessorStatus.SUCCESS,
+                null,
+                null
+            ),
+            new ProcessorExecutionDetail(
+                "processor2",
+                30,
+                List.of(3),
+                List.of(3),
+                ProcessorExecutionDetail.ProcessorStatus.SUCCESS,
+                null,
+                null
+            )
         );
         {
             SearchResponse response = new SearchResponse(
@@ -368,6 +385,7 @@ public class SearchResponseTests extends OpenSearchTestCase {
                     expectedString.append("{");
                     expectedString.append("\"processor_name\":\"").append(detail.getProcessorName()).append("\",");
                     expectedString.append("\"duration_millis\":").append(detail.getDurationMillis()).append(",");
+                    expectedString.append("\"status\":\"").append(detail.getStatus().toString().toLowerCase(Locale.ROOT)).append("\",");
                     expectedString.append("\"input_data\":").append(detail.getInputData()).append(",");
                     expectedString.append("\"output_data\":").append(detail.getOutputData());
                     expectedString.append("}");

--- a/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
@@ -176,7 +176,8 @@ public class SearchResponseTests extends OpenSearchTestCase {
                 timedOut,
                 terminatedEarly,
                 numReducePhases,
-                searchExtBuilders
+                searchExtBuilders,
+                Collections.emptyList()
             );
         } else {
             internalSearchResponse = InternalSearchResponse.empty();
@@ -321,7 +322,8 @@ public class SearchResponseTests extends OpenSearchTestCase {
                     false,
                     null,
                     1,
-                    List.of(new DummySearchExtBuilder(dummyId))
+                    List.of(new DummySearchExtBuilder(dummyId)),
+                    Collections.emptyList()
                 ),
                 null,
                 0,

--- a/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
@@ -378,7 +378,6 @@ public class SearchResponseTests extends OpenSearchTestCase {
                 expectedString.append("]");
             }
             expectedString.append("}");
-
             assertEquals(expectedString.toString(), Strings.toString(MediaTypeRegistry.JSON, response));
             List<SearchExtBuilder> searchExtBuilders = response.getInternalResponse().getSearchExtBuilders();
             assertEquals(1, searchExtBuilders.size());

--- a/server/src/test/java/org/opensearch/search/GenericSearchExtBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/GenericSearchExtBuilderTests.java
@@ -40,6 +40,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -251,7 +252,8 @@ public class GenericSearchExtBuilderTests extends OpenSearchTestCase {
                 timedOut,
                 terminatedEarly,
                 numReducePhases,
-                searchExtBuilders
+                searchExtBuilders,
+                Collections.emptyList()
             );
         } else {
             internalSearchResponse = InternalSearchResponse.empty();

--- a/server/src/test/java/org/opensearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/builder/SearchSourceBuilderTests.java
@@ -703,6 +703,30 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         }
     }
 
+    public void testVerbosePipeline() throws IOException {
+        {
+            String restContent = "{ \"verbose_pipeline\": true }";
+            try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
+                SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(parser);
+                assertTrue(searchSourceBuilder.verbosePipeline());
+            }
+        }
+        {
+            String restContent = "{ \"verbose_pipeline\": false }";
+            try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
+                SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(parser);
+                assertFalse(searchSourceBuilder.verbosePipeline());
+            }
+        }
+        {
+            String restContent = "{ \"query\": { \"match_all\": {} } }";
+            try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
+                SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(parser);
+                assertFalse(searchSourceBuilder.verbosePipeline());
+            }
+        }
+    }
+
     private void assertIndicesBoostParseErrorMessage(String restContent, String expectedErrorMessage) throws IOException {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
             ParsingException e = expectThrows(ParsingException.class, () -> SearchSourceBuilder.fromXContent(parser));

--- a/server/src/test/java/org/opensearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/builder/SearchSourceBuilderTests.java
@@ -722,7 +722,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
             String restContent = "{ \"query\": { \"match_all\": {} } }";
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
                 SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(parser);
-                assertNull(searchSourceBuilder.verbosePipeline());
+                assertFalse(searchSourceBuilder.verbosePipeline());
             }
         }
     }

--- a/server/src/test/java/org/opensearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/builder/SearchSourceBuilderTests.java
@@ -722,7 +722,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
             String restContent = "{ \"query\": { \"match_all\": {} } }";
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
                 SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(parser);
-                assertFalse(searchSourceBuilder.verbosePipeline());
+                assertNull(searchSourceBuilder.verbosePipeline());
             }
         }
     }

--- a/server/src/test/java/org/opensearch/search/pipeline/ProcessorExecutionDetailTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/ProcessorExecutionDetailTests.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.MediaType;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class ProcessorExecutionDetailTests extends OpenSearchTestCase {
+
+    public void testSerializationRoundtrip() throws IOException {
+        ProcessorExecutionDetail detail = new ProcessorExecutionDetail("testProcessor", 123L, Map.of("key", "value"), List.of(1, 2, 3));
+        ProcessorExecutionDetail deserialized;
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            detail.writeTo(output);
+            try (StreamInput input = output.bytes().streamInput()) {
+                deserialized = new ProcessorExecutionDetail(input);
+            }
+        }
+        assertEquals("testProcessor", deserialized.getProcessorName());
+        assertEquals(123L, deserialized.getDurationMillis());
+        assertEquals(Map.of("key", "value"), deserialized.getInputData());
+        assertEquals(List.of(1, 2, 3), deserialized.getOutputData());
+    }
+
+    public void testAddMethods() {
+        ProcessorExecutionDetail detail = new ProcessorExecutionDetail("testProcessor");
+        detail.addTook(456L);
+        detail.addInput(Map.of("newKey", "newValue"));
+        detail.addOutput(List.of(4, 5, 6));
+        assertEquals(456L, detail.getDurationMillis());
+        assertEquals(Map.of("newKey", "newValue"), detail.getInputData());
+        assertEquals(List.of(4, 5, 6), detail.getOutputData());
+    }
+
+    public void testEqualsAndHashCode() {
+        ProcessorExecutionDetail detail1 = new ProcessorExecutionDetail("processor1", 100L, "input1", "output1");
+        ProcessorExecutionDetail detail2 = new ProcessorExecutionDetail("processor1", 100L, "input1", "output1");
+        ProcessorExecutionDetail detail3 = new ProcessorExecutionDetail("processor2", 200L, "input2", "output2");
+
+        assertEquals(detail1, detail2);
+        assertNotEquals(detail1, detail3);
+        assertEquals(detail1.hashCode(), detail2.hashCode());
+        assertNotEquals(detail1.hashCode(), detail3.hashCode());
+    }
+
+    public void testToString() {
+        ProcessorExecutionDetail detail = new ProcessorExecutionDetail("processorZ", 500L, "inputData", "outputData");
+        String expected =
+            "ProcessorExecutionDetail{processorName='processorZ', durationMillis=500, inputData=inputData, outputData=outputData}";
+        assertEquals(expected, detail.toString());
+    }
+
+    public void testToXContent() throws IOException {
+        ProcessorExecutionDetail detail = new ProcessorExecutionDetail("testProcessor", 123L, Map.of("key1", "value1"), List.of(1, 2, 3));
+
+        XContentBuilder actualBuilder = XContentBuilder.builder(JsonXContent.jsonXContent);
+        detail.toXContent(actualBuilder, ToXContent.EMPTY_PARAMS);
+
+        String expected = "{"
+            + "  \"processor_name\": \"testProcessor\","
+            + "  \"duration_millis\": 123,"
+            + "  \"input_data\": {\"key1\": \"value1\"},"
+            + "  \"output_data\": [1, 2, 3]"
+            + "}";
+
+        XContentParser expectedParser = JsonXContent.jsonXContent.createParser(
+            this.xContentRegistry(),
+            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+            expected
+        );
+        XContentBuilder expectedBuilder = XContentBuilder.builder(JsonXContent.jsonXContent);
+        expectedBuilder.generator().copyCurrentStructure(expectedParser);
+
+        assertEquals(
+            XContentHelper.convertToMap(BytesReference.bytes(expectedBuilder), false, (MediaType) MediaTypeRegistry.JSON),
+            XContentHelper.convertToMap(BytesReference.bytes(actualBuilder), false, (MediaType) MediaTypeRegistry.JSON)
+        );
+    }
+
+    public void testFromXContent() throws IOException {
+        String json = "{"
+            + "  \"processor_name\": \"testProcessor\","
+            + "  \"duration_millis\": 123,"
+            + "  \"input_data\": {\"key1\": \"value1\"},"
+            + "  \"output_data\": [1, 2, 3]"
+            + "}";
+
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                this.xContentRegistry(),
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                json
+            )
+        ) {
+            ProcessorExecutionDetail detail = ProcessorExecutionDetail.fromXContent(parser);
+
+            assertEquals("testProcessor", detail.getProcessorName());
+            assertEquals(123L, detail.getDurationMillis());
+            assertEquals(Map.of("key1", "value1"), detail.getInputData());
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/search/pipeline/ProcessorExecutionDetailTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/ProcessorExecutionDetailTests.java
@@ -117,6 +117,7 @@ public class ProcessorExecutionDetailTests extends OpenSearchTestCase {
             assertEquals("testProcessor", detail.getProcessorName());
             assertEquals(123L, detail.getDurationMillis());
             assertEquals(Map.of("key1", "value1"), detail.getInputData());
+            assertEquals(List.of(1, 2, 3), detail.getOutputData());
         }
     }
 }

--- a/server/src/test/java/org/opensearch/search/pipeline/ProcessorExecutionDetailTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/ProcessorExecutionDetailTests.java
@@ -34,6 +34,7 @@ public class ProcessorExecutionDetailTests extends OpenSearchTestCase {
             Map.of("key", "value"),
             List.of(1, 2, 3),
             ProcessorExecutionDetail.ProcessorStatus.SUCCESS,
+            "",
             ""
         );
         ProcessorExecutionDetail deserialized;
@@ -59,52 +60,6 @@ public class ProcessorExecutionDetailTests extends OpenSearchTestCase {
         assertEquals(List.of(4, 5, 6), detail.getOutputData());
     }
 
-    public void testEqualsAndHashCode() {
-        ProcessorExecutionDetail detail1 = new ProcessorExecutionDetail(
-            "processor1",
-            100L,
-            "input1",
-            "output1",
-            ProcessorExecutionDetail.ProcessorStatus.SUCCESS,
-            ""
-        );
-        ProcessorExecutionDetail detail2 = new ProcessorExecutionDetail(
-            "processor1",
-            100L,
-            "input1",
-            "output1",
-            ProcessorExecutionDetail.ProcessorStatus.SUCCESS,
-            ""
-        );
-        ProcessorExecutionDetail detail3 = new ProcessorExecutionDetail(
-            "processor2",
-            200L,
-            "input2",
-            "output2",
-            ProcessorExecutionDetail.ProcessorStatus.SUCCESS,
-            ""
-        );
-
-        assertEquals(detail1, detail2);
-        assertNotEquals(detail1, detail3);
-        assertEquals(detail1.hashCode(), detail2.hashCode());
-        assertNotEquals(detail1.hashCode(), detail3.hashCode());
-    }
-
-    public void testToString() {
-        ProcessorExecutionDetail detail = new ProcessorExecutionDetail(
-            "processorZ",
-            500L,
-            "inputData",
-            "outputData",
-            ProcessorExecutionDetail.ProcessorStatus.SUCCESS,
-            ""
-        );
-        String expected =
-            "ProcessorExecutionDetail{processorName='processorZ', durationMillis=500, inputData=inputData, outputData=outputData, status=SUCCESS, errorMessage=''}";
-        assertEquals(expected, detail.toString());
-    }
-
     public void testToXContent() throws IOException {
         ProcessorExecutionDetail detail = new ProcessorExecutionDetail(
             "testProcessor",
@@ -112,7 +67,8 @@ public class ProcessorExecutionDetailTests extends OpenSearchTestCase {
             Map.of("key1", "value1"),
             List.of(1, 2, 3),
             ProcessorExecutionDetail.ProcessorStatus.SUCCESS,
-            ""
+            "",
+            null
         );
 
         XContentBuilder actualBuilder = XContentBuilder.builder(JsonXContent.jsonXContent);
@@ -147,7 +103,8 @@ public class ProcessorExecutionDetailTests extends OpenSearchTestCase {
             Map.of("key1", "value1"),
             List.of(1, 2, 3),
             ProcessorExecutionDetail.ProcessorStatus.FAIL,
-            "processor 1 fail"
+            "processor 1 fail",
+            "123"
         );
 
         XContentBuilder actualBuilder = XContentBuilder.builder(JsonXContent.jsonXContent);
@@ -155,6 +112,7 @@ public class ProcessorExecutionDetailTests extends OpenSearchTestCase {
 
         String expected = "{"
             + "  \"processor_name\": \"testProcessor\","
+            + "  \"tag\": \"123\","
             + "  \"duration_millis\": 123,"
             + "  \"status\": \"fail\","
             + "  \"error\": \"processor 1 fail\","

--- a/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
@@ -1828,12 +1828,10 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.source(SearchSourceBuilder.searchSource().verbosePipeline(true));
 
-        IllegalArgumentException e = expectThrows(
+        expectThrows(
             IllegalArgumentException.class,
             () -> searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver)
         );
-
-        assertEquals("The 'verbose pipelines' option requires a search pipeline to be defined.", e.getMessage());
     }
 
     public void testVerbosePipelineWithRequestProcessorOnly() throws Exception {

--- a/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
@@ -1828,10 +1828,11 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.source(SearchSourceBuilder.searchSource().verbosePipeline(true));
 
-        expectThrows(
+        IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> searchPipelineService.resolvePipeline(searchRequest, indexNameExpressionResolver)
         );
+        assertTrue(e.getMessage(), e.getMessage().contains("The 'verbose pipeline' option requires a search pipeline to be defined."));
     }
 
     public void testVerbosePipelineWithRequestProcessorOnly() throws Exception {

--- a/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchRequestProcessorWrapperTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchRequestProcessorWrapperTests.java
@@ -36,30 +36,26 @@ public class TrackingSearchRequestProcessorWrapperTests extends OpenSearchTestCa
         context = new PipelineProcessingContext();
     }
 
-    public void testProcessRequest() throws Exception {
+    public void testProcessRequestSuccess() throws Exception {
         SearchRequest inputRequest = new SearchRequest();
         inputRequest.source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()));
 
         SearchRequest outputRequest = new SearchRequest();
         outputRequest.source(new SearchSourceBuilder().query(QueryBuilders.termQuery("field", "value")));
+
         when(mockProcessor.processRequest(any(SearchRequest.class), eq(context))).thenReturn(outputRequest);
 
         SearchRequest result = wrapper.processRequest(inputRequest, context);
         assertEquals(outputRequest, result);
-        verify(mockProcessor).processRequest(inputRequest, context);
 
-        assertFalse(context.getProcessorExecutionDetails().isEmpty());
-        ProcessorExecutionDetail detail = context.getProcessorExecutionDetails().get(0);
-        assertEquals(wrapper.getType(), detail.getProcessorName());
-        assertNotNull(detail.getInputData());
-        assertNotNull(detail.getOutputData());
-        assertEquals(ProcessorExecutionDetail.ProcessorStatus.SUCCESS, detail.getStatus());
+        verify(mockProcessor).processRequest(inputRequest, context);
     }
 
     public void testProcessRequestException() throws Exception {
         SearchRequest inputRequest = new SearchRequest();
         inputRequest.source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()));
-        Exception processorException = new RuntimeException("Processor failed");
+
+        RuntimeException processorException = new UnsupportedOperationException("Processor failed");
 
         when(mockProcessor.processRequest(any(SearchRequest.class), eq(context))).thenThrow(processorException);
 
@@ -69,10 +65,6 @@ public class TrackingSearchRequestProcessorWrapperTests extends OpenSearchTestCa
         } catch (Exception e) {
             assertEquals("Processor failed", e.getMessage());
         }
-
-        ProcessorExecutionDetail detail = context.getProcessorExecutionDetails().get(0);
-        assertEquals(wrapper.getType(), detail.getProcessorName());
-        assertEquals(ProcessorExecutionDetail.ProcessorStatus.FAIL, detail.getStatus());
     }
 
     public void testProcessRequestAsyncSuccess() {

--- a/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchRequestProcessorWrapperTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchRequestProcessorWrapperTests.java
@@ -20,8 +20,6 @@ import org.mockito.Mockito;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class TrackingSearchRequestProcessorWrapperTests extends OpenSearchTestCase {
     private SearchRequestProcessor mockProcessor;
@@ -34,37 +32,6 @@ public class TrackingSearchRequestProcessorWrapperTests extends OpenSearchTestCa
         mockProcessor = Mockito.mock(SearchRequestProcessor.class);
         wrapper = new TrackingSearchRequestProcessorWrapper(mockProcessor);
         context = new PipelineProcessingContext();
-    }
-
-    public void testProcessRequestSuccess() throws Exception {
-        SearchRequest inputRequest = new SearchRequest();
-        inputRequest.source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()));
-
-        SearchRequest outputRequest = new SearchRequest();
-        outputRequest.source(new SearchSourceBuilder().query(QueryBuilders.termQuery("field", "value")));
-
-        when(mockProcessor.processRequest(any(SearchRequest.class), eq(context))).thenReturn(outputRequest);
-
-        SearchRequest result = wrapper.processRequest(inputRequest, context);
-        assertEquals(outputRequest, result);
-
-        verify(mockProcessor).processRequest(inputRequest, context);
-    }
-
-    public void testProcessRequestException() throws Exception {
-        SearchRequest inputRequest = new SearchRequest();
-        inputRequest.source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()));
-
-        RuntimeException processorException = new UnsupportedOperationException("Processor failed");
-
-        when(mockProcessor.processRequest(any(SearchRequest.class), eq(context))).thenThrow(processorException);
-
-        try {
-            wrapper.processRequest(inputRequest, context);
-            fail("Expected exception was not thrown");
-        } catch (Exception e) {
-            assertEquals("Processor failed", e.getMessage());
-        }
     }
 
     public void testProcessRequestAsyncSuccess() {

--- a/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchRequestProcessorWrapperTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchRequestProcessorWrapperTests.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
+
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TrackingSearchRequestProcessorWrapperTests extends OpenSearchTestCase {
+    private SearchRequestProcessor mockProcessor;
+    private TrackingSearchRequestProcessorWrapper wrapper;
+    private PipelineProcessingContext context;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        mockProcessor = Mockito.mock(SearchRequestProcessor.class);
+        wrapper = new TrackingSearchRequestProcessorWrapper(mockProcessor);
+        context = new PipelineProcessingContext();
+    }
+
+    public void testProcessRequest() throws Exception {
+        SearchRequest inputRequest = new SearchRequest();
+        inputRequest.source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()));
+
+        SearchRequest outputRequest = new SearchRequest();
+        outputRequest.source(new SearchSourceBuilder().query(QueryBuilders.termQuery("field", "value")));
+        when(mockProcessor.processRequest(any(SearchRequest.class), eq(context))).thenReturn(outputRequest);
+
+        SearchRequest result = wrapper.processRequest(inputRequest, context);
+        assertEquals(outputRequest, result);
+        verify(mockProcessor).processRequest(inputRequest, context);
+
+        assertFalse(context.getProcessorExecutionDetails().isEmpty());
+        ProcessorExecutionDetail detail = context.getProcessorExecutionDetails().get(0);
+        assertEquals(wrapper.getType(), detail.getProcessorName());
+        assertNotNull(detail.getInputData());
+        assertNotNull(detail.getOutputData());
+        assertEquals(ProcessorExecutionDetail.ProcessorStatus.SUCCESS, detail.getStatus());
+    }
+
+    public void testProcessRequestException() throws Exception {
+        SearchRequest inputRequest = new SearchRequest();
+        inputRequest.source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()));
+        Exception processorException = new RuntimeException("Processor failed");
+
+        when(mockProcessor.processRequest(any(SearchRequest.class), eq(context))).thenThrow(processorException);
+
+        try {
+            wrapper.processRequest(inputRequest, context);
+            fail("Expected exception was not thrown");
+        } catch (Exception e) {
+            assertEquals("Processor failed", e.getMessage());
+        }
+
+        ProcessorExecutionDetail detail = context.getProcessorExecutionDetails().get(0);
+        assertEquals(wrapper.getType(), detail.getProcessorName());
+        assertEquals(ProcessorExecutionDetail.ProcessorStatus.FAIL, detail.getStatus());
+    }
+
+    public void testProcessRequestAsyncSuccess() {
+        SearchRequest inputRequest = new SearchRequest();
+        inputRequest.source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()));
+
+        SearchRequest outputRequest = new SearchRequest();
+        outputRequest.source(new SearchSourceBuilder().query(QueryBuilders.termQuery("field", "value")));
+
+        doAnswer(invocation -> {
+            ActionListener<SearchRequest> listener = invocation.getArgument(2);
+            listener.onResponse(outputRequest);
+            return null;
+        }).when(mockProcessor).processRequestAsync(any(SearchRequest.class), eq(context), any());
+
+        ActionListener<SearchRequest> listener = ActionListener.wrap(response -> {
+            assertEquals(outputRequest, response);
+            ProcessorExecutionDetail detail = context.getProcessorExecutionDetails().get(0);
+            assertEquals(wrapper.getType(), detail.getProcessorName());
+            assertEquals(ProcessorExecutionDetail.ProcessorStatus.SUCCESS, detail.getStatus());
+        }, e -> fail("Unexpected exception: " + e.getMessage()));
+
+        wrapper.processRequestAsync(inputRequest, context, listener);
+    }
+
+}

--- a/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapperTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapperTests.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.pipeline;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.search.SearchHits;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
+
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TrackingSearchResponseProcessorWrapperTests extends OpenSearchTestCase {
+    private SearchResponseProcessor mockProcessor;
+    private TrackingSearchResponseProcessorWrapper wrapper;
+    private PipelineProcessingContext context;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        mockProcessor = Mockito.mock(SearchResponseProcessor.class);
+        wrapper = new TrackingSearchResponseProcessorWrapper(mockProcessor);
+        context = new PipelineProcessingContext();
+    }
+
+    public void testProcessResponse() throws Exception {
+        SearchRequest mockRequest = new SearchRequest();
+        SearchResponse inputResponse = Mockito.mock(SearchResponse.class);
+        SearchResponse outputResponse = Mockito.mock(SearchResponse.class);
+
+        when(inputResponse.getHits()).thenReturn(SearchHits.empty());
+        when(outputResponse.getHits()).thenReturn(SearchHits.empty());
+        when(mockProcessor.processResponse(eq(mockRequest), eq(inputResponse), eq(context))).thenReturn(outputResponse);
+
+        SearchResponse result = wrapper.processResponse(mockRequest, inputResponse, context);
+
+        assertEquals(outputResponse, result);
+        verify(mockProcessor).processResponse(mockRequest, inputResponse, context);
+
+        assertFalse(context.getProcessorExecutionDetails().isEmpty());
+        ProcessorExecutionDetail detail = context.getProcessorExecutionDetails().get(0);
+        assertEquals(wrapper.getType(), detail.getProcessorName());
+        assertNotNull(detail.getInputData());
+        assertNotNull(detail.getOutputData());
+        assertEquals(ProcessorExecutionDetail.ProcessorStatus.SUCCESS, detail.getStatus());
+    }
+
+    public void testProcessResponseAsync() {
+        SearchRequest mockRequest = new SearchRequest();
+        SearchResponse inputResponse = Mockito.mock(SearchResponse.class);
+        SearchResponse outputResponse = Mockito.mock(SearchResponse.class);
+
+        when(inputResponse.getHits()).thenReturn(SearchHits.empty());
+        when(outputResponse.getHits()).thenReturn(SearchHits.empty());
+
+        wrapper.processResponseAsync(mockRequest, inputResponse, context, new ActionListener<>() {
+            @Override
+            public void onResponse(SearchResponse result) {
+                assertEquals(outputResponse, result);
+                assertFalse(context.getProcessorExecutionDetails().isEmpty());
+                ProcessorExecutionDetail detail = context.getProcessorExecutionDetails().get(0);
+                assertEquals(wrapper.getType(), detail.getProcessorName());
+                assertNotNull(detail.getInputData());
+                assertNotNull(detail.getOutputData());
+                assertEquals(ProcessorExecutionDetail.ProcessorStatus.SUCCESS, detail.getStatus());
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("Should not trigger failure");
+            }
+        });
+
+        verify(mockProcessor).processResponseAsync(eq(mockRequest), eq(inputResponse), eq(context), any());
+    }
+}

--- a/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapperTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapperTests.java
@@ -57,6 +57,15 @@ public class TrackingSearchResponseProcessorWrapperTests extends OpenSearchTestC
         assertEquals(ProcessorExecutionDetail.ProcessorStatus.SUCCESS, detail.getStatus());
     }
 
+    public void testConstructorThrowsExceptionWhenProcessorIsNull() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> new TrackingSearchResponseProcessorWrapper(null)
+        );
+
+        assertEquals("Wrapped processor cannot be null.", exception.getMessage());
+    }
+
     public void testProcessResponseAsync() {
         SearchRequest mockRequest = new SearchRequest();
         SearchResponse inputResponse = Mockito.mock(SearchResponse.class);

--- a/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapperTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapperTests.java
@@ -15,6 +15,8 @@ import org.opensearch.search.SearchHits;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 
+import java.io.IOException;
+
 import org.mockito.Mockito;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -35,28 +37,6 @@ public class TrackingSearchResponseProcessorWrapperTests extends OpenSearchTestC
         context = new PipelineProcessingContext();
     }
 
-    public void testProcessResponse() throws Exception {
-        SearchRequest mockRequest = new SearchRequest();
-        SearchResponse inputResponse = Mockito.mock(SearchResponse.class);
-        SearchResponse outputResponse = Mockito.mock(SearchResponse.class);
-
-        when(inputResponse.getHits()).thenReturn(SearchHits.empty());
-        when(outputResponse.getHits()).thenReturn(SearchHits.empty());
-        when(mockProcessor.processResponse(eq(mockRequest), eq(inputResponse), eq(context))).thenReturn(outputResponse);
-
-        SearchResponse result = wrapper.processResponse(mockRequest, inputResponse, context);
-
-        assertEquals(outputResponse, result);
-        verify(mockProcessor).processResponse(mockRequest, inputResponse, context);
-
-        assertFalse(context.getProcessorExecutionDetails().isEmpty());
-        ProcessorExecutionDetail detail = context.getProcessorExecutionDetails().get(0);
-        assertEquals(wrapper.getType(), detail.getProcessorName());
-        assertNotNull(detail.getInputData());
-        assertNotNull(detail.getOutputData());
-        assertEquals(ProcessorExecutionDetail.ProcessorStatus.SUCCESS, detail.getStatus());
-    }
-
     public void testConstructorThrowsExceptionWhenProcessorIsNull() {
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
@@ -66,7 +46,7 @@ public class TrackingSearchResponseProcessorWrapperTests extends OpenSearchTestC
         assertEquals("Wrapped processor cannot be null.", exception.getMessage());
     }
 
-    public void testProcessResponseAsync() {
+    public void testProcessResponseAsync(){
         SearchRequest mockRequest = new SearchRequest();
         SearchResponse inputResponse = Mockito.mock(SearchResponse.class);
         SearchResponse outputResponse = Mockito.mock(SearchResponse.class);

--- a/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapperTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/TrackingSearchResponseProcessorWrapperTests.java
@@ -15,8 +15,6 @@ import org.opensearch.search.SearchHits;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 
-import java.io.IOException;
-
 import org.mockito.Mockito;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -46,7 +44,7 @@ public class TrackingSearchResponseProcessorWrapperTests extends OpenSearchTestC
         assertEquals("Wrapped processor cannot be null.", exception.getMessage());
     }
 
-    public void testProcessResponseAsync(){
+    public void testProcessResponseAsync() {
         SearchRequest mockRequest = new SearchRequest();
         SearchResponse inputResponse = Mockito.mock(SearchResponse.class);
         SearchResponse outputResponse = Mockito.mock(SearchResponse.class);


### PR DESCRIPTION
Jan 16 revision: 

1. Add two new fields: status and error

- status: Represents the execution status of the processor, with possible values such as SUCCESS and FAIL.
- error: Captures the error message or details if the processor encounters an issue during execution. If no error occurs, this field remains empty.
2. When verbose pipeline is enabled, errors in a processor will not interrupt the search but will document the error and continue searching

When the verbose pipeline mode is enabled, if a processor encounters an error during execution, the search process will not be interrupted. Instead, the error will be documented in the processor's execution details (e.g., in ProcessorExecutionDetail) and the remaining search process will proceed as normal.

```
{
            "processor_name": "rename_field",
            "duration_millis": 0,
            "status": "fail",
            "error": "Document with id 1 is missing field messag123e",
            "input_data": [
                {
                    "_index": "my_index",
                    "_id": "1",
                    "_score": 1.0,
                    "_source": {
                        "message": "This is a public message",
                        "visibility": "public"
                    }
                },
                {
                    "_index": "my_index",
                    "_id": "2",
                    "_score": 1.0,
                    "_source": {
                        "message": "This is a private message",
                        "visibility": "private"
                    }
                }
            ],
            "output_data": null
        },
        {
```
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
3. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
4. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Related RFC : #16705 

This PR introduces enhancements to OpenSearch's search pipeline functionality, focusing on improving the traceability and debugging of search request and response transformations. It addresses the increasing complexity of search pipeline processors by implementing verbose mode support, which provides detailed insights into processor execution.

1. **Adds Verbose Mode for Search Pipelines**:
   - Introduced the `verbose_pipeline` parameter to search requests, default to false.
   - Tracks each processor’s input, output, execution time, and status (success/failure).
   - Provides detailed logs of the data flow through request and response processors.

2. **Improves Pipeline Debugging**:
   - Captures step-by-step data transformations applied by each processor.
   - Includes execution metadata (e.g., timestamps and elapsed time) in search responses for better analysis.

3. **Supports All Pipeline Configurations**:
   - Works seamlessly with:
     - Default pipelines configured at the index level.
     - Pipelines explicitly specified in the search request.
     - Ad-hoc pipelines defined inline.

5. **Test Framework Enhancements**:
   - Added tests for verbose mode to ensure correct functionality and compatibility.



Example output with request processor: `filter_query` response processor: `rename_field` and `sort`
```
{
    "took": 29,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 1,
            "relation": "eq"
        },
        "max_score": 0.9116078,
        "hits": [
            {
                "_index": "my_index",
                "_id": "2",
                "_score": 0.9116078,
                "_source": {
                    "notification": "This is a public message 2",
                    "visibility": "public"
                }
            }
        ]
    },
    "processor_result": [
        {
            "processor_name": "filter_query",
            "duration_millis": 0,
            "input_data": {
                "query": {
                    "bool": {
                        "must": [
                            {
                                "match": {
                                    "message": {
                                        "query": "This is a public message 1",
                                        "operator": "OR",
                                        "prefix_length": 0,
                                        "max_expansions": 50,
                                        "fuzzy_transpositions": true,
                                        "lenient": false,
                                        "zero_terms_query": "NONE",
                                        "auto_generate_synonyms_phrase_query": true,
                                        "boost": 1.0
                                    }
                                }
                            }
                        ],
                        "adjust_pure_negative": true,
                        "boost": 1.0
                    }
                },
                "search_pipeline": "my_pipeline"
            },
            "output_data": {
                "query": {
                    "bool": {
                        "must": [
                            {
                                "bool": {
                                    "must": [
                                        {
                                            "match": {
                                                "message": {
                                                    "query": "This is a public message 1",
                                                    "operator": "OR",
                                                    "prefix_length": 0,
                                                    "max_expansions": 50,
                                                    "fuzzy_transpositions": true,
                                                    "lenient": false,
                                                    "zero_terms_query": "NONE",
                                                    "auto_generate_synonyms_phrase_query": true,
                                                    "boost": 1.0
                                                }
                                            }
                                        }
                                    ],
                                    "adjust_pure_negative": true,
                                    "boost": 1.0
                                }
                            }
                        ],
                        "filter": [
                            {
                                "term": {
                                    "visibility": {
                                        "value": "public",
                                        "boost": 1.0
                                    }
                                }
                            }
                        ],
                        "adjust_pure_negative": true,
                        "boost": 1.0
                    }
                },
                "search_pipeline": "my_pipeline"
            }
        },
        {
            "processor_name": "rename_field",
            "duration_millis": 0,
            "input_data": [
                {
                    "_index": "my_index",
                    "_id": "2",
                    "_score": 0.9116078,
                    "_source": {
                        "message": "This is a public message 2",
                        "visibility": "public"
                    }
                }
            ],
            "output_data": [
                {
                    "_index": "my_index",
                    "_id": "2",
                    "_score": 0.9116078,
                    "_source": {
                        "notification": "This is a public message 2",
                        "visibility": "public"
                    }
                }
            ]
        },
        {
            "processor_name": "sort",
            "duration_millis": 0,
            "input_data": [
                {
                    "_index": "my_index",
                    "_id": "2",
                    "_score": 0.9116078,
                    "_source": {
                        "notification": "This is a public message 2",
                        "visibility": "public"
                    }
                }
            ],
            "output_data": [
                {
                    "_index": "my_index",
                    "_id": "2",
                    "_score": 0.9116078,
                    "_source": {
                        "notification": "This is a public message 2",
                        "visibility": "public"
                    }
                }
            ]
        }
    ]
}
```
### Related Issues
Resolves #14745 
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
