### PR TITLE
[Pull-based Ingestion] Add support for dynamically updating ingestion error handling strategy with minor fixes

### DIFF
--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
@@ -8,13 +8,11 @@
 
 package org.opensearch.plugin.kafka;
 
-import org.junit.Assert;
 import org.opensearch.action.admin.cluster.node.info.NodeInfo;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.opensearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.Request;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.query.RangeQueryBuilder;
@@ -22,16 +20,16 @@ import org.opensearch.indices.pollingingest.PollingIngestStats;
 import org.opensearch.plugins.PluginInfo;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.transport.client.Requests;
+import org.junit.Assert;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Integration test for Kafka ingestion
@@ -56,7 +54,7 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
         );
     }
 
-    public void testKafkaIngestion() throws Exception {
+    public void testKafkaIngestion() {
         produceData("1", "name1", "24");
         produceData("2", "name2", "20");
         createIndexWithDefaultSettings(1, 0);
@@ -125,7 +123,7 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
         );
 
         RangeQueryBuilder query = new RangeQueryBuilder("age").gte(0);
-        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+        await().atMost(1, TimeUnit.MINUTES).untilAsserted(() -> {
             refresh("test_rewind_by_offset");
             SearchResponse response = client().prepareSearch("test_rewind_by_offset").setQuery(query).get();
             assertThat(response.getHits().getTotalHits().value(), is(1L));

--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/KafkaIngestionBaseIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/KafkaIngestionBaseIT.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.testcontainers.containers.KafkaContainer;
@@ -109,6 +110,18 @@ public class KafkaIngestionBaseIT extends OpenSearchIntegTestCase {
                 }
             }
         }, 1, TimeUnit.MINUTES);
+    }
+
+    protected void waitForState(Callable<Boolean> checkState) throws Exception {
+        assertBusy(() -> {
+            if (checkState.call() == false) {
+                fail("Provided state requirements not met");
+            }
+        }, 1, TimeUnit.MINUTES);
+    }
+
+    protected String getSettings(String indexName, String setting) {
+        return client().admin().indices().prepareGetSettings(indexName).get().getSetting(indexName, setting);
     }
 
     protected void createIndexWithDefaultSettings(int numShards, int numReplicas) {

--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/KafkaIngestionBaseIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/KafkaIngestionBaseIT.java
@@ -15,6 +15,8 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.junit.After;
@@ -107,5 +109,21 @@ public class KafkaIngestionBaseIT extends OpenSearchIntegTestCase {
                 }
             }
         }, 1, TimeUnit.MINUTES);
+    }
+
+    protected void createIndexWithDefaultSettings(int numShards, int numReplicas) {
+        createIndex(
+            indexName,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numReplicas)
+                .put("ingestion_source.type", "kafka")
+                .put("ingestion_source.pointer.init.reset", "earliest")
+                .put("ingestion_source.param.topic", topicName)
+                .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
+                .put("index.replication.type", "SEGMENT")
+                .build(),
+            "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
+        );
     }
 }

--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/RemoteStoreKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/RemoteStoreKafkaIT.java
@@ -16,9 +16,11 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.transport.client.Requests;
 
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.is;
 
@@ -46,20 +48,7 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
 
         internalCluster().startClusterManagerOnlyNode();
         final String nodeA = internalCluster().startDataOnlyNode();
-
-        createIndex(
-            indexName,
-            Settings.builder()
-                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
-                .put("ingestion_source.type", "kafka")
-                .put("ingestion_source.pointer.init.reset", "earliest")
-                .put("ingestion_source.param.topic", topicName)
-                .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
-                .put("index.replication.type", "SEGMENT")
-                .build(),
-            mapping
-        );
+        createIndexWithDefaultSettings(1, 1);
 
         ensureYellowAndNoInitializingShards(indexName);
         final String nodeB = internalCluster().startDataOnlyNode();
@@ -115,6 +104,19 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
         produceData("6", "name6", "41");
         refresh(indexName);
         waitForSearchableDocs(6, Arrays.asList(nodeB, nodeC));
+    }
+
+    public void testCloseIndex() throws Exception {
+        produceData("1", "name1", "24");
+        produceData("2", "name2", "20");
+        internalCluster().startClusterManagerOnlyNode();
+        final String nodeA = internalCluster().startDataOnlyNode();
+        final String nodeB = internalCluster().startDataOnlyNode();
+
+        createIndexWithDefaultSettings(1, 1);
+        ensureGreen(indexName);
+        waitForSearchableDocs(2, Arrays.asList(nodeA, nodeB));
+        client().admin().indices().close(Requests.closeIndexRequest(indexName)).get();
     }
 
     private void verifyRemoteStoreEnabled(String node) {

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -771,13 +771,17 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         Property.Final
     );
 
+    /**
+     * Defines the error strategy for pull-based ingestion.
+     */
     public static final String SETTING_INGESTION_SOURCE_ERROR_STRATEGY = "index.ingestion_source.error_strategy";
     public static final Setting<IngestionErrorStrategy.ErrorStrategy> INGESTION_SOURCE_ERROR_STRATEGY_SETTING = new Setting<>(
         SETTING_INGESTION_SOURCE_ERROR_STRATEGY,
         IngestionErrorStrategy.ErrorStrategy.DROP.name(),
         IngestionErrorStrategy.ErrorStrategy::parseFromString,
         (errorStrategy) -> {},
-        Property.IndexScope
+        Property.IndexScope,
+        Property.Dynamic
     );
 
     public static final Setting.AffixSetting<Object> INGESTION_SOURCE_PARAMS_SETTING = Setting.prefixKeySetting(

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -215,8 +215,14 @@ public class IngestionEngine extends InternalEngine {
                 commitData.put(HISTORY_UUID_KEY, historyUUID);
                 commitData.put(Engine.MIN_RETAINED_SEQNO, Long.toString(softDeletesPolicy.getMinRetainedSeqNo()));
 
-                // ingestion engine needs to record batch start pointer
-                commitData.put(StreamPoller.BATCH_START, streamPoller.getBatchStartPointer().asString());
+                /*
+                 * Ingestion engine needs to record batch start pointer.
+                 * Batch start pointer can be null at index creation time, if flush is called before the stream
+                 * poller has been completely initialized.
+                 */
+                if (streamPoller.getBatchStartPointer() != null) {
+                    commitData.put(StreamPoller.BATCH_START, streamPoller.getBatchStartPointer().asString());
+                }
                 final String currentForceMergeUUID = forceMergeUUID;
                 if (currentForceMergeUUID != null) {
                     commitData.put(FORCE_MERGE_UUID_KEY, currentForceMergeUUID);

--- a/server/src/main/java/org/opensearch/indices/pollingingest/BlockIngestionErrorStrategy.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/BlockIngestionErrorStrategy.java
@@ -30,7 +30,7 @@ public class BlockIngestionErrorStrategy implements IngestionErrorStrategy {
     }
 
     @Override
-    public boolean shouldPauseIngestion(Throwable e, ErrorStage stage) {
-        return true;
+    public boolean shouldIgnoreError(Throwable e, ErrorStage stage) {
+        return false;
     }
 }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DropIngestionErrorStrategy.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DropIngestionErrorStrategy.java
@@ -30,8 +30,8 @@ public class DropIngestionErrorStrategy implements IngestionErrorStrategy {
     }
 
     @Override
-    public boolean shouldPauseIngestion(Throwable e, ErrorStage stage) {
-        return false;
+    public boolean shouldIgnoreError(Throwable e, ErrorStage stage) {
+        return true;
     }
 
 }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/IngestionErrorStrategy.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/IngestionErrorStrategy.java
@@ -25,9 +25,9 @@ public interface IngestionErrorStrategy {
     void handleError(Throwable e, ErrorStage stage);
 
     /**
-     * Indicates if ingestion must be paused, blocking further writes.
+     * Indicates if the error should be ignored.
      */
-    boolean shouldPauseIngestion(Throwable e, ErrorStage stage);
+    boolean shouldIgnoreError(Throwable e, ErrorStage stage);
 
     static IngestionErrorStrategy create(ErrorStrategy errorStrategy, String ingestionSource) {
         switch (errorStrategy) {

--- a/server/src/main/java/org/opensearch/indices/pollingingest/MessageProcessorRunnable.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/MessageProcessorRunnable.java
@@ -46,15 +46,15 @@ import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
  */
 public class MessageProcessorRunnable implements Runnable {
     private static final Logger logger = LogManager.getLogger(MessageProcessorRunnable.class);
-
-    private final BlockingQueue<IngestionShardConsumer.ReadResult<? extends IngestionShardPointer, ? extends Message>> blockingQueue;
-    private final MessageProcessor messageProcessor;
-    private final CounterMetric stats = new CounterMetric();
-    private IngestionErrorStrategy errorStrategy;
-
     private static final String ID = "_id";
     private static final String OP_TYPE = "_op_type";
     private static final String SOURCE = "_source";
+    private static final int WAIT_BEFORE_RETRY_DURATION_MS = 5000;
+
+    private volatile IngestionErrorStrategy errorStrategy;
+    private final BlockingQueue<IngestionShardConsumer.ReadResult<? extends IngestionShardPointer, ? extends Message>> blockingQueue;
+    private final MessageProcessor messageProcessor;
+    private final CounterMetric stats = new CounterMetric();
 
     /**
      * Constructor.
@@ -223,32 +223,59 @@ public class MessageProcessorRunnable implements Runnable {
         return blockingQueue;
     }
 
+    /**
+     * Polls messages from the blocking queue and processes messages. If message processing fails, the failed message
+     * is retried indefinitely after a retry wait time, unless a DROP error policy is used to skip the failed message.
+     */
     @Override
     public void run() {
+        IngestionShardConsumer.ReadResult<? extends IngestionShardPointer, ? extends Message> readResult = null;
+
         while (!(Thread.currentThread().isInterrupted())) {
-            IngestionShardConsumer.ReadResult<? extends IngestionShardPointer, ? extends Message> result = null;
             try {
-                result = blockingQueue.poll(1000, TimeUnit.MILLISECONDS);
+                if (readResult == null) {
+                    readResult = blockingQueue.poll(1000, TimeUnit.MILLISECONDS);
+                }
             } catch (InterruptedException e) {
                 // TODO: add metric
                 logger.debug("MessageProcessorRunnable poll interruptedException", e);
                 Thread.currentThread().interrupt(); // Restore interrupt status
             }
-            if (result != null) {
+            if (readResult != null) {
                 try {
                     stats.inc();
-                    messageProcessor.process(result.getMessage(), result.getPointer());
+                    messageProcessor.process(readResult.getMessage(), readResult.getPointer());
+                    readResult = null;
                 } catch (Exception e) {
                     errorStrategy.handleError(e, IngestionErrorStrategy.ErrorStage.PROCESSING);
-                    if (errorStrategy.shouldPauseIngestion(e, IngestionErrorStrategy.ErrorStage.PROCESSING)) {
-                        Thread.currentThread().interrupt();
+                    if (errorStrategy.shouldIgnoreError(e, IngestionErrorStrategy.ErrorStage.PROCESSING)) {
+                        readResult = null;
+                    } else {
+                        waitBeforeRetry();
                     }
                 }
             }
         }
     }
 
+    private void waitBeforeRetry() {
+        try {
+            Thread.sleep(WAIT_BEFORE_RETRY_DURATION_MS);
+        } catch (InterruptedException e) {
+            logger.debug("MessageProcessor thread interrupted while waiting for retry", e);
+            Thread.currentThread().interrupt(); // Restore interrupt status
+        }
+    }
+
     public CounterMetric getStats() {
         return stats;
+    }
+
+    public IngestionErrorStrategy getErrorStrategy() {
+        return this.errorStrategy;
+    }
+
+    public void setErrorStrategy(IngestionErrorStrategy errorStrategy) {
+        this.errorStrategy = errorStrategy;
     }
 }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
@@ -52,6 +52,13 @@ public interface StreamPoller extends Closeable {
 
     PollingIngestStats getStats();
 
+    IngestionErrorStrategy getErrorStrategy();
+
+    /**
+     * Update the error strategy for the poller.
+     */
+    void updateErrorStrategy(IngestionErrorStrategy errorStrategy);
+
     /**
      * a state to indicate the current state of the poller
      */

--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -54,7 +54,6 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         messages = new ArrayList<>();
-        ;
         messages.add("{\"_id\":\"1\",\"_source\":{\"name\":\"bob\", \"age\": 24}}".getBytes(StandardCharsets.UTF_8));
         messages.add("{\"_id\":\"2\",\"_source\":{\"name\":\"alice\", \"age\": 21}}".getBytes(StandardCharsets.UTF_8));
         fakeConsumer = new FakeIngestionSource.FakeIngestionConsumer(messages, 0);
@@ -345,5 +344,13 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         // poller will continue to poll if an error is encountered during message processing but will be blocked by
         // the write to blockingQueue
         assertEquals(DefaultStreamPoller.State.POLLING, poller.getState());
+    }
+
+    public void testUpdateErrorStrategy() {
+        assertTrue(poller.getErrorStrategy() instanceof DropIngestionErrorStrategy);
+        assertTrue(processorRunnable.getErrorStrategy() instanceof DropIngestionErrorStrategy);
+        poller.updateErrorStrategy(new BlockIngestionErrorStrategy("ingestion_source"));
+        assertTrue(poller.getErrorStrategy() instanceof BlockIngestionErrorStrategy);
+        assertTrue(processorRunnable.getErrorStrategy() instanceof BlockIngestionErrorStrategy);
     }
 }


### PR DESCRIPTION
### Description
1. This PR is a follow up for #17427 to add support for dynamically updating ingestion error strategy using [update_settings](https://opensearch.org/docs/latest/api-reference/index-apis/update-settings/) API. 
2. Message processor will indefinitely retry failed messages after a wait time, if a BLOCK error strategy is used. Updating to DROP strategy will skip the failed messages.
3. Additionally, the PR includes minor fixes - fixes initial global checkpoint in p2p segRep mode which is validated by flows such as CloseIndex API and handle race condition on flush before poller is initialized completely.

This PR forms the base on which subsequent PRs will build on for adding pause/resume APIs.

### Related Issues
Resolves part of #17442. Subsequent PRs will add pause/resume APIs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
