### PR TITLE
Add the support of trusted file systems to AgentPolicy

### DIFF
--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
@@ -16,6 +16,7 @@ import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.spi.FileSystemProvider;
 import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.util.Collection;
@@ -46,15 +47,21 @@ public class FileInterceptor {
             return; /* noop */
         }
 
+        FileSystemProvider provider = null;
         String filePath = null;
         if (args.length > 0 && args[0] instanceof String pathStr) {
             filePath = Paths.get(pathStr).toAbsolutePath().toString();
         } else if (args.length > 0 && args[0] instanceof Path path) {
             filePath = path.toAbsolutePath().toString();
+            provider = path.getFileSystem().provider();
         }
 
         if (filePath == null) {
             return; // No valid file path found
+        }
+
+        if (provider != null && AgentPolicy.isTrustedFileSystem(provider.getScheme()) == true) {
+            return;
         }
 
         final StackWalker walker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
@@ -66,7 +73,7 @@ public class FileInterceptor {
 
         String targetFilePath = null;
         if (isMutating == false && isDelete == false) {
-            if (name.equals("newByteChannel") == true) {
+            if (name.equals("newByteChannel") == true || name.equals("open") == true) {
                 if (args.length > 1 && args[1] instanceof OpenOption[] opts) {
                     for (final OpenOption opt : opts) {
                         if (opt != StandardOpenOption.READ) {
@@ -89,20 +96,22 @@ public class FileInterceptor {
         for (final ProtectionDomain domain : callers) {
             // Handle FileChannel.open() separately to check read/write permissions properly
             if (method.getName().equals("open")) {
-                if (!policy.implies(domain, new FilePermission(filePath, "read,write"))) {
-                    throw new SecurityException("Denied OPEN access to file: " + filePath + ", domain: " + domain);
+                if (isMutating == true && !policy.implies(domain, new FilePermission(filePath, "read,write"))) {
+                    throw new SecurityException("Denied OPEN (read/write) access to file: " + filePath + ", domain: " + domain);
+                } else if (!policy.implies(domain, new FilePermission(filePath, "read"))) {
+                    throw new SecurityException("Denied OPEN (read) access to file: " + filePath + ", domain: " + domain);
                 }
             }
 
             // Handle Files.copy() separately to check read/write permissions properly
             if (method.getName().equals("copy")) {
                 if (!policy.implies(domain, new FilePermission(filePath, "read"))) {
-                    throw new SecurityException("Denied OPEN access to file: " + filePath + ", domain: " + domain);
+                    throw new SecurityException("Denied COPY (read) access to file: " + filePath + ", domain: " + domain);
                 }
 
                 if (targetFilePath != null) {
                     if (!policy.implies(domain, new FilePermission(targetFilePath, "write"))) {
-                        throw new SecurityException("Denied OPEN access to file: " + targetFilePath + ", domain: " + domain);
+                        throw new SecurityException("Denied COPY (write) access to file: " + targetFilePath + ", domain: " + domain);
                     }
                 }
             }

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/AgentTestCase.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/AgentTestCase.java
@@ -19,6 +19,10 @@ public abstract class AgentTestCase {
     @BeforeClass
     public static void setUp() {
         AgentPolicy.setPolicy(new Policy() {
-        }, Set.of(), (caller, chain) -> caller.getName().equalsIgnoreCase("worker.org.gradle.process.internal.worker.GradleWorkerMain"));
+        },
+            Set.of(),
+            Set.of(),
+            (caller, chain) -> caller.getName().equalsIgnoreCase("worker.org.gradle.process.internal.worker.GradleWorkerMain")
+        );
     }
 }

--- a/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/AgentPolicy.java
+++ b/libs/agent-sm/bootstrap/src/main/java/org/opensearch/javaagent/bootstrap/AgentPolicy.java
@@ -30,6 +30,7 @@ public class AgentPolicy {
     private static final Logger LOGGER = Logger.getLogger(AgentPolicy.class.getName());
     private static volatile Policy policy;
     private static volatile Set<String> trustedHosts;
+    private static volatile Set<String> trustedFileSystems;
     private static volatile BiFunction<Class<?>, Collection<Class<?>>, Boolean> classesThatCanExit;
 
     /**
@@ -124,23 +125,26 @@ public class AgentPolicy {
      * @param policy policy
      */
     public static void setPolicy(Policy policy) {
-        setPolicy(policy, Set.of(), new NoneCanExit());
+        setPolicy(policy, Set.of(), Set.of(), new NoneCanExit());
     }
 
     /**
      * Set Agent policy
      * @param policy policy
      * @param trustedHosts trusted hosts
+     * @param trustedFileSystems trusted file systems
      * @param classesThatCanExit classed that are allowed to call {@link System#exit}, {@link Runtime#halt}
      */
     public static void setPolicy(
         Policy policy,
         final Set<String> trustedHosts,
+        final Set<String> trustedFileSystems,
         final BiFunction<Class<?>, Collection<Class<?>>, Boolean> classesThatCanExit
     ) {
         if (AgentPolicy.policy == null) {
             AgentPolicy.policy = policy;
             AgentPolicy.trustedHosts = Collections.unmodifiableSet(trustedHosts);
+            AgentPolicy.trustedFileSystems = Collections.unmodifiableSet(trustedFileSystems);
             AgentPolicy.classesThatCanExit = classesThatCanExit;
             LOGGER.info("Policy attached successfully: " + policy);
         } else {
@@ -180,6 +184,15 @@ public class AgentPolicy {
      */
     public static boolean isTrustedHost(String hostname) {
         return AgentPolicy.trustedHosts.contains(hostname);
+    }
+
+    /**
+     * Check if file system is trusted
+     * @param fileSystem file system
+     * @return is trusted or not
+     */
+    public static boolean isTrustedFileSystem(String fileSystem) {
+        return AgentPolicy.trustedFileSystems.contains(fileSystem);
     }
 
     /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add the support of trusted file systems to AgentPolicy. The security checks where part of the `FileSystem` implementations (JDK) but we do use mock file systems (like Jimfs) in tests. Since we made checks global now, adding the support of trusted file systems (similarly to trusted hosts) to the `AgentPolicy`

### Related Issues
N/A

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
