### PR TITLE
Fix possible NPE in WorkerBulkByScrollTaskState.java

### DIFF
--- a/server/src/main/java/org/opensearch/index/reindex/WorkerBulkByScrollTaskState.java
+++ b/server/src/main/java/org/opensearch/index/reindex/WorkerBulkByScrollTaskState.java
@@ -296,7 +296,6 @@ public class WorkerBulkByScrollTaskState implements SuccessfullyProcessed {
                 return this;
             }
 
-            long remainingDelay = scheduled.getDelay(TimeUnit.NANOSECONDS);
             // Actually reschedule the task
             if (scheduled == null || false == scheduled.cancel()) {
                 // Couldn't cancel, probably because the task has finished or been scheduled. Either way we have nothing to do here.
@@ -304,6 +303,7 @@ public class WorkerBulkByScrollTaskState implements SuccessfullyProcessed {
                 return this;
             }
 
+            long remainingDelay = scheduled.getDelay(TimeUnit.NANOSECONDS);
             /* Strangely enough getting here doesn't mean that you actually
              * cancelled the request, just that you probably did. If you stress
              * test it you'll find that requests sneak through. So each request


### PR DESCRIPTION
### Description
Fix possible NPE in rethrottling requests.

No tests were run, i think this is useless here

### Related Issues
Resolves #17839 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
