### PR TITLE
FIX BytesRefsCollectionBuilderTests.testBuildSortedNotSorted; Followup for #17714: Remove redundant tests

### DIFF
--- a/server/src/test/java/org/opensearch/index/mapper/BytesRefsCollectionBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/BytesRefsCollectionBuilderTests.java
@@ -28,8 +28,10 @@ public class BytesRefsCollectionBuilderTests extends OpenSearchTestCase {
         Collection<BytesRef> sortedSet = assertCollectionBuilt(sortedBytesRefs);
         assertCollectionBuilt(bytesRefList);
 
-        assertTrue(sortedSet instanceof SortedSet<BytesRef>);
-        assertNull(((SortedSet<BytesRef>) sortedSet).comparator());
+        assertTrue(sortedSet.isEmpty() || sortedSet instanceof SortedSet<BytesRef>);
+        if (!sortedSet.isEmpty()) {
+            assertNull(((SortedSet<BytesRef>) sortedSet).comparator());
+        }
     }
 
     public void testBuildFooBar() {


### PR DESCRIPTION
I wasn't clear in communication under #17714. Let's sweep these tests.   

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
