### PR TITLE
Remove dependency on :test:framework in :libs:opensearch-agent-sm:agent-policy

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,11 +93,13 @@ arrow                 = "18.1.0"
 flatbuffers           = "2.0.0"
 
 [libraries]
+hamcrest = { group = "org.hamcrest", name = "hamcrest", version.ref = "hamcrest" }
 hdrhistogram = { group = "org.hdrhistogram", name = "HdrHistogram", version.ref = "hdrhistogram" }
 jakartaannotation = { group = "jakarta.annotation", name = "jakarta.annotation-api", version.ref = "jakarta_annotation" }
 jodatime = { group = "joda-time", name = "joda-time", version.ref = "joda" }
 jna = { group = "net.java.dev.jna", name = "jna", version.ref = "jna" }
 jtscore = { group = "org.locationtech.jts", name = "jts-core", version.ref = "jts" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 jzlib = { group = "com.jcraft", name = "jzlib", version.ref = "jzlib" }
 log4japi = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
 log4jjul = { group = "org.apache.logging.log4j", name = "log4j-jul", version.ref = "log4j" }

--- a/libs/agent-sm/agent-policy/build.gradle
+++ b/libs/agent-sm/agent-policy/build.gradle
@@ -21,3 +21,8 @@ base {
 }
 
 disableTasks('forbiddenApisMain')
+
+dependencies {
+  testImplementation libs.junit
+  testImplementation libs.hamcrest
+}

--- a/libs/agent-sm/agent-policy/build.gradle
+++ b/libs/agent-sm/agent-policy/build.gradle
@@ -21,7 +21,3 @@ base {
 }
 
 disableTasks('forbiddenApisMain')
-
-dependencies {
-  testImplementation(project(":test:framework"))
-}

--- a/libs/agent-sm/agent-policy/build.gradle
+++ b/libs/agent-sm/agent-policy/build.gradle
@@ -20,7 +20,7 @@ base {
   archivesName = 'opensearch-agent-policy'
 }
 
-disableTasks('forbiddenApisMain')
+disableTasks('forbiddenApisMain', 'forbiddenApisTest', 'testingConventions')
 
 dependencies {
   testImplementation libs.junit

--- a/libs/agent-sm/agent-policy/src/test/java/org/opensearch/secure_sm/policy/PolicyParserTests.java
+++ b/libs/agent-sm/agent-policy/src/test/java/org/opensearch/secure_sm/policy/PolicyParserTests.java
@@ -7,14 +7,17 @@
  */
 package org.opensearch.secure_sm.policy;
 
-import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.List;
 
-public class PolicyParserTests extends OpenSearchTestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class PolicyParserTests {
     private static final String POLICY = """
         grant codeBase "TestCodeBase" {
           permission java.net.NetPermission "accessUnixDomainSocket";
@@ -26,6 +29,7 @@ public class PolicyParserTests extends OpenSearchTestCase {
         };
         """;
 
+    @Test
     public void testPolicy() throws IOException, PolicyParser.ParsingException {
         try (Reader reader = new StringReader(POLICY)) {
             final List<GrantEntry> grantEntries = PolicyParser.read(reader);


### PR DESCRIPTION
### Description

This PR replaces the :test:framework dependency with JUnit directly in order to avoid circular dependencies on the `:libs:agent-sm:agent-policy` module

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/pull/17753/files#r2031916820

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
