### PR TITLE
Fix race condition in SearchOnlyReplicaIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/settings/SearchOnlyReplicaIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/settings/SearchOnlyReplicaIT.java
@@ -152,10 +152,15 @@ public class SearchOnlyReplicaIT extends RemoteStoreBaseIntegTestCase {
         String searchNode = internalCluster().startSearchOnlyNode();
         ensureGreen(TEST_INDEX);
         // Restart Search Node
-        internalCluster().restartNode(searchNode);
-        // Ensure search shard is unassigned
-        ensureYellowAndNoInitializingShards(TEST_INDEX);
-        assertActiveSearchShards(0);
+        internalCluster().restartNode(searchNode, new InternalTestCluster.RestartCallback() {
+            @Override
+            public Settings onNodeStopped(String nodeName) throws Exception {
+                // Ensure search shard is unassigned
+                ensureYellowAndNoInitializingShards(TEST_INDEX);
+                assertActiveSearchShards(0);
+                return super.onNodeStopped(nodeName);
+            }
+        });
         // Ensure search shard is recovered
         ensureGreen(TEST_INDEX);
         assertActiveSearchShards(1);


### PR DESCRIPTION
I observed a failure in local testing due to this issue. The code previously was assuming it would observe a yellow cluster after restarting a node, but the node could restart and re-join the cluster before the assertion causing a failure. The `onNodeStopped` callback lets the test execute code before the node is restarted, so it should fix this issue.

FYI @mch2 @vinaykpud 

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
