### PR TITLE
Add Windows 2025+Java 21 combination to build matrix

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -9,6 +9,10 @@ jobs:
       matrix:
         java: [ 21, 23 ]
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13, ubuntu-24.04-arm]
+        include:
+          - java: 21
+            os: 'windows-2025'
+            experimental: true
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
@@ -18,6 +22,7 @@ jobs:
           distribution: temurin
           cache: gradle
       - name: Run Gradle (precommit)
+        continue-on-error: ${{ matrix.experimental }}
         shell: bash
         run: |
           ./gradlew javadoc precommit --parallel


### PR DESCRIPTION
### Description

Adds Windows 2025 + JDK 21 combination to the Precommit build matrix.

See https://github.blog/changelog/2024-12-19-windows-server-2025-is-now-in-public-preview/

Marked as experimental as the GitHub image is in public preview.

### Check List
- [x] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
