### PR TITLE
[Java Agent Policy Parser] Skip evaluation of AttachPermission

### DIFF
--- a/libs/agent-sm/agent-policy/src/main/java/org/opensearch/secure_sm/policy/PolicyFile.java
+++ b/libs/agent-sm/agent-policy/src/main/java/org/opensearch/secure_sm/policy/PolicyFile.java
@@ -49,7 +49,8 @@ public class PolicyFile extends java.security.Policy {
         "org.bouncycastle.crypto.CryptoServicesPermission",
         "org.opensearch.script.ClassPermission",
         "javax.security.auth.AuthPermission",
-        "javax.security.auth.kerberos.ServicePermission"
+        "javax.security.auth.kerberos.ServicePermission",
+        "com.sun.tools.attach.AttachPermission"
     );
 
     private final PolicyInfo policyInfo;


### PR DESCRIPTION
A quick fix to unblock load of PA plugins which defines Attach Permissions in its policy.

Fixes: https://github.com/opensearch-project/performance-analyzer/issues/795

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
