### PR TITLE
Allow new feature flags registered from plugin

### DIFF
--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -181,6 +181,16 @@ public class FeatureFlags {
         }
 
         /**
+         * Enables plugins to provide their own feature flags
+         * by registering new flags. New flags should be registered statically
+         * to ensure they are known previous to initializeFeatureFlags().
+         * @param newFeatureFlag Feature flag to register.
+         */
+        void registerFeatureFlag(Setting<Boolean> newFeatureFlag) {
+            featureFlags.put(newFeatureFlag, newFeatureFlag.getDefault(Settings.EMPTY));
+        }
+
+        /**
          * Initialize feature flags map from the following sources:
          * (Each source overwrites previous feature flags)
          * - Set from setting default
@@ -272,6 +282,10 @@ public class FeatureFlags {
     /**
      * Server module public API.
      */
+    public static void registerFeatureFlag(Setting<Boolean> newFeatureFlag) {
+        featureFlagsImpl.registerFeatureFlag(newFeatureFlag);
+    }
+
     public static void initializeFeatureFlags(Settings openSearchSettings) {
         featureFlagsImpl.initializeFeatureFlags(openSearchSettings);
     }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -626,6 +626,10 @@ public class Node implements Closeable {
             additionalSettings.add(NODE_MASTER_SETTING);
             additionalSettings.add(NODE_REMOTE_CLUSTER_CLIENT);
             additionalSettings.addAll(pluginsService.getPluginSettings());
+            for (Setting<Boolean> ff : pluginsService.getPluginFeatureFlags()) {
+                FeatureFlags.registerFeatureFlag(ff);
+            }
+
             final List<String> additionalSettingsFilter = new ArrayList<>(pluginsService.getPluginSettingsFilter());
             for (final ExecutorBuilder<?> builder : threadPool.builders()) {
                 additionalSettings.addAll(builder.getRegisteredSettings());

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -537,7 +537,7 @@ public class Node implements Closeable {
             final Settings settings = pluginsService.updatedSettings();
 
             // Ensure to initialize Feature Flags via the settings from opensearch.yml
-            FeatureFlags.initializeFeatureFlags(settings);
+            FeatureFlags.initializeFeatureFlags(settings, pluginsService.getPluginFeatureFlags());
 
             final List<IdentityPlugin> identityPlugins = new ArrayList<>();
             identityPlugins.addAll(pluginsService.filterPlugins(IdentityPlugin.class));
@@ -626,9 +626,6 @@ public class Node implements Closeable {
             additionalSettings.add(NODE_MASTER_SETTING);
             additionalSettings.add(NODE_REMOTE_CLUSTER_CLIENT);
             additionalSettings.addAll(pluginsService.getPluginSettings());
-            for (Setting<Boolean> ff : pluginsService.getPluginFeatureFlags()) {
-                FeatureFlags.registerFeatureFlag(ff);
-            }
 
             final List<String> additionalSettingsFilter = new ArrayList<>(pluginsService.getPluginSettingsFilter());
             for (final ExecutorBuilder<?> builder : threadPool.builders()) {

--- a/server/src/main/java/org/opensearch/plugins/Plugin.java
+++ b/server/src/main/java/org/opensearch/plugins/Plugin.java
@@ -193,6 +193,13 @@ public abstract class Plugin implements Closeable {
     }
 
     /**
+     * Returns a list of additional {@link org.opensearch.common.util.FeatureFlags} settings for this plugin.
+     */
+    public List<Setting<Boolean>> getFeatureFlags() {
+        return Collections.emptyList();
+    }
+
+    /**
      * Returns a list of additional settings filter for this plugin
      */
     public List<String> getSettingsFilter() {

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -114,6 +114,10 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         return plugins.stream().flatMap(p -> p.v2().getSettings().stream()).collect(Collectors.toList());
     }
 
+    public List<Setting<Boolean>> getPluginFeatureFlags() {
+        return plugins.stream().flatMap(p -> p.v2().getFeatureFlags().stream()).collect(Collectors.toList());
+    }
+
     public List<String> getPluginSettingsFilter() {
         return plugins.stream().flatMap(p -> p.v2().getSettingsFilter().stream()).collect(Collectors.toList());
     }

--- a/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
+++ b/server/src/test/java/org/opensearch/common/util/FeatureFlagTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.common.util;
 
 import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -97,6 +98,30 @@ public class FeatureFlagTests extends OpenSearchTestCase {
         clearSystemProperty(DNE_FF);
         testFlagsImpl.initializeFeatureFlags(Settings.builder().put(DNE_FF, true).build());
         assertFalse(testFlagsImpl.isEnabled(DNE_FF));
+    }
+
+    @SuppressForbidden(reason = "Testing with system property")
+    public void testRegisterNewFlag() {
+        final String NEW_FLAG = FEATURE_FLAG_PREFIX + "newflag";
+        Setting<Boolean> NEW_FLAG_SETTING = Setting.boolSetting(NEW_FLAG, false, Setting.Property.NodeScope);
+
+        FeatureFlags.FeatureFlagsImpl testFlagsImpl = new FeatureFlags.FeatureFlagsImpl();
+        testFlagsImpl.registerFeatureFlag(NEW_FLAG_SETTING);
+        assertFalse(testFlagsImpl.isEnabled(NEW_FLAG));
+
+        // set with sys prop
+        setSystemPropertyTrue(NEW_FLAG);
+        testFlagsImpl.initializeFeatureFlags(Settings.EMPTY);
+        assertTrue(testFlagsImpl.isEnabled(NEW_FLAG));
+        clearSystemProperty(NEW_FLAG);
+        testFlagsImpl.initializeFeatureFlags(Settings.EMPTY);
+        assertFalse(testFlagsImpl.isEnabled(NEW_FLAG));
+
+        // set with settings
+        testFlagsImpl.initializeFeatureFlags(Settings.builder().put(NEW_FLAG, true).build());
+        assertTrue(testFlagsImpl.isEnabled(NEW_FLAG));
+        testFlagsImpl.initializeFeatureFlags(Settings.EMPTY);
+        assertFalse(testFlagsImpl.isEnabled(NEW_FLAG));
     }
 
     /**

--- a/server/src/test/java/org/opensearch/search/aggregations/startree/RangeAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/startree/RangeAggregatorTests.java
@@ -50,6 +50,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Random;
@@ -73,12 +74,12 @@ public class RangeAggregatorTests extends AggregatorTestCase {
 
     @Before
     public void setup() {
-        FeatureFlags.initializeFeatureFlags(Settings.builder().put(FeatureFlags.STAR_TREE_INDEX, true).build());
+        FeatureFlags.initializeFeatureFlags(Settings.builder().put(FeatureFlags.STAR_TREE_INDEX, true).build(), Collections.emptyList());
     }
 
     @After
     public void teardown() throws IOException {
-        FeatureFlags.initializeFeatureFlags(Settings.EMPTY);
+        FeatureFlags.initializeFeatureFlags(Settings.EMPTY, Collections.emptyList());
     }
 
     protected Codec getCodec() {


### PR DESCRIPTION
### Description
Per #17940 plugins need the ability to register their own feature flags in core.
Previously we could set/fetch flags directly from system properties allowing plugins to arbitrarily register new flags by settings a system property. Now that we maintain all registered flags in a map plugins need access to add their feature flags.

### Related Issues
Resolves #17940

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
