### PR TITLE
Use test-retry plugin in place of develocity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ plugins {
   id 'opensearch.docker-support'
   id 'opensearch.global-build-info'
   id "com.diffplug.spotless" version "6.25.0" apply false
+  id "org.gradle.test-retry" version "1.6.2" apply false
   id "test-report-aggregation"
   id 'jacoco-report-aggregation'
 }
@@ -69,13 +70,6 @@ apply from: 'gradle/fips.gradle'
 apply from: 'gradle/run.gradle'
 apply from: 'gradle/missing-javadoc.gradle'
 apply from: 'gradle/code-coverage.gradle'
-
-// Disable unconditional publishing of build scans
-develocity {
-  buildScan {
-    publishing.onlyIf { false }
-  }
-}
 
 // common maven publishing configuration
 allprojects {
@@ -475,8 +469,9 @@ gradle.projectsEvaluated {
 
 // test retry configuration
 subprojects {
+  apply plugin: "org.gradle.test-retry"
   tasks.withType(Test).configureEach {
-    develocity.testRetry {
+    retry {
       if (BuildParams.isCi()) {
         maxRetries = 3
         maxFailures = 10

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,9 +21,6 @@ org.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Xss2m \
     --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 options.forkOptions.memoryMaximumSize=3g
 
-# Disable Gradle Enterprise Gradle plugin's test retry
-systemProp.develocity.testretry.enabled.enabled=false
-
 # Disable duplicate project id detection
 # See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail
 systemProp.org.gradle.dependency.duplicate.project.detection=false

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,10 +9,6 @@
  * GitHub history for details.
  */
 
-plugins {
-  id "com.gradle.develocity" version "3.19.1"
-}
-
 ext.disableBuildCache = hasProperty('DISABLE_BUILD_CACHE') || System.getenv().containsKey('DISABLE_BUILD_CACHE')
 
 buildCache {


### PR DESCRIPTION
To fix the deprecation warnings in #13942 I believe I should have just removed the gradle enterprise plugin all together as I think it is unused. This commit goes back to using the open-source test-retry Gradle plugin and removes develocity.

This should not change the functionality of the test retry logic in any way.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
