### PR TITLE
[Java Agent Policy] Fix test fixtures

### DIFF
--- a/libs/agent-sm/agent-policy/build.gradle
+++ b/libs/agent-sm/agent-policy/build.gradle
@@ -20,8 +20,11 @@ base {
   archivesName = 'opensearch-agent-policy'
 }
 
-disableTasks('forbiddenApisMain')
+tasks.named('forbiddenApisMain').configure {
+  replaceSignatureFiles 'jdk-signatures'
+}
 
 dependencies {
-  testImplementation(project(":test:framework"))
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 }

--- a/libs/agent-sm/agent-policy/src/test/java/org/opensearch/secure_sm/policy/PolicyParserTests.java
+++ b/libs/agent-sm/agent-policy/src/test/java/org/opensearch/secure_sm/policy/PolicyParserTests.java
@@ -7,14 +7,17 @@
  */
 package org.opensearch.secure_sm.policy;
 
-import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.List;
 
-public class PolicyParserTests extends OpenSearchTestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class PolicyParserTests {
     private static final String POLICY = """
         grant codeBase "TestCodeBase" {
           permission java.net.NetPermission "accessUnixDomainSocket";
@@ -26,6 +29,7 @@ public class PolicyParserTests extends OpenSearchTestCase {
         };
         """;
 
+    @Test
     public void testPolicy() throws IOException, PolicyParser.ParsingException {
         try (Reader reader = new StringReader(POLICY)) {
             final List<GrantEntry> grantEntries = PolicyParser.read(reader);


### PR DESCRIPTION


### Description
This fixes the cyclic dependencies in test fixture where-in the Java agent should not take dependency on the ```test-framework```. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
 
Resolves comment https://github.com/opensearch-project/OpenSearch/pull/17753/files#r2031916820

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
