### PR TITLE
[Backport] [2.x] Update Andriy Redko (https://github.com/reta) affiliation (#17430)

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,7 +8,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 |--------------------------|---------------------------------------------------------|-------------|
 | Anas Alkouz              | [anasalkouz](https://github.com/anasalkouz)             | Amazon      |
 | Andrew Ross              | [andrross](https://github.com/andrross)                 | Amazon      |
-| Andriy Redko             | [reta](https://github.com/reta)                         | Aiven       |
+| Andriy Redko             | [reta](https://github.com/reta)                         | Independent |
 | Ankit Jain               | [jainankitk](https://github.com/jainankitk)             | Amazon      |
 | Ashish Singh             | [ashking94](https://github.com/ashking94)               | Amazon      |
 | Bukhtawar Khan           | [Bukhtawar](https://github.com/Bukhtawar)               | Amazon      |


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/17430 to `2.x`