### PR TITLE
Update JavaVersionChecker to enforce min of JDK21

### DIFF
--- a/distribution/tools/java-version-checker/src/main/java/org/opensearch/tools/java_version_checker/JavaVersionChecker.java
+++ b/distribution/tools/java-version-checker/src/main/java/org/opensearch/tools/java_version_checker/JavaVersionChecker.java
@@ -37,14 +37,14 @@ import java.util.Arrays;
 import java.util.Locale;
 
 /**
- * Simple program that checks if the runtime Java version is at least 11
+ * Simple program that checks if the runtime Java version is at least 21
  */
 final class JavaVersionChecker {
 
     private JavaVersionChecker() {}
 
     /**
-     * The main entry point. The exit code is 0 if the Java version is at least 11, otherwise the exit code is 1.
+     * The main entry point. The exit code is 0 if the Java version is at least 21, otherwise the exit code is 1.
      *
      * @param args the args to the program which are rejected if not empty
      */
@@ -53,10 +53,10 @@ final class JavaVersionChecker {
         if (args.length != 0) {
             throw new IllegalArgumentException("expected zero arguments but was " + Arrays.toString(args));
         }
-        if (Runtime.version().compareTo(Version.parse("11")) < 0) {
+        if (Runtime.version().compareTo(Version.parse("21")) < 0) {
             final String message = String.format(
                 Locale.ROOT,
-                "OpenSearch requires Java 11; your Java version from [%s] does not meet this requirement",
+                "OpenSearch requires Java 21; your Java version from [%s] does not meet this requirement",
                 System.getProperty("java.home")
             );
             errPrintln(message);


### PR DESCRIPTION
Manually tested this:

```
% JAVA_HOME=~/.sdkman/candidates/java/11.0.27-tem ./bin/opensearch
OpenJDK 64-Bit Server VM warning: Shared spaces are not supported in this VM
OpenSearch requires Java 21; your Java version from [/Users/andrross/.sdkman/candidates/java/11.0.27-tem] does not meet this requirement
```

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
