### PR TITLE
Add search backpressure service check for query group tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix exists queries on nested flat_object fields throws exception ([#16803](https://github.com/opensearch-project/OpenSearch/pull/16803))
 - Add highlighting for wildcard search on `match_only_text` field ([#17101](https://github.com/opensearch-project/OpenSearch/pull/17101))
 - Fix illegal argument exception when creating a PIT ([#16781](https://github.com/opensearch-project/OpenSearch/pull/16781))
+- Fix NPE in node stats due to QueryGroupTasks ([#17576](https://github.com/opensearch-project/OpenSearch/pull/17576))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/wlm/QueryGroupService.java
+++ b/server/src/main/java/org/opensearch/wlm/QueryGroupService.java
@@ -331,7 +331,7 @@ public class QueryGroupService extends AbstractLifecycleComponent
     public boolean shouldSBPHandle(Task t) {
         QueryGroupTask task = (QueryGroupTask) t;
         boolean isInvalidQueryGroupTask = true;
-        if (task.isQueryGroupSet() && !task.getQueryGroupId().equals(QueryGroupTask.DEFAULT_QUERY_GROUP_ID_SUPPLIER.get())) {
+        if (task.isQueryGroupSet() && !QueryGroupTask.DEFAULT_QUERY_GROUP_ID_SUPPLIER.get().equals(task.getQueryGroupId())) {
             isInvalidQueryGroupTask = activeQueryGroups.stream()
                 .noneMatch(queryGroup -> queryGroup.get_id().equals(task.getQueryGroupId()));
         }

--- a/server/src/main/java/org/opensearch/wlm/QueryGroupService.java
+++ b/server/src/main/java/org/opensearch/wlm/QueryGroupService.java
@@ -331,7 +331,7 @@ public class QueryGroupService extends AbstractLifecycleComponent
     public boolean shouldSBPHandle(Task t) {
         QueryGroupTask task = (QueryGroupTask) t;
         boolean isInvalidQueryGroupTask = true;
-        if (!task.getQueryGroupId().equals(QueryGroupTask.DEFAULT_QUERY_GROUP_ID_SUPPLIER.get())) {
+        if (task.isQueryGroupSet() && !task.getQueryGroupId().equals(QueryGroupTask.DEFAULT_QUERY_GROUP_ID_SUPPLIER.get())) {
             isInvalidQueryGroupTask = activeQueryGroups.stream()
                 .noneMatch(queryGroup -> queryGroup.get_id().equals(task.getQueryGroupId()));
         }
@@ -340,7 +340,7 @@ public class QueryGroupService extends AbstractLifecycleComponent
 
     @Override
     public void onTaskCompleted(Task task) {
-        if (!(task instanceof QueryGroupTask)) {
+        if (!(task instanceof QueryGroupTask) || !((QueryGroupTask) task).isQueryGroupSet()) {
             return;
         }
         final QueryGroupTask queryGroupTask = (QueryGroupTask) task;

--- a/server/src/test/java/org/opensearch/wlm/QueryGroupServiceTests.java
+++ b/server/src/test/java/org/opensearch/wlm/QueryGroupServiceTests.java
@@ -395,7 +395,7 @@ public class QueryGroupServiceTests extends OpenSearchTestCase {
     }
 
     public void testOnTaskCompleted() {
-        Task task = createMockTaskWithResourceStats(SearchTask.class, 100, 200, 0, 12);
+        Task task = new SearchTask(12, "", "", () -> "", null, null);
         mockThreadPool = new TestThreadPool("queryGroupServiceTests");
         mockThreadPool.getThreadContext().putHeader(QueryGroupTask.QUERY_GROUP_ID_HEADER, "testId");
         QueryGroupState queryGroupState = new QueryGroupState();

--- a/server/src/test/java/org/opensearch/wlm/QueryGroupServiceTests.java
+++ b/server/src/test/java/org/opensearch/wlm/QueryGroupServiceTests.java
@@ -442,7 +442,7 @@ public class QueryGroupServiceTests extends OpenSearchTestCase {
     }
 
     public void testShouldSBPHandle() {
-        QueryGroupTask task = createMockTaskWithResourceStats(SearchTask.class, 100, 200, 0, 12);
+        SearchTask task = createMockTaskWithResourceStats(SearchTask.class, 100, 200, 0, 12);
         QueryGroupState queryGroupState = new QueryGroupState();
         Set<QueryGroup> activeQueryGroups = new HashSet<>();
         mockQueryGroupStateMap.put("testId", queryGroupState);
@@ -464,6 +464,8 @@ public class QueryGroupServiceTests extends OpenSearchTestCase {
         mockThreadPool = new TestThreadPool("queryGroupServiceTests");
         mockThreadPool.getThreadContext()
             .putHeader(QueryGroupTask.QUERY_GROUP_ID_HEADER, QueryGroupTask.DEFAULT_QUERY_GROUP_ID_SUPPLIER.get());
+        // we haven't set the queryGroupId yet SBP should still track the task for cancellation
+        assertTrue(queryGroupService.shouldSBPHandle(task));
         task.setQueryGroupId(mockThreadPool.getThreadContext());
         assertTrue(queryGroupService.shouldSBPHandle(task));
 
@@ -490,6 +492,15 @@ public class QueryGroupServiceTests extends OpenSearchTestCase {
         );
         assertTrue(queryGroupService.shouldSBPHandle(task));
 
+        mockThreadPool.shutdownNow();
+
+        // test the case when SBP should not track the task
+        when(mockWorkloadManagementSettings.getWlmMode()).thenReturn(WlmMode.ENABLED);
+        task = new SearchTask(1, "", "test", () -> "", null, null);
+        mockThreadPool = new TestThreadPool("queryGroupServiceTests");
+        mockThreadPool.getThreadContext().putHeader(QueryGroupTask.QUERY_GROUP_ID_HEADER, "testId");
+        task.setQueryGroupId(mockThreadPool.getThreadContext());
+        assertFalse(queryGroupService.shouldSBPHandle(task));
     }
 
     private static Set<QueryGroup> getActiveQueryGroups(


### PR DESCRIPTION
### Description
This change is to address the bug when search backpressure service is gathering the node stats and there are `QueryGroupTask`s in the system which doesn't have the **queryGroupId** set. In this case there will be a NPE thrown for node stats due to this [line](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/wlm/QueryGroupService.java#L334).

But this will only happen for 2.x versions since they don't have the scroll API changes for setting the **queryGroupId** https://github.com/opensearch-project/OpenSearch/pull/17169. We had to remove the API change because of the backward compatibility failure which was blocking the merge but later maintainers removed the check for internalApi annotated classes since they are not meant to be used outside of opensearch core. 

I will also add that change in 2.x subsequently.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/17518#issuecomment-2701970433

### Check List
- [X] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
