### PR TITLE
Add a builder to ingestion source

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -1026,7 +1026,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
             final IngestionErrorStrategy.ErrorStrategy errorStrategy = INGESTION_SOURCE_ERROR_STRATEGY_SETTING.get(settings);
             final Map<String, Object> ingestionSourceParams = INGESTION_SOURCE_PARAMS_SETTING.getAsMap(settings);
-            return new IngestionSource(ingestionSourceType, pointerInitReset, errorStrategy, ingestionSourceParams);
+            return new IngestionSource.Builder(ingestionSourceType).setParams(ingestionSourceParams)
+                .setPointerInitReset(pointerInitReset)
+                .setErrorStrategy(errorStrategy)
+                .build();
         }
         return null;
     }

--- a/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
@@ -12,6 +12,7 @@ import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.indices.pollingingest.IngestionErrorStrategy;
 import org.opensearch.indices.pollingingest.StreamPoller;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -20,12 +21,12 @@ import java.util.Objects;
  */
 @ExperimentalApi
 public class IngestionSource {
-    private String type;
-    private PointerInitReset pointerInitReset;
-    private IngestionErrorStrategy.ErrorStrategy errorStrategy;
-    private Map<String, Object> params;
+    private final String type;
+    private final PointerInitReset pointerInitReset;
+    private final IngestionErrorStrategy.ErrorStrategy errorStrategy;
+    private final Map<String, Object> params;
 
-    public IngestionSource(
+    private IngestionSource(
         String type,
         PointerInitReset pointerInitReset,
         IngestionErrorStrategy.ErrorStrategy errorStrategy,
@@ -124,5 +125,54 @@ public class IngestionSource {
         public String toString() {
             return "PointerInitReset{" + "type='" + type + '\'' + ", value=" + value + '}';
         }
+    }
+
+    /**
+     * Builder for {@link IngestionSource}.
+     *
+     */
+    @ExperimentalApi
+    public static class Builder {
+        private String type;
+        private PointerInitReset pointerInitReset;
+        private IngestionErrorStrategy.ErrorStrategy errorStrategy;
+        private Map<String, Object> params;
+
+        public Builder(String type) {
+            this.type = type;
+            this.params = new HashMap<>();
+        }
+
+        public Builder(IngestionSource ingestionSource) {
+            this.type = ingestionSource.type;
+            this.pointerInitReset = ingestionSource.pointerInitReset;
+            this.errorStrategy = ingestionSource.errorStrategy;
+            this.params = ingestionSource.params;
+        }
+
+        public Builder setPointerInitReset(PointerInitReset pointerInitReset) {
+            this.pointerInitReset = pointerInitReset;
+            return this;
+        }
+
+        public Builder setErrorStrategy(IngestionErrorStrategy.ErrorStrategy errorStrategy) {
+            this.errorStrategy = errorStrategy;
+            return this;
+        }
+
+        public Builder setParams(Map<String, Object> params) {
+            this.params = params;
+            return this;
+        }
+
+        public Builder addParam(String key, Object value) {
+            this.params.put(key, value);
+            return this;
+        }
+
+        public IngestionSource build() {
+            return new IngestionSource(type, pointerInitReset, errorStrategy, params);
+        }
+
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
@@ -26,7 +26,10 @@ public class IngestionSourceTests extends OpenSearchTestCase {
     public void testConstructorAndGetters() {
         Map<String, Object> params = new HashMap<>();
         params.put("key", "value");
-        IngestionSource source = new IngestionSource("type", pointerInitReset, DROP, params);
+        IngestionSource source = new IngestionSource.Builder("type").setParams(params)
+            .setPointerInitReset(pointerInitReset)
+            .setErrorStrategy(DROP)
+            .build();
 
         assertEquals("type", source.getType());
         assertEquals(StreamPoller.ResetState.REWIND_BY_OFFSET, source.getPointerInitReset().getType());
@@ -38,36 +41,57 @@ public class IngestionSourceTests extends OpenSearchTestCase {
     public void testEquals() {
         Map<String, Object> params1 = new HashMap<>();
         params1.put("key", "value");
-        IngestionSource source1 = new IngestionSource("type", pointerInitReset, DROP, params1);
+        IngestionSource source1 = new IngestionSource.Builder("type").setParams(params1)
+            .setPointerInitReset(pointerInitReset)
+            .setErrorStrategy(DROP)
+            .build();
 
         Map<String, Object> params2 = new HashMap<>();
         params2.put("key", "value");
-        IngestionSource source2 = new IngestionSource("type", pointerInitReset, DROP, params2);
+        IngestionSource source2 = new IngestionSource.Builder("type").setParams(params2)
+            .setPointerInitReset(pointerInitReset)
+            .setErrorStrategy(DROP)
+            .build();
         assertTrue(source1.equals(source2));
         assertTrue(source2.equals(source1));
 
-        IngestionSource source3 = new IngestionSource("differentType", pointerInitReset, DROP, params1);
+        IngestionSource source3 = new IngestionSource.Builder("differentType").setParams(params1)
+            .setPointerInitReset(pointerInitReset)
+            .setErrorStrategy(DROP)
+            .build();
         assertFalse(source1.equals(source3));
     }
 
     public void testHashCode() {
         Map<String, Object> params1 = new HashMap<>();
         params1.put("key", "value");
-        IngestionSource source1 = new IngestionSource("type", pointerInitReset, DROP, params1);
+        IngestionSource source1 = new IngestionSource.Builder("type").setParams(params1)
+            .setPointerInitReset(pointerInitReset)
+            .setErrorStrategy(DROP)
+            .build();
 
         Map<String, Object> params2 = new HashMap<>();
         params2.put("key", "value");
-        IngestionSource source2 = new IngestionSource("type", pointerInitReset, DROP, params2);
+        IngestionSource source2 = new IngestionSource.Builder("type").setParams(params2)
+            .setPointerInitReset(pointerInitReset)
+            .setErrorStrategy(DROP)
+            .build();
         assertEquals(source1.hashCode(), source2.hashCode());
 
-        IngestionSource source3 = new IngestionSource("differentType", pointerInitReset, DROP, params1);
+        IngestionSource source3 = new IngestionSource.Builder("differentType").setParams(params1)
+            .setPointerInitReset(pointerInitReset)
+            .setErrorStrategy(DROP)
+            .build();
         assertNotEquals(source1.hashCode(), source3.hashCode());
     }
 
     public void testToString() {
         Map<String, Object> params = new HashMap<>();
         params.put("key", "value");
-        IngestionSource source = new IngestionSource("type", pointerInitReset, DROP, params);
+        IngestionSource source = new IngestionSource.Builder("type").setParams(params)
+            .setPointerInitReset(pointerInitReset)
+            .setErrorStrategy(DROP)
+            .build();
         String expected =
             "IngestionSource{type='type',pointer_init_reset='PointerInitReset{type='REWIND_BY_OFFSET', value=1000}',error_strategy='DROP', params={key=value}}";
         assertEquals(expected, source.toString());


### PR DESCRIPTION
### Description
As `IngestionSource` takes more arguments, it's better to change the constructor to a builder pattern

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
