### PR TITLE
Set Java version to 21 for use in bwc tests

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -14,7 +14,7 @@
 # are 'java' or 'openjdk' followed by the major release number.
 
 # See please https://docs.gradle.org/8.10/userguide/upgrading_version_8.html#minimum_daemon_jvm_version
-OPENSEARCH_BUILD_JAVA=openjdk17
-OPENSEARCH_RUNTIME_JAVA=java11
+OPENSEARCH_BUILD_JAVA=openjdk21
+OPENSEARCH_RUNTIME_JAVA=java21
 GRADLE_TASK=build
 GRADLE_EXTRA_ARGS=


### PR DESCRIPTION
My understanding is that BwcSetupExtension.java uses this Java version to compile this code when another branch checks out this branch to use in backward compatibility tests. This needs to be JDK21 in order for this code to compile correctly.

I believe #18043 is failing because this version is wrong.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
