### PR TITLE
[Backport] [2.x] Add 2.19.1 release notes (#17468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump netty from 4.1.117.Final to 4.1.118.Final ([#17320](https://github.com/opensearch-project/OpenSearch/pull/17320))
 - Bump `reactor_netty` from 1.1.26 to 1.1.27 ([#17322](https://github.com/opensearch-project/OpenSearch/pull/17322))
 - Bump `me.champeau.gradle.japicmp` from 0.4.5 to 0.4.6 ([#17375](https://github.com/opensearch-project/OpenSearch/pull/17375))
-- Bump `jetty` version from 9.4.55.v20240627 to 9.4.57.v20241219
 - Bump `net.minidev:json-smart` from 2.5.1 to 2.5.2 ([#17378](https://github.com/opensearch-project/OpenSearch/pull/17378))
 
 ### Changed
@@ -29,7 +28,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fix case insensitive and escaped query on wildcard ([#16827](https://github.com/opensearch-project/OpenSearch/pull/16827))
 - Fix illegal argument exception when creating a PIT ([#16781](https://github.com/opensearch-project/OpenSearch/pull/16781))
-- Fix HTTP API calls that hang with 'Accept-Encoding: zstd' ([#17408](https://github.com/opensearch-project/OpenSearch/pull/17408))
 
 ### Security
 

--- a/release-notes/opensearch.release-notes-2.19.1.md
+++ b/release-notes/opensearch.release-notes-2.19.1.md
@@ -1,0 +1,16 @@
+## 2025-02-27 Version 2.19.1 Release Notes
+
+## [2.19.1]
+### Added
+- Add execution_hint to cardinality aggregator request (#[17420](https://github.com/opensearch-project/OpenSearch/pull/17420))
+
+### Dependencies
+- Bump netty from 4.1.117.Final to 4.1.118.Final ([#17320](https://github.com/opensearch-project/OpenSearch/pull/17320))
+- Bump `jetty` version from 9.4.55.v20240627 to 9.4.57.v20241219
+
+### Changed
+
+### Deprecated
+
+### Fixed
+- Fix HTTP API calls that hang with 'Accept-Encoding: zstd' ([#17408](https://github.com/opensearch-project/OpenSearch/pull/17408))


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/17468 to `2.x`