### PR TITLE
Add UT for getSleepDuration in AbstractAsyncTask

### DIFF
--- a/server/src/test/java/org/opensearch/common/util/concurrent/AbstractAsyncTaskTests.java
+++ b/server/src/test/java/org/opensearch/common/util/concurrent/AbstractAsyncTaskTests.java
@@ -248,4 +248,26 @@ public class AbstractAsyncTaskTests extends OpenSearchTestCase {
             assertFalse(task.isScheduled());
         }
     }
+
+    public void testGetSleepDurationForFirstRefresh() {
+        AbstractAsyncTask task = new AbstractAsyncTask(
+            logger,
+            threadPool,
+            TimeValue.timeValueMillis(randomIntBetween(1, 2)),
+            true,
+            OpenSearchTestCase::randomBoolean
+        ) {
+            @Override
+            protected boolean mustReschedule() {
+                return true;
+            }
+
+            @Override
+            protected void runInternal() {
+                // no-op
+            }
+        };
+        // No exceptions should be thrown
+        task.getSleepDuration();
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR adds a simple UT to validate that the getSleepDuration does not thrown exception when doing refresh for the first time. 

### Check List
- [x] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
