### PR TITLE
Remove feature flag for ApproximatePointRangeQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Removed
 - Remove deprecated `batch_size` parameter from `_bulk` ([#14283](https://github.com/opensearch-project/OpenSearch/issues/14283))
+- Remove `FeatureFlags.APPROXIMATE_POINT_RANGE_QUERY_SETTING` since range query approximation is no longer experimental ([#17769](https://github.com/opensearch-project/OpenSearch/pull/17769))
 
 ### Fixed
 - Fix bytes parameter on `_cat/recovery` ([#17598](https://github.com/opensearch-project/OpenSearch/pull/17598))

--- a/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldTypeTests.java
@@ -51,6 +51,7 @@ import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.index.fielddata.IndexNumericFieldData;
 import org.opensearch.index.fielddata.LeafNumericFieldData;
 import org.opensearch.index.fielddata.SortedNumericDoubleValues;
+import org.opensearch.search.approximate.ApproximateScoreQuery;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -167,8 +168,8 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
     }
 
     private String getQueryString(Query query) {
-        assertTrue(query instanceof IndexOrDocValuesQuery);
-        return ((IndexOrDocValuesQuery) query).getIndexQuery().toString();
+        assertTrue(query instanceof ApproximateScoreQuery);
+        return ((IndexOrDocValuesQuery) ((ApproximateScoreQuery) query).getOriginalQuery()).getIndexQuery().toString();
     }
 
     public void testValueForSearch() {

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -122,15 +122,6 @@ public class FeatureFlags {
         Property.NodeScope
     );
 
-    /**
-     * Gates the functionality of ApproximatePointRangeQuery where we approximate query results.
-     */
-    public static final String APPROXIMATE_POINT_RANGE_QUERY = FEATURE_FLAG_PREFIX + "approximate_point_range_query.enabled";
-    public static final Setting<Boolean> APPROXIMATE_POINT_RANGE_QUERY_SETTING = Setting.boolSetting(
-        APPROXIMATE_POINT_RANGE_QUERY,
-        false,
-        Property.NodeScope
-    );
     public static final String TERM_VERSION_PRECOMMIT_ENABLE = OS_EXPERIMENTAL_PREFIX + "optimization.termversion.precommit.enabled";
     public static final Setting<Boolean> TERM_VERSION_PRECOMMIT_ENABLE_SETTING = Setting.boolSetting(
         TERM_VERSION_PRECOMMIT_ENABLE,

--- a/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
@@ -486,23 +486,16 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
                     } else {
                         query = pointRangeQuery;
                     }
-                    if (FeatureFlags.isEnabled(FeatureFlags.APPROXIMATE_POINT_RANGE_QUERY_SETTING)) {
-                        return new ApproximateScoreQuery(
-                            query,
-                            new ApproximatePointRangeQuery(
-                                name(),
-                                pack(new long[] { l }).bytes,
-                                pack(new long[] { u }).bytes,
-                                new long[] { l }.length
-                            ) {
-                                @Override
-                                protected String toString(int dimension, byte[] value) {
-                                    return Long.toString(LongPoint.decodeDimension(value, 0));
-                                }
-                            }
-                        );
-                    }
-                    return query;
+                    return new ApproximateScoreQuery(
+                        query,
+                        new ApproximatePointRangeQuery(
+                            name(),
+                            pack(new long[] { l }).bytes,
+                            pack(new long[] { u }).bytes,
+                            new long[] { l }.length,
+                            ApproximatePointRangeQuery.LONG_FORMAT
+                        )
+                    );
                 }
 
                 // Not searchable. Must have doc values.

--- a/server/src/main/java/org/opensearch/index/search/NestedHelper.java
+++ b/server/src/main/java/org/opensearch/index/search/NestedHelper.java
@@ -46,6 +46,7 @@ import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.ObjectMapper;
+import org.opensearch.search.approximate.ApproximateScoreQuery;
 
 /** Utility class to filter parent and children clauses when building nested
  * queries.
@@ -85,6 +86,8 @@ public final class NestedHelper {
             return mightMatchNestedDocs(((PointRangeQuery) query).getField());
         } else if (query instanceof IndexOrDocValuesQuery) {
             return mightMatchNestedDocs(((IndexOrDocValuesQuery) query).getIndexQuery());
+        } else if (query instanceof ApproximateScoreQuery) {
+            return mightMatchNestedDocs(((ApproximateScoreQuery) query).getOriginalQuery());
         } else if (query instanceof BooleanQuery) {
             final BooleanQuery bq = (BooleanQuery) query;
             final boolean hasRequiredClauses = bq.clauses().stream().anyMatch(BooleanClause::isRequired);
@@ -155,6 +158,8 @@ public final class NestedHelper {
             return mightMatchNonNestedDocs(((PointRangeQuery) query).getField(), nestedPath);
         } else if (query instanceof IndexOrDocValuesQuery) {
             return mightMatchNonNestedDocs(((IndexOrDocValuesQuery) query).getIndexQuery(), nestedPath);
+        } else if (query instanceof ApproximateScoreQuery) {
+            return mightMatchNonNestedDocs(((ApproximateScoreQuery) query).getOriginalQuery(), nestedPath);
         } else if (query instanceof BooleanQuery) {
             final BooleanQuery bq = (BooleanQuery) query;
             final boolean hasRequiredClauses = bq.clauses().stream().anyMatch(BooleanClause::isRequired);

--- a/server/src/main/java/org/opensearch/search/approximate/ApproximatePointRangeQuery.java
+++ b/server/src/main/java/org/opensearch/search/approximate/ApproximatePointRangeQuery.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.search.approximate;
 
+import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PointValues;
@@ -16,6 +17,7 @@ import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.PointRangeQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
@@ -24,41 +26,51 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.IntsRef;
-import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.sort.FieldSortBuilder;
 import org.opensearch.search.sort.SortOrder;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * An approximate-able version of {@link PointRangeQuery}. It creates an instance of {@link PointRangeQuery} but short-circuits the intersect logic
  * after {@code size} is hit
  */
-public abstract class ApproximatePointRangeQuery extends ApproximateQuery {
+public class ApproximatePointRangeQuery extends ApproximateQuery {
+    public static final Function<byte[], String> LONG_FORMAT = bytes -> Long.toString(LongPoint.decodeDimension(bytes, 0));
     private int size;
 
     private SortOrder sortOrder;
 
     public final PointRangeQuery pointRangeQuery;
 
-    protected ApproximatePointRangeQuery(String field, byte[] lowerPoint, byte[] upperPoint, int numDims) {
-        this(field, lowerPoint, upperPoint, numDims, 10_000, null);
+    public ApproximatePointRangeQuery(
+        String field,
+        byte[] lowerPoint,
+        byte[] upperPoint,
+        int numDims,
+        Function<byte[], String> valueToString
+    ) {
+        this(field, lowerPoint, upperPoint, numDims, SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO, null, valueToString);
     }
 
-    protected ApproximatePointRangeQuery(String field, byte[] lowerPoint, byte[] upperPoint, int numDims, int size) {
-        this(field, lowerPoint, upperPoint, numDims, size, null);
-    }
-
-    protected ApproximatePointRangeQuery(String field, byte[] lowerPoint, byte[] upperPoint, int numDims, int size, SortOrder sortOrder) {
+    protected ApproximatePointRangeQuery(
+        String field,
+        byte[] lowerPoint,
+        byte[] upperPoint,
+        int numDims,
+        int size,
+        SortOrder sortOrder,
+        Function<byte[], String> valueToString
+    ) {
         this.size = size;
         this.sortOrder = sortOrder;
         this.pointRangeQuery = new PointRangeQuery(field, lowerPoint, upperPoint, numDims) {
             @Override
             protected String toString(int dimension, byte[] value) {
-                return super.toString(field);
+                return valueToString.apply(value);
             }
         };
     }
@@ -77,6 +89,11 @@ public abstract class ApproximatePointRangeQuery extends ApproximateQuery {
 
     public void setSortOrder(SortOrder sortOrder) {
         this.sortOrder = sortOrder;
+    }
+
+    @Override
+    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+        return super.rewrite(indexSearcher);
     }
 
     @Override
@@ -344,7 +361,6 @@ public abstract class ApproximatePointRangeQuery extends ApproximateQuery {
                 if (checkValidPointValues(values) == false) {
                     return null;
                 }
-                final Weight weight = this;
                 if (size > values.size()) {
                     return pointRangeQueryWeight.scorerSupplier(context);
                 } else {
@@ -426,17 +442,26 @@ public abstract class ApproximatePointRangeQuery extends ApproximateQuery {
         }
         // size 0 could be set for caching
         if (context.from() + context.size() == 0) {
-            this.setSize(10_000);
+            this.setSize(SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO);
+        } else {
+            this.setSize(Math.max(context.from() + context.size(), context.trackTotalHitsUpTo()));
         }
-        this.setSize(Math.max(context.from() + context.size(), context.trackTotalHitsUpTo()));
         if (context.request() != null && context.request().source() != null) {
             FieldSortBuilder primarySortField = FieldSortBuilder.getPrimaryFieldSortOrNull(context.request().source());
-            if (primarySortField != null
-                && primarySortField.missing() == null
-                && primarySortField.getFieldName().equals(((RangeQueryBuilder) context.request().source().query()).fieldName())) {
-                if (primarySortField.order() == SortOrder.DESC) {
-                    this.setSortOrder(SortOrder.DESC);
+            if (primarySortField != null) {
+                if (!primarySortField.fieldName().equals(pointRangeQuery.getField())) {
+                    return false;
                 }
+                if (primarySortField.missing() != null) {
+                    // Cannot sort documents missing this field.
+                    return false;
+                }
+                if (context.request().source().searchAfter() != null) {
+                    // TODO: We *could* optimize searchAfter, especially when this is the only sort field, but existing pruning is pretty
+                    // good.
+                    return false;
+                }
+                this.setSortOrder(primarySortField.order());
             }
         }
         return true;
@@ -453,56 +478,16 @@ public abstract class ApproximatePointRangeQuery extends ApproximateQuery {
     }
 
     private boolean equalsTo(ApproximatePointRangeQuery other) {
-        return Objects.equals(pointRangeQuery.getField(), other.pointRangeQuery.getField())
-            && pointRangeQuery.getNumDims() == other.pointRangeQuery.getNumDims()
-            && pointRangeQuery.getBytesPerDim() == other.pointRangeQuery.getBytesPerDim()
-            && Arrays.equals(pointRangeQuery.getLowerPoint(), other.pointRangeQuery.getLowerPoint())
-            && Arrays.equals(pointRangeQuery.getUpperPoint(), other.pointRangeQuery.getUpperPoint());
+        return Objects.equals(pointRangeQuery, other.pointRangeQuery);
     }
 
     @Override
     public final String toString(String field) {
         final StringBuilder sb = new StringBuilder();
-        if (pointRangeQuery.getField().equals(field) == false) {
-            sb.append(pointRangeQuery.getField());
-            sb.append(':');
-        }
-
-        // print ourselves as "range per dimension"
-        for (int i = 0; i < pointRangeQuery.getNumDims(); i++) {
-            if (i > 0) {
-                sb.append(',');
-            }
-
-            int startOffset = pointRangeQuery.getBytesPerDim() * i;
-
-            sb.append('[');
-            sb.append(
-                toString(
-                    i,
-                    ArrayUtil.copyOfSubArray(pointRangeQuery.getLowerPoint(), startOffset, startOffset + pointRangeQuery.getBytesPerDim())
-                )
-            );
-            sb.append(" TO ");
-            sb.append(
-                toString(
-                    i,
-                    ArrayUtil.copyOfSubArray(pointRangeQuery.getUpperPoint(), startOffset, startOffset + pointRangeQuery.getBytesPerDim())
-                )
-            );
-            sb.append(']');
-        }
+        sb.append("Approximate(");
+        sb.append(pointRangeQuery.toString());
+        sb.append(")");
 
         return sb.toString();
     }
-
-    /**
-     * Returns a string of a single value in a human-readable format for debugging. This is used by
-     * {@link #toString()}.
-     *
-     * @param dimension dimension of the particular value
-     * @param value     single value, never null
-     * @return human readable value for debugging
-     */
-    protected abstract String toString(int dimension, byte[] value);
 }

--- a/server/src/main/java/org/opensearch/search/approximate/ApproximateScoreQuery.java
+++ b/server/src/main/java/org/opensearch/search/approximate/ApproximateScoreQuery.java
@@ -42,9 +42,10 @@ public final class ApproximateScoreQuery extends Query {
     }
 
     @Override
-    public final Query rewrite(IndexSearcher indexSearcher) throws IOException {
+    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
         if (resolvedQuery == null) {
-            throw new IllegalStateException("Cannot rewrite resolved query without setContext being called");
+            // Default to the original query. This suggests that we were not called from ContextIndexSearcher.
+            return originalQuery.rewrite(indexSearcher);
         }
         return resolvedQuery.rewrite(indexSearcher);
     }

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -191,6 +191,9 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
 
     @Override
     public Query rewrite(Query original) throws IOException {
+        if (original instanceof ApproximateScoreQuery) {
+            ((ApproximateScoreQuery) original).setContext(searchContext);
+        }
         if (profiler != null) {
             profiler.startRewriteTime();
         }
@@ -221,9 +224,6 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
                 profiler.pollLastElement();
             }
             return new ProfileWeight(query, weight, profile);
-        } else if (query instanceof ApproximateScoreQuery) {
-            ((ApproximateScoreQuery) query).setContext(searchContext);
-            return super.createWeight(query, scoreMode, boost);
         } else {
             return super.createWeight(query, scoreMode, boost);
         }

--- a/server/src/test/java/org/opensearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
@@ -46,7 +46,6 @@ import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.network.InetAddresses;
 import org.opensearch.common.time.DateMathParser;
-import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryStringQueryBuilder;
 import org.opensearch.lucene.queries.BinaryDocValuesRangeQuery;
@@ -57,11 +56,9 @@ import org.opensearch.test.AbstractQueryTestCase;
 import java.io.IOException;
 import java.net.InetAddress;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.apache.lucene.document.LongPoint.pack;
-import static org.junit.Assume.assumeThat;
 
 public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStringQueryBuilder> {
 
@@ -185,11 +182,6 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
             parser.parse(lowerBoundExact, () -> 0).toEpochMilli(),
             parser.parse(upperBoundExact, () -> 0).toEpochMilli()
         );
-        assumeThat(
-            "Using Approximate Range Query as default",
-            FeatureFlags.isEnabled(FeatureFlags.APPROXIMATE_POINT_RANGE_QUERY),
-            is(true)
-        );
         assertEquals(
             new ApproximateScoreQuery(
                 new IndexOrDocValuesQuery(
@@ -204,13 +196,9 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
                     DATE_FIELD_NAME,
                     pack(new long[] { parser.parse(lowerBoundExact, () -> 0).toEpochMilli() }).bytes,
                     pack(new long[] { parser.parse(upperBoundExact, () -> 0).toEpochMilli() }).bytes,
-                    new long[] { parser.parse(lowerBoundExact, () -> 0).toEpochMilli() }.length
-                ) {
-                    @Override
-                    protected String toString(int dimension, byte[] value) {
-                        return Long.toString(LongPoint.decodeDimension(value, 0));
-                    }
-                }
+                    new long[] { parser.parse(lowerBoundExact, () -> 0).toEpochMilli() }.length,
+                    ApproximatePointRangeQuery.LONG_FORMAT
+                )
             ),
             queryOnDateField
         );

--- a/server/src/test/java/org/opensearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/RangeFieldTypeTests.java
@@ -286,11 +286,6 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
         // compare lower and upper bounds with what we would get on a `date` field
         DateFieldType dateFieldType = new DateFieldType("field", DateFieldMapper.Resolution.MILLISECONDS, formatter);
         final Query queryOnDateField = dateFieldType.rangeQuery(from, to, true, true, relation, null, fieldType.dateMathParser(), context);
-        assumeThat(
-            "Using Approximate Range Query as default",
-            FeatureFlags.isEnabled(FeatureFlags.APPROXIMATE_POINT_RANGE_QUERY),
-            is(true)
-        );
         assertEquals(
             "field:[1465975790000 TO 1466062190999]",
             ((IndexOrDocValuesQuery) ((ApproximateScoreQuery) queryOnDateField).getOriginalQuery()).getIndexQuery().toString()

--- a/server/src/test/java/org/opensearch/index/query/RangeQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/RangeQueryBuilderTests.java
@@ -47,7 +47,6 @@ import org.apache.lucene.search.TermRangeQuery;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.geo.ShapeRelation;
 import org.opensearch.common.lucene.BytesRefs;
-import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.common.ParsingException;
 import org.opensearch.index.mapper.DateFieldMapper;
 import org.opensearch.index.mapper.FieldNamesFieldMapper;
@@ -69,12 +68,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.opensearch.index.query.QueryBuilders.rangeQuery;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.apache.lucene.document.LongPoint.pack;
-import static org.junit.Assume.assumeThat;
 
 public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuilder> {
     @Override
@@ -190,11 +187,6 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 assertThat(termRangeQuery.includesLower(), equalTo(queryBuilder.includeLower()));
                 assertThat(termRangeQuery.includesUpper(), equalTo(queryBuilder.includeUpper()));
             } else if (expectedFieldName.equals(DATE_FIELD_NAME)) {
-                assumeThat(
-                    "Using Approximate Range Query as default",
-                    FeatureFlags.isEnabled(FeatureFlags.APPROXIMATE_POINT_RANGE_QUERY),
-                    is(true)
-                );
                 assertThat(query, instanceOf(ApproximateScoreQuery.class));
                 Query approximationQuery = ((ApproximateScoreQuery) query).getApproximationQuery();
                 assertThat(approximationQuery, instanceOf(ApproximateQuery.class));
@@ -258,13 +250,9 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                             DATE_FIELD_NAME,
                             pack(new long[] { minLong }).bytes,
                             pack(new long[] { maxLong }).bytes,
-                            new long[] { minLong }.length
-                        ) {
-                            @Override
-                            protected String toString(int dimension, byte[] value) {
-                                return Long.toString(LongPoint.decodeDimension(value, 0));
-                            }
-                        }
+                            new long[] { minLong }.length,
+                            ApproximatePointRangeQuery.LONG_FORMAT
+                        )
                     ),
                     query
                 );
@@ -332,11 +320,6 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
             + "    }\n"
             + "}";
         Query parsedQuery = parseQuery(query).toQuery(createShardContext());
-        assumeThat(
-            "Using Approximate Range Query as default",
-            FeatureFlags.isEnabled(FeatureFlags.APPROXIMATE_POINT_RANGE_QUERY),
-            is(true)
-        );
         assertThat(parsedQuery, instanceOf(ApproximateScoreQuery.class));
         Query approximationQuery = ((ApproximateScoreQuery) parsedQuery).getApproximationQuery();
         assertThat(approximationQuery, instanceOf(ApproximateQuery.class));
@@ -354,13 +337,9 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                     DATE_FIELD_NAME,
                     pack(new long[] { lower }).bytes,
                     pack(new long[] { upper }).bytes,
-                    new long[] { lower }.length
-                ) {
-                    @Override
-                    protected String toString(int dimension, byte[] value) {
-                        return Long.toString(LongPoint.decodeDimension(value, 0));
-                    }
-                }
+                    new long[] { lower }.length,
+                    ApproximatePointRangeQuery.LONG_FORMAT
+                )
             ),
             parsedQuery
         );
@@ -392,11 +371,6 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
             + "    }\n"
             + "}\n";
         Query parsedQuery = parseQuery(query).toQuery(createShardContext());
-        assumeThat(
-            "Using Approximate Range Query as default",
-            FeatureFlags.isEnabled(FeatureFlags.APPROXIMATE_POINT_RANGE_QUERY),
-            is(true)
-        );
         assertThat(parsedQuery, instanceOf(ApproximateScoreQuery.class));
 
         long lower = DateTime.parse("2014-11-01T00:00:00.000+00").getMillis();
@@ -411,13 +385,9 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                     DATE_FIELD_NAME,
                     pack(new long[] { lower }).bytes,
                     pack(new long[] { upper }).bytes,
-                    new long[] { lower }.length
-                ) {
-                    @Override
-                    protected String toString(int dimension, byte[] value) {
-                        return Long.toString(LongPoint.decodeDimension(value, 0));
-                    }
-                }
+                    new long[] { lower }.length,
+                    ApproximatePointRangeQuery.LONG_FORMAT
+                )
             )
 
             ,
@@ -448,13 +418,9 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                     DATE_FIELD_NAME,
                     pack(new long[] { lower }).bytes,
                     pack(new long[] { upper }).bytes,
-                    new long[] { lower }.length
-                ) {
-                    @Override
-                    protected String toString(int dimension, byte[] value) {
-                        return Long.toString(LongPoint.decodeDimension(value, 0));
-                    }
-                }
+                    new long[] { lower }.length,
+                    ApproximatePointRangeQuery.LONG_FORMAT
+                )
             )
 
             ,
@@ -478,11 +444,6 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         Query parsedQuery = parseQuery(query).toQuery(context);
         assertThat(parsedQuery, instanceOf(DateRangeIncludingNowQuery.class));
         parsedQuery = ((DateRangeIncludingNowQuery) parsedQuery).getQuery();
-        assumeThat(
-            "Using Approximate Range Query as default",
-            FeatureFlags.isEnabled(FeatureFlags.APPROXIMATE_POINT_RANGE_QUERY),
-            is(true)
-        );
         assertThat(parsedQuery, instanceOf(ApproximateScoreQuery.class));
         parsedQuery = ((ApproximateScoreQuery) parsedQuery).getApproximationQuery();
         assertThat(parsedQuery, instanceOf(ApproximateQuery.class));

--- a/server/src/test/java/org/opensearch/search/approximate/ApproximatePointRangeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/approximate/ApproximatePointRangeQueryTests.java
@@ -60,11 +60,13 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
                     try {
                         long lower = RandomNumbers.randomLongBetween(random(), -100, 200);
                         long upper = lower + RandomNumbers.randomLongBetween(random(), 0, 100);
-                        Query approximateQuery = new ApproximatePointRangeQuery("point", pack(lower).bytes, pack(upper).bytes, dims) {
-                            protected String toString(int dimension, byte[] value) {
-                                return Long.toString(LongPoint.decodeDimension(value, 0));
-                            }
-                        };
+                        Query approximateQuery = new ApproximatePointRangeQuery(
+                            "point",
+                            pack(lower).bytes,
+                            pack(upper).bytes,
+                            dims,
+                            ApproximatePointRangeQuery.LONG_FORMAT
+                        );
                         Query query = LongPoint.newRangeQuery("point", lower, upper);
                         IndexSearcher searcher = new IndexSearcher(reader);
                         TopDocs topDocs = searcher.search(approximateQuery, 10);
@@ -100,11 +102,13 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
                     try {
                         long lower = 0;
                         long upper = 1000;
-                        Query approximateQuery = new ApproximatePointRangeQuery("point", pack(lower).bytes, pack(upper).bytes, dims) {
-                            protected String toString(int dimension, byte[] value) {
-                                return Long.toString(LongPoint.decodeDimension(value, 0));
-                            }
-                        };
+                        Query approximateQuery = new ApproximatePointRangeQuery(
+                            "point",
+                            pack(lower).bytes,
+                            pack(upper).bytes,
+                            dims,
+                            ApproximatePointRangeQuery.LONG_FORMAT
+                        );
                         IndexSearcher searcher = new IndexSearcher(reader);
                         TopDocs topDocs = searcher.search(approximateQuery, 10);
                         assertEquals(topDocs.totalHits, new TotalHits(1000, TotalHits.Relation.EQUAL_TO));
@@ -138,11 +142,15 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
                     try {
                         long lower = 0;
                         long upper = 45;
-                        Query approximateQuery = new ApproximatePointRangeQuery("point", pack(lower).bytes, pack(upper).bytes, dims, 10) {
-                            protected String toString(int dimension, byte[] value) {
-                                return Long.toString(LongPoint.decodeDimension(value, 0));
-                            }
-                        };
+                        Query approximateQuery = new ApproximatePointRangeQuery(
+                            "point",
+                            pack(lower).bytes,
+                            pack(upper).bytes,
+                            dims,
+                            10,
+                            null,
+                            ApproximatePointRangeQuery.LONG_FORMAT
+                        );
                         IndexSearcher searcher = new IndexSearcher(reader);
                         TopDocs topDocs = searcher.search(approximateQuery, 10);
                         assertEquals(topDocs.totalHits, new TotalHits(10, TotalHits.Relation.EQUAL_TO));
@@ -182,12 +190,10 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
                             pack(lower).bytes,
                             pack(upper).bytes,
                             dims,
-                            11_000
-                        ) {
-                            protected String toString(int dimension, byte[] value) {
-                                return Long.toString(LongPoint.decodeDimension(value, 0));
-                            }
-                        };
+                            11_000,
+                            null,
+                            ApproximatePointRangeQuery.LONG_FORMAT
+                        );
                         IndexSearcher searcher = new IndexSearcher(reader);
                         TopDocs topDocs = searcher.search(approximateQuery, 11000);
 
@@ -228,11 +234,15 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
                     try {
                         long lower = 0;
                         long upper = 100;
-                        Query approximateQuery = new ApproximatePointRangeQuery("point", pack(lower).bytes, pack(upper).bytes, dims, 10) {
-                            protected String toString(int dimension, byte[] value) {
-                                return Long.toString(LongPoint.decodeDimension(value, 0));
-                            }
-                        };
+                        Query approximateQuery = new ApproximatePointRangeQuery(
+                            "point",
+                            pack(lower).bytes,
+                            pack(upper).bytes,
+                            dims,
+                            10,
+                            null,
+                            ApproximatePointRangeQuery.LONG_FORMAT
+                        );
                         Query query = LongPoint.newRangeQuery("point", lower, upper);
 
                         IndexSearcher searcher = new IndexSearcher(reader);
@@ -278,12 +288,9 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
                             pack(upper).bytes,
                             dims,
                             10,
-                            SortOrder.ASC
-                        ) {
-                            protected String toString(int dimension, byte[] value) {
-                                return Long.toString(LongPoint.decodeDimension(value, 0));
-                            }
-                        };
+                            SortOrder.ASC,
+                            ApproximatePointRangeQuery.LONG_FORMAT
+                        );
                         Query query = LongPoint.newRangeQuery("point", lower, upper);
 
                         IndexSearcher searcher = new IndexSearcher(reader);
@@ -312,11 +319,13 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
     }
 
     public void testSize() {
-        ApproximatePointRangeQuery query = new ApproximatePointRangeQuery("point", pack(0).bytes, pack(20).bytes, 1) {
-            protected String toString(int dimension, byte[] value) {
-                return Long.toString(LongPoint.decodeDimension(value, 0));
-            }
-        };
+        ApproximatePointRangeQuery query = new ApproximatePointRangeQuery(
+            "point",
+            pack(0).bytes,
+            pack(20).bytes,
+            1,
+            ApproximatePointRangeQuery.LONG_FORMAT
+        );
         assertEquals(query.getSize(), 10_000);
 
         query.setSize(100);
@@ -325,11 +334,13 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
     }
 
     public void testSortOrder() {
-        ApproximatePointRangeQuery query = new ApproximatePointRangeQuery("point", pack(0).bytes, pack(20).bytes, 1) {
-            protected String toString(int dimension, byte[] value) {
-                return Long.toString(LongPoint.decodeDimension(value, 0));
-            }
-        };
+        ApproximatePointRangeQuery query = new ApproximatePointRangeQuery(
+            "point",
+            pack(0).bytes,
+            pack(20).bytes,
+            1,
+            ApproximatePointRangeQuery.LONG_FORMAT
+        );
         assertNull(query.getSortOrder());
 
         query.setSortOrder(SortOrder.ASC);
@@ -337,19 +348,23 @@ public class ApproximatePointRangeQueryTests extends OpenSearchTestCase {
     }
 
     public void testCanApproximate() {
-        ApproximatePointRangeQuery query = new ApproximatePointRangeQuery("point", pack(0).bytes, pack(20).bytes, 1) {
-            protected String toString(int dimension, byte[] value) {
-                return Long.toString(LongPoint.decodeDimension(value, 0));
-            }
-        };
+        ApproximatePointRangeQuery query = new ApproximatePointRangeQuery(
+            "point",
+            pack(0).bytes,
+            pack(20).bytes,
+            1,
+            ApproximatePointRangeQuery.LONG_FORMAT
+        );
 
         assertFalse(query.canApproximate(null));
 
-        ApproximatePointRangeQuery queryCanApproximate = new ApproximatePointRangeQuery("point", pack(0).bytes, pack(20).bytes, 1) {
-            protected String toString(int dimension, byte[] value) {
-                return Long.toString(LongPoint.decodeDimension(value, 0));
-            }
-
+        ApproximatePointRangeQuery queryCanApproximate = new ApproximatePointRangeQuery(
+            "point",
+            pack(0).bytes,
+            pack(20).bytes,
+            1,
+            ApproximatePointRangeQuery.LONG_FORMAT
+        ) {
             public boolean canApproximate(SearchContext context) {
                 return true;
             }

--- a/server/src/test/java/org/opensearch/search/approximate/ApproximateScoreQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/approximate/ApproximateScoreQueryTests.java
@@ -46,12 +46,9 @@ public class ApproximateScoreQueryTests extends OpenSearchTestCase {
             "test-index",
             pack(new long[] { l }).bytes,
             pack(new long[] { u }).bytes,
-            new long[] { l }.length
-        ) {
-            protected String toString(int dimension, byte[] value) {
-                return Long.toString(LongPoint.decodeDimension(value, 0));
-            }
-        };
+            new long[] { l }.length,
+            ApproximatePointRangeQuery.LONG_FORMAT
+        );
 
         ApproximateScoreQuery query = new ApproximateScoreQuery(originalQuery, approximateQuery);
         query.resolvedQuery = approximateQuery;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
We introduced `ApproximatePointRangeQuery` as an experimental feature flag in #13788, we're going to GA this approximate query in OS 3.0 and hence removing the feature flag.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] Functionality includes testing.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
