### PR TITLE
Fix FileInterceptor to properly check read / write sides path separation

### DIFF
--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorIntegTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorIntegTests.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("removal")
@@ -144,6 +145,7 @@ public class FileInterceptorIntegTests {
 
             // Test copy operation
             Files.copy(sourcePath, targetPath);
+            assertThrows(SecurityException.class, () -> Files.copy(sourcePath, tmpDir.getRoot().resolve("test-target-" + randomAlphaOfLength(8) + ".txt")));
 
             // Verify copy
             assertTrue("Target file should exist", Files.exists(targetPath));

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorIntegTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorIntegTests.java
@@ -145,7 +145,10 @@ public class FileInterceptorIntegTests {
 
             // Test copy operation
             Files.copy(sourcePath, targetPath);
-            assertThrows(SecurityException.class, () -> Files.copy(sourcePath, tmpDir.getRoot().resolve("test-target-" + randomAlphaOfLength(8) + ".txt")));
+            assertThrows(
+                SecurityException.class,
+                () -> Files.copy(sourcePath, tmpDir.getRoot().resolve("test-target-" + randomAlphaOfLength(8) + ".txt"))
+            );
 
             // Verify copy
             assertTrue("Target file should exist", Files.exists(targetPath));


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix FileInterceptor to properly check read / write sides path separation

### Related Issues
N/A

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
