### PR TITLE
Enable JUnit 5 usage in test framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added ability to retrieve value from DocValues in a flat_object filed([#16802](https://github.com/opensearch-project/OpenSearch/pull/16802))
 - Improve performace of NumericTermAggregation by avoiding unnecessary sorting([#17252](https://github.com/opensearch-project/OpenSearch/pull/17252))
 - [Rule Based Auto-tagging] Add in-memory attribute value store ([#17342](https://github.com/opensearch-project/OpenSearch/pull/17342))
+- Enable JUnit 5 usage in test framework ([#17475](https://github.com/opensearch-project/OpenSearch/pull/17475))
 
 ### Dependencies
 - Bump `org.awaitility:awaitility` from 4.2.0 to 4.3.0 ([#17230](https://github.com/opensearch-project/OpenSearch/pull/17230), [#17439](https://github.com/opensearch-project/OpenSearch/pull/17439))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,8 @@ bouncycastle="1.78"
 # test dependencies
 randomizedrunner  = "2.7.1"
 junit             = "4.13.2"
+junit5            = "5.12.0"
+junitplatform     = "1.12.0"
 hamcrest          = "2.1"
 mockito           = "5.14.2"
 objenesis         = "3.3"

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -53,6 +53,16 @@ dependencies {
   api "org.bouncycastle:bcpkix-jdk18on:${versions.bouncycastle}"
   api "org.bouncycastle:bcutil-jdk18on:${versions.bouncycastle}"
 
+  // Allow usage of JUnit 5
+  api "org.junit.jupiter:junit-jupiter-api:${versions.junit5}"
+  runtimeOnly "org.junit.jupiter:junit-jupiter-engine:${versions.junit5}"
+  // Maintain Junit 4 compatibility
+  runtimeOnly "org.junit.platform:junit-platform-commons:${versions.junitplatform}"
+  runtimeOnly "org.junit.platform:junit-platform-engine:${versions.junitplatform}"
+  testRuntimeOnly "org.junit.platform:junit-platform-launcher:${versions.junitplatform}"
+  testRuntimeOnly("org.junit.vintage:junit-vintage-engine:${versions.junit5}") {
+      exclude group: 'junit', module: 'junit'
+  }
   annotationProcessor "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 }
 
@@ -75,6 +85,13 @@ thirdPartyAudit.ignoreMissingClasses(
   // classes are missing
   'javax.servlet.ServletContextEvent',
   'javax.servlet.ServletContextListener',
+  'kotlin.Unit',
+  'kotlin.collections.ArraysKt',
+  'kotlin.collections.CollectionsKt',
+  'kotlin.jvm.functions.Function0',
+  'kotlin.jvm.functions.Function1',
+  'kotlin.jvm.internal.Intrinsics',
+  'kotlin.jvm.internal.Lambda',
   'org.apache.avalon.framework.logger.Logger',
   'org.apache.log.Hierarchy',
   'org.apache.log.Logger',
@@ -83,6 +100,7 @@ thirdPartyAudit.ignoreMissingClasses(
   'org.apache.log4j.Priority',
   'org.mockito.internal.creation.bytebuddy.inject.MockMethodDispatcher',
   'org.opentest4j.AssertionFailedError',
+  'org.opentest4j.TestAbortedException',
   'net.bytebuddy.agent.ByteBuddyAgent',
   'net.bytebuddy.agent.Installer'
 )
@@ -93,6 +111,8 @@ thirdPartyAudit.ignoreViolations(
 )
 
 test {
+  useJUnitPlatform()
+
   systemProperty 'tests.gradle_index_compat_versions', BuildParams.bwcVersions.indexCompatible.join(',')
   systemProperty 'tests.gradle_wire_compat_versions', BuildParams.bwcVersions.wireCompatible.join(',')
   systemProperty 'tests.gradle_unreleased_versions', BuildParams.bwcVersions.unreleased.join(',')


### PR DESCRIPTION
### Description

Adds dependencies on JUnit 5 while maintaining compatibilitly with JUnit 4.  JUnit 4 is still required for randomized testing.

### Related Issues
Resolves #17445 

### Check List
- [x] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
