### PR TITLE
Custom Gradle plugin to leverage java agent 

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/agent/JavaAgent.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/agent/JavaAgent.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gradle.agent;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.testing.Test;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Gradle plugin to automatically configure the OpenSearch Java agent
+ * for test tasks in OpenSearch plugin projects.
+ */
+public class JavaAgent implements Plugin<Project> {
+
+    /**
+     * Plugin implementation that sets up java agent configuration and applies it to test tasks.
+     */
+    @Override
+    public void apply(Project project) {
+        Configuration agentConfiguration = project.getConfigurations().findByName("agent");
+        if (agentConfiguration == null) {
+            agentConfiguration = project.getConfigurations().create("agent");
+        }
+
+        project.afterEvaluate(p -> {
+            String opensearchVersion = getOpensearchVersion(p);
+            String byteBuddyVersion = getByteBuddyVersion(p);
+
+            p.getDependencies().add("agent", "org.opensearch:opensearch-agent-bootstrap:" + opensearchVersion);
+            p.getDependencies().add("agent", "org.opensearch:opensearch-agent:" + opensearchVersion);
+            p.getDependencies().add("agent", "net.bytebuddy:byte-buddy:" + byteBuddyVersion);
+        });
+
+        Configuration finalAgentConfiguration = agentConfiguration;
+        TaskProvider<Copy> prepareJavaAgent = project.getTasks().register("prepareJavaAgent", Copy.class, task -> {
+            task.from(finalAgentConfiguration);
+            task.into(new File(project.getBuildDir(), "agent"));
+        });
+
+        project.getTasks().withType(Test.class).configureEach(testTask -> {
+            testTask.dependsOn(prepareJavaAgent);
+
+            final String opensearchVersion = getOpensearchVersion(project);
+
+            testTask.doFirst(task -> {
+                File agentJar = new File(project.getBuildDir(), "agent/opensearch-agent-" + opensearchVersion + ".jar");
+
+                testTask.jvmArgs("-javaagent:" + agentJar.getAbsolutePath());
+            });
+        });
+    }
+
+    /**
+     * Gets the OpenSearch version from project properties, with a fallback default.
+     *
+     * @param project The Gradle project
+     * @return The OpenSearch version to use
+     */
+    private String getOpensearchVersion(Project project) {
+        return Objects.requireNonNull(project.property("opensearch_version")).toString();
+    }
+
+    /**
+     * Gets the ByteBuddy version from project properties, with a fallback default.
+     *
+     * @param project The Gradle project
+     * @return The ByteBuddy version to use
+     */
+    private String getByteBuddyVersion(Project project) {
+        return (String) ((Map<?, ?>) project.property("versions")).get("bytebuddy");
+    }
+}

--- a/buildSrc/src/main/java/org/opensearch/gradle/agent/JavaAgent.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/agent/JavaAgent.java
@@ -16,7 +16,6 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 
 import java.io.File;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -37,11 +36,8 @@ public class JavaAgent implements Plugin<Project> {
 
         project.afterEvaluate(p -> {
             String opensearchVersion = getOpensearchVersion(p);
-            String byteBuddyVersion = getByteBuddyVersion(p);
-
             p.getDependencies().add("agent", "org.opensearch:opensearch-agent-bootstrap:" + opensearchVersion);
             p.getDependencies().add("agent", "org.opensearch:opensearch-agent:" + opensearchVersion);
-            p.getDependencies().add("agent", "net.bytebuddy:byte-buddy:" + byteBuddyVersion);
         });
 
         Configuration finalAgentConfiguration = agentConfiguration;
@@ -71,15 +67,5 @@ public class JavaAgent implements Plugin<Project> {
      */
     private String getOpensearchVersion(Project project) {
         return Objects.requireNonNull(project.property("opensearch_version")).toString();
-    }
-
-    /**
-     * Gets the ByteBuddy version from project properties, with a fallback default.
-     *
-     * @param project The Gradle project
-     * @return The ByteBuddy version to use
-     */
-    private String getByteBuddyVersion(Project project) {
-        return (String) ((Map<?, ?>) project.property("versions")).get("bytebuddy");
     }
 }

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/opensearch.java-agent.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/opensearch.java-agent.properties
@@ -1,0 +1,9 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+implementation-class=org.opensearch.gradle.agent.JavaAgent

--- a/buildSrc/src/test/java/org/opensearch/gradle/agent/JavaAgentTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/agent/JavaAgentTests.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gradle.agent;
+
+import org.opensearch.gradle.test.GradleUnitTestCase;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.tasks.Copy;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+public class JavaAgentTests extends GradleUnitTestCase {
+    private TemporaryFolder projectDir;
+    private final String PREPARE_JAVA_AGENT_TASK = "prepareJavaAgent";
+
+    @Before
+    public void setUp() throws IOException {
+        projectDir = new TemporaryFolder();
+        projectDir.create();
+    }
+
+    @After
+    public void tearDown() {
+        projectDir.delete();
+    }
+
+    /**
+     * This test is used to verify that adding the 'opensearch.java-agent' to the project
+     * creates the necessary agent configuration and tasks. This is basically
+     * a behavioral test of the {@link JavaAgent#apply(Project)} method.
+     */
+    @Test
+    public void applyJavaAgentPlugin() {
+        // Create an empty project and apply the JavaAgent plugin
+        Project project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply(JavaAgent.class);
+
+        // Verify the agent configuration was created
+        Configuration agentConfig = project.getConfigurations().findByName("agent");
+        assertNotNull("Agent configuration should be created", agentConfig);
+
+        // Verify the prepareJavaAgent task was created and is of the right type
+        assertNotNull("prepareJavaAgent task should be created", project.getTasks().findByName(PREPARE_JAVA_AGENT_TASK));
+        assertTrue("prepareJavaAgent task should be of type Copy", project.getTasks().findByName(PREPARE_JAVA_AGENT_TASK) instanceof Copy);
+
+        // Verify the destination directory of the Copy task
+        Copy prepareTask = (Copy) project.getTasks().findByName(PREPARE_JAVA_AGENT_TASK);
+        assertEquals(
+            "Destination directory should be build/agent",
+            new File(project.getBuildDir(), "agent"),
+            prepareTask.getDestinationDir()
+        );
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
To Support phasing off SecurityManager usage in favor of Java Agent a custom Gradle plugin from core should help leverage the java agent. 

Coming from https://github.com/opensearch-project/custom-codecs/pull/235#discussion_r2036383205 created a custom java agent plugin that can be applied as required.  The plugins can use as `apply plugin: 'opensearch.java-agent'`. With this we can remove the duplicate code across plugins.

I have tested by adding `apply plugin: 'opensearch.java-agent'` to job-scheduler and now able to run the tests depend on java agent.

### Related Issues
Part of https://github.com/opensearch-project/OpenSearch/issues/16634 and https://github.com/opensearch-project/OpenSearch/issues/16753

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
