### PR TITLE
add metric of skipped messages in pull-based ingestion processing

### DIFF
--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
@@ -69,8 +69,8 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
             PollingIngestStats stats = client().admin().indices().prepareStats(indexName).get().getIndex(indexName).getShards()[0]
                 .getPollingIngestStats();
             assertNotNull(stats);
-            assertThat(stats.getMessageProcessorStats().getTotalProcessedCount(), is(2L));
-            assertThat(stats.getConsumerStats().getTotalPolledCount(), is(2L));
+            assertThat(stats.getMessageProcessorStats().totalProcessedCount(), is(2L));
+            assertThat(stats.getConsumerStats().totalPolledCount(), is(2L));
         });
     }
 

--- a/plugins/ingestion-kinesis/src/internalClusterTest/java/org/opensearch/plugin/kinesis/IngestFromKinesisIT.java
+++ b/plugins/ingestion-kinesis/src/internalClusterTest/java/org/opensearch/plugin/kinesis/IngestFromKinesisIT.java
@@ -96,8 +96,8 @@ public class IngestFromKinesisIT extends KinesisIngestionBaseIT {
             PollingIngestStats stats = client().admin().indices().prepareStats("test").get().getIndex("test").getShards()[0]
                 .getPollingIngestStats();
             assertNotNull(stats);
-            assertThat(stats.getMessageProcessorStats().getTotalProcessedCount(), is(2L));
-            assertThat(stats.getConsumerStats().getTotalPolledCount(), is(2L));
+            assertThat(stats.getMessageProcessorStats().totalProcessedCount(), is(2L));
+            assertThat(stats.getConsumerStats().totalPolledCount(), is(2L));
         });
     }
 

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -355,7 +355,8 @@ public class DefaultStreamPoller implements StreamPoller {
     public PollingIngestStats getStats() {
         PollingIngestStats.Builder builder = new PollingIngestStats.Builder();
         builder.setTotalPolledCount(totalPolledCount.count());
-        builder.setTotalProcessedCount(processorRunnable.getStats().count());
+        builder.setTotalProcessedCount(processorRunnable.getProcessedCounter().count());
+        builder.setTotalSkippedCount(processorRunnable.getSkippedCounter().count());
         return builder.build();
     }
 

--- a/server/src/test/java/org/opensearch/indices/pollingingest/MessageProcessorTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/MessageProcessorTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.indices.pollingingest;
 
+import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.engine.FakeIngestionSource;
 import org.opensearch.index.engine.IngestionEngine;
@@ -55,7 +56,7 @@ public class MessageProcessorTests extends OpenSearchTestCase {
         when(documentMapper.parse(any())).thenReturn(parsedDocument);
         when(parsedDocument.rootDoc()).thenReturn(new ParseContext.Document());
 
-        Engine.Operation operation = processor.getOperation(payload, pointer);
+        Engine.Operation operation = processor.getOperation(payload, pointer, new CounterMetric());
 
         assertTrue(operation instanceof Engine.Index);
         ArgumentCaptor<SourceToParse> captor = ArgumentCaptor.forClass(SourceToParse.class);
@@ -68,7 +69,7 @@ public class MessageProcessorTests extends OpenSearchTestCase {
         byte[] payload = "{\"_id\":\"1\",\"_op_type\":\"delete\"}".getBytes(StandardCharsets.UTF_8);
         FakeIngestionSource.FakeIngestionShardPointer pointer = new FakeIngestionSource.FakeIngestionShardPointer(0);
 
-        Engine.Operation operation = processor.getOperation(payload, pointer);
+        Engine.Operation operation = processor.getOperation(payload, pointer, new CounterMetric());
 
         assertTrue(operation instanceof Engine.Delete);
         Engine.Delete deleteOperation = (Engine.Delete) operation;
@@ -79,13 +80,13 @@ public class MessageProcessorTests extends OpenSearchTestCase {
         byte[] payload = "{\"_id\":\"1\"}".getBytes(StandardCharsets.UTF_8);
         FakeIngestionSource.FakeIngestionShardPointer pointer = new FakeIngestionSource.FakeIngestionShardPointer(0);
 
-        Engine.Operation operation = processor.getOperation(payload, pointer);
+        Engine.Operation operation = processor.getOperation(payload, pointer, new CounterMetric());
         assertNull(operation);
 
         // source has wrong type
         payload = "{\"_id\":\"1\", \"_source\":1}".getBytes(StandardCharsets.UTF_8);
 
-        operation = processor.getOperation(payload, pointer);
+        operation = processor.getOperation(payload, pointer, new CounterMetric());
         assertNull(operation);
     }
 
@@ -93,7 +94,7 @@ public class MessageProcessorTests extends OpenSearchTestCase {
         byte[] payload = "{\"_id\":\"1\", \"_op_tpe\":\"update\"}".getBytes(StandardCharsets.UTF_8);
         FakeIngestionSource.FakeIngestionShardPointer pointer = new FakeIngestionSource.FakeIngestionShardPointer(0);
 
-        Engine.Operation operation = processor.getOperation(payload, pointer);
+        Engine.Operation operation = processor.getOperation(payload, pointer, new CounterMetric());
         assertNull(operation);
     }
 
@@ -104,7 +105,7 @@ public class MessageProcessorTests extends OpenSearchTestCase {
         ParsedDocument parsedDocument = mock(ParsedDocument.class);
         when(documentMapper.parse(any())).thenReturn(parsedDocument);
         when(parsedDocument.rootDoc()).thenReturn(new ParseContext.Document());
-        Engine.Operation operation = processor.getOperation(payload, pointer);
+        Engine.Operation operation = processor.getOperation(payload, pointer, new CounterMetric());
 
         assertTrue(operation instanceof Engine.Index);
         ArgumentCaptor<SourceToParse> captor = ArgumentCaptor.forClass(SourceToParse.class);
@@ -120,7 +121,7 @@ public class MessageProcessorTests extends OpenSearchTestCase {
         ParsedDocument parsedDocument = mock(ParsedDocument.class);
         when(documentMapper.parse(any())).thenReturn(parsedDocument);
         when(parsedDocument.rootDoc()).thenReturn(new ParseContext.Document());
-        Engine.Operation operation = processor.getOperation(payload, pointer);
+        Engine.Operation operation = processor.getOperation(payload, pointer, new CounterMetric());
         assertTrue(operation instanceof Engine.NoOp);
     }
 }

--- a/server/src/test/java/org/opensearch/indices/pollingingest/PollingIngestStatsTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/PollingIngestStatsTests.java
@@ -28,9 +28,11 @@ public class PollingIngestStatsTests extends OpenSearchTestCase {
         builder.endObject();
 
         String expected = "{\"polling_ingest_stats\":{\"message_processor_stats\":{\"total_processed_count\":"
-            + stats.getMessageProcessorStats().getTotalProcessedCount()
+            + stats.getMessageProcessorStats().totalProcessedCount()
+            + ",\"total_skipped_count\":"
+            + stats.getMessageProcessorStats().totalSkippedCount()
             + "},\"consumer_stats\":{\"total_polled_count\":"
-            + stats.getConsumerStats().getTotalPolledCount()
+            + stats.getConsumerStats().totalPolledCount()
             + "}}}";
 
         assertEquals(expected, builder.toString());
@@ -52,6 +54,7 @@ public class PollingIngestStatsTests extends OpenSearchTestCase {
     private PollingIngestStats createTestInstance() {
         return PollingIngestStats.builder()
             .setTotalProcessedCount(randomNonNegativeLong())
+            .setTotalSkippedCount(randomNonNegativeLong())
             .setTotalPolledCount(randomNonNegativeLong())
             .build();
     }


### PR DESCRIPTION

### Description
- add metric of skipped messages in pull-based ingestion processing
- use record class for the PollingIngestStats

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
