### PR TITLE
Fix primary shard balance parameter

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationConstraints.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationConstraints.java
@@ -43,4 +43,8 @@ public class AllocationConstraints {
         Constraint.ConstraintParams params = new Constraint.ConstraintParams(balancer, node, index, primaryThresholdWeight);
         return params.weight(constraints);
     }
+
+    public Constraint getConstraint(String constraint) {
+        return this.constraints.get(constraint);
+    }
 }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/Constraint.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/Constraint.java
@@ -24,8 +24,8 @@ import static org.opensearch.cluster.routing.allocation.ConstraintTypes.predicat
  */
 public class Constraint implements Predicate<Constraint.ConstraintParams> {
 
-    private boolean enable;
-    private Predicate<ConstraintParams> predicate;
+    private volatile boolean enable;
+    private final Predicate<ConstraintParams> predicate;
 
     public Constraint(Predicate<ConstraintParams> constraintPredicate) {
         this.predicate = constraintPredicate;
@@ -38,6 +38,10 @@ public class Constraint implements Predicate<Constraint.ConstraintParams> {
 
     public void setEnable(boolean enable) {
         this.enable = enable;
+    }
+
+    public boolean isEnable() {
+        return this.enable;
     }
 
     static class ConstraintParams {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/RebalanceConstraints.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/RebalanceConstraints.java
@@ -46,4 +46,8 @@ public class RebalanceConstraints {
         Constraint.ConstraintParams params = new Constraint.ConstraintParams(balancer, node, index, primaryConstraintThreshold);
         return params.weight(constraints);
     }
+
+    public Constraint getConstraint(String constraint) {
+        return this.constraints.get(constraint);
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Serval changes here:
- fix settings `preferPrimaryShardBalance/Rebalance` be reset when updating other settings due to a new `WeightFunction` object is created without inherit original `Constraint` parameters

https://github.com/opensearch-project/OpenSearch/blob/e34422bd838e92a55970399e2f273a8d1a25f496/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java#L302-L314

- separate preferPrimaryShardBalance/preferPrimaryShardRebalance updating;
- refactor some code

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
