### PR TITLE
attempt to fix flaky test in IngestFromKinesisIT

### DIFF
--- a/plugins/ingestion-kinesis/src/internalClusterTest/java/org/opensearch/plugin/kinesis/IngestFromKinesisIT.java
+++ b/plugins/ingestion-kinesis/src/internalClusterTest/java/org/opensearch/plugin/kinesis/IngestFromKinesisIT.java
@@ -8,6 +8,15 @@
 
 package org.opensearch.plugin.kinesis;
 
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamResponse;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorResponse;
+import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
+
 import org.opensearch.action.admin.cluster.node.info.NodeInfo;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoResponse;
@@ -28,14 +37,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.testcontainers.containers.localstack.LocalStackContainer;
-import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
-import software.amazon.awssdk.services.kinesis.model.DescribeStreamResponse;
-import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
-import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
-import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
-import software.amazon.awssdk.services.kinesis.model.GetShardIteratorResponse;
-import software.amazon.awssdk.services.kinesis.model.Record;
-import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
 
 import static org.hamcrest.Matchers.is;
 import static org.awaitility.Awaitility.await;
@@ -107,10 +108,7 @@ public class IngestFromKinesisIT extends KinesisIngestionBaseIT {
         logger.info("Produced message with sequence number: {}", sequenceNumber);
         produceData("4", "name4", "21");
 
-        await()
-            .atMost(5, TimeUnit.SECONDS)
-            .until(() -> isRewinded(sequenceNumber));
-
+        await().atMost(5, TimeUnit.SECONDS).until(() -> isRewinded(sequenceNumber));
 
         // create an index with ingestion source from kinesis
         createIndex(
@@ -142,8 +140,9 @@ public class IngestFromKinesisIT extends KinesisIngestionBaseIT {
     }
 
     private boolean isRewinded(String sequenceNumber) {
-        DescribeStreamResponse describeStreamResponse =
-            kinesisClient.describeStream(DescribeStreamRequest.builder().streamName(streamName).build());
+        DescribeStreamResponse describeStreamResponse = kinesisClient.describeStream(
+            DescribeStreamRequest.builder().streamName(streamName).build()
+        );
 
         String shardId = describeStreamResponse.streamDescription().shards().get(0).shardId();
 
@@ -158,7 +157,9 @@ public class IngestFromKinesisIT extends KinesisIngestionBaseIT {
         String shardIterator = iteratorResponse.shardIterator();
 
         // Use the iterator to read the record
-        GetRecordsRequest recordsRequest = GetRecordsRequest.builder().shardIterator(shardIterator).limit(1)  // Adjust as needed
+        GetRecordsRequest recordsRequest = GetRecordsRequest.builder()
+            .shardIterator(shardIterator)
+            .limit(1)  // Adjust as needed
             .build();
 
         GetRecordsResponse recordsResponse = kinesisClient.getRecords(recordsRequest);

--- a/plugins/ingestion-kinesis/src/internalClusterTest/java/org/opensearch/plugin/kinesis/IngestFromKinesisIT.java
+++ b/plugins/ingestion-kinesis/src/internalClusterTest/java/org/opensearch/plugin/kinesis/IngestFromKinesisIT.java
@@ -94,8 +94,11 @@ public class IngestFromKinesisIT extends KinesisIngestionBaseIT {
 
     public void testKinesisIngestion_RewindByOffset() throws InterruptedException {
         produceData("1", "name1", "24");
-        String sequenceNumber = produceData("2", "name2", "20");
-        Thread.sleep(1000);
+        produceData("2", "name2", "24");
+        String sequenceNumber = produceData("3", "name3", "20");
+        logger.info("Produced message with sequence number: {}", sequenceNumber);
+        produceData("4", "name4", "21");
+        Thread.sleep(2000);
 
         // create an index with ingestion source from kinesis
         createIndex(
@@ -122,7 +125,7 @@ public class IngestFromKinesisIT extends KinesisIngestionBaseIT {
         await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
             refresh("test_rewind_by_offset");
             SearchResponse response = client().prepareSearch("test_rewind_by_offset").setQuery(query).get();
-            assertThat(response.getHits().getTotalHits().value(), is(1L));
+            assertThat(response.getHits().getTotalHits().value(), is(2L));
         });
     }
 }


### PR DESCRIPTION

### Description
There's some flakiness of Kinesis integration tests, likely due to the fact that in LocalStack, the message propagation or availability might not be immediate. So when we immediately attempt to consume it, it might not be fully "visible" depending on timing, especially with a rewind to a precise AT_SEQUENCE_NUMBER. Tweaked the test with some more produced messages, and longer sleep so the records are committed and readable.


Ran the same tests 5 times locally, and test all passed.
