### PR TITLE
Add support for deriving source field from docValues in FieldMapper

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
@@ -76,7 +76,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;

--- a/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
@@ -35,6 +35,7 @@ package org.opensearch.index.mapper;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.LeafReader;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
@@ -570,6 +571,17 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     }
 
     protected abstract String contentType();
+
+    public Object getDerivedSource(LeafReader leafReader, int docId) throws IOException{
+        if (mappedFieldType.isDerivedSourceSupported() == false)
+            throw new UnsupportedOperationException("Derived source field is not supported for [" + name() + "] field");
+        return deriveSource(leafReader, docId);
+    }
+
+    // generic implementation, override in subclasses for specific implementation
+    protected Object deriveSource(LeafReader leafReader, int docId) throws IOException {
+        return null;
+    }
 
     /**
      * Multi field implementation used across field mappers

--- a/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
@@ -572,16 +572,23 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
     protected abstract String contentType();
 
-    public Object getDerivedSource(LeafReader leafReader, int docId) throws IOException {
+    /**
+     * Method used for deriving source and building it to XContentBuilder object
+     * @param builder - builder to store the derived source filed
+     * @param leafReader - leafReader to read data from
+     * @param docId - docId for which we want to derive the source
+     * @throws IOException
+     */
+    public void buildDerivedSource(XContentBuilder builder, LeafReader leafReader, int docId) throws IOException {
         if (mappedFieldType.isDerivedSourceSupported() == false) throw new UnsupportedOperationException(
             "Derived source field is not supported for [" + name() + "] field"
         );
-        return deriveSource(leafReader, docId);
+        deriveSource(builder, leafReader, docId);
     }
 
     // generic implementation, override in subclasses for specific implementation
-    protected Object deriveSource(LeafReader leafReader, int docId) throws IOException {
-        return null;
+    protected void deriveSource(XContentBuilder builder, LeafReader leafReader, int docId) throws IOException {
+        throw new UnsupportedOperationException("Derived source field is not supported for [" + name() + "] field");
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
@@ -572,9 +572,10 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
     protected abstract String contentType();
 
-    public Object getDerivedSource(LeafReader leafReader, int docId) throws IOException{
-        if (mappedFieldType.isDerivedSourceSupported() == false)
-            throw new UnsupportedOperationException("Derived source field is not supported for [" + name() + "] field");
+    public Object getDerivedSource(LeafReader leafReader, int docId) throws IOException {
+        if (mappedFieldType.isDerivedSourceSupported() == false) throw new UnsupportedOperationException(
+            "Derived source field is not supported for [" + name() + "] field"
+        );
         return deriveSource(leafReader, docId);
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
@@ -94,6 +94,26 @@ public abstract class MappedFieldType {
     private float boost;
     private NamedAnalyzer indexAnalyzer;
     private boolean eagerGlobalOrdinals;
+    private final boolean derivedSourceSupported;
+
+    public MappedFieldType(
+        String name,
+        boolean isIndexed,
+        boolean isStored,
+        boolean hasDocValues,
+        TextSearchInfo textSearchInfo,
+        Map<String, String> meta,
+        boolean derivedSourceSupported
+    ) {
+        setBoost(1.0f);
+        this.name = Objects.requireNonNull(name);
+        this.isIndexed = isIndexed;
+        this.isStored = isStored;
+        this.docValues = hasDocValues;
+        this.textSearchInfo = Objects.requireNonNull(textSearchInfo);
+        this.meta = meta;
+        this.derivedSourceSupported = derivedSourceSupported;
+    }
 
     public MappedFieldType(
         String name,
@@ -103,13 +123,7 @@ public abstract class MappedFieldType {
         TextSearchInfo textSearchInfo,
         Map<String, String> meta
     ) {
-        setBoost(1.0f);
-        this.name = Objects.requireNonNull(name);
-        this.isIndexed = isIndexed;
-        this.isStored = isStored;
-        this.docValues = hasDocValues;
-        this.textSearchInfo = Objects.requireNonNull(textSearchInfo);
-        this.meta = meta;
+        this(name, isIndexed, isStored, hasDocValues, textSearchInfo, meta, false);
     }
 
     /**
@@ -156,6 +170,10 @@ public abstract class MappedFieldType {
 
     public boolean hasDocValues() {
         return docValues;
+    }
+
+    public boolean isDerivedSourceSupported() {
+        return derivedSourceSupported;
     }
 
     public NamedAnalyzer indexAnalyzer() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add support for deriving source field from docValues in FieldMapper
Following changes have been done:
- Added interface method in FieldMapper for basic support
- Implemented above method in DateFieldMapper

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/17073

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
