### PR TITLE
Fix flaky multi match query test

### DIFF
--- a/server/src/test/java/org/opensearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/MultiMatchQueryBuilderTests.java
@@ -55,6 +55,7 @@ import org.opensearch.core.common.ParsingException;
 import org.opensearch.index.query.MultiMatchQueryBuilder.Type;
 import org.opensearch.index.search.MatchQuery;
 import org.opensearch.lucene.queries.ExtendedCommonTermsQuery;
+import org.opensearch.search.approximate.ApproximateScoreQuery;
 import org.opensearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
@@ -198,7 +199,8 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
                     instanceOf(PhraseQuery.class),
                     instanceOf(PointRangeQuery.class),
                     instanceOf(IndexOrDocValuesQuery.class),
-                    instanceOf(PrefixQuery.class)
+                    instanceOf(PrefixQuery.class),
+                    instanceOf(ApproximateScoreQuery.class)
                 )
             )
         );


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
On a different PR I observed this flaky test -- https://build.ci.opensearch.org/job/gradle-check/56357/testReport/junit/org.opensearch.index.query/MultiMatchQueryBuilderTests/testToQuery/

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] Functionality includes testing.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
