### PR TITLE
Introduce mapping transformer to allow transform mappings during index create/update or index template create/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Disable scoring of keyword term search by default, fallback logic with new use_similarity:true parameter ([#17889](https://github.com/opensearch-project/OpenSearch/pull/17889))
 - Add versioning support in pull-based ingestion ([#17918](https://github.com/opensearch-project/OpenSearch/pull/17918))
 - Introducing MergedSegmentWarmerFactory to support the extension of IndexWriter.IndexReaderWarmer ([#17881](https://github.com/opensearch-project/OpenSearch/pull/17881))
+- Introduce mapping transformer to allow transform mappings during index create/update or index template create/update ([#17635](https://github.com/opensearch-project/OpenSearch/pull/17635))
 
 ### Changed
 - Migrate BC libs to their FIPS counterparts ([#14912](https://github.com/opensearch-project/OpenSearch/pull/14912))

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -1754,6 +1754,10 @@ public class MetadataIndexTemplateService {
             return this;
         }
 
+        public String getMappings() {
+            return mappings;
+        }
+
         public PutRequest aliases(Set<Alias> aliases) {
             this.aliases.addAll(aliases);
             return this;

--- a/server/src/main/java/org/opensearch/cluster/metadata/Template.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/Template.java
@@ -94,7 +94,7 @@ public class Template extends AbstractDiffable<Template> implements ToXContentOb
     @Nullable
     private final Settings settings;
     @Nullable
-    private final CompressedXContent mappings;
+    private CompressedXContent mappings;
     @Nullable
     private final Map<String, AliasMetadata> aliases;
 
@@ -217,5 +217,9 @@ public class Template extends AbstractDiffable<Template> implements ToXContentOb
         } else {
             return mapping;
         }
+    }
+
+    public void setMappings(CompressedXContent mappings) {
+        this.mappings = mappings;
     }
 }

--- a/server/src/main/java/org/opensearch/index/mapper/MappingTransformer.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MappingTransformer.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.opensearch.core.action.ActionListener;
+
+import java.util.Map;
+
+import reactor.util.annotation.NonNull;
+
+/**
+ * A transformer to allow plugins to implement logic to transform the index mapping during
+ * index creation/update and index template creation/update on transport layer.
+ *
+ */
+public interface MappingTransformer {
+    default void transform(
+        final Map<String, Object> mapping,
+        final TransformContext context,
+        @NonNull final ActionListener<Void> listener
+    ) {
+        listener.onResponse(null);
+    }
+
+    /**
+     * Context for mapping transform. For now, we don't need any context, but it's defined for future scalability.
+     * It can be used to provide the info like we are transforming the mapping for what transport action. Or provide
+     * index setting info to help transform the mapping.
+     */
+    class TransformContext {}
+}

--- a/server/src/main/java/org/opensearch/index/mapper/MappingTransformerRegistry.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MappingTransformerRegistry.java
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugins.MapperPlugin;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import reactor.util.annotation.NonNull;
+
+/**
+ * This class collects all registered mapping transformers and applies them when needed.
+ */
+public class MappingTransformerRegistry {
+    private final List<MappingTransformer> transformers;
+    private final NamedXContentRegistry xContentRegistry;
+    protected final Logger logger = LogManager.getLogger(getClass());
+
+    public MappingTransformerRegistry(
+        @NonNull final List<MapperPlugin> mapperPlugins,
+        @NonNull final NamedXContentRegistry xContentRegistry
+    ) {
+        this.xContentRegistry = xContentRegistry;
+        this.transformers = new ArrayList<>();
+        // Collect transformers from all MapperPlugins
+        for (MapperPlugin plugin : mapperPlugins) {
+            transformers.addAll(plugin.getMappingTransformers());
+        }
+    }
+
+    private void applyNext(
+        @NonNull final Map<String, Object> mapping,
+        final MappingTransformer.TransformContext context,
+        @NonNull final AtomicInteger index,
+        @NonNull final ActionListener<String> listener
+    ) {
+        try {
+            // Parse the mapping after each transformer to catch corruption early and identify the faulty transformer.
+            final XContentBuilder builder = XContentFactory.jsonBuilder();
+            builder.map(mapping);
+            final String mappingString = builder.toString();
+            if (index.get() == transformers.size()) {
+                listener.onResponse(mappingString);
+                return;
+            }
+        } catch (IOException e) {
+            if (index.get() == 0) {
+                listener.onFailure(
+                    new RuntimeException(
+                        "Failed to transform the mapping due to the mapping is not a valid json string [" + mapping + "]",
+                        e
+                    )
+                );
+            } else {
+                listener.onFailure(
+                    new RuntimeException(
+                        "Failed to parse the mapping ["
+                            + mapping
+                            + "] transformed by"
+                            + " the transformer ["
+                            + transformers.get(index.get() - 1).getClass().getName()
+                            + "]",
+                        e
+                    )
+                );
+            }
+        }
+
+        final MappingTransformer transformer = transformers.get(index.getAndIncrement());
+        logger.debug("Applying mapping transformer: {}", transformer.getClass().getName());
+        transformer.transform(mapping, context, new ActionListener<>() {
+            @Override
+            public void onResponse(Void unused) {
+                logger.debug("Completed transformation: {}", transformer.getClass().getName());
+                applyNext(mapping, context, index, listener);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.error("Transformer {} failed: {}", transformer.getClass().getName(), e.getMessage());
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    /**
+     * Applies all registered transformers to the provided mapping which is in string format.
+     * @param mappingString The index mapping to transform.
+     * @param context Context for mapping transform
+     * @param mappingTransformListener A listener for mapping transform
+     */
+    public void applyTransformers(
+        final String mappingString,
+        final MappingTransformer.TransformContext context,
+        @NonNull final ActionListener<String> mappingTransformListener
+    ) {
+        if (transformers.isEmpty() || mappingString == null) {
+            mappingTransformListener.onResponse(mappingString);
+            return;
+        }
+
+        Map<String, Object> mappingMap;
+        try {
+            mappingMap = MapperService.parseMapping(xContentRegistry, mappingString);
+        } catch (IOException e) {
+            mappingTransformListener.onFailure(
+                new IllegalArgumentException(
+                    "Failed to transform the mappings because failed to parse the mappings [" + mappingString + "]",
+                    e
+                )
+            );
+            return;
+        }
+
+        final AtomicInteger index = new AtomicInteger(0);
+        applyNext(mappingMap, context, index, mappingTransformListener);
+    }
+}

--- a/server/src/main/java/org/opensearch/plugins/MapperPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/MapperPlugin.java
@@ -33,9 +33,11 @@
 package org.opensearch.plugins;
 
 import org.opensearch.index.mapper.Mapper;
+import org.opensearch.index.mapper.MappingTransformer;
 import org.opensearch.index.mapper.MetadataFieldMapper;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -90,4 +92,12 @@ public interface MapperPlugin {
      * get field mappings and field capabilities API will return every field that's present in the mappings.
      */
     Function<String, Predicate<String>> NOOP_FIELD_FILTER = index -> NOOP_FIELD_PREDICATE;
+
+    /**
+     * Returns mapper transformer implementations added by this plugin.
+     *
+     */
+    default List<MappingTransformer> getMappingTransformers() {
+        return Collections.emptyList();
+    }
 }

--- a/server/src/test/java/org/opensearch/action/admin/indices/create/TransportCreateIndexActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/create/TransportCreateIndexActionTests.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.create;
+
+import org.opensearch.action.support.ActionFilter;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.MetadataCreateIndexService;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.mapper.MappingTransformerRegistry;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.junit.Before;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportCreateIndexActionTests extends OpenSearchTestCase {
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private ThreadPool threadPool;
+    @Mock
+    private MetadataCreateIndexService createIndexService;
+    @Mock
+    private IndexNameExpressionResolver indexNameExpressionResolver;
+
+    @Mock
+    private MappingTransformerRegistry mappingTransformerRegistry;
+
+    @Mock
+    private ClusterState clusterState;
+
+    @Mock
+    private ActionListener<CreateIndexResponse> responseListener;
+
+    private TransportCreateIndexAction action;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        ActionFilter[] emptyActionFilters = new ActionFilter[] {};
+        when(actionFilters.filters()).thenReturn(emptyActionFilters);
+        action = new TransportCreateIndexAction(
+            transportService,
+            null, // ClusterService not needed for this test
+            threadPool,
+            createIndexService,
+            actionFilters,
+            indexNameExpressionResolver,
+            mappingTransformerRegistry
+        );
+    }
+
+    public void testClusterManagerOperation_usesTransformedMapping() {
+        when(indexNameExpressionResolver.resolveDateMathExpression(any())).thenReturn("test-index");
+
+        // Arrange: Create a test request
+        final CreateIndexRequest request = new CreateIndexRequest("test-index");
+        request.mapping("{\"properties\": {\"field\": {\"type\": \"text\"}}}");
+
+        // Mock transformed mapping result
+        final String transformedMapping = "{\"properties\": {\"field\": {\"type\": \"keyword\"}}}";
+
+        // Capture ActionListener passed to applyTransformers
+        final ArgumentCaptor<ActionListener<String>> listenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        doNothing().when(mappingTransformerRegistry).applyTransformers(
+            anyString(),
+            any(),
+            listenerCaptor.capture()
+        );
+
+        // Act: Call the method
+        action.clusterManagerOperation(request, clusterState, responseListener);
+
+        // Simulate transformation completion
+        listenerCaptor.getValue().onResponse(transformedMapping);
+
+        // Assert: Capture request sent to createIndexService
+        ArgumentCaptor<CreateIndexClusterStateUpdateRequest> updateRequestCaptor =
+            ArgumentCaptor.forClass(CreateIndexClusterStateUpdateRequest.class);
+        verify(createIndexService, times(1)).createIndex(updateRequestCaptor.capture(), any());
+
+        // Ensure transformed mapping is passed correctly
+        CreateIndexClusterStateUpdateRequest capturedRequest = updateRequestCaptor.getValue();
+        assertEquals(transformedMapping, capturedRequest.mappings());
+    }
+}

--- a/server/src/test/java/org/opensearch/action/admin/indices/mapping/put/TransportPutMappingActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/mapping/put/TransportPutMappingActionTests.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.mapping.put;
+
+import org.opensearch.action.RequestValidators;
+import org.opensearch.action.support.ActionFilter;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.MetadataMappingService;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.index.mapper.MappingTransformerRegistry;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.junit.Before;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportPutMappingActionTests extends OpenSearchTestCase {
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private ThreadPool threadPool;
+    @Mock
+    private IndexNameExpressionResolver indexNameExpressionResolver;
+
+    @Mock
+    private MetadataMappingService metadataMappingService;
+
+    @Mock
+    private MappingTransformerRegistry mappingTransformerRegistry;
+
+    @Mock
+    private RequestValidators<PutMappingRequest> requestValidators;
+
+    @Mock
+    private ClusterState clusterState;
+
+    @Mock
+    private ActionListener<AcknowledgedResponse> responseListener;
+
+    private TransportPutMappingAction action;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        ActionFilter[] emptyActionFilters = new ActionFilter[] {};
+        when(actionFilters.filters()).thenReturn(emptyActionFilters);
+        action = new TransportPutMappingAction(
+            transportService,
+            null, // ClusterService not needed for this test
+            threadPool,
+            metadataMappingService,
+            actionFilters,
+            indexNameExpressionResolver,
+            requestValidators,
+            mappingTransformerRegistry
+        );
+    }
+
+    public void testClusterManagerOperation_transformedMappingUsed() {
+        // Arrange: Create a test request
+        final PutMappingRequest request = new PutMappingRequest("index");
+        final String originalMapping = "{\"properties\": {\"field\": {\"type\": \"text\"}}}";
+        request.source(originalMapping, MediaTypeRegistry.JSON);
+
+        String transformedMapping = "{\"properties\": {\"field\": {\"type\": \"keyword\"}}}";
+
+        // Mock the transformer registry to return the transformed mapping
+        ArgumentCaptor<ActionListener<String>> listenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        doNothing().when(mappingTransformerRegistry).applyTransformers(anyString(), any(), listenerCaptor.capture());
+
+        // Act: Call the method
+        action.clusterManagerOperation(request, clusterState, responseListener);
+
+        // Simulate transformation completion
+        listenerCaptor.getValue().onResponse(transformedMapping);
+
+        // Assert: Verify the transformed mapping is passed to metadataMappingService
+        ArgumentCaptor<PutMappingClusterStateUpdateRequest> updateRequestCaptor = ArgumentCaptor.forClass(
+            PutMappingClusterStateUpdateRequest.class
+        );
+        verify(metadataMappingService, times(1)).putMapping(updateRequestCaptor.capture(), any());
+
+        // Ensure the transformed mapping is used correctly
+        PutMappingClusterStateUpdateRequest capturedRequest = updateRequestCaptor.getValue();
+        assertEquals(transformedMapping, capturedRequest.source());
+    }
+}

--- a/server/src/test/java/org/opensearch/action/admin/indices/template/put/TransportPutComponentTemplateActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/template/put/TransportPutComponentTemplateActionTests.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.template.put;
+
+import org.opensearch.action.support.ActionFilter;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.ComponentTemplate;
+import org.opensearch.cluster.metadata.MetadataIndexTemplateService;
+import org.opensearch.cluster.metadata.Template;
+import org.opensearch.common.compress.CompressedXContent;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.mapper.MappingTransformerRegistry;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.junit.Before;
+
+import java.io.IOException;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportPutComponentTemplateActionTests extends OpenSearchTestCase {
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private ThreadPool threadPool;
+    @Mock
+    private MappingTransformerRegistry mappingTransformerRegistry;
+    @Mock
+    private MetadataIndexTemplateService indexTemplateService;
+    @Mock
+    private ActionListener<AcknowledgedResponse> responseListener;
+    @Mock
+    private ClusterState clusterState;
+
+    private TransportPutComponentTemplateAction action;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        ActionFilter[] emptyActionFilters = new ActionFilter[] {};
+        when(actionFilters.filters()).thenReturn(emptyActionFilters);
+        action = new TransportPutComponentTemplateAction(
+            transportService,
+            null, // ClusterService not needed for this test
+            threadPool,
+            indexTemplateService,
+            actionFilters,
+            null, // IndexNameExpressionResolver not needed
+            null, // IndexScopedSettings not needed
+            mappingTransformerRegistry
+        );
+    }
+
+    public void testClusterManagerOperation_mappingTransformationApplied() throws IOException {
+        // Arrange: Create a test request and mock dependencies
+        PutComponentTemplateAction.Request request = new PutComponentTemplateAction.Request("test");
+        ComponentTemplate componentTemplate = mock(ComponentTemplate.class);
+        Template template = mock(Template.class);
+        when(componentTemplate.template()).thenReturn(template);
+        when(template.mappings()).thenReturn(new CompressedXContent("{\"properties\": {\"field\": {\"type\": \"text\"}}}"));
+        request.componentTemplate(componentTemplate);
+
+        String transformedMapping = "{\"properties\": {\"field\": {\"type\": \"keyword\"}}}";
+
+        // Mock mapping transformer to return transformed mapping
+        ArgumentCaptor<ActionListener<String>> listenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        doNothing().when(mappingTransformerRegistry).applyTransformers(anyString(), any(), listenerCaptor.capture());
+
+        // Act: Call the method
+        action.clusterManagerOperation(request, clusterState, responseListener);
+
+        // Simulate mapping transformation
+        listenerCaptor.getValue().onResponse(transformedMapping);
+
+        // Assert: Verify the transformed mappings are set correctly
+        verify(template, times(1)).setMappings(new CompressedXContent(transformedMapping));
+
+        // Verify that indexTemplateService.putComponentTemplate is called
+        verify(indexTemplateService, times(1)).putComponentTemplate(
+            eq(request.cause()),
+            eq(request.create()),
+            eq(request.name()),
+            eq(request.clusterManagerNodeTimeout()),
+            eq(componentTemplate),
+            eq(responseListener)
+        );
+    }
+}

--- a/server/src/test/java/org/opensearch/action/admin/indices/template/put/TransportPutComposableIndexTemplateActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/template/put/TransportPutComposableIndexTemplateActionTests.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.template.put;
+
+import org.opensearch.action.support.ActionFilter;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.ComposableIndexTemplate;
+import org.opensearch.cluster.metadata.MetadataIndexTemplateService;
+import org.opensearch.cluster.metadata.Template;
+import org.opensearch.common.compress.CompressedXContent;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.mapper.MappingTransformerRegistry;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.junit.Before;
+
+import java.io.IOException;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportPutComposableIndexTemplateActionTests extends OpenSearchTestCase {
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private ThreadPool threadPool;
+
+    @Mock
+    private MappingTransformerRegistry mappingTransformerRegistry;
+    @Mock
+    private MetadataIndexTemplateService indexTemplateService;
+    @Mock
+    private ActionListener<AcknowledgedResponse> responseListener;
+    @Mock
+    private ClusterState clusterState;
+
+    private TransportPutComposableIndexTemplateAction action;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        ActionFilter[] emptyActionFilters = new ActionFilter[] {};
+        when(actionFilters.filters()).thenReturn(emptyActionFilters);
+        action = new TransportPutComposableIndexTemplateAction(
+            transportService,
+            null, // ClusterService not needed for this test
+            threadPool,
+            indexTemplateService,
+            actionFilters,
+            null, // IndexNameExpressionResolver not needed
+            mappingTransformerRegistry
+        );
+    }
+
+    public void testClusterManagerOperation_mappingTransformationApplied() throws IOException {
+        // Arrange: Create a test request and mock dependencies
+        PutComposableIndexTemplateAction.Request request = new PutComposableIndexTemplateAction.Request("test");
+        ComposableIndexTemplate indexTemplate = mock(ComposableIndexTemplate.class);
+        Template template = mock(Template.class);
+        String transformedMapping = "{\"properties\": {\"field\": {\"type\": \"keyword\"}}}";
+        when(indexTemplate.template()).thenReturn(template);
+        when(template.mappings()).thenReturn(new CompressedXContent("{\"properties\": {\"field\": {\"type\": \"text\"}}}"));
+        request.indexTemplate(indexTemplate);
+
+        // Mock mapping transformer to return transformed mapping
+        ArgumentCaptor<ActionListener<String>> listenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        doNothing().when(mappingTransformerRegistry).applyTransformers(anyString(), any(), listenerCaptor.capture());
+
+        // Act: Call the method
+        action.clusterManagerOperation(request, clusterState, responseListener);
+
+        // Simulate mapping transformation
+        listenerCaptor.getValue().onResponse(transformedMapping);
+
+        // Assert: Verify the transformed mappings are set correctly
+        verify(template, times(1)).setMappings(new CompressedXContent(transformedMapping));
+
+        // Verify that indexTemplateService.putIndexTemplateV2 is called
+        verify(indexTemplateService, times(1)).putIndexTemplateV2(
+            eq(request.cause()),
+            eq(request.create()),
+            eq(request.name()),
+            eq(request.clusterManagerNodeTimeout()),
+            eq(indexTemplate),
+            eq(responseListener)
+        );
+    }
+}

--- a/server/src/test/java/org/opensearch/action/admin/indices/template/put/TransportPutIndexTemplateActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/template/put/TransportPutIndexTemplateActionTests.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.template.put;
+
+import org.opensearch.action.support.ActionFilter;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.MetadataIndexTemplateService;
+import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.index.mapper.MappingTransformerRegistry;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.junit.Before;
+
+import java.util.Collections;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportPutIndexTemplateActionTests extends OpenSearchTestCase {
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private ThreadPool threadPool;
+
+    @Mock
+    private MappingTransformerRegistry mappingTransformerRegistry;
+    @Mock
+    private MetadataIndexTemplateService indexTemplateService;
+    @Mock
+    private ActionListener<AcknowledgedResponse> responseListener;
+    @Mock
+    private ClusterState clusterState;
+
+    private final IndexScopedSettings indexScopedSettings = new IndexScopedSettings(Settings.EMPTY, Collections.emptySet());
+
+    private TransportPutIndexTemplateAction action;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        ActionFilter[] emptyActionFilters = new ActionFilter[] {};
+        when(actionFilters.filters()).thenReturn(emptyActionFilters);
+        action = new TransportPutIndexTemplateAction(
+            transportService,
+            null, // ClusterService not needed for this test
+            threadPool,
+            indexTemplateService,
+            actionFilters,
+            null, // IndexNameExpressionResolver not needed
+            indexScopedSettings,
+            mappingTransformerRegistry
+        );
+    }
+
+    public void testClusterManagerOperation_mappingTransformationApplied() {
+        // Arrange: Mock the request and response
+        PutIndexTemplateRequest request = new PutIndexTemplateRequest("test");
+        String originalMappings = "{\"properties\":{\"field\":{\"type\":\"text\"}}}";
+        request.mapping(originalMappings, MediaTypeRegistry.JSON);
+
+        // Mock the transformed mapping
+        String transformedMappings = "{\"properties\":{\"field\":{\"type\":\"keyword\"}}}";
+
+        // Mock mapping transformer to return transformed mapping
+        ArgumentCaptor<ActionListener<String>> listenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        doNothing().when(mappingTransformerRegistry).applyTransformers(anyString(), any(), listenerCaptor.capture());
+
+        // Act: Call the method
+        action.clusterManagerOperation(request, clusterState, responseListener);
+
+        // Simulate mapping transformation
+        listenerCaptor.getValue().onResponse(transformedMappings);
+
+        // Assert: Verify that the transformed mappings are passed to the template service
+        ArgumentCaptor<MetadataIndexTemplateService.PutRequest> putRequestCaptor = ArgumentCaptor.forClass(
+            MetadataIndexTemplateService.PutRequest.class
+        );
+        verify(indexTemplateService).putTemplate(putRequestCaptor.capture(), any());
+
+        // Verify the transformed mappings are set in the PutRequest
+        assertEquals(transformedMappings, putRequestCaptor.getValue().getMappings());
+    }
+}

--- a/server/src/test/java/org/opensearch/index/mapper/MappingTransformerRegistryTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/MappingTransformerRegistryTests.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import joptsimple.internal.Strings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.plugins.MapperPlugin;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MappingTransformerRegistryTests extends OpenSearchTestCase {
+    @Mock
+    private MapperPlugin mapperPlugin;
+    @Mock
+    private NamedXContentRegistry xContentRegistry;
+    @Mock
+    private ActionListener<String> listener;
+    @Mock
+    private MappingTransformer transformer;
+
+    private MappingTransformerRegistry registry;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(mapperPlugin.getMappingTransformers()).thenReturn(List.of(transformer));
+        registry = new MappingTransformerRegistry(List.of(mapperPlugin), xContentRegistry);
+        // Mock dummy transformer behavior which does not modify the mapping
+        doAnswer(invocation -> {
+            final ActionListener<Void> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(null);
+            return null;
+        }).when(transformer).transform(any(), any(), any());
+    }
+
+    public void testApplyTransformers_whenNoTransformers_returnMappingDirectly() {
+        final String mapping = Strings.EMPTY;
+        final MappingTransformerRegistry mappingTransformerRegistry = new MappingTransformerRegistry(
+            Collections.emptyList(),
+            xContentRegistry
+        );
+
+        mappingTransformerRegistry.applyTransformers(mapping, null, listener);
+
+        verify(listener, Mockito.times(1)).onResponse(mapping);
+    }
+
+    public void testApplyTransformers_WithNullMapping_ShouldReturnNull() {
+        registry.applyTransformers(null, null, listener);
+
+        verify(listener).onResponse(null);
+    }
+
+    public void testApplyTransformers_WithTransformerApplied() throws IOException {
+        final String inputMappingString = "{\"field\": \"value\"}";
+        final String expectedTransformedMappingString = "{\"field\":\"transformedValue\"}";
+
+        doAnswer(invocation -> {
+            Map<String, Object> mapping = invocation.getArgument(0);
+            assertEquals(mapping.get("field"), "value");
+            mapping.put("field", "transformedValue"); // Simulating transformation
+            ActionListener<Void> actionListener = invocation.getArgument(2);
+            actionListener.onResponse(null);
+            return null;
+        }).when(transformer).transform(any(), any(), any());
+
+        registry.applyTransformers(inputMappingString, null, listener);
+
+        ArgumentCaptor<String> responseCaptor = ArgumentCaptor.forClass(String.class);
+        verify(listener).onResponse(responseCaptor.capture());
+
+        String transformedMapping = responseCaptor.getValue();
+        assertEquals(expectedTransformedMappingString, transformedMapping);
+    }
+
+    public void testApplyTransformers_WhenTransformerFails_ShouldCallOnFailure() {
+        final String inputMappingString = "{\"field\": \"value\"}";
+        final String errorMsg = "Transformation failed";
+
+        doAnswer(invocation -> {
+            ActionListener<Void> actionListener = invocation.getArgument(2);
+            actionListener.onFailure(new RuntimeException(errorMsg));
+            return null;
+        }).when(transformer).transform(any(), any(), any());
+
+        registry.applyTransformers(inputMappingString, null, listener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(exceptionCaptor.capture());
+
+        assertTrue(exceptionCaptor.getValue() instanceof RuntimeException);
+        assertTrue(exceptionCaptor.getValue().getMessage().contains(errorMsg));
+    }
+}

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -188,6 +188,7 @@ import org.opensearch.index.SegmentReplicationPressureService;
 import org.opensearch.index.SegmentReplicationStatsTracker;
 import org.opensearch.index.analysis.AnalysisRegistry;
 import org.opensearch.index.engine.MergedSegmentWarmerFactory;
+import org.opensearch.index.mapper.MappingTransformerRegistry;
 import org.opensearch.index.remote.RemoteStorePressureService;
 import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.seqno.GlobalCheckpointSyncAction;
@@ -1933,6 +1934,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
             private Coordinator coordinator;
             private RemoteStoreNodeService remoteStoreNodeService;
 
+            private final MappingTransformerRegistry mappingTransformerRegistry;
+
             private Map<ActionType, TransportAction> actions = new HashMap<>();
 
             TestClusterNode(DiscoveryNode node) throws IOException {
@@ -2195,6 +2198,9 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     DefaultRemoteStoreSettings.INSTANCE,
                     null
                 );
+
+                mappingTransformerRegistry = new MappingTransformerRegistry(List.of(), namedXContentRegistry);
+
                 actions.put(
                     CreateIndexAction.INSTANCE,
                     new TransportCreateIndexAction(
@@ -2203,7 +2209,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         threadPool,
                         metadataCreateIndexService,
                         actionFilters,
-                        indexNameExpressionResolver
+                        indexNameExpressionResolver,
+                        mappingTransformerRegistry
                     )
                 );
                 final MetadataDeleteIndexService metadataDeleteIndexService = new MetadataDeleteIndexService(
@@ -2309,7 +2316,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         metadataMappingService,
                         actionFilters,
                         indexNameExpressionResolver,
-                        new RequestValidators<>(Collections.emptyList())
+                        new RequestValidators<>(Collections.emptyList()),
+                        mappingTransformerRegistry
                     )
                 );
                 actions.put(


### PR DESCRIPTION
### Description
In this PR we introduce the mapping transformer to the core to allow transforming the mapping during index create/update and index template create/update. We want to do this because we have a use case in neural search plugin where we want to auto generate the semantic fields(e.g. knn_vector or rank_feature) in the mappings based on the model id defined in the semantic field(A new field type introduced by neural search plugin). In this way we can simplify the neural search set up.

Potentially in future this feature can be leveraged by other plugins to auto transform the mapping based on the certain config defined by users.

### Related Issues
Resolves [#[17500]](https://github.com/opensearch-project/OpenSearch/issues/17500) - Proposal to introduce the mapping transformer into core.

[#[803]](https://github.com/opensearch-project/neural-search/issues/803) - Proposal to support semantic field in neural search.
[#[1211]](https://github.com/opensearch-project/neural-search/issues/1211) - HLD of the semantic field.


### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
