### PR TITLE
[Backport 2.x] Remove dblock@ from maintainers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,27 +11,27 @@
 #   3. Use the command palette to run the CODEOWNERS: Show owners of current file command, which will display all code owners for the current file.
 
 # Default ownership for all repo files
-* @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dblock @dbwiddis @gbbafna @jainankitk @kotwanikunal @linuxpi @mch2 @msfroh @nknize @owaiskazi19  @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
+* @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dbwiddis @gbbafna @jainankitk @kotwanikunal @linuxpi @mch2 @msfroh @nknize @owaiskazi19  @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
 
-/modules/lang-painless/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @dblock @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
-/modules/parent-join/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @dblock @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
+/modules/lang-painless/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
+/modules/parent-join/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
 /modules/transport-netty4/ @peternied
 
 /plugins/identity-shiro/ @peternied @cwperks
 
-/server/src/internalClusterTest/java/org/opensearch/index/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dblock @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
-/server/src/internalClusterTest/java/org/opensearch/search/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dblock @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
+/server/src/internalClusterTest/java/org/opensearch/index/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
+/server/src/internalClusterTest/java/org/opensearch/search/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
 
 /server/src/main/java/org/opensearch/extensions/ @peternied
 /server/src/main/java/org/opensearch/identity/ @peternied @cwperks 
-/server/src/main/java/org/opensearch/index/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dblock @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
-/server/src/main/java/org/opensearch/search/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dblock @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
+/server/src/main/java/org/opensearch/index/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
+/server/src/main/java/org/opensearch/search/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
 /server/src/main/java/org/opensearch/threadpool/ @jed326 @peternied
 /server/src/main/java/org/opensearch/transport/ @peternied
 
-/server/src/test/java/org/opensearch/index/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dblock @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
-/server/src/test/java/org/opensearch/search/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dblock @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
+/server/src/test/java/org/opensearch/index/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
+/server/src/test/java/org/opensearch/search/ @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dbwiddis @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
 
 /.github/ @jed326 @peternied
 
-/MAINTAINERS.md @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dblock @dbwiddis @gaobinlong @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @peternied @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah
+/MAINTAINERS.md @anasalkouz @andrross @ashking94 @Bukhtawar @CEHENKLE @cwperks @dbwiddis @gaobinlong @gbbafna @jed326 @kotwanikunal @mch2 @msfroh @nknize @owaiskazi19 @peternied @reta @Rishikesh1159 @sachinpkale @saratvemulapalli @shwetathareja @sohami @VachaShah

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,45 +4,45 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer               | GitHub ID                                               | Affiliation |
-| ------------------------ | ------------------------------------------------------- | ----------- |
-| Anas Alkouz              | [anasalkouz](https://github.com/anasalkouz)             | Amazon      |
-| Andrew Ross              | [andrross](https://github.com/andrross)                 | Amazon      |
-| Andriy Redko             | [reta](https://github.com/reta)                         | Independent |
-| Ankit Jain               | [jainankitk](https://github.com/jainankitk)             | Amazon      |
-| Ashish Singh             | [ashking94](https://github.com/ashking94)               | Amazon      |
-| Bukhtawar Khan           | [Bukhtawar](https://github.com/Bukhtawar)               | Amazon      |
-| Charlotte Henkle         | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
-| Craig Perkins            | [cwperks](https://github.com/cwperks)                   | Amazon      |
-| Dan Widdis               | [dbwiddis](https://github.com/dbwiddis)                 | Amazon      |
-| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)                     | Independent |
-| Binlong Gao              | [gaobinlong](https://github.com/gaobinlong)             | Amazon      |
-| Gaurav Bafna             | [gbbafna](https://github.com/gbbafna)                   | Amazon      |
-| Jay Deng                 | [jed326](https://github.com/jed326)                     | Amazon      |
-| Kunal Kotwani            | [kotwanikunal](https://github.com/kotwanikunal)         | Amazon      |
-| Varun Bansal             | [linuxpi](https://github.com/linuxpi)                   | Amazon      |
-| Marc Handalian           | [mch2](https://github.com/mch2)                         | Amazon      |
-| Michael Froh             | [msfroh](https://github.com/msfroh)                     | Amazon      |
-| Nick Knize               | [nknize](https://github.com/nknize)                     | Lucenia     |
-| Owais Kazi               | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
-| Peter Nied               | [peternied](https://github.com/peternied)               | Amazon      |
-| Rishikesh Pasham         | [Rishikesh1159](https://github.com/Rishikesh1159)       | Amazon      |
-| Sachin Kale              | [sachinpkale](https://github.com/sachinpkale)           | Amazon      |
-| Sarat Vemulapalli        | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
-| Shweta Thareja           | [shwetathareja](https://github.com/shwetathareja)       | Amazon      |
-| Sorabh Hamirwasia        | [sohami](https://github.com/sohami)                     | Amazon      |
-| Vacha Shah               | [VachaShah](https://github.com/VachaShah)               | Amazon      |
+| Maintainer        | GitHub ID                                               | Affiliation |
+| ----------------- | ------------------------------------------------------- | ----------- |
+| Anas Alkouz       | [anasalkouz](https://github.com/anasalkouz)             | Amazon      |
+| Andrew Ross       | [andrross](https://github.com/andrross)                 | Amazon      |
+| Andriy Redko      | [reta](https://github.com/reta)                         | Independent |
+| Ankit Jain        | [jainankitk](https://github.com/jainankitk)             | Amazon      |
+| Ashish Singh      | [ashking94](https://github.com/ashking94)               | Amazon      |
+| Bukhtawar Khan    | [Bukhtawar](https://github.com/Bukhtawar)               | Amazon      |
+| Charlotte Henkle  | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
+| Craig Perkins     | [cwperks](https://github.com/cwperks)                   | Amazon      |
+| Dan Widdis        | [dbwiddis](https://github.com/dbwiddis)                 | Amazon      |
+| Binlong Gao       | [gaobinlong](https://github.com/gaobinlong)             | Amazon      |
+| Gaurav Bafna      | [gbbafna](https://github.com/gbbafna)                   | Amazon      |
+| Jay Deng          | [jed326](https://github.com/jed326)                     | Amazon      |
+| Kunal Kotwani     | [kotwanikunal](https://github.com/kotwanikunal)         | Amazon      |
+| Varun Bansal      | [linuxpi](https://github.com/linuxpi)                   | Amazon      |
+| Marc Handalian    | [mch2](https://github.com/mch2)                         | Amazon      |
+| Michael Froh      | [msfroh](https://github.com/msfroh)                     | Amazon      |
+| Nick Knize        | [nknize](https://github.com/nknize)                     | Lucenia     |
+| Owais Kazi        | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
+| Peter Nied        | [peternied](https://github.com/peternied)               | Amazon      |
+| Rishikesh Pasham  | [Rishikesh1159](https://github.com/Rishikesh1159)       | Amazon      |
+| Sachin Kale       | [sachinpkale](https://github.com/sachinpkale)           | Amazon      |
+| Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
+| Shweta Thareja    | [shwetathareja](https://github.com/shwetathareja)       | Amazon      |
+| Sorabh Hamirwasia | [sohami](https://github.com/sohami)                     | Amazon      |
+| Vacha Shah        | [VachaShah](https://github.com/VachaShah)               | Amazon      |
 
 ## Emeritus
 
-| Maintainer            | GitHub ID                                   | Affiliation |
-| --------------------- | ------------------------------------------- | ----------- |
-| Megha Sai Kavikondala | [meghasaik](https://github.com/meghasaik)   | Amazon      |
-| Xue Zhou              | [xuezhou25](https://github.com/xuezhou25)   | Amazon      |
-| Kartik Ganesh         | [kartg](https://github.com/kartg)           | Amazon      |
-| Abbas Hussain         | [abbashus](https://github.com/abbashus)     | Meta        |
-| Himanshu Setia        | [setiah](https://github.com/setiah)         | Amazon      |
-| Ryan Bogan            | [ryanbogan](https://github.com/ryanbogan)   | Amazon      |
-| Rabi Panda            | [adnapibar](https://github.com/adnapibar)   | Independent |
-| Tianli Feng           | [tlfeng](https://github.com/tlfeng)         | Amazon      |
-| Suraj Singh           | [dreamer-89](https://github.com/dreamer-89) | Amazon      |
+| Maintainer               | GitHub ID                                   | Affiliation |
+| ------------------------ | ------------------------------------------- | ----------- |
+| Megha Sai Kavikondala    | [meghasaik](https://github.com/meghasaik)   | Amazon      |
+| Xue Zhou                 | [xuezhou25](https://github.com/xuezhou25)   | Amazon      |
+| Kartik Ganesh            | [kartg](https://github.com/kartg)           | Amazon      |
+| Abbas Hussain            | [abbashus](https://github.com/abbashus)     | Meta        |
+| Himanshu Setia           | [setiah](https://github.com/setiah)         | Amazon      |
+| Ryan Bogan               | [ryanbogan](https://github.com/ryanbogan)   | Amazon      |
+| Rabi Panda               | [adnapibar](https://github.com/adnapibar)   | Independent |
+| Tianli Feng              | [tlfeng](https://github.com/tlfeng)         | Amazon      |
+| Suraj Singh              | [dreamer-89](https://github.com/dreamer-89) | Amazon      |
+| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)         | Independent |


### PR DESCRIPTION
### Description

Backport of https://github.com/opensearch-project/OpenSearch/pull/17805.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
