### PR TITLE
fix: correct decimal detection in range filtering issue#17247

### DIFF
--- a/server/src/main/java/org/opensearch/search/startree/filter/provider/DimensionFilterMapper.java
+++ b/server/src/main/java/org/opensearch/search/startree/filter/provider/DimensionFilterMapper.java
@@ -161,14 +161,14 @@ abstract class NumericNonDecimalMapper extends NumericMapper {
         Long parsedLow = rawLow == null ? defaultMinimum() : numberFieldType.numberType().parse(rawLow, true).longValue();
         Long parsedHigh = rawHigh == null ? defaultMaximum() : numberFieldType.numberType().parse(rawHigh, true).longValue();
 
-        boolean lowerTermHasDecimalPart = hasDecimalPart(parsedLow);
+        boolean lowerTermHasDecimalPart = hasDecimalPart(rawLow);
         if ((lowerTermHasDecimalPart == false && includeLow == false) || (lowerTermHasDecimalPart && signum(parsedLow) > 0)) {
             if (parsedLow.equals(defaultMaximum())) {
                 return new MatchNoneFilter();
             }
             ++parsedLow;
         }
-        boolean upperTermHasDecimalPart = hasDecimalPart(parsedHigh);
+        boolean upperTermHasDecimalPart = hasDecimalPart(rawHigh);
         if ((upperTermHasDecimalPart == false && includeHigh == false) || (upperTermHasDecimalPart && signum(parsedHigh) < 0)) {
             if (parsedHigh.equals(defaultMinimum())) {
                 return new MatchNoneFilter();


### PR DESCRIPTION
### Description
Previously, hasDecimalPart(parsedLow) and hasDecimalPart(parsedHigh) were used after converting values to Long, causing loss of decimal precision and incorrect range adjustments.

Now, hasDecimalPart(rawLow) and hasDecimalPart(rawHigh) are used instead, ensuring proper detection before conversion and preventing off-by-one errors in range filters.

### Related Issues
Resolves #17247 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing. (Working on them...)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
