### PR TITLE
Gradle plugin support for dependencies in plugin descriptor properties

### DIFF
--- a/buildSrc/src/main/groovy/org/opensearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -113,8 +113,15 @@ class PluginBuildPlugin implements Plugin<Project> {
                     'customFolderName'    : extension1.customFolderName,
                     'extendedPlugins'     : extension1.extendedPlugins.join(','),
                     'hasNativeController' : extension1.hasNativeController,
-                    'requiresKeystore'    : extension1.requiresKeystore
+                    'requiresKeystore'    : extension1.requiresKeystore,
+                    'dependencies'        : extension1.dependencies
             ]
+
+            // Clear opensearch version if dependencies are specified
+            if (extension1.dependencies != null && !extension1.dependencies.trim().isEmpty()) {
+                properties.put('opensearchVersion', '');
+            }
+
             project.tasks.named('pluginProperties').configure {
                 expand(properties)
                 inputs.properties(properties)

--- a/buildSrc/src/main/java/org/opensearch/gradle/plugin/PluginPropertiesExtension.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/plugin/PluginPropertiesExtension.java
@@ -53,6 +53,8 @@ public class PluginPropertiesExtension {
 
     private String customFolderName = "";
 
+    private String dependencies = "";
+
     /** Other plugins this plugin extends through SPI */
     private List<String> extendedPlugins = new ArrayList<>();
 
@@ -84,6 +86,14 @@ public class PluginPropertiesExtension {
 
     public void setCustomFolderName(String customFolderName) {
         this.customFolderName = customFolderName;
+    }
+
+    public String getDependencies() {
+        return dependencies;
+    }
+
+    public void setDependencies(String dependencies) {
+        this.dependencies = dependencies;
     }
 
     public String getName() {

--- a/buildSrc/src/main/resources/plugin-descriptor.properties
+++ b/buildSrc/src/main/resources/plugin-descriptor.properties
@@ -59,3 +59,6 @@ extended.plugins=${extendedPlugins}
 #
 # 'has.native.controller': whether or not the plugin has a native controller
 has.native.controller=${hasNativeController}
+#
+# 'dependencies': any dependencies specified by the plugin
+dependencies=${dependencies}

--- a/buildSrc/src/test/java/org/opensearch/gradle/plugin/PluginBuildPluginTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/plugin/PluginBuildPluginTests.java
@@ -39,8 +39,8 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Before;
-import org.junit.Ignore;
 
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.mockito.Mockito;
@@ -72,7 +72,6 @@ public class PluginBuildPluginTests extends GradleUnitTestCase {
         });
     }
 
-    @Ignore("https://github.com/elastic/elasticsearch/issues/47123")
     public void testApplyWithAfterEvaluate() {
         project.getExtensions().getExtraProperties().set("bwcVersions", Mockito.mock(BwcVersions.class));
         project.getPlugins().apply(PluginBuildPlugin.class);
@@ -88,5 +87,16 @@ public class PluginBuildPluginTests extends GradleUnitTestCase {
             "Task to generate notice not created: " + project.getTasks().stream().map(Task::getPath).collect(Collectors.joining(", ")),
             project.getTasks().findByName("generateNotice")
         );
+        Map<String, Object> taskProperties = project.getTasks().findByName("pluginProperties").getInputs().getProperties();
+        assertTrue(taskProperties.containsKey("description"));
+        assertTrue(taskProperties.containsKey("version"));
+        assertTrue(taskProperties.containsKey("name"));
+        assertTrue(taskProperties.containsKey("classname"));
+        assertTrue(taskProperties.containsKey("javaVersion"));
+        assertTrue(taskProperties.containsKey("opensearchVersion"));
+        assertTrue(taskProperties.containsKey("customFolderName"));
+        assertTrue(taskProperties.containsKey("extendedPlugins"));
+        assertTrue(taskProperties.containsKey("hasNativeController"));
+        assertTrue(taskProperties.containsKey("dependencies"));
     }
 }

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
@@ -277,7 +277,9 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
                 "java.version",
                 System.getProperty("java.specification.version"),
                 "classname",
-                "FakePlugin"
+                "FakePlugin",
+                "dependencies",
+                ""
             ),
             Arrays.stream(additionalProps)
         ).toArray(String[]::new);
@@ -300,7 +302,9 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
                 "java.version",
                 System.getProperty("java.specification.version"),
                 "classname",
-                "FakePlugin"
+                "FakePlugin",
+                "opensearch.version",
+                ""
             ),
             Arrays.stream(additionalProps)
         ).toArray(String[]::new);

--- a/server/src/main/java/org/opensearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfo.java
@@ -289,19 +289,19 @@ public class PluginInfo implements Writeable, ToXContentObject {
 
         final String opensearchVersionString = propsMap.remove("opensearch.version");
         final String dependenciesValue = propsMap.remove("dependencies");
-        if (opensearchVersionString == null && dependenciesValue == null) {
+        if (isBlank(opensearchVersionString) && isBlank(dependenciesValue)) {
             throw new IllegalArgumentException(
                 "Either [opensearch.version] or [dependencies] property must be specified for the plugin [" + name + "]"
             );
         }
-        if (opensearchVersionString != null && dependenciesValue != null) {
+        if (!isBlank(opensearchVersionString) && !isBlank(dependenciesValue)) {
             throw new IllegalArgumentException(
                 "Only one of [opensearch.version] or [dependencies] property can be specified for the plugin [" + name + "]"
             );
         }
 
         final List<SemverRange> opensearchVersionRanges = new ArrayList<>();
-        if (opensearchVersionString != null) {
+        if (!isBlank(opensearchVersionString)) {
             opensearchVersionRanges.add(SemverRange.fromString(opensearchVersionString));
         } else {
             Map<String, String> dependenciesMap;
@@ -591,5 +591,9 @@ public class PluginInfo implements Writeable, ToXContentObject {
             .append("Folder name: ")
             .append(customFolderName);
         return information.toString();
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
     }
 }


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/OpenSearch/pull/11441 added support for semver ranges in dependencies of plugins. This commit updates the `opensearchplugin` (from `org.opensearch.gradle:build-tools`) to support `dependencies` property when building plugins. Without this support, plugin's plugin-descriptor.properties file would require manual update to add `dependencies` property. With this support, it would be possible to build plugins with semver range support for opensearch using gradle code. Example usage:

```
opensearchplugin {
  description = '<Plugin description>'
  classname = '<Plugin class name>'
  dependencies = '{opensearch: "3.0.0"}'
}
```
Since no plugin is currently using `dependencies` property, this change would simply add empty `dependencies` property to plugin-descriptor.properties file. Example:
```
description=The Mapper Murmur3 plugin allows to compute hashes of a field's values at index-time and to store them in the index.
version=3.0.0-SNAPSHOT
name=mapper-murmur3
classname=org.opensearch.plugin.mapper.MapperMurmur3Plugin
java.version=21
opensearch.version=3.0.0
custom.foldername=
extended.plugins=
has.native.controller=false
dependencies=
```

Note - before this commit, opensearch process would reject above mentioned plugin-descriptor.properties file since it contains both `opensearch.version` and `dependencies` property. With this commit, PluginInfo is being updated to allow files like above since one of these properties is empty. 
Hence this is a breaking change in opensearchplugin. The plugin-descriptor.properties file created by this plugin would not be accepted by older opensearch versions.

Following is an example of plugin-descriptor.properties file with `dependencies` property specified by the plugin in build.gradle (note empty `opensearch.version` property):

```
description=The Mapper Murmur3 plugin allows to compute hashes of a field's values at index-time and to store them in the index.
version=3.0.0-SNAPSHOT
name=mapper-murmur3
classname=org.opensearch.plugin.mapper.MapperMurmur3Plugin
java.version=21
opensearch.version=
custom.foldername=
extended.plugins=
has.native.controller=false
dependencies={opensearch: "3.0.0"}
```
### Related Issues
Resolves #13187 

### Check List
- [X] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
