### PR TITLE
Fix flaky test SegmentReplicationIT.testReplicaAlreadyAtCheckpoint

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -1893,6 +1893,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", randomInt()).get();
         refresh(INDEX_NAME);
 
+        waitForSearchableDocs(1, primaryNode, replicaNode, replicaNode2);
+
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNode));
         ensureYellowAndNoInitializingShards(INDEX_NAME);
         IndexShard replica_1 = getIndexShard(replicaNode, INDEX_NAME);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationIT.java
@@ -1892,19 +1892,29 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
         // index a doc.
         client().prepareIndex(INDEX_NAME).setId("1").setSource("foo", randomInt()).get();
         refresh(INDEX_NAME);
-
         waitForSearchableDocs(1, primaryNode, replicaNode, replicaNode2);
 
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNode));
         ensureYellowAndNoInitializingShards(INDEX_NAME);
-        IndexShard replica_1 = getIndexShard(replicaNode, INDEX_NAME);
-        IndexShard replica_2 = getIndexShard(replicaNode2, INDEX_NAME);
+        AtomicReference<IndexShard> replica_1 = new AtomicReference<>();
+        AtomicReference<IndexShard> replica_2 = new AtomicReference<>();
         // wait until a replica is promoted & finishes engine flip, we don't care which one
         AtomicReference<IndexShard> primary = new AtomicReference<>();
         assertBusy(() -> {
-            assertTrue("replica should be promoted as a primary", replica_1.routingEntry().primary() || replica_2.routingEntry().primary());
-            primary.set(replica_1.routingEntry().primary() ? replica_1 : replica_2);
-        });
+            IndexShard replicaShard1 = getIndexShard(replicaNode, INDEX_NAME);
+            IndexShard replicaShard2 = getIndexShard(replicaNode2, INDEX_NAME);
+
+            assertNotNull("Replica shard 1 should not be null", replicaShard1);
+            assertNotNull("Replica shard 2 should not be null", replicaShard2);
+
+            replica_1.set(replicaShard1);
+            replica_2.set(replicaShard2);
+            assertTrue(
+                "replica should be promoted as a primary",
+                replica_1.get().routingEntry().primary() || replica_2.get().routingEntry().primary()
+            );
+            primary.set(replica_1.get().routingEntry().primary() ? replica_1.get() : replica_2.get());
+        }, 60, TimeUnit.SECONDS);
 
         FlushRequest request = new FlushRequest(INDEX_NAME);
         request.force(true);
@@ -1912,8 +1922,8 @@ public class SegmentReplicationIT extends SegmentReplicationBaseIT {
 
         assertBusy(() -> {
             assertEquals(
-                replica_1.getLatestReplicationCheckpoint().getSegmentInfosVersion(),
-                replica_2.getLatestReplicationCheckpoint().getSegmentInfosVersion()
+                replica_1.get().getLatestReplicationCheckpoint().getSegmentInfosVersion(),
+                replica_2.get().getLatestReplicationCheckpoint().getSegmentInfosVersion()
             );
         });
 


### PR DESCRIPTION
### Description
In the SegmentReplicationIT.testReplicaAlreadyAtCheckpoint test, we are creating three nodes with one primary node and two replica nodes. After ingesting documents to the primary shard, we are not checking if the segment replication to both replica 1 and 2 has finished. Without verifying this, we are stopping the primary node. This behavior leads to the test being flaky when the replication has not completed.

```
1> org.opensearch.transport.NodeDisconnectedException: [node_t0][127.0.0.1:41957][disconnected] disconnected
  1> [2025-01-15T22:22:47,061][INFO ][o.o.c.c.FollowersChecker ] [node_t0] FollowerChecker{discoveryNode={node_t1}{jpNpHksYQ7-Fb8W2sTp8Sg}{RSZGRaXJQfWjT8jbA4p4iA}{127.0.0.1}{127.0.0.1:42245}{d}{shard_indexing_pressure_enabled=true}, failureCountSinceLastSuccess=0, [cluster.fault_detection.follower_check.retry_count]=3} marking node as faulty
  1> [2025-01-15T22:22:47,057][ERROR][o.o.i.r.SegmentReplicationTargetService] [node_t3] [shardId [test-idx-1][0]] [replication id 5] Replication failed, timing data: {INIT=0, GET_CHECKPOINT_INFO=1, FILE_DIFF=0, REPLICATING=0}
  1> org.opensearch.indices.replication.common.ReplicationFailedException: Segment Replication failed
  1> 	at org.opensearch.indices.replication.SegmentReplicator$2.onFailure(SegmentReplicator.java:154) [main/:?]
  1> 	at org.opensearch.core.action.ActionListener$1.onFailure(ActionListener.java:90) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
  1> 	at org.opensearch.action.ActionRunnable.onFailure(ActionRunnable.java:104) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:54) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.OpenSearchExecutors$DirectExecutorService.execute(OpenSearchExecutors.java:341) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.ListenableFuture.notifyListener(ListenableFuture.java:120) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.ListenableFuture.lambda$done$0(ListenableFuture.java:112) [main/:?]
  1> 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597) [?:?]
  1> 	at org.opensearch.common.util.concurrent.ListenableFuture.done(ListenableFuture.java:112) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.BaseFuture.setException(BaseFuture.java:178) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.ListenableFuture.onFailure(ListenableFuture.java:149) [main/:?]
  1> 	at org.opensearch.action.StepListener.innerOnFailure(StepListener.java:84) [main/:?]
  1> 	at org.opensearch.core.action.NotifyOnceListener.onFailure(NotifyOnceListener.java:65) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
  1> 	at org.opensearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:75) [main/:?]
  1> 	at org.opensearch.telemetry.tracing.handler.TraceableTransportResponseHandler.handleException(TraceableTransportResponseHandler.java:81) [main/:?]
  1> 	at org.opensearch.transport.TransportService$ContextRestoreResponseHandler.handleException(TransportService.java:1505) [main/:?]
  1> 	at org.opensearch.transport.TransportService$8.run(TransportService.java:1357) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:932) [main/:?]
  1> 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) [?:?]
  1> 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) [?:?]
  1> 	at java.base/java.lang.Thread.run(Thread.java:1575) [?:?]
  1> Caused by: org.opensearch.transport.NodeDisconnectedException: [node_t1][127.0.0.1:42245][internal:index/shard/replication/get_segment_files] disconnected
  1> [2025-01-15T22:22:47,057][ERROR][o.o.i.r.SegmentReplicationTargetService] [node_t2] [shardId [test-idx-1][0]] [replication id 6] Replication failed, timing data: {INIT=0, GET_CHECKPOINT_INFO=1, FILE_DIFF=0, REPLICATING=0}
  1> org.opensearch.indices.replication.common.ReplicationFailedException: Segment Replication failed
  1> 	at org.opensearch.indices.replication.SegmentReplicator$2.onFailure(SegmentReplicator.java:154) [main/:?]
  1> 	at org.opensearch.core.action.ActionListener$1.onFailure(ActionListener.java:90) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
  1> 	at org.opensearch.action.ActionRunnable.onFailure(ActionRunnable.java:104) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:54) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.OpenSearchExecutors$DirectExecutorService.execute(OpenSearchExecutors.java:341) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.ListenableFuture.notifyListener(ListenableFuture.java:120) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.ListenableFuture.lambda$done$0(ListenableFuture.java:112) [main/:?]
  1> 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597) [?:?]
  1> 	at org.opensearch.common.util.concurrent.ListenableFuture.done(ListenableFuture.java:112) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.BaseFuture.setException(BaseFuture.java:178) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.ListenableFuture.onFailure(ListenableFuture.java:149) [main/:?]
  1> 	at org.opensearch.action.StepListener.innerOnFailure(StepListener.java:84) [main/:?]
  1> 	at org.opensearch.core.action.NotifyOnceListener.onFailure(NotifyOnceListener.java:65) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
  1> 	at org.opensearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:75) [main/:?]
  1> 	at org.opensearch.telemetry.tracing.handler.TraceableTransportResponseHandler.handleException(TraceableTransportResponseHandler.java:81) [main/:?]
  1> 	at org.opensearch.transport.TransportService$ContextRestoreResponseHandler.handleException(TransportService.java:1505) [main/:?]
  1> 	at org.opensearch.transport.TransportService$8.run(TransportService.java:1357) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:932) [main/:?]
  1> 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) [?:?]
  1> 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) [?:?]
  1> 	at java.base/java.lang.Thread.run(Thread.java:1575) [?:?]
  1> Caused by: org.opensearch.transport.NodeDisconnectedException: [node_t1][127.0.0.1:42245][internal:index/shard/replication/get_segment_files] disconnected
  1> [2025-01-15T22:22:47,061][WARN ][o.o.i.r.OngoingSegmentReplications] [node_t1] Cancelling replications for allocationIds [nVfWi-IOQ06hLbKTnK05VQ]
  1> [2025-01-15T22:22:47,065][WARN ][o.o.c.r.a.AllocationService] [node_t0] Falling back to single shard assignment since batch mode disable or multiple custom allocators set
  1> [2025-01-15T22:22:47,064][ERROR][o.o.i.r.SegmentReplicationTargetService] [node_t3] [shardId [test-idx-1][0]] [replication id 7] Replication failed, timing data: {INIT=0, REPLICATING=0}
  1> org.opensearch.indices.replication.common.ReplicationFailedException: Segment Replication failed
  1> 	at org.opensearch.indices.replication.SegmentReplicator$2.onFailure(SegmentReplicator.java:154) [main/:?]
  1> 	at org.opensearch.core.action.ActionListener$1.onFailure(ActionListener.java:90) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
  1> 	at org.opensearch.action.ActionRunnable.onFailure(ActionRunnable.java:104) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:54) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.OpenSearchExecutors$DirectExecutorService.execute(OpenSearchExecutors.java:341) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.ListenableFuture.notifyListener(ListenableFuture.java:120) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.ListenableFuture.addListener(ListenableFuture.java:82) [main/:?]
  1> 	at org.opensearch.action.StepListener.whenComplete(StepListener.java:95) [main/:?]
  1> 	at org.opensearch.indices.replication.SegmentReplicationTarget.startReplication(SegmentReplicationTarget.java:179) [main/:?]
  1> 	at org.opensearch.indices.replication.SegmentReplicator.start(SegmentReplicator.java:137) [main/:?]
  1> 	at org.opensearch.indices.replication.SegmentReplicator$ReplicationRunner.doRun(SegmentReplicator.java:123) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:991) [main/:?]
  1> 	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [main/:?]
  1> 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) [?:?]
  1> 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) [?:?]
  1> 	at java.base/java.lang.Thread.run(Thread.java:1575) [?:?]
  1> Caused by: org.opensearch.transport.NodeNotConnectedException: [node_t1][127.0.0.1:42245] Node not connected
  1> 	at org.opensearch.transport.ClusterConnectionManager.getConnection(ClusterConnectionManager.java:223) ~[main/:?]
  1> 	at org.opensearch.test.transport.StubbableConnectionManager.getConnection(StubbableConnectionManager.java:93) ~[framework-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
  1> 	at org.opensearch.transport.TransportService.getConnection(TransportService.java:898) ~[main/:?]
  1> 	at org.opensearch.transport.TransportService.sendRequest(TransportService.java:857) ~[main/:?]
  1> 	at org.opensearch.indices.replication.PrimaryShardReplicationSource.getCheckpointMetadata(PrimaryShardReplicationSource.java:66) ~[main/:?]
  1> 	at org.opensearch.indices.replication.SegmentReplicationTarget.startReplication(SegmentReplicationTarget.java:177) ~[main/:?]
  1> 	... 7 more
```

With this change we are ensuring replication has finished before stopping the primary node. 

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/14328
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
