### PR TITLE
Fix red index on close for remote enabled clusters

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
@@ -40,6 +40,7 @@ import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.Lock;
 import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
@@ -166,7 +167,7 @@ public class ReadOnlyEngine extends Engine {
     }
 
     protected void ensureMaxSeqNoEqualsToGlobalCheckpoint(final SeqNoStats seqNoStats) {
-        if (requireCompleteHistory == false) {
+        if (requireCompleteHistory == false || isClosedRemoteIndex()) {
             return;
         }
         // Before 3.0 the global checkpoint is not known and up to date when the engine is created after
@@ -185,6 +186,14 @@ public class ReadOnlyEngine extends Engine {
                     + "]"
             );
         }
+    }
+
+    /**
+     * Returns true if this is a remote store index (included if migrating as well) which is closed.
+     */
+    private boolean isClosedRemoteIndex() {
+        return this.engineConfig.getIndexSettings().isAssignedOnRemoteNode()
+            && this.engineConfig.getIndexSettings().getIndexMetadata().getState() == IndexMetadata.State.CLOSE;
     }
 
     protected boolean assertMaxSeqNoEqualsToGlobalCheckpoint(final long maxSeqNo, final long globalCheckpoint) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The check of comparing the max seq no and global checkpoint during bootstrap of ReadOnlyEngine for remote store enabled index is not required since the global checkpoint does not play a role with remote store. With a similar PR (https://github.com/opensearch-project/OpenSearch/pull/15990), changes were made to track the global checkpoint that has been updated as part of the successful translog upload to remote store. There are still cases where the global checkpoint appears to be changing locally but not getting updated on remote store. 

### Check List
- ~[ ] Functionality includes testing.~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
