### PR TITLE
Fix flaky tests from`SegmentReplicationAllocationIT`

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -170,16 +170,14 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
 
         // Remove a node
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(nodeNames.get(0)));
-        internalCluster().validateClusterFormed();
-        ensureGreen(TimeValue.timeValueSeconds(120));
+        ensureGreen(TimeValue.timeValueSeconds(60));
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         logger.info(ShardAllocations.printShardDistribution(state));
         verifyPerIndexPrimaryBalance();
 
         // Add a new node
         internalCluster().startDataOnlyNode();
-        internalCluster().validateClusterFormed();
-        ensureGreen(TimeValue.timeValueSeconds(120));
+        ensureGreen(TimeValue.timeValueSeconds(60));
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         logger.info(ShardAllocations.printShardDistribution(state));
         verifyPerIndexPrimaryBalance();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -364,17 +364,12 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
                 totalPrimaryShards += index.primaryShardsActive();
             }
             final int avgPrimaryShardsPerNode = (int) Math.ceil(totalPrimaryShards * 1f / currentState.getRoutingNodes().size());
-            logger.info("--> totalPrimaryShards = {}", totalPrimaryShards);
-            logger.info("--> totalNodes = {}", currentState.getRoutingNodes().size());
-            logger.info("--> avgPrimaryShardsPerNode = {}", avgPrimaryShardsPerNode);
-            logger.info("--> UL = {}", avgPrimaryShardsPerNode * (1 + buffer));
             for (RoutingNode node : nodes) {
                 final int primaryCount = node.shardsWithState(STARTED)
                     .stream()
                     .filter(ShardRouting::primary)
                     .collect(Collectors.toList())
                     .size();
-                logger.info("--> {}: primaryCount = {}", node.nodeId(), primaryCount);
                 assertTrue(primaryCount <= (avgPrimaryShardsPerNode * (1 + buffer)));
             }
         }, 60, TimeUnit.SECONDS);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -170,14 +170,16 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
 
         // Remove a node
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(nodeNames.get(0)));
-        ensureGreen(TimeValue.timeValueSeconds(60));
+        internalCluster().validateClusterFormed();
+        ensureGreen(TimeValue.timeValueSeconds(100));
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         logger.info(ShardAllocations.printShardDistribution(state));
         verifyPerIndexPrimaryBalance();
 
         // Add a new node
         internalCluster().startDataOnlyNode();
-        ensureGreen(TimeValue.timeValueSeconds(60));
+        internalCluster().validateClusterFormed();
+        ensureGreen(TimeValue.timeValueSeconds(100));
         state = client().admin().cluster().prepareState().execute().actionGet().getState();
         logger.info(ShardAllocations.printShardDistribution(state));
         verifyPerIndexPrimaryBalance();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -254,19 +254,19 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
         final int maxReplicaCount = 2;
         final int maxShardCount = 2;
         final int numberOfIndices = randomIntBetween(1, 10);
+        final int maxPossibleShards = numberOfIndices * maxShardCount * (1 + maxReplicaCount);
 
         List<List<Integer>> shardAndReplicaCounts = new ArrayList<>();
-        int shardCount, replicaCount, totalPrimaryShards = 0;
+        int shardCount, replicaCount, totalShards = 0;
         for (int i = 0; i < numberOfIndices; i++) {
             shardCount = randomIntBetween(1, maxShardCount);
             replicaCount = randomIntBetween(1, maxReplicaCount);
             shardAndReplicaCounts.add(Arrays.asList(shardCount, replicaCount));
-            totalPrimaryShards += shardCount;
+            totalShards += shardCount * (1 + replicaCount);
         }
-
-        // Create a strictly higher number of nodes than number of shards to reduce chances of SameShardAllocationDecider kicking-in
+        // Create a strictly higher number of nodes than the number of shards to reduce chances of SameShardAllocationDecider kicking-in
         // and preventing primary relocations
-        final int nodeCount = randomIntBetween(Math.max(3, totalPrimaryShards + 1), numberOfIndices * maxShardCount + 1);
+        final int nodeCount = randomIntBetween(totalShards, maxPossibleShards) + 1;
         final float buffer = randomIntBetween(1, 4) * 0.10f;
         logger.info("--> Creating {} nodes", nodeCount);
         final List<String> nodeNames = new ArrayList<>();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/SegmentReplicationAllocationIT.java
@@ -253,7 +253,7 @@ public class SegmentReplicationAllocationIT extends SegmentReplicationBaseIT {
         internalCluster().startClusterManagerOnlyNode();
         final int maxReplicaCount = 2;
         final int maxShardCount = 2;
-        final int numberOfIndices = randomIntBetween(1, 10);
+        final int numberOfIndices = randomIntBetween(1, 3);
         final int maxPossibleShards = numberOfIndices * maxShardCount * (1 + maxReplicaCount);
 
         List<List<Integer>> shardAndReplicaCounts = new ArrayList<>();


### PR DESCRIPTION
### Description

#### `testAllocationAndRebalanceWithDisruption`
* In the original test, we needed to make sure that the cluster had more no. of data nodes than the number of shard copies but it was not actually a guarantee leading to the flaky nature of tests.
* We are now pre-generating the random index/shard counts and then spawning the data nodes accordingly.
* Also decreased the upper limit on number of indices because original limit would have caused spawning of as high as 60 data nodes (`10 * 2 * (1 + 2)`) which was causing transport related failures unrelated to the scope of the test.
* Tested the new changes with ~3.4K consecutive IT runs without any failures
```
BUILD SUCCESSFUL in 18s
60 actionable tasks: 1 executed, 59 up-to-date
[2025-02-22 23:19:08] : ===================================================================
[2025-02-22 23:19:08] : counter=3412
[2025-02-22 23:19:08] : ===================================================================
```

#### `testSingleIndexShardAllocation`
* Based on the failure logs from recent PR builds ([examples](https://metrics.opensearch.org/_dashboards/app/dashboards#/view/e5e64d40-ed31-11ee-be99-69d1dbc75083?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-90d,to:now))&_a=(description:'',filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'2e729590-eb26-11ee-b008-6583d3dd450c',key:test_name,negate:!f,params:(query:org.opensearch.indices.replication.SegmentReplicationAllocationIT.testSingleIndexShardAllocation),type:phrase),query:(match_phrase:(test_name:org.opensearch.indices.replication.SegmentReplicationAllocationIT.testSingleIndexShardAllocation)))),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:SegmentReplicationAllocationIT),timeRestore:!t,title:'OpenSearch%20Gradle%20Check%20Report',viewMode:view))), we can see that the test used to fail occasionally with
```
java.lang.AssertionError: timed out waiting for green state
	at __randomizedtesting.SeedInfo.seed([7386032F53A52312:A9C55268C678FC7D]:0)
	at org.junit.Assert.fail(Assert.java:89)
	at org.opensearch.test.OpenSearchIntegTestCase.ensureColor(OpenSearchIntegTestCase.java:981)
	at org.opensearch.test.OpenSearchIntegTestCase.ensureColor(OpenSearchIntegTestCase.java:933)
	at org.opensearch.test.OpenSearchIntegTestCase.ensureGreen(OpenSearchIntegTestCase.java:898)
	at org.opensearch.indices.replication.SegmentReplicationAllocationIT.testSingleIndexShardAllocation(SegmentReplicationAllocationIT.java:179)
```
* The test creates an index with 50 shards, each with 1 replica. Thus upon removal/addition of a node in the test, the relocations end up taking longer than the previously stipulated 60 seconds:
```
ensureGreen(TimeValue.timeValueSeconds(60));
```
* Confirmed this by lowering the await time and the test started failing more frequently.
* As a fix we have increased the the await time and also added an extra check for cluster's stability:
```
internalCluster().validateClusterFormed();
ensureGreen(TimeValue.timeValueSeconds(100));
``` 
* Tested the new changes with ~2.5K+ consecutive IT runs without any failures
```
BUILD SUCCESSFUL in 27s
60 actionable tasks: 1 executed, 59 up-to-date
[2025-02-24 23:44:43] : ===================================================================
[2025-02-24 23:44:43] : counter=2506
[2025-02-24 23:44:43] : ===================================================================
```

### Related Issues
Resolves #14327

### Check List
- [x] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
