### PR TITLE
Increased the scope of File Interceptor to intercept methods from FileSystemProvider.class

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchTestBasePlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchTestBasePlugin.java
@@ -166,7 +166,7 @@ public class OpenSearchTestBasePlugin implements Plugin<Project> {
                 "java.security.properties",
                 project.getRootProject().getLayout().getProjectDirectory() + "/distribution/src/config/" + securityFile
             );
-
+            nonInputProperties.systemProperty("project.integTest.dir", project.getBuildDir().toPath().resolve("testclusters"));
             // don't track these as inputs since they contain absolute paths and break cache relocatability
             File gradleHome = project.getGradle().getGradleUserHomeDir();
             String gradleVersion = project.getGradle().getGradleVersion();

--- a/libs/agent-sm/agent-policy/src/main/java/org/opensearch/secure_sm/policy/PolicyFile.java
+++ b/libs/agent-sm/agent-policy/src/main/java/org/opensearch/secure_sm/policy/PolicyFile.java
@@ -137,7 +137,13 @@ public class PolicyFile extends java.security.Policy {
         while ((b = pe.name().indexOf("${{", startIndex)) != -1 && (e = pe.name().indexOf("}}", b)) != -1) {
             sb.append(pe.name(), startIndex, b);
             String value = pe.name().substring(b + 3, e);
-            sb.append("${{").append(value).append("}}");
+            String propertyValue = System.getProperty(value);
+            if (propertyValue != null) {
+                sb.append(propertyValue);
+            } else {
+                // replacement not found
+                sb.append("${{").append(value).append("}}");
+            }
             startIndex = e + 2;
         }
 

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/Agent.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/Agent.java
@@ -15,6 +15,7 @@ import java.net.Socket;
 import java.nio.channels.FileChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
+import java.nio.file.spi.FileSystemProvider;
 import java.util.Map;
 
 import net.bytebuddy.ByteBuddy;
@@ -77,6 +78,7 @@ public class Agent {
             .or(ElementMatchers.isSubTypeOf(Socket.class));
         final Junction<TypeDescription> pathType = ElementMatchers.isSubTypeOf(Files.class);
         final Junction<TypeDescription> fileChannelType = ElementMatchers.isSubTypeOf(FileChannel.class);
+        final Junction<TypeDescription> fileSystemProviderType = ElementMatchers.isSubTypeOf(FileSystemProvider.class);
 
         final AgentBuilder.Transformer socketTransformer = (b, typeDescription, classLoader, module, pd) -> b.visit(
             Advice.to(SocketChannelInterceptor.class)
@@ -106,7 +108,7 @@ public class Agent {
             .ignore(ElementMatchers.nameContains("$MockitoMock$")) /* ingore all Mockito mocks */
             .type(socketType)
             .transform(socketTransformer)
-            .type(pathType.or(fileChannelType))
+            .type(pathType.or(fileChannelType).or(fileSystemProviderType))
             .transform(fileTransformer)
             .type(ElementMatchers.is(java.lang.System.class))
             .transform(

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
@@ -8,8 +8,6 @@
 
 package org.opensearch.javaagent;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.javaagent.bootstrap.AgentPolicy;
 
 import java.io.FilePermission;
@@ -31,8 +29,6 @@ import net.bytebuddy.asm.Advice;
  * FileInterceptor
  */
 public class FileInterceptor {
-    private static final Logger logger = LogManager.getLogger(FileInterceptor.class);
-
     /**
      * FileInterceptor
      */

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
@@ -111,7 +111,7 @@ public class FileInterceptor {
                                 }
                             }
                         } else {
-                            logger.warn("Unknown type: {} for args[1] for method name: {}", args[1].getClass(), method.getName());
+                            throw new SecurityException("Unsupported argument type: " + args[1].getClass().getName());
                         }
                     }
                 } else if (name.equals("copy") == true) {

--- a/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
+++ b/libs/agent-sm/agent/src/main/java/org/opensearch/javaagent/FileInterceptor.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.javaagent;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.javaagent.bootstrap.AgentPolicy;
 
 import java.io.FilePermission;
@@ -29,6 +31,8 @@ import net.bytebuddy.asm.Advice;
  * FileInterceptor
  */
 public class FileInterceptor {
+    private static final Logger logger = LogManager.getLogger(FileInterceptor.class);
+
     /**
      * FileInterceptor
      */
@@ -103,8 +107,15 @@ public class FileInterceptor {
                                     break;
                                 }
                             }
+                        } else if (args[1] instanceof Object[] opts) {
+                            for (final Object opt : opts) {
+                                if (opt != StandardOpenOption.READ) {
+                                    isMutating = true;
+                                    break;
+                                }
+                            }
                         } else {
-                            //Add a Warn statement for any other type or args we might be missing
+                            logger.warn("Unknown type: {} for args[1] for method name: {}", args[1].getClass(), method.getName());
                         }
                     }
                 } else if (name.equals("copy") == true) {

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorNegativeIntegTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorNegativeIntegTests.java
@@ -54,8 +54,6 @@ public class FileInterceptorNegativeIntegTests {
     @Test
     public void testFileInputStream() {
         Path tmpDir = getTestDir();
-        assertTrue("Tmp directory should exist", Files.exists(tmpDir));
-        assertTrue("Tmp directory should be writable", Files.isWritable(tmpDir));
 
         // Create a unique file name
         String fileName = "test-" + randomAlphaOfLength(8) + ".txt";
@@ -72,8 +70,6 @@ public class FileInterceptorNegativeIntegTests {
     @Test
     public void testOpenForReadAndWrite() {
         Path tmpDir = getTestDir();
-        assertTrue("Tmp directory should exist", Files.exists(tmpDir));
-        assertTrue("Tmp directory should be writable", Files.isWritable(tmpDir));
 
         // Create a unique file name
         String fileName = "test-" + randomAlphaOfLength(8) + ".txt";
@@ -146,7 +142,8 @@ public class FileInterceptorNegativeIntegTests {
 
         // Verify Error when reading file
         SecurityException exception = assertThrows(SecurityException.class, () -> Files.readAllLines(tempPath));
-        assertTrue(exception.getMessage().contains("Denied READ access to file"));
+        System.out.println(exception);
+        assertTrue(exception.getMessage().contains("Denied OPEN (read) access to file"));
     }
 
     @Test

--- a/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorNegativeIntegTests.java
+++ b/libs/agent-sm/agent/src/test/java/org/opensearch/javaagent/FileInterceptorNegativeIntegTests.java
@@ -1,0 +1,161 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.javaagent;
+
+import org.opensearch.javaagent.bootstrap.AgentPolicy;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.security.PermissionCollection;
+import java.security.Permissions;
+import java.security.Policy;
+import java.security.ProtectionDomain;
+import java.util.UUID;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("removal")
+public class FileInterceptorNegativeIntegTests {
+    private static Path getTestDir() {
+        Path baseDir = Path.of(System.getProperty("user.dir"));
+        Path integTestFiles = baseDir.resolve("integ-test-files").normalize();
+        return integTestFiles;
+    }
+
+    private String randomAlphaOfLength(int length) {
+        // Using UUID to generate random string and taking first 'length' characters
+        return UUID.randomUUID().toString().replaceAll("-", "").substring(0, length);
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Policy policy = new Policy() {
+            @Override
+            public PermissionCollection getPermissions(ProtectionDomain domain) {
+                Permissions permissions = new Permissions();
+                return permissions;
+            }
+        };
+        AgentPolicy.setPolicy(policy);
+    }
+
+    @Test
+    public void testFileInputStream() {
+        Path tmpDir = getTestDir();
+        assertTrue("Tmp directory should exist", Files.exists(tmpDir));
+        assertTrue("Tmp directory should be writable", Files.isWritable(tmpDir));
+
+        // Create a unique file name
+        String fileName = "test-" + randomAlphaOfLength(8) + ".txt";
+        Path tempPath = tmpDir.resolve(fileName);
+
+        // Verify error when writing Content
+        String content = "test content";
+        SecurityException exception = assertThrows("", SecurityException.class, () -> {
+            Files.write(tempPath, content.getBytes(StandardCharsets.UTF_8));
+        });
+        assertTrue(exception.getMessage().contains("Denied WRITE access to file"));
+    }
+
+    @Test
+    public void testOpenForReadAndWrite() {
+        Path tmpDir = getTestDir();
+        assertTrue("Tmp directory should exist", Files.exists(tmpDir));
+        assertTrue("Tmp directory should be writable", Files.isWritable(tmpDir));
+
+        // Create a unique file name
+        String fileName = "test-" + randomAlphaOfLength(8) + ".txt";
+        Path tempPath = tmpDir.resolve(fileName);
+
+        // Verify error when opening file
+        SecurityException exception = assertThrows("", SecurityException.class, () -> {
+            FileChannel.open(tempPath, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+        });
+        assertTrue(exception.getMessage().contains("Denied OPEN (read/write) access to file"));
+    }
+
+    @Test
+    public void testCopy() {
+        Path tmpDir = getTestDir();
+        Path sourcePath = tmpDir.resolve("test-source-" + randomAlphaOfLength(8) + ".txt");
+        Path targetPath = tmpDir.resolve("test-target-" + randomAlphaOfLength(8) + ".txt");
+
+        // Verify Error when copying file
+        SecurityException exception = assertThrows(SecurityException.class, () -> Files.copy(sourcePath, targetPath));
+        assertTrue(exception.getMessage().contains("Denied COPY (read) access to file"));
+    }
+
+    @Test
+    public void testCreateFile() {
+        Path tmpDir = getTestDir();
+        Path tempPath = tmpDir.resolve("test-create-" + randomAlphaOfLength(8) + ".txt");
+
+        // Verify Error when creating file
+        SecurityException exception = assertThrows(SecurityException.class, () -> Files.createFile(tempPath));
+        assertTrue(exception.getMessage().contains("Denied WRITE access to file"));
+    }
+
+    @Test
+    public void testMove() {
+        Path tmpDir = getTestDir();
+        Path sourcePath = tmpDir.resolve("test-source-" + randomAlphaOfLength(8) + ".txt");
+        Path targetPath = tmpDir.resolve("test-target-" + randomAlphaOfLength(8) + ".txt");
+
+        // Verify Error when moving file
+        SecurityException exception = assertThrows(SecurityException.class, () -> Files.move(sourcePath, targetPath));
+        assertTrue(exception.getMessage().contains("Denied WRITE access to file"));
+    }
+
+    @Test
+    public void testCreateLink() throws Exception {
+        Path tmpDir = getTestDir();
+        Path originalPath = tmpDir.resolve("test-original-" + randomAlphaOfLength(8) + ".txt");
+        Path linkPath = tmpDir.resolve("test-link-" + randomAlphaOfLength(8) + ".txt");
+
+        // Verify Error when creating link
+        SecurityException exception = assertThrows(SecurityException.class, () -> Files.createLink(linkPath, originalPath));
+        assertTrue(exception.getMessage().contains("Denied WRITE access to file"));
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        Path tmpDir = getTestDir();
+        Path tempPath = tmpDir.resolve("test-delete-" + randomAlphaOfLength(8) + ".txt");
+
+        // Verify Error when deleting file
+        SecurityException exception = assertThrows(SecurityException.class, () -> Files.delete(tempPath));
+        assertTrue(exception.getMessage().contains("Denied DELETE access to file"));
+    }
+
+    @Test
+    public void testReadAllLines() throws Exception {
+        Path tmpDir = getTestDir();
+        Path tempPath = tmpDir.resolve("test-readAllLines-" + randomAlphaOfLength(8) + ".txt");
+
+        // Verify Error when reading file
+        SecurityException exception = assertThrows(SecurityException.class, () -> Files.readAllLines(tempPath));
+        assertTrue(exception.getMessage().contains("Denied READ access to file"));
+    }
+
+    @Test
+    public void testNewOutputStream() throws Exception {
+        Path tmpDir = getTestDir();
+        Path tempPath = tmpDir.resolve("test-readAllLines-" + randomAlphaOfLength(8) + ".txt");
+
+        // Verify error when calling newOutputStream
+        SecurityException exception = assertThrows(SecurityException.class, () -> Files.newOutputStream(tempPath));
+        assertTrue(exception.getMessage().contains("Denied OPEN (read/write) access to file"));
+    }
+}

--- a/server/src/main/resources/org/opensearch/bootstrap/test-framework.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/test-framework.policy
@@ -170,6 +170,7 @@ grant codeBase "file:${gradle.worker.jar}" {
 grant {
   // since the gradle test worker jar is on the test classpath, our tests should be able to read it
   permission java.io.FilePermission "${gradle.worker.jar}", "read";
+  permission java.io.FilePermission "${{project.integTest.dir}}/-", "read";
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   permission java.lang.RuntimePermission "reflectionFactoryAccess";
   permission java.lang.RuntimePermission "accessClassInPackage.sun.reflect";


### PR DESCRIPTION
### Description
Increased the scope of File Interceptor to intercept methods from FileSystemProvider.class, as newByteChannel is currently not being intercepted.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
