### PR TITLE
Fix GRPC AUX_TRANSPORT_PORT and SETTING_GRPC_PORT settings and remove lingering HTTP terminology 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix Shallow copy snapshot failures on closed index ([#16868](https://github.com/opensearch-project/OpenSearch/pull/16868))
 - Fix multi-value sort for unsigned long ([#16732](https://github.com/opensearch-project/OpenSearch/pull/16732))
 - The `phone-search` analyzer no longer emits the tel/sip prefix, international calling code, extension numbers and unformatted input as a token ([#16993](https://github.com/opensearch-project/OpenSearch/pull/16993))
-- Fix GRPC AUX_TRANSPORT_PORT and SETTING_GRPC_PORT settings and remove lingering HTTP terminology  ([#17037](https://github.com/opensearch-project/OpenSearch/pull/17037))
+- Fix GRPC AUX_TRANSPORT_PORT and SETTING_GRPC_PORT settings and remove lingering HTTP terminology ([#17037](https://github.com/opensearch-project/OpenSearch/pull/17037))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix Shallow copy snapshot failures on closed index ([#16868](https://github.com/opensearch-project/OpenSearch/pull/16868))
 - Fix multi-value sort for unsigned long ([#16732](https://github.com/opensearch-project/OpenSearch/pull/16732))
 - The `phone-search` analyzer no longer emits the tel/sip prefix, international calling code, extension numbers and unformatted input as a token ([#16993](https://github.com/opensearch-project/OpenSearch/pull/16993))
+- Fix GRPC AUX_TRANSPORT_PORT and SETTING_GRPC_PORT settings and remove lingering HTTP terminology  ([#17037](https://github.com/opensearch-project/OpenSearch/pull/17037))
 
 ### Security
 

--- a/plugins/transport-grpc/src/main/java/org/opensearch/transport/grpc/GrpcPlugin.java
+++ b/plugins/transport-grpc/src/main/java/org/opensearch/transport/grpc/GrpcPlugin.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
 import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.GRPC_TRANSPORT_SETTING_KEY;
 import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_BIND_HOST;
 import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_HOST;
-import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_PORTS;
+import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_PORT;
 import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_PUBLISH_HOST;
 import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_PUBLISH_PORT;
 import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_WORKER_COUNT;
@@ -58,7 +58,7 @@ public final class GrpcPlugin extends Plugin implements NetworkPlugin {
     @Override
     public List<Setting<?>> getSettings() {
         return List.of(
-            SETTING_GRPC_PORTS,
+            SETTING_GRPC_PORT,
             SETTING_GRPC_HOST,
             SETTING_GRPC_PUBLISH_HOST,
             SETTING_GRPC_BIND_HOST,

--- a/plugins/transport-grpc/src/main/java/org/opensearch/transport/grpc/Netty4GrpcServerTransport.java
+++ b/plugins/transport-grpc/src/main/java/org/opensearch/transport/grpc/Netty4GrpcServerTransport.java
@@ -134,7 +134,7 @@ public class Netty4GrpcServerTransport extends NetworkPlugin.AuxTransport {
      * @param networkService the bind/publish addresses.
      */
     public Netty4GrpcServerTransport(Settings settings, List<BindableService> services, NetworkService networkService) {
-        logger.debug("Initializing netty4GrpcServerTransport with settings = {}", settings);
+        logger.debug("Initializing Netty4GrpcServerTransport with settings = {}", settings);
         this.settings = Objects.requireNonNull(settings);
         this.services = Objects.requireNonNull(services);
         this.networkService = Objects.requireNonNull(networkService);

--- a/plugins/transport-grpc/src/main/java/org/opensearch/transport/grpc/Netty4GrpcServerTransport.java
+++ b/plugins/transport-grpc/src/main/java/org/opensearch/transport/grpc/Netty4GrpcServerTransport.java
@@ -63,9 +63,9 @@ public class Netty4GrpcServerTransport extends NetworkPlugin.AuxTransport {
 
     /**
      * Port range on which to bind.
-     * Note this setting is configured through AffixSetting AUX_TRANSPORT_PORTS where the aux transport type matches the GRPC_TRANSPORT_SETTING_KEY.
+     * Note this setting is configured through AffixSetting AUX_TRANSPORT_PORT where the aux transport type matches the GRPC_TRANSPORT_SETTING_KEY.
      */
-    public static final Setting<PortsRange> SETTING_GRPC_PORTS = AUX_TRANSPORT_PORTS.getConcreteSettingForNamespace(
+    public static final Setting<PortsRange> SETTING_GRPC_PORT = AUX_TRANSPORT_PORT.getConcreteSettingForNamespace(
         GRPC_TRANSPORT_SETTING_KEY
     );
 
@@ -134,20 +134,21 @@ public class Netty4GrpcServerTransport extends NetworkPlugin.AuxTransport {
      * @param networkService the bind/publish addresses.
      */
     public Netty4GrpcServerTransport(Settings settings, List<BindableService> services, NetworkService networkService) {
+        logger.debug("Initializing netty4GrpcServerTransport with settings = {}", settings);
         this.settings = Objects.requireNonNull(settings);
         this.services = Objects.requireNonNull(services);
         this.networkService = Objects.requireNonNull(networkService);
 
-        final List<String> httpBindHost = SETTING_GRPC_BIND_HOST.get(settings);
-        this.bindHosts = (httpBindHost.isEmpty() ? NetworkService.GLOBAL_NETWORK_BIND_HOST_SETTING.get(settings) : httpBindHost).toArray(
+        final List<String> grpcBindHost = SETTING_GRPC_BIND_HOST.get(settings);
+        this.bindHosts = (grpcBindHost.isEmpty() ? NetworkService.GLOBAL_NETWORK_BIND_HOST_SETTING.get(settings) : grpcBindHost).toArray(
             Strings.EMPTY_ARRAY
         );
 
-        final List<String> httpPublishHost = SETTING_GRPC_PUBLISH_HOST.get(settings);
-        this.publishHosts = (httpPublishHost.isEmpty() ? NetworkService.GLOBAL_NETWORK_PUBLISH_HOST_SETTING.get(settings) : httpPublishHost)
+        final List<String> grpcPublishHost = SETTING_GRPC_PUBLISH_HOST.get(settings);
+        this.publishHosts = (grpcPublishHost.isEmpty() ? NetworkService.GLOBAL_NETWORK_PUBLISH_HOST_SETTING.get(settings) : grpcPublishHost)
             .toArray(Strings.EMPTY_ARRAY);
 
-        this.port = SETTING_GRPC_PORTS.get(settings);
+        this.port = SETTING_GRPC_PORT.get(settings);
         this.nettyEventLoopThreads = SETTING_GRPC_WORKER_COUNT.get(settings);
     }
 
@@ -229,7 +230,7 @@ public class Netty4GrpcServerTransport extends NetworkPlugin.AuxTransport {
                     + publishInetAddress
                     + "). "
                     + "Please specify a unique port by setting "
-                    + SETTING_GRPC_PORTS.getKey()
+                    + SETTING_GRPC_PORT.getKey()
                     + " or "
                     + SETTING_GRPC_PUBLISH_PORT.getKey()
             );

--- a/plugins/transport-grpc/src/test/java/org/opensearch/transport/grpc/Netty4GrpcServerTransportTests.java
+++ b/plugins/transport-grpc/src/test/java/org/opensearch/transport/grpc/Netty4GrpcServerTransportTests.java
@@ -44,6 +44,6 @@ public class Netty4GrpcServerTransportTests extends OpenSearchTestCase {
     }
 
     private static Settings createSettings() {
-        return Settings.builder().put(Netty4GrpcServerTransport.SETTING_GRPC_PORTS.getKey(), getPortRange()).build();
+        return Settings.builder().put(Netty4GrpcServerTransport.SETTING_GRPC_PORT.getKey(), getPortRange()).build();
     }
 }

--- a/server/src/main/java/org/opensearch/bootstrap/Security.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Security.java
@@ -74,7 +74,7 @@ import java.util.regex.Pattern;
 import static org.opensearch.bootstrap.FilePermissionUtils.addDirectoryPath;
 import static org.opensearch.bootstrap.FilePermissionUtils.addSingleFilePath;
 import static org.opensearch.plugins.NetworkPlugin.AuxTransport.AUX_PORT_DEFAULTS;
-import static org.opensearch.plugins.NetworkPlugin.AuxTransport.AUX_TRANSPORT_PORTS;
+import static org.opensearch.plugins.NetworkPlugin.AuxTransport.AUX_TRANSPORT_PORT;
 import static org.opensearch.plugins.NetworkPlugin.AuxTransport.AUX_TRANSPORT_TYPES_SETTING;
 
 /**
@@ -423,7 +423,7 @@ final class Security {
     }
 
     /**
-     * Add dynamic {@link SocketPermission} based on AffixSetting AUX_TRANSPORT_PORTS.
+     * Add dynamic {@link SocketPermission} based on AffixSetting AUX_TRANSPORT_PORT.
      * If an auxiliary transport type is enabled but has no corresponding port range setting fall back to AUX_PORT_DEFAULTS.
      *
      * @param policy the {@link Permissions} instance to apply the dynamic {@link SocketPermission}s to.
@@ -432,7 +432,7 @@ final class Security {
     private static void addSocketPermissionForAux(final Permissions policy, final Settings settings) {
         Set<PortsRange> portsRanges = new HashSet<>();
         for (String auxType : AUX_TRANSPORT_TYPES_SETTING.get(settings)) {
-            Setting<PortsRange> auxTypePortSettings = AUX_TRANSPORT_PORTS.getConcreteSettingForNamespace(auxType);
+            Setting<PortsRange> auxTypePortSettings = AUX_TRANSPORT_PORT.getConcreteSettingForNamespace(auxType);
             if (auxTypePortSettings.exists(settings)) {
                 portsRanges.add(auxTypePortSettings.get(settings));
             } else {

--- a/server/src/main/java/org/opensearch/plugins/NetworkPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/NetworkPlugin.java
@@ -79,9 +79,9 @@ public interface NetworkPlugin {
         public static final String AUX_SETTINGS_PREFIX = "aux.transport.";
         public static final String AUX_TRANSPORT_TYPES_KEY = AUX_SETTINGS_PREFIX + "types";
         public static final String AUX_PORT_DEFAULTS = "9400-9500";
-        public static final Setting.AffixSetting<PortsRange> AUX_TRANSPORT_PORTS = affixKeySetting(
+        public static final Setting.AffixSetting<PortsRange> AUX_TRANSPORT_PORT = affixKeySetting(
             AUX_SETTINGS_PREFIX,
-            "ports",
+            "port",
             key -> new Setting<>(key, AUX_PORT_DEFAULTS, PortsRange::new, Setting.Property.NodeScope)
         );
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
1. Rename [AUX_TRANSPORT_PORT](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/plugins/NetworkPlugin.java#L82-L86) setting from `aux.transport.experimental-transport-grpc.ports` to `aux.transport.experimental-transport-grpc.port` for consistency with the [http.port](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/http/HttpTransportSettings.java#L114) cluster setting. 
2. Fix lingering HTTP terminology in [Netty4GrpcServerTransport.java](https://github.com/opensearch-project/OpenSearch/blob/main/plugins/transport-grpc/src/main/java/org/opensearch/transport/grpc/Netty4GrpcServerTransport.java#L141-L148) (`httpBindHost`-> `grpcBindHost`, `httpPublishHost` -> `grpcPublishHost`) 
3. Add a debug log for the GRPC transport settings in [Netty4GrpcServerTransport constructor](https://github.com/opensearch-project/OpenSearch/blob/main/plugins/transport-grpc/src/main/java/org/opensearch/transport/grpc/Netty4GrpcServerTransport.java#L136)

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/16556
<!-- List any other related issues here -->

Test plan:
1. Terminal 1: Enable the transport-grpc plugin and set a custom grpc port 
```
 ./gradlew run  -PinstalledPlugins="['transport-grpc']" --info -Dtests.opensearch.aux.transport.types="[experimental-transport-grpc]"  -Dtests.opensearch.aux.transport.experimental-transport-grpc.port=28234
```
2. Terminal 2: Submit a grpc request to that port to ensure the GRPC server is running
```
~/opensearch on [grpc-settings-fixes] %  grpcurl -plaintext localhost:28234 list

grpc.health.v1.Health
grpc.reflection.v1alpha.ServerReflection
```
### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
