### PR TITLE
[WLM] add wlm support for scroll API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix multi-value sort for unsigned long ([#16732](https://github.com/opensearch-project/OpenSearch/pull/16732))
 - The `phone-search` analyzer no longer emits the tel/sip prefix, international calling code, extension numbers and unformatted input as a token ([#16993](https://github.com/opensearch-project/OpenSearch/pull/16993))
 - Fix GRPC AUX_TRANSPORT_PORT and SETTING_GRPC_PORT settings and remove lingering HTTP terminology ([#17037](https://github.com/opensearch-project/OpenSearch/pull/17037))
+- [WLM] Add WLM support for search scroll API ([#16981](https://github.com/opensearch-project/OpenSearch/pull/16981))
 - Fix exists queries on nested flat_object fields throws exception ([#16803](https://github.com/opensearch-project/OpenSearch/pull/16803))
 
 ### Security

--- a/server/src/main/java/org/opensearch/wlm/QueryGroupTask.java
+++ b/server/src/main/java/org/opensearch/wlm/QueryGroupTask.java
@@ -33,7 +33,7 @@ public class QueryGroupTask extends CancellableTask {
     public static final Supplier<String> DEFAULT_QUERY_GROUP_ID_SUPPLIER = () -> "DEFAULT_QUERY_GROUP";
     private final LongSupplier nanoTimeSupplier;
     private String queryGroupId;
-    private boolean isEligibleForTracking = false;
+    private boolean isQueryGroupSet = false;
 
     public QueryGroupTask(long id, String type, String action, String description, TaskId parentTaskId, Map<String, String> headers) {
         this(id, type, action, description, parentTaskId, headers, NO_TIMEOUT, System::nanoTime);
@@ -82,7 +82,7 @@ public class QueryGroupTask extends CancellableTask {
      * @param threadContext current threadContext
      */
     public final void setQueryGroupId(final ThreadContext threadContext) {
-        isEligibleForTracking = true;
+        isQueryGroupSet = true;
         if (threadContext != null && threadContext.getHeader(QUERY_GROUP_ID_HEADER) != null) {
             this.queryGroupId = threadContext.getHeader(QUERY_GROUP_ID_HEADER);
         } else {
@@ -94,8 +94,8 @@ public class QueryGroupTask extends CancellableTask {
         return nanoTimeSupplier.getAsLong() - getStartTimeNanos();
     }
 
-    public boolean isEligibleForTracking() {
-        return isEligibleForTracking;
+    public boolean isQueryGroupSet() {
+        return isQueryGroupSet;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/wlm/QueryGroupTask.java
+++ b/server/src/main/java/org/opensearch/wlm/QueryGroupTask.java
@@ -33,6 +33,7 @@ public class QueryGroupTask extends CancellableTask {
     public static final Supplier<String> DEFAULT_QUERY_GROUP_ID_SUPPLIER = () -> "DEFAULT_QUERY_GROUP";
     private final LongSupplier nanoTimeSupplier;
     private String queryGroupId;
+    private boolean isEligibleForTracking = false;
 
     public QueryGroupTask(long id, String type, String action, String description, TaskId parentTaskId, Map<String, String> headers) {
         this(id, type, action, description, parentTaskId, headers, NO_TIMEOUT, System::nanoTime);
@@ -81,6 +82,7 @@ public class QueryGroupTask extends CancellableTask {
      * @param threadContext current threadContext
      */
     public final void setQueryGroupId(final ThreadContext threadContext) {
+        isEligibleForTracking = true;
         if (threadContext != null && threadContext.getHeader(QUERY_GROUP_ID_HEADER) != null) {
             this.queryGroupId = threadContext.getHeader(QUERY_GROUP_ID_HEADER);
         } else {
@@ -90,6 +92,10 @@ public class QueryGroupTask extends CancellableTask {
 
     public long getElapsedTime() {
         return nanoTimeSupplier.getAsLong() - getStartTimeNanos();
+    }
+
+    public boolean isEligibleForTracking() {
+        return isEligibleForTracking;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/wlm/tracker/QueryGroupResourceUsageTrackerService.java
+++ b/server/src/main/java/org/opensearch/wlm/tracker/QueryGroupResourceUsageTrackerService.java
@@ -76,7 +76,7 @@ public class QueryGroupResourceUsageTrackerService {
             .stream()
             .filter(QueryGroupTask.class::isInstance)
             .map(QueryGroupTask.class::cast)
-            .filter(QueryGroupTask::isEligibleForTracking)
+            .filter(QueryGroupTask::isQueryGroupSet)
             .collect(Collectors.groupingBy(QueryGroupTask::getQueryGroupId, Collectors.mapping(task -> task, Collectors.toList())));
     }
 }

--- a/server/src/main/java/org/opensearch/wlm/tracker/QueryGroupResourceUsageTrackerService.java
+++ b/server/src/main/java/org/opensearch/wlm/tracker/QueryGroupResourceUsageTrackerService.java
@@ -76,6 +76,7 @@ public class QueryGroupResourceUsageTrackerService {
             .stream()
             .filter(QueryGroupTask.class::isInstance)
             .map(QueryGroupTask.class::cast)
+            .filter(QueryGroupTask::isEligibleForTracking)
             .collect(Collectors.groupingBy(QueryGroupTask::getQueryGroupId, Collectors.mapping(task -> task, Collectors.toList())));
     }
 }

--- a/server/src/test/java/org/opensearch/wlm/tracker/QueryGroupTaskResourceTrackingTests.java
+++ b/server/src/test/java/org/opensearch/wlm/tracker/QueryGroupTaskResourceTrackingTests.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.wlm.tracker;
+
+import org.opensearch.action.search.SearchTask;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.tasks.TaskId;
+import org.opensearch.tasks.TaskResourceTrackingService;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.wlm.QueryGroupLevelResourceUsageView;
+import org.opensearch.wlm.QueryGroupTask;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class QueryGroupTaskResourceTrackingTests extends OpenSearchTestCase {
+    ThreadPool threadPool;
+    QueryGroupResourceUsageTrackerService queryGroupResourceUsageTrackerService;
+    TaskResourceTrackingService taskResourceTrackingService;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool("workload-management-tracking-thread-pool");
+        taskResourceTrackingService = new TaskResourceTrackingService(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            threadPool
+        );
+        queryGroupResourceUsageTrackerService = new QueryGroupResourceUsageTrackerService(taskResourceTrackingService);
+    }
+
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdownNow();
+    }
+
+    public void testValidQueryGroupTasksCase() {
+        taskResourceTrackingService.setTaskResourceTrackingEnabled(true);
+        QueryGroupTask task = new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>());
+        taskResourceTrackingService.startTracking(task);
+
+        // since the query group id is not set we should not track this task
+        Map<String, QueryGroupLevelResourceUsageView> resourceUsageViewMap = queryGroupResourceUsageTrackerService
+            .constructQueryGroupLevelUsageViews();
+        assertTrue(resourceUsageViewMap.isEmpty());
+
+        // Now since this task has a valid queryGroupId header it should be tracked
+        try (ThreadContext.StoredContext context = threadPool.getThreadContext().stashContext()) {
+            threadPool.getThreadContext().putHeader(QueryGroupTask.QUERY_GROUP_ID_HEADER, "testHeader");
+            task.setQueryGroupId(threadPool.getThreadContext());
+            resourceUsageViewMap = queryGroupResourceUsageTrackerService.constructQueryGroupLevelUsageViews();
+            assertFalse(resourceUsageViewMap.isEmpty());
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/wlm/tracker/ResourceUsageCalculatorTrackerServiceTests.java
+++ b/server/src/test/java/org/opensearch/wlm/tracker/ResourceUsageCalculatorTrackerServiceTests.java
@@ -146,7 +146,7 @@ public class ResourceUsageCalculatorTrackerServiceTests extends OpenSearchTestCa
         when(task.getTotalResourceUtilization(ResourceStats.MEMORY)).thenReturn(heapUsage);
         when(task.getStartTimeNanos()).thenReturn((long) 0);
         when(task.getElapsedTime()).thenReturn(clock.getTime());
-        when(task.isEligibleForTracking()).thenReturn(true);
+        when(task.isQueryGroupSet()).thenReturn(true);
 
         AtomicBoolean isCancelled = new AtomicBoolean(false);
         doAnswer(invocation -> {

--- a/server/src/test/java/org/opensearch/wlm/tracker/ResourceUsageCalculatorTrackerServiceTests.java
+++ b/server/src/test/java/org/opensearch/wlm/tracker/ResourceUsageCalculatorTrackerServiceTests.java
@@ -146,6 +146,7 @@ public class ResourceUsageCalculatorTrackerServiceTests extends OpenSearchTestCa
         when(task.getTotalResourceUtilization(ResourceStats.MEMORY)).thenReturn(heapUsage);
         when(task.getStartTimeNanos()).thenReturn((long) 0);
         when(task.getElapsedTime()).thenReturn(clock.getTime());
+        when(task.isEligibleForTracking()).thenReturn(true);
 
         AtomicBoolean isCancelled = new AtomicBoolean(false);
         doAnswer(invocation -> {


### PR DESCRIPTION
### Description
This change mitigates the **warn** level logs from `QueryGroupTask#getQueryGroupId` method when the `queryGroupId` is `null`.  Currently all APIs which use `SearchTask` or `SearchShardTask` for task level resource tracking have to call the `setQueryGroupId` method otherwise this results in generating the log mentioned in the related issues.  

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/16874

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
