### PR TITLE
[Pull-based Ingestion] Offset management, support rewind by offset or timestamp

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added ConfigurationUtils to core for the ease of configuration parsing [#17223](https://github.com/opensearch-project/OpenSearch/pull/17223)
 - Add execution_hint to cardinality aggregator request (#[17312](https://github.com/opensearch-project/OpenSearch/pull/17312))
 - Arrow Flight RPC plugin with Flight server bootstrap logic and client for internode communication ([#16962](https://github.com/opensearch-project/OpenSearch/pull/16962))
+- Added offset management for the pull-based Ingestion ([#17354](https://github.com/opensearch-project/OpenSearch/pull/17354))
 
 ### Dependencies
 - Update Apache Lucene to 10.1.0 ([#16366](https://github.com/opensearch-project/OpenSearch/pull/16366))

--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
@@ -119,6 +119,7 @@ public class IngestFromKafkaIT extends OpenSearchIntegTestCase {
                     .put("ingestion_source.pointer.init.reset.value", "1739459600000")
                     .put("ingestion_source.param.topic", "test")
                     .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
+                    .put("ingestion_source.param.auto.offset.reset", "latest")
                     .build(),
                 "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
             );
@@ -148,6 +149,7 @@ public class IngestFromKafkaIT extends OpenSearchIntegTestCase {
                     .put("ingestion_source.pointer.init.reset.value", "1")
                     .put("ingestion_source.param.topic", "test")
                     .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
+                    .put("ingestion_source.param.auto.offset.reset", "latest")
                     .build(),
                 "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
             );

--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
@@ -116,7 +116,7 @@ public class IngestFromKafkaIT extends OpenSearchIntegTestCase {
                     // 1739459500000 is the timestamp of the first message
                     // 1739459800000 is the timestamp of the second message
                     // by resetting to 1739459600000, only the second message will be ingested
-                    .put("ingestion_source.pointer.init.reset.value", 1739459600000L)
+                    .put("ingestion_source.pointer.init.reset.value", "1739459600000")
                     .put("ingestion_source.param.topic", "test")
                     .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                     .build(),
@@ -145,7 +145,7 @@ public class IngestFromKafkaIT extends OpenSearchIntegTestCase {
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                     .put("ingestion_source.type", "kafka")
                     .put("ingestion_source.pointer.init.reset", "rewind_by_offset")
-                    .put("ingestion_source.pointer.init.reset.value", 1L)
+                    .put("ingestion_source.pointer.init.reset.value", "1")
                     .put("ingestion_source.param.topic", "test")
                     .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                     .build(),

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
@@ -143,8 +143,9 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     }
 
     @Override
-    public IngestionShardPointer pointerFromTimestampMillis(long timestampMillis) {
+    public IngestionShardPointer pointerFromTimestampMillis(String timestampMillisStr) {
         long offset = AccessController.doPrivileged((PrivilegedAction<Long>) () -> {
+            long timestampMillis = Long.parseLong(timestampMillisStr);
             Map<TopicPartition, OffsetAndTimestamp> position = consumer.offsetsForTimes(
                 Collections.singletonMap(topicPartition, timestampMillis)
             );
@@ -159,15 +160,16 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
         });
         if (offset < 0) {
             // no message found for the timestamp, return the latest offset
-            logger.warn("No message found for timestamp {}, seeking to the latest", timestampMillis);
+            logger.warn("No message found for timestamp {}, seeking to the latest", timestampMillisStr);
             return latestPointer();
         }
         return new KafkaOffset(offset);
     }
 
     @Override
-    public IngestionShardPointer pointerFromOffset(long offset) {
-        return new KafkaOffset(offset);
+    public IngestionShardPointer pointerFromOffset(String offset) {
+        long offsetValue = Long.parseLong(offset);
+        return new KafkaOffset(offsetValue);
     }
 
     private synchronized List<ReadResult<KafkaOffset, KafkaMessage>> fetch(long startOffset, long maxMessages, int timeoutMillis) {

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaSourceConfig.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaSourceConfig.java
@@ -18,6 +18,7 @@ import java.util.Map;
 public class KafkaSourceConfig {
     private final String PROP_TOPIC = "topic";
     private final String PROP_BOOTSTRAP_SERVERS = "bootstrap_servers";
+    // TODO: support pass any generic kafka configs
     private final String PROP_AUTO_OFFSET_RESET = "auto.offset.reset";
 
     private final String topic;

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaSourceConfig.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaSourceConfig.java
@@ -18,9 +18,11 @@ import java.util.Map;
 public class KafkaSourceConfig {
     private final String PROP_TOPIC = "topic";
     private final String PROP_BOOTSTRAP_SERVERS = "bootstrap_servers";
+    private final String PROP_AUTO_OFFSET_RESET = "auto.offset.reset";
 
     private final String topic;
     private final String bootstrapServers;
+    private final String autoOffsetResetConfig;
 
     /**
      * Constructor
@@ -29,6 +31,7 @@ public class KafkaSourceConfig {
     public KafkaSourceConfig(Map<String, Object> params) {
         this.topic = ConfigurationUtils.readStringProperty(params, PROP_TOPIC);
         this.bootstrapServers = ConfigurationUtils.readStringProperty(params, PROP_BOOTSTRAP_SERVERS);
+        this.autoOffsetResetConfig = ConfigurationUtils.readOptionalStringProperty(params, PROP_AUTO_OFFSET_RESET);
     }
 
     /**
@@ -46,5 +49,14 @@ public class KafkaSourceConfig {
      */
     public String getBootstrapServers() {
         return bootstrapServers;
+    }
+
+    /**
+     * Get the auto offset reset configuration
+     *
+     * @return the auto offset reset configuration
+     */
+    public String getAutoOffsetResetConfig() {
+        return autoOffsetResetConfig;
     }
 }

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionConsumerTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionConsumerTests.java
@@ -96,7 +96,7 @@ public class KafkaPartitionConsumerTests extends OpenSearchTestCase {
             Collections.singletonMap(topicPartition, new org.apache.kafka.clients.consumer.OffsetAndTimestamp(5L, 1000L))
         );
 
-        KafkaOffset offset = (KafkaOffset) consumer.pointerFromTimestampMillis(1000L);
+        KafkaOffset offset = (KafkaOffset) consumer.pointerFromTimestampMillis("1000");
 
         assertEquals(5L, offset.getOffset());
     }

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionConsumerTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionConsumerTests.java
@@ -96,7 +96,7 @@ public class KafkaPartitionConsumerTests extends OpenSearchTestCase {
             Collections.singletonMap(topicPartition, new org.apache.kafka.clients.consumer.OffsetAndTimestamp(5L, 1000L))
         );
 
-        KafkaOffset offset = (KafkaOffset) consumer.pointerFromTimestampMillis("1000");
+        KafkaOffset offset = (KafkaOffset) consumer.pointerFromTimestampMillis(1000);
 
         assertEquals(5L, offset.getOffset());
     }

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionConsumerTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionConsumerTests.java
@@ -90,6 +90,22 @@ public class KafkaPartitionConsumerTests extends OpenSearchTestCase {
         assertEquals(10L, offset.getOffset());
     }
 
+    public void testPointerFromTimestampMillis() {
+        TopicPartition topicPartition = new TopicPartition("test-topic", 0);
+        when(mockConsumer.offsetsForTimes(Collections.singletonMap(topicPartition, 1000L))).thenReturn(
+            Collections.singletonMap(topicPartition, new org.apache.kafka.clients.consumer.OffsetAndTimestamp(5L, 1000L))
+        );
+
+        KafkaOffset offset = (KafkaOffset) consumer.pointerFromTimestampMillis(1000L);
+
+        assertEquals(5L, offset.getOffset());
+    }
+
+    public void testPointerFromOffset() {
+        KafkaOffset offset = new KafkaOffset(5L);
+        assertEquals(5L, offset.getOffset());
+    }
+
     public void testTopicDoesNotExist() {
         Map<String, Object> params = new HashMap<>();
         params.put("topic", "non-existent-topic");

--- a/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
@@ -61,6 +61,9 @@ public class IngestionSource {
         return "IngestionSource{" + "type='" + type + '\'' + ",pointer_init_reset='" + pointerInitReset + '\'' + ", params=" + params + '}';
     }
 
+    /**
+     * Class encapsulating the configuration of a pointer initialization.
+     */
     @ExperimentalApi
     public static class PointerInitReset {
         private final StreamPoller.ResetState type;

--- a/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
@@ -9,6 +9,7 @@
 package org.opensearch.cluster.metadata;
 
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.indices.pollingingest.StreamPoller;
 
 import java.util.Map;
 import java.util.Objects;
@@ -62,19 +63,19 @@ public class IngestionSource {
 
     @ExperimentalApi
     public static class PointerInitReset {
-        private final String type;
-        private final long value;
+        private final StreamPoller.ResetState type;
+        private final String value;
 
-        public PointerInitReset(String policy, long value) {
-            this.type = policy;
+        public PointerInitReset(StreamPoller.ResetState type, String value) {
+            this.type = type;
             this.value = value;
         }
 
-        public String getType() {
+        public StreamPoller.ResetState getType() {
             return type;
         }
 
-        public long getValue() {
+        public String getValue() {
             return value;
         }
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
@@ -19,10 +19,10 @@ import java.util.Objects;
 @ExperimentalApi
 public class IngestionSource {
     private String type;
-    private String pointerInitReset;
+    private PointerInitReset pointerInitReset;
     private Map<String, Object> params;
 
-    public IngestionSource(String type, String pointerInitReset, Map<String, Object> params) {
+    public IngestionSource(String type, PointerInitReset pointerInitReset, Map<String, Object> params) {
         this.type = type;
         this.pointerInitReset = pointerInitReset;
         this.params = params;
@@ -32,7 +32,7 @@ public class IngestionSource {
         return type;
     }
 
-    public String getPointerInitReset() {
+    public PointerInitReset getPointerInitReset() {
         return pointerInitReset;
     }
 
@@ -58,5 +58,42 @@ public class IngestionSource {
     @Override
     public String toString() {
         return "IngestionSource{" + "type='" + type + '\'' + ",pointer_init_reset='" + pointerInitReset + '\'' + ", params=" + params + '}';
+    }
+
+    @ExperimentalApi
+    public static class PointerInitReset {
+        private final String type;
+        private final long value;
+
+        public PointerInitReset(String policy, long value) {
+            this.type = policy;
+            this.value = value;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public long getValue() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            PointerInitReset pointerInitReset = (PointerInitReset) o;
+            return Objects.equals(type, pointerInitReset.type) && Objects.equals(value, pointerInitReset.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(type, value);
+        }
+
+        @Override
+        public String toString() {
+            return "PointerInitReset{" + "type='" + type + '\'' + ", value=" + value + '}';
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -263,6 +263,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 // Settings for ingestion source
                 IndexMetadata.INGESTION_SOURCE_TYPE_SETTING,
                 IndexMetadata.INGESTION_SOURCE_POINTER_INIT_RESET_SETTING,
+                IndexMetadata.INGESTION_SOURCE_POINTER_INIT_RESET_VALUE_SETTING,
                 IndexMetadata.INGESTION_SOURCE_PARAMS_SETTING,
 
                 // validate that built-in similarities don't get redefined

--- a/server/src/main/java/org/opensearch/index/IngestionShardConsumer.java
+++ b/server/src/main/java/org/opensearch/index/IngestionShardConsumer.java
@@ -88,7 +88,7 @@ public interface IngestionShardConsumer<T extends IngestionShardPointer, M exten
      * @param timestampMillis the timestamp in milliseconds
      * @return the ingestion shard pointer corresponding to the given timestamp
      */
-    IngestionShardPointer pointerFromTimestampMillis(long timestampMillis);
+    IngestionShardPointer pointerFromTimestampMillis(String timestampMillis);
 
     /**
      * Returns an ingestion shard pointer based on the provided offset.
@@ -96,7 +96,7 @@ public interface IngestionShardConsumer<T extends IngestionShardPointer, M exten
      * @param offset the offset value
      * @return the ingestion shard pointer corresponding to the given offset
      */
-    IngestionShardPointer pointerFromOffset(long offset);
+    IngestionShardPointer pointerFromOffset(String offset);
 
     /**
      * @return the shard id

--- a/server/src/main/java/org/opensearch/index/IngestionShardConsumer.java
+++ b/server/src/main/java/org/opensearch/index/IngestionShardConsumer.java
@@ -83,6 +83,22 @@ public interface IngestionShardConsumer<T extends IngestionShardPointer, M exten
     IngestionShardPointer latestPointer();
 
     /**
+     * Returns an ingestion shard pointer based on the provided timestamp in milliseconds.
+     *
+     * @param timestampMillis the timestamp in milliseconds
+     * @return the ingestion shard pointer corresponding to the given timestamp
+     */
+    IngestionShardPointer pointerFromTimestampMillis(long timestampMillis);
+
+    /**
+     * Returns an ingestion shard pointer based on the provided offset.
+     *
+     * @param offset the offset value
+     * @return the ingestion shard pointer corresponding to the given offset
+     */
+    IngestionShardPointer pointerFromOffset(long offset);
+
+    /**
      * @return the shard id
      */
     int getShardId();

--- a/server/src/main/java/org/opensearch/index/IngestionShardConsumer.java
+++ b/server/src/main/java/org/opensearch/index/IngestionShardConsumer.java
@@ -88,7 +88,7 @@ public interface IngestionShardConsumer<T extends IngestionShardPointer, M exten
      * @param timestampMillis the timestamp in milliseconds
      * @return the ingestion shard pointer corresponding to the given timestamp
      */
-    IngestionShardPointer pointerFromTimestampMillis(String timestampMillis);
+    IngestionShardPointer pointerFromTimestampMillis(long timestampMillis);
 
     /**
      * Returns an ingestion shard pointer based on the provided offset.

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -173,7 +173,7 @@ public class IngestionEngine extends Engine {
 
         Map<String, String> commitData = commitDataAsMap();
         StreamPoller.ResetState resetState = StreamPoller.ResetState.valueOf(
-            ingestionSource.getPointerInitReset().toUpperCase(Locale.ROOT)
+            ingestionSource.getPointerInitReset().getType().toUpperCase(Locale.ROOT)
         );
         IngestionShardPointer startPointer = null;
         Set<IngestionShardPointer> persistedPointers = new HashSet<>();
@@ -191,7 +191,8 @@ public class IngestionEngine extends Engine {
             resetState = StreamPoller.ResetState.NONE;
         }
 
-        streamPoller = new DefaultStreamPoller(startPointer, persistedPointers, ingestionShardConsumer, this, resetState);
+        long resetValue = ingestionSource.getPointerInitReset().getValue();
+        streamPoller = new DefaultStreamPoller(startPointer, persistedPointers, ingestionShardConsumer, this, resetState, resetValue);
         streamPoller.start();
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -65,7 +65,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -172,9 +171,7 @@ public class IngestionEngine extends Engine {
         logger.info("created ingestion consumer for shard [{}]", engineConfig.getShardId());
 
         Map<String, String> commitData = commitDataAsMap();
-        StreamPoller.ResetState resetState = StreamPoller.ResetState.valueOf(
-            ingestionSource.getPointerInitReset().getType().toUpperCase(Locale.ROOT)
-        );
+        StreamPoller.ResetState resetState = ingestionSource.getPointerInitReset().getType();
         IngestionShardPointer startPointer = null;
         Set<IngestionShardPointer> persistedPointers = new HashSet<>();
         if (commitData.containsKey(StreamPoller.BATCH_START)) {
@@ -191,7 +188,7 @@ public class IngestionEngine extends Engine {
             resetState = StreamPoller.ResetState.NONE;
         }
 
-        long resetValue = ingestionSource.getPointerInitReset().getValue();
+        String resetValue = ingestionSource.getPointerInitReset().getValue();
         streamPoller = new DefaultStreamPoller(startPointer, persistedPointers, ingestionShardConsumer, this, resetState, resetValue);
         streamPoller.start();
     }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -161,7 +161,7 @@ public class DefaultStreamPoller implements StreamPoller {
                             logger.info("Resetting offset by seeking to offset {}", batchStartPointer.asString());
                             break;
                         case REWIND_BY_TIMESTAMP:
-                            batchStartPointer = consumer.pointerFromTimestampMillis(resetValue);
+                            batchStartPointer = consumer.pointerFromTimestampMillis(Long.parseLong(resetValue));
                             logger.info(
                                 "Resetting offset by seeking to timestamp {}, corresponding offset {}",
                                 resetValue,

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -52,7 +52,7 @@ public class DefaultStreamPoller implements StreamPoller {
     private IngestionShardPointer batchStartPointer;
 
     private ResetState resetState;
-    private final long resetValue;
+    private final String resetValue;
 
     private Set<IngestionShardPointer> persistedPointers;
 
@@ -70,7 +70,7 @@ public class DefaultStreamPoller implements StreamPoller {
         IngestionShardConsumer consumer,
         IngestionEngine ingestionEngine,
         ResetState resetState,
-        long resetValue
+        String resetValue
     ) {
         this(
             startPointer,
@@ -88,7 +88,7 @@ public class DefaultStreamPoller implements StreamPoller {
         IngestionShardConsumer consumer,
         MessageProcessorRunnable processorRunnable,
         ResetState resetState,
-        long resetValue
+        String resetValue
     ) {
         this.consumer = Objects.requireNonNull(consumer);
         this.resetState = resetState;

--- a/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
@@ -66,6 +66,8 @@ public interface StreamPoller extends Closeable {
     enum ResetState {
         EARLIEST,
         LATEST,
+        REWIND_BY_OFFSET,
+        REWIND_BY_TIMESTAMP,
         NONE,
     }
 }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.indices.pollingingest;
 
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.IngestionShardPointer;
 
 import java.io.Closeable;
@@ -63,6 +64,7 @@ public interface StreamPoller extends Closeable {
     /**
      *  a reset state to indicate how to reset the pointer
      */
+    @ExperimentalApi
     enum ResetState {
         EARLIEST,
         LATEST,

--- a/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
@@ -15,10 +15,12 @@ import java.util.Map;
 
 public class IngestionSourceTests extends OpenSearchTestCase {
 
+    private final IngestionSource.PointerInitReset pointerInitReset = new IngestionSource.PointerInitReset("pointerInitReset", 0);
+
     public void testConstructorAndGetters() {
         Map<String, Object> params = new HashMap<>();
         params.put("key", "value");
-        IngestionSource source = new IngestionSource("type", "pointerInitReset", params);
+        IngestionSource source = new IngestionSource("type", pointerInitReset, params);
 
         assertEquals("type", source.getType());
         assertEquals("pointerInitReset", source.getPointerInitReset());
@@ -28,38 +30,38 @@ public class IngestionSourceTests extends OpenSearchTestCase {
     public void testEquals() {
         Map<String, Object> params1 = new HashMap<>();
         params1.put("key", "value");
-        IngestionSource source1 = new IngestionSource("type", "pointerInitReset", params1);
+        IngestionSource source1 = new IngestionSource("type", pointerInitReset, params1);
 
         Map<String, Object> params2 = new HashMap<>();
         params2.put("key", "value");
-        IngestionSource source2 = new IngestionSource("type", "pointerInitReset", params2);
+        IngestionSource source2 = new IngestionSource("type", pointerInitReset, params2);
 
         assertTrue(source1.equals(source2));
         assertTrue(source2.equals(source1));
 
-        IngestionSource source3 = new IngestionSource("differentType", "pointerInitReset", params1);
+        IngestionSource source3 = new IngestionSource("differentType", pointerInitReset, params1);
         assertFalse(source1.equals(source3));
     }
 
     public void testHashCode() {
         Map<String, Object> params1 = new HashMap<>();
         params1.put("key", "value");
-        IngestionSource source1 = new IngestionSource("type", "pointerInitReset", params1);
+        IngestionSource source1 = new IngestionSource("type", pointerInitReset, params1);
 
         Map<String, Object> params2 = new HashMap<>();
         params2.put("key", "value");
-        IngestionSource source2 = new IngestionSource("type", "pointerInitReset", params2);
+        IngestionSource source2 = new IngestionSource("type", pointerInitReset, params2);
 
         assertEquals(source1.hashCode(), source2.hashCode());
 
-        IngestionSource source3 = new IngestionSource("differentType", "pointerInitReset", params1);
+        IngestionSource source3 = new IngestionSource("differentType", pointerInitReset, params1);
         assertNotEquals(source1.hashCode(), source3.hashCode());
     }
 
     public void testToString() {
         Map<String, Object> params = new HashMap<>();
         params.put("key", "value");
-        IngestionSource source = new IngestionSource("type", "pointerInitReset", params);
+        IngestionSource source = new IngestionSource("type", pointerInitReset, params);
 
         String expected = "IngestionSource{type='type',pointer_init_reset='pointerInitReset', params={key=value}}";
         assertEquals(expected, source.toString());

--- a/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 public class IngestionSourceTests extends OpenSearchTestCase {
 
-    private final IngestionSource.PointerInitReset pointerInitReset = new IngestionSource.PointerInitReset("pointerInitReset", 0);
+    private final IngestionSource.PointerInitReset pointerInitReset = new IngestionSource.PointerInitReset("pointerInitReset", 1000L);
 
     public void testConstructorAndGetters() {
         Map<String, Object> params = new HashMap<>();
@@ -23,7 +23,8 @@ public class IngestionSourceTests extends OpenSearchTestCase {
         IngestionSource source = new IngestionSource("type", pointerInitReset, params);
 
         assertEquals("type", source.getType());
-        assertEquals("pointerInitReset", source.getPointerInitReset());
+        assertEquals("pointerInitReset", source.getPointerInitReset().getType());
+        assertEquals(1000L, source.getPointerInitReset().getValue());
         assertEquals(params, source.params());
     }
 
@@ -63,7 +64,7 @@ public class IngestionSourceTests extends OpenSearchTestCase {
         params.put("key", "value");
         IngestionSource source = new IngestionSource("type", pointerInitReset, params);
 
-        String expected = "IngestionSource{type='type',pointer_init_reset='pointerInitReset', params={key=value}}";
+        String expected = "IngestionSource{type='type',pointer_init_reset='PointerInitReset{type='pointerInitReset', value=1000}', params={key=value}}";
         assertEquals(expected, source.toString());
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.cluster.metadata;
 
+import org.opensearch.indices.pollingingest.StreamPoller;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.HashMap;
@@ -15,7 +16,10 @@ import java.util.Map;
 
 public class IngestionSourceTests extends OpenSearchTestCase {
 
-    private final IngestionSource.PointerInitReset pointerInitReset = new IngestionSource.PointerInitReset("pointerInitReset", 1000L);
+    private final IngestionSource.PointerInitReset pointerInitReset = new IngestionSource.PointerInitReset(
+        StreamPoller.ResetState.REWIND_BY_OFFSET,
+        "1000"
+    );
 
     public void testConstructorAndGetters() {
         Map<String, Object> params = new HashMap<>();
@@ -23,8 +27,8 @@ public class IngestionSourceTests extends OpenSearchTestCase {
         IngestionSource source = new IngestionSource("type", pointerInitReset, params);
 
         assertEquals("type", source.getType());
-        assertEquals("pointerInitReset", source.getPointerInitReset().getType());
-        assertEquals(1000L, source.getPointerInitReset().getValue());
+        assertEquals(StreamPoller.ResetState.REWIND_BY_OFFSET, source.getPointerInitReset().getType());
+        assertEquals("1000", source.getPointerInitReset().getValue());
         assertEquals(params, source.params());
     }
 
@@ -64,7 +68,8 @@ public class IngestionSourceTests extends OpenSearchTestCase {
         params.put("key", "value");
         IngestionSource source = new IngestionSource("type", pointerInitReset, params);
 
-        String expected = "IngestionSource{type='type',pointer_init_reset='PointerInitReset{type='pointerInitReset', value=1000}', params={key=value}}";
+        String expected =
+            "IngestionSource{type='type',pointer_init_reset='PointerInitReset{type='REWIND_BY_OFFSET', value=1000}', params={key=value}}";
         assertEquals(expected, source.toString());
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
+++ b/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
@@ -94,13 +94,13 @@ public class FakeIngestionSource {
         }
 
         @Override
-        public IngestionShardPointer pointerFromTimestampMillis(long timestampMillis) {
+        public IngestionShardPointer pointerFromTimestampMillis(String timestampMillis) {
             throw new UnsupportedOperationException("Not implemented yet.");
         }
 
         @Override
-        public IngestionShardPointer pointerFromOffset(long offset) {
-            return new FakeIngestionShardPointer(offset);
+        public IngestionShardPointer pointerFromOffset(String offset) {
+            return new FakeIngestionShardPointer(Long.parseLong(offset));
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
+++ b/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
@@ -95,7 +95,7 @@ public class FakeIngestionSource {
 
         @Override
         public IngestionShardPointer pointerFromTimestampMillis(long timestampMillis) {
-            return new FakeIngestionShardPointer(0); // Placeholder implementation
+            throw new UnsupportedOperationException("Not implemented yet.");
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
+++ b/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
@@ -94,7 +94,7 @@ public class FakeIngestionSource {
         }
 
         @Override
-        public IngestionShardPointer pointerFromTimestampMillis(String timestampMillis) {
+        public IngestionShardPointer pointerFromTimestampMillis(long timestampMillis) {
             throw new UnsupportedOperationException("Not implemented yet.");
         }
 

--- a/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
+++ b/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
@@ -94,6 +94,16 @@ public class FakeIngestionSource {
         }
 
         @Override
+        public IngestionShardPointer pointerFromTimestampMillis(long timestampMillis) {
+            return new FakeIngestionShardPointer(0); // Placeholder implementation
+        }
+
+        @Override
+        public IngestionShardPointer pointerFromOffset(long offset) {
+            return new FakeIngestionShardPointer(offset);
+        }
+
+        @Override
         public int getShardId() {
             return shardId;
         }

--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -149,6 +149,22 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         assertEquals(new FakeIngestionSource.FakeIngestionShardPointer(2), poller.getBatchStartPointer());
     }
 
+    public void testResetStateRewindByOffset() throws InterruptedException {
+        poller = new DefaultStreamPoller(
+            new FakeIngestionSource.FakeIngestionShardPointer(2),
+            persistedPointers,
+            fakeConsumer,
+            processorRunnable,
+            StreamPoller.ResetState.REWIND_BY_OFFSET,
+            1L
+        );
+
+        poller.start();
+        Thread.sleep(sleepTime); // Allow some time for the poller to run
+        // 1 message is processed
+        verify(processor, times(1)).process(any(), any());
+    }
+
     public void testStartPollWithoutStart() {
         try {
             poller.startPoll();

--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -52,7 +52,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             persistedPointers,
             fakeConsumer,
             processorRunnable,
-            StreamPoller.ResetState.NONE
+            StreamPoller.ResetState.NONE,
+            0L
         );
     }
 
@@ -90,7 +91,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             persistedPointers,
             fakeConsumer,
             processorRunnable,
-            StreamPoller.ResetState.NONE
+            StreamPoller.ResetState.NONE,
+            0L
         );
         poller.start();
         Thread.sleep(sleepTime); // Allow some time for the poller to run
@@ -118,7 +120,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             persistedPointers,
             fakeConsumer,
             processorRunnable,
-            StreamPoller.ResetState.EARLIEST
+            StreamPoller.ResetState.EARLIEST,
+            0L
         );
 
         poller.start();
@@ -134,7 +137,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             persistedPointers,
             fakeConsumer,
             processorRunnable,
-            StreamPoller.ResetState.LATEST
+            StreamPoller.ResetState.LATEST,
+            0L
         );
 
         poller.start();

--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -20,8 +20,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -34,7 +37,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     private MessageProcessorRunnable.MessageProcessor processor;
     private List<byte[]> messages;
     private Set<IngestionShardPointer> persistedPointers;
-    private final int sleepTime = 300;
+    private final int awaitTime = 300;
 
     @Before
     public void setUp() throws Exception {
@@ -66,16 +69,32 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     }
 
     public void testPauseAndResume() throws InterruptedException {
+        // We'll use a latch that counts the number of messages processed.
+        CountDownLatch pauseLatch = new CountDownLatch(2);
+        doAnswer(invocation -> {
+            pauseLatch.countDown();
+            return null;
+        }).when(processor).process(any(), any());
+
         poller.pause();
         poller.start();
-        Thread.sleep(sleepTime); // Allow some time for the poller to run
+
+        // Wait briefly to ensure that no processing occurs.
+        boolean processedWhilePaused = pauseLatch.await(awaitTime, TimeUnit.MILLISECONDS);
+        // Expecting the latch NOT to reach zero because we are paused.
+        assertFalse("Messages should not be processed while paused", processedWhilePaused);
         assertEquals(DefaultStreamPoller.State.PAUSED, poller.getState());
         assertTrue(poller.isPaused());
-        // no messages are processed
         verify(processor, never()).process(any(), any());
 
+        CountDownLatch resumeLatch = new CountDownLatch(2);
+        doAnswer(invocation -> {
+            resumeLatch.countDown();
+            return null;
+        }).when(processor).process(any(), any());
+
         poller.resume();
-        Thread.sleep(sleepTime); // Allow some time for the poller to run
+        resumeLatch.await();
         assertFalse(poller.isPaused());
         // 2 messages are processed
         verify(processor, times(2)).process(any(), any());
@@ -94,8 +113,15 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             StreamPoller.ResetState.NONE,
             ""
         );
+
+        CountDownLatch latch = new CountDownLatch(2);
+        doAnswer(invocation -> {
+            latch.countDown();
+            return null;
+        }).when(processor).process(any(), any());
+
         poller.start();
-        Thread.sleep(sleepTime); // Allow some time for the poller to run
+        latch.await();
         // 2 messages are processed, 2 messages are skipped
         verify(processor, times(2)).process(any(), any());
         assertEquals(new FakeIngestionSource.FakeIngestionShardPointer(2), poller.getMaxPersistedPointer());
@@ -108,7 +134,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
 
     public void testClose() throws InterruptedException {
         poller.start();
-        Thread.sleep(sleepTime); // Allow some time for the poller to run
+        waitUntil(() -> poller.getState() == DefaultStreamPoller.State.POLLING, awaitTime, TimeUnit.MILLISECONDS);
         poller.close();
         assertTrue(poller.isClosed());
         assertEquals(DefaultStreamPoller.State.CLOSED, poller.getState());
@@ -123,9 +149,14 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             StreamPoller.ResetState.EARLIEST,
             ""
         );
+        CountDownLatch latch = new CountDownLatch(2);
+        doAnswer(invocation -> {
+            latch.countDown();
+            return null;
+        }).when(processor).process(any(), any());
 
         poller.start();
-        Thread.sleep(sleepTime); // Allow some time for the poller to run
+        latch.await();
 
         // 2 messages are processed
         verify(processor, times(2)).process(any(), any());
@@ -142,7 +173,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         );
 
         poller.start();
-        Thread.sleep(sleepTime); // Allow some time for the poller to run
+        waitUntil(() -> poller.getState() == DefaultStreamPoller.State.POLLING, awaitTime, TimeUnit.MILLISECONDS);
         // no messages processed
         verify(processor, never()).process(any(), any());
         // reset to the latest
@@ -158,9 +189,14 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             StreamPoller.ResetState.REWIND_BY_OFFSET,
             "1"
         );
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            latch.countDown();
+            return null;
+        }).when(processor).process(any(), any());
 
         poller.start();
-        Thread.sleep(sleepTime); // Allow some time for the poller to run
+        latch.await();
         // 1 message is processed
         verify(processor, times(1)).process(any(), any());
     }
@@ -176,7 +212,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
 
     public void testStartClosedPoller() throws InterruptedException {
         poller.start();
-        Thread.sleep(sleepTime);
+        waitUntil(() -> poller.getState() == DefaultStreamPoller.State.POLLING, awaitTime, TimeUnit.MILLISECONDS);
         poller.close();
         try {
             poller.startPoll();

--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -53,7 +53,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             fakeConsumer,
             processorRunnable,
             StreamPoller.ResetState.NONE,
-            0L
+            ""
         );
     }
 
@@ -92,7 +92,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             fakeConsumer,
             processorRunnable,
             StreamPoller.ResetState.NONE,
-            0L
+            ""
         );
         poller.start();
         Thread.sleep(sleepTime); // Allow some time for the poller to run
@@ -121,7 +121,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             fakeConsumer,
             processorRunnable,
             StreamPoller.ResetState.EARLIEST,
-            0L
+            ""
         );
 
         poller.start();
@@ -138,7 +138,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             fakeConsumer,
             processorRunnable,
             StreamPoller.ResetState.LATEST,
-            0L
+            ""
         );
 
         poller.start();
@@ -156,7 +156,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             fakeConsumer,
             processorRunnable,
             StreamPoller.ResetState.REWIND_BY_OFFSET,
-            1L
+            "1"
         );
 
         poller.start();


### PR DESCRIPTION
### Description
This PR supports starting the ingestion from a user-specified timestamp or offset when creating the new index.
- added two new ResetState: `REWIND_BY_OFFSET` and `REWIND_BY_TIMESTAMP`
- added new setting `ingestion_source.pointer.init.reset.value` to `IndexMetadata`, controls the rewind offset or timestamp in millis
- added corresponding integration tests


### Related Issues
Resolves #17318 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
