### PR TITLE
Increase Kafka topic polling time in test to 10 seconds

### DIFF
--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaUtils.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaUtils.java
@@ -53,19 +53,16 @@ public class KafkaUtils {
         }
 
         // validates topic is created
-        await().atMost(3, TimeUnit.SECONDS).until(() -> checkTopicExistence(topicName, bootstrapServers));
+        await().atMost(10, TimeUnit.SECONDS).until(() -> checkTopicExistence(topicName, bootstrapServers));
     }
 
     public static boolean checkTopicExistence(String topicName, String bootstrapServers) {
         return getAdminClient(bootstrapServers, (client -> {
-            Map<String, KafkaFuture<TopicDescription>> topics = client.describeTopics(List.of(topicName)).values();
+            Map<String, KafkaFuture<TopicDescription>> topics = client.describeTopics(List.of(topicName)).topicNameValues();
 
             try {
                 return topics.containsKey(topicName) && topics.get(topicName).get().name().equals(topicName);
-            } catch (InterruptedException e) {
-                LOGGER.error("error on checkTopicExistence", e);
-                return false;
-            } catch (ExecutionException e) {
+            } catch (InterruptedException | ExecutionException e) {
                 LOGGER.error("error on checkTopicExistence", e);
                 return false;
             }
@@ -73,13 +70,12 @@ public class KafkaUtils {
     }
 
     private static <Rep> Rep getAdminClient(String bootstrapServer, Function<AdminClient, Rep> function) {
-        AdminClient adminClient = KafkaAdminClient.create(
-            Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer, AdminClientConfig.CLIENT_ID_CONFIG, "test")
-        );
-        try {
+        try (
+            AdminClient adminClient = KafkaAdminClient.create(
+                Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer, AdminClientConfig.CLIENT_ID_CONFIG, "test")
+            )
+        ) {
             return function.apply(adminClient);
-        } finally {
-            adminClient.close();
         }
     }
 }


### PR DESCRIPTION
We've seen multiple failures where the 3 second timeout was breached. This happens in the test setup of many different tests so multiple individual test failures have been reported.

Also replace deprecated method in Kafka API and simplify a couple other code paths.

Resolves #17215

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
