### PR TITLE
Add remote to local pool change handling in TargetPoolAllocationDecider

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/WarmIndexSegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/WarmIndexSegmentReplicationIT.java
@@ -128,10 +128,7 @@ public class WarmIndexSegmentReplicationIT extends SegmentReplicationBaseIT {
 
     @Override
     public Settings indexSettings() {
-        return Settings.builder()
-            .put(super.indexSettings())
-            .put(IndexModule.INDEX_STORE_LOCALITY_SETTING.getKey(), IndexModule.DataLocalityType.PARTIAL.name())
-            .build();
+        return Settings.builder().put(super.indexSettings()).put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), true).build();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/OperationRouting.java
@@ -269,8 +269,7 @@ public class OperationRouting {
             }
 
             if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)
-                && IndexModule.DataLocalityType.PARTIAL.name()
-                    .equals(indexMetadataForShard.getSettings().get(IndexModule.INDEX_STORE_LOCALITY_SETTING.getKey()))
+                && indexMetadataForShard.getSettings().getAsBoolean(IndexModule.IS_WARM_INDEX_SETTING.getKey(), false)
                 && (preference == null || preference.isEmpty())) {
                 preference = Preference.PRIMARY_FIRST.type();
             }

--- a/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/OperationRoutingTests.java
@@ -1088,7 +1088,7 @@ public class OperationRoutingTests extends OpenSearchTestCase {
                 .settings(
                     Settings.builder()
                         .put(state.metadata().index(indexName).getSettings())
-                        .put(IndexModule.INDEX_STORE_LOCALITY_SETTING.getKey(), IndexModule.DataLocalityType.PARTIAL)
+                        .put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), true)
                         .build()
                 )
                 .build();

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/TieringAllocationBaseTestCase.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/TieringAllocationBaseTestCase.java
@@ -15,7 +15,6 @@ import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexModule;
 
-import static org.opensearch.index.IndexModule.INDEX_STORE_LOCALITY_SETTING;
 import static org.opensearch.index.IndexModule.INDEX_TIERING_STATE;
 
 @SuppressForbidden(reason = "feature flag overrides")
@@ -24,8 +23,9 @@ public abstract class TieringAllocationBaseTestCase extends RemoteShardsBalancer
     public ClusterState updateIndexMetadataForTiering(
         ClusterState clusterState,
         int localIndices,
+        int remoteIndices,
         String tieringState,
-        String dataLocality
+        boolean isWarmIndex
     ) {
         Metadata.Builder mb = Metadata.builder(clusterState.metadata());
         for (int i = 0; i < localIndices; i++) {
@@ -38,8 +38,21 @@ public abstract class TieringAllocationBaseTestCase extends RemoteShardsBalancer
                             .put(settings)
                             .put(settings)
                             .put(INDEX_TIERING_STATE.getKey(), tieringState)
-                            .put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), true)
-                            .put(INDEX_STORE_LOCALITY_SETTING.getKey(), dataLocality)
+                            .put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), isWarmIndex)
+                    )
+            );
+        }
+        for (int i = 0; i < remoteIndices; i++) {
+            IndexMetadata indexMetadata = clusterState.metadata().index(getIndexName(i, true));
+            Settings settings = indexMetadata.getSettings();
+            mb.put(
+                IndexMetadata.builder(indexMetadata)
+                    .settings(
+                        Settings.builder()
+                            .put(settings)
+                            .put(settings)
+                            .put(INDEX_TIERING_STATE.getKey(), tieringState)
+                            .put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), isWarmIndex)
                     )
             );
         }

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/TargetPoolAllocationDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/TargetPoolAllocationDeciderTests.java
@@ -113,7 +113,7 @@ public class TargetPoolAllocationDeciderTests extends RemoteShardsBalancerBaseTe
     }
 
     public void testTargetPoolDedicatedSearchNodeAllocationDecisions() {
-        ClusterState clusterState = createInitialCluster(3, 3, true, 2, 2);
+        ClusterState clusterState = createInitialCluster(3, 3, true, 2, 2, false);
         AllocationService service = this.createRemoteCapableAllocationService();
         clusterState = allocateShardsAndBalance(clusterState, service);
 
@@ -202,7 +202,7 @@ public class TargetPoolAllocationDeciderTests extends RemoteShardsBalancerBaseTe
     }
 
     public void testDebugMessage() {
-        ClusterState clusterState = createInitialCluster(3, 3, true, 2, 2);
+        ClusterState clusterState = createInitialCluster(3, 3, true, 2, 2, false);
         AllocationService service = this.createRemoteCapableAllocationService();
         clusterState = allocateShardsAndBalance(clusterState, service);
 


### PR DESCRIPTION
This PR adds following changes.
- Changes in TargetPoolAllocationDecider - If shards exists in REMOTE_POOL node and shard pool changes for these shards. Decider should make sure these can no longer remain on the REMOTE_POOL nodes.
- Changed INDEX_STORE_LOCALITY_SETTING setting occurrences to IS_WARM_INDEX setting 

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
