### PR TITLE
Throwing exception for any update call for Append only indices

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -1327,6 +1327,13 @@ public class InternalEngine extends Engine {
     }
 
     private void updateDocs(final Term uid, final List<ParseContext.Document> docs, final IndexWriter indexWriter) throws IOException {
+        if (engineConfig.getIndexSettings().getIndexMetadata().isAppendOnlyIndex()) {
+            failEngine(
+                "Failing shard as update operation is not allowed for append only index ",
+                new EngineException(shardId, "Unable to update document as it is an append only index")
+            );
+        }
+
         if (docs.size() > 1) {
             indexWriter.softUpdateDocuments(uid, docs, softDeletesField);
         } else {


### PR DESCRIPTION
### Description
Fail the engine incase of any update operation on Engine for append only indices.

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
