### PR TITLE
Add HTTP/2 protocol support to HttpRequest.HttpVersion

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -57,7 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix compression support for h2c protocol ([#4944](https://github.com/opensearch-project/OpenSearch/pull/4944))
 - Don't over-allocate in HeapBufferedAsyncEntityConsumer in order to consume the response ([#9993](https://github.com/opensearch-project/OpenSearch/pull/9993))
 - Fix swapped field formats in nodes API where `total_indexing_buffer_in_bytes` and `total_indexing_buffer` values were reversed ([#17070](https://github.com/opensearch-project/OpenSearch/pull/17070))
-
+- Add HTTP/2 protocol support to HttpRequest.HttpVersion ([#17248](https://github.com/opensearch-project/OpenSearch/pull/17248))
 
 ### Security
 

--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4HttpRequest.java
@@ -217,6 +217,8 @@ public class Netty4HttpRequest implements HttpRequest {
             return HttpRequest.HttpVersion.HTTP_1_0;
         } else if (request.protocolVersion().equals(io.netty.handler.codec.http.HttpVersion.HTTP_1_1)) {
             return HttpRequest.HttpVersion.HTTP_1_1;
+        } else if (request.protocolVersion().equals("HTTP/2.0")) {
+            return HttpRequest.HttpVersion.HTTP_2_0;
         } else {
             throw new IllegalArgumentException("Unexpected http protocol version: " + request.protocolVersion());
         }

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpRequest.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpRequest.java
@@ -156,6 +156,8 @@ class ReactorNetty4HttpRequest implements HttpRequest {
             return HttpRequest.HttpVersion.HTTP_1_0;
         } else if (protocol.equals(io.netty.handler.codec.http.HttpVersion.HTTP_1_1.toString())) {
             return HttpRequest.HttpVersion.HTTP_1_1;
+        } else if (protocol.equals("HTTP/2.0")) {
+            return HttpRequest.HttpVersion.HTTP_2_0;
         } else {
             throw new IllegalArgumentException("Unexpected http protocol version: " + protocol);
         }

--- a/server/src/main/java/org/opensearch/http/HttpRequest.java
+++ b/server/src/main/java/org/opensearch/http/HttpRequest.java
@@ -59,7 +59,8 @@ public interface HttpRequest {
     @PublicApi(since = "1.0.0")
     enum HttpVersion {
         HTTP_1_0,
-        HTTP_1_1
+        HTTP_1_1,
+        HTTP_2_0
     }
 
     /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add HTTP/2 protocol support to HttpRequest.HttpVersion

### Related Issues
N/A
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
