### PR TITLE
[Backport 2.19]Add search backpressure service check for query group tasks (#17576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Fix NPE in node stats due to QueryGroupTasks ([#17576](https://github.com/opensearch-project/OpenSearch/pull/17576))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/wlm/QueryGroupService.java
+++ b/server/src/main/java/org/opensearch/wlm/QueryGroupService.java
@@ -331,7 +331,7 @@ public class QueryGroupService extends AbstractLifecycleComponent
     public boolean shouldSBPHandle(Task t) {
         QueryGroupTask task = (QueryGroupTask) t;
         boolean isInvalidQueryGroupTask = true;
-        if (!task.getQueryGroupId().equals(QueryGroupTask.DEFAULT_QUERY_GROUP_ID_SUPPLIER.get())) {
+        if (task.isQueryGroupSet() && !QueryGroupTask.DEFAULT_QUERY_GROUP_ID_SUPPLIER.get().equals(task.getQueryGroupId())) {
             isInvalidQueryGroupTask = activeQueryGroups.stream()
                 .noneMatch(queryGroup -> queryGroup.get_id().equals(task.getQueryGroupId()));
         }
@@ -340,7 +340,7 @@ public class QueryGroupService extends AbstractLifecycleComponent
 
     @Override
     public void onTaskCompleted(Task task) {
-        if (!(task instanceof QueryGroupTask)) {
+        if (!(task instanceof QueryGroupTask) || !((QueryGroupTask) task).isQueryGroupSet()) {
             return;
         }
         final QueryGroupTask queryGroupTask = (QueryGroupTask) task;


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/OpenSearch/commit/8ee5eebc3728a19487c0604d9828f92770fcd7ec from https://github.com/opensearch-project/OpenSearch/pull/17576.
