### PR TITLE
Remove interception of unix domain sockets connections

### DIFF
--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/SocketChannelInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/SocketChannelInterceptor.java
@@ -13,9 +13,7 @@ import org.opensearch.javaagent.bootstrap.AgentPolicy;
 import java.lang.StackWalker.Option;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
-import java.net.NetPermission;
 import java.net.SocketPermission;
-import java.net.UnixDomainSocketAddress;
 import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.util.Collection;
@@ -58,13 +56,6 @@ public class SocketChannelInterceptor {
                     if (!policy.implies(domain, permission)) {
                         throw new SecurityException("Denied access to: " + host + ", domain " + domain);
                     }
-                }
-            }
-        } else if (args[0] instanceof UnixDomainSocketAddress address) {
-            final NetPermission permission = new NetPermission("accessUnixDomainSocket");
-            for (ProtectionDomain domain : callers) {
-                if (!policy.implies(domain, permission)) {
-                    throw new SecurityException("Denied access to: " + address + ", domain " + domain);
                 }
             }
         }

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/SocketChannelInterceptorTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/SocketChannelInterceptorTests.java
@@ -13,7 +13,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.UnixDomainSocketAddress;
 import java.nio.channels.SocketChannel;
 
 import static org.junit.Assert.assertThrows;
@@ -23,8 +22,6 @@ public class SocketChannelInterceptorTests extends AgentTestCase {
     public void testConnections() throws IOException {
         try (SocketChannel channel = SocketChannel.open()) {
             assertThrows(SecurityException.class, () -> channel.connect(new InetSocketAddress("localhost", 9200)));
-
-            assertThrows(SecurityException.class, () -> channel.connect(UnixDomainSocketAddress.of("fake-path")));
 
             assertThrows(SecurityException.class, () -> channel.connect(new InetSocketAddress("opensearch.org", 80)));
         }


### PR DESCRIPTION
The major motivation to remove the interception of unix domain sockets connections is to reduce the churn of granting allow access to domain sockets across multiple places in core and more importantly across plugins.  A recent stream of updates haven't had been able to resolve errors on window build (see https://github.com/opensearch-project/custom-codecs/pull/235). 

While this could be a temporary change: there are arguments that this change is generally safe since we can trust IPC communications. See more discussion [at](https://github.com/opensearch-project/custom-codecs/pull/235#discussion_r2036367093)

At this point in time, we would like to get the windows build making some progress to be able to identify what else is broken and needs to be patched across various plugins. 

If we are not comfortable removing this interception, we can come back to it in RC-2 with the right sets of plumbings needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
