### PR TITLE
Wildcard field use only 3-gram to index

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Stop minimizing automata used for case-insensitive matches ([#17268](https://github.com/opensearch-project/OpenSearch/pull/17268))
 - Refactor the `:server` module `org.opensearch.client` to `org.opensearch.transport.client` to eliminate top level split packages for JPMS support ([#17272](https://github.com/opensearch-project/OpenSearch/pull/17272))
 - Use Lucene `BM25Similarity` as default since the `LegacyBM25Similarity` is marked as deprecated ([#17306](https://github.com/opensearch-project/OpenSearch/pull/17306))
+- Wildcard field index only 3gram of the input data [#17349](https://github.com/opensearch-project/OpenSearch/pull/17349)
 
 ### Deprecated
 

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/40_wildcard.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/40_wildcard.yml
@@ -1,0 +1,307 @@
+# refactored from rest-api-spec/src/main/resources/rest-api-spec/test/search/270_wildcard_fieldtype_queries.yml
+---
+"search on mixed state":
+  # "term query matches exact value"
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field: "AbCd"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field.doc_values: "AbCd"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+
+  # term query matches lowercase-normalized value
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field.lower: "abcd"
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.1._id: "7" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field.lower: "ABCD"
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.1._id: "7" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field: "abcd"
+  - match: { hits.total.value: 0 }
+
+  # wildcard query matches
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "*Node*Exception*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+  # wildcard query matches lowercase-normalized field
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field.lower:
+                value: "*node*exception*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field.lower:
+                value: "*NODE*EXCEPTION*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "*node*exception*"
+  - match: { hits.total.value: 0 }
+
+  # prefix query matches
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            prefix:
+              my_field:
+                value: "[2024-06-08T"
+  - match: { hits.total.value: 3 }
+
+  # regexp query matches
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: ".*06-08.*cluster-manager node.*"
+  - match: { hits.total.value: 2 }
+
+  # regexp query matches lowercase-normalized field
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field.lower:
+                value: ".*06-08.*Cluster-Manager Node.*"
+  - match: { hits.total.value: 2 }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: ".*06-08.*Cluster-Manager Node.*"
+  - match: { hits.total.value: 0 }
+
+  # wildcard match-all works
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "*"
+  - match: { hits.total.value: 8 }
+
+  # regexp match-all works
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: ".*"
+  - match: { hits.total.value: 8 }
+
+  # terms query on wildcard field matches
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            terms: { my_field: [ "AbCd" ] }
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+
+  # case insensitive query on wildcard field
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "AbCd"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "AbCd"
+                case_insensitive: true
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.1._id: "7" }
+
+  # case insensitive regexp query on wildcard field
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: "AbCd"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: "AbCd"
+                case_insensitive: true
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.1._id: "7" }
+
+  # wildcard query works on values contains escaped characters
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "8" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "\\\\\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "9" }
+
+  # regexp query works on values contains escaped characters
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: "\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "8" }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: "\\\\\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "9" }
+
+  # term query contains escaped characters
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field: "\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "9" }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field: "*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "8"}
+
+  # terms query contains escaped characters
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            terms: { my_field: ["*"] }
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "8" }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            terms: { my_field: [ "\\*" ] }
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "9" }

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/40_wildcard.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/40_wildcard.yml
@@ -151,7 +151,7 @@
             wildcard:
               my_field:
                 value: "*"
-  - match: { hits.total.value: 8 }
+  - match: { hits.total.value: 6 }
 
   # regexp match-all works
   - do:
@@ -162,7 +162,7 @@
             regexp:
               my_field:
                 value: ".*"
-  - match: { hits.total.value: 8 }
+  - match: { hits.total.value: 6 }
 
   # terms query on wildcard field matches
   - do:
@@ -198,110 +198,3 @@
   - match: { hits.total.value: 2 }
   - match: { hits.hits.0._id: "5" }
   - match: { hits.hits.1._id: "7" }
-
-  # case insensitive regexp query on wildcard field
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            regexp:
-              my_field:
-                value: "AbCd"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "5" }
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            regexp:
-              my_field:
-                value: "AbCd"
-                case_insensitive: true
-  - match: { hits.total.value: 2 }
-  - match: { hits.hits.0._id: "5" }
-  - match: { hits.hits.1._id: "7" }
-
-  # wildcard query works on values contains escaped characters
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            wildcard:
-              my_field:
-                value: "\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "8" }
-
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            wildcard:
-              my_field:
-                value: "\\\\\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "9" }
-
-  # regexp query works on values contains escaped characters
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            regexp:
-              my_field:
-                value: "\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "8" }
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            regexp:
-              my_field:
-                value: "\\\\\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "9" }
-
-  # term query contains escaped characters
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            term:
-              my_field: "\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "9" }
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            term:
-              my_field: "*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "8"}
-
-  # terms query contains escaped characters
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            terms: { my_field: ["*"] }
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "8" }
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            terms: { my_field: [ "\\*" ] }
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "9" }

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/40_wildcard.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/40_wildcard.yml
@@ -1,0 +1,346 @@
+# refactored from rest-api-spec/src/main/resources/rest-api-spec/test/search/270_wildcard_fieldtype_queries.yml
+---
+"Create index with Wildcard field":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              my_field:
+                type: wildcard
+                fields:
+                  lower:
+                    type: wildcard
+                    normalizer: lowercase
+                  doc_values:
+                    type: wildcard
+                    doc_values: true
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "test", "_id":1}}'
+          - '{"my_field": "org.opensearch.transport.NodeDisconnectedException: [node_s0][127.0.0.1:39953][disconnected] disconnected"}'
+          - '{"index": {"_index": "test", "_id":2}}'
+          - '{"my_field": "[2024-06-08T06:31:37,443][INFO ][o.o.c.c.Coordinator      ] [node_s2] cluster-manager node [{node_s0}{Nj7FjR7hRP2lh_zur8KN_g}{OTGOoWmmSsWP_RQ3tIKJ9g}{127.0.0.1}{127.0.0.1:39953}{imr}{shard_indexing_pressure_enabled=true}] failed, restarting discovery"}'
+          - '{"index": {"_index": "test", "_id":3}}'
+          - '{"my_field": "[2024-06-08T06:31:37,451][INFO ][o.o.c.s.ClusterApplierService] [node_s2] cluster-manager node changed {previous [{node_s0}{Nj7FjR7hRP2lh_zur8KN_g}{OTGOoWmmSsWP_RQ3tIKJ9g}{127.0.0.1}{127.0.0.1:39953}{imr}{shard_indexing_pressure_enabled=true}], current []}, term: 1, version: 24, reason: becoming candidate: onLeaderFailure"}'
+          - '{"index": {"_index": "test", "_id":4}}'
+          - '{"my_field": "[2024-06-08T06:31:37,452][WARN ][o.o.c.NodeConnectionsService] [node_s1] failed to connect to {node_s0}{Nj7FjR7hRP2lh_zur8KN_g}{OTGOoWmmSsWP_RQ3tIKJ9g}{127.0.0.1}{127.0.0.1:39953}{imr}{shard_indexing_pressure_enabled=true} (tried [1] times)"}'
+          - '{"index": {"_index": "test", "_id":5}}'
+          - '{"my_field": "AbCd"}'
+          - '{"index": {"_index": "test", "_id":6}}'
+          - '{"other_field": "test"}'
+          - '{"index": {"_index": "test", "_id":7}}'
+          - '{"my_field": "ABCD"}'
+          - '{"index": {"_index": "test", "_id":8}}'
+          - '{"my_field": "*"}'
+          - '{"index": {"_index": "test", "_id":9}}'
+          - '{"my_field": "\\*"}'
+
+  # "term query matches exact value"
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field: "AbCd"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field.doc_values: "AbCd"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+
+  # term query matches lowercase-normalized value
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field.lower: "abcd"
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.1._id: "7" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field.lower: "ABCD"
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.1._id: "7" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field: "abcd"
+  - match: { hits.total.value: 0 }
+
+  # wildcard query matches
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "*Node*Exception*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+  # wildcard query matches lowercase-normalized field
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field.lower:
+                value: "*node*exception*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field.lower:
+                value: "*NODE*EXCEPTION*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "*node*exception*"
+  - match: { hits.total.value: 0 }
+
+  # prefix query matches
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            prefix:
+              my_field:
+                value: "[2024-06-08T"
+  - match: { hits.total.value: 3 }
+
+  # regexp query matches
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: ".*06-08.*cluster-manager node.*"
+  - match: { hits.total.value: 2 }
+
+  # regexp query matches lowercase-normalized field
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field.lower:
+                value: ".*06-08.*Cluster-Manager Node.*"
+  - match: { hits.total.value: 2 }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: ".*06-08.*Cluster-Manager Node.*"
+  - match: { hits.total.value: 0 }
+
+  # wildcard match-all works
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "*"
+  - match: { hits.total.value: 8 }
+
+  # regexp match-all works
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: ".*"
+  - match: { hits.total.value: 8 }
+
+  # terms query on wildcard field matches
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            terms: { my_field: [ "AbCd" ] }
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+
+  # case insensitive query on wildcard field
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "AbCd"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "AbCd"
+                case_insensitive: true
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.1._id: "7" }
+
+  # case insensitive regexp query on wildcard field
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: "AbCd"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: "AbCd"
+                case_insensitive: true
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.1._id: "7" }
+
+  # wildcard query works on values contains escaped characters
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "8" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "\\\\\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "9" }
+
+  # regexp query works on values contains escaped characters
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: "\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "8" }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: "\\\\\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "9" }
+
+  # term query contains escaped characters
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field: "\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "9" }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field: "*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "8"}
+
+  # terms query contains escaped characters
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            terms: { my_field: ["*"] }
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "8" }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            terms: { my_field: [ "\\*" ] }
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "9" }

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/40_wildcard.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/40_wildcard.yml
@@ -35,10 +35,6 @@
           - '{"other_field": "test"}'
           - '{"index": {"_index": "test", "_id":7}}'
           - '{"my_field": "ABCD"}'
-          - '{"index": {"_index": "test", "_id":8}}'
-          - '{"my_field": "*"}'
-          - '{"index": {"_index": "test", "_id":9}}'
-          - '{"my_field": "\\*"}'
 
   # "term query matches exact value"
   - do:
@@ -190,7 +186,7 @@
             wildcard:
               my_field:
                 value: "*"
-  - match: { hits.total.value: 8 }
+  - match: { hits.total.value: 6 }
 
   # regexp match-all works
   - do:
@@ -201,7 +197,7 @@
             regexp:
               my_field:
                 value: ".*"
-  - match: { hits.total.value: 8 }
+  - match: { hits.total.value: 6 }
 
   # terms query on wildcard field matches
   - do:
@@ -237,110 +233,3 @@
   - match: { hits.total.value: 2 }
   - match: { hits.hits.0._id: "5" }
   - match: { hits.hits.1._id: "7" }
-
-  # case insensitive regexp query on wildcard field
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            regexp:
-              my_field:
-                value: "AbCd"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "5" }
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            regexp:
-              my_field:
-                value: "AbCd"
-                case_insensitive: true
-  - match: { hits.total.value: 2 }
-  - match: { hits.hits.0._id: "5" }
-  - match: { hits.hits.1._id: "7" }
-
-  # wildcard query works on values contains escaped characters
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            wildcard:
-              my_field:
-                value: "\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "8" }
-
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            wildcard:
-              my_field:
-                value: "\\\\\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "9" }
-
-  # regexp query works on values contains escaped characters
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            regexp:
-              my_field:
-                value: "\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "8" }
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            regexp:
-              my_field:
-                value: "\\\\\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "9" }
-
-  # term query contains escaped characters
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            term:
-              my_field: "\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "9" }
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            term:
-              my_field: "*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "8"}
-
-  # terms query contains escaped characters
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            terms: { my_field: ["*"] }
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "8" }
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            terms: { my_field: [ "\\*" ] }
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "9" }

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/40_wildcard.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/40_wildcard.yml
@@ -1,0 +1,307 @@
+# refactored from rest-api-spec/src/main/resources/rest-api-spec/test/search/270_wildcard_fieldtype_queries.yml
+---
+"search after upgrade":
+  # "term query matches exact value"
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field: "AbCd"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field.doc_values: "AbCd"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+
+  # term query matches lowercase-normalized value
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field.lower: "abcd"
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.1._id: "7" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field.lower: "ABCD"
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.1._id: "7" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field: "abcd"
+  - match: { hits.total.value: 0 }
+
+  # wildcard query matches
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "*Node*Exception*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+  # wildcard query matches lowercase-normalized field
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field.lower:
+                value: "*node*exception*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field.lower:
+                value: "*NODE*EXCEPTION*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "*node*exception*"
+  - match: { hits.total.value: 0 }
+
+  # prefix query matches
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            prefix:
+              my_field:
+                value: "[2024-06-08T"
+  - match: { hits.total.value: 3 }
+
+  # regexp query matches
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: ".*06-08.*cluster-manager node.*"
+  - match: { hits.total.value: 2 }
+
+  # regexp query matches lowercase-normalized field
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field.lower:
+                value: ".*06-08.*Cluster-Manager Node.*"
+  - match: { hits.total.value: 2 }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: ".*06-08.*Cluster-Manager Node.*"
+  - match: { hits.total.value: 0 }
+
+  # wildcard match-all works
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "*"
+  - match: { hits.total.value: 8 }
+
+  # regexp match-all works
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: ".*"
+  - match: { hits.total.value: 8 }
+
+  # terms query on wildcard field matches
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            terms: { my_field: [ "AbCd" ] }
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+
+  # case insensitive query on wildcard field
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "AbCd"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "AbCd"
+                case_insensitive: true
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.1._id: "7" }
+
+  # case insensitive regexp query on wildcard field
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: "AbCd"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "5" }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: "AbCd"
+                case_insensitive: true
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.1._id: "7" }
+
+  # wildcard query works on values contains escaped characters
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "8" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            wildcard:
+              my_field:
+                value: "\\\\\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "9" }
+
+  # regexp query works on values contains escaped characters
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: "\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "8" }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              my_field:
+                value: "\\\\\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "9" }
+
+  # term query contains escaped characters
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field: "\\*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "9" }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            term:
+              my_field: "*"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "8"}
+
+  # terms query contains escaped characters
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            terms: { my_field: ["*"] }
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "8" }
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            terms: { my_field: [ "\\*" ] }
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "9" }

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/40_wildcard.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/40_wildcard.yml
@@ -151,7 +151,7 @@
             wildcard:
               my_field:
                 value: "*"
-  - match: { hits.total.value: 8 }
+  - match: { hits.total.value: 6 }
 
   # regexp match-all works
   - do:
@@ -162,7 +162,7 @@
             regexp:
               my_field:
                 value: ".*"
-  - match: { hits.total.value: 8 }
+  - match: { hits.total.value: 6 }
 
   # terms query on wildcard field matches
   - do:
@@ -198,110 +198,3 @@
   - match: { hits.total.value: 2 }
   - match: { hits.hits.0._id: "5" }
   - match: { hits.hits.1._id: "7" }
-
-  # case insensitive regexp query on wildcard field
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            regexp:
-              my_field:
-                value: "AbCd"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "5" }
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            regexp:
-              my_field:
-                value: "AbCd"
-                case_insensitive: true
-  - match: { hits.total.value: 2 }
-  - match: { hits.hits.0._id: "5" }
-  - match: { hits.hits.1._id: "7" }
-
-  # wildcard query works on values contains escaped characters
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            wildcard:
-              my_field:
-                value: "\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "8" }
-
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            wildcard:
-              my_field:
-                value: "\\\\\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "9" }
-
-  # regexp query works on values contains escaped characters
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            regexp:
-              my_field:
-                value: "\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "8" }
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            regexp:
-              my_field:
-                value: "\\\\\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "9" }
-
-  # term query contains escaped characters
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            term:
-              my_field: "\\*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "9" }
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            term:
-              my_field: "*"
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "8"}
-
-  # terms query contains escaped characters
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            terms: { my_field: ["*"] }
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "8" }
-  - do:
-      search:
-        index: test
-        body:
-          query:
-            terms: { my_field: [ "\\*" ] }
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._id: "9" }

--- a/server/src/main/java/org/opensearch/index/mapper/WildcardFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/WildcardFieldMapper.java
@@ -159,6 +159,7 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
 
     }
 
+    public static final int NGRAM_SIZE = 3;
     public static final String CONTENT_TYPE = "wildcard";
     public static final TypeParser PARSER = new TypeParser((n, c) -> new WildcardFieldMapper.Builder(n, c.getIndexAnalyzers()));
 
@@ -230,97 +231,49 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
     /**
      * Tokenizer to emit tokens to support wildcard first-phase matching.
      * <p>
-     * Will emit all substrings of length 1,2, and 3, with 0-valued anchors for the prefix/suffix.
+     * Will emit all substrings of only 3, with 0-valued anchors for the prefix/suffix.
      * <p>
      * For example, given the string "lucene", output the following terms:
      * <p>
-     * [0, 'l']
+     * [0, 0, 'l']
      * [0, 'l', 'u']
-     * ['l']
-     * ['l', 'u']
      * ['l', 'u', 'c']
-     * ['u']
-     * ['u','c']
      * ['u','c','e']
-     * ['c']
-     * ['c', 'e']
      * ['c', 'e', 'n']
-     * ['e']
-     * ['e', 'n']
      * ['e', 'n', 'e']
-     * ['n']
-     * ['n', 'e']
      * ['n', 'e', 0]
-     * ['e']
-     * ['e', 0]
+     * ['e', 0, 0]
      * <p>
      * Visible for testing.
      */
     static final class WildcardFieldTokenizer extends Tokenizer {
         private final CharTermAttribute charTermAttribute = addAttribute(CharTermAttribute.class);
-        private final char[] buffer = new char[3]; // Ring buffer for up to 3 chars
-        private int offset = 0; // Position in the buffer
-        private int length = 2; // First token is anchor + first char
+        private final char[] buffer = new char[NGRAM_SIZE]; // Ring buffer for up to 3 chars
+        private int offset = NGRAM_SIZE - 1; // next position in buffer to store next input char
 
         @Override
         public void reset() throws IOException {
             super.reset();
-            buffer[0] = 0;
-            int firstChar = input.read();
-            if (firstChar != -1) {
-                buffer[1] = (char) firstChar;
-                int secondChar = input.read();
-                if (secondChar != -1) {
-                    buffer[2] = (char) secondChar;
-                } else {
-                    buffer[2] = 0;
-                }
-            } else {
-                buffer[1] = 0;
+            for (int i = 0; i < NGRAM_SIZE - 1; i++) {
+                buffer[i] = 0;
             }
-
         }
 
         @Override
         public boolean incrementToken() throws IOException {
-            charTermAttribute.setLength(length);
-            int numZeroes = 0;
-            for (int i = 0; i < length; i++) {
-                char curChar = buffer[(i + offset) % 3];
-                if (curChar == 0) {
-                    numZeroes++;
-                }
-                charTermAttribute.buffer()[i] = buffer[(i + offset) % 3];
+            charTermAttribute.setLength(NGRAM_SIZE);
+            int c = input.read();
+            c = c == -1 ? 0 : c;
+
+            buffer[offset++ % NGRAM_SIZE] = (char) c;
+            boolean has_next = false;
+            for (int i = 0; i < NGRAM_SIZE; i++) {
+                char curChar = buffer[(offset + i) % NGRAM_SIZE];
+                charTermAttribute.buffer()[i] = curChar;
+                has_next |= curChar != 0;
             }
-            if (numZeroes == 2) {
-                // Two zeroes usually means we're done.
-                if (length == 3 && charTermAttribute.buffer()[1] != 0) {
-                    // The only case where we're not done is if the input has exactly 1 character, so the buffer
-                    // contains 0, char, 0. In that case, we return char now, then return char, 0 on the next iteration
-                    charTermAttribute.buffer()[0] = charTermAttribute.buffer()[1];
-                    charTermAttribute.buffer()[1] = 0;
-                    charTermAttribute.setLength(1);
-                    length = 2;
-                    offset = 1;
-                    return true;
-                }
-                return false;
-            }
-            if (length == 3) {
-                // Read the next character, overwriting the current offset
-                int nextChar = input.read();
-                if (nextChar != -1) {
-                    buffer[offset] = (char) nextChar;
-                } else {
-                    // End of input. Pad with extra 0 to trigger the logic above.
-                    buffer[offset] = 0;
-                }
-                offset = (offset + 1) % 3;
-                length = 1;
-            } else {
-                length = length + 1;
-            }
-            return true;
+
+            return has_next;
         }
     }
 
@@ -479,8 +432,8 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
             Query approximation;
             if (requiredNGrams.isEmpty()) {
                 // This only happens when all characters are wildcard characters (* or ?),
-                // or it's the empty string.
-                if (value.length() == 0 || value.contains("?")) {
+                // or it's only contains sequential characters less than NGRAM_SIZE (which defaults to 3).
+                if (findNonWildcardSequence(value, 0) != value.length() || value.length() == 0 || value.contains("?")) {
                     approximation = this.existsQuery(context);
                 } else {
                     return existsQuery(context);
@@ -502,15 +455,20 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
             int pos = 0;
             String rawSequence = null;
             String currentSequence = null;
+            char[] buffer = new char[NGRAM_SIZE];
             if (!value.startsWith("?") && !value.startsWith("*")) {
                 // Can add prefix term
                 rawSequence = getNonWildcardSequence(value, 0);
                 currentSequence = performEscape(rawSequence, regexpMode);
-                if (currentSequence.length() == 1) {
-                    terms.add(new String(new char[] { 0, currentSequence.charAt(0) }));
-                } else {
-                    terms.add(new String(new char[] { 0, currentSequence.charAt(0), currentSequence.charAt(1) }));
+
+                // buffer[0] is automatically set to 0
+                Arrays.fill(buffer, (char) 0);
+                int startIdx = Math.max(NGRAM_SIZE - currentSequence.length(), 1);
+                for (int j = 0; j < currentSequence.length() && j < NGRAM_SIZE - 1; j++) {
+                    buffer[startIdx + j] = currentSequence.charAt(j);
                 }
+
+                terms.add(new String(buffer));
             } else {
                 pos = findNonWildcardSequence(value, pos);
                 rawSequence = getNonWildcardSequence(value, pos);
@@ -518,23 +476,27 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
             while (pos < value.length()) {
                 boolean isEndOfValue = pos + rawSequence.length() == value.length();
                 currentSequence = performEscape(rawSequence, regexpMode);
-                if (!currentSequence.isEmpty() && currentSequence.length() < 3 && !isEndOfValue && pos > 0) {
-                    // If this is a prefix or suffix of length < 3, then we already have a longer token including the anchor.
-                    terms.add(currentSequence);
-                } else {
-                    for (int i = 0; i < currentSequence.length() - 2; i++) {
-                        terms.add(currentSequence.substring(i, i + 3));
-                    }
+
+                for (int i = 0; i < currentSequence.length() - NGRAM_SIZE + 1; i++) {
+                    terms.add(currentSequence.substring(i, i + 3));
                 }
                 if (isEndOfValue) {
                     // This is the end of the input. We can attach a suffix anchor.
-                    if (currentSequence.length() == 1) {
-                        terms.add(new String(new char[] { currentSequence.charAt(0), 0 }));
-                    } else {
-                        char a = currentSequence.charAt(currentSequence.length() - 2);
-                        char b = currentSequence.charAt(currentSequence.length() - 1);
-                        terms.add(new String(new char[] { a, b, 0 }));
+                    // special case when we should generate '0xxxxxxx0', where we have (NGRAM_SIZE - 2) * x
+                    Arrays.fill(buffer, (char) 0);
+                    if (pos == 0 && currentSequence.length() == NGRAM_SIZE - 2) {
+                        for (int i = 0; i < currentSequence.length(); i++) {
+                            buffer[i + 1] = currentSequence.charAt(i);
+                        }
+                        terms.add(new String(buffer));
+                        Arrays.fill(buffer, (char) 0);
                     }
+                    int rightStartIdx = NGRAM_SIZE - currentSequence.length() - 2;
+                    rightStartIdx = rightStartIdx < 0 ? NGRAM_SIZE - 2 : rightStartIdx;
+                    for (int j = 0; j < currentSequence.length() && j < NGRAM_SIZE - 1; j++) {
+                        buffer[rightStartIdx - j] = currentSequence.charAt(currentSequence.length() - j - 1);
+                    }
+                    terms.add(new String(buffer));
                 }
                 pos = findNonWildcardSequence(value, pos + rawSequence.length());
                 rawSequence = getNonWildcardSequence(value, pos);

--- a/server/src/test/java/org/opensearch/index/mapper/WildcardFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/WildcardFieldMapperTests.java
@@ -82,22 +82,11 @@ public class WildcardFieldMapperTests extends MapperTestCase {
             List.of(
                 WildcardFieldTypeTests.prefixAnchored("p"),
                 WildcardFieldTypeTests.prefixAnchored("pi"),
-                "p",
-                "pi",
                 "pic",
-                "i",
-                "ic",
                 "ick",
-                "c",
-                "ck",
                 "ckl",
-                "k",
-                "kl",
                 "kle",
-                "l",
-                "le",
                 WildcardFieldTypeTests.suffixAnchored("le"),
-                "e",
                 WildcardFieldTypeTests.suffixAnchored("e")
             ),
             terms
@@ -111,7 +100,14 @@ public class WildcardFieldMapperTests extends MapperTestCase {
                 terms.add(charTermAttribute.toString());
             }
         }
-        assertEquals(List.of(WildcardFieldTypeTests.prefixAnchored("a"), "a", WildcardFieldTypeTests.suffixAnchored("a")), terms);
+        assertEquals(
+            List.of(
+                WildcardFieldTypeTests.prefixAnchored("a"),
+                WildcardFieldTypeTests.suffixAnchored((char) 0 + "a"),
+                WildcardFieldTypeTests.suffixAnchored("a")
+            ),
+            terms
+        );
     }
 
     public void testEnableDocValues() throws IOException {
@@ -188,13 +184,8 @@ public class WildcardFieldMapperTests extends MapperTestCase {
             List.of(
                 WildcardFieldTypeTests.prefixAnchored("a"),
                 WildcardFieldTypeTests.prefixAnchored("ab"),
-                "a",
-                "ab",
                 "abc",
-                "b",
-                "bc",
                 WildcardFieldTypeTests.suffixAnchored("bc"),
-                "c",
                 WildcardFieldTypeTests.suffixAnchored("c")
             ),
             terms
@@ -242,13 +233,8 @@ public class WildcardFieldMapperTests extends MapperTestCase {
             List.of(
                 WildcardFieldTypeTests.prefixAnchored("u"),
                 WildcardFieldTypeTests.prefixAnchored("ur"),
-                "u",
-                "ur",
                 "uri",
-                "r",
-                "ri",
                 WildcardFieldTypeTests.suffixAnchored("ri"),
-                "i",
                 WildcardFieldTypeTests.suffixAnchored("i")
             ),
             terms
@@ -281,16 +267,9 @@ public class WildcardFieldMapperTests extends MapperTestCase {
             List.of(
                 WildcardFieldTypeTests.prefixAnchored("1"),
                 WildcardFieldTypeTests.prefixAnchored("12"),
-                "1",
-                "12",
                 "123",
-                "2",
-                "23",
                 "234",
-                "3",
-                "34",
                 WildcardFieldTypeTests.suffixAnchored("34"),
-                "4",
                 WildcardFieldTypeTests.suffixAnchored("4")
             ),
             terms


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Accorrding the test result of #17099 , change wildcard field to only index 3-gram of the input data, instead of 1-3 gram, to reduce the overall index size caused by long positing list of single and double charaters, which is not really helpful when search. And also help to increase the write speed.

### Related Issues
Resolves #17099

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
