### PR TITLE
Improve performance of the bitmap filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support object fields in star-tree index([#16728](https://github.com/opensearch-project/OpenSearch/pull/16728/))
 - Support searching from doc_value using termQueryCaseInsensitive/termQuery in flat_object/keyword field([#16974](https://github.com/opensearch-project/OpenSearch/pull/16974/))
 - Added a new `time` field to replace the deprecated `getTime` field in `GetStats`. ([#17009](https://github.com/opensearch-project/OpenSearch/pull/17009))
+- Improve performance of the bitmap filtering([#16936](https://github.com/opensearch-project/OpenSearch/pull/16936/))
 
 ### Dependencies
 - Bump `com.google.cloud:google-cloud-core-http` from 2.23.0 to 2.47.0 ([#16504](https://github.com/opensearch-project/OpenSearch/pull/16504))

--- a/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
@@ -42,15 +42,22 @@ import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.sandbox.document.BigIntegerPoint;
 import org.apache.lucene.sandbox.document.HalfFloatPoint;
 import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.IndexSortSortedNumericDocValuesRangeQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.PointInSetQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.opensearch.common.Explicit;
@@ -1508,36 +1515,89 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
             return builder.apply(l, u);
         }
 
-        static PointInSetQuery bitmapIndexQuery(String field, RoaringBitmap bitmap) {
-            final BytesRef encoded = new BytesRef(new byte[Integer.BYTES]);
-            return new PointInSetQuery(field, 1, Integer.BYTES, new PointInSetQuery.Stream() {
-
-                final Iterator<Integer> iterator = bitmap.iterator();
+        static Query bitmapIndexQuery(String field, RoaringBitmap bitmap) {
+            return new Query() {
 
                 @Override
-                public BytesRef next() {
-                    int value;
-                    if (iterator.hasNext()) {
-                        value = iterator.next();
-                    } else {
-                        return null;
-                    }
-                    IntPoint.encodeDimension(value, encoded.bytes, 0);
-                    return encoded;
-                }
-            }) {
-                @Override
-                public Query rewrite(IndexSearcher indexSearcher) throws IOException {
-                    if (bitmap.isEmpty()) {
-                        return new MatchNoDocsQuery();
-                    }
-                    return super.rewrite(indexSearcher);
+                public String toString(String field) {
+                    return "";
                 }
 
                 @Override
-                protected String toString(byte[] value) {
-                    assert value.length == Integer.BYTES;
-                    return Integer.toString(IntPoint.decodeDimension(value, 0));
+                public void visit(QueryVisitor visitor) {
+
+                }
+
+                @Override
+                public boolean equals(Object obj) {
+                    return false;
+                }
+
+                @Override
+                public int hashCode() {
+                    return 0;
+                }
+
+                @Override
+                public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
+                    return new ConstantScoreWeight(this, boost) {
+                        @Override
+                        public Scorer scorer(LeafReaderContext context) throws IOException {
+                            return scorerSupplier(context).get(Long.MAX_VALUE);
+                        }
+
+                        @Override
+                        public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                            return new ScorerSupplier() {
+                                @Override
+                                public Scorer get(long leadCost) throws IOException {
+
+                                    final BytesRef encoded = new BytesRef(new byte[Integer.BYTES]);
+                                    Query query = new PointInSetQuery(field, 1, Integer.BYTES, new PointInSetQuery.Stream() {
+
+                                        final Iterator<Integer> iterator = bitmap.iterator();
+
+                                        @Override
+                                        public BytesRef next() {
+                                            int value;
+                                            if (iterator.hasNext()) {
+                                                value = iterator.next();
+                                            } else {
+                                                return null;
+                                            }
+                                            IntPoint.encodeDimension(value, encoded.bytes, 0);
+                                            return encoded;
+                                        }
+                                    }) {
+                                        @Override
+                                        public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+                                            if (bitmap.isEmpty()) {
+                                                return new MatchNoDocsQuery();
+                                            }
+                                            return super.rewrite(indexSearcher);
+                                        }
+
+                                        @Override
+                                        protected String toString(byte[] value) {
+                                            assert value.length == Integer.BYTES;
+                                            return Integer.toString(IntPoint.decodeDimension(value, 0));
+                                        }
+                                    };
+                                    return query.createWeight(searcher, scoreMode, boost).scorer(context);
+                                }
+
+                                @Override
+                                public long cost() {
+                                    return bitmap.getLongCardinality();
+                                }
+                            };
+                        }
+
+                        @Override
+                        public boolean isCacheable(LeafReaderContext ctx) {
+                            return false;
+                        }
+                    };
                 }
             };
         }

--- a/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
@@ -80,6 +80,7 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.lookup.SearchLookup;
 import org.opensearch.search.query.BitmapDocValuesQuery;
+import org.opensearch.search.query.BitmapIndexQuery;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -97,7 +98,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.opensearch.search.query.BitmapIndexQuery;
 import org.roaringbitmap.RoaringBitmap;
 
 /**
@@ -1555,6 +1555,7 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
                                     final BytesRef encoded = new BytesRef(new byte[Integer.BYTES]);
                                     Query query = new PointInSetQuery(field, 1, Integer.BYTES, new PointInSetQuery.Stream() {
                                         final Iterator<Integer> iterator = bitmap.iterator();
+
                                         @Override
                                         public BytesRef next() {
                                             int value;

--- a/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
@@ -97,6 +97,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.opensearch.search.query.BitmapIndexQuery;
 import org.roaringbitmap.RoaringBitmap;
 
 /**
@@ -895,10 +896,10 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
                 }
 
                 if (isSearchable && hasDocValues) {
-                    return new IndexOrDocValuesQuery(bitmapIndexQuery(field, bitmap), new BitmapDocValuesQuery(field, bitmap));
+                    return new IndexOrDocValuesQuery(new BitmapIndexQuery(field, bitmap), new BitmapDocValuesQuery(field, bitmap));
                 }
                 if (isSearchable) {
-                    return bitmapIndexQuery(field, bitmap);
+                    return new BitmapIndexQuery(field, bitmap);
                 }
                 return new BitmapDocValuesQuery(field, bitmap);
             }
@@ -1551,12 +1552,9 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
                             return new ScorerSupplier() {
                                 @Override
                                 public Scorer get(long leadCost) throws IOException {
-
                                     final BytesRef encoded = new BytesRef(new byte[Integer.BYTES]);
                                     Query query = new PointInSetQuery(field, 1, Integer.BYTES, new PointInSetQuery.Stream() {
-
                                         final Iterator<Integer> iterator = bitmap.iterator();
-
                                         @Override
                                         public BytesRef next() {
                                             int value;
@@ -1583,6 +1581,7 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
                                             return Integer.toString(IntPoint.decodeDimension(value, 0));
                                         }
                                     };
+
                                     return query.createWeight(searcher, scoreMode, boost).scorer(context);
                                 }
 

--- a/server/src/main/java/org/opensearch/search/query/BitmapDocValuesQuery.java
+++ b/server/src/main/java/org/opensearch/search/query/BitmapDocValuesQuery.java
@@ -111,8 +111,7 @@ public class BitmapDocValuesQuery extends Query implements Accountable {
 
     @Override
     public String toString(String field) {
-        // bitmap may contain high cardinality, so choose to not show the actual values in it
-        return field + " cardinality: " + bitmap.getLongCardinality();
+        return "BitmapDocValuesQuery(field=" + field + ")";
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/query/BitmapDocValuesQuery.java
+++ b/server/src/main/java/org/opensearch/search/query/BitmapDocValuesQuery.java
@@ -141,8 +141,8 @@ public class BitmapDocValuesQuery extends Query implements Accountable {
 
     @Override
     public long ramBytesUsed() {
-        return RamUsageEstimator.shallowSizeOfInstance(BitmapDocValuesQuery.class) + RamUsageEstimator.sizeOfObject(field)
-            + RamUsageEstimator.sizeOfObject(bitmap);
+        return RamUsageEstimator.shallowSizeOfInstance(BitmapIndexQuery.class) + RamUsageEstimator.sizeOf(field) + bitmap
+            .getLongSizeInBytes();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/query/BitmapDocValuesQuery.java
+++ b/server/src/main/java/org/opensearch/search/query/BitmapDocValuesQuery.java
@@ -30,6 +30,8 @@ import java.util.Objects;
 
 import org.roaringbitmap.RoaringBitmap;
 
+import static org.opensearch.search.query.BitmapIndexQuery.checkArgs;
+
 /**
  * Filter with bitmap
  * <p>
@@ -43,6 +45,7 @@ public class BitmapDocValuesQuery extends Query implements Accountable {
     final long max;
 
     public BitmapDocValuesQuery(String field, RoaringBitmap bitmap) {
+        checkArgs(field, bitmap);
         this.field = field;
         this.bitmap = bitmap;
         if (!bitmap.isEmpty()) {

--- a/server/src/main/java/org/opensearch/search/query/BitmapDocValuesQuery.java
+++ b/server/src/main/java/org/opensearch/search/query/BitmapDocValuesQuery.java
@@ -114,7 +114,7 @@ public class BitmapDocValuesQuery extends Query implements Accountable {
 
     @Override
     public String toString(String field) {
-        return "BitmapDocValuesQuery(field=" + field + ")";
+        return "BitmapDocValuesQuery(field=" + this.field + ")";
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/query/BitmapIndexQuery.java
+++ b/server/src/main/java/org/opensearch/search/query/BitmapIndexQuery.java
@@ -278,7 +278,7 @@ public class BitmapIndexQuery extends Query implements Accountable {
 
     @Override
     public long ramBytesUsed() {
-        return RamUsageEstimator.shallowSizeOfInstance(BitmapIndexQuery.class) + RamUsageEstimator.sizeOfObject(field) + RamUsageEstimator
-            .sizeOfObject(bitmap);
+        return RamUsageEstimator.shallowSizeOfInstance(BitmapIndexQuery.class) + RamUsageEstimator.sizeOf(field) + bitmap
+            .getLongSizeInBytes();
     }
 }

--- a/server/src/main/java/org/opensearch/search/query/BitmapIndexQuery.java
+++ b/server/src/main/java/org/opensearch/search/query/BitmapIndexQuery.java
@@ -1,0 +1,266 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.query;
+
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefIterator;
+import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.roaringbitmap.RoaringBitmap;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * A query that matches all documents that contain a set of integer numbers represented by bitmap
+ *
+ * @opensearch.internal
+ */
+public class BitmapIndexQuery extends Query implements Accountable {
+
+    private final RoaringBitmap bitmap;
+    private final String field;
+
+    public BitmapIndexQuery(String field, RoaringBitmap bitmap) {
+        this.bitmap = bitmap;
+        this.field = field;
+    }
+
+    private static BytesRefIterator bitmapEncodedIterator(RoaringBitmap bitmap) {
+        return new BytesRefIterator() {
+            private final Iterator<Integer> iterator = bitmap.iterator();
+            private final BytesRef encoded = new BytesRef(new byte[Integer.BYTES]);
+
+            @Override
+            public BytesRef next() {
+                int value;
+                if (iterator.hasNext()) {
+                    value = iterator.next();
+                } else {
+                    return null;
+                }
+                IntPoint.encodeDimension(value, encoded.bytes, 0);
+                return encoded;
+            }
+        };
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new ConstantScoreWeight(this, boost) {
+            @Override
+            public Scorer scorer(LeafReaderContext context) throws IOException {
+                ScorerSupplier scorerSupplier = scorerSupplier(context);
+                if (scorerSupplier == null) {
+                    return null;
+                }
+                return scorerSupplier.get(Long.MAX_VALUE);
+            }
+
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                final Weight weight = this;
+                LeafReader reader = context.reader();
+                // get point value
+                // only works for one dimension
+                PointValues values = reader.getPointValues(field);
+                if (values == null) {
+                    return null;
+                }
+                if (values.getNumIndexDimensions() != 1) {
+                    throw new IllegalArgumentException("field must have only one dimension");
+                }
+
+                return new ScorerSupplier() {
+                    long cost = -1; // calculate lazily, and only once
+
+                    @Override
+                    public Scorer get(long leadCost) throws IOException {
+                        DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+                        MergePointVisitor visitor = new MergePointVisitor(result);
+                        values.intersect(visitor);
+                        return new ConstantScoreScorer(weight, score(), scoreMode, result.build().iterator());
+                    }
+
+                    @Override
+                    public long cost() {
+                        if (cost == -1) {
+                            cost = bitmap.getLongCardinality();
+                        }
+                        return cost;
+                    }
+                };
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                // This query depend only on segment-immutable structure points
+                return true;
+            }
+        };
+    }
+
+    private class MergePointVisitor implements PointValues.IntersectVisitor {
+        private final DocIdSetBuilder result;
+        private final BytesRefIterator iterator;
+        private BytesRef nextQueryPoint;
+        private final ArrayUtil.ByteArrayComparator comparator;
+        private DocIdSetBuilder.BulkAdder adder;
+
+        public MergePointVisitor(DocIdSetBuilder result)
+            throws IOException {
+            this.result = result;
+            this.comparator = ArrayUtil.getUnsignedComparator(Integer.BYTES);
+            this.iterator = bitmapEncodedIterator(bitmap);
+            nextQueryPoint = iterator.next();
+        }
+
+        @Override
+        public void grow(int count) {
+            adder = result.grow(count);
+        }
+
+        @Override
+        public void visit(int docID) {
+            adder.add(docID);
+        }
+
+        @Override
+        public void visit(DocIdSetIterator iterator) throws IOException {
+            adder.add(iterator);
+        }
+
+        @Override
+        public void visit(int docID, byte[] packedValue) {
+            if (matches(packedValue)) {
+                visit(docID);
+            }
+        }
+
+        @Override
+        public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
+            if (matches(packedValue)) {
+                adder.add(iterator);
+            }
+        }
+
+        private boolean matches(byte[] packedValue) {
+            while (nextQueryPoint != null) {
+                int cmp = comparator.compare(nextQueryPoint.bytes, nextQueryPoint.offset, packedValue, 0);
+                if (cmp == 0) {
+                    return true;
+                } else if (cmp < 0) {
+                    // Query point is before index point, so we move to next query point
+                    try {
+                        nextQueryPoint = iterator.next();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                } else {
+                    // Query point is after index point, so we don't collect and we return:
+                    break;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+            while (nextQueryPoint != null) {
+                int cmpMin =
+                    comparator.compare(nextQueryPoint.bytes, nextQueryPoint.offset, minPackedValue, 0);
+                if (cmpMin < 0) {
+                    // query point is before the start of this cell
+                    try {
+                        nextQueryPoint = iterator.next();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                    continue;
+                }
+                int cmpMax =
+                    comparator.compare(nextQueryPoint.bytes, nextQueryPoint.offset, maxPackedValue, 0);
+                if (cmpMax > 0) {
+                    // query point is after the end of this cell
+                    return PointValues.Relation.CELL_OUTSIDE_QUERY;
+                }
+
+                if (cmpMin == 0 && cmpMax == 0) {
+                    // NOTE: we only hit this if we are on a cell whose min and max values are exactly equal
+                    // to our point,
+                    // which can easily happen if many (> 512) docs share this one value
+                    return PointValues.Relation.CELL_INSIDE_QUERY;
+                } else {
+                    return PointValues.Relation.CELL_CROSSES_QUERY;
+                }
+            }
+
+            // We exhausted all points in the query:
+            return PointValues.Relation.CELL_OUTSIDE_QUERY;
+        }
+    }
+
+    @Override
+    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+        if (bitmap.isEmpty()) {
+            return new MatchNoDocsQuery();
+        }
+        return super.rewrite(indexSearcher);
+    }
+
+    @Override
+    public String toString(String field) {
+        return "BitmapIndexQuery(field=" + field + ")";
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(field)) {
+            visitor.visitLeaf(this);
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (sameClassAs(other) == false) {
+            return false;
+        }
+        BitmapIndexQuery that = (BitmapIndexQuery) other;
+        return field.equals(that.field) && bitmap.equals(that.bitmap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classHash(), field, bitmap);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return RamUsageEstimator.shallowSizeOfInstance(BitmapIndexQuery.class) + RamUsageEstimator.sizeOfObject(field)
+            + RamUsageEstimator.sizeOfObject(bitmap);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/query/BitmapIndexQuery.java
+++ b/server/src/main/java/org/opensearch/search/query/BitmapIndexQuery.java
@@ -47,8 +47,18 @@ public class BitmapIndexQuery extends Query implements Accountable {
     private final String field;
 
     public BitmapIndexQuery(String field, RoaringBitmap bitmap) {
+        checkArgs(field, bitmap);
         this.bitmap = bitmap;
         this.field = field;
+    }
+
+    static void checkArgs(String field, RoaringBitmap bitmap) {
+        if (field == null) {
+            throw new IllegalArgumentException("field must not be null");
+        }
+        if (bitmap == null) {
+            throw new IllegalArgumentException("bitmap must not be null");
+        }
     }
 
     interface BitmapIterator extends BytesRefIterator {

--- a/server/src/test/java/org/opensearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/NumberFieldTypeTests.java
@@ -970,6 +970,9 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         ft = new NumberFieldType("field", NumberType.INTEGER, false, false, true, true, null, Collections.emptyMap());
         assertEquals(new BitmapDocValuesQuery("field", r), ft.bitmapQuery(bitmap));
 
+        ft = new NumberFieldType("field", NumberType.INTEGER, true, false, false, true, null, Collections.emptyMap());
+        assertEquals(new BitmapIndexQuery("field", r), ft.bitmapQuery(bitmap));
+
         Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, new IndexWriterConfig());
         DirectoryReader reader = DirectoryReader.open(w);

--- a/server/src/test/java/org/opensearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/NumberFieldTypeTests.java
@@ -76,6 +76,7 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.MultiValueMode;
 import org.opensearch.search.query.BitmapDocValuesQuery;
+import org.opensearch.search.query.BitmapIndexQuery;
 import org.junit.Before;
 
 import java.io.ByteArrayInputStream;
@@ -962,7 +963,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
 
         NumberFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER);
         assertEquals(
-            new IndexOrDocValuesQuery(NumberType.bitmapIndexQuery("field", r), new BitmapDocValuesQuery("field", r)),
+            new IndexOrDocValuesQuery(new BitmapIndexQuery("field", r), new BitmapDocValuesQuery("field", r)),
             ft.bitmapQuery(bitmap)
         );
 

--- a/server/src/test/java/org/opensearch/search/query/BitmapDocValuesQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/query/BitmapDocValuesQueryTests.java
@@ -12,14 +12,9 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.IntField;
 import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.SortedNumericDocValues;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.opensearch.test.OpenSearchTestCase;
@@ -28,7 +23,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 

--- a/server/src/test/java/org/opensearch/search/query/BitmapIndexQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/query/BitmapIndexQueryTests.java
@@ -23,16 +23,21 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
+import org.opensearch.common.Randomness;
+import org.opensearch.test.OpenSearchTestCase;
 import org.junit.After;
 import org.junit.Before;
-import org.opensearch.test.OpenSearchTestCase;
-import org.roaringbitmap.RoaringBitmap;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
+
+import org.roaringbitmap.RoaringBitmap;
 
 public class BitmapIndexQueryTests extends OpenSearchTestCase {
     private Directory dir;
@@ -86,11 +91,11 @@ public class BitmapIndexQueryTests extends OpenSearchTestCase {
         assertEquals(expected, actual);
     }
 
+    // use doc values to get the actual value of the matching docs
+    // cannot directly check the docId because test can randomize segment numbers
     static List<Integer> getMatchingValues(Weight weight, IndexReader reader) throws IOException {
         List<Integer> actual = new LinkedList<>();
         for (LeafReaderContext leaf : reader.leaves()) {
-            // use doc values to get the actual value of the matching docs and assert
-            // cannot directly check the docId because test can randomize segment numbers
             SortedNumericDocValues dv = DocValues.getSortedNumeric(leaf.reader(), "product_id");
             Scorer scorer = weight.scorer(leaf);
             DocIdSetIterator disi = scorer.iterator();
@@ -135,6 +140,42 @@ public class BitmapIndexQueryTests extends OpenSearchTestCase {
 
         Set<Integer> actual = new HashSet<>(getMatchingValues(weight, searcher.getIndexReader()));
         Set<Integer> expected = Set.of(2, 3);
+        assertEquals(expected, actual);
+    }
+
+    public void testRandomDocumentsAndQueries() throws IOException {
+        Random random = Randomness.get();
+        int valueRange = 10_000; // the range of query values should be within indexed values
+
+        for (int i = 0; i < valueRange + 1; i++) {
+            Document d = new Document();
+            d.add(new IntField("product_id", i, Field.Store.NO));
+            w.addDocument(d);
+        }
+
+        w.commit();
+        reader = DirectoryReader.open(w);
+        searcher = newSearcher(reader);
+
+        // Generate random values for bitmap query
+        Set<Integer> queryValues = new HashSet<>();
+        int numberOfValues = 5;
+        for (int i = 0; i < numberOfValues; i++) {
+            int value = random.nextInt(valueRange) + 1;
+            queryValues.add(value);
+        }
+        RoaringBitmap bitmap = new RoaringBitmap();
+        bitmap.add(queryValues.stream().mapToInt(Integer::intValue).toArray());
+
+        BitmapIndexQuery query = new BitmapIndexQuery("product_id", bitmap);
+        Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE_NO_SCORES, 1f);
+
+        Set<Integer> actualSet = new HashSet<>(getMatchingValues(weight, searcher.getIndexReader()));
+
+        List<Integer> expected = new ArrayList<>(queryValues);
+        Collections.sort(expected);
+        List<Integer> actual = new ArrayList<>(actualSet);
+        Collections.sort(actual);
         assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

This change adds a new bitmap index query that solves existing performance issue described in the related issue below. In short, the time spent in constructor and cost estimation.

Bitmap index query takes advantage of the index structure or points of the numeric field, and traverse points to return an iterator of matching doc ids. Matching doc here means its value is inside the bitmap.

The main reason bitmap index query is needed is to support IndexOrDocValuesQuery.
IndexOrDocValuesQuery can decide which query, index or doc value, to supply scorer at the runtime depending on the comparison between cost of the chosen lead iterator (c_lead) and the index query (c_iq). For example, we have a term filter that matches **1%** of the total documents, and a numeric range IndexOrDocValuesQuery matches **10%** of the total documents. Obviously term filter will become the lead iterator since it's matching fewer docs. And more importantly, IndexOrDocValuesQuery will choose doc value query at runtime because the c_iq = 10 x c_lead. Note IndexOrDocValuesQuery has a heuristic to choose doc value query only when cost of index query is 8 times the lead iterator cost. https://github.com/apache/lucene/blob/ddf538d43e94a814f783fcc40728ee45038a03a1/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java#L170-L174

Another reason bitmap index query is useful is it's much faster than doc value query when the size of queried terms is small, like only 0.01% of the total docs. It's because index structure is always much faster to find a smaller matching set than doc value which needs to iterate over all documents. This is useful either when bitmap query is used alone, or chosen as the lead iterator.

#### Benchmark

I use a 3 nodes cluster, one node is purely client, the other two nodes each holding one primary shard.
The index has 100 million ordered numeric documents.

![query_time_comparison](https://github.com/user-attachments/assets/0110f845-2b89-41ed-9f46-2b6a67812a78)
This is the results of running simple terms query, using index or doc values. X axis represents the number of IDs that are queried. For example, 10^5 means randomly choosing 100K different numbers from 100M which is 0.1% of total documents. You can see when the size of queried IDs become larger, bitmap queries are performing better, mostly because of the saved network bandwidth.

---

![query_time_comparison_2](https://github.com/user-attachments/assets/4a248732-8a3d-4863-a89e-c00d0357f309)
If we just look at the 2 bitmap queries, index and doc value, you may wonder why doc value becomes much faster than index when size of queried terms becomes large. I turn on the `track_total_hits` and the result is below as expected. So by default the query will stop iterate when there are 10K matches, and the larger the queried terms, the denser matched documents can be iterated by doc values, which is what I think the reason.
![query_time_comparison_track_total_hits](https://github.com/user-attachments/assets/49a1f843-56ad-4b32-952c-51ab5170d93a)

#### Choose the Cost

The cost of bitmap index query is chosen to be based on the cardinality of the bitmap because we do iterate over the items in the bitmap. Below are the results of using the cardinality as the cost and run conjunction query of term filter plus bitmap query. Note the legend here has a little mistake, (index) actually represents bitmap IndexOrDocValuesQuery. Red dotted line indicates the query size of the term filter.

![query_time_comparison_100K](https://github.com/user-attachments/assets/aef70af2-3115-408e-962e-ac502a8829d9)

For 100K or 0.1% query size of the term filter, the IndexOrDocValuesQuery always beats the pure DocValuesQuery.

![query_time_comparison_1M](https://github.com/user-attachments/assets/0b31e221-d85c-4bd5-bfed-5d888c8b4cd7)

However, for 1M or 1% query size, the IndexOrDocValuesQuery seems either may take over the lead iterator at the wrong time, or not choosing the doc values query when it should.
I can see at this condition, at 25K the pure doc values is already better, but the big speed up comes late at between 250K~500K, so I decide to add a 20X penalty to the cost which currently is just the cardinality, and re-run the benchmark.

![query_time_comparison_1M_20pen](https://github.com/user-attachments/assets/02911ae6-fbe5-4b67-b309-4e34de33e257)


### Related Issues
Resolves #16317 

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
