### PR TITLE
Adjust the `getAutoExpandReplicaChanges` logic to honor `search_only` mode.

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -761,6 +761,7 @@ public class UpdateNumberOfReplicasIT extends OpenSearchIntegTestCase {
             .metadata()
             .index(TEST_INDEX)
             .getNumberOfReplicas();
+
         assertEquals(2, afterExpansionReplicas);
 
         // Add the search_only block
@@ -774,6 +775,7 @@ public class UpdateNumberOfReplicasIT extends OpenSearchIntegTestCase {
         );
         // This adds 3 data nodes
         allowNodes(TEST_INDEX, 4);
+        ensureGreen(TEST_INDEX);
 
         // Verify same replicas
         int finalReplicas = client().admin().cluster().prepareState().get().getState().metadata().index(TEST_INDEX).getNumberOfReplicas();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -42,6 +42,8 @@ import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Priority;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
@@ -737,6 +739,42 @@ public class UpdateNumberOfReplicasIT extends OpenSearchIntegTestCase {
             manageReplicaSettingForDefaultReplica(false);
             randomIndexTemplate();
         }
+    }
+
+    public void testSkipSearchOnlyIndexForAutoExpandReplicasIT() throws Exception {
+        final String TEST_INDEX = "test";
+
+        // Create index with auto expand replicas
+        assertAcked(prepareCreate(TEST_INDEX, 2, Settings.builder().put("auto_expand_replicas", "0-all")));
+
+        int initialReplicas = client().admin().cluster().prepareState().get().getState().metadata().index(TEST_INDEX).getNumberOfReplicas();
+        assertEquals(1, initialReplicas);
+
+        // This adds 2 data nodes
+        allowNodes(TEST_INDEX, 3);
+        ensureGreen(TEST_INDEX);
+
+        // Verify replicas were expanded
+        int afterExpansionReplicas = client().admin().cluster().prepareState().get().getState().metadata().index(TEST_INDEX).getNumberOfReplicas();
+        assertEquals(2, afterExpansionReplicas);
+
+        // Add the search_only block
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(TEST_INDEX)
+                .setSettings(Settings.builder().put(IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING.getKey(), true))
+                .execute()
+                .actionGet()
+        );
+        // This adds 3 data nodes
+        allowNodes(TEST_INDEX, 4);
+
+        // Verify same replicas
+        int finalReplicas = client().admin().cluster().prepareState().get().getState().metadata().index(TEST_INDEX).getNumberOfReplicas();
+
+        // Assert that replica count didn't change after enabling search-only mode
+        assertEquals("Replica count should not change for search_only index", afterExpansionReplicas, finalReplicas);
     }
 
 }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -42,8 +42,6 @@ import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Priority;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.FeatureFlags;
-import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
@@ -755,7 +753,14 @@ public class UpdateNumberOfReplicasIT extends OpenSearchIntegTestCase {
         ensureGreen(TEST_INDEX);
 
         // Verify replicas were expanded
-        int afterExpansionReplicas = client().admin().cluster().prepareState().get().getState().metadata().index(TEST_INDEX).getNumberOfReplicas();
+        int afterExpansionReplicas = client().admin()
+            .cluster()
+            .prepareState()
+            .get()
+            .getState()
+            .metadata()
+            .index(TEST_INDEX)
+            .getNumberOfReplicas();
         assertEquals(2, afterExpansionReplicas);
 
         // Add the search_only block

--- a/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
@@ -181,6 +181,7 @@ public final class AutoExpandReplicas {
         Map<Integer, List<String>> nrReplicasChanged = new HashMap<>();
 
         for (final IndexMetadata indexMetadata : metadata) {
+            // Skip the replica auto-expansion for indices in search_only mode with the SEARCH_ONLY block
             if (indexMetadata.getSettings().getAsBoolean(IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING.getKey(), false)) {
                 continue;
             }

--- a/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
@@ -181,6 +181,9 @@ public final class AutoExpandReplicas {
         Map<Integer, List<String>> nrReplicasChanged = new HashMap<>();
 
         for (final IndexMetadata indexMetadata : metadata) {
+            if (indexMetadata.getSettings().getAsBoolean(IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING.getKey(), false)) {
+                continue;
+            }
             if (indexMetadata.getState() == IndexMetadata.State.OPEN || isIndexVerifiedBeforeClosed(indexMetadata)) {
                 AutoExpandReplicas autoExpandReplicas = SETTING.get(indexMetadata.getSettings());
                 autoExpandReplicas.getDesiredNumberOfReplicas(indexMetadata, allocation).ifPresent(numberOfReplicas -> {

--- a/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
@@ -181,11 +181,11 @@ public final class AutoExpandReplicas {
         Map<Integer, List<String>> nrReplicasChanged = new HashMap<>();
 
         for (final IndexMetadata indexMetadata : metadata) {
-            // Skip the replica auto-expansion for indices in search_only mode with the SEARCH_ONLY block
-            if (indexMetadata.getSettings().getAsBoolean(IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING.getKey(), false)) {
-                continue;
-            }
             if (indexMetadata.getState() == IndexMetadata.State.OPEN || isIndexVerifiedBeforeClosed(indexMetadata)) {
+                // Skip the replica auto-expansion for indices in search_only mode with the SEARCH_ONLY block
+                if (indexMetadata.getSettings().getAsBoolean(IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING.getKey(), false)) {
+                    continue;
+                }
                 AutoExpandReplicas autoExpandReplicas = SETTING.get(indexMetadata.getSettings());
                 autoExpandReplicas.getDesiredNumberOfReplicas(indexMetadata, allocation).ifPresent(numberOfReplicas -> {
                     if (numberOfReplicas != indexMetadata.getNumberOfReplicas()) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adjust the `getAutoExpandReplicaChanges` logic to honor search_only mode.

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/17864
- RW Separation META Issue: https://github.com/opensearch-project/OpenSearch/issues/15306
- Scale to zero (search only mode): https://github.com/opensearch-project/OpenSearch/issues/16720

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
