### PR TITLE
Cardinality Aggregation dynamic pruning null pointer exception catch

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -382,7 +382,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
          */
         private void prune(int doc) {
             if (queue.size() == 0) {
-                return ;
+                return;
             }
             DisiWrapper top = queue.top();
             if (top == null) {

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -382,7 +382,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
          */
         private void prune(int doc) {
             if (queue.size() == 0) {
-                return;
+                return ;
             }
             DisiWrapper top = queue.top();
             if (top == null) {

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -382,11 +382,11 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
          */
         private void prune(int doc) {
             if (queue.size() == 0) {
-                return ;
+                return;
             }
             DisiWrapper top = queue.top();
             if (top == null) {
-                return ;
+                return;
             }
             int curTopDoc = top.doc;
             if (curTopDoc == doc) {

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -381,7 +381,13 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
          * Note: the queue may be empty or the queue top may be null after pruning
          */
         private void prune(int doc) {
+            if (queue.size() == 0) {
+                return ;
+            }
             DisiWrapper top = queue.top();
+            if (top == null) {
+                return ;
+            }
             int curTopDoc = top.doc;
             if (curTopDoc == doc) {
                 do {


### PR DESCRIPTION
### Description
There was a possibility of a null pointer exception error when the BooleanScorer passes in a null document. The document is assumed to not be null, and while that might be true for the DefaultBulkScorer, it is not checked in the BooleanScorer.

### Related Issues
Resolves #17739

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

