### PR TITLE
Change IOContext from READONCE to DEFAULT to avoid WrongThreadException (#17502)

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -460,7 +460,7 @@ public final class RemoteStoreRefreshListener extends ReleasableRetryableRefresh
                 batchUploadListener.onFailure(ex);
             });
             statsListener.beforeUpload(src);
-            remoteDirectory.copyFrom(storeDirectory, src, IOContext.READONCE, aggregatedListener, isLowPriorityUpload());
+            remoteDirectory.copyFrom(storeDirectory, src, IOContext.DEFAULT, aggregatedListener, isLowPriorityUpload());
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
@@ -357,6 +357,7 @@ public class RemoteDirectory extends Directory {
         ActionListener<Void> listener,
         boolean lowPriorityUpload
     ) throws Exception {
+        assert ioContext != IOContext.READONCE : "Remote upload will fail with IoContext.READONCE";
         long expectedChecksum = calculateChecksumOfChecksum(from, src);
         long contentLength;
         try (IndexInput indexInput = from.openInput(src, ioContext)) {

--- a/server/src/test/java/org/opensearch/index/store/RemoteDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteDirectoryTests.java
@@ -94,7 +94,7 @@ public class RemoteDirectoryTests extends OpenSearchTestCase {
             storeDirectory,
             filename,
             filename,
-            IOContext.READ,
+            IOContext.DEFAULT,
             () -> postUploadInvoked.set(true),
             new ActionListener<>() {
                 @Override
@@ -132,7 +132,7 @@ public class RemoteDirectoryTests extends OpenSearchTestCase {
             storeDirectory,
             filename,
             filename,
-            IOContext.READ,
+            IOContext.DEFAULT,
             () -> postUploadInvoked.set(true),
             new ActionListener<>() {
                 @Override


### PR DESCRIPTION
Backport https://github.com/opensearch-project/OpenSearch/commit/588f46d731587bebd54511dc2df21a2f4ffb9f32 from https://github.com/opensearch-project/OpenSearch/pull/17502