### PR TITLE
[Optimization] Move bloom filter init logic outside of the FuzzyFilteredFieldsProducer constructor

### DIFF
--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/AbstractFuzzySet.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/AbstractFuzzySet.java
@@ -18,7 +18,7 @@ import java.util.Iterator;
 /**
  * Encapsulates common behaviour implementation for a fuzzy set.
  */
-public abstract class AbstractFuzzySet implements FuzzySet {
+public abstract class AbstractFuzzySet<T extends FuzzySet.Meta> implements FuzzySet<T> {
 
     /**
      * Add an item to this fuzzy set.

--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/FuzzySetFactory.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/FuzzySetFactory.java
@@ -42,6 +42,11 @@ public class FuzzySetFactory {
         }
     }
 
+    public static CheckedSupplier<FuzzySet, IOException> buildSetProvider(IndexInput in) throws IOException {
+        FuzzySet.SetType setType = FuzzySet.SetType.from(in.readString());
+        return setType.extractMetaAndGetSupplier(in);
+    }
+
     public static FuzzySet deserializeFuzzySet(IndexInput in) throws IOException {
         FuzzySet.SetType setType = FuzzySet.SetType.from(in.readString());
         return setType.getDeserializer().apply(in);

--- a/server/src/main/java/org/opensearch/index/codec/fuzzy/IndexInputImmutableLongArray.java
+++ b/server/src/main/java/org/opensearch/index/codec/fuzzy/IndexInputImmutableLongArray.java
@@ -38,7 +38,7 @@ class IndexInputImmutableLongArray implements LongArray {
     }
 
     @Override
-    public synchronized long get(long index) {
+    public long get(long index) {
         try {
             // Multiplying by 8 since each long is 8 bytes, and we need to get the long value at (index * 8) in the
             // RandomAccessInput being accessed.

--- a/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java
@@ -278,6 +278,9 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     @Override
     public void preParse(ParseContext context) throws IOException {
+        if (enabled != SourceFieldStatus.ENABLED) {
+            return;
+        }
         BytesReference originalSource = context.sourceToParse().source();
         MediaType contentType = context.sourceToParse().getMediaType();
         final BytesReference adaptedSource = applyFilters(originalSource, contentType);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Optimization] Move bloom filter init logic outside of the FuzzyFilteredFieldsProducer constructor. This ensures we don't need to synchronize on bloom filter access across multiple term queries on same segment.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/17167

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
