### PR TITLE
Add deprecation warning for  /_cat/snapshots in favor of /_cat/snapshots/{repository}

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use BC libraries to parse PEM files, increase key length, allow general use of known cryptographic binary extensions, remove unused BC dependencies ([#3420](https://github.com/opensearch-project/OpenSearch/pull/14912))
 
 ### Deprecated
+- Add deprecation warning for `_cat/snapshots` in favor of `_cat/snapshots/<repository>` ([#9345](https://github.com/opensearch-project/OpenSearch/pull/9345))
 
 ### Removed
 - Remove deprecated code to add node name into log pattern of log4j property file ([#4568](https://github.com/opensearch-project/OpenSearch/pull/4568))

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.snapshots/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.snapshots/10_basic.yml
@@ -77,3 +77,28 @@
                /^   snap1\s+ SUCCESS\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ \S+\s+ 2\s+ 2\s+ 0\s+ 2\s*\n
                     snap2\s+ SUCCESS\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ \d+\s+ \d\d\:\d\d\:\d\d\s+ \S+\s+ 2\s+ 2\s+ 0\s+ 2\s*\n
                $/
+
+---
+"Test deprecated _cat/snapshots endpoint":
+  - skip:
+      version: " - 2.18.99"
+      reason: "Deprecation added in 2.19"
+      features: [ "warnings" ]
+
+  - do:
+      snapshot.create_repository:
+        repository: dep_test_repo
+        body:
+          type: fs
+          settings:
+            location: "dep_test_repo_loc"
+
+  - do:
+      warnings:
+        - "[/_cat/snapshots] is a deprecated endpoint. Please use [/_cat/snapshots/{repository}] instead."
+      cat.snapshots:
+        q: "repository:dep_test_repo"
+
+  - match:
+      $body: |
+               /^$/

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.snapshots/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.snapshots/10_basic.yml
@@ -81,8 +81,8 @@
 ---
 "Test deprecated _cat/snapshots endpoint":
   - skip:
-      version: " - 2.18.99"
-      reason: "Deprecation added in 2.19"
+      version: " - 3.0.0"
+      reason: "Deprecation added in 3.0"
       features: [ "warnings" ]
 
   - do:

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestSnapshotAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestSnapshotAction.java
@@ -48,10 +48,10 @@ import org.opensearch.transport.client.node.NodeClient;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.singletonList;
 import static org.opensearch.rest.RestRequest.Method.GET;
 
 /**
@@ -63,9 +63,20 @@ public class RestSnapshotAction extends AbstractCatAction {
 
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestSnapshotAction.class);
 
+    private static final String DEPRECATED_MESSAGE_CAT_SNAPSHOTS = String.format(
+        Locale.ROOT,
+        "[%s] is a deprecated endpoint. Please use [/_cat/snapshots/{repository}] instead.",
+        "/_cat/snapshots"
+    );
+
     @Override
     public List<Route> routes() {
-        return unmodifiableList(asList(new Route(GET, "/_cat/snapshots"), new Route(GET, "/_cat/snapshots/{repository}")));
+        return singletonList(new Route(GET, "/_cat/snapshots/{repository}"));
+    }
+
+    @Override
+    public List<DeprecatedRoute> deprecatedRoutes() {
+        return singletonList(new DeprecatedRoute(GET, "/_cat/snapshots", DEPRECATED_MESSAGE_CAT_SNAPSHOTS));
     }
 
     @Override
@@ -77,7 +88,6 @@ public class RestSnapshotAction extends AbstractCatAction {
     public RestChannelConsumer doCatRequest(final RestRequest request, NodeClient client) {
         GetSnapshotsRequest getSnapshotsRequest = new GetSnapshotsRequest().repository(request.param("repository"))
             .snapshots(new String[] { GetSnapshotsRequest.ALL_SNAPSHOTS });
-
         getSnapshotsRequest.ignoreUnavailable(request.paramAsBoolean("ignore_unavailable", getSnapshotsRequest.ignoreUnavailable()));
 
         getSnapshotsRequest.clusterManagerNodeTimeout(


### PR DESCRIPTION
### Description
Per #16648 mark `/_cat/snapshots` as deprecated. Redundant with the more explicit `/_cat/snapshots/{repository}`.

Adds deprecation log for this route:
```
~/fdev curl -i -H "Accept: application/json" -H "X-Opaque-Id: 123" "localhost:9200/_cat/snapshots"
HTTP/1.1 400 Bad Request
X-Opaque-Id: 123
Warning: 299 OpenSearch-3.0.0-SNAPSHOT-4a53ff24adbec1d5aeb3d73548171870a3de925d "[/_cat/snapshots] is a deprecated endpoint. Please use [/_cat/snapshots/{repository}] instead."
X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
content-type: application/json; charset=UTF-8
content-length: 243
```

### Related Issues
Resolves #16648 

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
