### PR TITLE
Adds integration tests for SocketChannel Interceptor

### DIFF
--- a/libs/agent-sm/agent/build.gradle
+++ b/libs/agent-sm/agent/build.gradle
@@ -6,18 +6,17 @@ base {
 }
 
 configurations {
-  bootstrap.extendsFrom(implementation)
+  bootstrapConfiguration.extendsFrom(implementation)
 }
 
 dependencies {
   implementation project(":libs:agent-sm:bootstrap")
   implementation "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
   compileOnly "com.google.code.findbugs:jsr305:3.0.2"
-}
 
-var bootClasspath = configurations.bootstrap.incoming.artifactView { }.files
-  .getFiles()
-  .collect { it.name }
+  testImplementation project(":test:framework")
+  testImplementation "junit:junit:${versions.junit}"
+}
 
 jar {
   manifest {
@@ -26,7 +25,7 @@ jar {
       "Can-Retransform-Classes": "true",
       "Agent-Class": "org.opensearch.javaagent.Agent",
       "Premain-Class": "org.opensearch.javaagent.Agent",
-      "Boot-Class-Path":  bootClasspath.join(' ')
+      "Boot-Class-Path": 'byte-buddy-1.17.2.jar opensearch-agent-bootstrap-3.0.0-SNAPSHOT.jar'
     )
   }
 }
@@ -42,10 +41,20 @@ tasks.named('forbiddenApisMain').configure {
   replaceSignatureFiles 'jdk-signatures'
 }
 
-task prepareAgent(type: Copy) {
-  from(configurations.runtimeClasspath)
+task copyJars(type: Copy) {
+  from configurations.runtimeClasspath
   into "$buildDir/distributions"
   dependsOn jar
+}
+
+tasks.named('test') {
+  dependsOn(copyJars)
+
+  doFirst {
+    def agentPath = jar.archiveFile.get().asFile.absolutePath
+    jvmArgs += ["-javaagent:${agentPath}"]
+    systemProperty 'javaagent.path', agentPath
+  }
 }
 
 thirdPartyAudit {
@@ -60,5 +69,5 @@ thirdPartyAudit {
 }
 
 tasks.named('validateNebulaPom') {
-  dependsOn prepareAgent
+  dependsOn copyJars
 }

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/SuppressForbidden.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/SuppressForbidden.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.javaagent;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to suppress forbidden-apis errors inside a whole class, a method, or a field.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
+@interface SuppressForbidden {
+    String reason();
+}

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/SocketIntegTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/SocketIntegTests.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.javaagent;
+
+import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.net.UnknownHostException;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@SuppressForbidden(reason = "Test class needs to use socket connections and DNS resolution for testing network permissions")
+@AwaitsFix(bugUrl = "Awaiting fix for: https://github.com/opensearch-project/OpenSearch/issues/17662")
+public class SocketIntegTests extends OpenSearchTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    public void testLocalSocketConnection() throws IOException {
+        try (ServerSocketChannel serverChannel = ServerSocketChannel.open()) {
+            serverChannel.bind(new InetSocketAddress("localhost", 0));
+            int port = ((InetSocketAddress) serverChannel.getLocalAddress()).getPort();
+
+            new Thread(() -> {
+                try {
+                    serverChannel.accept();
+                } catch (IOException ignored) {}
+            }).start();
+
+            try (SocketChannel clientChannel = SocketChannel.open(new InetSocketAddress("localhost", port))) {
+                assertTrue("Client should be connected", clientChannel.isConnected());
+            }
+        }
+    }
+
+    public void testBasicUnixDomainSocket() throws IOException {
+        // Skip test if not running on Unix-like system
+        assumeTrue("Test requires Unix-like system", System.getProperty("os.name").toLowerCase().matches(".*(unix|linux|mac).*"));
+
+        Path socketPath = Path.of("/tmp/test-" + System.nanoTime() + ".sock");
+
+        ServerSocketChannel serverChannel = null;
+        SocketChannel clientChannel = null;
+        SocketChannel acceptedChannel = null;
+
+        try {
+            // Create Unix Domain Socket server
+            UnixDomainSocketAddress address = UnixDomainSocketAddress.of(socketPath);
+            serverChannel = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
+            serverChannel.bind(address);
+
+            // Configure non-blocking mode
+            serverChannel.configureBlocking(false);
+
+            // Connect client
+            clientChannel = SocketChannel.open(StandardProtocolFamily.UNIX);
+            clientChannel.connect(address);
+
+            // Accept the connection
+            acceptedChannel = serverChannel.accept();
+            assertNotNull("Server should accept the connection", acceptedChannel);
+
+            // Verify connections
+            assertTrue("Client should be connected", clientChannel.isConnected());
+            assertTrue("Accepted channel should be connected", acceptedChannel.isConnected());
+
+        } finally {
+            // Cleanup
+            if (acceptedChannel != null) {
+                acceptedChannel.close();
+            }
+            if (clientChannel != null) {
+                clientChannel.close();
+            }
+            if (serverChannel != null) {
+                serverChannel.close();
+            }
+            Files.deleteIfExists(socketPath);
+        }
+    }
+
+    public void testExternalHostConnection() throws IOException {
+        try (SocketChannel clientChannel = SocketChannel.open()) {
+            clientChannel.connect(new InetSocketAddress("opensearch.org", 80));
+            assertTrue("Client should be connected to external host", clientChannel.isConnected());
+        }
+    }
+
+    public void testHostnameResolution() throws UnknownHostException {
+        InetAddress address = InetAddress.getByName("opensearch.org");
+        assertNotNull("Host should be resolvable", address);
+    }
+
+}

--- a/libs/agent-sm/agent/src/test/resources/org/opensearch/bootstrap/test.policy
+++ b/libs/agent-sm/agent/src/test/resources/org/opensearch/bootstrap/test.policy
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+grant {
+  permission java.net.NetPermission "accessUnixDomainSocket";
+  permission java.net.SocketPermission "*", "connect,resolve";
+};


### PR DESCRIPTION
### Description
This PR adds Integration tests for socket channel interceptor, these should be intercepted by the Agent without needing to call an instance of SocketChannelInterceptor within tests.

Run tests via: `./gradlew :libs:opensearch-agent-sm:agent:test --tests "org.opensearch.javaagent.SocketIntegTests" --info`

### Related Issues
Resolves #17664 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
