### PR TITLE
Add OpenSearch project name and logo with # symbol during build

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -164,6 +164,19 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         final Jvm gradleJvm = Jvm.current();
         final String gradleJvmDetails = getJavaInstallation(gradleJvm.getJavaHome()).getDisplayName();
 
+        String[] lines = {
+            " ####  #####  ###### #    #  ##### ######   ##    #####   #### #    # ",
+            "#    # #    # #      ##   # #      #       #  #  #    # #    # #    # ",
+            "#    # #    # #      # #  # #      #      #    # #    # #      #    # ",
+            "#    # #####  #####  #  # #  ####  #####  ###### #####  #      ###### ",
+            "#    # #      #      #   ##      # #      #    # #   #  #      #    # ",
+            "#    # #      #      #    # #    # #      #    # #    # #    # #    # ",
+            " ####  #      ###### #    #  ####  ###### #    # #    #  ####  #    # "
+        };
+
+        for (String line : lines) {
+            LOGGER.quiet(line);
+        }
         LOGGER.quiet("=======================================");
         LOGGER.quiet("OpenSearch Build Hamster says Hello!");
         LOGGER.quiet("  Gradle Version        : " + GradleVersion.current().getVersion());


### PR DESCRIPTION
### Pending logo

### Description
```
========================= WARNING =========================
         Backwards compatibility tests are disabled!
See https://github.com/opensearch-project/OpenSearch/issues/4173
===========================================================
 ####  #####  ###### #    #  ##### ######   ##    #####   #### #    #
#    # #    # #      ##   # #      #       #  #  #    # #    # #    #
#    # #    # #      # #  # #      #      #    # #    # #      #    #
#    # #####  #####  #  # #  ####  #####  ###### #####  #      ######
#    # #      #      #   ##      # #      #    # #   #  #      #    #
#    # #      #      #    # #    # #      #    # #    # #    # #    #
 ####  #      ###### #    #  ####  ###### #    # #    #  ####  #    #
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.12
  OS Info               : Mac OS X 14.6.1 (aarch64)
  JDK Version           : 23 (Amazon Corretto JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/amazon-corretto-23.jdk/Contents/Home
  Random Testing Seed   : 6B9C78BBD8E00F50
  In FIPS 140 mode      : false
=======================================
```
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
