### PR TITLE
Resolve compile error in DefaultStreamPoller

### DIFF
--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -206,7 +206,7 @@ public class DefaultStreamPoller implements StreamPoller {
                     results = consumer.readNext(initialBatchStartPointer, true, maxPollSize, pollTimeout);
                     includeBatchStartPointer = false;
                 } else if (failedShardPointer != null) {
-                    results = consumer.readNext(failedShardPointer, true, MAX_POLL_SIZE, POLL_TIMEOUT);
+                    results = consumer.readNext(failedShardPointer, true, maxPollSize, pollTimeout);
                     failedShardPointer = null;
                 } else {
                     results = consumer.readNext(maxPollSize, pollTimeout);


### PR DESCRIPTION
### Description

There's a compile error due to the both change in the DefaultStreamPoller class in the latest 2 PRs https://github.com/opensearch-project/OpenSearch/pull/17995/files#diff-f8b0b74e29348e27ce7f607a570e6fe30656f008a5296f637597aad55edbb293R218 and https://github.com/opensearch-project/OpenSearch/pull/17995/files#diff-f8b0b74e29348e27ce7f607a570e6fe30656f008a5296f637597aad55edbb293R218, need to replace the two parameters with the local variables.

<img width="1164" alt="image" src="https://github.com/user-attachments/assets/759a500d-2cb3-499d-8eac-05eeafa425c4" />

### Related Issues
No issue.

### Check List
<del>- [ ] Functionality includes testing.
<del>- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
<del>- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
