### PR TITLE
Fix ConcurrentModificationException in RemoteFsTimestampAwareTranslog.trimUnreferencedReaders

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
@@ -125,19 +125,17 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
         }
 
         // Update file tracker to reflect local translog state
-        Optional<Long> minLiveGeneration = readers.stream().map(BaseTranslogReader::getGeneration).min(Long::compareTo);
-        if (minLiveGeneration.isPresent()) {
-            List<String> staleFilesInTracker = new ArrayList<>();
-            for (String file : fileTransferTracker.allUploaded()) {
-                if (file.endsWith(TRANSLOG_FILE_SUFFIX)) {
-                    long generation = Translog.parseIdFromFileName(file);
-                    if (generation < minLiveGeneration.get()) {
-                        staleFilesInTracker.add(file);
-                        staleFilesInTracker.add(Translog.getCommitCheckpointFileName(generation));
-                    }
+        long minLiveGeneration = getMinFileGeneration();
+        List<String> staleFilesInTracker = new ArrayList<>();
+        for (String file : fileTransferTracker.allUploaded()) {
+            if (file.endsWith(TRANSLOG_FILE_SUFFIX)) {
+                long generation = Translog.parseIdFromFileName(file);
+                if (generation < minLiveGeneration) {
+                    staleFilesInTracker.add(file);
+                    staleFilesInTracker.add(Translog.getCommitCheckpointFileName(generation));
                 }
-                fileTransferTracker.delete(staleFilesInTracker);
             }
+            fileTransferTracker.delete(staleFilesInTracker);
         }
 
         // This is to ensure that after the permits are acquired during primary relocation, there are no further modification on remote

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java
@@ -135,8 +135,8 @@ public class RemoteFsTimestampAwareTranslog extends RemoteFsTranslog {
                     staleFilesInTracker.add(Translog.getCommitCheckpointFileName(generation));
                 }
             }
-            fileTransferTracker.delete(staleFilesInTracker);
         }
+        fileTransferTracker.delete(staleFilesInTracker);
 
         // This is to ensure that after the permits are acquired during primary relocation, there are no further modification on remote
         // store.


### PR DESCRIPTION
### Description
- In `RemoteFsTimestampAwareTranslog.trimUnreferencedReaders`, in order to update file tracker to reflect local translog state, we fetch the minimum generation across all readers and delete all generations from `FileTransferTracker` that are less than the min generation.

https://github.com/opensearch-project/OpenSearch/blob/34ef1462abd55e931961c08d21b1dfa5855b8121/server/src/main/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslog.java#L128-L141 

- But `readers` is ArrayList, that means without locking readers if we try to read the list contents, we will get `ConcurrentModificationException` if a other thread is writing to readers.
- This was revealed by flaky test https://github.com/opensearch-project/OpenSearch/issues/15818 where test is failing with following stack trace:

```
java.util.ConcurrentModificationException
	at __randomizedtesting.SeedInfo.seed([B332A1405CA5C597:97EB586D87323614]:0)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1715)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:702)
	at java.base/java.util.stream.ReferencePipeline.min(ReferencePipeline.java:748)
	at org.opensearch.index.translog.RemoteFsTimestampAwareTranslog.trimUnreferencedReaders(RemoteFsTimestampAwareTranslog.java:128)
	at org.opensearch.index.translog.RemoteFsTimestampAwareTranslog.trimUnreferencedReaders(RemoteFsTimestampAwareTranslog.java:117)
	at org.opensearch.index.translog.Translog.lambda$acquireTranslogGenFromDeletionPolicy$12(Translog.java:744)
	at org.opensearch.index.translog.MultiSnapshot.close(MultiSnapshot.java:99)
	at org.opensearch.index.translog.Translog$SeqNoFilterSnapshot.close(Translog.java:1044)
	at org.opensearch.index.translog.RemoteFsTranslogTests$5.doRun(RemoteFsTranslogTests.java:1188)
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
	at java.base/java.lang.Thread.run(Thread.java:1575)
```

- But there already exists a method in `Translog` class that safely returns the min generation by taking a read lock: `getMinFileGeneration()`
- In this PR, we use `getMinFileGeneration()` to get the min generation.

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/15818

### Check List
- ~[ ] Functionality includes testing.~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
