### PR TITLE
BUG: Fix premature repository close in remote store factories

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryFactory.java
@@ -64,8 +64,9 @@ public class RemoteSegmentStoreDirectoryFactory implements IndexStorePlugin.Dire
     public Directory newDirectory(String repositoryName, String indexUUID, ShardId shardId, RemoteStorePathStrategy pathStrategy)
         throws IOException {
         assert Objects.nonNull(pathStrategy);
-        try (Repository repository = repositoriesService.get().repository(repositoryName)) {
-
+        try {
+            //noinspection resource
+            Repository repository = repositoriesService.get().repository(repositoryName);
             assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
             BlobStoreRepository blobStoreRepository = ((BlobStoreRepository) repository);
             BlobPath repositoryBasePath = blobStoreRepository.basePath();

--- a/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/lockmanager/RemoteStoreLockManagerFactory.java
@@ -55,7 +55,8 @@ public class RemoteStoreLockManagerFactory {
         RemoteStorePathStrategy pathStrategy,
         String segmentsPathFixedPrefix
     ) {
-        try (Repository repository = repositoriesService.repository(repositoryName)) {
+        try {
+            Repository repository = repositoriesService.repository(repositoryName);
             assert repository instanceof BlobStoreRepository : "repository should be instance of BlobStoreRepository";
             BlobPath repositoryBasePath = ((BlobStoreRepository) repository).basePath();
 


### PR DESCRIPTION
### Description
Incorrect use of try-with-resources on the shared Repository object in RemoteStoreLockManagerFactory and RemoteSegmentStoreDirectoryFactory caused the underlying BlobStoreRepository, AzureStorageService, and its MI executor to be closed prematurely during shard/directory initialization for remote store. This led to CredentialUnavailableException on subsequent operations. This change removes the try-with-resources to prevent automatic closing.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
