### PR TITLE
Remove tj-actions/changed-files usage from the Github Action checks since it has been compromised

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -16,24 +16,8 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  check-files:
-    runs-on: ubuntu-latest
-    outputs:
-      RUN_GRADLE_CHECK: ${{ steps.changed-files-specific.outputs.any_changed }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get changed files
-      id: changed-files-specific
-      uses: tj-actions/changed-files@v45
-      with:
-        files_ignore: |
-          release-notes/*.md
-          .github/**
-          *.md
-
   gradle-check:
-    needs: check-files
-    if: github.repository == 'opensearch-project/OpenSearch' && needs.check-files.outputs.RUN_GRADLE_CHECK == 'true'
+    if: github.repository == 'opensearch-project/OpenSearch'
     permissions:
       contents: read # to fetch code (actions/checkout)
       pull-requests: write # to create or update comment (peter-evans/create-or-update-comment)
@@ -164,10 +148,10 @@ jobs:
             Please examine the workflow log, locate, and copy-paste the failure(s) below, then iterate to green. Is the failure [a flaky test](https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md#flaky-tests) unrelated to your change?
 
   check-result:
-    needs: [check-files, gradle-check]
+    needs: [gradle-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Fail if gradle-check fails
-        if: ${{ needs.check-files.outputs.RUN_GRADLE_CHECK && needs.gradle-check.result == 'failure' }}
+        if: ${{ needs.gradle-check.result == 'failure' }}
         run: exit 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Remove tj-actions/changed-files usage from the Github Action checks since it has been compromised. See please https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised 

### Related Issues
N/A

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
