### PR TITLE
Mark StepListener as @opensearch.api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow extended plugins to be optional ([#16909](https://github.com/opensearch-project/OpenSearch/pull/16909))
 - Use the correct type to widen the sort fields when merging top docs ([#16881](https://github.com/opensearch-project/OpenSearch/pull/16881))
 - Limit reader writer separation to remote store enabled clusters [#16760](https://github.com/opensearch-project/OpenSearch/pull/16760)
+- Mark StepListener as @opensearch.api ([#17076](https://github.com/opensearch-project/OpenSearch/pull/17076))
 
 ### Deprecated
 - Performing update operation with default pipeline or final pipeline is deprecated ([#16712](https://github.com/opensearch-project/OpenSearch/pull/16712))

--- a/server/src/main/java/org/opensearch/action/StepListener.java
+++ b/server/src/main/java/org/opensearch/action/StepListener.java
@@ -68,7 +68,7 @@ import java.util.function.Consumer;
  * @opensearch.api
  */
 
-@PublicApi(since = "2.19.0")
+@PublicApi(since = "1.0.0")
 public final class StepListener<Response> extends NotifyOnceListener<Response> {
     private final ListenableFuture<Response> delegate;
 

--- a/server/src/main/java/org/opensearch/action/StepListener.java
+++ b/server/src/main/java/org/opensearch/action/StepListener.java
@@ -33,6 +33,7 @@
 package org.opensearch.action;
 
 import org.opensearch.common.CheckedConsumer;
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.util.concurrent.FutureUtils;
 import org.opensearch.common.util.concurrent.ListenableFuture;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
@@ -64,9 +65,10 @@ import java.util.function.Consumer;
  *  }
  * }</pre>
  *
- * @opensearch.internal
+ * @opensearch.api
  */
 
+@PublicApi(since = "2.19.0")
 public final class StepListener<Response> extends NotifyOnceListener<Response> {
     private final ListenableFuture<Response> delegate;
 


### PR DESCRIPTION
### Description

Opening up this small PR to mark the [StepListener](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/StepListener.java) as `@opensearch.api` due to its current use across a few plugins in the default distribution: https://github.com/search?q=org%3Aopensearch-project%20StepListener&type=code

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
