### PR TITLE
Closing the directory reader to fix test

### DIFF
--- a/server/src/test/java/org/opensearch/search/aggregations/startree/RangeAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/startree/RangeAggregatorTests.java
@@ -174,6 +174,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             }
         }
 
+        ir.close();
         reader.close();
         directory.close();
     }


### PR DESCRIPTION

```
./gradlew ':server:test' --tests "org.opensearch.search.aggregations.startree.RangeAggregatorTests.testRangeAggregation" -Dtests.seed=A5CF5DD34EE06092 -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=nl -Dtests.timezone=Asia/Ust-Nera -Druntime.java=21
```

Able to consistently reproduce failure locally and the test fixes after change. 

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/17928

