### PR TITLE
Resolve integTest bug on deb to check for opensearch:adm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change priority for scheduling reroute during timeout([#16445](https://github.com/opensearch-project/OpenSearch/pull/16445))
 - Renaming the node role search to warm ([#17573](https://github.com/opensearch-project/OpenSearch/pull/17573))
 - Introduce a new search node role to hold search only shards ([#17620](https://github.com/opensearch-project/OpenSearch/pull/17620))
+- Fix systemd integTest on deb regarding path ownership check ([#17641](https://github.com/opensearch-project/OpenSearch/pull/17641)) 
 
 ### Dependencies
 - Bump `ch.qos.logback:logback-core` from 1.5.16 to 1.5.17 ([#17609](https://github.com/opensearch-project/OpenSearch/pull/17609))

--- a/qa/systemd-test/src/test/java/org/opensearch/systemdinteg/SystemdIntegTests.java
+++ b/qa/systemd-test/src/test/java/org/opensearch/systemdinteg/SystemdIntegTests.java
@@ -116,7 +116,8 @@ public class SystemdIntegTests extends LuceneTestCase {
             assertTrue("Path should exist: " + path, checkPathExists(path));
             assertTrue("Path should be readable: " + path, checkPathReadable(path));
             assertTrue("Path should be writable: " + path, checkPathWritable(path));
-            assertEquals("Path should be owned by opensearch:opensearch", "opensearch:opensearch", getPathOwnership(path));
+            String ownership = getPathOwnership(path);
+            assertTrue("Path should be owned by opensearch:opensearch or opensearch:adm", ownership.equals("opensearch:opensearch") || ownership.equals("opensearch:adm"));
         }
     }
 


### PR DESCRIPTION
### Description
Resolves integTest bug on deb to check for `opensearch:adm`

### Related Issues
Resolves #17614 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
