### PR TITLE
[Pull-based ingestion] Emit lag metric for pull-based ingestion poller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Unset discovery nodes for every transport node actions request ([#17682](https://github.com/opensearch-project/OpenSearch/pull/17682))
 - Implement parallel shard refresh behind cluster settings ([#17782](https://github.com/opensearch-project/OpenSearch/pull/17782))
 - Bump OpenSearch Core main branch to 3.0.0 ([#18039](https://github.com/opensearch-project/OpenSearch/pull/18039))
+- Update API of Message in index to add the timestamp for lag calculation in ingestion polling ([#17977](https://github.com/opensearch-project/OpenSearch/pull/17977/))
+
 
 ### Changed
 - Change the default max header size from 8KB to 16KB. ([#18024](https://github.com/opensearch-project/OpenSearch/pull/18024))

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaMessage.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaMessage.java
@@ -17,15 +17,18 @@ import org.opensearch.index.Message;
 public class KafkaMessage implements Message<byte[]> {
     private final byte[] key;
     private final byte[] payload;
+    private final Long timestamp;
 
     /**
      * Constructor
      * @param key the key of the message
      * @param payload the payload of the message
+     * @param timestamp the timestamp of the message in milliseconds
      */
-    public KafkaMessage(@Nullable byte[] key, byte[] payload) {
+    public KafkaMessage(@Nullable byte[] key, byte[] payload, Long timestamp) {
         this.key = key;
         this.payload = payload;
+        this.timestamp = timestamp;
     }
 
     /**
@@ -39,5 +42,10 @@ public class KafkaMessage implements Message<byte[]> {
     @Override
     public byte[] getPayload() {
         return payload;
+    }
+
+    @Override
+    public Long getTimestamp() {
+        return timestamp;
     }
 }

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
@@ -235,7 +235,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
             }
             lastFetchedOffset = currentOffset;
             KafkaOffset kafkaOffset = new KafkaOffset(currentOffset);
-            KafkaMessage message = new KafkaMessage(messageAndOffset.key(), messageAndOffset.value());
+            KafkaMessage message = new KafkaMessage(messageAndOffset.key(), messageAndOffset.value(), messageAndOffset.timestamp());
             results.add(new ReadResult<>(kafkaOffset, message));
         }
         return results;

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaMessageTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaMessageTests.java
@@ -16,18 +16,20 @@ public class KafkaMessageTests extends OpenSearchTestCase {
         byte[] key = { 1, 2, 3 };
         byte[] payload = { 4, 5, 6 };
 
-        KafkaMessage message = new KafkaMessage(key, payload);
+        KafkaMessage message = new KafkaMessage(key, payload, 1000L);
 
         Assert.assertArrayEquals(key, message.getKey());
         Assert.assertArrayEquals(payload, message.getPayload());
+        Assert.assertEquals(1000L, message.getTimestamp().longValue());
     }
 
     public void testConstructorWithNullKey() {
         byte[] payload = { 4, 5, 6 };
 
-        KafkaMessage message = new KafkaMessage(null, payload);
+        KafkaMessage message = new KafkaMessage(null, payload, null);
 
         assertNull(message.getKey());
         Assert.assertArrayEquals(payload, message.getPayload());
+        Assert.assertNull(message.getTimestamp());
     }
 }

--- a/plugins/ingestion-kinesis/src/main/java/org/opensearch/plugin/kinesis/KinesisMessage.java
+++ b/plugins/ingestion-kinesis/src/main/java/org/opensearch/plugin/kinesis/KinesisMessage.java
@@ -15,17 +15,25 @@ import org.opensearch.index.Message;
  */
 public class KinesisMessage implements Message<byte[]> {
     private final byte[] payload;
+    private final Long timestamp;
 
     /**
      * Constructor
      * @param payload the payload of the message
+     * @param timestamp the timestamp of the message in milliseconds
      */
-    public KinesisMessage(byte[] payload) {
+    public KinesisMessage(byte[] payload, Long timestamp) {
         this.payload = payload;
+        this.timestamp = timestamp;
     }
 
     @Override
     public byte[] getPayload() {
         return payload;
+    }
+
+    @Override
+    public Long getTimestamp() {
+        return timestamp;
     }
 }

--- a/plugins/ingestion-kinesis/src/main/java/org/opensearch/plugin/kinesis/KinesisShardConsumer.java
+++ b/plugins/ingestion-kinesis/src/main/java/org/opensearch/plugin/kinesis/KinesisShardConsumer.java
@@ -234,7 +234,7 @@ public class KinesisShardConsumer implements IngestionShardConsumer<SequenceNumb
 
         for (Record record : records) {
             SequenceNumber sequenceNumber1 = new SequenceNumber(record.sequenceNumber());
-            KinesisMessage message = new KinesisMessage(record.data().asByteArray());
+            KinesisMessage message = new KinesisMessage(record.data().asByteArray(), record.approximateArrivalTimestamp().toEpochMilli());
             results.add(new ReadResult<>(sequenceNumber1, message));
         }
 

--- a/plugins/ingestion-kinesis/src/main/java/org/opensearch/plugin/kinesis/KinesisShardConsumer.java
+++ b/plugins/ingestion-kinesis/src/main/java/org/opensearch/plugin/kinesis/KinesisShardConsumer.java
@@ -234,7 +234,8 @@ public class KinesisShardConsumer implements IngestionShardConsumer<SequenceNumb
 
         for (Record record : records) {
             SequenceNumber sequenceNumber1 = new SequenceNumber(record.sequenceNumber());
-            KinesisMessage message = new KinesisMessage(record.data().asByteArray(), record.approximateArrivalTimestamp().toEpochMilli());
+            Long timestamp = record.approximateArrivalTimestamp() != null ? record.approximateArrivalTimestamp().toEpochMilli() : null;
+            KinesisMessage message = new KinesisMessage(record.data().asByteArray(), timestamp);
             results.add(new ReadResult<>(sequenceNumber1, message));
         }
 

--- a/plugins/ingestion-kinesis/src/test/java/org/opensearch/plugin/kinesis/KinesisMessageTests.java
+++ b/plugins/ingestion-kinesis/src/test/java/org/opensearch/plugin/kinesis/KinesisMessageTests.java
@@ -14,14 +14,16 @@ import org.junit.Assert;
 public class KinesisMessageTests extends OpenSearchTestCase {
     public void testConstructorAndGetters() {
         byte[] payload = { 1, 2, 3 };
-        KinesisMessage message = new KinesisMessage(payload);
+        KinesisMessage message = new KinesisMessage(payload, 1000L);
 
         Assert.assertArrayEquals("Payload should be correctly initialized and returned", payload, message.getPayload());
+        Assert.assertEquals(1000L, message.getTimestamp().longValue());
     }
 
     public void testConstructorWithNullPayload() {
-        KinesisMessage message = new KinesisMessage(null);
+        KinesisMessage message = new KinesisMessage(null, null);
 
         Assert.assertNull("Payload should be null", message.getPayload());
+        Assert.assertNull("Timestamp should be null", message.getTimestamp());
     }
 }

--- a/server/src/main/java/org/opensearch/index/Message.java
+++ b/server/src/main/java/org/opensearch/index/Message.java
@@ -16,4 +16,10 @@ import org.opensearch.common.annotation.ExperimentalApi;
 @ExperimentalApi
 public interface Message<T> {
     T getPayload();
+
+    /**
+     * Get the timestamp of the message in milliseconds
+     * @return the timestamp of the message
+     */
+    Long getTimestamp();
 }

--- a/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
+++ b/server/src/test/java/org/opensearch/index/engine/FakeIngestionSource.java
@@ -135,6 +135,11 @@ public class FakeIngestionSource {
         }
 
         @Override
+        public Long getTimestamp() {
+            return System.currentTimeMillis();
+        }
+
+        @Override
         public String toString() {
             return new String(payload, StandardCharsets.UTF_8);
         }

--- a/server/src/test/java/org/opensearch/indices/pollingingest/PollingIngestStatsTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/PollingIngestStatsTests.java
@@ -33,6 +33,8 @@ public class PollingIngestStatsTests extends OpenSearchTestCase {
             + stats.getMessageProcessorStats().totalSkippedCount()
             + "},\"consumer_stats\":{\"total_polled_count\":"
             + stats.getConsumerStats().totalPolledCount()
+            + ",\"lag_in_millis\":"
+            + stats.getConsumerStats().lagInMillis()
             + "}}}";
 
         assertEquals(expected, builder.toString());
@@ -56,6 +58,7 @@ public class PollingIngestStatsTests extends OpenSearchTestCase {
             .setTotalProcessedCount(randomNonNegativeLong())
             .setTotalSkippedCount(randomNonNegativeLong())
             .setTotalPolledCount(randomNonNegativeLong())
+            .setLagInMillis(randomNonNegativeLong())
             .build();
     }
 }


### PR DESCRIPTION
### Description
Emit lag metric for pull-based ingestion poller

Also update the API of message to return the timestamp of the message

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
