### PR TITLE
[Enhancement] Optimize Merge On KNN Field when soft_delete mode

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -2346,7 +2346,7 @@ public class InternalEngine extends Engine {
             new SoftDeletesRetentionMergePolicy(
                 Lucene.SOFT_DELETES_FIELD,
                 softDeletesPolicy::getRetentionQuery,
-                new PrunePostingsMergePolicy(mergePolicy, IdFieldMapper.NAME)
+                new PrunePostingsAndKnnMergePolicy(mergePolicy, IdFieldMapper.NAME)
             )
         );
         boolean shuffleForcedMerge = Booleans.parseBoolean(System.getProperty("opensearch.shuffle_forced_merge", Boolean.TRUE.toString()));

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -1782,7 +1782,7 @@ public class InternalEngineTests extends EngineTestCase {
                         new SoftDeletesRetentionMergePolicy(
                             Lucene.SOFT_DELETES_FIELD,
                             MatchAllDocsQuery::new,
-                            new PrunePostingsMergePolicy(indexWriterConfig.getMergePolicy(), "_id")
+                            new PrunePostingsAndKnnMergePolicy(indexWriterConfig.getMergePolicy(), "_id")
                         )
                     )
                 )


### PR DESCRIPTION
### Description
[Describe what this change achieves]
when #1933 and #2077, OpenSearch always use soft deletes. but it would bring some performance drops.

OpenSearch K-NN would use `KNN80BinaryDocValues` with native engine and `KNNVectorValues` with lucene engine. 

I found some scenarios as followings:

in some update scenarios, like index 10000 docs, and update/delete 60% docs, in one segment. 
and then happens merge tasks. nativeEngine would merge all docs including deleted docs because of soft_delete mode.

but we do not want to do heavy construct HNSW graph which is a CPU consuming tasks. and merge task take a very long time to index useless docs.

so i think we can skip this soft_delete docs at merge and it can optimize merge and index time obviously 30% at out benchmarks


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
