### PR TITLE
Fix match query on a scaled_float property no longer matches for some values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Fix match query on a `scaled_float` property no longer matches for some values ([#17879](https://github.com/opensearch-project/OpenSearch/pull/17879))
 
 ### Security
 

--- a/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/ScaledFloatFieldMapper.java
@@ -229,7 +229,7 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
         @Override
         public Query termQuery(Object value, QueryShardContext context) {
             failIfNotIndexedAndNoDocValues();
-            long scaledValue = Math.round(scale(value));
+            long scaledValue = parsedLong(parse(value), scalingFactor);
             Query query = NumberFieldMapper.NumberType.LONG.termQuery(name(), scaledValue, hasDocValues(), isSearchable());
             if (boost() != 1f) {
                 query = new BoostQuery(query, boost());
@@ -242,7 +242,7 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
             failIfNotIndexedAndNoDocValues();
             List<Long> scaledValues = new ArrayList<>(values.size());
             for (Object value : values) {
-                long scaledValue = Math.round(scale(value));
+                long scaledValue = parsedLong(parse(value), scalingFactor);
                 scaledValues.add(scaledValue);
             }
             Query query = NumberFieldMapper.NumberType.LONG.termsQuery(
@@ -465,7 +465,7 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
                 throw new IllegalArgumentException("[scaled_float] only supports finite values, but got [" + doubleValue + "]");
             }
         }
-        long scaledValue = Math.round(doubleValue * scalingFactor);
+        long scaledValue = parsedLong(doubleValue, scalingFactor);
 
         List<Field> fields = NumberFieldMapper.NumberType.LONG.createFields(fieldType().name(), scaledValue, indexed, hasDocValues, stored);
         context.doc().addAll(fields);
@@ -481,6 +481,10 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
 
     private static Double parse(XContentParser parser, boolean coerce) throws IOException {
         return parser.doubleValue(coerce);
+    }
+
+    private static long parsedLong(double value, double scalingFactor) {
+        return Math.round(value * scalingFactor);
     }
 
     /**

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/scaled_float/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/scaled_float/10_basic.yml
@@ -36,6 +36,17 @@ setup:
         body: { "number" : 1.53 }
 
   - do:
+      index:
+        index: test
+        id: 5
+        body: { "number": "92233720368547750" }
+  - do:
+      index:
+        index: test
+        id: 6
+        body: { "number": 92233720368547750 }
+
+  - do:
       indices.refresh: {}
 
 ---
@@ -46,9 +57,9 @@ setup:
         rest_total_hits_as_int: true
         body: { "size" : 0, "aggs" : { "my_terms" : { "terms" : { "field" : "number" } } } }
 
-  - match: { hits.total: 4 }
+  - match: { hits.total: 6 }
 
-  - length: { aggregations.my_terms.buckets: 3 }
+  - length: { aggregations.my_terms.buckets: 4 }
 
   - match: { aggregations.my_terms.buckets.0.key: 1.53 }
 
@@ -56,17 +67,17 @@ setup:
 
   - match: { aggregations.my_terms.buckets.0.doc_count: 2 }
 
-  - match: { aggregations.my_terms.buckets.1.key: -2.1 }
-
-  - is_false: aggregations.my_terms.buckets.1.key_as_string
-
-  - match: { aggregations.my_terms.buckets.1.doc_count: 1 }
-
-  - match: { aggregations.my_terms.buckets.2.key: 1 }
+  - match: { aggregations.my_terms.buckets.2.key: -2.1 }
 
   - is_false: aggregations.my_terms.buckets.2.key_as_string
 
   - match: { aggregations.my_terms.buckets.2.doc_count: 1 }
+
+  - match: { aggregations.my_terms.buckets.3.key: 1 }
+
+  - is_false: aggregations.my_terms.buckets.3.key_as_string
+
+  - match: { aggregations.my_terms.buckets.3.doc_count: 1 }
 
 ---
 "Search":
@@ -76,14 +87,14 @@ setup:
         rest_total_hits_as_int: true
         body: { "size" : 0, "query" : { "range" : { "number" : { "gte" : -2 } } } }
 
-  - match: { hits.total: 3 }
+  - match: { hits.total: 5 }
 
   - do:
       search:
         rest_total_hits_as_int: true
         body: { "size" : 0, "query" : { "range" : { "number" : { "gte" : 0 } } } }
 
-  - match: { hits.total: 3 }
+  - match: { hits.total: 5 }
 
   - do:
       search:
@@ -91,6 +102,40 @@ setup:
         body: { "size" : 0, "query" : { "range" : { "number" : { "lt" : 1.5 } } } }
 
   - match: { hits.total: 2 }
+
+  - do:
+      search:
+        index: test
+        body: {
+          "query": {
+            "term": {
+              "number": "92233720368547750"
+            }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.0._source.number: "92233720368547750" }
+  - match: { hits.hits.1._id: "6" }
+  - match: { hits.hits.1._source.number: 92233720368547750 }
+
+  - do:
+      search:
+        index: test
+        body: {
+          "query": {
+            "terms": {
+              "number": [ "92233720368547750" ]
+            }
+          }
+        }
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._id: "5" }
+  - match: { hits.hits.0._source.number: "92233720368547750" }
+  - match: { hits.hits.1._id: "6" }
+  - match: { hits.hits.1._source.number: 92233720368547750 }
 
 ---
 "Sort":
@@ -103,7 +148,7 @@ setup:
             number:
               order: asc
 
-  - match: { hits.total.value: 4 }
+  - match: { hits.total.value: 6 }
   - match: { hits.hits.0._id: "3" }
   - match: { hits.hits.0.sort.0: -2.1 }
 
@@ -119,7 +164,7 @@ setup:
               order: asc
               numeric_type: long
 
-  - match: { hits.total.value: 4 }
+  - match: { hits.total.value: 6 }
   - match: { hits.hits.0._id: "3" }
   - match: { hits.hits.0.sort.0: -2 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR only  addresses the mismatch issue.

As it's known, `float` and `double` types suffer from precision loss, and it's inevitable. When reading `doc_value` in the filed(such as range, sorting, or aggregation), it can lead to unforeseen exceptions. The root cause lies in the fact that the precision of float/double data is already lost before storing. 
https://github.com/opensearch-project/OpenSearch/blob/9db5e67b3ba819c977d2d767ae0b8b22ed7dd61c/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/ScaledFloatFieldMapper.java#L468

It can be extremely terrifying when related to money.

To solve it, I will submit a new PR. In this PR, I will create a new type `big_decimal`, supported by BigDecimal to effectively eliminate the precision loss.

### Related Issues
Resolves #12433
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
