### PR TITLE
Fix flaky test SegmentReplicationTargetServiceTests.testStartReplicationListenerSuccess

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1723,7 +1723,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 return Optional.empty();
             }
         } catch (AlreadyClosedException e) {
-            logger.warn("failed to get ReplicationEngine", e);
+            // If shard already closed, return empty and do not perform segment replication related operations
+            logger.debug("failed to get ReplicationEngine", e);
             return Optional.empty();
         }
     }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1723,15 +1723,17 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 return Optional.empty();
             }
         } catch (AlreadyClosedException e) {
-            // If shard already closed, return empty and do not perform segment replication related operations
+            // If shard already closed, return empty. The logic related to segment replication will not continue to execute after judging
+            // that the return value is empty, and there will be no side effects.
             logger.debug("failed to get ReplicationEngine", e);
             return Optional.empty();
         }
     }
 
     public void finalizeReplication(SegmentInfos infos) throws IOException {
-        if (getReplicationEngine().isPresent()) {
-            getReplicationEngine().get().updateSegments(infos);
+        Optional<NRTReplicationEngine> engineOptional = getReplicationEngine();
+        if (engineOptional.isPresent()) {
+            engineOptional.get().updateSegments(infos);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1716,9 +1716,14 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     public Optional<NRTReplicationEngine> getReplicationEngine() {
-        if (getEngine() instanceof NRTReplicationEngine) {
-            return Optional.of((NRTReplicationEngine) getEngine());
-        } else {
+        try {
+            if (getEngine() instanceof NRTReplicationEngine) {
+                return Optional.of((NRTReplicationEngine) getEngine());
+            } else {
+                return Optional.empty();
+            }
+        } catch (AlreadyClosedException e) {
+            logger.warn("failed to get ReplicationEngine", e);
             return Optional.empty();
         }
     }

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -146,6 +146,7 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
 
             // Assertions
             shards.assertAllEqual(numDocs);
+            assertTrue(primaryShard.getReplicationEngine().isEmpty());
             assertFalse(replicaShard.getReplicationEngine().isEmpty());
             replicaShard.close("test", false, false);
             assertTrue(replicaShard.getReplicationEngine().isEmpty());

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationIndexShardTests.java
@@ -146,6 +146,9 @@ public class SegmentReplicationIndexShardTests extends OpenSearchIndexLevelRepli
 
             // Assertions
             shards.assertAllEqual(numDocs);
+            assertFalse(replicaShard.getReplicationEngine().isEmpty());
+            replicaShard.close("test", false, false);
+            assertTrue(replicaShard.getReplicationEngine().isEmpty());
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

This PR fixes the flaky test `org.opensearch.indices.replication.SegmentReplicationTargetServiceTests#testStartReplicationListenerSuccess`.

Reproduce method command reference [gradle check](https://build.ci.opensearch.org/job/gradle-check/53583/testReport/junit/org.opensearch.indices.replication/SegmentReplicationTargetServiceTests/testStartReplicationListenerSuccess/).

```
./gradlew ':server:test' --tests "org.opensearch.indices.replication.SegmentReplicationTargetServiceTests.testStartReplicationListenerSuccess" -Dtests.seed=67540127BBCFAD6A -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=fr-CA -Dtests.timezone=Africa/Casablanca -Druntime.java=21
```

This test cannot be reproduced stably, and there may be `1` error every `1000` runs.

The error message is as follows: 
```
févr. 18, 2025 6:47:01 PM com.carrotsearch.randomizedtesting.RandomizedRunner$QueueUncaughtExceptionsHandler uncaughtException
AVERTISSEMENT: Uncaught exception in thread: Thread[#1897,opensearch[org.opensearch.indices.replication.SegmentReplicationTargetServiceTests][generic][T#2],5,TGRP-SegmentReplicationTargetServiceTests]
org.apache.lucene.store.AlreadyClosedException: engine is closed
	at __randomizedtesting.SeedInfo.seed([67540127BBCFAD6A]:0)
	at org.opensearch.index.shard.IndexShard.getEngine(IndexShard.java:3762)
	at org.opensearch.index.shard.IndexShard.getReplicationEngine(IndexShard.java:1697)
	at org.opensearch.index.shard.IndexShard.isSegmentReplicationAllowed(IndexShard.java:1828)
	at org.opensearch.index.shard.IndexShard.shouldProcessCheckpoint(IndexShard.java:1847)
	at org.opensearch.indices.replication.SegmentReplicationTargetService.onNewCheckpoint(SegmentReplicationTargetService.java:324)
	at org.opensearch.indices.replication.SegmentReplicationTargetService.lambda$processLatestReceivedCheckpoint$12(SegmentReplicationTargetService.java:484)
	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:955)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

### Related Issues
Resolves #[[15829](https://github.com/opensearch-project/OpenSearch/issues/15829)]
<!-- List any other related issues here -->

### Solution

In process segment replication, obtain `NRTReplicationEngine` through `IndexShard#getReplicationEngine`
If the `Engine` has been closed, return an exception `AlreadyClosedException`

Although `IndexShardState.STARTED` is checked before calling `IndexShard#getReplicationEngine`, shard close may be inserted between them, and atomicity cannot be guaranteed.

We can improve method `IndexShard#getReplicationEngine` by returning `Optional.empty()` when `getEngine()` throws a 
`AlreadyClosedException`. 

The logic related to segment replication will not continue to execute after judging that the return value is empty (`IndexShard#finalizeReplication` / `IndexShard#isSegmentReplicationAllowed` / `SegmentReplicationTargetService#forceReplication`), and there will be no side effects.

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
