### PR TITLE
Add support for append only indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add stats for remote publication failure and move download failure stats to remote methods([#16682](https://github.com/opensearch-project/OpenSearch/pull/16682/))
 - Update script supports java.lang.String.sha1() and java.lang.String.sha256() methods ([#16923](https://github.com/opensearch-project/OpenSearch/pull/16923))
 - Added a precaution to handle extreme date values during sorting to prevent `arithmetic_exception: long overflow` ([#16812](https://github.com/opensearch-project/OpenSearch/pull/16812)).
+- Add support for append only indices([#17039](https://github.com/opensearch-project/OpenSearch/pull/17039))
 - Add `verbose_pipeline` parameter to output each processor's execution details ([#16843](https://github.com/opensearch-project/OpenSearch/pull/16843)).
 - Add search replica stats to segment replication stats API ([#16678](https://github.com/opensearch-project/OpenSearch/pull/16678))
 - Introduce a setting to disable download of full cluster state from remote on term mismatch([#16798](https://github.com/opensearch-project/OpenSearch/pull/16798/))

--- a/libs/core/src/main/java/org/opensearch/core/index/AppendOnlyIndexOperationRetryException.java
+++ b/libs/core/src/main/java/org/opensearch/core/index/AppendOnlyIndexOperationRetryException.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.core.index;
+
+import org.opensearch.OpenSearchException;
+
+/**
+ * This exception indicates that retry has been made during indexing for AppendOnly index. If the response of any
+ * indexing request contains this Exception in the response, we do not need to add a translog entry for this request.
+ *
+ * @opensearch.internal
+ */
+public class AppendOnlyIndexOperationRetryException extends OpenSearchException {
+    public AppendOnlyIndexOperationRetryException(String message) {
+        super(message);
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/action/bulk/AppendOnlyIndicesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/bulk/AppendOnlyIndicesIT.java
@@ -1,0 +1,219 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.bulk;
+
+import org.opensearch.action.admin.cluster.node.stats.NodeStats;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.ingest.IngestTestPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.ConnectTransportException;
+import org.opensearch.transport.TransportService;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING;
+import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING;
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.containsString;
+
+public class AppendOnlyIndicesIT extends OpenSearchIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(IngestTestPlugin.class, MockTransportService.TestPlugin.class);
+    }
+
+    public void testIndexDocumentWithACustomDocIdForAppendOnlyIndices() throws Exception {
+        Client client = internalCluster().coordOnlyNodeClient();
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("index")
+                .setSettings(
+                    Settings.builder()
+                        .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+                        .put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                        .put(IndexMetadata.INDEX_APPEND_ONLY_ENABLED_SETTING.getKey(), true)
+                )
+        );
+        ensureGreen("index");
+
+        BulkRequestBuilder bulkBuilder = client.prepareBulk();
+
+        XContentBuilder doc = null;
+        doc = jsonBuilder().startObject().field("foo", "bar").endObject();
+        bulkBuilder.add(client.prepareIndex("index").setId(Integer.toString(0)).setSource(doc));
+
+        BulkResponse response = bulkBuilder.get();
+        assertThat(
+            response.getItems()[0].getFailureMessage(),
+            containsString(
+                "Operation [INDEX] is not allowed with a custom document id 0 as setting `"
+                    + IndexMetadata.INDEX_APPEND_ONLY_ENABLED_SETTING.getKey()
+                    + "` is enabled for this index: index;"
+            )
+        );
+    }
+
+    public void testUpdateDeleteDocumentForAppendOnlyIndices() throws Exception {
+        Client client = internalCluster().coordOnlyNodeClient();
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("index")
+                .setSettings(
+                    Settings.builder()
+                        .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+                        .put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                        .put(IndexMetadata.INDEX_APPEND_ONLY_ENABLED_SETTING.getKey(), true)
+                )
+        );
+        ensureGreen("index");
+
+        BulkRequestBuilder bulkBuilder = client.prepareBulk();
+
+        XContentBuilder doc = null;
+        doc = jsonBuilder().startObject().field("foo", "bar").endObject();
+        bulkBuilder.add(client.prepareIndex("index").setSource(doc));
+
+        bulkBuilder.get();
+        BulkResponse response = client().prepareBulk().add(client().prepareUpdate("index", "0").setDoc("foo", "updated")).get();
+        assertThat(
+            response.getItems()[0].getFailureMessage(),
+            containsString(
+                "Operation [UPDATE] is not allowed as setting `"
+                    + IndexMetadata.INDEX_APPEND_ONLY_ENABLED_SETTING.getKey()
+                    + "` is enabled for this index"
+            )
+        );
+
+        response = client().prepareBulk().add(client().prepareDelete("index", "0")).get();
+        assertThat(
+            response.getItems()[0].getFailureMessage(),
+            containsString(
+                "Operation [DELETE] is not allowed as setting `"
+                    + IndexMetadata.INDEX_APPEND_ONLY_ENABLED_SETTING.getKey()
+                    + "` is enabled for this index"
+            )
+        );
+    }
+
+    public void testRetryForAppendOnlyIndices() throws Exception {
+        final AtomicBoolean exceptionThrown = new AtomicBoolean(false);
+        int numDocs = scaledRandomIntBetween(100, 1000);
+        Client client = internalCluster().coordOnlyNodeClient();
+        NodesStatsResponse nodeStats = client().admin().cluster().prepareNodesStats().get();
+        NodeStats unluckyNode = randomFrom(
+            nodeStats.getNodes().stream().filter((s) -> s.getNode().isDataNode()).collect(Collectors.toList())
+        );
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("index")
+                .setSettings(
+                    Settings.builder()
+                        .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+                        .put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                        .put(IndexMetadata.INDEX_APPEND_ONLY_ENABLED_SETTING.getKey(), true)
+                )
+        );
+        ensureGreen("index");
+        logger.info("unlucky node: {}", unluckyNode.getNode());
+        // create a transport service that throws a ConnectTransportException for one bulk request and therefore triggers a retry.
+        for (NodeStats dataNode : nodeStats.getNodes()) {
+            if (exceptionThrown.get()) {
+                break;
+            }
+
+            MockTransportService mockTransportService = ((MockTransportService) internalCluster().getInstance(
+                TransportService.class,
+                dataNode.getNode().getName()
+            ));
+            mockTransportService.addSendBehavior(
+                internalCluster().getInstance(TransportService.class, unluckyNode.getNode().getName()),
+                (connection, requestId, action, request, options) -> {
+                    connection.sendRequest(requestId, action, request, options);
+                    if (action.equals(TransportShardBulkAction.ACTION_NAME) && exceptionThrown.compareAndSet(false, true)) {
+                        logger.debug("Throw ConnectTransportException");
+                        throw new ConnectTransportException(connection.getNode(), action);
+                    }
+                }
+            );
+        }
+
+        BulkRequestBuilder bulkBuilder = client.prepareBulk();
+
+        for (int i = 0; i < numDocs; i++) {
+            XContentBuilder doc = null;
+            doc = jsonBuilder().startObject().field("foo", "bar").endObject();
+            bulkBuilder.add(client.prepareIndex("index").setSource(doc));
+        }
+
+        BulkResponse response = bulkBuilder.get();
+        for (BulkItemResponse singleIndexResponse : response.getItems()) {
+            // Retry will not create a new version.
+            assertThat(singleIndexResponse.getVersion(), equalTo(1L));
+        }
+    }
+
+    public void testNodeReboot() throws Exception {
+        int numDocs = scaledRandomIntBetween(100, 1000);
+        Client client = internalCluster().coordOnlyNodeClient();
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("index")
+                .setSettings(
+                    Settings.builder()
+                        .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+                        .put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                        .put(IndexMetadata.INDEX_APPEND_ONLY_ENABLED_SETTING.getKey(), true)
+                )
+        );
+
+        ensureGreen("index");
+
+        BulkRequestBuilder bulkBuilder = client.prepareBulk();
+
+        for (int i = 0; i < numDocs; i++) {
+            XContentBuilder doc = null;
+            doc = jsonBuilder().startObject().field("foo", "bar").endObject();
+            bulkBuilder.add(client.prepareIndex("index").setSource(doc));
+        }
+
+        BulkResponse response = bulkBuilder.get();
+        assertFalse(response.hasFailures());
+        internalCluster().restartRandomDataNode();
+        ensureGreen("index");
+        refresh();
+        SearchResponse searchResponse = client().prepareSearch()
+            .setQuery(QueryBuilders.matchAllQuery())
+            .setIndices("index")
+            .setSize(numDocs)
+            .get();
+
+        assertBusy(() -> { assertHitCount(searchResponse, numDocs); }, 20L, TimeUnit.SECONDS);
+
+    }
+}

--- a/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
@@ -66,6 +66,7 @@ import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.ValidationException;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.unit.TimeValue;
@@ -540,12 +541,17 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                 if (docWriteRequest == null) {
                     continue;
                 }
+
                 if (addFailureIfRequiresAliasAndAliasIsMissing(docWriteRequest, i, metadata)) {
                     continue;
                 }
                 if (addFailureIfIndexIsUnavailable(docWriteRequest, i, concreteIndices, metadata)) {
                     continue;
                 }
+                if (addFailureIfAppendOnlyIndexAndOpsDeleteOrUpdate(docWriteRequest, i, concreteIndices, metadata)) {
+                    continue;
+                }
+
                 Index concreteIndex = concreteIndices.resolveIfAbsent(docWriteRequest);
                 try {
                     // The ConcreteIndices#resolveIfAbsent(...) method validates via IndexNameExpressionResolver whether
@@ -747,6 +753,47 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                     run();
                 }
             });
+        }
+
+        private boolean addFailureIfAppendOnlyIndexAndOpsDeleteOrUpdate(
+            DocWriteRequest<?> request,
+            int idx,
+            final ConcreteIndices concreteIndices,
+            Metadata metadata
+        ) {
+            Index concreteIndex = concreteIndices.resolveIfAbsent(request);
+            final IndexMetadata indexMetadata = metadata.index(concreteIndex);
+            if (indexMetadata.isAppendOnlyIndex()) {
+                if ((request.opType() == DocWriteRequest.OpType.UPDATE || request.opType() == DocWriteRequest.OpType.DELETE)) {
+                    ValidationException exception = new ValidationException();
+                    exception.addValidationError(
+                        "Operation ["
+                            + request.opType()
+                            + "] is not allowed as setting `"
+                            + IndexMetadata.INDEX_APPEND_ONLY_ENABLED_SETTING.getKey()
+                            + "` is enabled for this index: "
+                            + request.index()
+                    );
+                    addFailure(request, idx, exception);
+                    return true;
+                } else if (request.id() != null && request.opType() == DocWriteRequest.OpType.INDEX) {
+                    ValidationException exception = new ValidationException();
+                    exception.addValidationError(
+                        "Operation ["
+                            + request.opType()
+                            + "] is not allowed with a custom document id "
+                            + request.id()
+                            + " as setting `"
+                            + IndexMetadata.INDEX_APPEND_ONLY_ENABLED_SETTING.getKey()
+                            + "` is enabled for this index: "
+                            + request.index()
+                    );
+                    addFailure(request, idx, exception);
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private boolean addFailureIfRequiresAliasAndAliasIsMissing(DocWriteRequest<?> request, int idx, final Metadata metadata) {

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -351,6 +351,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     );
 
     public static final String SETTING_REMOTE_STORE_ENABLED = "index.remote_store.enabled";
+    public static final String SETTING_INDEX_APPEND_ONLY_ENABLED = "index.append_only.enabled";
 
     public static final String SETTING_REMOTE_SEGMENT_STORE_REPOSITORY = "index.remote_store.segment.repository";
 
@@ -391,6 +392,16 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         Property.IndexScope,
         Property.PrivateIndex,
         Property.Dynamic
+    );
+
+    /**
+     * Used to specify if the index data should be persisted in the remote store.
+     */
+    public static final Setting<Boolean> INDEX_APPEND_ONLY_ENABLED_SETTING = Setting.boolSetting(
+        SETTING_INDEX_APPEND_ONLY_ENABLED,
+        false,
+        Property.IndexScope,
+        Property.Final
     );
 
     /**
@@ -722,6 +733,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     private final boolean isRemoteSnapshot;
 
     private final int indexTotalShardsPerNodeLimit;
+    private final boolean isAppendOnlyIndex;
 
     private final Context context;
 
@@ -753,6 +765,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         final Map<String, RolloverInfo> rolloverInfos,
         final boolean isSystem,
         final int indexTotalShardsPerNodeLimit,
+        boolean isAppendOnlyIndex,
         final Context context
     ) {
 
@@ -790,6 +803,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         this.isSystem = isSystem;
         this.isRemoteSnapshot = IndexModule.Type.REMOTE_SNAPSHOT.match(this.settings);
         this.indexTotalShardsPerNodeLimit = indexTotalShardsPerNodeLimit;
+        this.isAppendOnlyIndex = isAppendOnlyIndex;
         this.context = context;
         assert numberOfShards * routingFactor == routingNumShards : routingNumShards + " must be a multiple of " + numberOfShards;
     }
@@ -950,6 +964,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     public int getIndexTotalShardsPerNodeLimit() {
         return this.indexTotalShardsPerNodeLimit;
+    }
+
+    public boolean isAppendOnlyIndex() {
+        return this.isAppendOnlyIndex;
     }
 
     @Nullable
@@ -1745,6 +1763,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             }
 
             final int indexTotalShardsPerNodeLimit = ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.get(settings);
+            final boolean isAppendOnlyIndex = INDEX_APPEND_ONLY_ENABLED_SETTING.get(settings);
 
             final String uuid = settings.get(SETTING_INDEX_UUID, INDEX_UUID_NA_VALUE);
 
@@ -1776,6 +1795,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 rolloverInfos,
                 isSystem,
                 indexTotalShardsPerNodeLimit,
+                isAppendOnlyIndex,
                 context
             );
         }

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -109,6 +109,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexMetadata.INDEX_FORMAT_SETTING,
                 IndexMetadata.INDEX_HIDDEN_SETTING,
                 IndexMetadata.INDEX_REPLICATION_TYPE_SETTING,
+                IndexMetadata.INDEX_APPEND_ONLY_ENABLED_SETTING,
                 SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING,
                 SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING,
                 SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO_SETTING,

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -88,6 +88,7 @@ import org.opensearch.common.util.concurrent.ReleasableLock;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.Assertions;
 import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.core.index.AppendOnlyIndexOperationRetryException;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.VersionType;
@@ -932,19 +933,21 @@ public class InternalEngine extends Engine {
                     final Translog.Location location;
                     if (indexResult.getResultType() == Result.Type.SUCCESS) {
                         location = translogManager.add(new Translog.Index(index, indexResult));
-                    } else if (indexResult.getSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO) {
-                        // if we have document failure, record it as a no-op in the translog and Lucene with the generated seq_no
-                        final NoOp noOp = new NoOp(
-                            indexResult.getSeqNo(),
-                            index.primaryTerm(),
-                            index.origin(),
-                            index.startTime(),
-                            indexResult.getFailure().toString()
-                        );
-                        location = innerNoOp(noOp).getTranslogLocation();
-                    } else {
-                        location = null;
-                    }
+                    } else if (indexResult.getSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO
+                        && indexResult.getFailure() != null
+                        && !(indexResult.getFailure() instanceof AppendOnlyIndexOperationRetryException)) {
+                            // if we have document failure, record it as a no-op in the translog and Lucene with the generated seq_no
+                            final NoOp noOp = new NoOp(
+                                indexResult.getSeqNo(),
+                                index.primaryTerm(),
+                                index.origin(),
+                                index.startTime(),
+                                indexResult.getFailure().toString()
+                            );
+                            location = innerNoOp(noOp).getTranslogLocation();
+                        } else {
+                            location = null;
+                        }
                     indexResult.setTranslogLocation(location);
                 }
                 if (plan.indexIntoLucene && indexResult.getResultType() == Result.Type.SUCCESS) {
@@ -955,7 +958,9 @@ public class InternalEngine extends Engine {
                     );
                 }
                 localCheckpointTracker.markSeqNoAsProcessed(indexResult.getSeqNo());
-                if (indexResult.getTranslogLocation() == null) {
+                if (indexResult.getTranslogLocation() == null
+                    && !(indexResult.getFailure() != null
+                        && (indexResult.getFailure() instanceof AppendOnlyIndexOperationRetryException))) {
                     // the op is coming from the translog (and is hence persisted already) or it does not have a sequence number
                     assert index.origin().isFromTranslog() || indexResult.getSeqNo() == SequenceNumbers.UNASSIGNED_SEQ_NO;
                     localCheckpointTracker.markSeqNoAsPersisted(indexResult.getSeqNo());
@@ -1049,7 +1054,7 @@ public class InternalEngine extends Engine {
         } else {
             versionMap.enforceSafeAccess();
             // resolves incoming version
-            final VersionValue versionValue = resolveDocVersion(index, index.getIfSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO);
+            final VersionValue versionValue = resolveDocVersion(index, true);
             final long currentVersion;
             final boolean currentNotFoundOrDeleted;
             if (versionValue == null) {
@@ -1092,6 +1097,15 @@ public class InternalEngine extends Engine {
                     final Exception reserveError = tryAcquireInFlightDocs(index, reservingDocs);
                     if (reserveError != null) {
                         plan = IndexingStrategy.failAsTooManyDocs(reserveError);
+                    } else if (currentVersion >= 1 && engineConfig.getIndexSettings().getIndexMetadata().isAppendOnlyIndex()) {
+                        // Retry happens for indexing requests for append only indices, since we are rejecting update requests
+                        // at Transport layer itself. So for any retry, we are reconstructing response from already indexed
+                        // document version for append only index.
+                        AppendOnlyIndexOperationRetryException retryException = new AppendOnlyIndexOperationRetryException(
+                            "Indexing operation retried for append only indices"
+                        );
+                        final IndexResult result = new IndexResult(retryException, currentVersion, versionValue.term, versionValue.seqNo);
+                        plan = IndexingStrategy.failAsIndexAppendOnly(result, currentVersion, 0);
                     } else {
                         plan = IndexingStrategy.processNormally(
                             currentNotFoundOrDeleted,
@@ -1282,6 +1296,10 @@ public class InternalEngine extends Engine {
         static IndexingStrategy failAsTooManyDocs(Exception e) {
             final IndexResult result = new IndexResult(e, Versions.NOT_FOUND);
             return new IndexingStrategy(false, false, false, false, Versions.NOT_FOUND, 0, result);
+        }
+
+        static IndexingStrategy failAsIndexAppendOnly(IndexResult result, long versionForIndexing, int reservedDocs) {
+            return new IndexingStrategy(false, false, false, true, versionForIndexing, reservedDocs, result);
         }
     }
 


### PR DESCRIPTION
### Description
Adding support for Append only indices where we are disabling any form of updates and deletes on the index. We are also preventing passing a custom doc id for bulk indexing requests. Append only indices will be supported through a configurable setting. If this setting is enabled, all update and delete operations on the index (UPDATE, DELETE, UPSERT, UPDATE BY QUERY, DELETE BY QUERY, etc,) will be blocked.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/12886

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
