### PR TITLE
[Flaky Test] Fix Flaky Test ShuffleForcedMergePolicyTests.testDiagnostics

### DIFF
--- a/server/src/test/java/org/opensearch/lucene/index/ShuffleForcedMergePolicyTests.java
+++ b/server/src/test/java/org/opensearch/lucene/index/ShuffleForcedMergePolicyTests.java
@@ -43,6 +43,7 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.TieredMergePolicy;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.Directory;
@@ -59,13 +60,17 @@ public class ShuffleForcedMergePolicyTests extends BaseMergePolicyTestCase {
     public void testDiagnostics() throws IOException {
         try (Directory dir = newDirectory()) {
             IndexWriterConfig iwc = newIndexWriterConfig().setMaxFullFlushMergeWaitMillis(0);
-            MergePolicy mp = new ShuffleForcedMergePolicy(newTieredMergePolicy());
+            TieredMergePolicy tieredMergePolicy = newTieredMergePolicy();
+            // ensure only trigger one Merge when flushing, and there are remaining segments to be force merged
+            tieredMergePolicy.setSegmentsPerTier(8);
+            tieredMergePolicy.setMaxMergeAtOnce(8);
+            MergePolicy mp = new ShuffleForcedMergePolicy(tieredMergePolicy);
             iwc.setMergePolicy(mp);
             boolean sorted = random().nextBoolean();
             if (sorted) {
                 iwc.setIndexSort(new Sort(new SortField("sort", SortField.Type.INT)));
             }
-            int numDocs = atLeast(100);
+            int numDocs = 90 + random().nextInt(10);
 
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
                 for (int i = 0; i < numDocs; i++) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
There is a situation where all segments are triggered to  merged into one segment before forceMerging.  When forceMerge is called, there will be no segments to merge.

`reader.leaves()` contains the segments being merged.

It may be caused by upgrading to lucene10.

### Related Issues
Resolves #17294
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
