### PR TITLE
fixed negative year range for default date type formate

### DIFF
--- a/server/src/main/java/org/opensearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/opensearch/common/time/DateFormatters.java
@@ -87,10 +87,23 @@ public class DateFormatters {
         .toFormatter(Locale.ROOT)
         .withResolverStyle(ResolverStyle.STRICT);
 
+    private static final DateTimeFormatter STRICT_YEAR_MONTH_DAY_PRINTER = new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4, 9, SignStyle.EXCEEDS_PAD)
+        .optionalStart()
+        .appendLiteral("-")
+        .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
+        .optionalStart()
+        .appendLiteral('-')
+        .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
+        .optionalEnd()
+        .optionalEnd()
+        .toFormatter(Locale.ROOT)
+        .withResolverStyle(ResolverStyle.STRICT);
+
     private static final DateTimeFormatter STRICT_YEAR_MONTH_DAY_FORMATTER = new DateTimeFormatterBuilder().appendValue(
         ChronoField.YEAR,
         4,
-        10,
+        4,
         SignStyle.EXCEEDS_PAD
     )
         .optionalStart()
@@ -118,7 +131,7 @@ public class DateFormatters {
         .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_DATE_OPTIONAL_TIME_PRINTER = new DateTimeFormatterBuilder().append(
-        STRICT_YEAR_MONTH_DAY_FORMATTER
+        STRICT_YEAR_MONTH_DAY_PRINTER
     )
         .appendLiteral('T')
         .optionalStart()
@@ -207,7 +220,7 @@ public class DateFormatters {
         .withResolverStyle(ResolverStyle.STRICT);
 
     private static final DateTimeFormatter STRICT_DATE_OPTIONAL_TIME_PRINTER_NANOS = new DateTimeFormatterBuilder().append(
-        STRICT_YEAR_MONTH_DAY_FORMATTER
+        STRICT_YEAR_MONTH_DAY_PRINTER
     )
         .appendLiteral('T')
         .optionalStart()
@@ -687,7 +700,7 @@ public class DateFormatters {
      */
     private static final DateFormatter STRICT_YEAR_MONTH = new JavaDateFormatter(
         "strict_year_month",
-        new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4, 4, SignStyle.EXCEEDS_PAD)
             .appendLiteral("-")
             .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
             .toFormatter(Locale.ROOT)
@@ -699,7 +712,7 @@ public class DateFormatters {
      */
     private static final DateFormatter STRICT_YEAR = new JavaDateFormatter(
         "strict_year",
-        new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4, 4, SignStyle.EXCEEDS_PAD)
             .toFormatter(Locale.ROOT)
             .withResolverStyle(ResolverStyle.STRICT)
     );
@@ -749,7 +762,7 @@ public class DateFormatters {
     private static final DateTimeFormatter STRICT_ORDINAL_DATE_TIME_NO_MILLIS_BASE = new DateTimeFormatterBuilder().appendValue(
         ChronoField.YEAR,
         4,
-        10,
+        4,
         SignStyle.EXCEEDS_PAD
     )
         .appendLiteral('-')
@@ -886,7 +899,7 @@ public class DateFormatters {
     private static final DateTimeFormatter STRICT_ORDINAL_DATE_TIME_PRINTER = new DateTimeFormatterBuilder().appendValue(
         ChronoField.YEAR,
         4,
-        10,
+        4,
         SignStyle.EXCEEDS_PAD
     )
         .appendLiteral('-')
@@ -904,7 +917,7 @@ public class DateFormatters {
     private static final DateTimeFormatter STRICT_ORDINAL_DATE_TIME_FORMATTER_BASE = new DateTimeFormatterBuilder().appendValue(
         ChronoField.YEAR,
         4,
-        10,
+        4,
         SignStyle.EXCEEDS_PAD
     )
         .appendLiteral('-')
@@ -1207,7 +1220,7 @@ public class DateFormatters {
     );
 
     private static final DateTimeFormatter STRICT_ORDINAL_DATE_FORMATTER = new DateTimeFormatterBuilder().parseCaseInsensitive()
-        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .appendValue(ChronoField.YEAR, 4, 4, SignStyle.EXCEEDS_PAD)
         .appendLiteral('-')
         .appendValue(DAY_OF_YEAR, 3)
         .optionalStart()
@@ -1235,7 +1248,7 @@ public class DateFormatters {
     private static final DateTimeFormatter DATE_FORMATTER = new DateTimeFormatterBuilder().appendValue(
         ChronoField.YEAR,
         1,
-        5,
+        9,
         SignStyle.NORMAL
     )
         .optionalStart()

--- a/server/src/test/java/org/opensearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/opensearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -548,6 +548,15 @@ public class JavaJodaTimeDuellingTests extends OpenSearchTestCase {
         assertSameDate("2012-W1-1", "weekyear_week_day");
     }
 
+    public void testParsing() {
+        // considered as year
+        assertSameDate("1234", "strict_date_optional_time||epoch_millis");
+        // considered as 12345 milliseconds since epoch
+        assertSameDate("12345", "strict_date_optional_time||epoch_millis");
+        // considered as 561600000 milliseconds before epoch
+        assertSameDate("-561600000", "strict_date_optional_time||epoch_millis");
+    }
+
     public void testCompositeParsing() {
         // in all these examples the second pattern will be used
         assertSameDate("2014-06-06T12:01:02.123", "yyyy-MM-dd'T'HH:mm:ss||yyyy-MM-dd'T'HH:mm:ss.SSS");

--- a/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
@@ -268,6 +268,22 @@ public class DateFormattersTests extends OpenSearchTestCase {
         }
     }
 
+    public void testNegativeEpochMilliWithDefaultFormatters() {
+        {
+            DateFormatter formatter = DateFormatter.forPattern("strict_date_optional_time||epoch_millis");
+            TemporalAccessor accessor = formatter.parse("-2177434800");
+            assertThat(DateFormatters.from(accessor).toInstant().toEpochMilli(), is(-2177434800L));
+            assertThat(formatter.pattern(), is("strict_date_optional_time||epoch_millis"));
+        }
+
+        {
+            DateFormatter formatter = DateFormatter.forPattern("strict_date_optional_time||epoch_millis");
+            TemporalAccessor accessor = formatter.parse("-561600000");
+            assertThat(DateFormatters.from(accessor).toInstant().toEpochMilli(), is(-561600000L));
+            assertThat(formatter.pattern(), is("strict_date_optional_time||epoch_millis"));
+        }
+    }
+
     public void testParsersWithMultipleInternalFormats() throws Exception {
         ZonedDateTime first = DateFormatters.from(
             DateFormatters.forPattern("strict_date_optional_time_nanos").parse("2018-05-15T17:14:56+0100")

--- a/server/src/test/java/org/opensearch/common/time/JavaDateMathParserTests.java
+++ b/server/src/test/java/org/opensearch/common/time/JavaDateMathParserTests.java
@@ -345,7 +345,9 @@ public class JavaDateMathParserTests extends OpenSearchTestCase {
         // a timestamp before 100000 is a year
         assertDateMathEquals("9999", "9999-01-01T00:00:00.000");
         assertDateMathEquals("10000", "10000-01-01T00:00:00.000");
-        assertDateMathEquals("100000", "1970-01-01T00:01:40.000");
+        assertDateMathEquals("100000", "100000-01-01T00:00:00.000");
+        // a timestamp with more than 9digits is epoch, for date_optional_time
+        assertDateMathEquals("1000000000", "1970-01-12T13:46:40.000Z");
 
         // but 10000 with T is still a date format
         assertDateMathEquals("10000-01-01T", "10000-01-01T00:00:00.000");

--- a/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
@@ -155,7 +155,6 @@ public class DateFieldMapperTests extends MapperTestCase {
             "2016-03-99",
             "failed to parse date field [2016-03-99] with format [strict_date_optional_time||epoch_millis]"
         );
-        testIgnoreMalformedForValue("-2147483648", "Invalid value for Year (valid values -999999999 - 999999999): -2147483648");
     }
 
     public void testIgnoreMalformed() throws IOException {
@@ -168,7 +167,6 @@ public class DateFieldMapperTests extends MapperTestCase {
             "2016-03-99",
             "failed to parse date field [2016-03-99] with format [strict_date_time_no_millis||strict_date_optional_time||epoch_millis]"
         );
-        testIgnoreMalformedForValue("-2147483648", "Invalid value for Year (valid values -999999999 - 999999999): -2147483648");
     }
 
     private void testIgnoreMalformedForValue(String value, String expectedCause) throws IOException {

--- a/server/src/test/java/org/opensearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DateFieldTypeTests.java
@@ -528,9 +528,10 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
             "2020-01-01T00:00:00Z",
             null,
             "2021-01-01T00:00:00Z",
-            "+292278994-08-17T07:12:55.807Z",
+            // Max supported year is 9999
+            "9999-08-17T07:12:55.807Z",
             null,
-            "-292275055-05-16T16:47:04.192Z"
+            "-9999-05-16T16:47:04.192Z"
         );
 
         int numNullDates = 0;
@@ -585,8 +586,8 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
         );
 
         Query rangeQuery = ft.rangeQuery(
-            "-292275055-05-16T16:47:04.192Z",
-            "+292278994-08-17T07:12:55.807Z",
+            "-9999-05-16T16:47:04.192Z",
+            "9999-08-17T07:12:55.807Z",
             true,
             true,
             null,


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Negative epoch millis with certain length, results with parsing exception for fields using default format ("strict_date_optional_time||epoch_millis").

negative values(-561600000, -5616000000) are parsed incorrectly with default format "strict_date_optional_time||epoch_millis".
with error message,
java.lang.ArithmeticException: long overflow

negative values(-2177434800) are parsed incorrectly with default format "strict_date_optional_time||epoch_millis"
with error message, 
java.time.DateTimeException: Invalid value for Year (valid values -999999999 - 999999999): -2177434800

Fixed by reducing length from 10 to 4 - Helped to parse values correctly now.

### Related Issues
Resolves #16979
<!-- List any other related issues here -->

### Check List
- [X] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).