### PR TITLE
[Backport] [2.x] Bump com.azure:azure-storage-blob from 12.29.1 to 12.30.0 in /plugins/repository-azure (#17667)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `ch.qos.logback:logback-classic` from 1.5.16 to 1.5.17 ([#17497](https://github.com/opensearch-project/OpenSearch/pull/17497))
 - Bump `software.amazon.awssdk` from 2.20.86 to 2.30.31 ([17396](https://github.com/opensearch-project/OpenSearch/pull/17396))
 - Bump `org.jruby.jcodings:jcodings` from 1.0.61 to 1.0.63 ([#17560](https://github.com/opensearch-project/OpenSearch/pull/17560))
-- Bump `com.azure:azure-storage-blob` from 12.28.1 to 12.29.1 ([#17562](https://github.com/opensearch-project/OpenSearch/pull/17562))
+- Bump `com.azure:azure-storage-blob` from 12.28.1 to 12.30.0 ([#17562](https://github.com/opensearch-project/OpenSearch/pull/17562), [#17667](https://github.com/opensearch-project/OpenSearch/pull/17667))
 
 ### Changed
 - Convert transport-reactor-netty4 to use gradle version catalog [#17233](https://github.com/opensearch-project/OpenSearch/pull/17233)

--- a/plugins/repository-azure/build.gradle
+++ b/plugins/repository-azure/build.gradle
@@ -56,7 +56,7 @@ dependencies {
   api "io.netty:netty-resolver-dns:${versions.netty}"
   api "io.netty:netty-transport-native-unix-common:${versions.netty}"
   implementation project(':modules:transport-netty4')
-  api 'com.azure:azure-storage-blob:12.29.1'
+  api 'com.azure:azure-storage-blob:12.30.0'
   api 'com.azure:azure-identity:1.14.2'
   // Start of transitive dependencies for azure-identity
   api 'com.microsoft.azure:msal4j-persistence-extension:1.3.0'

--- a/plugins/repository-azure/licenses/azure-storage-blob-12.29.1.jar.sha1
+++ b/plugins/repository-azure/licenses/azure-storage-blob-12.29.1.jar.sha1
@@ -1,1 +1,0 @@
-bf6845feeee7e47da636afcfa28f3affbf1fede5

--- a/plugins/repository-azure/licenses/azure-storage-blob-12.30.0.jar.sha1
+++ b/plugins/repository-azure/licenses/azure-storage-blob-12.30.0.jar.sha1
@@ -1,0 +1,1 @@
+a187bbdf04d9d4c0144ef619ba02ce1cd07211ac


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/OpenSearch/pull/17667 to `2.x`