### PR TITLE
[WLM Auto tagging] Add compressed trie structure to store Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added new Setting property UnmodifiableOnRestore to prevent updating settings on restore snapshot ([#16957](https://github.com/opensearch-project/OpenSearch/pull/16957))
 - Introduce Template query ([#16818](https://github.com/opensearch-project/OpenSearch/pull/16818))
 - Propagate the sourceIncludes and excludes fields from fetchSourceContext to FieldsVisitor. ([#17080](https://github.com/opensearch-project/OpenSearch/pull/17080))
+- [Automated Tagging] Add In-memory data structure to store and process Rules. ([#16971](https://github.com/opensearch-project/OpenSearch/pull/16971))
 - [Star Tree] [Search] Resolving Date histogram with metric aggregation using star-tree ([#16674](https://github.com/opensearch-project/OpenSearch/pull/16674))
 - [Star Tree] [Search] Extensible design to support different query and field types ([#17137](https://github.com/opensearch-project/OpenSearch/pull/17137))
 

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructure.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructure.java
@@ -8,6 +8,12 @@
 
 package org.opensearch.plugin.wlm.rule.structure;
 
+import java.util.List;
+
 public interface FastPrefixMatchingStructure {
-    void add(String s);
+    void insert(String key, String value);
+
+    List<String> search(String key);
+
+    boolean delete(String key);
 }

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructure.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructure.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.structure;
+
+public interface FastPrefixMatchingStructure {
+    void add(String s);
+}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructure.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructure.java
@@ -10,10 +10,31 @@ package org.opensearch.plugin.wlm.rule.structure;
 
 import java.util.List;
 
+/**
+ * Common interface which exposes methods to add/search/delete Rule attributes
+ */
 public interface FastPrefixMatchingStructure {
+    /**
+     * Inserts the rule output against the attribute value denoted by key
+     * @param key
+     * @param value
+     */
     void insert(String key, String value);
 
+    /**
+     * Searches for a key in structure.
+     *
+     * @param key The key to search for.
+     * @return A list of string values associated with the key or its prefixes.
+     *         Returns an empty list if no matches are found.
+     */
     List<String> search(String key);
 
+    /**
+     * Deletes a key from the structure.
+     *
+     * @param key The key to be deleted.
+     * @return true if the key was successfully deleted, false otherwise.
+     */
     boolean delete(String key);
 }

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/Rule.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/Rule.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.structure;
+
+import java.util.List;
+import java.util.Map;
+
+public class Rule {
+    Map<String, List<String>> attributes;
+}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/RuleAttributeTrie.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/RuleAttributeTrie.java
@@ -28,7 +28,7 @@ public class RuleAttributeTrie implements FastPrefixMatchingStructure {
      * @param value The value associated with the key.
      */
     public void insert(String key, String value) {
-        if (!IsvalidValue(value)) {
+        if (!isValidValue(value)) {
             throw new IllegalArgumentException(
                 "Invalid attribute value: " + value + " it should match the regex " + ALLOWED_ATTRIBUTE_VALUES
             );
@@ -37,7 +37,7 @@ public class RuleAttributeTrie implements FastPrefixMatchingStructure {
         root = inserter.insert();
     }
 
-    private boolean IsvalidValue(String value) {
+    private boolean isValidValue(String value) {
         return ALLOWED_ATTRIBUTE_VALUES.matches(value);
     }
 

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/RuleAttributeTrie.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/RuleAttributeTrie.java
@@ -38,7 +38,7 @@ public class RuleAttributeTrie implements FastPrefixMatchingStructure {
     }
 
     private boolean isValidValue(String value) {
-        return ALLOWED_ATTRIBUTE_VALUES.matches(value);
+        return value.matches(ALLOWED_ATTRIBUTE_VALUES);
     }
 
     /**

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/RuleAttributeTrie.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/RuleAttributeTrie.java
@@ -19,7 +19,7 @@ public class RuleAttributeTrie implements FastPrefixMatchingStructure {
     private TrieNode root;
 
     /**
-     * Constructs an empty AugmentedTrie.
+     * Constructs an empty Trie.
      */
     public RuleAttributeTrie() {
         root = new TrieNode("");

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/RuleAttributeTrie.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/RuleAttributeTrie.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.structure;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class RuleAttributeTrie implements FastPrefixMatchingStructure {
+    private static final Pattern ALLOWED_ATTRIBUTE_VALUES = Pattern.compile("^[a-zA-Z0-9-_]+\\*?$");
+    @Override
+    public void add(String s) {
+
+    }
+
+    public enum RuleAttributeName {
+        USERNAME("username"),
+        INDEX_PATTERN("index_pattern");
+        private final String name;
+
+        RuleAttributeName(String name) {
+            this.name = name;
+        }
+
+        public String getName() { return name; }
+
+        public static RuleAttributeName fromString(String name) {
+            for (RuleAttributeName attributeName : RuleAttributeName.values()) {
+                if (attributeName.getName().equals(name)) {
+                    return attributeName;
+                }
+            }
+            throw new IllegalArgumentException("Invalid rule attribute name [" + name + "]");
+        }
+
+    }
+
+    public static class LabeledNode {
+        private String label;
+        private Map<String, LabeledNode> children = new HashMap<>();
+
+        public LabeledNode() {}
+
+        public LabeledNode(String label) {
+            this.label = label;
+        }
+    }
+}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/RuleAttributeTrie.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/RuleAttributeTrie.java
@@ -10,8 +10,12 @@ package org.opensearch.plugin.wlm.rule.structure;
 
 import java.util.List;
 
+/**
+ * Per attribute in memory storage structure for Rules
+ */
 public class RuleAttributeTrie implements FastPrefixMatchingStructure {
     private static final String ALLOWED_ATTRIBUTE_VALUES = "^[a-zA-Z0-9-_]+\\*?$";
+    private static final int ATTRIBUTE_MAX_LENGTH = 100;
     private TrieNode root;
 
     /**
@@ -38,7 +42,7 @@ public class RuleAttributeTrie implements FastPrefixMatchingStructure {
     }
 
     private boolean isValidValue(String value) {
-        return value.matches(ALLOWED_ATTRIBUTE_VALUES);
+        return value.length() <= ATTRIBUTE_MAX_LENGTH && value.matches(ALLOWED_ATTRIBUTE_VALUES);
     }
 
     /**

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieDeleter.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieDeleter.java
@@ -9,7 +9,7 @@
 package org.opensearch.plugin.wlm.rule.structure;
 
 /**
- * Handles the deletion operation for the Augmented Trie.
+ * Handles the deletion operation for the Trie.
  */
 class TrieDeleter {
     private TrieNode root;

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieDeleter.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieDeleter.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.structure;
+
+/**
+ * Handles the deletion operation for the Augmented Trie.
+ */
+class TrieDeleter {
+    private TrieNode root;
+    private String key;
+
+    /**
+     * Constructs a TrieDeleter with the given root and key.
+     *
+     * @param root The root node of the trie.
+     * @param key  The key to be deleted.
+     */
+    public TrieDeleter(TrieNode root, String key) {
+        this.root = root;
+        this.key = key;
+    }
+
+    /**
+     * Performs the deletion operation.
+     *
+     * @return true if the key was successfully deleted, false otherwise.
+     */
+    public boolean delete() {
+        TrieNode current = root;
+        TrieNode parent = null;
+        String remainingKey = key;
+        while (!remainingKey.isEmpty()) {
+            TrieNode childNode = current.findCommonPrefixChild(remainingKey);
+
+            if (childNode == null) {
+                return false;
+            }
+            parent = current;
+            current = childNode;
+            remainingKey = remainingKey.substring(childNode.getKey().length());
+        }
+        final boolean deleted = current.isEndOfWord();
+
+        if (deleted) {
+            current.setEndOfWord(false);
+            current.setValue(null);
+            if (current.getChildren().isEmpty()) {
+                deleteLeafNode(parent, current);
+            }
+        }
+
+        return deleted;
+    }
+
+    private static void deleteLeafNode(TrieNode parent, TrieNode current) {
+        if (parent != null) {
+            parent.getChildren().remove(current.getKey());
+        }
+    }
+}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieInserter.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieInserter.java
@@ -9,7 +9,7 @@
 package org.opensearch.plugin.wlm.rule.structure;
 
 /**
- * Handles the insertion operation for the Augmented Trie.
+ * Handles the insertion operation for the Trie.
  */
 class TrieInserter {
     private TrieNode root;

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieInserter.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieInserter.java
@@ -31,7 +31,8 @@ class TrieInserter {
 
     /**
      * Performs the insertion operation.
-     * <ol>Method should handle 3 cases
+     * Method should handle 3 cases
+     * <ol>
      * <li>Simple addition of new child </li>
      * <li>insert splits a node</li>
      * <li>inserted key is a prefix to existing key|s, this could either mark a node as endOfWord or it could also split the node</li>

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieInserter.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieInserter.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.structure;
+
+/**
+ * Handles the insertion operation for the Augmented Trie.
+ */
+class TrieInserter {
+    private TrieNode root;
+    private String key;
+    private String value;
+
+    /**
+     * Constructs a TrieInserter with the given root, key, and value.
+     *
+     * @param root  The root node of the trie.
+     * @param key   The key to be inserted.
+     * @param value The value associated with the key.
+     */
+    public TrieInserter(TrieNode root, String key, String value) {
+        this.root = root;
+        this.key = key;
+        this.value = value;
+    }
+
+    /**
+     * Performs the insertion operation.
+     * <ol>Method should handle 3 cases
+     * <li>Simple addition of new child </li>
+     * <li>insert splits a node</li>
+     * <li>inserted key is a prefix to existing key|s, this could either mark a node as endOfWord or it could also split the node</li>
+     * </ol>
+     * @return The root node of the trie after insertion.
+     */
+    public TrieNode insert() {
+        TrieNode current = root;
+        String remainingKey = key;
+        while (!remainingKey.isEmpty()) {
+            TrieNode child = current.findCommonPrefixChild(remainingKey);
+
+            if (child == null) {
+                boolean partialMatch = false;
+                // partial match
+                for (String childKey : current.getChildren().keySet()) {
+                    int commonPrefixLength = getLongestCommonPrefixLength(childKey, remainingKey);
+                    if (commonPrefixLength > 0) {
+                        TrieNode newNode = current.splitNode(childKey, commonPrefixLength);
+
+                        remainingKey = remainingKey.substring(commonPrefixLength);
+
+                        current = newNode;
+                        partialMatch = true;
+                        break;
+                    }
+                }
+                // no match
+                if (!partialMatch) {
+                    current = current.addNewChild(remainingKey);
+                    remainingKey = "";
+                }
+            } else {
+                current = child;
+                remainingKey = remainingKey.substring(child.getKey().length());
+            }
+        }
+        updateNodeValue(current);
+        return root;
+    }
+
+    private void updateNodeValue(TrieNode node) {
+        node.setValue(value);
+        node.setEndOfWord(true);
+    }
+
+    private int getLongestCommonPrefixLength(String str1, String str2) {
+        int minLength = Math.min(str1.length(), str2.length());
+        for (int i = 0; i < minLength; i++) {
+            if (str1.charAt(i) != str2.charAt(i)) {
+                return i;
+            }
+        }
+        return minLength;
+    }
+}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieNode.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieNode.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.Queue;
 
 /**
- * Represents a node in the Augmented Trie.
+ * Represents a node in the Trie.
  * Each node contains a key, an optional value, and references to child nodes.
  */
 class TrieNode {

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieNode.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieNode.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.structure;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+
+/**
+ * Represents a node in the Augmented Trie.
+ * Each node contains a key, an optional value, and references to child nodes.
+ */
+class TrieNode {
+    public static final int CLOSEST_LIMIT = 5;
+    private Map<String, TrieNode> children;
+    private String key;
+    private String value;
+    private boolean isEndOfWord;
+
+    /**
+     * Constructs a TrieNode with the given key.
+     *
+     * @param key The key associated with this node.
+     */
+    public TrieNode(String key) {
+        this.children = new HashMap<>();
+        this.key = key;
+        this.value = null;
+        this.isEndOfWord = false;
+    }
+
+    // Getters and setters
+    public Map<String, TrieNode> getChildren() {
+        return children;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public boolean isEndOfWord() {
+        return isEndOfWord;
+    }
+
+    public void setEndOfWord(boolean endOfWord) {
+        isEndOfWord = endOfWord;
+    }
+
+    public TrieNode addNewChild(String key) {
+        TrieNode newNode = new TrieNode(key);
+        newNode.setValue(value);
+        newNode.setEndOfWord(true);
+        getChildren().put(key, newNode);
+        return newNode;
+    }
+
+    public TrieNode splitNode(String childKey, int commonPrefixLength) {
+        String commonPrefix = childKey.substring(0, commonPrefixLength);
+        TrieNode newNode = new TrieNode(commonPrefix);
+        TrieNode childNode = getChildren().get(childKey);
+
+        // remove the existing partially matching child node since we will split that
+        getChildren().remove(childKey);
+        // re-attach common prefix as direct child
+        getChildren().put(commonPrefix, newNode);
+
+        childNode.setKey(childKey.substring(commonPrefixLength));
+
+        newNode.getChildren().put(childKey.substring(commonPrefixLength), childNode);
+        return newNode;
+    }
+
+    public TrieNode findCommonPrefixChild(String key) {
+        return getChildren().entrySet()
+            .stream()
+            .filter(entry -> key.startsWith(entry.getKey()))
+            .findFirst()
+            .map(Map.Entry::getValue)
+            .orElse(null);
+    }
+
+    public List<String> findTopFiveClosest() {
+        List<String> ans = new ArrayList<>(CLOSEST_LIMIT);
+        Queue<TrieNode> queue = new LinkedList<>();
+        queue.offer(this);
+
+        while (!queue.isEmpty() && ans.size() < CLOSEST_LIMIT) {
+            TrieNode current = queue.poll();
+            if (current.isEndOfWord()) {
+                ans.add(current.getValue());
+            }
+            queue.addAll(current.getChildren().values());
+        }
+
+        return ans;
+    }
+}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieSearcher.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieSearcher.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.structure;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Handles the search operation for the Augmented Trie.
+ */
+class TrieSearcher {
+    private TrieNode root;
+    private String key;
+
+    /**
+     * Constructs a TrieSearcher with the given root and key.
+     *
+     * @param root The root node of the trie.
+     * @param key  The key to search for.
+     */
+    public TrieSearcher(TrieNode root, String key) {
+        this.root = root;
+        this.key = key;
+    }
+
+    /**
+     * Performs the search operation.
+     *
+     * @return The value associated with the key if found, or a list of top 5 closest matches,
+     *         or null if no matches found.
+     */
+    public List<String> search() {
+        SearchResult result = findNode();
+        return result.matchType.processResult(result.node);
+    }
+
+    private SearchResult findNode() {
+        TrieNode current = root;
+        String remainingKey = key;
+
+        while (!remainingKey.isEmpty()) {
+            TrieNode child = findCommonPrefixChild(current, remainingKey);
+            if (child == null) {
+                return handleNoChildWithProperPrefixCase(current, remainingKey);
+            }
+            current = child;
+            remainingKey = removePrefix(remainingKey, child.getKey());
+        }
+
+        return new SearchResult(current, current.isEndOfWord() ? MatchType.EXACT_MATCH : MatchType.PARTIAL_MATCH);
+    }
+
+    private static SearchResult handleNoChildWithProperPrefixCase(TrieNode current, String remainingKey) {
+        // there are two scenarios now
+        // 1. there is no key that starts with the remaining key
+        // 2. there might be a key that completely consumes the remaining key as prefix , example key: "apple", remainingKey: "app"
+        for (String childKey : current.getChildren().keySet()) {
+            if (childKey.startsWith(remainingKey)) {
+                return new SearchResult(current.getChildren().get(childKey), MatchType.PARTIAL_MATCH);
+            }
+        }
+        return new SearchResult(null, MatchType.NO_MATCH);
+    }
+
+    private TrieNode findCommonPrefixChild(TrieNode node, String key) {
+        return node.getChildren()
+            .entrySet()
+            .stream()
+            .filter(entry -> key.startsWith(entry.getKey()))
+            .findFirst()
+            .map(Map.Entry::getValue)
+            .orElse(null);
+    }
+
+    private String removePrefix(String str, String prefix) {
+        return str.substring(prefix.length());
+    }
+
+    private enum MatchType {
+        EXACT_MATCH(node -> Collections.singletonList(node.getValue())),
+        PARTIAL_MATCH(TrieNode::findTopFiveClosest),
+        NO_MATCH(n -> Collections.emptyList());
+
+        final Function<TrieNode, List<String>> resultProcessor;
+
+        MatchType(Function<TrieNode, List<String>> resultProcessor) {
+            this.resultProcessor = resultProcessor;
+        }
+
+        public List<String> processResult(TrieNode node) {
+            return resultProcessor.apply(node);
+        }
+    }
+
+    private static class SearchResult {
+        TrieNode node;
+        MatchType matchType;
+
+        SearchResult(TrieNode node, MatchType matchType) {
+            this.node = node;
+            this.matchType = matchType;
+        }
+    }
+}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieSearcher.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/TrieSearcher.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * Handles the search operation for the Augmented Trie.
+ * Handles the search operation for the Trie.
  */
 class TrieSearcher {
     private TrieNode root;

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/package-info.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/package-info.java
@@ -7,10 +7,3 @@
  */
 
 package org.opensearch.plugin.wlm.rule.structure;
-
-import java.util.List;
-import java.util.Map;
-
-public class Rule {
-    Map<String, List<String>> attributes;
-}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/package-info.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/structure/package-info.java
@@ -6,4 +6,8 @@
  * compatible open source license.
  */
 
+/**
+ * This package defines the constructs for RuleStorage
+ */
+
 package org.opensearch.plugin.wlm.rule.structure;

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructureTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructureTests.java
@@ -9,160 +9,109 @@
 package org.opensearch.plugin.wlm.rule.structure;
 
 import org.opensearch.test.OpenSearchTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-    FastPrefixMatchingStructureTests.InsertionTests.class,
-    FastPrefixMatchingStructureTests.SearchTests.class,
-    FastPrefixMatchingStructureTests.DeletionTests.class,
-    FastPrefixMatchingStructureTests.EdgeCaseTests.class })
-public class FastPrefixMatchingStructureTests {
+public class FastPrefixMatchingStructureTests extends OpenSearchTestCase {
+    FastPrefixMatchingStructure trie;
 
-    public static class BaseTest extends OpenSearchTestCase {
-        protected FastPrefixMatchingStructure trie;
-
-        public void setUp() throws Exception {
-            super.setUp();
-            trie = new RuleAttributeTrie();
-        }
+    public void setUp() throws Exception {
+        super.setUp();
+        trie = new RuleAttributeTrie();
+        trie.insert("apple", "fruit");
+        trie.insert("app", "application");
+        trie.insert("application", "software");
+        trie.insert("appreciate", "value");
+        trie.insert("book", "reading");
+        trie.insert("bookstore", "shop");
     }
 
-    public static class InsertionTests extends BaseTest {
-        @Test
-        public void testInsertSinglePair() {
-            trie.insert("apple", "fruit");
-            assertEquals(Collections.singletonList("fruit"), trie.search("apple"));
-        }
-
-        @Test
-        public void testInsertMultiplePairs() {
-            trie.insert("apple", "fruit");
-            trie.insert("app", "application");
-            trie.insert("application", "software");
-
-            assertEquals(Collections.singletonList("fruit"), trie.search("apple"));
-            assertEquals(Collections.singletonList("application"), trie.search("app"));
-            assertEquals(Collections.singletonList("software"), trie.search("application"));
-        }
-
-        @Test
-        public void testOverwriteExistingKey() {
-            trie.insert("apple", "fruit");
-            trie.insert("apple", "company");
-            assertEquals(Collections.singletonList("company"), trie.search("apple"));
-        }
-
-        @Test
-        public void testInsertKeysWithCommonPrefixes() {
-            trie.insert("car", "vehicle");
-            trie.insert("cart", "shopping");
-            trie.insert("cartoon", "animation");
-
-            assertEquals(Collections.singletonList("vehicle"), trie.search("car"));
-            assertEquals(Collections.singletonList("shopping"), trie.search("cart"));
-            assertEquals(Collections.singletonList("animation"), trie.search("cartoon"));
-        }
+    public void testInsertSinglePair() {
+        trie.insert("apple", "fruit");
+        assertEquals(Collections.singletonList("fruit"), trie.search("apple"));
     }
 
-    public static class SearchTests extends BaseTest {
+    public void testInsertMultiplePairs() {
+        trie.insert("apple", "fruit");
+        trie.insert("app", "application");
+        trie.insert("application", "software");
 
-        public void setUp() throws Exception {
-            super.setUp();
-            trie.insert("apple", "fruit");
-            trie.insert("app", "application");
-            trie.insert("application", "software");
-            trie.insert("appreciate", "value");
-            trie.insert("book", "reading");
-            trie.insert("bookstore", "shop");
-        }
-
-        @Test
-        public void testSearchExistingKeys() {
-            assertEquals(Collections.singletonList("fruit"), trie.search("apple"));
-            assertEquals(Collections.singletonList("application"), trie.search("app"));
-            assertEquals(Collections.singletonList("reading"), trie.search("book"));
-        }
-
-        @Test
-        public void testSearchNonExistingKeys() {
-            assertTrue(trie.search("cocktail").isEmpty());
-            assertTrue(trie.search("mock").isEmpty());
-        }
-
-        @Test
-        public void testSearchPartialKeys() {
-            List<String> result = trie.search("ap");
-            assertEquals(4, result.size());
-            assertTrue(result.containsAll(Arrays.asList("fruit", "application", "software", "value")));
-        }
+        assertEquals(Collections.singletonList("fruit"), trie.search("apple"));
+        assertEquals(Collections.singletonList("application"), trie.search("app"));
+        assertEquals(Collections.singletonList("software"), trie.search("application"));
     }
 
-    public static class DeletionTests extends BaseTest {
-
-        public void setUp() throws Exception {
-            super.setUp();
-            trie.insert("apple", "fruit");
-            trie.insert("app", "application");
-            trie.insert("application", "software");
-            trie.insert("appreciate", "value");
-            trie.insert("book", "reading");
-            trie.insert("bookstore", "shop");
-        }
-
-        @Test
-        public void testDeleteExistingKey() {
-            assertTrue(trie.delete("apple"));
-            assertTrue(trie.search("apple").isEmpty());
-            assertFalse(trie.search("app").isEmpty());
-        }
-
-        @Test
-        public void testDeleteNonExistingKey() {
-            assertFalse(trie.delete("appl"));
-            assertFalse(trie.search("apple").isEmpty());
-        }
-
-        @Test
-        public void testDeleteKeyAndVerifyPartialSearch() {
-            assertTrue(trie.delete("app"));
-            List<String> result = trie.search("ap");
-            assertEquals(3, result.size());
-            assertTrue(result.containsAll(Arrays.asList("fruit", "software", "value")));
-        }
-
-        @Test
-        public void testDeleteAllKeysWithCommonPrefix() {
-            assertTrue(trie.delete("apple"));
-            assertTrue(trie.delete("app"));
-            assertTrue(trie.delete("application"));
-            assertTrue(trie.delete("appreciate"));
-
-            assertTrue(trie.search("ap").isEmpty());
-            assertFalse(trie.search("book").isEmpty());
-        }
+    public void testOverwriteExistingKey() {
+        trie.insert("apple", "fruit");
+        trie.insert("apple", "company");
+        assertEquals(Collections.singletonList("company"), trie.search("apple"));
     }
 
-    public static class EdgeCaseTests extends BaseTest {
+    public void testInsertKeysWithCommonPrefixes() {
+        trie.insert("car", "vehicle");
+        trie.insert("cart", "shopping");
+        trie.insert("cartoon", "animation");
 
-        @Test
-        public void testInsertAndSearchEmptyString() {
-            trie.insert("", "empty");
-            assertEquals(Collections.singletonList("empty"), trie.search(""));
-        }
+        assertEquals(Collections.singletonList("vehicle"), trie.search("car"));
+        assertEquals(Collections.singletonList("shopping"), trie.search("cart"));
+        assertEquals(Collections.singletonList("animation"), trie.search("cartoon"));
+    }
 
+    public void testSearchExistingKeys() {
+        assertEquals(Collections.singletonList("fruit"), trie.search("apple"));
+        assertEquals(Collections.singletonList("application"), trie.search("app"));
+        assertEquals(Collections.singletonList("reading"), trie.search("book"));
+    }
 
-        @Test
-        public void testDeleteEmptyString() {
-            trie.insert("", "empty");
-            assertTrue(trie.delete(""));
-            assertTrue(trie.search("").isEmpty());
-        }
+    public void testSearchNonExistingKeys() {
+        assertTrue(trie.search("cocktail").isEmpty());
+        assertTrue(trie.search("mock").isEmpty());
+    }
+
+    public void testSearchPartialKeys() {
+        List<String> result = trie.search("ap");
+        assertEquals(4, result.size());
+        assertTrue(result.containsAll(Arrays.asList("fruit", "application", "software", "value")));
+    }
+
+    public void testDeleteExistingKey() {
+        assertTrue(trie.delete("apple"));
+        assertTrue(trie.search("apple").isEmpty());
+        assertFalse(trie.search("app").isEmpty());
+    }
+
+    public void testDeleteNonExistingKey() {
+        assertFalse(trie.delete("appl"));
+        assertFalse(trie.search("apple").isEmpty());
+    }
+
+    public void testDeleteKeyAndVerifyPartialSearch() {
+        assertTrue(trie.delete("app"));
+        List<String> result = trie.search("ap");
+        assertEquals(3, result.size());
+        assertTrue(result.containsAll(Arrays.asList("fruit", "software", "value")));
+    }
+
+    public void testDeleteAllKeysWithCommonPrefix() {
+        assertTrue(trie.delete("apple"));
+        assertTrue(trie.delete("app"));
+        assertTrue(trie.delete("application"));
+        assertTrue(trie.delete("appreciate"));
+
+        assertTrue(trie.search("ap").isEmpty());
+        assertFalse(trie.search("book").isEmpty());
+    }
+
+    public void testInsertAndSearchEmptyString() {
+        trie.insert("", "empty");
+        assertEquals(Collections.singletonList("empty"), trie.search(""));
+    }
+
+    public void testDeleteEmptyString() {
+        trie = new RuleAttributeTrie();
+        trie.insert("", "empty");
+        assertTrue(trie.delete(""));
+        assertTrue(trie.search("").isEmpty());
     }
 }

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructureTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructureTests.java
@@ -9,10 +9,165 @@
 package org.opensearch.plugin.wlm.rule.structure;
 
 import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
-public class FastPrefixMatchingStructureTests extends OpenSearchTestCase {
-    FastPrefixMatchingStructure fastPrefixMatchingStructure = ;
-    public void shouldAddAString() {
-        fastPrefixMatchingStructure.add("adffadsas");
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    FastPrefixMatchingStructureTests.InsertionTests.class,
+    FastPrefixMatchingStructureTests.SearchTests.class,
+    FastPrefixMatchingStructureTests.DeletionTests.class,
+    FastPrefixMatchingStructureTests.EdgeCaseTests.class })
+public class FastPrefixMatchingStructureTests {
+
+    public static class BaseTest extends OpenSearchTestCase {
+        protected FastPrefixMatchingStructure trie;
+
+        public void setUp() throws Exception {
+            super.setUp();
+            trie = new RuleAttributeTrie();
+        }
+    }
+
+    public static class InsertionTests extends BaseTest {
+        @Test
+        public void testInsertSinglePair() {
+            trie.insert("apple", "fruit");
+            assertEquals(Collections.singletonList("fruit"), trie.search("apple"));
+        }
+
+        @Test
+        public void testInsertMultiplePairs() {
+            trie.insert("apple", "fruit");
+            trie.insert("app", "application");
+            trie.insert("application", "software");
+
+            assertEquals(Collections.singletonList("fruit"), trie.search("apple"));
+            assertEquals(Collections.singletonList("application"), trie.search("app"));
+            assertEquals(Collections.singletonList("software"), trie.search("application"));
+        }
+
+        @Test
+        public void testOverwriteExistingKey() {
+            trie.insert("apple", "fruit");
+            trie.insert("apple", "company");
+            assertEquals(Collections.singletonList("company"), trie.search("apple"));
+        }
+
+        @Test
+        public void testInsertKeysWithCommonPrefixes() {
+            trie.insert("car", "vehicle");
+            trie.insert("cart", "shopping");
+            trie.insert("cartoon", "animation");
+
+            assertEquals(Collections.singletonList("vehicle"), trie.search("car"));
+            assertEquals(Collections.singletonList("shopping"), trie.search("cart"));
+            assertEquals(Collections.singletonList("animation"), trie.search("cartoon"));
+        }
+    }
+
+    public static class SearchTests extends BaseTest {
+
+        public void setUp() throws Exception {
+            super.setUp();
+            trie.insert("apple", "fruit");
+            trie.insert("app", "application");
+            trie.insert("application", "software");
+            trie.insert("appreciate", "value");
+            trie.insert("book", "reading");
+            trie.insert("bookstore", "shop");
+        }
+
+        @Test
+        public void testSearchExistingKeys() {
+            assertEquals(Collections.singletonList("fruit"), trie.search("apple"));
+            assertEquals(Collections.singletonList("application"), trie.search("app"));
+            assertEquals(Collections.singletonList("reading"), trie.search("book"));
+        }
+
+        @Test
+        public void testSearchNonExistingKeys() {
+            assertTrue(trie.search("cocktail").isEmpty());
+            assertTrue(trie.search("mock").isEmpty());
+        }
+
+        @Test
+        public void testSearchPartialKeys() {
+            List<String> result = trie.search("ap");
+            assertEquals(4, result.size());
+            assertTrue(result.containsAll(Arrays.asList("fruit", "application", "software", "value")));
+        }
+    }
+
+    public static class DeletionTests extends BaseTest {
+
+        public void setUp() throws Exception {
+            super.setUp();
+            trie.insert("apple", "fruit");
+            trie.insert("app", "application");
+            trie.insert("application", "software");
+            trie.insert("appreciate", "value");
+            trie.insert("book", "reading");
+            trie.insert("bookstore", "shop");
+        }
+
+        @Test
+        public void testDeleteExistingKey() {
+            assertTrue(trie.delete("apple"));
+            assertTrue(trie.search("apple").isEmpty());
+            assertFalse(trie.search("app").isEmpty());
+        }
+
+        @Test
+        public void testDeleteNonExistingKey() {
+            assertFalse(trie.delete("appl"));
+            assertFalse(trie.search("apple").isEmpty());
+        }
+
+        @Test
+        public void testDeleteKeyAndVerifyPartialSearch() {
+            assertTrue(trie.delete("app"));
+            List<String> result = trie.search("ap");
+            assertEquals(3, result.size());
+            assertTrue(result.containsAll(Arrays.asList("fruit", "software", "value")));
+        }
+
+        @Test
+        public void testDeleteAllKeysWithCommonPrefix() {
+            assertTrue(trie.delete("apple"));
+            assertTrue(trie.delete("app"));
+            assertTrue(trie.delete("application"));
+            assertTrue(trie.delete("appreciate"));
+
+            assertTrue(trie.search("ap").isEmpty());
+            assertFalse(trie.search("book").isEmpty());
+        }
+    }
+
+    public static class EdgeCaseTests extends BaseTest {
+
+        @Test
+        public void testInsertAndSearchEmptyString() {
+            trie.insert("", "empty");
+            assertEquals(Collections.singletonList("empty"), trie.search(""));
+        }
+
+        @Test
+        public void testInsertEmptyValue() {
+            trie.insert("emptyvalue", "");
+            assertEquals(Collections.singletonList(""), trie.search("emptyvalue"));
+        }
+
+        @Test
+        public void testDeleteEmptyString() {
+            trie.insert("", "empty");
+            assertTrue(trie.delete(""));
+            assertTrue(trie.search("").isEmpty());
+        }
     }
 }

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructureTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructureTests.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class FastPrefixMatchingStructureTests extends OpenSearchTestCase {
     FastPrefixMatchingStructure trie;
 
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         trie = new RuleAttributeTrie();
@@ -29,22 +30,16 @@ public class FastPrefixMatchingStructureTests extends OpenSearchTestCase {
     }
 
     public void testInsertSinglePair() {
-        trie.insert("apple", "fruit");
         assertEquals(Collections.singletonList("fruit"), trie.search("apple"));
     }
 
     public void testInsertMultiplePairs() {
-        trie.insert("apple", "fruit");
-        trie.insert("app", "application");
-        trie.insert("application", "software");
-
         assertEquals(Collections.singletonList("fruit"), trie.search("apple"));
         assertEquals(Collections.singletonList("application"), trie.search("app"));
         assertEquals(Collections.singletonList("software"), trie.search("application"));
     }
 
     public void testOverwriteExistingKey() {
-        trie.insert("apple", "fruit");
         trie.insert("apple", "company");
         assertEquals(Collections.singletonList("company"), trie.search("apple"));
     }

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructureTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructureTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.plugin.wlm.rule.structure;
 
 import org.opensearch.test.OpenSearchTestCase;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructureTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructureTests.java
@@ -157,11 +157,6 @@ public class FastPrefixMatchingStructureTests {
             assertEquals(Collections.singletonList("empty"), trie.search(""));
         }
 
-        @Test
-        public void testInsertEmptyValue() {
-            trie.insert("emptyvalue", "");
-            assertEquals(Collections.singletonList(""), trie.search("emptyvalue"));
-        }
 
         @Test
         public void testDeleteEmptyString() {

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructureTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/structure/FastPrefixMatchingStructureTests.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.structure;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class FastPrefixMatchingStructureTests extends OpenSearchTestCase {
+    FastPrefixMatchingStructure fastPrefixMatchingStructure = ;
+    public void shouldAddAString() {
+        fastPrefixMatchingStructure.add("adffadsas");
+    }
+}


### PR DESCRIPTION
### Description
This change introduces the compressed trie structure which will store and perform matching for Rules. This is one of the foundational change in order to do the Rule based automatic tagging.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/16888

### Check List
- [X] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
