### PR TITLE
Fix flaky test AzureBlobStoreRepositoryTests

### DIFF
--- a/plugins/repository-azure/src/internalClusterTest/java/org/opensearch/repositories/azure/AzureBlobStoreRepositoryTests.java
+++ b/plugins/repository-azure/src/internalClusterTest/java/org/opensearch/repositories/azure/AzureBlobStoreRepositoryTests.java
@@ -60,9 +60,11 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import fixture.azure.AzureHttpHandler;
+import org.opensearch.test.OpenSearchIntegTestCase;
 import reactor.core.scheduler.Schedulers;
 
 @SuppressForbidden(reason = "this test uses a HttpServer to emulate an Azure endpoint")
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST)
 public class AzureBlobStoreRepositoryTests extends OpenSearchMockAPIBasedRepositoryIntegTestCase {
     @AfterClass
     public static void shutdownSchedulers() {

--- a/plugins/repository-azure/src/internalClusterTest/java/org/opensearch/repositories/azure/AzureBlobStoreRepositoryTests.java
+++ b/plugins/repository-azure/src/internalClusterTest/java/org/opensearch/repositories/azure/AzureBlobStoreRepositoryTests.java
@@ -49,6 +49,7 @@ import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.blobstore.OpenSearchMockAPIBasedRepositoryIntegTestCase;
+import org.opensearch.test.OpenSearchIntegTestCase;
 import org.junit.AfterClass;
 
 import java.io.IOException;
@@ -60,7 +61,6 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import fixture.azure.AzureHttpHandler;
-import org.opensearch.test.OpenSearchIntegTestCase;
 import reactor.core.scheduler.Schedulers;
 
 @SuppressForbidden(reason = "this test uses a HttpServer to emulate an Azure endpoint")


### PR DESCRIPTION
### Description
- Due to the default `SUITE` scope on AzureBlobStoreRepositoryTests, the number of documents indexed with each test gets added and huge number of documents and segments created as part of this takes time for snapshot to create and eventually times out the test suite.
- We can reproduce this issue with following:
```
/gradlew ':plugins:repository-azure:internalClusterTest' --tests "org.opensearch.repositories.azure.AzureBlobStoreRepositoryTests"  -Dtests.seed=773F78819373DA07
```
- As part of this PR, we change the scope to `TEST`.

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/14291

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
