### PR TITLE
[Backport 3.0] Unset discovery nodes for every transport node actions request (#17682)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.x]
 ### Added
 - Add multi-threaded writer support in pull-based ingestion ([#17912](https://github.com/opensearch-project/OpenSearch/pull/17912))
+- Unset discovery nodes for every transport node actions request ([#17682](https://github.com/opensearch-project/OpenSearch/pull/17682))
 
 ### Changed
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
@@ -70,7 +70,7 @@ public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequ
      * threads for all nodes is used.
      */
     public NodesHotThreadsRequest(String... nodesIds) {
-        super(false, nodesIds);
+        super(nodesIds);
     }
 
     public int threads() {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -72,7 +72,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * for all nodes will be returned.
      */
     public NodesInfoRequest(String... nodesIds) {
-        super(false, nodesIds);
+        super(nodesIds);
         defaultMetrics();
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsRequest.java
@@ -60,7 +60,7 @@ public class NodesReloadSecureSettingsRequest extends BaseNodesRequest<NodesRelo
     private SecureString secureSettingsPassword;
 
     public NodesReloadSecureSettingsRequest() {
-        super(true, (String[]) null);
+        super((String[]) null);
     }
 
     public NodesReloadSecureSettingsRequest(StreamInput in) throws IOException {
@@ -84,7 +84,7 @@ public class NodesReloadSecureSettingsRequest extends BaseNodesRequest<NodesRelo
      * nodes.
      */
     public NodesReloadSecureSettingsRequest(String... nodesIds) {
-        super(true, nodesIds);
+        super(nodesIds);
     }
 
     @Nullable

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -58,7 +58,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
     private final Set<String> requestedMetrics = new HashSet<>();
 
     public NodesStatsRequest() {
-        super(false, (String[]) null);
+        super((String[]) null);
     }
 
     public NodesStatsRequest(StreamInput in) throws IOException {
@@ -74,7 +74,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
      * for all nodes will be returned.
      */
     public NodesStatsRequest(String... nodesIds) {
-        super(false, nodesIds);
+        super(nodesIds);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/usage/NodesUsageRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/usage/NodesUsageRequest.java
@@ -61,7 +61,7 @@ public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
      * passed, usage for all nodes will be returned.
      */
     public NodesUsageRequest(String... nodesIds) {
-        super(false, nodesIds);
+        super(nodesIds);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -161,7 +161,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
         }
 
         public Request(String[] nodesIds) {
-            super(false, nodesIds);
+            super(nodesIds);
         }
 
         public Request snapshots(Snapshot[] snapshots) {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/stats/ClusterStatsRequest.java
@@ -83,7 +83,7 @@ public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
      * based on all nodes will be returned.
      */
     public ClusterStatsRequest(String... nodesIds) {
-        super(false, nodesIds);
+        super(nodesIds);
     }
 
     public boolean useAggregatedNodeLevelResponses() {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/wlm/WlmStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/wlm/WlmStatsRequest.java
@@ -37,13 +37,13 @@ public class WlmStatsRequest extends BaseNodesRequest<WlmStatsRequest> {
      * for all nodes will be returned.
      */
     public WlmStatsRequest(String[] nodesIds, Set<String> workloadGroupIds, Boolean breach) {
-        super(false, nodesIds);
+        super(nodesIds);
         this.workloadGroupIds = workloadGroupIds;
         this.breach = breach;
     }
 
     public WlmStatsRequest() {
-        super(false, (String[]) null);
+        super((String[]) null);
         workloadGroupIds = new HashSet<>();
         this.breach = false;
     }

--- a/server/src/main/java/org/opensearch/action/admin/indices/dangling/find/FindDanglingIndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/dangling/find/FindDanglingIndexRequest.java
@@ -53,7 +53,7 @@ public class FindDanglingIndexRequest extends BaseNodesRequest<FindDanglingIndex
     }
 
     public FindDanglingIndexRequest(String indexUUID) {
-        super(false, Strings.EMPTY_ARRAY);
+        super(Strings.EMPTY_ARRAY);
         this.indexUUID = indexUUID;
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/dangling/list/ListDanglingIndicesRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/dangling/list/ListDanglingIndicesRequest.java
@@ -58,12 +58,12 @@ public class ListDanglingIndicesRequest extends BaseNodesRequest<ListDanglingInd
     }
 
     public ListDanglingIndicesRequest() {
-        super(false, Strings.EMPTY_ARRAY);
+        super(Strings.EMPTY_ARRAY);
         this.indexUUID = null;
     }
 
     public ListDanglingIndicesRequest(String indexUUID) {
-        super(false, Strings.EMPTY_ARRAY);
+        super(Strings.EMPTY_ARRAY);
         this.indexUUID = indexUUID;
     }
 

--- a/server/src/main/java/org/opensearch/action/search/GetAllPitNodesRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/GetAllPitNodesRequest.java
@@ -27,7 +27,7 @@ public class GetAllPitNodesRequest extends BaseNodesRequest<GetAllPitNodesReques
 
     @Inject
     public GetAllPitNodesRequest(DiscoveryNode... concreteNodes) {
-        super(false, concreteNodes);
+        super(concreteNodes);
     }
 
     public GetAllPitNodesRequest(StreamInput in) throws IOException {

--- a/server/src/main/java/org/opensearch/action/support/nodes/BaseNodesRequest.java
+++ b/server/src/main/java/org/opensearch/action/support/nodes/BaseNodesRequest.java
@@ -63,16 +63,11 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
     /**
      * once {@link #nodesIds} are resolved this will contain the concrete nodes that are part of this request. If set, {@link #nodesIds}
      * will be ignored and this will be used.
-     * */
+     * <p>
+     * Note: concreteNodes when accessed by transport actions will be null.
+     * See {@link TransportNodesAction.AsyncAction#AsyncAction}
+     **/
     private DiscoveryNode[] concreteNodes;
-
-    /**
-     * Since do not use the discovery nodes coming from the request in all code paths following a request extended off from
-     * BaseNodeRequest, we do not require it to sent around across all nodes.
-     *
-     * Setting default behavior as `true` but can be explicitly changed in requests that do not require.
-     */
-    private boolean includeDiscoveryNodes = true;
 
     private final TimeValue DEFAULT_TIMEOUT_SECS = TimeValue.timeValueSeconds(30);
 
@@ -89,20 +84,9 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
         this.nodesIds = nodesIds;
     }
 
-    protected BaseNodesRequest(boolean includeDiscoveryNodes, String... nodesIds) {
-        this.nodesIds = nodesIds;
-        this.includeDiscoveryNodes = includeDiscoveryNodes;
-    }
-
     protected BaseNodesRequest(DiscoveryNode... concreteNodes) {
         this.nodesIds = null;
         this.concreteNodes = concreteNodes;
-    }
-
-    protected BaseNodesRequest(boolean includeDiscoveryNodes, DiscoveryNode... concreteNodes) {
-        this.nodesIds = null;
-        this.concreteNodes = concreteNodes;
-        this.includeDiscoveryNodes = includeDiscoveryNodes;
     }
 
     public final String[] nodesIds() {
@@ -137,10 +121,6 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
 
     public void setConcreteNodes(DiscoveryNode[] concreteNodes) {
         this.concreteNodes = concreteNodes;
-    }
-
-    public boolean getIncludeDiscoveryNodes() {
-        return includeDiscoveryNodes;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/opensearch/action/support/nodes/TransportNodesAction.java
@@ -240,12 +240,10 @@ public abstract class TransportNodesAction<
             }
             this.responses = new AtomicReferenceArray<>(request.concreteNodes().length);
             this.concreteNodes = request.concreteNodes();
-            if (request.getIncludeDiscoveryNodes() == false) {
-                // As we transfer the ownership of discovery nodes to route the request to into the AsyncAction class,
-                // we remove the list of DiscoveryNodes from the request. This reduces the payload of the request and improves
-                // the number of concrete nodes in the memory.
-                request.setConcreteNodes(null);
-            }
+            // As we transfer the ownership of discovery nodes to route the request to into the AsyncAction class,
+            // we remove the list of DiscoveryNodes from the request. This reduces the payload of the request and improves
+            // the number of concrete nodes in the memory.
+            request.setConcreteNodes(null);
         }
 
         void start() {

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayMetaState.java
@@ -133,7 +133,7 @@ public class TransportNodesListGatewayMetaState extends TransportNodesAction<
         }
 
         public Request(String... nodesIds) {
-            super(false, nodesIds);
+            super(nodesIds);
         }
     }
 

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -197,7 +197,7 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
         }
 
         public Request(ShardId shardId, String customDataPath, DiscoveryNode[] nodes) {
-            super(false, nodes);
+            super(nodes);
             this.shardId = Objects.requireNonNull(shardId);
             this.customDataPath = Objects.requireNonNull(customDataPath);
         }

--- a/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayStartedShardsBatch.java
+++ b/server/src/main/java/org/opensearch/gateway/TransportNodesListGatewayStartedShardsBatch.java
@@ -182,7 +182,7 @@ public class TransportNodesListGatewayStartedShardsBatch extends TransportNodesA
         }
 
         public Request(DiscoveryNode[] nodes, Map<ShardId, ShardAttributes> shardAttributes) {
-            super(false, nodes);
+            super(nodes);
             this.shardAttributes = Objects.requireNonNull(shardAttributes);
         }
 

--- a/server/src/main/java/org/opensearch/indices/store/TransportNodesListShardStoreMetadata.java
+++ b/server/src/main/java/org/opensearch/indices/store/TransportNodesListShardStoreMetadata.java
@@ -176,7 +176,7 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         }
 
         public Request(ShardId shardId, String customDataPath, DiscoveryNode[] nodes) {
-            super(false, nodes);
+            super(nodes);
             this.shardId = Objects.requireNonNull(shardId);
             this.customDataPath = Objects.requireNonNull(customDataPath);
         }

--- a/server/src/main/java/org/opensearch/indices/store/TransportNodesListShardStoreMetadataBatch.java
+++ b/server/src/main/java/org/opensearch/indices/store/TransportNodesListShardStoreMetadataBatch.java
@@ -188,7 +188,7 @@ public class TransportNodesListShardStoreMetadataBatch extends TransportNodesAct
         }
 
         public Request(Map<ShardId, ShardAttributes> shardAttributes, DiscoveryNode[] nodes) {
-            super(false, nodes);
+            super(nodes);
             this.shardAttributes = Objects.requireNonNull(shardAttributes);
         }
 

--- a/server/src/test/java/org/opensearch/action/support/nodes/TransportNodesActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/nodes/TransportNodesActionTests.java
@@ -168,25 +168,9 @@ public class TransportNodesActionTests extends OpenSearchTestCase {
         assertEquals(clusterService.state().nodes().getDataNodes().size(), capturedRequests.size());
     }
 
-    public void testTransportNodesActionWithDiscoveryNodesIncluded() {
-        String[] nodeIds = clusterService.state().nodes().getNodes().keySet().toArray(new String[0]);
-        TestNodesRequest request = new TestNodesRequest(true, nodeIds);
-        getTestTransportNodesAction().new AsyncAction(null, request, new PlainActionFuture<>()).start();
-        Map<String, List<CapturingTransport.CapturedRequest>> capturedRequests = transport.getCapturedRequestsByTargetNodeAndClear();
-        List<TestNodeRequest> capturedTransportNodeRequestList = capturedRequests.values()
-            .stream()
-            .flatMap(Collection::stream)
-            .map(capturedRequest -> (TestNodeRequest) capturedRequest.request)
-            .collect(Collectors.toList());
-        assertEquals(nodeIds.length, capturedTransportNodeRequestList.size());
-        capturedTransportNodeRequestList.forEach(
-            capturedRequest -> assertEquals(nodeIds.length, capturedRequest.testNodesRequest.concreteNodes().length)
-        );
-    }
-
     public void testTransportNodesActionWithDiscoveryNodesReset() {
         String[] nodeIds = clusterService.state().nodes().getNodes().keySet().toArray(new String[0]);
-        TestNodesRequest request = new TestNodesRequest(false, nodeIds);
+        TestNodesRequest request = new TestNodesRequest(nodeIds);
         getTestTransportNodesAction().new AsyncAction(null, request, new PlainActionFuture<>()).start();
         Map<String, List<CapturingTransport.CapturedRequest>> capturedRequests = transport.getCapturedRequestsByTargetNodeAndClear();
         List<TestNodeRequest> capturedTransportNodeRequestList = capturedRequests.values()
@@ -388,10 +372,6 @@ public class TransportNodesActionTests extends OpenSearchTestCase {
 
         TestNodesRequest(String... nodesIds) {
             super(nodesIds);
-        }
-
-        TestNodesRequest(boolean includeDiscoveryNodes, String... nodesIds) {
-            super(includeDiscoveryNodes, nodesIds);
         }
     }
 


### PR DESCRIPTION
### Description
Unset discovery nodes for every transport node actions request (#17682)
- Backporting #17682 to 3.0

### Related Issues
Resolves #17008 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
