### PR TITLE
Propagate includes and excludes from fetchSourceContext to FieldsVisitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Improve flat_object field parsing performance by reducing two passes to a single pass ([#16297](https://github.com/opensearch-project/OpenSearch/pull/16297))
 - Improve performance of the bitmap filtering([#16936](https://github.com/opensearch-project/OpenSearch/pull/16936/))
 - Introduce Template query ([#16818](https://github.com/opensearch-project/OpenSearch/pull/16818))
+- Propagate the sourceIncludes and excludes fields from fetchSourceContext to FieldsVisitor. ([#17080](https://github.com/opensearch-project/OpenSearch/pull/17080))
 
 ### Dependencies
 - Bump `com.google.cloud:google-cloud-core-http` from 2.23.0 to 2.47.0 ([#16504](https://github.com/opensearch-project/OpenSearch/pull/16504))

--- a/server/src/main/java/org/opensearch/index/fieldvisitor/CustomFieldsVisitor.java
+++ b/server/src/main/java/org/opensearch/index/fieldvisitor/CustomFieldsVisitor.java
@@ -52,6 +52,11 @@ public class CustomFieldsVisitor extends FieldsVisitor {
         this.fields = fields;
     }
 
+    public CustomFieldsVisitor(Set<String> fields, boolean loadSource, String[] includes, String[] excludes) {
+        super(loadSource, includes, excludes);
+        this.fields = fields;
+    }
+
     @Override
     public Status needsField(FieldInfo fieldInfo) {
         if (super.needsField(fieldInfo) == Status.YES) {

--- a/server/src/main/java/org/opensearch/index/fieldvisitor/FieldsVisitor.java
+++ b/server/src/main/java/org/opensearch/index/fieldvisitor/FieldsVisitor.java
@@ -34,6 +34,7 @@ package org.opensearch.index.fieldvisitor;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.util.BytesRef;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.index.mapper.IdFieldMapper;
@@ -66,17 +67,29 @@ public class FieldsVisitor extends StoredFieldVisitor {
     private final boolean loadSource;
     private final String sourceFieldName;
     private final Set<String> requiredFields;
+    private final String[] sourceIncludes;
+    private final String[] sourceExcludes;
     protected BytesReference source;
     protected String id;
     protected Map<String, List<Object>> fieldsValues;
 
     public FieldsVisitor(boolean loadSource) {
-        this(loadSource, SourceFieldMapper.NAME);
+        this(loadSource, SourceFieldMapper.NAME, null, null);
+    }
+
+    public FieldsVisitor(boolean loadSource, String[] includes, String[] excludes) {
+        this(loadSource, SourceFieldMapper.NAME, includes, excludes);
     }
 
     public FieldsVisitor(boolean loadSource, String sourceFieldName) {
+        this(loadSource, sourceFieldName, null, null);
+    }
+
+    public FieldsVisitor(boolean loadSource, String sourceFieldName, String[] includes, String[] excludes) {
         this.loadSource = loadSource;
         this.sourceFieldName = sourceFieldName;
+        this.sourceIncludes = includes != null ? includes : Strings.EMPTY_ARRAY;
+        this.sourceExcludes = excludes != null ? excludes : Strings.EMPTY_ARRAY;
         requiredFields = new HashSet<>();
         reset();
     }
@@ -160,6 +173,22 @@ public class FieldsVisitor extends StoredFieldVisitor {
 
     public BytesReference source() {
         return source;
+    }
+
+    /**
+     * Returns the array containing the source fields to include
+     * @return String[] sourceIncludes
+     */
+    public String[] includes() {
+        return sourceIncludes;
+    }
+
+    /**
+     * Returns the array containing the source fields to exclude
+     * @return String[] sourceExcludes
+     */
+    public String[] excludes() {
+        return sourceExcludes;
     }
 
     public String id() {

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -221,7 +221,7 @@ public class FetchPhase {
         }
     }
 
-    private FieldsVisitor createStoredFieldsVisitor(SearchContext context, Map<String, Set<String>> storedToRequestedFields) {
+    protected FieldsVisitor createStoredFieldsVisitor(SearchContext context, Map<String, Set<String>> storedToRequestedFields) {
         StoredFieldsContext storedFieldsContext = context.storedFieldsContext();
 
         if (storedFieldsContext == null) {
@@ -230,7 +230,11 @@ public class FetchPhase {
                 context.fetchSourceContext(new FetchSourceContext(true));
             }
             boolean loadSource = sourceRequired(context);
-            return new FieldsVisitor(loadSource);
+            return new FieldsVisitor(
+                loadSource,
+                context.hasFetchSourceContext() ? context.fetchSourceContext().includes() : null,
+                context.hasFetchSourceContext() ? context.fetchSourceContext().excludes() : null
+            );
         } else if (storedFieldsContext.fetchFields() == false) {
             // disable stored fields entirely
             return null;
@@ -262,9 +266,18 @@ public class FetchPhase {
             boolean loadSource = sourceRequired(context);
             if (storedToRequestedFields.isEmpty()) {
                 // empty list specified, default to disable _source if no explicit indication
-                return new FieldsVisitor(loadSource);
+                return new FieldsVisitor(
+                    loadSource,
+                    context.hasFetchSourceContext() ? context.fetchSourceContext().includes() : null,
+                    context.hasFetchSourceContext() ? context.fetchSourceContext().excludes() : null
+                );
             } else {
-                return new CustomFieldsVisitor(storedToRequestedFields.keySet(), loadSource);
+                return new CustomFieldsVisitor(
+                    storedToRequestedFields.keySet(),
+                    loadSource,
+                    context.hasFetchSourceContext() ? context.fetchSourceContext().includes() : null,
+                    context.hasFetchSourceContext() ? context.fetchSourceContext().excludes() : null
+                );
             }
         }
     }

--- a/server/src/test/java/org/opensearch/index/mapper/StoredNumericValuesTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/StoredNumericValuesTests.java
@@ -41,9 +41,11 @@ import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.index.fieldvisitor.CustomFieldsVisitor;
+import org.opensearch.index.fieldvisitor.FieldsVisitor;
 import org.opensearch.index.mapper.MapperService.MergeReason;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
@@ -199,5 +201,37 @@ public class StoredNumericValuesTests extends OpenSearchSingleNodeTestCase {
 
         reader.close();
         writer.close();
+    }
+
+    public void testFieldsVisitorValidateIncludesExcludes() throws Exception {
+        Set<String> fieldNames = Sets.newHashSet(
+            "field1",
+            "field2",
+            "field3",
+            "field4",
+            "field5",
+            "field6",
+            "field7",
+            "field8",
+            "field9",
+            "field10",
+            "field11"
+        );
+        String[] includes = { "field1", "field2", "field3" };
+        String[] excludes = { "field7", "field8" };
+
+        CustomFieldsVisitor fieldsVisitor = new CustomFieldsVisitor(fieldNames, false, includes, excludes);
+
+        assertArrayEquals(fieldsVisitor.includes(), includes);
+        assertArrayEquals(fieldsVisitor.excludes(), excludes);
+
+        FieldsVisitor fieldsVisitor1 = new FieldsVisitor(false, includes, excludes);
+        assertArrayEquals(fieldsVisitor1.includes(), includes);
+        assertArrayEquals(fieldsVisitor1.excludes(), excludes);
+
+        FieldsVisitor fieldsVisitor2 = new FieldsVisitor(false);
+        assertArrayEquals(fieldsVisitor2.includes(), Strings.EMPTY_ARRAY);
+        assertArrayEquals(fieldsVisitor2.excludes(), Strings.EMPTY_ARRAY);
+
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The change is to propagate the source includes and source excludes fields that are present in the `FetchSourceContext`. 
This is as part of the open questions in this RFC https://github.com/opensearch-project/k-NN/issues/2377 

### Related Issues
PR is part of [#2377](https://github.com/opensearch-project/k-NN/issues/2377) 
as part of the Derived source feature for k-NN. 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
