### PR TITLE
Fix ignore_malformed index-level override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix AutoDateHistogramAggregator rounding assertion failure ([#17023](https://github.com/opensearch-project/OpenSearch/pull/17023))
 - Add highlighting for wildcard search on `match_only_text` field ([#17101](https://github.com/opensearch-project/OpenSearch/pull/17101))
 - Fix the failing CI's with `Failed to load eclipse jdt formatter` error ([#17172](https://github.com/opensearch-project/OpenSearch/pull/17172))
+- Fix index-level `ignore_malformed` settings overriding field-level settings ([#17319](https://github.com/opensearch-project/OpenSearch/pull/17319)))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
@@ -202,7 +202,9 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return context.path().pathAsText(name);
         }
 
-        /** Set metadata on this field. */
+        /**
+         * Set metadata on this field.
+         */
         public T meta(Map<String, String> meta) {
             this.meta = meta;
             return (T) this;
@@ -268,8 +270,6 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         try {
             parseCreateField(context);
         } catch (Exception e) {
-            boolean ignore_malformed = false;
-            if (context.indexSettings() != null) ignore_malformed = IGNORE_MALFORMED_SETTING.get(context.indexSettings().getSettings());
             String valuePreview = "";
             try {
                 XContentParser parser = context.parser();
@@ -280,27 +280,23 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                     valuePreview = complexValue.toString();
                 }
             } catch (Exception innerException) {
-                if (ignore_malformed == false) {
-                    throw new MapperParsingException(
-                        "failed to parse field [{}] of type [{}] in document with id '{}'. " + "Could not parse field value preview,",
-                        e,
-                        fieldType().name(),
-                        fieldType().typeName(),
-                        context.sourceToParse().id()
-                    );
-                }
-            }
-
-            if (ignore_malformed == false) {
                 throw new MapperParsingException(
-                    "failed to parse field [{}] of type [{}] in document with id '{}'. " + "Preview of field's value: '{}'",
+                    "failed to parse field [{}] of type [{}] in document with id '{}'. " + "Could not parse field value preview,",
                     e,
                     fieldType().name(),
                     fieldType().typeName(),
-                    context.sourceToParse().id(),
-                    valuePreview
+                    context.sourceToParse().id()
                 );
             }
+
+            throw new MapperParsingException(
+                "failed to parse field [{}] of type [{}] in document with id '{}'. " + "Preview of field's value: '{}'",
+                e,
+                fieldType().name(),
+                fieldType().typeName(),
+                context.sourceToParse().id(),
+                valuePreview
+            );
         }
         multiFields.parse(this, context);
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This pull request reverts code from #4494, which caused index-level `ignore_malformed` settings to override field-level ones, and implements an alternative in DocumentParser

### Related Issues
Resolves #16599 
Related to #4002 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
