### PR TITLE
Fix flaky test RemoteIndexRecoveryIT.testRerouteRecovery

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexRecoveryIT.java
@@ -250,7 +250,7 @@ public class IndexRecoveryIT extends OpenSearchIntegTestCase {
         assertThat(state.getStage(), not(equalTo(Stage.DONE)));
     }
 
-    private void slowDownRecovery(ByteSizeValue shardSize) {
+    public void slowDownRecovery(ByteSizeValue shardSize) {
         long chunkSize = Math.max(1, shardSize.getBytes() / 10);
         assertTrue(
             client().admin()
@@ -528,7 +528,7 @@ public class IndexRecoveryIT extends OpenSearchIntegTestCase {
             assertThat(indicesService.indexServiceSafe(index).getShard(0).recoveryStats().currentAsSource(), equalTo(1));
             indicesService = internalCluster().getInstance(IndicesService.class, nodeB);
             assertThat(indicesService.indexServiceSafe(index).getShard(0).recoveryStats().currentAsTarget(), equalTo(1));
-        }, TimeValue.timeValueSeconds(10), TimeValue.timeValueMillis(500));
+        }, TimeValue.timeValueSeconds(60), TimeValue.timeValueMillis(500));
 
         logger.info("--> request recoveries");
         RecoveryResponse response = client().admin().indices().prepareRecoveries(INDEX_NAME).execute().actionGet();


### PR DESCRIPTION
### Description
- `IndexRecoveryIT.testRerouteRecovery` triggers shard movement and verifies few details while recovery is in progress. It also slows down recovery to make sure that shard is not moved before we assert.
- When we extended `RemoteIndexRecoveryIT extends `IndexRecoveryIT`, we reduced number of docs to be ingested by 5x (this is to decrease test run time as latency of ingestion is higher with remote store enabled).
- https://github.com/opensearch-project/OpenSearch/blob/c06f53e3a73c5fd6011fa6f7581d5a97c25c848a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteIndexRecoveryIT.java#L67-L70
- But we did not slowed down recovery by 5x. This leads to flaky behaviour in the test where recovery completes before we check recovery stats.
- To avoid the flakiness, in this PR, we have slowed down recovery by 5X.


### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/14323

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
