### PR TITLE
Intellij needs :libs:agent-sm:bootstrap at runtime

### DIFF
--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -53,7 +53,7 @@ dependencies {
   api "org.bouncycastle:bcpkix-fips:${versions.bouncycastle_pkix}"
   api "org.bouncycastle:bcutil-fips:${versions.bouncycastle_util}"
 
-  compileOnly project(":libs:agent-sm:bootstrap")
+  implementation project(":libs:agent-sm:bootstrap")
   compileOnly "com.github.spotbugs:spotbugs-annotations:4.9.0"
 
   annotationProcessor "org.apache.logging.log4j:log4j-core:${versions.log4j}"


### PR DESCRIPTION
### Description
IntelliJ seems to fail to find agent-sm libraries on fresh start when running tests from ide.

Testing on a clean IntelliJ with:
File -> Invalidate caches... -> Check all options
`./gradlew clean`
Then run any IntegTest w/ IntelliJ.

I think there are two issues with the order IntelliJ tries to source the agent-sm libs:

1. `java: package org.opensearch.javaagent.bootstrap does not exist`
Running integ tests from their parent class implementation does not include `agent-sm:bootstrap` in the classpath correctly. Moving `agent-sm:bootstrap` to implementation dependency for `:test:framework` module mitigates this issue.

2. `Error opening zip file or JAR manifest missing :<repo-path>/OpenSearch/libs/agent-sm/agent/build/distributions/opensearch-agent-3.0.0-SNAPSHOT.jar`
On a fresh build IntelliJ does not evaluate the agent-sm project previous to :test:framework libraries. Similar to #17886.

... Still trying to find a fix for 2.

### Related Issues
N/A

### Check List
~~- [ ] Functionality includes testing.~~
~~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~~
~~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
