### PR TITLE
[Pull-based Ingestion] disable push-API for indexing in ingestionEngine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added scale to zero (`search_only` mode) support for OpenSearch reader writer separation ([#17299](https://github.com/opensearch-project/OpenSearch/pull/17299)
 - [Star Tree] [Search] Resolving numeric range aggregation with metric aggregation using star-tree ([#17273](https://github.com/opensearch-project/OpenSearch/pull/17273))
 - Added Search Only strict routing setting ([#17803](https://github.com/opensearch-project/OpenSearch/pull/17803))
+- Disable the index API for ingestion engine ([#17768](https://github.com/opensearch-project/OpenSearch/pull/17768))
 
 ### Changed
 - Migrate BC libs to their FIPS counterparts ([#14912](https://github.com/opensearch-project/OpenSearch/pull/14912))

--- a/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
+++ b/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
@@ -104,6 +104,8 @@ public final class ExceptionsHelper {
                 return RestStatus.TOO_MANY_REQUESTS;
             } else if (t instanceof NotXContentException) {
                 return RestStatus.BAD_REQUEST;
+            } else if (t instanceof  UnsupportedOperationException) {
+                return RestStatus.BAD_REQUEST;
             }
         }
         return RestStatus.INTERNAL_SERVER_ERROR;

--- a/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
+++ b/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
@@ -104,7 +104,7 @@ public final class ExceptionsHelper {
                 return RestStatus.TOO_MANY_REQUESTS;
             } else if (t instanceof NotXContentException) {
                 return RestStatus.BAD_REQUEST;
-            } else if (t instanceof  UnsupportedOperationException) {
+            } else if (t instanceof UnsupportedOperationException) {
                 return RestStatus.BAD_REQUEST;
             }
         }

--- a/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
+++ b/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
@@ -104,8 +104,6 @@ public final class ExceptionsHelper {
                 return RestStatus.TOO_MANY_REQUESTS;
             } else if (t instanceof NotXContentException) {
                 return RestStatus.BAD_REQUEST;
-            } else if (t instanceof UnsupportedOperationException) {
-                return RestStatus.BAD_REQUEST;
             }
         }
         return RestStatus.INTERNAL_SERVER_ERROR;

--- a/server/src/main/java/org/opensearch/OpenSearchServerException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchServerException.java
@@ -1224,5 +1224,13 @@ public final class OpenSearchServerException {
                 V_3_0_0
             )
         );
+        registerExceptionHandle(
+            new OpenSearchExceptionHandle(
+                org.opensearch.index.engine.IngestionEngineException.class,
+                org.opensearch.index.engine.IngestionEngineException::new,
+                176,
+                V_3_0_0
+            )
+        );
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -145,7 +145,9 @@ public class IngestionEngine extends InternalEngine {
 
     @Override
     public IndexResult index(Index index) throws IOException {
-        throw new UnsupportedOperationException("push-based indexing is not supported in ingestion engine, use streaming source instead");
+        throw new IngestionEngineException(
+            new UnsupportedOperationException("push-based indexing is not supported in ingestion engine, use streaming source instead")
+        );
     }
 
     /**
@@ -178,7 +180,9 @@ public class IngestionEngine extends InternalEngine {
 
     @Override
     public DeleteResult delete(Delete delete) throws IOException {
-        throw new UnsupportedOperationException("push-based deletion is not supported in ingestion engine, use streaming source instead");
+        throw new IngestionEngineException(
+            new UnsupportedOperationException("push-based deletion is not supported in ingestion engine, use streaming source instead")
+        );
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -145,9 +145,7 @@ public class IngestionEngine extends InternalEngine {
 
     @Override
     public IndexResult index(Index index) throws IOException {
-        throw new IngestionEngineException(
-            new UnsupportedOperationException("push-based indexing is not supported in ingestion engine, use streaming source instead")
-        );
+        throw new IngestionEngineException("push-based indexing is not supported in ingestion engine, use streaming source instead");
     }
 
     /**
@@ -180,9 +178,7 @@ public class IngestionEngine extends InternalEngine {
 
     @Override
     public DeleteResult delete(Delete delete) throws IOException {
-        throw new IngestionEngineException(
-            new UnsupportedOperationException("push-based deletion is not supported in ingestion engine, use streaming source instead")
-        );
+        throw new IngestionEngineException("push-based deletion is not supported in ingestion engine, use streaming source instead");
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -35,6 +35,7 @@ import org.opensearch.indices.pollingingest.PollingIngestStats;
 import org.opensearch.indices.pollingingest.StreamPoller;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -145,6 +146,16 @@ public class IngestionEngine extends InternalEngine {
 
     @Override
     public IndexResult index(Index index) throws IOException {
+        throw new UnsupportedEncodingException("push-based indexing is not supported in ingestion engine, use streaming source instead");
+    }
+
+    /**
+     * Indexes the document into the engine. This is used internally by the stream poller only.
+     * @param index the index request
+     * @return the index result
+     * @throws IOException if an error occurs
+     */
+    public IndexResult indexInternal(Index index) throws IOException {
         assert Objects.equals(index.uid().field(), IdFieldMapper.NAME) : index.uid().field();
         ensureOpen();
         final IndexResult indexResult;
@@ -168,7 +179,7 @@ public class IngestionEngine extends InternalEngine {
 
     @Override
     public DeleteResult delete(Delete delete) throws IOException {
-        return null;
+        throw new UnsupportedEncodingException("push-based deletion is not supported in ingestion engine, use streaming source instead");
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -35,7 +35,6 @@ import org.opensearch.indices.pollingingest.PollingIngestStats;
 import org.opensearch.indices.pollingingest.StreamPoller;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -146,7 +145,7 @@ public class IngestionEngine extends InternalEngine {
 
     @Override
     public IndexResult index(Index index) throws IOException {
-        throw new UnsupportedEncodingException("push-based indexing is not supported in ingestion engine, use streaming source instead");
+        throw new UnsupportedOperationException("push-based indexing is not supported in ingestion engine, use streaming source instead");
     }
 
     /**
@@ -179,7 +178,7 @@ public class IngestionEngine extends InternalEngine {
 
     @Override
     public DeleteResult delete(Delete delete) throws IOException {
-        throw new UnsupportedEncodingException("push-based deletion is not supported in ingestion engine, use streaming source instead");
+        throw new UnsupportedOperationException("push-based deletion is not supported in ingestion engine, use streaming source instead");
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngineException.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngineException.java
@@ -10,9 +10,21 @@ package org.opensearch.index.engine;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchWrapperException;
+import org.opensearch.core.common.io.stream.StreamInput;
 
+import java.io.IOException;
+
+/**
+ * Exception thrown when there is an error in the ingestion engine.
+ *
+ * @opensearch.internal
+ */
 public class IngestionEngineException extends OpenSearchException implements OpenSearchWrapperException {
     public IngestionEngineException(Throwable cause) {
         super(cause);
+    }
+
+    public IngestionEngineException(StreamInput in) throws IOException {
+        super(in);
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngineException.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngineException.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchWrapperException;
+
+public class IngestionEngineException extends OpenSearchException implements OpenSearchWrapperException {
+    public IngestionEngineException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngineException.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngineException.java
@@ -11,6 +11,7 @@ package org.opensearch.index.engine;
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchWrapperException;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.rest.RestStatus;
 
 import java.io.IOException;
 
@@ -20,11 +21,16 @@ import java.io.IOException;
  * @opensearch.internal
  */
 public class IngestionEngineException extends OpenSearchException implements OpenSearchWrapperException {
-    public IngestionEngineException(Throwable cause) {
-        super(cause);
+    public IngestionEngineException(String message) {
+        super(message);
     }
 
     public IngestionEngineException(StreamInput in) throws IOException {
         super(in);
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.BAD_REQUEST;
     }
 }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/MessageProcessorRunnable.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/MessageProcessorRunnable.java
@@ -119,7 +119,7 @@ public class MessageProcessorRunnable implements Runnable {
                 Engine.Operation operation = getOperation(payload, pointer);
                 switch (operation.operationType()) {
                     case INDEX:
-                        engine.index((Engine.Index) operation);
+                        engine.indexInternal((Engine.Index) operation);
                         break;
                     case DELETE:
                         engine.delete((Engine.Delete) operation);

--- a/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/opensearch/ExceptionSerializationTests.java
@@ -87,6 +87,7 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentLocation;
 import org.opensearch.crypto.CryptoRegistryException;
 import org.opensearch.env.ShardLockObtainFailedException;
+import org.opensearch.index.engine.IngestionEngineException;
 import org.opensearch.index.engine.RecoveryEngineException;
 import org.opensearch.index.query.QueryShardException;
 import org.opensearch.index.seqno.RetentionLeaseAlreadyExistsException;
@@ -896,6 +897,7 @@ public class ExceptionSerializationTests extends OpenSearchTestCase {
         ids.put(173, ViewAlreadyExistsException.class);
         ids.put(174, InvalidIndexContextException.class);
         ids.put(175, ResponseLimitBreachedException.class);
+        ids.put(176, IngestionEngineException.class);
         ids.put(10001, IndexCreateBlockException.class);
 
         Map<Class<? extends OpenSearchException>, Integer> reverse = new HashMap<>();

--- a/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
@@ -132,7 +132,7 @@ public class IngestionEngineTests extends EngineTestCase {
 
     public void testPushAPIFailures() {
         assertThrows(IngestionEngineException.class, () -> ingestionEngine.index(Mockito.any(Engine.Index.class)));
-        assertThrows(IngestionEngineException.class, () -> ingestionEngine.delete(Mockito.any(Engine.Index.class)));
+        assertThrows(IngestionEngineException.class, () -> ingestionEngine.delete(Mockito.any(Engine.Delete.class)));
     }
 
     public void testCreationFailure() throws IOException {

--- a/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
@@ -131,8 +131,10 @@ public class IngestionEngineTests extends EngineTestCase {
     }
 
     public void testPushAPIFailures() {
-        assertThrows(IngestionEngineException.class, () -> ingestionEngine.index(Mockito.any(Engine.Index.class)));
-        assertThrows(IngestionEngineException.class, () -> ingestionEngine.delete(Mockito.any(Engine.Delete.class)));
+        Engine.Index indexMock = Mockito.mock(Engine.Index.class);
+        assertThrows(IngestionEngineException.class, () -> ingestionEngine.index(indexMock));
+        Engine.Delete deleteMock = Mockito.mock(Engine.Delete.class);
+        assertThrows(IngestionEngineException.class, () -> ingestionEngine.delete(deleteMock));
     }
 
     public void testCreationFailure() throws IOException {

--- a/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
@@ -131,8 +131,8 @@ public class IngestionEngineTests extends EngineTestCase {
     }
 
     public void testPushAPIFailures() {
-        assertThrows(IngestionEngineException.class, () -> ingestionEngine.index(Mockito.any()));
-        assertThrows(IngestionEngineException.class, () -> ingestionEngine.delete(Mockito.any()));
+        assertThrows(IngestionEngineException.class, () -> ingestionEngine.index(Mockito.any(Engine.Index.class)));
+        assertThrows(IngestionEngineException.class, () -> ingestionEngine.delete(Mockito.any(Engine.Index.class)));
     }
 
     public void testCreationFailure() throws IOException {

--- a/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
@@ -35,6 +35,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.mockito.Mockito;
+
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -126,6 +128,22 @@ public class IngestionEngineTests extends EngineTestCase {
         ingestionEngine.close();
         ingestionEngine = buildIngestionEngine(new AtomicLong(0), ingestionEngineStore, indexSettings);
         waitForResults(ingestionEngine, 4);
+    }
+
+    public void testPushAPIFailures() throws IOException {
+        try {
+            ingestionEngine.index(Mockito.any());
+            fail("Expected UnsupportedOperationException to be thrown");
+        } catch (Exception e) {
+            assertEquals("push-based indexing is not supported in ingestion engine, use streaming source instead", e.getMessage());
+        }
+
+        try {
+            ingestionEngine.delete(Mockito.any());
+            fail("Expected UnsupportedOperationException to be thrown");
+        } catch (Exception e) {
+            assertEquals("push-based deletion is not supported in ingestion engine, use streaming source instead", e.getMessage());
+        }
     }
 
     public void testCreationFailure() throws IOException {

--- a/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
@@ -130,20 +130,9 @@ public class IngestionEngineTests extends EngineTestCase {
         waitForResults(ingestionEngine, 4);
     }
 
-    public void testPushAPIFailures() throws IOException {
-        try {
-            ingestionEngine.index(Mockito.any());
-            fail("Expected UnsupportedOperationException to be thrown");
-        } catch (Exception e) {
-            assertEquals("push-based indexing is not supported in ingestion engine, use streaming source instead", e.getMessage());
-        }
-
-        try {
-            ingestionEngine.delete(Mockito.any());
-            fail("Expected UnsupportedOperationException to be thrown");
-        } catch (Exception e) {
-            assertEquals("push-based deletion is not supported in ingestion engine, use streaming source instead", e.getMessage());
-        }
+    public void testPushAPIFailures() {
+        assertThrows(UnsupportedOperationException.class, () -> ingestionEngine.index(Mockito.any()));
+        assertThrows(UnsupportedOperationException.class, () -> ingestionEngine.delete(Mockito.any()));
     }
 
     public void testCreationFailure() throws IOException {

--- a/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
@@ -131,8 +131,8 @@ public class IngestionEngineTests extends EngineTestCase {
     }
 
     public void testPushAPIFailures() {
-        assertThrows(UnsupportedOperationException.class, () -> ingestionEngine.index(Mockito.any()));
-        assertThrows(UnsupportedOperationException.class, () -> ingestionEngine.delete(Mockito.any()));
+        assertThrows(IngestionEngineException.class, () -> ingestionEngine.index(Mockito.any()));
+        assertThrows(IngestionEngineException.class, () -> ingestionEngine.delete(Mockito.any()));
     }
 
     public void testCreationFailure() throws IOException {


### PR DESCRIPTION
### Description
The indexing API call will fail for ingestion engine. For example

```
curl -X PUT -H 'Content-Type: application/json' http://localhost:9200/my-index/_doc/1 --data '
{
  "name": "John Doe",
  "age": 24
}
'
```
returns
```
{"error":{"root_cause":[{"type":"unsupported_operation_exception","reason":"push-based indexing is not supported in ingestion engine, use streaming source instead"}],"type":"unsupported_operation_exception","reason":"push-based indexing is not supported in ingestion engine, use streaming source instead"},"status":400}%
```

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/16930

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
