### PR TITLE
Additional settings for gRPC experimental transport.

### DIFF
--- a/plugins/transport-grpc/README.md
+++ b/plugins/transport-grpc/README.md
@@ -17,14 +17,18 @@ setting 'aux.transport.types',                                      '[experiment
 setting 'aux.transport.experimental-secure-transport-grpc.port',    '9400-9500' //optional
 ```
 
-Other settings are agnostic as to the gRPC transport type:
+Other gRPC settings:
 
 ```
-setting 'grpc.publish_port',        '9400'
-setting 'grpc.host',                '["0.0.0.0"]'
-setting 'grpc.bind_host',           '["0.0.0.0", "::", "10.0.0.1"]'
-setting 'grpc.publish_host',        '["thisnode.example.com"]'
-setting 'grpc.netty.worker_count',  '2'
+setting 'grpc.publish_port',                            '9400'
+setting 'grpc.host',                                    '["0.0.0.0"]'
+setting 'grpc.bind_host',                               '["0.0.0.0", "::", "10.0.0.1"]'
+setting 'grpc.publish_host',                            '["thisnode.example.com"]'
+setting 'grpc.netty.worker_count',                      '2'
+setting 'grpc.netty.max_concurrent_connection_calls',   '200'
+setting 'grpc.netty.max_connection_age',                '500ms'
+setting 'grpc.netty.max_connection_idle',               '2m'
+setting 'grpc.netty.keepalive_timeout',                 '1s'
 ```
 
 ## Testing

--- a/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/GrpcPlugin.java
+++ b/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/GrpcPlugin.java
@@ -42,6 +42,10 @@ import io.grpc.BindableService;
 import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.GRPC_TRANSPORT_SETTING_KEY;
 import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_BIND_HOST;
 import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_HOST;
+import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_KEEPALIVE_TIMEOUT;
+import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_MAX_CONCURRENT_CONNECTION_CALLS;
+import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_MAX_CONNECTION_AGE;
+import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_MAX_CONNECTION_IDLE;
 import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_PORT;
 import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_PUBLISH_HOST;
 import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_PUBLISH_PORT;
@@ -145,12 +149,16 @@ public final class GrpcPlugin extends Plugin implements NetworkPlugin {
     public List<Setting<?>> getSettings() {
         return List.of(
             SETTING_GRPC_PORT,
+            SETTING_GRPC_PUBLISH_PORT,
             SETTING_GRPC_SECURE_PORT,
             SETTING_GRPC_HOST,
             SETTING_GRPC_PUBLISH_HOST,
             SETTING_GRPC_BIND_HOST,
             SETTING_GRPC_WORKER_COUNT,
-            SETTING_GRPC_PUBLISH_PORT
+            SETTING_GRPC_MAX_CONCURRENT_CONNECTION_CALLS,
+            SETTING_GRPC_MAX_CONNECTION_AGE,
+            SETTING_GRPC_MAX_CONNECTION_IDLE,
+            SETTING_GRPC_KEEPALIVE_TIMEOUT
         );
     }
 

--- a/plugins/transport-grpc/src/test/java/org/opensearch/plugin/transport/grpc/GrpcPluginTests.java
+++ b/plugins/transport-grpc/src/test/java/org/opensearch/plugin/transport/grpc/GrpcPluginTests.java
@@ -31,6 +31,10 @@ import org.mockito.MockitoAnnotations;
 import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.GRPC_TRANSPORT_SETTING_KEY;
 import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_BIND_HOST;
 import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_HOST;
+import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_KEEPALIVE_TIMEOUT;
+import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_MAX_CONCURRENT_CONNECTION_CALLS;
+import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_MAX_CONNECTION_AGE;
+import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_MAX_CONNECTION_IDLE;
 import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_PORT;
 import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_PUBLISH_HOST;
 import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_PUBLISH_PORT;
@@ -97,9 +101,16 @@ public class GrpcPluginTests extends OpenSearchTestCase {
         assertTrue("SETTING_GRPC_BIND_HOST should be included", settings.contains(SETTING_GRPC_BIND_HOST));
         assertTrue("SETTING_GRPC_WORKER_COUNT should be included", settings.contains(SETTING_GRPC_WORKER_COUNT));
         assertTrue("SETTING_GRPC_PUBLISH_PORT should be included", settings.contains(SETTING_GRPC_PUBLISH_PORT));
+        assertTrue(
+            "SETTING_GRPC_MAX_CONCURRENT_CONNECTION_CALLS should be included",
+            settings.contains(SETTING_GRPC_MAX_CONCURRENT_CONNECTION_CALLS)
+        );
+        assertTrue("SETTING_GRPC_MAX_CONNECTION_AGE should be included", settings.contains(SETTING_GRPC_MAX_CONNECTION_AGE));
+        assertTrue("SETTING_GRPC_MAX_CONNECTION_IDLE should be included", settings.contains(SETTING_GRPC_MAX_CONNECTION_IDLE));
+        assertTrue("SETTING_GRPC_KEEPALIVE_TIMEOUT should be included", settings.contains(SETTING_GRPC_KEEPALIVE_TIMEOUT));
 
         // Verify the number of settings
-        assertEquals("Should return 7 settings", 7, settings.size());
+        assertEquals("Should return 11 settings", 11, settings.size());
     }
 
     public void testGetAuxTransports() {


### PR DESCRIPTION
### Description
Additional settings for experimental gRPC transport plugin.
Particularly settings related to managing client connection lifetimes.

`grpc.netty.max_concurrent_connection_calls`
Limit concurrent in flight requests per client connection.

`grpc.netty.max_connection_age`
Set timeout for persistent connections.

`grpc.netty.max_connection_idle`
Set timeout for idle connections.

`grpc.netty.keepalive_timeout`
Set timeout for connection keepalive pings.
### Related Issues
Resolves #17783

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
