### PR TITLE
Fix Shallow copy snapshot failures on closed index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix _list/shards API failing when closed indices are present ([#16606](https://github.com/opensearch-project/OpenSearch/pull/16606))
 - Fix remote shards balance ([#15335](https://github.com/opensearch-project/OpenSearch/pull/15335))
 - Always use `constant_score` query for `match_only_text` field ([#16964](https://github.com/opensearch-project/OpenSearch/pull/16964))
+- Fix Shallow copy snapshot failures on closed index ([#16868](https://github.com/opensearch-project/OpenSearch/pull/16868))
 
 ### Security
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreIT.java
@@ -39,6 +39,9 @@ import org.opensearch.indices.recovery.PeerRecoveryTargetService;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.snapshots.SnapshotInfo;
+import org.opensearch.snapshots.SnapshotState;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.transport.MockTransportService;
@@ -1077,5 +1080,68 @@ public class RemoteStoreIT extends RemoteStoreBaseIntegTestCase {
         client().admin().indices().close(Requests.closeIndexRequest(INDEX_NAME)).actionGet();
         Thread.sleep(10000);
         ensureGreen(INDEX_NAME);
+    }
+
+    public void testSuccessfulShallowV1SnapshotPostIndexClose() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(1);
+        createIndex(INDEX_NAME, remoteStoreIndexSettings(0, 10000L, -1));
+        ensureGreen(INDEX_NAME);
+
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder().put(CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING.getKey(), "0ms"));
+
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        logger.info("Create shallow snapshot setting enabled repo");
+        String shallowSnapshotRepoName = "shallow-snapshot-repo-name";
+        Path shallowSnapshotRepoPath = randomRepoPath();
+        Settings.Builder settings = Settings.builder()
+            .put("location", shallowSnapshotRepoPath)
+            .put(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY.getKey(), Boolean.TRUE);
+        createRepository(shallowSnapshotRepoName, "fs", settings);
+
+        for (int i = 0; i < 10; i++) {
+            indexBulk(INDEX_NAME, 1);
+        }
+        flushAndRefresh(INDEX_NAME);
+
+        logger.info("Verify shallow snapshot created before close");
+        final String snapshot1 = "snapshot1";
+        SnapshotInfo snapshotInfo1 = internalCluster().client()
+            .admin()
+            .cluster()
+            .prepareCreateSnapshot(shallowSnapshotRepoName, snapshot1)
+            .setIndices(INDEX_NAME)
+            .setWaitForCompletion(true)
+            .get()
+            .getSnapshotInfo();
+
+        assertEquals(SnapshotState.SUCCESS, snapshotInfo1.state());
+        assertTrue(snapshotInfo1.successfulShards() > 0);
+        assertEquals(0, snapshotInfo1.failedShards());
+
+        for (int i = 0; i < 10; i++) {
+            indexBulk(INDEX_NAME, 1);
+        }
+
+        // close index
+        client().admin().indices().close(Requests.closeIndexRequest(INDEX_NAME)).actionGet();
+        Thread.sleep(1000);
+        logger.info("Verify shallow snapshot created after close");
+        final String snapshot2 = "snapshot2";
+
+        SnapshotInfo snapshotInfo2 = internalCluster().client()
+            .admin()
+            .cluster()
+            .prepareCreateSnapshot(shallowSnapshotRepoName, snapshot2)
+            .setIndices(INDEX_NAME)
+            .setWaitForCompletion(true)
+            .get()
+            .getSnapshotInfo();
+
+        assertEquals(SnapshotState.SUCCESS, snapshotInfo2.state());
+        assertTrue(snapshotInfo2.successfulShards() > 0);
+        assertEquals(0, snapshotInfo2.failedShards());
     }
 }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1629,7 +1629,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * @return Tuple(Tuple(primaryTerm, commitGeneration), indexFilesToFileLengthMap)
      * @throws IOException
      */
-
     public Tuple<Tuple<Long, Long>, Map<String, Long>> acquireLastRemoteUploadedIndexCommit() throws IOException {
         if (!indexSettings.isAssignedOnRemoteNode()) {
             throw new IllegalStateException("Index is not assigned on Remote Node");

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1635,6 +1635,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             throw new IllegalStateException("Index is not assigned on Remote Node");
         }
         RemoteSegmentMetadata lastUploadedMetadata = getRemoteDirectory().readLatestMetadataFile();
+        if (lastUploadedMetadata == null) {
+            throw new IllegalStateException("No metadata file found in remote store");
+        }
         final Map<String, Long> indexFilesToFileLengthMap = lastUploadedMetadata.getMetadata()
             .entrySet()
             .stream()

--- a/server/src/main/java/org/opensearch/repositories/FilterRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/FilterRepository.java
@@ -237,7 +237,9 @@ public class FilterRepository implements Repository {
         String shardStateIdentifier,
         IndexShardSnapshotStatus snapshotStatus,
         long primaryTerm,
+        long commitGeneration,
         long startTime,
+        Map<String, Long> indexFilesToFileLengthMap,
         ActionListener<String> listener
     ) {
         in.snapshotRemoteStoreIndexShard(
@@ -248,7 +250,9 @@ public class FilterRepository implements Repository {
             shardStateIdentifier,
             snapshotStatus,
             primaryTerm,
+            commitGeneration,
             startTime,
+            indexFilesToFileLengthMap,
             listener
         );
     }

--- a/server/src/main/java/org/opensearch/repositories/FilterRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/FilterRepository.java
@@ -237,9 +237,7 @@ public class FilterRepository implements Repository {
         String shardStateIdentifier,
         IndexShardSnapshotStatus snapshotStatus,
         long primaryTerm,
-        long commitGeneration,
         long startTime,
-        Map<String, Long> indexFilesToFileLengthMap,
         ActionListener<String> listener
     ) {
         in.snapshotRemoteStoreIndexShard(
@@ -250,9 +248,7 @@ public class FilterRepository implements Repository {
             shardStateIdentifier,
             snapshotStatus,
             primaryTerm,
-            commitGeneration,
             startTime,
-            indexFilesToFileLengthMap,
             listener
         );
     }

--- a/server/src/main/java/org/opensearch/repositories/Repository.java
+++ b/server/src/main/java/org/opensearch/repositories/Repository.java
@@ -406,6 +406,43 @@ public interface Repository extends LifecycleComponent {
         Store store,
         SnapshotId snapshotId,
         IndexId indexId,
+        IndexCommit snapshotIndexCommit,
+        @Nullable String shardStateIdentifier,
+        IndexShardSnapshotStatus snapshotStatus,
+        long primaryTerm,
+        long startTime,
+        ActionListener<String> listener
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Adds a reference of remote store data for a index commit point.
+     * <p>
+     * The index commit point can be obtained by using {@link org.opensearch.index.engine.Engine#acquireLastIndexCommit} method.
+     * Or for closed index can be obtained by reading last remote uploaded metadata by using {@link org.opensearch.index.shard.IndexShard#acquireLastRemoteUploadedIndexCommit} method.
+     * Repository implementations shouldn't release the snapshot index commit point. It is done by the method caller.
+     * <p>
+     * As snapshot process progresses, implementation of this method should update {@link IndexShardSnapshotStatus} object and check
+     * {@link IndexShardSnapshotStatus#isAborted()} to see if the snapshot process should be aborted.
+     * @param store                    store to be snapshotted
+     * @param snapshotId               snapshot id
+     * @param indexId                  id for the index being snapshotted
+     * @param snapshotIndexCommit      commit point
+     * @param shardStateIdentifier     a unique identifier of the state of the shard that is stored with the shard's snapshot and used
+     *                                 to detect if the shard has changed between snapshots. If {@code null} is passed as the identifier
+     *                                 snapshotting will be done by inspecting the physical files referenced by {@code snapshotIndexCommit}
+     * @param snapshotStatus           snapshot status
+     * @param primaryTerm              current Primary Term
+     * @param commitGeneration         current commit generation
+     * @param startTime                start time of the snapshot commit, this will be used as the start time for snapshot.
+     * @param indexFilesToFileLengthMap map of index files to file length
+     * @param listener                 listener invoked on completion
+     */
+    default void snapshotRemoteStoreIndexShard(
+        Store store,
+        SnapshotId snapshotId,
+        IndexId indexId,
         @Nullable IndexCommit snapshotIndexCommit,
         @Nullable String shardStateIdentifier,
         IndexShardSnapshotStatus snapshotStatus,

--- a/server/src/main/java/org/opensearch/repositories/Repository.java
+++ b/server/src/main/java/org/opensearch/repositories/Repository.java
@@ -406,11 +406,13 @@ public interface Repository extends LifecycleComponent {
         Store store,
         SnapshotId snapshotId,
         IndexId indexId,
-        IndexCommit snapshotIndexCommit,
+        @Nullable IndexCommit snapshotIndexCommit,
         @Nullable String shardStateIdentifier,
         IndexShardSnapshotStatus snapshotStatus,
         long primaryTerm,
+        long commitGeneration,
         long startTime,
+        @Nullable Map<String, Long> indexFilesToFileLengthMap,
         ActionListener<String> listener
     ) {
         throw new UnsupportedOperationException();

--- a/server/src/main/java/org/opensearch/repositories/Repository.java
+++ b/server/src/main/java/org/opensearch/repositories/Repository.java
@@ -420,7 +420,7 @@ public interface Repository extends LifecycleComponent {
      * Adds a reference of remote store data for a index commit point.
      * <p>
      * The index commit point can be obtained by using {@link org.opensearch.index.engine.Engine#acquireLastIndexCommit} method.
-     * Or for closed index can be obtained by reading last remote uploaded metadata by using {@link org.opensearch.index.shard.IndexShard#acquireLastRemoteUploadedIndexCommit} method.
+     * Or for closed index can be obtained by reading last remote uploaded metadata by using {@link org.opensearch.index.shard.IndexShard#fetchLastRemoteUploadedSegmentMetadata()} method.
      * Repository implementations shouldn't release the snapshot index commit point. It is done by the method caller.
      * <p>
      * As snapshot process progresses, implementation of this method should update {@link IndexShardSnapshotStatus} object and check

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -3750,6 +3750,33 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         SnapshotId snapshotId,
         IndexId indexId,
         IndexCommit snapshotIndexCommit,
+        @Nullable String shardStateIdentifier,
+        IndexShardSnapshotStatus snapshotStatus,
+        long primaryTerm,
+        long startTime,
+        ActionListener<String> listener
+    ) {
+        snapshotRemoteStoreIndexShard(
+            store,
+            snapshotId,
+            indexId,
+            snapshotIndexCommit,
+            shardStateIdentifier,
+            snapshotStatus,
+            primaryTerm,
+            snapshotIndexCommit.getGeneration(),
+            startTime,
+            null,
+            listener
+        );
+    }
+
+    @Override
+    public void snapshotRemoteStoreIndexShard(
+        Store store,
+        SnapshotId snapshotId,
+        IndexId indexId,
+        IndexCommit snapshotIndexCommit,
         String shardStateIdentifier,
         IndexShardSnapshotStatus snapshotStatus,
         long primaryTerm,
@@ -3760,10 +3787,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     ) {
         if (isReadOnly()) {
             listener.onFailure(new RepositoryException(metadata.name(), "cannot snapshot shard on a readonly repository"));
-            return;
-        }
-        if (snapshotIndexCommit == null && indexFilesToFileLengthMap == null) {
-            listener.onFailure(new RepositoryException(metadata.name(), "both snapshot index commit and index files map cannot be null"));
             return;
         }
 

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
@@ -372,9 +372,9 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
         ActionListener<String> listener
     ) {
         try {
-            final IndexService indexService = indicesService.indexService(shardId.getIndex());
+            final IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
             final IndexShard indexShard = indexService.getShardOrNull(shardId.id());
-            boolean closedIndex = indexService.getMetadata().getState() == IndexMetadata.State.CLOSE;
+            final boolean closedIndex = indexService.getMetadata().getState() == IndexMetadata.State.CLOSE;
             if (indexShard.routingEntry().primary() == false) {
                 throw new IndexShardSnapshotFailedException(shardId, "snapshot should be performed only on primary");
             }

--- a/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/opensearch/snapshots/SnapshotShardsService.java
@@ -44,9 +44,11 @@ import org.opensearch.cluster.SnapshotsInProgress;
 import org.opensearch.cluster.SnapshotsInProgress.ShardSnapshotStatus;
 import org.opensearch.cluster.SnapshotsInProgress.ShardState;
 import org.opensearch.cluster.SnapshotsInProgress.State;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.lifecycle.AbstractLifecycleComponent;
 import org.opensearch.common.settings.Settings;
@@ -74,7 +76,6 @@ import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
-import java.nio.file.NoSuchFileException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -371,7 +372,9 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
         ActionListener<String> listener
     ) {
         try {
-            final IndexShard indexShard = indicesService.indexServiceSafe(shardId.getIndex()).getShardOrNull(shardId.id());
+            final IndexService indexService = indicesService.indexService(shardId.getIndex());
+            final IndexShard indexShard = indexService.getShardOrNull(shardId.id());
+            boolean closedIndex = indexService.getMetadata().getState() == IndexMetadata.State.CLOSE;
             if (indexShard.routingEntry().primary() == false) {
                 throw new IndexShardSnapshotFailedException(shardId, "snapshot should be performed only on primary");
             }
@@ -398,24 +401,39 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 if (remoteStoreIndexShallowCopy && indexShard.indexSettings().isRemoteStoreEnabled()) {
                     long startTime = threadPool.relativeTimeInMillis();
                     long primaryTerm = indexShard.getOperationPrimaryTerm();
-                    // we flush first to make sure we get the latest writes snapshotted
-                    wrappedSnapshot = indexShard.acquireLastIndexCommitAndRefresh(true);
-                    IndexCommit snapshotIndexCommit = wrappedSnapshot.get();
-                    long commitGeneration = snapshotIndexCommit.getGeneration();
+                    long commitGeneration = 0L;
+                    Map<String, Long> indexFilesToFileLengthMap = null;
+                    IndexCommit snapshotIndexCommit = null;
+
                     try {
+                        if (closedIndex) {
+                            final Tuple<Tuple<Long, Long>, Map<String, Long>> tuple = indexShard.acquireLastRemoteUploadedIndexCommit();
+                            primaryTerm = tuple.v1().v1();
+                            commitGeneration = tuple.v1().v2();
+                            indexFilesToFileLengthMap = tuple.v2();
+                        } else {
+                            wrappedSnapshot = indexShard.acquireLastIndexCommitAndRefresh(true);
+                            snapshotIndexCommit = wrappedSnapshot.get();
+                            commitGeneration = snapshotIndexCommit.getGeneration();
+                        }
                         indexShard.acquireLockOnCommitData(snapshot.getSnapshotId().getUUID(), primaryTerm, commitGeneration);
-                    } catch (NoSuchFileException e) {
-                        wrappedSnapshot.close();
-                        logger.warn(
-                            "Exception while acquiring lock on primaryTerm = {} and generation = {}",
-                            primaryTerm,
-                            commitGeneration
-                        );
-                        indexShard.flush(new FlushRequest(shardId.getIndexName()).force(true));
-                        wrappedSnapshot = indexShard.acquireLastIndexCommit(false);
-                        snapshotIndexCommit = wrappedSnapshot.get();
-                        commitGeneration = snapshotIndexCommit.getGeneration();
-                        indexShard.acquireLockOnCommitData(snapshot.getSnapshotId().getUUID(), primaryTerm, commitGeneration);
+                    } catch (IOException e) {
+                        if (closedIndex) {
+                            logger.warn("Exception while reading latest metadata file from remote store");
+                            throw e;
+                        } else {
+                            wrappedSnapshot.close();
+                            logger.warn(
+                                "Exception while acquiring lock on primaryTerm = {} and generation = {}",
+                                primaryTerm,
+                                commitGeneration
+                            );
+                            indexShard.flush(new FlushRequest(shardId.getIndexName()).force(true));
+                            wrappedSnapshot = indexShard.acquireLastIndexCommit(false);
+                            snapshotIndexCommit = wrappedSnapshot.get();
+                            commitGeneration = snapshotIndexCommit.getGeneration();
+                            indexShard.acquireLockOnCommitData(snapshot.getSnapshotId().getUUID(), primaryTerm, commitGeneration);
+                        }
                     }
                     try {
                         repository.snapshotRemoteStoreIndexShard(
@@ -423,11 +441,13 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                             snapshot.getSnapshotId(),
                             indexId,
                             snapshotIndexCommit,
-                            getShardStateId(indexShard, snapshotIndexCommit),
+                            null,
                             snapshotStatus,
                             primaryTerm,
+                            commitGeneration,
                             startTime,
-                            ActionListener.runBefore(listener, wrappedSnapshot::close)
+                            indexFilesToFileLengthMap,
+                            closedIndex ? listener : ActionListener.runBefore(listener, wrappedSnapshot::close)
                         );
                     } catch (IndexShardSnapshotFailedException e) {
                         logger.error(

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -892,7 +892,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
             replicateSegments(primaryShard, shards.getReplicas());
             shards.assertAllEqual(10);
 
-            final SnapshotShardsService shardsService = getSnapshotShardsService(replicaShard);
+            final SnapshotShardsService shardsService = getSnapshotShardsService(replicaShard, shards.getIndexMetadata());
             final Snapshot snapshot = new Snapshot(randomAlphaOfLength(10), new SnapshotId(randomAlphaOfLength(5), randomAlphaOfLength(5)));
 
             final ClusterState initState = addSnapshotIndex(clusterService.state(), snapshot, replicaShard, SnapshotsInProgress.State.INIT);
@@ -956,13 +956,14 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
         }
     }
 
-    private SnapshotShardsService getSnapshotShardsService(IndexShard replicaShard) {
+    private SnapshotShardsService getSnapshotShardsService(IndexShard replicaShard, IndexMetadata indexMetadata) {
         final TransportService transportService = mock(TransportService.class);
         when(transportService.getThreadPool()).thenReturn(threadPool);
         final IndicesService indicesService = mock(IndicesService.class);
         final IndexService indexService = mock(IndexService.class);
         when(indicesService.indexServiceSafe(any())).thenReturn(indexService);
         when(indexService.getShardOrNull(anyInt())).thenReturn(replicaShard);
+        when(indexService.getMetadata()).thenReturn(indexMetadata);
         return new SnapshotShardsService(settings, clusterService, createRepositoriesService(), transportService, indicesService);
     }
 

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -68,6 +68,7 @@ import org.opensearch.indices.replication.common.ReplicationListener;
 import org.opensearch.indices.replication.common.ReplicationState;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.repositories.IndexId;
+import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.snapshots.Snapshot;
 import org.opensearch.snapshots.SnapshotId;
 import org.opensearch.snapshots.SnapshotInfoTests;
@@ -892,10 +893,21 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
             replicateSegments(primaryShard, shards.getReplicas());
             shards.assertAllEqual(10);
 
-            final SnapshotShardsService shardsService = getSnapshotShardsService(replicaShard, shards.getIndexMetadata());
+            final SnapshotShardsService shardsService = getSnapshotShardsService(
+                replicaShard,
+                shards.getIndexMetadata(),
+                false,
+                createRepositoriesService()
+            );
             final Snapshot snapshot = new Snapshot(randomAlphaOfLength(10), new SnapshotId(randomAlphaOfLength(5), randomAlphaOfLength(5)));
 
-            final ClusterState initState = addSnapshotIndex(clusterService.state(), snapshot, replicaShard, SnapshotsInProgress.State.INIT);
+            final ClusterState initState = addSnapshotIndex(
+                clusterService.state(),
+                snapshot,
+                replicaShard,
+                SnapshotsInProgress.State.INIT,
+                false
+            );
             shardsService.clusterChanged(new ClusterChangedEvent("test", initState, clusterService.state()));
 
             CountDownLatch latch = new CountDownLatch(1);
@@ -907,7 +919,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
                 shardsService.clusterChanged(
                     new ClusterChangedEvent(
                         "test",
-                        addSnapshotIndex(clusterService.state(), snapshot, replicaShard, SnapshotsInProgress.State.STARTED),
+                        addSnapshotIndex(clusterService.state(), snapshot, replicaShard, SnapshotsInProgress.State.STARTED, false),
                         initState
                     )
                 );
@@ -956,22 +968,30 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
         }
     }
 
-    private SnapshotShardsService getSnapshotShardsService(IndexShard replicaShard, IndexMetadata indexMetadata) {
+    protected SnapshotShardsService getSnapshotShardsService(
+        IndexShard indexShard,
+        IndexMetadata indexMetadata,
+        boolean closedIdx,
+        RepositoriesService repositoriesService
+    ) {
         final TransportService transportService = mock(TransportService.class);
         when(transportService.getThreadPool()).thenReturn(threadPool);
         final IndicesService indicesService = mock(IndicesService.class);
         final IndexService indexService = mock(IndexService.class);
         when(indicesService.indexServiceSafe(any())).thenReturn(indexService);
-        when(indexService.getShardOrNull(anyInt())).thenReturn(replicaShard);
-        when(indexService.getMetadata()).thenReturn(indexMetadata);
-        return new SnapshotShardsService(settings, clusterService, createRepositoriesService(), transportService, indicesService);
+        when(indexService.getShardOrNull(anyInt())).thenReturn(indexShard);
+        when(indexService.getMetadata()).thenReturn(
+            new IndexMetadata.Builder(indexMetadata).state(closedIdx ? IndexMetadata.State.CLOSE : IndexMetadata.State.OPEN).build()
+        );
+        return new SnapshotShardsService(settings, clusterService, repositoriesService, transportService, indicesService);
     }
 
-    private ClusterState addSnapshotIndex(
+    protected ClusterState addSnapshotIndex(
         ClusterState state,
         Snapshot snapshot,
         IndexShard shard,
-        SnapshotsInProgress.State snapshotState
+        SnapshotsInProgress.State snapshotState,
+        boolean shallowCopySnapshot
     ) {
         final Map<ShardId, SnapshotsInProgress.ShardSnapshotStatus> shardsBuilder = new HashMap<>();
         ShardRouting shardRouting = shard.shardRouting;
@@ -992,7 +1012,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
             null,
             SnapshotInfoTests.randomUserMetadata(),
             VersionUtils.randomVersion(random()),
-            false
+            shallowCopySnapshot
         );
         return ClusterState.builder(state)
             .putCustom(SnapshotsInProgress.TYPE, SnapshotsInProgress.of(Collections.singletonList(entry)))

--- a/server/src/test/java/org/opensearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/opensearch/repositories/RepositoriesServiceTests.java
@@ -774,7 +774,9 @@ public class RepositoriesServiceTests extends OpenSearchTestCase {
             String shardStateIdentifier,
             IndexShardSnapshotStatus snapshotStatus,
             long primaryTerm,
+            long commitGeneration,
             long startTime,
+            Map<String, Long> indexFilesToFileLengthMap,
             ActionListener<String> listener
         ) {
 

--- a/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
@@ -289,6 +289,10 @@ public abstract class OpenSearchIndexLevelReplicationTestCase extends IndexShard
             return new EngineConfigFactory(indexSettings);
         }
 
+        public IndexMetadata getIndexMetadata() {
+            return indexMetadata;
+        }
+
         public int indexDocs(final int numOfDoc) throws Exception {
             for (int doc = 0; doc < numOfDoc; doc++) {
                 final IndexRequest indexRequest = new IndexRequest(index.getName()).id(Integer.toString(docId.incrementAndGet()))


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
We observed for a remote-store backed index, if the index get’s closed, the shallow snapshot fails for the shard with error : 
`java.nio.file.NoSuchFileException: Metadata file is not present for given primary term <X> and generation <Y> `. 
On root causing the issue we found : 
* There is difference in last segment generation on local node directory & remote store directory. Where remote store lags by 1 generation.
* The shallow_v1 snapshot tries to find the latest segment generation on remote store, which was failing since it never got uploaded.
* The last segment_N file while closing the index got uploaded to the remote store.
* But post successful close, we open a read_only engine for the index, which performs the recovery and creates a new segment_N file, but since it will not be having any refresh_listener available the new file will not get uploaded to remote store ever.

Approach : 
* Take snapshot with last successfully uploaded segment generation
* We fetch the latest metadata file from remote directory and take lock on that commit generation.

### Related Issues
Resolves [#13805]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
