### PR TITLE
Fix flaky test due to incorrect use of SSDV.nextOrd()

### DIFF
--- a/server/src/test/java/org/opensearch/index/fielddata/ordinals/MultiOrdinalsTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/ordinals/MultiOrdinalsTests.java
@@ -128,10 +128,10 @@ public class MultiOrdinalsTests extends OpenSearchTestCase {
                     assertThat((long) singleOrds.ordValue(), equalTo(docOrds.get(0)));
 
                     assertTrue(docs.advanceExact(docId));
+                    assertEquals(docOrds.size(), docs.docValueCount());
                     for (Long ord : docOrds) {
                         assertThat(docs.nextOrd(), equalTo(ord));
                     }
-                    assertEquals(SortedSetDocValues.NO_MORE_DOCS, docs.nextOrd());
                 }
                 for (int i = docId + 1; i < ordAndId.id; i++) {
                     assertFalse(singleOrds.advanceExact(i));
@@ -277,10 +277,10 @@ public class MultiOrdinalsTests extends OpenSearchTestCase {
             long[] ords = ordinalPlan[doc];
             assertEquals(ords.length > 0, docs.advanceExact(doc));
             if (ords.length > 0) {
+                assertEquals(ords.length, docs.docValueCount());
                 for (long ord : ords) {
                     assertThat(docs.nextOrd(), equalTo(ord));
                 }
-                assertThat(docs.nextOrd(), equalTo((long) SortedSetDocValues.NO_MORE_DOCS));
             }
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Lucene 10 makes it illegal to call `SortedSetDocValues#nextOrd()` more than#docValueCount() times for the currently-positioned doc. This was causing flakiness in `MultiOrdinalsTests` as encountered in PR https://github.com/opensearch-project/OpenSearch/pull/17446 with failure https://build.ci.opensearch.org/job/gradle-check/54686/testReport/junit/org.opensearch.index.fielddata.ordinals/MultiOrdinalsTests/testRandomValues/


https://github.com/apache/lucene/blob/e7f9bc837e419672d9bfc829d01e643df667e9d4/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValues.java#L36

We need to address this throughout the codebase thus created https://github.com/opensearch-project/OpenSearch/issues/17628
### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/17628 
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
~~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~~
~~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
