### PR TITLE
Updated nomenclature to differentiate between hot and warm tiering implementation.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add filter function for AbstractQueryBuilder, BoolQueryBuilder, ConstantScoreQueryBuilder([#17409](https://github.com/opensearch-project/OpenSearch/pull/17409))
 - [Star Tree] [Search] Resolving keyword & numeric bucket aggregation with metric aggregation using star-tree ([#17165](https://github.com/opensearch-project/OpenSearch/pull/17165))
 - Added error handling support for the pull-based ingestion ([#17427](https://github.com/opensearch-project/OpenSearch/pull/17427))
+- Added Warm index setting and Updated nomenclature to differentiate between hot and warm tiering implementation ([#17490](https://github.com/opensearch-project/OpenSearch/pull/17490))
 
 
 ### Dependencies

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/WarmIndexSegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/WarmIndexSegmentReplicationIT.java
@@ -150,7 +150,7 @@ public class WarmIndexSegmentReplicationIT extends SegmentReplicationBaseIT {
     @Override
     protected Settings featureFlagSettings() {
         Settings.Builder featureSettings = Settings.builder();
-        featureSettings.put(FeatureFlags.TIERED_REMOTE_INDEX, true);
+        featureSettings.put(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG, true);
         return featureSettings.build();
     }
 

--- a/server/src/main/java/org/opensearch/action/ActionModule.java
+++ b/server/src/main/java/org/opensearch/action/ActionModule.java
@@ -654,7 +654,7 @@ public class ActionModule extends AbstractModule {
         actions.register(CreateSnapshotAction.INSTANCE, TransportCreateSnapshotAction.class);
         actions.register(CloneSnapshotAction.INSTANCE, TransportCloneSnapshotAction.class);
         actions.register(RestoreSnapshotAction.INSTANCE, TransportRestoreSnapshotAction.class);
-        if (FeatureFlags.isEnabled(FeatureFlags.TIERED_REMOTE_INDEX)) {
+        if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)) {
             actions.register(HotToWarmTieringAction.INSTANCE, TransportHotToWarmTieringAction.class);
         }
         actions.register(SnapshotsStatusAction.INSTANCE, TransportSnapshotsStatusAction.class);
@@ -996,7 +996,7 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestNodeAttrsAction());
         registerHandler.accept(new RestRepositoriesAction());
         registerHandler.accept(new RestSnapshotAction());
-        if (FeatureFlags.isEnabled(FeatureFlags.TIERED_REMOTE_INDEX)) {
+        if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)) {
             registerHandler.accept(new RestWarmTieringAction());
         }
         registerHandler.accept(new RestTemplatesAction());

--- a/server/src/main/java/org/opensearch/action/admin/indices/tiering/TieringUtils.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/tiering/TieringUtils.java
@@ -22,26 +22,25 @@ public class TieringUtils {
 
     /**
      *  Checks if the specified shard is a partial shard by
-     *  checking the INDEX_STORE_LOCALITY_SETTING for its index.
-     *  see {@link #isPartialIndex(IndexMetadata)}
+     *  checking the WARM_INDEX_ENABLED_SETTING for its index.
+     *  see {@link #isWarmIndex(IndexMetadata)} (IndexMetadata)}
      * @param shard ShardRouting object representing the shard
      * @param allocation RoutingAllocation object representing the allocation
      * @return true if the shard is a partial shard, false otherwise
      */
     public static boolean isPartialShard(ShardRouting shard, RoutingAllocation allocation) {
         IndexMetadata indexMetadata = allocation.metadata().getIndexSafe(shard.index());
-        return isPartialIndex(indexMetadata);
+        return isWarmIndex(indexMetadata);
     }
 
     /**
-     * Checks if the specified index is a partial index by
-     * checking the INDEX_STORE_LOCALITY_SETTING for the index.
+     * Checks if the specified index is a warm index by
+     * checking the WARM_INDEX_ENABLED_SETTING for the index.
      *
      * @param indexMetadata the metadata of the index
-     * @return true if the index is a partial index, false otherwise
+     * @return true if the index is a warm index, false otherwise
      */
-    public static boolean isPartialIndex(final IndexMetadata indexMetadata) {
-        return IndexModule.DataLocalityType.PARTIAL.name()
-            .equals(indexMetadata.getSettings().get(IndexModule.INDEX_STORE_LOCALITY_SETTING.getKey()));
+    public static boolean isWarmIndex(final IndexMetadata indexMetadata) {
+        return indexMetadata.getSettings().getAsBoolean(IndexModule.IS_WARM_INDEX_SETTING.getKey(), false);
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
@@ -256,7 +256,7 @@ public class OperationRouting {
                 preference = Preference.PRIMARY.type();
             }
 
-            if (FeatureFlags.isEnabled(FeatureFlags.TIERED_REMOTE_INDEX)
+            if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)
                 && IndexModule.DataLocalityType.PARTIAL.name()
                     .equals(indexMetadataForShard.getSettings().get(IndexModule.INDEX_STORE_LOCALITY_SETTING.getKey()))
                 && (preference == null || preference.isEmpty())) {

--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingPool.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingPool.java
@@ -13,7 +13,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.allocation.RoutingAllocation;
 import org.opensearch.common.util.FeatureFlags;
 
-import static org.opensearch.action.admin.indices.tiering.TieringUtils.isPartialIndex;
+import static org.opensearch.action.admin.indices.tiering.TieringUtils.isWarmIndex;
 
 /**
  *  {@link RoutingPool} defines the different node types based on the assigned capabilities. The methods
@@ -62,6 +62,9 @@ public enum RoutingPool {
      */
     public static RoutingPool getIndexPool(IndexMetadata indexMetadata) {
         return indexMetadata.isRemoteSnapshot()
-            || (FeatureFlags.isEnabled(FeatureFlags.TIERED_REMOTE_INDEX) && isPartialIndex(indexMetadata)) ? REMOTE_CAPABLE : LOCAL_ONLY;
+            || (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG) && isWarmIndex(indexMetadata))
+                ? REMOTE_CAPABLE
+                : LOCAL_ONLY;
+
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -561,7 +561,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
      */
     private boolean canShardBeSkipped(ShardRouting shardRouting) {
         return (RoutingPool.REMOTE_CAPABLE.equals(RoutingPool.getShardPool(shardRouting, allocation))
-            && !(FeatureFlags.isEnabled(FeatureFlags.TIERED_REMOTE_INDEX) && isPartialShard(shardRouting, allocation)));
+            && !(FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG) && isPartialShard(shardRouting, allocation)));
     }
 
     /**
@@ -771,7 +771,7 @@ public class LocalShardsBalancer extends ShardsBalancer {
                 assert rn.nodeId().equals(shard.currentNodeId());
                 /* we skip relocating shards here since we expect an initializing shard with the same id coming in */
                 if ((RoutingPool.LOCAL_ONLY.equals(RoutingPool.getShardPool(shard, allocation))
-                    || (FeatureFlags.isEnabled(FeatureFlags.TIERED_REMOTE_INDEX) && isPartialShard(shard, allocation)))
+                    || (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG) && isPartialShard(shard, allocation)))
                     && shard.state() != RELOCATING) {
                     node.addShard(shard);
                     ++totalShardCount;

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/RemoteShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/RemoteShardsBalancer.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
-import static org.opensearch.action.admin.indices.tiering.TieringUtils.isPartialIndex;
+import static org.opensearch.action.admin.indices.tiering.TieringUtils.isWarmIndex;
 
 /**
  * A {@link RemoteShardsBalancer} used by the {@link BalancedShardsAllocator} to perform allocation operations
@@ -348,7 +348,7 @@ public final class RemoteShardsBalancer extends ShardsBalancer {
                 // to re-fetch any shard blocks from the repository.
                 if (shard.primary()) {
                     if (RecoverySource.Type.SNAPSHOT.equals(shard.recoverySource().getType()) == false
-                        && isPartialIndex(allocation.metadata().getIndexSafe(shard.index())) == false) {
+                        && isWarmIndex(allocation.metadata().getIndexSafe(shard.index())) == false) {
                         unassignedShard = shard.updateUnassigned(shard.unassignedInfo(), RecoverySource.EmptyStoreRecoverySource.INSTANCE);
                     }
                 }

--- a/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
@@ -33,7 +33,7 @@ public class FeatureFlagSettings extends AbstractScopedSettings {
         FeatureFlags.EXTENSIONS_SETTING,
         FeatureFlags.TELEMETRY_SETTING,
         FeatureFlags.DATETIME_FORMATTER_CACHING_SETTING,
-        FeatureFlags.TIERED_REMOTE_INDEX_SETTING,
+        FeatureFlags.WRITABLE_WARM_INDEX_SETTING,
         FeatureFlags.REMOTE_STORE_MIGRATION_EXPERIMENTAL_SETTING,
         FeatureFlags.STAR_TREE_INDEX_SETTING,
         FeatureFlags.APPLICATION_BASED_CONFIGURATION_TEMPLATES_SETTING,

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -291,8 +291,9 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
      * setting should be moved to {@link #BUILT_IN_INDEX_SETTINGS}.
      */
     public static final Map<String, List<Setting>> FEATURE_FLAGGED_INDEX_SETTINGS = Map.of(
-        FeatureFlags.TIERED_REMOTE_INDEX,
-        List.of(IndexModule.INDEX_STORE_LOCALITY_SETTING, IndexModule.INDEX_TIERING_STATE),
+        FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG,
+        // TODO: Create a separate feature flag for hot tiering index state.
+        List.of(IndexModule.INDEX_STORE_LOCALITY_SETTING, IndexModule.INDEX_TIERING_STATE, IndexModule.IS_WARM_INDEX_SETTING),
         FeatureFlags.READER_WRITER_SPLIT_EXPERIMENTAL,
         List.of(IndexMetadata.INDEX_NUMBER_OF_SEARCH_REPLICAS_SETTING)
     );

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -51,10 +51,10 @@ public class FeatureFlags {
     public static final String DATETIME_FORMATTER_CACHING = "opensearch.experimental.optimization.datetime_formatter_caching.enabled";
 
     /**
-     * Gates the functionality of remote index having the capability to move across different tiers
+     * Gates the functionality of warm index having the capability to store data remotely.
      * Once the feature is ready for release, this feature flag can be removed.
      */
-    public static final String TIERED_REMOTE_INDEX = "opensearch.experimental.feature.tiered_remote_index.enabled";
+    public static final String WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG = "opensearch.experimental.feature.writable_warm_index.enabled";
 
     /**
      * Gates the functionality of background task execution.
@@ -79,7 +79,11 @@ public class FeatureFlags {
         Property.NodeScope
     );
 
-    public static final Setting<Boolean> TIERED_REMOTE_INDEX_SETTING = Setting.boolSetting(TIERED_REMOTE_INDEX, false, Property.NodeScope);
+    public static final Setting<Boolean> WRITABLE_WARM_INDEX_SETTING = Setting.boolSetting(
+        WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG,
+        false,
+        Property.NodeScope
+    );
 
     public static final Setting<Boolean> READER_WRITER_SPLIT_EXPERIMENTAL_SETTING = Setting.boolSetting(
         READER_WRITER_SPLIT_EXPERIMENTAL,
@@ -128,7 +132,7 @@ public class FeatureFlags {
         EXTENSIONS_SETTING,
         TELEMETRY_SETTING,
         DATETIME_FORMATTER_CACHING_SETTING,
-        TIERED_REMOTE_INDEX_SETTING,
+        WRITABLE_WARM_INDEX_SETTING,
         STAR_TREE_INDEX_SETTING,
         APPLICATION_BASED_CONFIGURATION_TEMPLATES_SETTING,
         READER_WRITER_SPLIT_EXPERIMENTAL_SETTING,

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -145,7 +145,7 @@ public final class IndexModule {
     );
 
     /**
-     * Index setting which used to determine how the data is cached locally fully or partially
+     * Index setting which used to determine how the data is cached locally fully or partially.
      */
     public static final Setting<DataLocalityType> INDEX_STORE_LOCALITY_SETTING = new Setting<>(
         "index.store.data_locality",
@@ -154,6 +154,8 @@ public final class IndexModule {
         Property.IndexScope,
         Property.NodeScope
     );
+
+    public static final Setting<Boolean> IS_WARM_INDEX_SETTING = Setting.boolSetting("index.warm", false, Property.IndexScope);
 
     public static final Setting<String> INDEX_RECOVERY_TYPE_SETTING = new Setting<>(
         "index.recovery.type",

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -652,9 +652,9 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             }
 
             Directory directory = null;
-            if (FeatureFlags.isEnabled(FeatureFlags.TIERED_REMOTE_INDEX_SETTING) &&
+            if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_SETTING) &&
             // TODO : Need to remove this check after support for hot indices is added in Composite Directory
-                this.indexSettings.isStoreLocalityPartial()) {
+                this.indexSettings.isWarmIndex()) {
                 Directory localDirectory = directoryFactory.newDirectory(this.indexSettings, path);
                 directory = new CompositeDirectory(localDirectory, remoteDirectory, fileCache);
             } else {

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -790,7 +790,8 @@ public final class IndexSettings {
     private final int numberOfShards;
     private final ReplicationType replicationType;
     private volatile boolean isRemoteStoreEnabled;
-    private final boolean isStoreLocalityPartial;
+    // For warm index we would partially store files in local.
+    private final boolean isWarmIndex;
     private volatile TimeValue remoteTranslogUploadBufferInterval;
     private volatile String remoteStoreTranslogRepository;
     private volatile String remoteStoreRepository;
@@ -994,10 +995,9 @@ public final class IndexSettings {
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
         replicationType = IndexMetadata.INDEX_REPLICATION_TYPE_SETTING.get(settings);
         isRemoteStoreEnabled = settings.getAsBoolean(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, false);
-        isStoreLocalityPartial = settings.get(
-            IndexModule.INDEX_STORE_LOCALITY_SETTING.getKey(),
-            IndexModule.DataLocalityType.FULL.toString()
-        ).equalsIgnoreCase(IndexModule.DataLocalityType.PARTIAL.toString());
+
+        isWarmIndex = settings.getAsBoolean(IndexModule.IS_WARM_INDEX_SETTING.getKey(), false);
+
         remoteStoreTranslogRepository = settings.get(IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY);
         remoteTranslogUploadBufferInterval = INDEX_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING.get(settings);
         remoteStoreRepository = settings.get(IndexMetadata.SETTING_REMOTE_SEGMENT_STORE_REPOSITORY);
@@ -1372,10 +1372,10 @@ public final class IndexSettings {
     }
 
     /**
-     * Returns true if the store locality is partial
+     * Returns true if the index is writable warm index and has partial store locality.
      */
-    public boolean isStoreLocalityPartial() {
-        return isStoreLocalityPartial;
+    public boolean isWarmIndex() {
+        return isWarmIndex;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
@@ -370,7 +370,7 @@ public class NRTReplicationEngine extends Engine {
         ensureOpen();
         // Skip flushing for indices with partial locality (warm indices)
         // For these indices, we don't need to commit as we will sync from the remote store on re-open
-        if (engineConfig.getIndexSettings().isStoreLocalityPartial()) {
+        if (engineConfig.getIndexSettings().isWarmIndex()) {
             return;
         }
         // readLock is held here to wait/block any concurrent close that acquires the writeLock.
@@ -447,7 +447,7 @@ public class NRTReplicationEngine extends Engine {
                     latestSegmentInfos.changed();
                 }
                 try {
-                    if (engineConfig.getIndexSettings().isStoreLocalityPartial() == false) {
+                    if (engineConfig.getIndexSettings().isWarmIndex() == false) {
                         commitSegmentInfos(latestSegmentInfos);
                     }
                 } catch (IOException e) {

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -5142,7 +5142,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             } else {
                 storeDirectory = store.directory();
             }
-            if (indexSettings.isStoreLocalityPartial() == false) {
+            if (indexSettings.isWarmIndex() == false) {
                 copySegmentFiles(storeDirectory, remoteDirectory, null, uploadedSegments, overrideLocal, onFileSync);
             }
 
@@ -5160,7 +5160,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     }
                 }
                 assert Arrays.stream(store.directory().listAll()).filter(f -> f.startsWith(IndexFileNames.SEGMENTS)).findAny().isEmpty()
-                    || indexSettings.isStoreLocalityPartial() : "There should not be any segments file in the dir";
+                    || indexSettings.isWarmIndex() : "There should not be any segments file in the dir";
                 store.commitSegmentInfos(infosSnapshot, processedLocalCheckpoint, processedLocalCheckpoint);
             }
             syncSegmentSuccess = true;

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -206,7 +206,7 @@ public class SegmentReplicationTarget extends ReplicationTarget {
 
         // Return an empty list for warm indices, In this case, replica shards don't require downloading files from remote storage
         // as replicas will sync all files from remote in case of failure.
-        if (indexShard.indexSettings().isStoreLocalityPartial()) {
+        if (indexShard.indexSettings().isWarmIndex()) {
             return Collections.emptyList();
         }
         final Store.RecoveryDiff diff = Store.segmentReplicationDiff(checkpointInfo.getMetadataMap(), indexShard.getSegmentMetadataMap());

--- a/server/src/test/java/org/opensearch/action/admin/indices/tiering/TransportHotToWarmTieringActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/tiering/TransportHotToWarmTieringActionTests.java
@@ -44,7 +44,7 @@ public class TransportHotToWarmTieringActionTests extends OpenSearchIntegTestCas
     @Override
     protected Settings featureFlagSettings() {
         Settings.Builder featureSettings = Settings.builder();
-        featureSettings.put(FeatureFlags.TIERED_REMOTE_INDEX, true);
+        featureSettings.put(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG, true);
         return featureSettings.build();
     }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
@@ -1060,7 +1060,7 @@ public class OperationRoutingTests extends OpenSearchTestCase {
 
     @SuppressForbidden(reason = "feature flag overrides")
     public void testPartialIndexPrimaryDefault() throws Exception {
-        System.setProperty(FeatureFlags.TIERED_REMOTE_INDEX, "true");
+        System.setProperty(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG, "true");
         final int numIndices = 1;
         final int numShards = 2;
         final int numReplicas = 2;
@@ -1116,7 +1116,7 @@ public class OperationRoutingTests extends OpenSearchTestCase {
         } finally {
             IOUtils.close(clusterService);
             terminate(threadPool);
-            System.setProperty(FeatureFlags.TIERED_REMOTE_INDEX, "false");
+            System.setProperty(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG, "false");
         }
     }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/ShardsTieringAllocationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/ShardsTieringAllocationTests.java
@@ -29,7 +29,7 @@ public class ShardsTieringAllocationTests extends TieringAllocationBaseTestCase 
 
     @Before
     public void setup() {
-        FeatureFlagSetter.set(FeatureFlags.TIERED_REMOTE_INDEX);
+        FeatureFlagSetter.set(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG);
     }
 
     public void testShardsInLocalPool() {
@@ -107,7 +107,10 @@ public class ShardsTieringAllocationTests extends TieringAllocationBaseTestCase 
     public void testShardPoolForPartialIndices() {
         String index = "test-index";
         IndexMetadata indexMetadata = IndexMetadata.builder(index)
-            .settings(settings(Version.CURRENT).put(INDEX_STORE_LOCALITY_SETTING.getKey(), IndexModule.DataLocalityType.PARTIAL.name()))
+            .settings(
+                settings(Version.CURRENT).put(INDEX_STORE_LOCALITY_SETTING.getKey(), IndexModule.DataLocalityType.PARTIAL.name())
+                    .put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), true)
+            )
             .numberOfShards(PRIMARIES)
             .numberOfReplicas(REPLICAS)
             .build();

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/TieringAllocationBaseTestCase.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/TieringAllocationBaseTestCase.java
@@ -13,6 +13,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexModule;
 
 import static org.opensearch.index.IndexModule.INDEX_STORE_LOCALITY_SETTING;
 import static org.opensearch.index.IndexModule.INDEX_TIERING_STATE;
@@ -37,6 +38,7 @@ public abstract class TieringAllocationBaseTestCase extends RemoteShardsBalancer
                             .put(settings)
                             .put(settings)
                             .put(INDEX_TIERING_STATE.getKey(), tieringState)
+                            .put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), true)
                             .put(INDEX_STORE_LOCALITY_SETTING.getKey(), dataLocality)
                     )
             );


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- We currently only have tiering implementation for warm indices.
- The current nomenclature for feature flags and settings are too generic and cant differentiate between hot and warm indices.
- Since we want to implement tiering for hot indices as well in near future; we would want to update the nomenclature to be extensible and easy to understand, this PR present the nomenclature changes.

### Related Issues
Resolves #[[17489](https://github.com/opensearch-project/OpenSearch/issues/17489)]
<!-- List any other related issues here -->

Meta Issue https://github.com/opensearch-project/OpenSearch/issues/13149

### Check List
- [NA] Functionality includes testing.
- [NA ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [NA] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
