### PR TITLE
Mute ClusterMaxMergesAtOnceIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/ClusterMaxMergesAtOnceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/ClusterMaxMergesAtOnceIT.java
@@ -64,6 +64,7 @@ public class ClusterMaxMergesAtOnceIT extends AbstractSnapshotIntegTestCase {
         internalCluster().startClusterManagerOnlyNode();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/18056")
     public void testClusterLevelDefaultUpdatesMergePolicy() throws ExecutionException, InterruptedException {
         String clusterManagerName = internalCluster().getClusterManagerName();
         List<String> dataNodes = new ArrayList<>(internalCluster().getDataNodeNames());


### PR DESCRIPTION
### Related Issues
Related to #18056

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
