### PR TITLE
Remove deprecated batch_size parameter from _bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Deprecated
 
 ### Removed
+- Remove deprecated `batch_size` parameter from `_bulk` ([#14283](https://github.com/opensearch-project/OpenSearch/issues/14283))
 
 ### Fixed
 - Fix bytes parameter on `_cat/recovery` ([#17598](https://github.com/opensearch-project/OpenSearch/pull/17598))

--- a/server/src/internalClusterTest/java/org/opensearch/ingest/IngestClientIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/ingest/IngestClientIT.java
@@ -162,14 +162,6 @@ public class IngestClientIT extends ParameterizedStaticSettingsOpenSearchIntegTe
     }
 
     public void testBulkWithIngestFailures() throws Exception {
-        runBulkTestWithRandomDocs(false);
-    }
-
-    public void testBulkWithIngestFailuresWithBatchSize() throws Exception {
-        runBulkTestWithRandomDocs(true);
-    }
-
-    private void runBulkTestWithRandomDocs(boolean shouldSetBatchSize) throws Exception {
         createIndex("index");
 
         BytesReference source = BytesReference.bytes(
@@ -188,9 +180,6 @@ public class IngestClientIT extends ParameterizedStaticSettingsOpenSearchIntegTe
 
         int numRequests = scaledRandomIntBetween(32, 128);
         BulkRequest bulkRequest = new BulkRequest();
-        if (shouldSetBatchSize) {
-            bulkRequest.batchSize(scaledRandomIntBetween(2, numRequests));
-        }
         for (int i = 0; i < numRequests; i++) {
             IndexRequest indexRequest = new IndexRequest("index").id(Integer.toString(i)).setPipeline("_id");
             indexRequest.source(Requests.INDEX_CONTENT_TYPE, "field", "value", "fail", i % 2 == 0);
@@ -244,7 +233,6 @@ public class IngestClientIT extends ParameterizedStaticSettingsOpenSearchIntegTe
         client().admin().cluster().putPipeline(putPipelineRequest).get();
 
         BulkRequest bulkRequest = new BulkRequest();
-        bulkRequest.batchSize(3);
         bulkRequest.add(
             new IndexRequest("index").id("_fail").setPipeline("_id").source(Requests.INDEX_CONTENT_TYPE, "field", "value", "fail", true)
         );

--- a/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java
@@ -963,8 +963,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                 }
             },
             bulkRequestModifier::markItemAsDropped,
-            executorName,
-            original
+            executorName
         );
     }
 

--- a/server/src/main/java/org/opensearch/ingest/IngestService.java
+++ b/server/src/main/java/org/opensearch/ingest/IngestService.java
@@ -40,7 +40,6 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.DocWriteRequest;
-import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.TransportBulkAction;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.ingest.DeletePipelineRequest;
@@ -567,8 +566,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         BiConsumer<Integer, Exception> onFailure,
         BiConsumer<Thread, Exception> onCompletion,
         IntConsumer onDropped,
-        String executorName,
-        BulkRequest originalBulkRequest
+        String executorName
     ) {
         threadPool.executor(executorName).execute(new AbstractRunnable() {
 
@@ -579,7 +577,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
 
             @Override
             protected void doRun() {
-                runBulkRequestInBatch(numberOfActionRequests, actionRequests, onFailure, onCompletion, onDropped, originalBulkRequest);
+                runBulkRequestInBatch(numberOfActionRequests, actionRequests, onFailure, onCompletion, onDropped);
             }
         });
     }
@@ -589,8 +587,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         Iterable<DocWriteRequest<?>> actionRequests,
         BiConsumer<Integer, Exception> onFailure,
         BiConsumer<Thread, Exception> onCompletion,
-        IntConsumer onDropped,
-        BulkRequest originalBulkRequest
+        IntConsumer onDropped
     ) {
 
         final Thread originalThread = Thread.currentThread();
@@ -635,7 +632,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
             i++;
         }
 
-        int batchSize = Math.min(numberOfActionRequests, originalBulkRequest.batchSize());
+        int batchSize = numberOfActionRequests;
         List<List<IndexRequestWrapper>> batches = prepareBatches(batchSize, indexRequestWrappers);
         logger.debug("batchSize: {}, batches: {}", batchSize, batches.size());
 

--- a/server/src/main/java/org/opensearch/rest/action/document/RestBulkAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/document/RestBulkAction.java
@@ -36,7 +36,6 @@ import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkShardRequest;
 import org.opensearch.action.support.ActiveShardCount;
-import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
@@ -67,8 +66,6 @@ import static org.opensearch.rest.RestRequest.Method.PUT;
 public class RestBulkAction extends BaseRestHandler {
 
     private final boolean allowExplicitIndex;
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestBulkAction.class);
-    static final String BATCH_SIZE_DEPRECATED_MESSAGE = "The batch size option in bulk API is deprecated and will be removed in 3.0.";
 
     public RestBulkAction(Settings settings) {
         this.allowExplicitIndex = MULTI_ALLOW_EXPLICIT_INDEX.get(settings);
@@ -100,10 +97,6 @@ public class RestBulkAction extends BaseRestHandler {
         Boolean defaultRequireAlias = request.paramAsBoolean(DocWriteRequest.REQUIRE_ALIAS, null);
         bulkRequest.timeout(request.paramAsTime("timeout", BulkShardRequest.DEFAULT_TIMEOUT));
         bulkRequest.setRefreshPolicy(request.param("refresh"));
-        if (request.hasParam("batch_size")) {
-            deprecationLogger.deprecate("batch_size_deprecation", BATCH_SIZE_DEPRECATED_MESSAGE);
-        }
-        bulkRequest.batchSize(request.paramAsInt("batch_size", Integer.MAX_VALUE));
         bulkRequest.add(
             request.requiredContent(),
             defaultIndex,

--- a/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/TransportBulkActionIngestTests.java
@@ -346,8 +346,7 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
             failureHandler.capture(),
             completionHandler.capture(),
             any(),
-            eq(Names.WRITE),
-            eq(bulkRequest)
+            eq(Names.WRITE)
         );
         completionHandler.getValue().accept(null, exception);
         assertTrue(failureCalled.get());
@@ -384,8 +383,7 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
             failureHandler.capture(),
             completionHandler.capture(),
             any(),
-            eq(Names.WRITE),
-            any()
+            eq(Names.WRITE)
         );
         completionHandler.getValue().accept(null, exception);
         assertTrue(failureCalled.get());
@@ -431,8 +429,7 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
             failureHandler.capture(),
             completionHandler.capture(),
             any(),
-            eq(Names.SYSTEM_WRITE),
-            eq(bulkRequest)
+            eq(Names.SYSTEM_WRITE)
         );
         completionHandler.getValue().accept(null, exception);
         assertTrue(failureCalled.get());
@@ -463,7 +460,7 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
         action.execute(null, bulkRequest, listener);
 
         // should not have executed ingest locally
-        verify(ingestService, never()).executeBulkRequest(anyInt(), any(), any(), any(), any(), any(), any());
+        verify(ingestService, never()).executeBulkRequest(anyInt(), any(), any(), any(), any(), any());
         // but instead should have sent to a remote node with the transport service
         ArgumentCaptor<DiscoveryNode> node = ArgumentCaptor.forClass(DiscoveryNode.class);
         verify(transportService).sendRequest(node.capture(), eq(BulkAction.NAME), any(), remoteResponseHandler.capture());
@@ -503,7 +500,7 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
         singleItemBulkWriteAction.execute(null, indexRequest, listener);
 
         // should not have executed ingest locally
-        verify(ingestService, never()).executeBulkRequest(anyInt(), any(), any(), any(), any(), any(), any());
+        verify(ingestService, never()).executeBulkRequest(anyInt(), any(), any(), any(), any(), any());
         // but instead should have sent to a remote node with the transport service
         ArgumentCaptor<DiscoveryNode> node = ArgumentCaptor.forClass(DiscoveryNode.class);
         verify(transportService).sendRequest(node.capture(), eq(BulkAction.NAME), any(), remoteResponseHandler.capture());
@@ -589,8 +586,7 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
             failureHandler.capture(),
             completionHandler.capture(),
             any(),
-            eq(Names.WRITE),
-            eq(bulkRequest)
+            eq(Names.WRITE)
         );
         assertEquals(indexRequest1.getPipeline(), "default_pipeline");
         assertEquals(indexRequest2.getPipeline(), "default_pipeline");
@@ -633,8 +629,7 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
             failureHandler.capture(),
             completionHandler.capture(),
             any(),
-            eq(Names.WRITE),
-            any()
+            eq(Names.WRITE)
         );
         completionHandler.getValue().accept(null, exception);
         assertFalse(action.indexCreated); // still no index yet, the ingest node failed.
@@ -721,8 +716,7 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
             failureHandler.capture(),
             completionHandler.capture(),
             any(),
-            eq(Names.WRITE),
-            any()
+            eq(Names.WRITE)
         );
     }
 
@@ -761,8 +755,7 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
             failureHandler.capture(),
             completionHandler.capture(),
             any(),
-            eq(Names.WRITE),
-            any()
+            eq(Names.WRITE)
         );
     }
 
@@ -787,8 +780,7 @@ public class TransportBulkActionIngestTests extends OpenSearchTestCase {
             failureHandler.capture(),
             completionHandler.capture(),
             any(),
-            eq(Names.WRITE),
-            any()
+            eq(Names.WRITE)
         );
         assertEquals(indexRequest.getPipeline(), "default_pipeline");
         completionHandler.getValue().accept(null, exception);

--- a/server/src/test/java/org/opensearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/opensearch/ingest/IngestServiceTests.java
@@ -122,7 +122,6 @@ import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -148,7 +147,6 @@ public class IngestServiceTests extends OpenSearchTestCase {
         when(threadPool.generic()).thenReturn(executorService);
         when(threadPool.executor(anyString())).thenReturn(executorService);
         mockBulkRequest = mock(BulkRequest.class);
-        lenient().when(mockBulkRequest.batchSize()).thenReturn(1);
     }
 
     public void testIngestPlugin() {
@@ -228,8 +226,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            new BulkRequest()
+            Names.WRITE
         );
 
         assertTrue(failure.get());
@@ -931,8 +928,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            bulkRequest
+            Names.WRITE
         );
 
         assertTrue(failure.get());
@@ -978,8 +974,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            bulkRequest
+            Names.WRITE
         );
         verify(failureHandler, times(1)).accept(
             argThat((Integer item) -> item == 2),
@@ -1015,8 +1010,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            mockBulkRequest
+            Names.WRITE
         );
         verify(failureHandler, never()).accept(any(), any());
         verify(completionHandler, times(1)).accept(Thread.currentThread(), null);
@@ -1047,8 +1041,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            mockBulkRequest
+            Names.WRITE
         );
         verify(failureHandler, never()).accept(any(), any());
         verify(completionHandler, times(1)).accept(Thread.currentThread(), null);
@@ -1107,8 +1100,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            mockBulkRequest
+            Names.WRITE
         );
         verify(processor).execute(any(), any());
         verify(failureHandler, never()).accept(any(), any());
@@ -1152,8 +1144,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            mockBulkRequest
+            Names.WRITE
         );
         verify(processor).execute(eqIndexTypeId(indexRequest.version(), indexRequest.versionType(), emptyMap()), any());
         verify(failureHandler, times(1)).accept(eq(0), any(RuntimeException.class));
@@ -1211,8 +1202,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            mockBulkRequest
+            Names.WRITE
         );
         verify(failureHandler, never()).accept(eq(0), any(IngestProcessorException.class));
         verify(completionHandler, times(1)).accept(Thread.currentThread(), null);
@@ -1261,8 +1251,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            mockBulkRequest
+            Names.WRITE
         );
         verify(processor).execute(eqIndexTypeId(indexRequest.version(), indexRequest.versionType(), emptyMap()), any());
         verify(failureHandler, times(1)).accept(eq(0), any(RuntimeException.class));
@@ -1322,8 +1311,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             errorHandler::put,
             completionHandler::put,
             indexReq -> {},
-            Names.WRITE,
-            bulkRequest
+            Names.WRITE
         );
 
         MatcherAssert.assertThat(errorHandler.entrySet(), hasSize(numIndexRequests));
@@ -1383,8 +1371,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             requestItemErrorHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            bulkRequest
+            Names.WRITE
         );
 
         verify(requestItemErrorHandler, never()).accept(any(), any());
@@ -1452,8 +1439,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            mockBulkRequest
+            Names.WRITE
         );
         final IngestStats afterFirstRequestStats = ingestService.stats();
         assertThat(afterFirstRequestStats.getPipelineStats().size(), equalTo(2));
@@ -1477,8 +1463,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            mockBulkRequest
+            Names.WRITE
         );
         final IngestStats afterSecondRequestStats = ingestService.stats();
         assertThat(afterSecondRequestStats.getPipelineStats().size(), equalTo(2));
@@ -1507,8 +1492,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            mockBulkRequest
+            Names.WRITE
         );
         final IngestStats afterThirdRequestStats = ingestService.stats();
         assertThat(afterThirdRequestStats.getPipelineStats().size(), equalTo(2));
@@ -1541,8 +1525,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             indexReq -> {},
-            Names.WRITE,
-            mockBulkRequest
+            Names.WRITE
         );
         final IngestStats afterForthRequestStats = ingestService.stats();
         assertThat(afterForthRequestStats.getPipelineStats().size(), equalTo(2));
@@ -1640,8 +1623,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler,
             completionHandler,
             dropHandler,
-            Names.WRITE,
-            bulkRequest
+            Names.WRITE
         );
         verify(failureHandler, never()).accept(any(), any());
         verify(completionHandler, times(1)).accept(Thread.currentThread(), null);
@@ -1732,8 +1714,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
                 (integer, e) -> {},
                 (thread, e) -> {},
                 indexReq -> {},
-                Names.WRITE,
-                mockBulkRequest
+                Names.WRITE
             );
         }
 
@@ -1876,77 +1857,6 @@ public class IngestServiceTests extends OpenSearchTestCase {
         }
     }
 
-    public void testExecuteBulkRequestInBatch() {
-        CompoundProcessor mockCompoundProcessor = mockCompoundProcessor();
-        IngestService ingestService = createWithProcessors(
-            Collections.singletonMap("mock", (factories, tag, description, config) -> mockCompoundProcessor)
-        );
-        createPipeline("_id", ingestService);
-        BulkRequest bulkRequest = new BulkRequest();
-        IndexRequest indexRequest1 = new IndexRequest("_index").id("_id1").source(emptyMap()).setPipeline("_id").setFinalPipeline("_none");
-        bulkRequest.add(indexRequest1);
-        IndexRequest indexRequest2 = new IndexRequest("_index").id("_id2").source(emptyMap()).setPipeline("_id").setFinalPipeline("_none");
-        bulkRequest.add(indexRequest2);
-        IndexRequest indexRequest3 = new IndexRequest("_index").id("_id3").source(emptyMap()).setPipeline("_none").setFinalPipeline("_id");
-        bulkRequest.add(indexRequest3);
-        IndexRequest indexRequest4 = new IndexRequest("_index").id("_id4").source(emptyMap()).setPipeline("_id").setFinalPipeline("_none");
-        bulkRequest.add(indexRequest4);
-        bulkRequest.batchSize(2);
-        @SuppressWarnings("unchecked")
-        final BiConsumer<Integer, Exception> failureHandler = mock(BiConsumer.class);
-        @SuppressWarnings("unchecked")
-        final BiConsumer<Thread, Exception> completionHandler = mock(BiConsumer.class);
-        ingestService.executeBulkRequest(
-            4,
-            bulkRequest.requests(),
-            failureHandler,
-            completionHandler,
-            indexReq -> {},
-            Names.WRITE,
-            bulkRequest
-        );
-        verify(failureHandler, never()).accept(any(), any());
-        verify(completionHandler, times(1)).accept(Thread.currentThread(), null);
-        verify(mockCompoundProcessor, times(2)).batchExecute(any(), any());
-        verify(mockCompoundProcessor, never()).execute(any(), any());
-    }
-
-    public void testExecuteBulkRequestInBatchWithDefaultAndFinalPipeline() {
-        CompoundProcessor mockCompoundProcessor = mockCompoundProcessor();
-        IngestService ingestService = createWithProcessors(
-            Collections.singletonMap("mock", (factories, tag, description, config) -> mockCompoundProcessor)
-        );
-        ClusterState clusterState = createPipeline("_id", ingestService);
-        createPipeline("_final", ingestService, clusterState);
-        BulkRequest bulkRequest = new BulkRequest();
-        IndexRequest indexRequest1 = new IndexRequest("_index").id("_id1").source(emptyMap()).setPipeline("_id").setFinalPipeline("_final");
-        bulkRequest.add(indexRequest1);
-        IndexRequest indexRequest2 = new IndexRequest("_index").id("_id2").source(emptyMap()).setPipeline("_id").setFinalPipeline("_final");
-        bulkRequest.add(indexRequest2);
-        IndexRequest indexRequest3 = new IndexRequest("_index").id("_id3").source(emptyMap()).setPipeline("_id").setFinalPipeline("_final");
-        bulkRequest.add(indexRequest3);
-        IndexRequest indexRequest4 = new IndexRequest("_index").id("_id4").source(emptyMap()).setPipeline("_id").setFinalPipeline("_final");
-        bulkRequest.add(indexRequest4);
-        bulkRequest.batchSize(2);
-        @SuppressWarnings("unchecked")
-        final BiConsumer<Integer, Exception> failureHandler = mock(BiConsumer.class);
-        @SuppressWarnings("unchecked")
-        final BiConsumer<Thread, Exception> completionHandler = mock(BiConsumer.class);
-        ingestService.executeBulkRequest(
-            4,
-            bulkRequest.requests(),
-            failureHandler,
-            completionHandler,
-            indexReq -> {},
-            Names.WRITE,
-            bulkRequest
-        );
-        verify(failureHandler, never()).accept(any(), any());
-        verify(completionHandler, times(1)).accept(Thread.currentThread(), null);
-        verify(mockCompoundProcessor, times(4)).batchExecute(any(), any());
-        verify(mockCompoundProcessor, never()).execute(any(), any());
-    }
-
     public void testExecuteBulkRequestInBatchFallbackWithOneDocument() {
         CompoundProcessor mockCompoundProcessor = mockCompoundProcessor();
         IngestService ingestService = createWithProcessors(
@@ -1956,20 +1866,11 @@ public class IngestServiceTests extends OpenSearchTestCase {
         BulkRequest bulkRequest = new BulkRequest();
         IndexRequest indexRequest1 = new IndexRequest("_index").id("_id1").source(emptyMap()).setPipeline("_id").setFinalPipeline("_none");
         bulkRequest.add(indexRequest1);
-        bulkRequest.batchSize(2);
         @SuppressWarnings("unchecked")
         final BiConsumer<Integer, Exception> failureHandler = mock(BiConsumer.class);
         @SuppressWarnings("unchecked")
         final BiConsumer<Thread, Exception> completionHandler = mock(BiConsumer.class);
-        ingestService.executeBulkRequest(
-            1,
-            bulkRequest.requests(),
-            failureHandler,
-            completionHandler,
-            indexReq -> {},
-            Names.WRITE,
-            bulkRequest
-        );
+        ingestService.executeBulkRequest(1, bulkRequest.requests(), failureHandler, completionHandler, indexReq -> {}, Names.WRITE);
         verify(failureHandler, never()).accept(any(), any());
         verify(completionHandler, times(1)).accept(Thread.currentThread(), null);
         verify(mockCompoundProcessor, never()).batchExecute(any(), any());
@@ -1994,20 +1895,11 @@ public class IngestServiceTests extends OpenSearchTestCase {
             .setPipeline("_none")
             .setFinalPipeline("_none");
         bulkRequest.add(indexRequest2);
-        bulkRequest.batchSize(2);
         @SuppressWarnings("unchecked")
         final BiConsumer<Integer, Exception> failureHandler = mock(BiConsumer.class);
         @SuppressWarnings("unchecked")
         final BiConsumer<Thread, Exception> completionHandler = mock(BiConsumer.class);
-        ingestService.executeBulkRequest(
-            2,
-            bulkRequest.requests(),
-            failureHandler,
-            completionHandler,
-            indexReq -> {},
-            Names.WRITE,
-            bulkRequest
-        );
+        ingestService.executeBulkRequest(2, bulkRequest.requests(), failureHandler, completionHandler, indexReq -> {}, Names.WRITE);
         verify(failureHandler, never()).accept(any(), any());
         verify(completionHandler, times(1)).accept(Thread.currentThread(), null);
         verify(mockCompoundProcessor, never()).batchExecute(any(), any());
@@ -2024,20 +1916,11 @@ public class IngestServiceTests extends OpenSearchTestCase {
         // will not be handled as not valid document type
         bulkRequest.add(new DeleteRequest("_index", "_id"));
         bulkRequest.add(new DeleteRequest("_index", "_id"));
-        bulkRequest.batchSize(2);
         @SuppressWarnings("unchecked")
         final BiConsumer<Integer, Exception> failureHandler = mock(BiConsumer.class);
         @SuppressWarnings("unchecked")
         final BiConsumer<Thread, Exception> completionHandler = mock(BiConsumer.class);
-        ingestService.executeBulkRequest(
-            2,
-            bulkRequest.requests(),
-            failureHandler,
-            completionHandler,
-            indexReq -> {},
-            Names.WRITE,
-            bulkRequest
-        );
+        ingestService.executeBulkRequest(2, bulkRequest.requests(), failureHandler, completionHandler, indexReq -> {}, Names.WRITE);
         verify(failureHandler, never()).accept(any(), any());
         verify(completionHandler, times(1)).accept(Thread.currentThread(), null);
         verify(mockCompoundProcessor, never()).batchExecute(any(), any());
@@ -2057,20 +1940,11 @@ public class IngestServiceTests extends OpenSearchTestCase {
         bulkRequest.add(indexRequest1);
         IndexRequest indexRequest2 = new IndexRequest("_index").id("_id2").source(emptyMap()).setPipeline("_id").setFinalPipeline("_none");
         bulkRequest.add(indexRequest2);
-        bulkRequest.batchSize(2);
         @SuppressWarnings("unchecked")
         final BiConsumer<Integer, Exception> failureHandler = mock(BiConsumer.class);
         @SuppressWarnings("unchecked")
         final BiConsumer<Thread, Exception> completionHandler = mock(BiConsumer.class);
-        ingestService.executeBulkRequest(
-            2,
-            bulkRequest.requests(),
-            failureHandler,
-            completionHandler,
-            indexReq -> {},
-            Names.WRITE,
-            bulkRequest
-        );
+        ingestService.executeBulkRequest(2, bulkRequest.requests(), failureHandler, completionHandler, indexReq -> {}, Names.WRITE);
         verify(failureHandler, times(2)).accept(any(), any());
         verify(completionHandler, times(1)).accept(Thread.currentThread(), null);
         verify(mockCompoundProcessor, times(1)).batchExecute(any(), any());
@@ -2091,7 +1965,6 @@ public class IngestServiceTests extends OpenSearchTestCase {
         bulkRequest.add(indexRequest2);
         IndexRequest indexRequest3 = new IndexRequest("_index").id("_id3").source(emptyMap()).setPipeline("_id").setFinalPipeline("_none");
         bulkRequest.add(indexRequest3);
-        bulkRequest.batchSize(3);
 
         List<IngestDocumentWrapper> results = Arrays.asList(
             new IngestDocumentWrapper(0, IngestService.toIngestDocument(indexRequest1), null),
@@ -2114,8 +1987,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler::put,
             completionHandler::put,
             dropHandler::add,
-            Names.WRITE,
-            bulkRequest
+            Names.WRITE
         );
         assertEquals(Set.of(1), failureHandler.keySet());
         assertEquals(List.of(2), dropHandler);
@@ -2149,8 +2021,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler::put,
             completionHandler::put,
             dropHandler::add,
-            Names.WRITE,
-            bulkRequest
+            Names.WRITE
         );
         assertTrue(failureHandler.isEmpty());
         assertTrue(dropHandler.isEmpty());
@@ -2180,7 +2051,6 @@ public class IngestServiceTests extends OpenSearchTestCase {
         bulkRequest.add(indexRequest3);
         IndexRequest indexRequest4 = new IndexRequest("_index").id("_id4").source(emptyMap()).setPipeline("_id").setFinalPipeline("_none");
         bulkRequest.add(indexRequest4);
-        bulkRequest.batchSize(4);
         final Map<Integer, Exception> failureHandler = new HashMap<>();
         final Map<Thread, Exception> completionHandler = new HashMap<>();
         ingestService.executeBulkRequest(
@@ -2189,8 +2059,7 @@ public class IngestServiceTests extends OpenSearchTestCase {
             failureHandler::put,
             completionHandler::put,
             indexReq -> {},
-            Names.WRITE,
-            bulkRequest
+            Names.WRITE
         );
         assertTrue(failureHandler.isEmpty());
         assertEquals(Set.of(Thread.currentThread()), completionHandler.keySet());


### PR DESCRIPTION
### Related Issues
Resolves #14283

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
