### PR TITLE
[Pull-based Ingestion] Add error handling strategy to pull-based ingestion

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added offset management for the pull-based Ingestion ([#17354](https://github.com/opensearch-project/OpenSearch/pull/17354))
 - Add filter function for AbstractQueryBuilder, BoolQueryBuilder, ConstantScoreQueryBuilder([#17409](https://github.com/opensearch-project/OpenSearch/pull/17409))
 - [Star Tree] [Search] Resolving keyword & numeric bucket aggregation with metric aggregation using star-tree ([#17165](https://github.com/opensearch-project/OpenSearch/pull/17165))
+- Added error handling support for the pull-based ingestion ([#17427](https://github.com/opensearch-project/OpenSearch/pull/17427))
 
 ### Dependencies
 - Update Apache Lucene to 10.1.0 ([#16366](https://github.com/opensearch-project/OpenSearch/pull/16366))

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
@@ -133,6 +133,11 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
     }
 
     @Override
+    public KafkaOffset nextPointer(KafkaOffset pointer) {
+        return new KafkaOffset(pointer.getOffset() + 1);
+    }
+
+    @Override
     public IngestionShardPointer earliestPointer() {
         long startOffset = AccessController.doPrivileged(
             (PrivilegedAction<Long>) () -> consumer.beginningOffsets(Collections.singletonList(topicPartition))

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -771,28 +771,13 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         Property.Final
     );
 
-    public static final String SETTING_INGESTION_SOURCE_ERROR_STRATEGY = "index.ingestion_source.error.strategy";
-    public static final Setting<String> INGESTION_SOURCE_ERROR_STRATEGY_SETTING = Setting.simpleString(
+    public static final String SETTING_INGESTION_SOURCE_ERROR_STRATEGY = "index.ingestion_source.error_strategy";
+    public static final Setting<IngestionErrorStrategy.ErrorStrategy> INGESTION_SOURCE_ERROR_STRATEGY_SETTING = new Setting<>(
         SETTING_INGESTION_SOURCE_ERROR_STRATEGY,
         IngestionErrorStrategy.ErrorStrategy.DROP.name(),
-        new Setting.Validator<>() {
-
-            @Override
-            public void validate(final String value) {
-                try {
-                    IngestionErrorStrategy.ErrorStrategy.valueOf(value.toUpperCase(Locale.ROOT));
-                } catch (IllegalArgumentException e) {
-                    throw new IllegalArgumentException("Invalid value for " + SETTING_INGESTION_SOURCE_ERROR_STRATEGY + " [" + value + "]");
-                }
-            }
-
-            @Override
-            public void validate(final String value, final Map<Setting<?>, Object> settings) {
-                validate(value);
-            }
-        },
-        Property.IndexScope,
-        Property.Dynamic
+        IngestionErrorStrategy.ErrorStrategy::parseFromString,
+        (errorStrategy) -> {},
+        Property.IndexScope
     );
 
     public static final Setting.AffixSetting<Object> INGESTION_SOURCE_PARAMS_SETTING = Setting.prefixKeySetting(
@@ -1030,10 +1015,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 pointerInitResetValue
             );
 
-            final String errorStrategyString = INGESTION_SOURCE_ERROR_STRATEGY_SETTING.get(settings);
-            IngestionErrorStrategy.ErrorStrategy errorStrategy = IngestionErrorStrategy.ErrorStrategy.valueOf(
-                errorStrategyString.toUpperCase(Locale.ROOT)
-            );
+            final IngestionErrorStrategy.ErrorStrategy errorStrategy = INGESTION_SOURCE_ERROR_STRATEGY_SETTING.get(settings);
             final Map<String, Object> ingestionSourceParams = INGESTION_SOURCE_PARAMS_SETTING.getAsMap(settings);
             return new IngestionSource(ingestionSourceType, pointerInitReset, errorStrategy, ingestionSourceParams);
         }

--- a/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
@@ -9,6 +9,7 @@
 package org.opensearch.cluster.metadata;
 
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.indices.pollingingest.IngestionErrorStrategy;
 import org.opensearch.indices.pollingingest.StreamPoller;
 
 import java.util.Map;
@@ -21,12 +22,19 @@ import java.util.Objects;
 public class IngestionSource {
     private String type;
     private PointerInitReset pointerInitReset;
+    private IngestionErrorStrategy.ErrorStrategy errorStrategy;
     private Map<String, Object> params;
 
-    public IngestionSource(String type, PointerInitReset pointerInitReset, Map<String, Object> params) {
+    public IngestionSource(
+        String type,
+        PointerInitReset pointerInitReset,
+        IngestionErrorStrategy.ErrorStrategy errorStrategy,
+        Map<String, Object> params
+    ) {
         this.type = type;
         this.pointerInitReset = pointerInitReset;
         this.params = params;
+        this.errorStrategy = errorStrategy;
     }
 
     public String getType() {
@@ -35,6 +43,10 @@ public class IngestionSource {
 
     public PointerInitReset getPointerInitReset() {
         return pointerInitReset;
+    }
+
+    public IngestionErrorStrategy.ErrorStrategy getErrorStrategy() {
+        return errorStrategy;
     }
 
     public Map<String, Object> params() {
@@ -48,17 +60,30 @@ public class IngestionSource {
         IngestionSource ingestionSource = (IngestionSource) o;
         return Objects.equals(type, ingestionSource.type)
             && Objects.equals(pointerInitReset, ingestionSource.pointerInitReset)
+            && Objects.equals(errorStrategy, ingestionSource.errorStrategy)
             && Objects.equals(params, ingestionSource.params);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, pointerInitReset, params);
+        return Objects.hash(type, pointerInitReset, params, errorStrategy);
     }
 
     @Override
     public String toString() {
-        return "IngestionSource{" + "type='" + type + '\'' + ",pointer_init_reset='" + pointerInitReset + '\'' + ", params=" + params + '}';
+        return "IngestionSource{"
+            + "type='"
+            + type
+            + '\''
+            + ",pointer_init_reset='"
+            + pointerInitReset
+            + '\''
+            + ",error_strategy='"
+            + errorStrategy
+            + '\''
+            + ", params="
+            + params
+            + '}';
     }
 
     /**

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -266,6 +266,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexMetadata.INGESTION_SOURCE_POINTER_INIT_RESET_SETTING,
                 IndexMetadata.INGESTION_SOURCE_POINTER_INIT_RESET_VALUE_SETTING,
                 IndexMetadata.INGESTION_SOURCE_PARAMS_SETTING,
+                IndexMetadata.INGESTION_SOURCE_ERROR_STRATEGY_SETTING,
 
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {

--- a/server/src/main/java/org/opensearch/index/IngestionShardConsumer.java
+++ b/server/src/main/java/org/opensearch/index/IngestionShardConsumer.java
@@ -73,6 +73,11 @@ public interface IngestionShardConsumer<T extends IngestionShardPointer, M exten
     T nextPointer();
 
     /**
+     * @return the immediate next pointer from the provided start pointer
+     */
+    T nextPointer(T startPointer);
+
+    /**
      * @return the earliest pointer in the shard
      */
     IngestionShardPointer earliestPointer();

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -30,6 +30,7 @@ import org.opensearch.index.translog.TranslogStats;
 import org.opensearch.index.translog.listener.CompositeTranslogEventListener;
 import org.opensearch.indices.pollingingest.DefaultStreamPoller;
 import org.opensearch.indices.pollingingest.PollingIngestStats;
+import org.opensearch.indices.pollingingest.IngestionErrorStrategy;
 import org.opensearch.indices.pollingingest.StreamPoller;
 
 import java.io.IOException;
@@ -99,12 +100,21 @@ public class IngestionEngine extends InternalEngine {
         }
 
         String resetValue = ingestionSource.getPointerInitReset().getValue();
-        streamPoller = new DefaultStreamPoller(startPointer, persistedPointers, ingestionShardConsumer, this, resetState, resetValue);
+        IngestionErrorStrategy ingestionErrorStrategy = IngestionErrorStrategy.create(
+            ingestionSource.getErrorStrategy(),
+            ingestionSource.getType()
+        );
 
-        // Poller is only started on the primary shard. Replica shards will rely on segment replication.
-        if (!engineConfig.isReadOnlyReplica()) {
-            streamPoller.start();
-        }
+        streamPoller = new DefaultStreamPoller(
+            startPointer,
+            persistedPointers,
+            ingestionShardConsumer,
+            this,
+            resetState,
+            resetValue,
+            ingestionErrorStrategy
+        );
+        streamPoller.start();
     }
 
     protected Set<IngestionShardPointer> fetchPersistedOffsets(DirectoryReader directoryReader, IngestionShardPointer batchStart)

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -29,8 +29,8 @@ import org.opensearch.index.translog.TranslogManager;
 import org.opensearch.index.translog.TranslogStats;
 import org.opensearch.index.translog.listener.CompositeTranslogEventListener;
 import org.opensearch.indices.pollingingest.DefaultStreamPoller;
-import org.opensearch.indices.pollingingest.PollingIngestStats;
 import org.opensearch.indices.pollingingest.IngestionErrorStrategy;
+import org.opensearch.indices.pollingingest.PollingIngestStats;
 import org.opensearch.indices.pollingingest.StreamPoller;
 
 import java.io.IOException;

--- a/server/src/main/java/org/opensearch/indices/pollingingest/BlockIngestionErrorStrategy.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/BlockIngestionErrorStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.pollingingest;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * This error handling strategy blocks on failures preventing processing of remaining updates in the ingestion source.
+ */
+public class BlockIngestionErrorStrategy implements IngestionErrorStrategy {
+    private static final Logger logger = LogManager.getLogger(BlockIngestionErrorStrategy.class);
+    private final String ingestionSource;
+
+    public BlockIngestionErrorStrategy(String ingestionSource) {
+        this.ingestionSource = ingestionSource;
+    }
+
+    @Override
+    public void handleError(Throwable e, ErrorStage stage) {
+        logger.error("Error processing update from {}: {}", ingestionSource, e);
+
+        // todo: record blocking update and emit metrics
+    }
+
+    @Override
+    public boolean shouldPauseIngestion(Throwable e, ErrorStage stage) {
+        return true;
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DropIngestionErrorStrategy.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DropIngestionErrorStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.pollingingest;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * This error handling strategy drops failures and proceeds with remaining updates in the ingestion source.
+ */
+public class DropIngestionErrorStrategy implements IngestionErrorStrategy {
+    private static final Logger logger = LogManager.getLogger(DropIngestionErrorStrategy.class);
+    private final String ingestionSource;
+
+    public DropIngestionErrorStrategy(String ingestionSource) {
+        this.ingestionSource = ingestionSource;
+    }
+
+    @Override
+    public void handleError(Throwable e, ErrorStage stage) {
+        logger.error("Error processing update from {}: {}", ingestionSource, e);
+
+        // todo: record failed update stats and emit metrics
+    }
+
+    @Override
+    public boolean shouldPauseIngestion(Throwable e, ErrorStage stage) {
+        return false;
+    }
+
+}

--- a/server/src/main/java/org/opensearch/indices/pollingingest/IngestionErrorStrategy.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/IngestionErrorStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.pollingingest;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+/**
+ * Defines the error handling strategy when an error is encountered either during polling records from ingestion source
+ * or during processing the polled records.
+ */
+@ExperimentalApi
+public interface IngestionErrorStrategy {
+
+    /**
+     * Process and record the error.
+     */
+    void handleError(Throwable e, ErrorStage stage);
+
+    /**
+     * Indicates if ingestion must be paused, blocking further writes.
+     */
+    boolean shouldPauseIngestion(Throwable e, ErrorStage stage);
+
+    static IngestionErrorStrategy create(ErrorStrategy errorStrategy, String ingestionSource) {
+        switch (errorStrategy) {
+            case BLOCK:
+                return new BlockIngestionErrorStrategy(ingestionSource);
+            case DROP:
+            default:
+                return new DropIngestionErrorStrategy(ingestionSource);
+        }
+    }
+
+    /**
+     * Indicates available error handling strategies
+     */
+    @ExperimentalApi
+    enum ErrorStrategy {
+        DROP,
+        BLOCK
+    }
+
+    /**
+     * Indicates different stages of encountered errors
+     */
+    @ExperimentalApi
+    enum ErrorStage {
+        POLLING,
+        PROCESSING
+    }
+
+}

--- a/server/src/main/java/org/opensearch/indices/pollingingest/IngestionErrorStrategy.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/IngestionErrorStrategy.java
@@ -10,6 +10,8 @@ package org.opensearch.indices.pollingingest;
 
 import org.opensearch.common.annotation.ExperimentalApi;
 
+import java.util.Locale;
+
 /**
  * Defines the error handling strategy when an error is encountered either during polling records from ingestion source
  * or during processing the polled records.
@@ -43,7 +45,15 @@ public interface IngestionErrorStrategy {
     @ExperimentalApi
     enum ErrorStrategy {
         DROP,
-        BLOCK
+        BLOCK;
+
+        public static ErrorStrategy parseFromString(String errorStrategy) {
+            try {
+                return ErrorStrategy.valueOf(errorStrategy.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid ingestion errorStrategy: " + errorStrategy, e);
+            }
+        }
     }
 
     /**

--- a/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
@@ -14,6 +14,8 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.opensearch.indices.pollingingest.IngestionErrorStrategy.ErrorStrategy.DROP;
+
 public class IngestionSourceTests extends OpenSearchTestCase {
 
     private final IngestionSource.PointerInitReset pointerInitReset = new IngestionSource.PointerInitReset(
@@ -24,52 +26,50 @@ public class IngestionSourceTests extends OpenSearchTestCase {
     public void testConstructorAndGetters() {
         Map<String, Object> params = new HashMap<>();
         params.put("key", "value");
-        IngestionSource source = new IngestionSource("type", pointerInitReset, params);
+        IngestionSource source = new IngestionSource("type", pointerInitReset, DROP, params);
 
         assertEquals("type", source.getType());
         assertEquals(StreamPoller.ResetState.REWIND_BY_OFFSET, source.getPointerInitReset().getType());
         assertEquals("1000", source.getPointerInitReset().getValue());
+        assertEquals(DROP, source.getErrorStrategy());
         assertEquals(params, source.params());
     }
 
     public void testEquals() {
         Map<String, Object> params1 = new HashMap<>();
         params1.put("key", "value");
-        IngestionSource source1 = new IngestionSource("type", pointerInitReset, params1);
+        IngestionSource source1 = new IngestionSource("type", pointerInitReset, DROP, params1);
 
         Map<String, Object> params2 = new HashMap<>();
         params2.put("key", "value");
-        IngestionSource source2 = new IngestionSource("type", pointerInitReset, params2);
-
+        IngestionSource source2 = new IngestionSource("type", pointerInitReset, DROP, params2);
         assertTrue(source1.equals(source2));
         assertTrue(source2.equals(source1));
 
-        IngestionSource source3 = new IngestionSource("differentType", pointerInitReset, params1);
+        IngestionSource source3 = new IngestionSource("differentType", pointerInitReset, DROP, params1);
         assertFalse(source1.equals(source3));
     }
 
     public void testHashCode() {
         Map<String, Object> params1 = new HashMap<>();
         params1.put("key", "value");
-        IngestionSource source1 = new IngestionSource("type", pointerInitReset, params1);
+        IngestionSource source1 = new IngestionSource("type", pointerInitReset, DROP, params1);
 
         Map<String, Object> params2 = new HashMap<>();
         params2.put("key", "value");
-        IngestionSource source2 = new IngestionSource("type", pointerInitReset, params2);
-
+        IngestionSource source2 = new IngestionSource("type", pointerInitReset, DROP, params2);
         assertEquals(source1.hashCode(), source2.hashCode());
 
-        IngestionSource source3 = new IngestionSource("differentType", pointerInitReset, params1);
+        IngestionSource source3 = new IngestionSource("differentType", pointerInitReset, DROP, params1);
         assertNotEquals(source1.hashCode(), source3.hashCode());
     }
 
     public void testToString() {
         Map<String, Object> params = new HashMap<>();
         params.put("key", "value");
-        IngestionSource source = new IngestionSource("type", pointerInitReset, params);
-
+        IngestionSource source = new IngestionSource("type", pointerInitReset, DROP, params);
         String expected =
-            "IngestionSource{type='type',pointer_init_reset='PointerInitReset{type='REWIND_BY_OFFSET', value=1000}', params={key=value}}";
+            "IngestionSource{type='type',pointer_init_reset='PointerInitReset{type='REWIND_BY_OFFSET', value=1000}',error_strategy='DROP', params={key=value}}";
         assertEquals(expected, source.toString());
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
+++ b/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
@@ -84,6 +84,11 @@ public class FakeIngestionSource {
         }
 
         @Override
+        public FakeIngestionShardPointer nextPointer(FakeIngestionShardPointer startPointer) {
+            return new FakeIngestionShardPointer(startPointer.offset + 1);
+        }
+
+        @Override
         public FakeIngestionShardPointer earliestPointer() {
             return new FakeIngestionShardPointer(0);
         }


### PR DESCRIPTION
### Description
This PR is a follow up for [pull-based-ingestion](https://github.com/opensearch-project/OpenSearch/pull/16958) to add error handling support. We introduce the following two strategies:
1. DROP: Drop errors and proceed with remaining updates in the ingestion source.
2. BLOCK: Block on any errors, preventing further writes.

This PR adds the drop/block support along with required interfaces. A follow up PR will add metric emission and record the errors.

When using Block strategy, we need a way to allow users to resume ingestion. Ingestion management APIs will be added to allow users more flexibility as part of https://github.com/opensearch-project/OpenSearch/issues/17442

### Related Issues
Resolves #17085

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
