### PR TITLE
Fix FileInterceptor's delete calls for Unix Domain Sockets on Windows

### DIFF
--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
@@ -12,6 +12,7 @@ import org.opensearch.javaagent.bootstrap.AgentPolicy;
 
 import java.io.FilePermission;
 import java.lang.reflect.Method;
+import java.net.NetPermission;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -72,63 +73,69 @@ public class FileInterceptor {
         final boolean isDelete = isMutating == false ? name.startsWith("delete") : false;
 
         // This is Windows implementation of UNIX Domain Sockets (close)
-        if (walker.getCallerClass().getName().equalsIgnoreCase("sun.nio.ch.PipeImpl$Initializer$LoopbackConnector") == true) {
-            return;
-        }
+        if (isDelete == true
+            && walker.getCallerClass().getName().equalsIgnoreCase("sun.nio.ch.PipeImpl$Initializer$LoopbackConnector") == true) {
+            final NetPermission permission = new NetPermission("accessUnixDomainSocket");
+            for (ProtectionDomain domain : callers) {
+                if (!policy.implies(domain, permission)) {
+                    throw new SecurityException("Denied access to: " + filePath + ", domain " + domain);
+                }
+            }
+        } else {
+            String targetFilePath = null;
+            if (isMutating == false && isDelete == false) {
+                if (name.equals("newByteChannel") == true || name.equals("open") == true) {
+                    if (args.length > 1 && args[1] instanceof OpenOption[] opts) {
+                        for (final OpenOption opt : opts) {
+                            if (opt != StandardOpenOption.READ) {
+                                isMutating = true;
+                                break;
+                            }
+                        }
 
-        String targetFilePath = null;
-        if (isMutating == false && isDelete == false) {
-            if (name.equals("newByteChannel") == true || name.equals("open") == true) {
-                if (args.length > 1 && args[1] instanceof OpenOption[] opts) {
-                    for (final OpenOption opt : opts) {
-                        if (opt != StandardOpenOption.READ) {
-                            isMutating = true;
-                            break;
+                    }
+                } else if (name.equals("copy") == true) {
+                    if (args.length > 1 && args[1] instanceof String pathStr) {
+                        targetFilePath = Paths.get(pathStr).toAbsolutePath().toString();
+                    } else if (args.length > 1 && args[1] instanceof Path path) {
+                        targetFilePath = path.toAbsolutePath().toString();
+                    }
+                }
+            }
+
+            // Check each permission separately
+            for (final ProtectionDomain domain : callers) {
+                // Handle FileChannel.open() separately to check read/write permissions properly
+                if (method.getName().equals("open")) {
+                    if (isMutating == true && !policy.implies(domain, new FilePermission(filePath, "read,write"))) {
+                        throw new SecurityException("Denied OPEN (read/write) access to file: " + filePath + ", domain: " + domain);
+                    } else if (!policy.implies(domain, new FilePermission(filePath, "read"))) {
+                        throw new SecurityException("Denied OPEN (read) access to file: " + filePath + ", domain: " + domain);
+                    }
+                }
+
+                // Handle Files.copy() separately to check read/write permissions properly
+                if (method.getName().equals("copy")) {
+                    if (!policy.implies(domain, new FilePermission(filePath, "read"))) {
+                        throw new SecurityException("Denied COPY (read) access to file: " + filePath + ", domain: " + domain);
+                    }
+
+                    if (targetFilePath != null) {
+                        if (!policy.implies(domain, new FilePermission(targetFilePath, "write"))) {
+                            throw new SecurityException("Denied COPY (write) access to file: " + targetFilePath + ", domain: " + domain);
                         }
                     }
-
-                }
-            } else if (name.equals("copy") == true) {
-                if (args.length > 1 && args[1] instanceof String pathStr) {
-                    targetFilePath = Paths.get(pathStr).toAbsolutePath().toString();
-                } else if (args.length > 1 && args[1] instanceof Path path) {
-                    targetFilePath = path.toAbsolutePath().toString();
-                }
-            }
-        }
-
-        // Check each permission separately
-        for (final ProtectionDomain domain : callers) {
-            // Handle FileChannel.open() separately to check read/write permissions properly
-            if (method.getName().equals("open")) {
-                if (isMutating == true && !policy.implies(domain, new FilePermission(filePath, "read,write"))) {
-                    throw new SecurityException("Denied OPEN (read/write) access to file: " + filePath + ", domain: " + domain);
-                } else if (!policy.implies(domain, new FilePermission(filePath, "read"))) {
-                    throw new SecurityException("Denied OPEN (read) access to file: " + filePath + ", domain: " + domain);
-                }
-            }
-
-            // Handle Files.copy() separately to check read/write permissions properly
-            if (method.getName().equals("copy")) {
-                if (!policy.implies(domain, new FilePermission(filePath, "read"))) {
-                    throw new SecurityException("Denied COPY (read) access to file: " + filePath + ", domain: " + domain);
                 }
 
-                if (targetFilePath != null) {
-                    if (!policy.implies(domain, new FilePermission(targetFilePath, "write"))) {
-                        throw new SecurityException("Denied COPY (write) access to file: " + targetFilePath + ", domain: " + domain);
-                    }
+                // File mutating operations
+                if (isMutating && !policy.implies(domain, new FilePermission(filePath, "write"))) {
+                    throw new SecurityException("Denied WRITE access to file: " + filePath + ", domain: " + domain);
                 }
-            }
 
-            // File mutating operations
-            if (isMutating && !policy.implies(domain, new FilePermission(filePath, "write"))) {
-                throw new SecurityException("Denied WRITE access to file: " + filePath + ", domain: " + domain);
-            }
-
-            // File deletion operations
-            if (isDelete && !policy.implies(domain, new FilePermission(filePath, "delete"))) {
-                throw new SecurityException("Denied DELETE access to file: " + filePath + ", domain: " + domain);
+                // File deletion operations
+                if (isDelete && !policy.implies(domain, new FilePermission(filePath, "delete"))) {
+                    throw new SecurityException("Denied DELETE access to file: " + filePath + ", domain: " + domain);
+                }
             }
         }
     }

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
@@ -71,6 +71,11 @@ public class FileInterceptor {
         boolean isMutating = name.equals("move") || name.equals("write") || name.startsWith("create");
         final boolean isDelete = isMutating == false ? name.startsWith("delete") : false;
 
+        // This is Windows implementation of UNIX Domain Sockets (close)
+        if (walker.getCallerClass().getName().equalsIgnoreCase("sun.nio.ch.PipeImpl$Initializer$LoopbackConnector") == true) {
+            return;
+        }
+
         String targetFilePath = null;
         if (isMutating == false && isDelete == false) {
             if (name.equals("newByteChannel") == true || name.equals("open") == true) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix FileInterceptor's delete calls for Unix Domain Sockets on Windows

### Related Issues
See please https://github.com/opensearch-project/custom-codecs/actions/runs/14370198700/job/40291704566?pr=235

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
