### PR TITLE
Check for gradle.xml before trying to modify it

### DIFF
--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -114,10 +114,12 @@ if (System.getProperty('idea.active') == 'true') {
  */
 void modifyXml(Object path, Action<? super Node> action) {
   File xmlFile = project.file(path)
-  Node xml = new XmlParser().parse(xmlFile)
-  action.execute(xml)
+  if (xmlFile.exists()) {
+    Node xml = new XmlParser().parse(xmlFile)
+    action.execute(xml)
 
-  xmlFile.withPrintWriter { writer ->
-    new XmlNodePrinter(writer).print(xml)
+    xmlFile.withPrintWriter { writer ->
+      new XmlNodePrinter(writer).print(xml)
+    }
   }
 }


### PR DESCRIPTION
### Description
I set up a new laptop with a fresh install of IntelliJ this week.

When I tried importing OpenSearch, it failed to do the IDE setup, because we check the `.idea/gradle.xml` file for Gradle-specific JVM configuration (forcing Gradle to use the project JVM). It looks like IntelliJ has stopped creating the `gradle.xml` file under the project by default, so I got a `FileNotFoundException`.

To fix it / work around, I checked for existence of the file before trying to modify it. I think this is worth doing anyway and doesn't hurt. Maybe other new contributors will run into the same problem and this will help them.

### Related Issues
N/A

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
