### PR TITLE
Fix exists query for flat object

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/100_partial_flat_object.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/100_partial_flat_object.yml
@@ -513,7 +513,7 @@ teardown:
           _source: true,
           query: {
             "exists": {
-              "field": issue.labels.type
+              "field": issue.labels.category.type
             }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/100_partial_flat_object.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/100_partial_flat_object.yml
@@ -506,20 +506,6 @@ teardown:
 
   - length: { hits.hits: 2 }
 
-  # Exists Query with nested dot path, use the flat_object_field_name.last_key
-  - do:
-      search:
-        body: {
-          _source: true,
-          query: {
-            "exists": {
-              "field": issue.labels.category.type
-            }
-          }
-        }
-
-  - length: { hits.hits: 3 }
-
   # Exists Query without dot path for the flat_object_field_name
   - do:
       search:
@@ -613,3 +599,22 @@ teardown:
 
   - length: { hits.hits: 1 }
   - match: { hits.hits.0._source.issue.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }
+
+---
+"Exists query for sub field":
+  - skip:
+      version: " - 2.99.99"
+      reason: "exists query for sub field of flat_object field has bug before 3.0.0"
+
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            "exists": {
+              "field": issue.labels.category.type
+            }
+          }
+        }
+
+  - length: { hits.hits: 3 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/105_partial_flat_object_nested.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/105_partial_flat_object_nested.yml
@@ -516,7 +516,7 @@ teardown:
               path: "issue",
               query: {
                 "exists": {
-                  "field": issue.labels.type
+                  "field": issue.labels.category.type
                 } } }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/105_partial_flat_object_nested.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/105_partial_flat_object_nested.yml
@@ -506,23 +506,6 @@ teardown:
 
   - length: { hits.hits: 2 }
 
-  # Exists Query with nested dot path, use the flat_object_field_name.last_key
-  - do:
-      search:
-        body: {
-          _source: true,
-          query: {
-            nested: {
-              path: "issue",
-              query: {
-                "exists": {
-                  "field": issue.labels.category.type
-                } } }
-          }
-        }
-
-  - length: { hits.hits: 2 }
-
   # Exists Query without dot path for the flat_object_field_name
   - do:
       search:
@@ -634,3 +617,27 @@ teardown:
 
   - length: { hits.hits: 1 }
   - match: { hits.hits.0._source.issue.0.labels.comment: [ [ "Doe","Shipped" ],[ "John","Approved" ] ] }
+
+---
+"Exists query for sub field":
+  - skip:
+      version: " - 2.99.99"
+      reason: "exists query for sub field of flat_object field has bug before 3.0.0"
+
+  - do:
+      search:
+        body: {
+          _source: true,
+          query: {
+            nested: {
+              path: "issue",
+              query: {
+                "exists": {
+                  "field": issue.labels.category.type
+                }
+              }
+            }
+          }
+        }
+
+  - length: { hits.hits: 2 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/91_flat_object_null_value.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/91_flat_object_null_value.yml
@@ -373,7 +373,7 @@ teardown:
         body: {
           _source: true,
           query: {
-            exists: { "field": "record.d" }
+            exists: { "field": "record.name.d.name" }
           },
           sort: [{ order: asc}]
         }

--- a/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FlatObjectFieldMapper.java
@@ -478,8 +478,7 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
             String searchKey;
             String searchField;
             if (isSubField()) {
-                searchKey = this.rootFieldName;
-                searchField = name();
+                return rangeQuery(null, null, true, true, context);
             } else {
                 if (hasDocValues()) {
                     return new FieldExistsQuery(name());


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The current implementation of exists query for subfield uses an inverted index under `<field name>` to perform the query, this inverted index create mapping for each level of subfields. Taking a field `field1` with `flat_object` type and a doc with value `{"field1": {"field2" : {"field3": "a"}}}`, the inverted index under `field1` field contains terms `field1.field2` and `field1.field3`, when we run the query `{"query": {"exists": {"field": "field1.field2.field3"}}}`, it turns into term query `"field1": "field1.field2.field3"`, there is no match term obviously.

Since `PathAndValue` field contains `<full path>=<value>` term or doc values, we can use the user specified field name append `=` symbol as prefix to run the query, which equals to range query with both `lowerTerm` and `upperTerm` are `null`.

### Related Issues
Resolves #17069

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
