### PR TITLE
[bug fix] fix precompute ordering in max & min aggregator

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/MinAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/MinAggregator.java
@@ -109,6 +109,22 @@ class MinAggregator extends NumericMetricsAggregator.SingleValue implements Star
         if (valuesSource == null) {
             return false;
         }
+
+        if (pointConverter != null) {
+            Number segMin = findLeafMinValue(ctx.reader(), pointField, pointConverter);
+            if (segMin != null) {
+                /*
+                 * There is no parent aggregator (see {@link MinAggregator#getPointReaderOrNull}
+                 * so the ordinal for the bucket is always 0.
+                 */
+                double min = mins.get(0);
+                min = Math.min(min, segMin.doubleValue());
+                mins.set(0, min);
+                // the minimum value has been extracted, we don't need to collect hits on this segment.
+                return true;
+            }
+        }
+
         CompositeIndexFieldInfo supportedStarTree = getSupportedStarTree(this.context.getQueryShardContext());
         if (supportedStarTree != null) {
             if (parent != null && subAggregators.length == 0) {
@@ -130,20 +146,6 @@ class MinAggregator extends NumericMetricsAggregator.SingleValue implements Star
                 return LeafBucketCollector.NO_OP_COLLECTOR;
             } else {
                 // we have no parent and the values source is empty so we can skip collecting hits.
-                throw new CollectionTerminatedException();
-            }
-        }
-        if (pointConverter != null) {
-            Number segMin = findLeafMinValue(ctx.reader(), pointField, pointConverter);
-            if (segMin != null) {
-                /*
-                 * There is no parent aggregator (see {@link MinAggregator#getPointReaderOrNull}
-                 * so the ordinal for the bucket is always 0.
-                 */
-                double min = mins.get(0);
-                min = Math.min(min, segMin.doubleValue());
-                mins.set(0, min);
-                // the minimum value has been extracted, we don't need to collect hits on this segment.
                 throw new CollectionTerminatedException();
             }
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixes ordering change of pre-computation steps in Max/Min aggregator which was accidentally changed in https://github.com/opensearch-project/OpenSearch/pull/16733/

### Related Issues
For match-all cases, max/min aggregation without any parent/child aggregations can be precomputed faster than star-tree, so that's why it was prioritized over star-tree pre-computation. This ordering was modified accidentally in the [above](https://github.com/opensearch-project/OpenSearch/pull/16733/) refactoring change, so making this change back.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
