### PR TITLE
[Pull-based Ingestion] add basic NodeStats metrics

### DIFF
--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
@@ -16,6 +16,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.indices.pollingingest.PollingIngestStats;
 import org.opensearch.plugins.PluginInfo;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.junit.Assert;
@@ -75,6 +76,10 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
             refresh("test");
             SearchResponse response = client().prepareSearch("test").setQuery(query).get();
             assertThat(response.getHits().getTotalHits().value(), is(1L));
+            PollingIngestStats stats = client().admin().indices().prepareStats("test").get().getIndex("test").getShards()[0].getPollingIngestStats();
+            assertNotNull(stats);
+            assertThat(stats.getMessageProcessorStats().getTotalProcessedCount(), is(2L));
+            assertThat(stats.getConsumerStats().getTotalPolledCount(), is(2L));
         });
     }
 

--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
@@ -76,7 +76,8 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
             refresh("test");
             SearchResponse response = client().prepareSearch("test").setQuery(query).get();
             assertThat(response.getHits().getTotalHits().value(), is(1L));
-            PollingIngestStats stats = client().admin().indices().prepareStats("test").get().getIndex("test").getShards()[0].getPollingIngestStats();
+            PollingIngestStats stats = client().admin().indices().prepareStats("test").get().getIndex("test").getShards()[0]
+                .getPollingIngestStats();
             assertNotNull(stats);
             assertThat(stats.getMessageProcessorStats().getTotalProcessedCount(), is(2L));
             assertThat(stats.getConsumerStats().getTotalPolledCount(), is(2L));

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -56,6 +56,7 @@ import org.opensearch.index.seqno.RetentionLeaseStats;
 import org.opensearch.index.seqno.SeqNoStats;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.pollingingest.PollingIngestStats;
 import org.opensearch.node.NodeService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportRequest;
@@ -210,15 +211,18 @@ public class TransportClusterStatsAction extends TransportNodesAction<
                         CommitStats commitStats;
                         SeqNoStats seqNoStats;
                         RetentionLeaseStats retentionLeaseStats;
+                        PollingIngestStats pollingIngestStats;
                         try {
                             commitStats = indexShard.commitStats();
                             seqNoStats = indexShard.seqNoStats();
                             retentionLeaseStats = indexShard.getRetentionLeaseStats();
+                            pollingIngestStats = indexShard.pollingIngestStats();
                         } catch (final AlreadyClosedException e) {
                             // shard is closed - no stats is fine
                             commitStats = null;
                             seqNoStats = null;
                             retentionLeaseStats = null;
+                            pollingIngestStats = null;
                         }
                         shardsStats.add(
                             new ShardStats(
@@ -227,7 +231,8 @@ public class TransportClusterStatsAction extends TransportNodesAction<
                                 new CommonStats(indicesService.getIndicesQueryCache(), indexShard, commonStatsFlags),
                                 commitStats,
                                 seqNoStats,
-                                retentionLeaseStats
+                                retentionLeaseStats,
+                                pollingIngestStats
                             )
                         );
                     }

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/ShardStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/ShardStats.java
@@ -44,6 +44,7 @@ import org.opensearch.index.engine.CommitStats;
 import org.opensearch.index.seqno.RetentionLeaseStats;
 import org.opensearch.index.seqno.SeqNoStats;
 import org.opensearch.index.shard.ShardPath;
+import org.opensearch.indices.pollingingest.PollingIngestStats;
 
 import java.io.IOException;
 
@@ -64,6 +65,9 @@ public class ShardStats implements Writeable, ToXContentFragment {
 
     @Nullable
     private RetentionLeaseStats retentionLeaseStats;
+
+    @Nullable
+    private PollingIngestStats pollingIngestStats;
 
     /**
      * Gets the current retention lease stats.
@@ -87,6 +91,7 @@ public class ShardStats implements Writeable, ToXContentFragment {
         isCustomDataPath = in.readBoolean();
         seqNoStats = in.readOptionalWriteable(SeqNoStats::new);
         retentionLeaseStats = in.readOptionalWriteable(RetentionLeaseStats::new);
+        pollingIngestStats = in.readOptionalWriteable(PollingIngestStats::new);
     }
 
     public ShardStats(
@@ -95,7 +100,8 @@ public class ShardStats implements Writeable, ToXContentFragment {
         final CommonStats commonStats,
         final CommitStats commitStats,
         final SeqNoStats seqNoStats,
-        final RetentionLeaseStats retentionLeaseStats
+        final RetentionLeaseStats retentionLeaseStats,
+        final PollingIngestStats pollingIngestStats
     ) {
         this.shardRouting = routing;
         this.dataPath = shardPath.getRootDataPath().toString();
@@ -105,6 +111,7 @@ public class ShardStats implements Writeable, ToXContentFragment {
         this.commonStats = commonStats;
         this.seqNoStats = seqNoStats;
         this.retentionLeaseStats = retentionLeaseStats;
+        this.pollingIngestStats = pollingIngestStats;
     }
 
     /**
@@ -126,6 +133,11 @@ public class ShardStats implements Writeable, ToXContentFragment {
     @Nullable
     public SeqNoStats getSeqNoStats() {
         return this.seqNoStats;
+    }
+
+    @Nullable
+    public PollingIngestStats getPollingIngestStats() {
+        return this.pollingIngestStats;
     }
 
     public String getDataPath() {
@@ -150,6 +162,7 @@ public class ShardStats implements Writeable, ToXContentFragment {
         out.writeBoolean(isCustomDataPath);
         out.writeOptionalWriteable(seqNoStats);
         out.writeOptionalWriteable(retentionLeaseStats);
+        out.writeOptionalWriteable(pollingIngestStats);
     }
 
     @Override
@@ -170,6 +183,9 @@ public class ShardStats implements Writeable, ToXContentFragment {
         }
         if (retentionLeaseStats != null) {
             retentionLeaseStats.toXContent(builder, params);
+        }
+        if (pollingIngestStats != null) {
+            pollingIngestStats.toXContent(builder, params);
         }
         builder.startObject(Fields.SHARD_PATH);
         builder.field(Fields.STATE_PATH, statePath);

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/ShardStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/ShardStats.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.action.admin.indices.stats;
 
+import org.opensearch.Version;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.PublicApi;
@@ -91,7 +92,9 @@ public class ShardStats implements Writeable, ToXContentFragment {
         isCustomDataPath = in.readBoolean();
         seqNoStats = in.readOptionalWriteable(SeqNoStats::new);
         retentionLeaseStats = in.readOptionalWriteable(RetentionLeaseStats::new);
-        pollingIngestStats = in.readOptionalWriteable(PollingIngestStats::new);
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            pollingIngestStats = in.readOptionalWriteable(PollingIngestStats::new);
+        }
     }
 
     public ShardStats(
@@ -162,7 +165,9 @@ public class ShardStats implements Writeable, ToXContentFragment {
         out.writeBoolean(isCustomDataPath);
         out.writeOptionalWriteable(seqNoStats);
         out.writeOptionalWriteable(retentionLeaseStats);
-        out.writeOptionalWriteable(pollingIngestStats);
+        if (out.getVersion().onOrAfter((Version.V_3_0_0))) {
+            out.writeOptionalWriteable(pollingIngestStats);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -156,6 +156,14 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
             retentionLeaseStats = null;
             pollingIngestStats = null;
         }
-        return new ShardStats(indexShard.routingEntry(), indexShard.shardPath(), commonStats, commitStats, seqNoStats, retentionLeaseStats, pollingIngestStats);
+        return new ShardStats(
+            indexShard.routingEntry(),
+            indexShard.shardPath(),
+            commonStats,
+            commitStats,
+            seqNoStats,
+            retentionLeaseStats,
+            pollingIngestStats
+        );
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -148,7 +148,6 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
             seqNoStats = indexShard.seqNoStats();
             retentionLeaseStats = indexShard.getRetentionLeaseStats();
             pollingIngestStats = indexShard.pollingIngestStats();
-
         } catch (final AlreadyClosedException e) {
             // shard is closed - no stats is fine
             commitStats = null;

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -52,6 +52,7 @@ import org.opensearch.index.seqno.SeqNoStats;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ShardNotFoundException;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.pollingingest.PollingIngestStats;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
@@ -141,16 +142,20 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
         CommitStats commitStats;
         SeqNoStats seqNoStats;
         RetentionLeaseStats retentionLeaseStats;
+        PollingIngestStats pollingIngestStats;
         try {
             commitStats = indexShard.commitStats();
             seqNoStats = indexShard.seqNoStats();
             retentionLeaseStats = indexShard.getRetentionLeaseStats();
+            pollingIngestStats = indexShard.pollingIngestStats();
+
         } catch (final AlreadyClosedException e) {
             // shard is closed - no stats is fine
             commitStats = null;
             seqNoStats = null;
             retentionLeaseStats = null;
+            pollingIngestStats = null;
         }
-        return new ShardStats(indexShard.routingEntry(), indexShard.shardPath(), commonStats, commitStats, seqNoStats, retentionLeaseStats);
+        return new ShardStats(indexShard.routingEntry(), indexShard.shardPath(), commonStats, commitStats, seqNoStats, retentionLeaseStats, pollingIngestStats);
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -93,6 +93,7 @@ import org.opensearch.index.translog.DefaultTranslogDeletionPolicy;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.index.translog.TranslogDeletionPolicy;
 import org.opensearch.index.translog.TranslogManager;
+import org.opensearch.indices.pollingingest.PollingIngestStats;
 import org.opensearch.search.suggest.completion.CompletionStats;
 
 import java.io.Closeable;
@@ -944,6 +945,10 @@ public abstract class Engine implements LifecycleAware, Closeable {
         }
         writerSegmentStats(stats);
         return stats;
+    }
+
+    public PollingIngestStats pollingIngestStats() {
+        return null;
     }
 
     protected TranslogDeletionPolicy getTranslogDeletionPolicy(EngineConfig engineConfig) {

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -947,6 +947,9 @@ public abstract class Engine implements LifecycleAware, Closeable {
         return stats;
     }
 
+    /**
+     * @return Stats for pull-based ingestion.
+     */
     public PollingIngestStats pollingIngestStats() {
         return null;
     }

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -29,6 +29,7 @@ import org.opensearch.index.translog.TranslogManager;
 import org.opensearch.index.translog.TranslogStats;
 import org.opensearch.index.translog.listener.CompositeTranslogEventListener;
 import org.opensearch.indices.pollingingest.DefaultStreamPoller;
+import org.opensearch.indices.pollingingest.PollingIngestStats;
 import org.opensearch.indices.pollingingest.StreamPoller;
 
 import java.io.IOException;
@@ -287,5 +288,10 @@ public class IngestionEngine extends InternalEngine {
 
     protected Map<String, String> commitDataAsMap() {
         return commitDataAsMap(indexWriter);
+    }
+
+    @Override
+    public PollingIngestStats pollingIngestStats() {
+        return streamPoller.getStats();
     }
 }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -184,6 +184,7 @@ import org.opensearch.indices.IndexingMemoryController;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.RemoteStoreSettings;
 import org.opensearch.indices.cluster.IndicesClusterStateService;
+import org.opensearch.indices.pollingingest.PollingIngestStats;
 import org.opensearch.indices.recovery.PeerRecoveryTargetService;
 import org.opensearch.indices.recovery.RecoveryFailedException;
 import org.opensearch.indices.recovery.RecoveryListener;
@@ -1531,6 +1532,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     public CompletionStats completionStats(String... fields) {
         readAllowed();
         return getEngine().completionStats(fields);
+    }
+
+    public PollingIngestStats pollingIngestStats() {
+        return getEngine().pollingIngestStats();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -149,6 +149,7 @@ import org.opensearch.indices.cluster.IndicesClusterStateService;
 import org.opensearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.opensearch.indices.mapper.MapperRegistry;
 import org.opensearch.indices.pollingingest.IngestionEngineFactory;
+import org.opensearch.indices.pollingingest.PollingIngestStats;
 import org.opensearch.indices.recovery.PeerRecoveryTargetService;
 import org.opensearch.indices.recovery.RecoveryListener;
 import org.opensearch.indices.recovery.RecoverySettings;
@@ -758,15 +759,18 @@ public class IndicesService extends AbstractLifecycleComponent
         CommitStats commitStats;
         SeqNoStats seqNoStats;
         RetentionLeaseStats retentionLeaseStats;
+        PollingIngestStats pollingIngestStats;
         try {
             commitStats = indexShard.commitStats();
             seqNoStats = indexShard.seqNoStats();
             retentionLeaseStats = indexShard.getRetentionLeaseStats();
+            pollingIngestStats = indexShard.pollingIngestStats();
         } catch (AlreadyClosedException e) {
             // shard is closed - no stats is fine
             commitStats = null;
             seqNoStats = null;
             retentionLeaseStats = null;
+            pollingIngestStats = null;
         }
 
         return new IndexShardStats(
@@ -778,7 +782,8 @@ public class IndicesService extends AbstractLifecycleComponent
                     new CommonStats(indicesService.getIndicesQueryCache(), indexShard, flags),
                     commitStats,
                     seqNoStats,
-                    retentionLeaseStats
+                    retentionLeaseStats,
+                    pollingIngestStats
                 ) }
         );
     }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/MessageProcessorRunnable.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/MessageProcessorRunnable.java
@@ -14,6 +14,7 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.Term;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.common.lucene.uid.Versions;
+import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.common.bytes.BytesArray;
@@ -48,6 +49,7 @@ public class MessageProcessorRunnable implements Runnable {
 
     private final BlockingQueue<IngestionShardConsumer.ReadResult<? extends IngestionShardPointer, ? extends Message>> blockingQueue;
     private final MessageProcessor messageProcessor;
+    private final CounterMetric stats = new CounterMetric();
 
     private static final String ID = "_id";
     private static final String OP_TYPE = "_op_type";
@@ -229,8 +231,13 @@ public class MessageProcessorRunnable implements Runnable {
                 Thread.currentThread().interrupt(); // Restore interrupt status
             }
             if (result != null) {
+                stats.inc();
                 messageProcessor.process(result.getMessage(), result.getPointer());
             }
         }
+    }
+
+    public CounterMetric getStats() {
+        return stats;
     }
 }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/PollingIngestStats.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/PollingIngestStats.java
@@ -18,19 +18,20 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * Stats for pull-based ingestion
+ */
 @ExperimentalApi
 public class PollingIngestStats implements Writeable, ToXContentFragment {
     private final MessageProcessorStats messageProcessorStats;
     private final ConsumerStats consumerStats;
+    // TODO: add error stats from error handling sink
 
     public PollingIngestStats(MessageProcessorStats messageProcessorStats, ConsumerStats consumerStats) {
         this.messageProcessorStats = messageProcessorStats;
         this.consumerStats = consumerStats;
     }
 
-    /**
-     * Read from a stream.
-     */
     public PollingIngestStats(StreamInput in) throws IOException {
         long totalProcessedCount = in.readLong();
         this.messageProcessorStats = new MessageProcessorStats(totalProcessedCount);
@@ -70,8 +71,7 @@ public class PollingIngestStats implements Writeable, ToXContentFragment {
         if (this == o) return true;
         if (!(o instanceof PollingIngestStats)) return false;
         PollingIngestStats that = (PollingIngestStats) o;
-        return Objects.equals(messageProcessorStats, that.messageProcessorStats) &&
-                Objects.equals(consumerStats, that.consumerStats);
+        return Objects.equals(messageProcessorStats, that.messageProcessorStats) && Objects.equals(consumerStats, that.consumerStats);
     }
 
     @Override
@@ -136,8 +136,7 @@ public class PollingIngestStats implements Writeable, ToXContentFragment {
         private long totalProcessedCount;
         private long totalPolledCount;
 
-        public Builder() {
-        }
+        public Builder() {}
 
         public Builder setTotalProcessedCount(long totalProcessedCount) {
             this.totalProcessedCount = totalProcessedCount;

--- a/server/src/main/java/org/opensearch/indices/pollingingest/PollingIngestStats.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/PollingIngestStats.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.pollingingest;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+@ExperimentalApi
+public class PollingIngestStats implements Writeable, ToXContentFragment {
+    private final MessageProcessorStats messageProcessorStats;
+    private final ConsumerStats consumerStats;
+
+    public PollingIngestStats(MessageProcessorStats messageProcessorStats, ConsumerStats consumerStats) {
+        this.messageProcessorStats = messageProcessorStats;
+        this.consumerStats = consumerStats;
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public PollingIngestStats(StreamInput in) throws IOException {
+        long totalProcessedCount = in.readLong();
+        this.messageProcessorStats = new MessageProcessorStats(totalProcessedCount);
+        long totalPolledCount = in.readLong();
+        this.consumerStats = new ConsumerStats(totalPolledCount);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeLong(messageProcessorStats.getTotalProcessedCount());
+        out.writeLong(consumerStats.getTotalPolledCount());
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("polling_ingest_stats");
+        builder.startObject("message_processor_stats");
+        builder.field("total_processed_count", messageProcessorStats.getTotalProcessedCount());
+        builder.endObject();
+        builder.startObject("consumer_stats");
+        builder.field("total_polled_count", consumerStats.getTotalPolledCount());
+        builder.endObject();
+        builder.endObject();
+        return builder;
+    }
+
+    public MessageProcessorStats getMessageProcessorStats() {
+        return messageProcessorStats;
+    }
+
+    public ConsumerStats getConsumerStats() {
+        return consumerStats;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PollingIngestStats)) return false;
+        PollingIngestStats that = (PollingIngestStats) o;
+        return Objects.equals(messageProcessorStats, that.messageProcessorStats) &&
+                Objects.equals(consumerStats, that.consumerStats);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(messageProcessorStats, consumerStats);
+    }
+
+    @ExperimentalApi
+    public static class MessageProcessorStats {
+        private final long totalProcessedCount;
+
+        public MessageProcessorStats(long totalProcessedCount) {
+            this.totalProcessedCount = totalProcessedCount;
+        }
+
+        public long getTotalProcessedCount() {
+            return totalProcessedCount;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof MessageProcessorStats)) return false;
+            MessageProcessorStats that = (MessageProcessorStats) o;
+            return totalProcessedCount == that.totalProcessedCount;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(totalProcessedCount);
+        }
+    }
+
+    @ExperimentalApi
+    public static class ConsumerStats {
+        private final long totalPolledCount;
+
+        public ConsumerStats(long totalPolledCount) {
+            this.totalPolledCount = totalPolledCount;
+        }
+
+        public long getTotalPolledCount() {
+            return totalPolledCount;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ConsumerStats)) return false;
+            ConsumerStats that = (ConsumerStats) o;
+            return totalPolledCount == that.totalPolledCount;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(totalPolledCount);
+        }
+    }
+
+    @ExperimentalApi
+    public static class Builder {
+        private long totalProcessedCount;
+        private long totalPolledCount;
+
+        public Builder() {
+        }
+
+        public Builder setTotalProcessedCount(long totalProcessedCount) {
+            this.totalProcessedCount = totalProcessedCount;
+            return this;
+        }
+
+        public Builder setTotalPolledCount(long totalPolledCount) {
+            this.totalPolledCount = totalPolledCount;
+            return this;
+        }
+
+        public PollingIngestStats build() {
+            MessageProcessorStats messageProcessorStats = new MessageProcessorStats(totalProcessedCount);
+            ConsumerStats consumerStats = new ConsumerStats(totalPolledCount);
+            return new PollingIngestStats(messageProcessorStats, consumerStats);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/pollingingest/PollingIngestStats.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/PollingIngestStats.java
@@ -79,6 +79,9 @@ public class PollingIngestStats implements Writeable, ToXContentFragment {
         return Objects.hash(messageProcessorStats, consumerStats);
     }
 
+    /**
+     * Stats for message processor
+     */
     @ExperimentalApi
     public static class MessageProcessorStats {
         private final long totalProcessedCount;
@@ -105,6 +108,9 @@ public class PollingIngestStats implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * Stats for consumer (poller)
+     */
     @ExperimentalApi
     public static class ConsumerStats {
         private final long totalPolledCount;
@@ -131,6 +137,9 @@ public class PollingIngestStats implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * Builder for {@link PollingIngestStats}
+     */
     @ExperimentalApi
     public static class Builder {
         private long totalProcessedCount;
@@ -155,6 +164,11 @@ public class PollingIngestStats implements Writeable, ToXContentFragment {
         }
     }
 
+    /**
+     * Returns a new builder for creating a {@link PollingIngestStats} instance.
+     *
+     * @return a new {@code Builder} instance
+     */
     public static Builder builder() {
         return new Builder();
     }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
@@ -50,6 +50,8 @@ public interface StreamPoller extends Closeable {
      */
     IngestionShardPointer getBatchStartPointer();
 
+    PollingIngestStats getStats();
+
     /**
      * a state to indicate the current state of the poller
      */

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -1413,6 +1413,7 @@ public class NodeStatsTests extends OpenSearchTestCase {
                     createRandomCommonStats(),
                     null,
                     null,
+                    null,
                     null
                 );
                 List<ShardStats> shardStatsList = new ArrayList<>();
@@ -1462,6 +1463,7 @@ public class NodeStatsTests extends OpenSearchTestCase {
                 shardRouting,
                 new ShardPath(false, path, path, shardRouting.shardId()),
                 commonStats,
+                null,
                 null,
                 null,
                 null

--- a/server/src/test/java/org/opensearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
@@ -402,6 +402,7 @@ public class ClusterStatsNodesTests extends OpenSearchTestCase {
                 commonStats,
                 null,
                 null,
+                null,
                 null
             );
             shardStatsList.add(shardStats);

--- a/server/src/test/java/org/opensearch/action/admin/cluster/stats/ClusterStatsResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/stats/ClusterStatsResponseTests.java
@@ -270,6 +270,7 @@ public class ClusterStatsResponseTests extends OpenSearchTestCase {
                 commonStats,
                 null,
                 null,
+                null,
                 null
             );
             shardStatsList.add(shardStats);

--- a/server/src/test/java/org/opensearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -422,7 +422,7 @@ public class TransportRolloverActionTests extends OpenSearchTestCase {
                 stats.get = new GetStats();
                 stats.flush = new FlushStats();
                 stats.warmer = new WarmerStats();
-                shardStats.add(new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, null, null));
+                shardStats.add(new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, null, null, null));
             }
         }
         return IndicesStatsTests.newIndicesStatsResponse(

--- a/server/src/test/java/org/opensearch/action/admin/indices/shards/CatShardsResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/shards/CatShardsResponseTests.java
@@ -152,7 +152,7 @@ public class CatShardsResponseTests extends OpenSearchTestCase {
                 Path path = createTempDir().resolve("indices").resolve(index.getUUID()).resolve(String.valueOf(shardId));
                 ShardPath shardPath = new ShardPath(false, path, path, shId);
                 ShardRouting routing = createShardRouting(shId, (shardId == 0));
-                shards.add(new ShardStats(routing, shardPath, new CommonStats(), null, null, null));
+                shards.add(new ShardStats(routing, shardPath, new CommonStats(), null, null, null, null));
             }
         }
         return new IndicesStatsResponse(shards.toArray(new ShardStats[0]), 0, 0, 0, null);

--- a/server/src/test/java/org/opensearch/action/admin/indices/stats/IndicesStatsResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/stats/IndicesStatsResponseTests.java
@@ -88,7 +88,7 @@ public class IndicesStatsResponseTests extends OpenSearchTestCase {
                 Path path = createTempDir().resolve("indices").resolve(index.getUUID()).resolve(String.valueOf(shardId));
                 ShardPath shardPath = new ShardPath(false, path, path, shId);
                 ShardRouting routing = createShardRouting(index, shId, (shardId == 0));
-                shards.add(new ShardStats(routing, shardPath, null, null, null, null));
+                shards.add(new ShardStats(routing, shardPath, null, null, null, null, null));
                 AtomicLong primaryShardsCounter = expectedIndexToPrimaryShardsCount.computeIfAbsent(
                     index.getName(),
                     k -> new AtomicLong(0L)

--- a/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/opensearch/cluster/DiskUsageTests.java
@@ -135,8 +135,8 @@ public class DiskUsageTests extends OpenSearchTestCase {
         CommonStats commonStats1 = new CommonStats();
         commonStats1.store = new StoreStats(1000, 0L);
         ShardStats[] stats = new ShardStats[] {
-            new ShardStats(test_0, new ShardPath(false, test0Path, test0Path, test_0.shardId()), commonStats0, null, null, null),
-            new ShardStats(test_1, new ShardPath(false, test1Path, test1Path, test_1.shardId()), commonStats1, null, null, null) };
+            new ShardStats(test_0, new ShardPath(false, test0Path, test0Path, test_0.shardId()), commonStats0, null, null, null, null),
+            new ShardStats(test_1, new ShardPath(false, test1Path, test1Path, test_1.shardId()), commonStats1, null, null, null, null) };
         final Map<String, Long> shardSizes = new HashMap<>();
         final Map<ShardRouting, String> routingToPath = new HashMap<>();
         InternalClusterInfoService.buildShardLevelInfo(logger, stats, shardSizes, routingToPath, new HashMap<>());

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -1696,7 +1696,8 @@ public class IndexShardTests extends IndexShardTestCase {
             new CommonStats(new IndicesQueryCache(Settings.EMPTY), shard, new CommonStatsFlags()),
             shard.commitStats(),
             shard.seqNoStats(),
-            shard.getRetentionLeaseStats()
+            shard.getRetentionLeaseStats(),
+            shard.pollingIngestStats()
         );
         assertEquals(shard.shardPath().getRootDataPath().toString(), stats.getDataPath());
         assertEquals(shard.shardPath().getRootStatePath().toString(), stats.getStatePath());
@@ -1838,7 +1839,8 @@ public class IndexShardTests extends IndexShardTestCase {
             new CommonStats(new IndicesQueryCache(Settings.EMPTY), shard, new CommonStatsFlags()),
             shard.commitStats(),
             shard.seqNoStats(),
-            shard.getRetentionLeaseStats()
+            shard.getRetentionLeaseStats(),
+            shard.pollingIngestStats()
         );
         RemoteSegmentStats remoteSegmentStats = shardStats.getStats().getSegments().getRemoteSegmentStats();
         assertRemoteSegmentStats(remoteSegmentTransferTracker, remoteSegmentStats);

--- a/server/src/test/java/org/opensearch/indices/pollingingest/PollingIngestStatsTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/PollingIngestStatsTests.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.pollingingest;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class PollingIngestStatsTests extends OpenSearchTestCase {
+
+    public void testToXContent() throws IOException {
+        PollingIngestStats stats = createTestInstance();
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        builder.startObject();
+        stats.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        String expected = "{\"polling_ingest_stats\":{\"message_processor_stats\":{\"total_processed_count\":"
+            + stats.getMessageProcessorStats().getTotalProcessedCount()
+            + "},\"consumer_stats\":{\"total_polled_count\":"
+            + stats.getConsumerStats().getTotalPolledCount()
+            + "}}}";
+
+        assertEquals(expected, builder.toString());
+    }
+
+    public void testSerialization() throws IOException {
+        PollingIngestStats original = createTestInstance();
+
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            original.writeTo(output);
+
+            try (StreamInput input = output.bytes().streamInput()) {
+                PollingIngestStats deserialized = new PollingIngestStats(input);
+                assertEquals(original, deserialized);
+            }
+        }
+    }
+
+    private PollingIngestStats createTestInstance() {
+        return PollingIngestStats.builder()
+            .setTotalProcessedCount(randomNonNegativeLong())
+            .setTotalPolledCount(randomNonNegativeLong())
+            .build();
+    }
+}

--- a/server/src/test/java/org/opensearch/rest/action/cat/RestShardsActionTests.java
+++ b/server/src/test/java/org/opensearch/rest/action/cat/RestShardsActionTests.java
@@ -93,6 +93,7 @@ public class RestShardsActionTests extends OpenSearchTestCase {
                 commonStats,
                 null,
                 null,
+                null,
                 null
             );
             shardStatsMap.put(shardRouting, shardStats);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR adds the basic NodeStats metrics to pull-based ingestion.

- Added total polled and total processed message count metrics, as part of IndexShardStats.
- Tested in the Kafka integration test
- TODO: add metrics for error handling and consume lag.

### Related Issues
Resolves #17077 
<!-- List any other related issues here -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
