### PR TITLE
Ignore 3.0 branch for breaking changes check

### DIFF
--- a/.github/workflows/detect-breaking-change.yml
+++ b/.github/workflows/detect-breaking-change.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches-ignore:
       - main # This branch represents a to-be-released version of OpenSearch where breaking changes are allowed
+      - '3.0' # We must establish a baseline 3.0 release version before adding enforcement
 
 jobs:
   detect-breaking-change:
@@ -26,4 +27,3 @@ jobs:
       with:
         name: java-compatibility-report.html
         path: ${{ github.workspace }}/server/build/reports/java-compatibility/report.html
-  


### PR DESCRIPTION
We'll need to come back and update this after the 3.0 release but for now we should not be enforcing breaking changes against 3.0.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
