### PR TITLE
Fix socket interceptor and add unit test

### DIFF
--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/SocketChannelInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/SocketChannelInterceptor.java
@@ -18,7 +18,7 @@ import java.net.SocketPermission;
 import java.net.UnixDomainSocketAddress;
 import java.security.Policy;
 import java.security.ProtectionDomain;
-import java.util.stream.Stream;
+import java.util.Collection;
 
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.Origin;
@@ -47,26 +47,26 @@ public class SocketChannelInterceptor {
         }
 
         final StackWalker walker = StackWalker.getInstance(Option.RETAIN_CLASS_REFERENCE);
-        final Stream<ProtectionDomain> callers = walker.walk(StackCallerProtectionDomainChainExtractor.INSTANCE);
+        final Collection<ProtectionDomain> callers = walker.walk(StackCallerProtectionDomainChainExtractor.INSTANCE);
 
         if (args[0] instanceof InetSocketAddress address) {
             if (!AgentPolicy.isTrustedHost(address.getHostString())) {
                 final String host = address.getHostString() + ":" + address.getPort();
 
                 final SocketPermission permission = new SocketPermission(host, "connect,resolve");
-                callers.forEach(domain -> {
+                for (ProtectionDomain domain : callers) {
                     if (!policy.implies(domain, permission)) {
                         throw new SecurityException("Denied access to: " + host + ", domain " + domain);
                     }
-                });
+                }
             }
         } else if (args[0] instanceof UnixDomainSocketAddress address) {
             final NetPermission permission = new NetPermission("accessUnixDomainSocket");
-            callers.forEach(domain -> {
+            for (ProtectionDomain domain : callers) {
                 if (!policy.implies(domain, permission)) {
                     throw new SecurityException("Denied access to: " + address + ", domain " + domain);
                 }
-            });
+            }
         }
     }
 }

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/StackCallerProtectionDomainChainExtractor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/StackCallerProtectionDomainChainExtractor.java
@@ -10,13 +10,15 @@ package org.opensearch.javaagent;
 
 import java.lang.StackWalker.StackFrame;
 import java.security.ProtectionDomain;
+import java.util.Collection;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * Stack Caller Chain Extractor
  */
-public final class StackCallerProtectionDomainChainExtractor implements Function<Stream<StackFrame>, Stream<ProtectionDomain>> {
+public final class StackCallerProtectionDomainChainExtractor implements Function<Stream<StackFrame>, Collection<ProtectionDomain>> {
     /**
      * Single instance of stateless class.
      */
@@ -32,10 +34,10 @@ public final class StackCallerProtectionDomainChainExtractor implements Function
      * @param frames stack frames
      */
     @Override
-    public Stream<ProtectionDomain> apply(Stream<StackFrame> frames) {
+    public Collection<ProtectionDomain> apply(Stream<StackFrame> frames) {
         return frames.map(StackFrame::getDeclaringClass)
             .map(Class::getProtectionDomain)
             .filter(pd -> pd.getCodeSource() != null) /* JDK */
-            .distinct();
+            .collect(Collectors.toSet());
     }
 }

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/AgentTestCase.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/AgentTestCase.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.javaagent;
+
+import org.opensearch.javaagent.bootstrap.AgentPolicy;
+import org.junit.BeforeClass;
+
+import java.security.Policy;
+import java.util.Set;
+
+public abstract class AgentTestCase {
+    @SuppressWarnings("removal")
+    @BeforeClass
+    public static void setUp() {
+        AgentPolicy.setPolicy(new Policy() {
+        }, Set.of(), (caller, chain) -> caller.getName().equalsIgnoreCase("worker.org.gradle.process.internal.worker.GradleWorkerMain"));
+    }
+}

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/AgentTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/AgentTests.java
@@ -8,21 +8,9 @@
 
 package org.opensearch.javaagent;
 
-import org.opensearch.javaagent.bootstrap.AgentPolicy;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.security.Policy;
-import java.util.Set;
-
-public class AgentTests {
-    @SuppressWarnings("removal")
-    @BeforeClass
-    public static void setUp() {
-        AgentPolicy.setPolicy(new Policy() {
-        }, Set.of(), (caller, chain) -> caller.getName().equalsIgnoreCase("worker.org.gradle.process.internal.worker.GradleWorkerMain"));
-    }
-
+public class AgentTests extends AgentTestCase {
     @Test(expected = SecurityException.class)
     public void testSystemExitIsForbidden() {
         System.exit(0);

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/SocketChannelInterceptorTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/SocketChannelInterceptorTests.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.javaagent;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.SocketChannel;
+
+import static org.junit.Assert.assertThrows;
+
+public class SocketChannelInterceptorTests extends AgentTestCase {
+    @Test
+    public void test() throws IOException {
+        try (SocketChannel channel = SocketChannel.open()) {
+            assertThrows(SecurityException.class, () -> channel.connect(new InetSocketAddress("localhost", 9200)));
+
+            assertThrows(SecurityException.class, () -> channel.connect(UnixDomainSocketAddress.of("fake-path")));
+        }
+    }
+}


### PR DESCRIPTION
The optimization of using a Stream instead of a Collection caused problems with class not found and/or illegal access errors when using the lambda function in the `Stream::forEach` call in the intercept method.

FYI @RajatGupta02 

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
