### PR TITLE
fix explain action on query rewrite

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -74,6 +74,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix swapped field formats in nodes API where `total_indexing_buffer_in_bytes` and `total_indexing_buffer` values were reversed ([#17070](https://github.com/opensearch-project/OpenSearch/pull/17070))
 - Add HTTP/2 protocol support to HttpRequest.HttpVersion ([#17248](https://github.com/opensearch-project/OpenSearch/pull/17248))
 - Fix missing bucket in terms aggregation with missing value ([#17418](https://github.com/opensearch-project/OpenSearch/pull/17418))
+- Fix explain action on query rewrite ([#17286](https://github.com/opensearch-project/OpenSearch/pull/17286))
 
 ### Security
 


### PR DESCRIPTION
### Description
There is an exception when call explain in "by_doc_id" mode. Response looks like this:
```
{
    "error": {
        "root_cause": [
            {
                "type": "query_shard_exception",
                "reason": "failed to create query: async actions are left after rewrite",
                "index": "my-nlp-index-1",
                "index_uuid": "I6_pzGG3QBWw0B6KeOJ1pA"
            }
        ],
        "type": "query_shard_exception",
        "reason": "failed to create query: async actions are left after rewrite",
        "index": "my-nlp-index-1",
        "index_uuid": "I6_pzGG3QBWw0B6KeOJ1pA",
        "caused_by": {
            "type": "illegal_state_exception",
            "reason": "async actions are left after rewrite"
        }
    },
    "status": 400
}
```


The error were caught from `TransportExplainAction -> Rewriteable.java` because there still be asyncActions left when the flag `assertNoAsyncTasks` returned as true.

<img width="771" alt="Screenshot 2025-01-29 at 8 29 43 PM" src="https://github.com/user-attachments/assets/d6719034-5414-4ce4-8aed-4f73b2dd0a10" />



The conflict is down to:
1.  The NeuralQueryBuilder or TermsQueryBuilder `doRewrite` method introduces asynchronous actions via `queryRewriteContext.registerAsyncAction`. So it then returns a context with potentially unresolved async tasks. 

2. `Rewritable.rewrite` then checks`assertNoAsyncTasks` flag, throws the exception if there exists any async tasks left.

Fix in this PR is resolve this conflict:
- by moving the query rewrite to coordinator - ` TransportExplainAction.`
- verify the changes from local using `TermsQueryBuilder`
  - Before fix
  - <img width="775" alt="Screenshot 2025-01-30 at 9 30 29 PM" src="https://github.com/user-attachments/assets/b2338a3e-11e4-4eff-b276-81900991ce02" />
   - After fix
   - <img width="775" alt="Screenshot 2025-01-30 at 9 24 10 PM" src="https://github.com/user-attachments/assets/93719490-38f2-4832-852b-fbfbf86e9b73" />



### Related Issues
Resolves - https://github.com/opensearch-project/neural-search/issues/1126

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
