### PR TITLE
Add Response Status Number in Http Trace Logs.

### DIFF
--- a/server/src/main/java/org/opensearch/http/HttpTracer.java
+++ b/server/src/main/java/org/opensearch/http/HttpTracer.java
@@ -116,10 +116,11 @@ class HttpTracer {
     ) {
         logger.trace(
             new ParameterizedMessage(
-                "[{}][{}][{}][{}][{}] sent response to [{}] success [{}]",
+                "[{}][{}][{}][{}][{}][{}] sent response to [{}] success [{}]",
                 requestId,
                 opaqueHeader,
                 restResponse.status(),
+                restResponse.status().getStatus(),
                 restResponse.contentType(),
                 contentLength,
                 httpChannel,

--- a/server/src/test/java/org/opensearch/http/AbstractHttpServerTransportTests.java
+++ b/server/src/test/java/org/opensearch/http/AbstractHttpServerTransportTests.java
@@ -285,6 +285,8 @@ public class AbstractHttpServerTransportTests extends OpenSearchTestCase {
                             + opaqueId
                             + "\\]\\["
                             + (badRequest ? "BAD_REQUEST" : "OK")
+                            + "\\]\\["
+                            + (badRequest ? "400" : "200")
                             + "\\]\\[null\\]\\[0\\] sent response to \\[.*"
                     )
                 );


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR adds response status number like `200` for `OK` response in the Http Trace Logs.

### Related Issues
Current Http Response Logs when Trace is enabled:
```
[runTask-0] [2][null][OK][application/json; charset=UTF-8][442] sent response to [Netty4HttpChannel{localAddress=/local:9200, remoteAddress=/remote:1}] success [true]
```
PR changes Http Response Logs when Trace is enabled to:
```
[runTask-0] [2][null][OK][200][application/json; charset=UTF-8][442] sent response to [Netty4HttpChannel{localAddress=/local:9200, remoteAddress=/remote:1}] success [true]
```
### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
