### PR TITLE
Add Craig Perkins as OpenSearch Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Ashish Singh             | [ashking94](https://github.com/ashking94)               | Amazon      |
 | Bukhtawar Khan           | [Bukhtawar](https://github.com/Bukhtawar)               | Amazon      |
 | Charlotte Henkle         | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
+| Craig Perkins            | [cwperks](https://github.com/cwperks)                   | Amazon      |
 | Dan Widdis               | [dbwiddis](https://github.com/dbwiddis)                 | Amazon      |
 | Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)                     | Amazon      |
 | Gao Binlong              | [gaobinlong](https://github.com/gaobinlong)             | Amazon      |


### PR DESCRIPTION
Following the process at https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer, I have nominated and other maintainers have agreed to add Craig Perkins (@cwperks) as a co-Maintainer of the OpenSearch repository. Craig has kindly accepted the invitation.

Craig has been a long-time and consistent contributor to OpenSearch since 2022. Out of a raw total of 157 PRs I tried to filter out backports, merges, version bumps, and minor changes and still have almost 50 substantive contributions. 
 
Most recently, he fixed a longstanding pet peeve of mine: his very first PR to the project was a CVE-fixing version bump (https://github.com/opensearch-project/OpenSearch/pull/3772) that dependabot missed. He followed through on that in exploring and committing a switch to a version catalog that not only aids dependabot but can help plugins and other dependencies keep in sync without jar hell. 
 - https://github.com/opensearch-project/OpenSearch/pull/16284 and https://github.com/opensearch-project/OpenSearch/pull/16707
 
Some time back he started with a bug fix for regex recursion, took some feedback that I thought about in a comment (but failed to implement myself) and implemented an elegant non-recursive much more performant shortcut:
- https://github.com/opensearch-project/OpenSearch/pull/11060
 
Some other highlights:
 
Multiple security and identity-related PRs. More significant ones:
 - https://github.com/opensearch-project/OpenSearch/pull/15016 and https://github.com/opensearch-project/OpenSearch/pull/15039 Thread Context Permission (resubmit of previously reviewed/closed PR)
 - https://github.com/opensearch-project/OpenSearch/pull/14630 Identity Aware Plugin Extension point
 - https://github.com/opensearch-project/OpenSearch/pull/14415 (and others) System Index registry
 - https://github.com/opensearch-project/OpenSearch/pull/12865 Keystore password integration with env variable
 - https://github.com/opensearch-project/OpenSearch/pull/11170 Search template refactoring to enable permissions
 
Added code to prevent accidentally bypassing RestHandler.Wrapper:
 - https://github.com/opensearch-project/OpenSearch/pull/16154
 
Bugfixes:
 - https://github.com/opensearch-project/OpenSearch/pull/12849
 - https://github.com/opensearch-project/OpenSearch/pull/11711
 
Unglamorous but helpful and necessary glue work:
 - https://github.com/opensearch-project/OpenSearch/pull/15238
 - https://github.com/opensearch-project/OpenSearch/pull/13127
 - https://github.com/opensearch-project/OpenSearch/pull/13067
 - https://github.com/opensearch-project/OpenSearch/pull/7632
 
The whole identity experimental feature
 - https://github.com/opensearch-project/OpenSearch/pulls?q=is%3Apr+author%3Acwperks+Feature%2Fidentity
 
He's committed upstream to Lucene:
 - https://github.com/apache/lucene/pull/14057
 
He's created 19 issues including bugs and feature requests, of which 10 have been actioned
 - https://github.com/opensearch-project/OpenSearch/issues?q=+is%3Aissue+author%3Acwperks
 
He has reviewed 72 PRs (that he didn't author):
 - https://github.com/opensearch-project/OpenSearch/pulls?q=is%3Apr+reviewed-by%3Acwperks+-author%3Acwperks
 
I believe Craig has already been participating as much or more than many maintainers (myself included) and would be a valuable addition to the maintainer team.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
