### PR TITLE
Fix the compiler task status reporting for annotation processor

### DIFF
--- a/libs/common/src/test/java/org/opensearch/common/annotation/processor/ApiAnnotationProcessorTests.java
+++ b/libs/common/src/test/java/org/opensearch/common/annotation/processor/ApiAnnotationProcessorTests.java
@@ -8,8 +8,11 @@
 
 package org.opensearch.common.annotation.processor;
 
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.annotation.InternalApi;
 import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 import javax.tools.Diagnostic;
 
@@ -20,10 +23,14 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 
+@SuppressForbidden(reason = "TemporaryFolder does not support Path-based APIs")
 @SuppressWarnings("deprecation")
 public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements CompilerSupport {
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
     public void testPublicApiMethodArgumentNotAnnotated() {
-        final CompilerResult result = compile("PublicApiMethodArgumentNotAnnotated.java", "NotAnnotated.java");
+        final CompilerResult result = compile(folder.getRoot().toPath(), "PublicApiMethodArgumentNotAnnotated.java", "NotAnnotated.java");
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -44,7 +51,11 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
     }
 
     public void testPublicApiMethodArgumentNotAnnotatedGenerics() {
-        final CompilerResult result = compile("PublicApiMethodArgumentNotAnnotatedGenerics.java", "NotAnnotated.java");
+        final CompilerResult result = compile(
+            folder.getRoot().toPath(),
+            "PublicApiMethodArgumentNotAnnotatedGenerics.java",
+            "NotAnnotated.java"
+        );
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -65,7 +76,11 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
     }
 
     public void testPublicApiMethodThrowsNotAnnotated() {
-        final CompilerResult result = compile("PublicApiMethodThrowsNotAnnotated.java", "PublicApiAnnotated.java");
+        final CompilerResult result = compile(
+            folder.getRoot().toPath(),
+            "PublicApiMethodThrowsNotAnnotated.java",
+            "PublicApiAnnotated.java"
+        );
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -86,7 +101,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
     }
 
     public void testPublicApiMethodArgumentNotAnnotatedPackagePrivate() {
-        final CompilerResult result = compile("PublicApiMethodArgumentNotAnnotatedPackagePrivate.java");
+        final CompilerResult result = compile(folder.getRoot().toPath(), "PublicApiMethodArgumentNotAnnotatedPackagePrivate.java");
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -120,7 +135,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
     }
 
     public void testPublicApiMethodArgumentAnnotatedPackagePrivate() {
-        final CompilerResult result = compile("PublicApiMethodArgumentAnnotatedPackagePrivate.java");
+        final CompilerResult result = compile(folder.getRoot().toPath(), "PublicApiMethodArgumentAnnotatedPackagePrivate.java");
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -141,7 +156,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
     }
 
     public void testPublicApiWithInternalApiMethod() {
-        final CompilerResult result = compile("PublicApiWithInternalApiMethod.java");
+        final CompilerResult result = compile(folder.getRoot().toPath(), "PublicApiWithInternalApiMethod.java");
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -164,40 +179,48 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
      * The constructor arguments have relaxed semantics at the moment: those could be not annotated or be annotated as {@link InternalApi}
      */
     public void testPublicApiConstructorArgumentNotAnnotated() {
-        final CompilerResult result = compile("PublicApiConstructorArgumentNotAnnotated.java", "NotAnnotated.java");
-        assertThat(result, instanceOf(Failure.class));
+        final CompilerResult result = compile(
+            folder.getRoot().toPath(),
+            "PublicApiConstructorArgumentNotAnnotated.java",
+            "NotAnnotated.java"
+        );
+        assertThat(result, instanceOf(Success.class));
 
-        final Failure failure = (Failure) result;
-        assertThat(failure.diagnotics(), hasSize(2));
+        final Success success = (Success) result;
+        assertThat(success.diagnotics(), hasSize(2));
 
-        assertThat(failure.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
+        assertThat(success.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
     }
 
     /**
      * The constructor arguments have relaxed semantics at the moment: those could be not annotated or be annotated as {@link InternalApi}
      */
     public void testPublicApiConstructorArgumentAnnotatedInternalApi() {
-        final CompilerResult result = compile("PublicApiConstructorArgumentAnnotatedInternalApi.java", "InternalApiAnnotated.java");
-        assertThat(result, instanceOf(Failure.class));
+        final CompilerResult result = compile(
+            folder.getRoot().toPath(),
+            "PublicApiConstructorArgumentAnnotatedInternalApi.java",
+            "InternalApiAnnotated.java"
+        );
+        assertThat(result, instanceOf(Success.class));
 
-        final Failure failure = (Failure) result;
-        assertThat(failure.diagnotics(), hasSize(2));
+        final Success success = (Success) result;
+        assertThat(success.diagnotics(), hasSize(2));
 
-        assertThat(failure.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
+        assertThat(success.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
     }
 
     public void testPublicApiWithExperimentalApiMethod() {
-        final CompilerResult result = compile("PublicApiWithExperimentalApiMethod.java");
-        assertThat(result, instanceOf(Failure.class));
+        final CompilerResult result = compile(folder.getRoot().toPath(), "PublicApiWithExperimentalApiMethod.java");
+        assertThat(result, instanceOf(Success.class));
 
-        final Failure failure = (Failure) result;
-        assertThat(failure.diagnotics(), hasSize(2));
+        final Success success = (Success) result;
+        assertThat(success.diagnotics(), hasSize(2));
 
-        assertThat(failure.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
+        assertThat(success.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
     }
 
     public void testPublicApiMethodReturnNotAnnotated() {
-        final CompilerResult result = compile("PublicApiMethodReturnNotAnnotated.java", "NotAnnotated.java");
+        final CompilerResult result = compile(folder.getRoot().toPath(), "PublicApiMethodReturnNotAnnotated.java", "NotAnnotated.java");
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -218,7 +241,11 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
     }
 
     public void testPublicApiMethodReturnNotAnnotatedGenerics() {
-        final CompilerResult result = compile("PublicApiMethodReturnNotAnnotatedGenerics.java", "NotAnnotated.java");
+        final CompilerResult result = compile(
+            folder.getRoot().toPath(),
+            "PublicApiMethodReturnNotAnnotatedGenerics.java",
+            "NotAnnotated.java"
+        );
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -239,7 +266,11 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
     }
 
     public void testPublicApiMethodReturnNotAnnotatedArray() {
-        final CompilerResult result = compile("PublicApiMethodReturnNotAnnotatedArray.java", "NotAnnotated.java");
+        final CompilerResult result = compile(
+            folder.getRoot().toPath(),
+            "PublicApiMethodReturnNotAnnotatedArray.java",
+            "NotAnnotated.java"
+        );
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -260,7 +291,11 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
     }
 
     public void testPublicApiMethodReturnNotAnnotatedBoundedGenerics() {
-        final CompilerResult result = compile("PublicApiMethodReturnNotAnnotatedBoundedGenerics.java", "NotAnnotated.java");
+        final CompilerResult result = compile(
+            folder.getRoot().toPath(),
+            "PublicApiMethodReturnNotAnnotatedBoundedGenerics.java",
+            "NotAnnotated.java"
+        );
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -282,6 +317,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
 
     public void testPublicApiMethodReturnNotAnnotatedAnnotation() {
         final CompilerResult result = compile(
+            folder.getRoot().toPath(),
             "PublicApiMethodReturnNotAnnotatedAnnotation.java",
             "PublicApiAnnotated.java",
             "NotAnnotatedAnnotation.java"
@@ -306,57 +342,57 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
     }
 
     public void testPublicApiMethodReturnNotAnnotatedWildcardGenerics() {
-        final CompilerResult result = compile("PublicApiMethodReturnNotAnnotatedWildcardGenerics.java");
-        assertThat(result, instanceOf(Failure.class));
+        final CompilerResult result = compile(folder.getRoot().toPath(), "PublicApiMethodReturnNotAnnotatedWildcardGenerics.java");
+        assertThat(result, instanceOf(Success.class));
 
-        final Failure failure = (Failure) result;
-        assertThat(failure.diagnotics(), hasSize(2));
+        final Success success = (Success) result;
+        assertThat(success.diagnotics(), hasSize(2));
 
-        assertThat(failure.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
+        assertThat(success.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
     }
 
     public void testPublicApiWithPackagePrivateMethod() {
-        final CompilerResult result = compile("PublicApiWithPackagePrivateMethod.java", "NotAnnotated.java");
-        assertThat(result, instanceOf(Failure.class));
+        final CompilerResult result = compile(folder.getRoot().toPath(), "PublicApiWithPackagePrivateMethod.java", "NotAnnotated.java");
+        assertThat(result, instanceOf(Success.class));
 
-        final Failure failure = (Failure) result;
-        assertThat(failure.diagnotics(), hasSize(2));
+        final Success success = (Success) result;
+        assertThat(success.diagnotics(), hasSize(2));
 
-        assertThat(failure.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
+        assertThat(success.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
     }
 
     public void testPublicApiMethodReturnSelf() {
-        final CompilerResult result = compile("PublicApiMethodReturnSelf.java");
-        assertThat(result, instanceOf(Failure.class));
+        final CompilerResult result = compile(folder.getRoot().toPath(), "PublicApiMethodReturnSelf.java");
+        assertThat(result, instanceOf(Success.class));
 
-        final Failure failure = (Failure) result;
-        assertThat(failure.diagnotics(), hasSize(2));
+        final Success success = (Success) result;
+        assertThat(success.diagnotics(), hasSize(2));
 
-        assertThat(failure.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
+        assertThat(success.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
     }
 
     public void testExperimentalApiMethodReturnSelf() {
-        final CompilerResult result = compile("ExperimentalApiMethodReturnSelf.java");
-        assertThat(result, instanceOf(Failure.class));
+        final CompilerResult result = compile(folder.getRoot().toPath(), "ExperimentalApiMethodReturnSelf.java");
+        assertThat(result, instanceOf(Success.class));
 
-        final Failure failure = (Failure) result;
-        assertThat(failure.diagnotics(), hasSize(2));
+        final Success success = (Success) result;
+        assertThat(success.diagnotics(), hasSize(2));
 
-        assertThat(failure.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
+        assertThat(success.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
     }
 
     public void testDeprecatedApiMethodReturnSelf() {
-        final CompilerResult result = compile("DeprecatedApiMethodReturnSelf.java");
-        assertThat(result, instanceOf(Failure.class));
+        final CompilerResult result = compile(folder.getRoot().toPath(), "DeprecatedApiMethodReturnSelf.java");
+        assertThat(result, instanceOf(Success.class));
 
-        final Failure failure = (Failure) result;
-        assertThat(failure.diagnotics(), hasSize(2));
+        final Success success = (Success) result;
+        assertThat(success.diagnotics(), hasSize(2));
 
-        assertThat(failure.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
+        assertThat(success.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
     }
 
     public void testPublicApiPackagePrivate() {
-        final CompilerResult result = compile("PublicApiPackagePrivate.java");
+        final CompilerResult result = compile(folder.getRoot().toPath(), "PublicApiPackagePrivate.java");
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -376,7 +412,11 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
     }
 
     public void testPublicApiMethodGenericsArgumentNotAnnotated() {
-        final CompilerResult result = compile("PublicApiMethodGenericsArgumentNotAnnotated.java", "NotAnnotated.java");
+        final CompilerResult result = compile(
+            folder.getRoot().toPath(),
+            "PublicApiMethodGenericsArgumentNotAnnotated.java",
+            "NotAnnotated.java"
+        );
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -397,27 +437,35 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
     }
 
     public void testPublicApiMethodReturnAnnotatedArray() {
-        final CompilerResult result = compile("PublicApiMethodReturnAnnotatedArray.java", "PublicApiAnnotated.java");
-        assertThat(result, instanceOf(Failure.class));
+        final CompilerResult result = compile(
+            folder.getRoot().toPath(),
+            "PublicApiMethodReturnAnnotatedArray.java",
+            "PublicApiAnnotated.java"
+        );
+        assertThat(result, instanceOf(Success.class));
 
-        final Failure failure = (Failure) result;
-        assertThat(failure.diagnotics(), hasSize(2));
+        final Success success = (Success) result;
+        assertThat(success.diagnotics(), hasSize(2));
 
-        assertThat(failure.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
+        assertThat(success.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
     }
 
     public void testPublicApiMethodGenericsArgumentAnnotated() {
-        final CompilerResult result = compile("PublicApiMethodGenericsArgumentAnnotated.java", "PublicApiAnnotated.java");
-        assertThat(result, instanceOf(Failure.class));
+        final CompilerResult result = compile(
+            folder.getRoot().toPath(),
+            "PublicApiMethodGenericsArgumentAnnotated.java",
+            "PublicApiAnnotated.java"
+        );
+        assertThat(result, instanceOf(Success.class));
 
-        final Failure failure = (Failure) result;
-        assertThat(failure.diagnotics(), hasSize(2));
+        final Success success = (Success) result;
+        assertThat(success.diagnotics(), hasSize(2));
 
-        assertThat(failure.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
+        assertThat(success.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
     }
 
     public void testPublicApiAnnotatedNotOpensearch() {
-        final CompilerResult result = compileWithPackage("org.acme", "PublicApiAnnotated.java");
+        final CompilerResult result = compileWithPackage(folder.getRoot().toPath(), "org.acme", "PublicApiAnnotated.java");
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -438,6 +486,7 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
 
     public void testPublicApiMethodReturnAnnotatedGenerics() {
         final CompilerResult result = compile(
+            folder.getRoot().toPath(),
             "PublicApiMethodReturnAnnotatedGenerics.java",
             "PublicApiAnnotated.java",
             "NotAnnotatedAnnotation.java"
@@ -465,30 +514,34 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
      * The type could expose protected inner types which are still considered to be a public API when used
      */
     public void testPublicApiWithProtectedInterface() {
-        final CompilerResult result = compile("PublicApiWithProtectedInterface.java");
-        assertThat(result, instanceOf(Failure.class));
+        final CompilerResult result = compile(folder.getRoot().toPath(), "PublicApiWithProtectedInterface.java");
+        assertThat(result, instanceOf(Success.class));
 
-        final Failure failure = (Failure) result;
-        assertThat(failure.diagnotics(), hasSize(2));
+        final Success success = (Success) result;
+        assertThat(success.diagnotics(), hasSize(2));
 
-        assertThat(failure.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
+        assertThat(success.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
     }
 
     /**
      * The constructor arguments have relaxed semantics at the moment: those could be not annotated or be annotated as {@link InternalApi}
      */
     public void testPublicApiConstructorAnnotatedInternalApi() {
-        final CompilerResult result = compile("PublicApiConstructorAnnotatedInternalApi.java", "NotAnnotated.java");
-        assertThat(result, instanceOf(Failure.class));
+        final CompilerResult result = compile(
+            folder.getRoot().toPath(),
+            "PublicApiConstructorAnnotatedInternalApi.java",
+            "NotAnnotated.java"
+        );
+        assertThat(result, instanceOf(Success.class));
 
-        final Failure failure = (Failure) result;
-        assertThat(failure.diagnotics(), hasSize(2));
+        final Success success = (Success) result;
+        assertThat(success.diagnotics(), hasSize(2));
 
-        assertThat(failure.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
+        assertThat(success.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
     }
 
     public void testPublicApiUnparseableVersion() {
-        final CompilerResult result = compile("PublicApiAnnotatedUnparseable.java");
+        final CompilerResult result = compile(folder.getRoot().toPath(), "PublicApiAnnotatedUnparseable.java");
         assertThat(result, instanceOf(Failure.class));
 
         final Failure failure = (Failure) result;
@@ -508,13 +561,13 @@ public class ApiAnnotationProcessorTests extends OpenSearchTestCase implements C
     }
 
     public void testPublicApiWithDeprecatedApiMethod() {
-        final CompilerResult result = compile("PublicApiWithDeprecatedApiMethod.java");
-        assertThat(result, instanceOf(Failure.class));
+        final CompilerResult result = compile(folder.getRoot().toPath(), "PublicApiWithDeprecatedApiMethod.java");
+        assertThat(result, instanceOf(Success.class));
 
-        final Failure failure = (Failure) result;
-        assertThat(failure.diagnotics(), hasSize(2));
+        final Success success = (Success) result;
+        assertThat(success.diagnotics(), hasSize(2));
 
-        assertThat(failure.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
+        assertThat(success.diagnotics(), not(hasItem(matching(Diagnostic.Kind.ERROR))));
     }
 
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix the compiler task status reporting for annotation processor. The Java compiler was reporting failures previously only because the `SecurityManager` was preventing the writing of class files into `build` folder. This was not very important because the annotation processing was always happening before (and this is what tests were checking). The change fixes the issue by outputting class files into temporary folder.

### Related Issues
Follow up on https://github.com/opensearch-project/OpenSearch/pull/16962

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
