### PR TITLE
Fix compilation issue for #17535 backport PR

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreStatsIT.java
@@ -283,16 +283,16 @@ public class RemoteStoreStatsIT extends RemoteStoreBaseIntegTestCase {
                 // Existing validation logic
                 List<RemoteStoreStats> primaryStatsList = Arrays.stream(response.getRemoteStoreStats())
                     .filter(remoteStoreStats -> remoteStoreStats.getShardRouting().primary())
-                    .toList();
+                    .collect(Collectors.toList());
                 assertEquals(1, primaryStatsList.size());
 
                 List<RemoteStoreStats> replicaStatsList = Arrays.stream(response.getRemoteStoreStats())
                     .filter(remoteStoreStats -> !remoteStoreStats.getShardRouting().primary())
-                    .toList();
+                    .collect(Collectors.toList());
                 assertEquals(1, replicaStatsList.size());
 
-                RemoteSegmentTransferTracker.Stats primaryStats = primaryStatsList.getFirst().getSegmentStats();
-                RemoteSegmentTransferTracker.Stats replicaStats = replicaStatsList.getFirst().getSegmentStats();
+                RemoteSegmentTransferTracker.Stats primaryStats = primaryStatsList.get(0).getSegmentStats();
+                RemoteSegmentTransferTracker.Stats replicaStats = replicaStatsList.get(0).getSegmentStats();
 
                 // Existing assertions
                 assertTrue(primaryStats.totalUploadsStarted > 0);
@@ -409,7 +409,7 @@ public class RemoteStoreStatsIT extends RemoteStoreBaseIntegTestCase {
                 assertEquals(0, stats.getSegmentStats().directoryFileTransferTrackerStats.transferredBytesSucceeded);
             });
         } else {
-            RemoteSegmentTransferTracker.Stats replicaStats = zeroStateReplicaStats.getFirst().getSegmentStats();
+            RemoteSegmentTransferTracker.Stats replicaStats = zeroStateReplicaStats.get(0).getSegmentStats();
             assertEquals(0, replicaStats.directoryFileTransferTrackerStats.transferredBytesStarted);
             assertEquals(0, replicaStats.directoryFileTransferTrackerStats.transferredBytesSucceeded);
         }
@@ -434,8 +434,8 @@ public class RemoteStoreStatsIT extends RemoteStoreBaseIntegTestCase {
 
             RemoteSegmentTransferTracker.Stats primaryStats = Arrays.stream(zeroStateResponse.getRemoteStoreStats())
                 .filter(remoteStoreStats -> remoteStoreStats.getShardRouting().primary())
-                .toList()
-                .getFirst()
+                .collect(Collectors.toList())
+                .get(0)
                 .getSegmentStats();
 
             validateZeroStatePrimaryStats(primaryStats);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
During the build of backport PR https://github.com/opensearch-project/OpenSearch/pull/17543 (backport of https://github.com/opensearch-project/OpenSearch/pull/17535), the compilation is failing due to usage of methods introduced in jdk 16 & 21. In this PR, we have moved back to supported methods already being used.

### Check List
- ~[ ] Functionality includes testing.~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
