### PR TITLE
[Backport] [1.x] Fix java.security.AccessControlException during OpenSearch server shutdown cycle (#17183)

### DIFF
--- a/modules/transport-netty4/src/main/java/org/opensearch/transport/SharedGroupFactory.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/transport/SharedGroupFactory.java
@@ -46,7 +46,7 @@ import org.opensearch.transport.netty4.Netty4Transport;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.opensearch.common.util.concurrent.OpenSearchExecutors.daemonThreadFactory;
+import static org.opensearch.common.util.concurrent.OpenSearchExecutors.privilegedDaemonThreadFactory;
 
 /**
  * Creates and returns {@link io.netty.channel.EventLoopGroup} instances. It will return a shared group for
@@ -90,7 +90,7 @@ public final class SharedGroupFactory {
             if (dedicatedHttpGroup == null) {
                 NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup(
                     httpWorkerCount,
-                    daemonThreadFactory(settings, HttpServerTransport.HTTP_SERVER_WORKER_THREAD_NAME_PREFIX)
+                    privilegedDaemonThreadFactory(settings, HttpServerTransport.HTTP_SERVER_WORKER_THREAD_NAME_PREFIX)
                 );
                 dedicatedHttpGroup = new SharedGroup(new RefCountedGroup(eventLoopGroup));
             }
@@ -102,7 +102,7 @@ public final class SharedGroupFactory {
         if (genericGroup == null) {
             EventLoopGroup eventLoopGroup = new NioEventLoopGroup(
                 workerCount,
-                daemonThreadFactory(settings, TcpTransport.TRANSPORT_WORKER_THREAD_NAME_PREFIX)
+                privilegedDaemonThreadFactory(settings, TcpTransport.TRANSPORT_WORKER_THREAD_NAME_PREFIX)
             );
             this.genericGroup = new RefCountedGroup(eventLoopGroup);
         } else {

--- a/modules/transport-netty4/src/main/plugin-metadata/plugin-security.policy
+++ b/modules/transport-netty4/src/main/plugin-metadata/plugin-security.policy
@@ -30,7 +30,7 @@
  * GitHub history for details.
  */
 
-grant codeBase "${codebase.netty-common}" {
+grant {
    // for reading the system-wide configuration for the backlog of established sockets
    permission java.io.FilePermission "/proc/sys/net/core/somaxconn", "read";
 
@@ -39,9 +39,8 @@ grant codeBase "${codebase.netty-common}" {
 
    // Netty sets custom classloader for some of its internal threads
    permission java.lang.RuntimePermission "*", "setContextClassLoader";
-};
+   permission java.lang.RuntimePermission "getClassLoader";
 
-grant codeBase "${codebase.netty-transport}" {
    // Netty NioEventLoop wants to change this, because of https://bugs.openjdk.java.net/browse/JDK-6427854
    // the bug says it only happened rarely, and that its fixed, but apparently it still happens rarely!
    permission java.util.PropertyPermission "sun.nio.ch.bugLevel", "write";

--- a/server/src/main/java/org/opensearch/common/util/concurrent/OpenSearchExecutors.java
+++ b/server/src/main/java/org/opensearch/common/util/concurrent/OpenSearchExecutors.java
@@ -41,6 +41,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.node.Node;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.AbstractExecutorService;
@@ -337,6 +339,24 @@ public class OpenSearchExecutors {
         return new OpenSearchThreadFactory(namePrefix);
     }
 
+    public static ThreadFactory privilegedDaemonThreadFactory(Settings settings, String namePrefix) {
+        return privilegedDaemonThreadFactory(threadName(settings, namePrefix));
+    }
+
+    public static ThreadFactory privilegedDaemonThreadFactory(String nodeName, String namePrefix) {
+        assert nodeName != null && false == nodeName.isEmpty();
+        return privilegedDaemonThreadFactory(threadName(nodeName, namePrefix));
+    }
+
+    public static ThreadFactory privilegedDaemonThreadFactory(String namePrefix) {
+        return new PrivilegedOpenSearchThreadFactory(namePrefix);
+    }
+
+    /**
+     * A thread factory
+     *
+     * @opensearch.internal
+     */
     static class OpenSearchThreadFactory implements ThreadFactory {
 
         final ThreadGroup group;
@@ -352,6 +372,42 @@ public class OpenSearchExecutors {
         @Override
         public Thread newThread(Runnable r) {
             Thread t = new Thread(group, r, namePrefix + "[T#" + threadNumber.getAndIncrement() + "]", 0);
+            t.setDaemon(true);
+            return t;
+        }
+
+    }
+
+    /**
+     * A thread factory
+     *
+     * @opensearch.internal
+     */
+    static class PrivilegedOpenSearchThreadFactory implements ThreadFactory {
+
+        final ThreadGroup group;
+        final AtomicInteger threadNumber = new AtomicInteger(1);
+        final String namePrefix;
+
+        @SuppressWarnings("removal")
+        PrivilegedOpenSearchThreadFactory(String namePrefix) {
+            this.namePrefix = namePrefix;
+            SecurityManager s = System.getSecurityManager();
+            group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            final Thread t = new Thread(group, new Runnable() {
+                @SuppressWarnings({ "deprecation", "removal" })
+                @Override
+                public void run() {
+                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                        r.run();
+                        return null;
+                    });
+                }
+            }, namePrefix + "[T#" + threadNumber.getAndIncrement() + "]", 0);
             t.setDaemon(true);
             return t;
         }

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -46,6 +46,7 @@ grant codeBase "${codebase.opensearch-secure-sm}" {
 grant codeBase "${codebase.opensearch}" {
   // needed for loading plugins which may expect the context class loader to be set
   permission java.lang.RuntimePermission "setContextClassLoader";
+  permission java.lang.RuntimePermission "getClassLoader";
 };
 
 //// Very special jar permissions:


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/17183 to `1.x`