### PR TITLE
Close all byte streams in RemoteSegmentMetadataHandlerTests

### DIFF
--- a/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/metadata/RemoteSegmentMetadataHandlerTests.java
@@ -74,11 +74,12 @@ public class RemoteSegmentMetadataHandlerTests extends IndexShardTestCase {
         indexOutput.writeLong(0);
         indexOutput.writeBytes(new byte[0], 0);
         indexOutput.close();
-        RemoteSegmentMetadata metadata = remoteSegmentMetadataHandler.readContent(
-            new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))
-        );
-        assertEquals(expectedOutput, metadata.toMapOfStrings());
-        assertEquals(replicationCheckpoint.getSegmentsGen(), metadata.getGeneration());
+        try (ByteArrayIndexInput byteArrayIndexInput = new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))){
+            RemoteSegmentMetadata metadata = remoteSegmentMetadataHandler.readContent(byteArrayIndexInput);
+            assertEquals(expectedOutput, metadata.toMapOfStrings());
+            assertEquals(replicationCheckpoint.getSegmentsGen(), metadata.getGeneration());
+        }
+        output.close();
     }
 
     public void testReadContentWithSegmentInfos() throws IOException {
@@ -93,12 +94,13 @@ public class RemoteSegmentMetadataHandlerTests extends IndexShardTestCase {
         indexOutput.writeLong(segmentInfosBytes.length);
         indexOutput.writeBytes(segmentInfosBytes, 0, segmentInfosBytes.length);
         indexOutput.close();
-        RemoteSegmentMetadata metadata = remoteSegmentMetadataHandler.readContent(
-            new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))
-        );
-        assertEquals(expectedOutput, metadata.toMapOfStrings());
-        assertEquals(replicationCheckpoint.getSegmentsGen(), metadata.getGeneration());
-        assertArrayEquals(segmentInfosBytes, metadata.getSegmentInfosBytes());
+        try (ByteArrayIndexInput byteArrayIndexInput = new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))) {
+            RemoteSegmentMetadata metadata = remoteSegmentMetadataHandler.readContent(byteArrayIndexInput);
+            assertEquals(expectedOutput, metadata.toMapOfStrings());
+            assertEquals(replicationCheckpoint.getSegmentsGen(), metadata.getGeneration());
+            assertArrayEquals(segmentInfosBytes, metadata.getSegmentInfosBytes());
+        }
+        output.close();
     }
 
     public void testWriteContent() throws IOException {
@@ -118,13 +120,14 @@ public class RemoteSegmentMetadataHandlerTests extends IndexShardTestCase {
         remoteSegmentMetadataHandler.writeContent(indexOutput, remoteSegmentMetadata);
         indexOutput.close();
 
-        RemoteSegmentMetadata metadata = remoteSegmentMetadataHandler.readContent(
-            new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))
-        );
-        assertEquals(expectedOutput, metadata.toMapOfStrings());
-        assertEquals(replicationCheckpoint.getSegmentsGen(), metadata.getGeneration());
-        assertEquals(replicationCheckpoint.getPrimaryTerm(), metadata.getPrimaryTerm());
-        assertArrayEquals(segmentInfosBytes, metadata.getSegmentInfosBytes());
+        try (ByteArrayIndexInput byteArrayIndexInput = new ByteArrayIndexInput("dummy bytes", BytesReference.toBytes(output.bytes()))) {
+            RemoteSegmentMetadata metadata = remoteSegmentMetadataHandler.readContent(byteArrayIndexInput);
+            assertEquals(expectedOutput, metadata.toMapOfStrings());
+            assertEquals(replicationCheckpoint.getSegmentsGen(), metadata.getGeneration());
+            assertEquals(replicationCheckpoint.getPrimaryTerm(), metadata.getPrimaryTerm());
+            assertArrayEquals(segmentInfosBytes, metadata.getSegmentInfosBytes());
+        }
+        output.close();
     }
 
     private Map<String, String> getDummyData() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Attempting to fix RemoteSegmentMetadataHandlerTests flaky test by closing all open byte streams

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/14367


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
