### PR TITLE
fixed default formatter negative epoch milli errors

### DIFF
--- a/server/src/main/java/org/opensearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/opensearch/common/time/DateFormatters.java
@@ -90,7 +90,7 @@ public class DateFormatters {
     private static final DateTimeFormatter STRICT_YEAR_MONTH_DAY_FORMATTER = new DateTimeFormatterBuilder().appendValue(
         ChronoField.YEAR,
         4,
-        10,
+        4,
         SignStyle.EXCEEDS_PAD
     )
         .optionalStart()

--- a/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
@@ -268,6 +268,22 @@ public class DateFormattersTests extends OpenSearchTestCase {
         }
     }
 
+    public void testNegativeEpochMilliWithDefaultFormatters() {
+        {
+            DateFormatter formatter = DateFormatter.forPattern("strict_date_optional_time||epoch_millis");
+            TemporalAccessor accessor = formatter.parse("-2177434800");
+            assertThat(DateFormatters.from(accessor).toInstant().toEpochMilli(), is(-2177434800L));
+            assertThat(formatter.pattern(), is("strict_date_optional_time||epoch_millis"));
+        }
+
+        {
+            DateFormatter formatter = DateFormatter.forPattern("strict_date_optional_time||epoch_millis");
+            TemporalAccessor accessor = formatter.parse("-561600000");
+            assertThat(DateFormatters.from(accessor).toInstant().toEpochMilli(), is(-561600000L));
+            assertThat(formatter.pattern(), is("strict_date_optional_time||epoch_millis"));
+        }
+    }
+
     public void testParsersWithMultipleInternalFormats() throws Exception {
         ZonedDateTime first = DateFormatters.from(
             DateFormatters.forPattern("strict_date_optional_time_nanos").parse("2018-05-15T17:14:56+0100")


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Negative epoch millis with certain length, results with parsing exception for fields using default format ("strict_date_optional_time||epoch_millis").

negative values(-561600000, -5616000000) are parsed incorrectly with default format "strict_date_optional_time||epoch_millis".
with error message,
java.lang.ArithmeticException: long overflow

negative values(-2177434800) are parsed incorrectly with default format "strict_date_optional_time||epoch_millis"
with error message, 
java.time.DateTimeException: Invalid value for Year (valid values -999999999 - 999999999): -2177434800

Fixed by reducing length from 10 to 4 - Helped to parse values correctly now.

### Related Issues
Resolves #16979
<!-- List any other related issues here -->

### Check List
- [X] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
