### PR TITLE
Change IOContext from READONCE to DEFAULT to avoid WrongThreadException

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -459,7 +459,7 @@ public final class RemoteStoreRefreshListener extends ReleasableRetryableRefresh
                 batchUploadListener.onFailure(ex);
             });
             statsListener.beforeUpload(src);
-            remoteDirectory.copyFrom(storeDirectory, src, IOContext.READONCE, aggregatedListener, isLowPriorityUpload());
+            remoteDirectory.copyFrom(storeDirectory, src, IOContext.DEFAULT, aggregatedListener, isLowPriorityUpload());
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
@@ -383,6 +383,7 @@ public class RemoteDirectory extends Directory {
         ActionListener<Void> listener,
         boolean lowPriorityUpload
     ) throws Exception {
+        assert ioContext != IOContext.READONCE : "Remote upload will fail with IoContext.READONCE";
         long expectedChecksum = calculateChecksumOfChecksum(from, src);
         long contentLength;
         try (IndexInput indexInput = from.openInput(src, ioContext)) {

--- a/server/src/test/java/org/opensearch/index/store/RemoteDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteDirectoryTests.java
@@ -92,7 +92,7 @@ public class RemoteDirectoryTests extends OpenSearchTestCase {
             storeDirectory,
             filename,
             filename,
-            IOContext.READONCE,
+            IOContext.DEFAULT,
             () -> postUploadInvoked.set(true),
             new ActionListener<>() {
                 @Override
@@ -130,7 +130,7 @@ public class RemoteDirectoryTests extends OpenSearchTestCase {
             storeDirectory,
             filename,
             filename,
-            IOContext.READONCE,
+            IOContext.DEFAULT,
             () -> postUploadInvoked.set(true),
             new ActionListener<>() {
                 @Override


### PR DESCRIPTION
### Description
- As part of https://github.com/opensearch-project/OpenSearch/pull/15333, read context in RemoteStoreRefreshListener is changed from `DEFAULT` to `READONCE`.
- But this fails with `java.lang.WrongThreadException: Attempted access outside owning thread`. 
```
Caused by: java.lang.WrongThreadException: Attempted access outside owning thread
                at java.base/jdk.internal.foreign.MemorySessionImpl.wrongThread(MemorySessionImpl.java:315) ~[?:?]
                at java.base/jdk.internal.misc.ScopedMemoryAccess$ScopedAccessError.newRuntimeException(ScopedMemoryAccess.java:113) ~[?:?]
                at java.base/jdk.internal.foreign.MemorySessionImpl.checkValidState(MemorySessionImpl.java:219) ~[?:?]
                at java.base/jdk.internal.foreign.ConfinedSession.justClose(ConfinedSession.java:83) ~[?:?]
                at java.base/jdk.internal.foreign.MemorySessionImpl.close(MemorySessionImpl.java:242) ~[?:?]
                at java.base/jdk.internal.foreign.MemorySessionImpl$1.close(MemorySessionImpl.java:88) ~[?:?]
                at org.apache.lucene.store.MemorySegmentIndexInput.close(MemorySegmentIndexInput.java:514) ~[lucene-core-9.12.1.jar:9.12.1 7a97a05a239d6fb9f1f347aa09bfa52e875be092 - 2024-12-09 16:47:48]
                at org.opensearch.common.blobstore.transfer.stream.OffsetRangeIndexInputStream$OffsetRangeRefCount.lambda$new$0(OffsetRangeIndexInputStream.java:157) ~[opensearch-2.19.1.jar:2.19.1]
                at org.opensearch.common.concurrent.RefCountedReleasable.closeInternal(RefCountedReleasable.java:49) ~[opensearch-2.19.1.jar:2.19.1]
                at org.opensearch.common.util.concurrent.AbstractRefCounted.decRef(AbstractRefCounted.java:78) ~[opensearch-common-2.19.1.jar:2.19.1]
                at org.opensearch.common.util.concurrent.RunOnce.run(RunOnce.java:55) ~[opensearch-2.19.1.jar:2.19.1]
                at org.opensearch.common.blobstore.transfer.stream.OffsetRangeIndexInputStream.close(OffsetRangeIndexInputStream.java:167) ~[opensearch-2.19.1.jar:2.19.1]
                at org.opensearch.common.blobstore.transfer.stream.RateLimitingOffsetRangeInputStream.close(RateLimitingOffsetRangeInputStream.java:86) ~[opensearch-2.19.1.jar:2.19.1]
                at java.base/java.io.BufferedInputStream.close(BufferedInputStream.java:618) ~[?:?]
                at org.opensearch.repositories.s3.async.AsyncPartsHandler$UploadTrackedBufferedInputStream.close(AsyncPartsHandler.java:204) ~[repository-s3-2.19.1.jar:2.19.1]
                at org.opensearch.repositories.s3.async.AsyncTransferManager.releaseResourcesSafely(AsyncTransferManager.java:446) ~[repository-s3-2.19.1.jar:2.19.1]
                at org.opensearch.repositories.s3.async.AsyncTransferManager.lambda$uploadInOneChunk$19(AsyncTransferManager.java:403) [repository-s3-2.19.1.jar:2.19.1]
                at java.base/java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:934) ~[?:?]
                ... 49 more
```
- This is due to the async flow of `repository-s3` where IndexInput is getting close in the following code flow.
https://github.com/opensearch-project/OpenSearch/blob/f6d6aa61e5039e4c6143cc25a71c3e448572dd33/server/src/main/java/org/opensearch/common/blobstore/transfer/stream/OffsetRangeIndexInputStream.java#L149-L162
- Remote store integ tests use FsRepository but as the implementation changes for repository-s3, ideally we need to integ tests that talk directly to s3. We will take this up as a follow-up task.

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/15902

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
