### PR TITLE
Add read and write optional enum sets methods to stream input and output

### DIFF
--- a/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java
@@ -1305,6 +1305,21 @@ public abstract class StreamInput extends InputStream {
         return res;
     }
 
+    /**
+     * Reads an optional enum with type E that was serialized based on the value of its ordinal
+     * The set is expected to have been written using {@link StreamOutput#writeOptionalEnumSet(EnumSet)}
+     *
+     * @return the enum set of strings
+     * @throws IOException if an I/O exception occurs reading the set
+     */
+    public <E extends Enum<E>> EnumSet<E> readOptionalEnumSet(Class<E> enumClass) throws IOException {
+        if (readBoolean()) {
+            return readEnumSet(enumClass);
+        } else {
+            return null;
+        }
+    }
+
     public static StreamInput wrap(byte[] bytes) {
         return wrap(bytes, 0, bytes.length);
     }

--- a/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamOutput.java
+++ b/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamOutput.java
@@ -1256,6 +1256,19 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     /**
+     * Writes an optional EnumSet with type E that by serialized it based on it's ordinal value
+     * For null enum set, writes false;
+     */
+    public <E extends Enum<E>> void writeOptionalEnumSet(@Nullable EnumSet<E> enumSet) throws IOException {
+        if (enumSet != null) {
+            writeBoolean(true);
+            writeEnumSet(enumSet);
+        } else {
+            writeBoolean(false);
+        }
+    }
+
+    /**
      * Write a {@link TimeValue} to the stream
      */
     public void writeTimeValue(TimeValue timeValue) throws IOException {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
In some plugins there are use cases to read and write optional EnumSets to and from StreamOutput/StreamInput, similar to existing `readOptionalStringCollection`/`writeOptionalStringList` methods. 

Currently this is done with plugin specific private helper methods, but since this functionality is common to multiple plugins and we are planning on building similar systems for geospatial and search relevance lab plugins, it may be more elegant to consolidate them in core. Examples:
- [ml-commons MLStatsInput](https://github.com/opensearch-project/ml-commons/blob/main/plugin/src/main/java/org/opensearch/ml/stats/MLStatsInput.java#L142)
- [Open PR for neural search NeuralStatsInput](https://github.com/opensearch-project/neural-search/pull/1208/files#diff-4780716fe9d34e228bdb31b6aa819080ab4861b1fcde599e6356ded5cc3e4d22R134)

### Related Issues
n/a

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
