### PR TITLE
Pr branch conditional single upload

### DIFF
--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
@@ -53,6 +53,8 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectAttributes;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
@@ -63,6 +65,7 @@ import software.amazon.awssdk.utils.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.SetOnce;
@@ -97,6 +100,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -507,6 +511,92 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
 
     private String buildKey(String blobName) {
         return keyPath + blobName;
+    }
+
+    /**
+     * Executes a upload to S3 using a conditional If-Match header.
+     * The upload only proceeds if the existing object's ETag matches the provided value.
+     *
+     * @param blobStore     the S3 blob store
+     * @param blobName      the key (name) of the blob
+     * @param input         the input stream containing the blob data
+     * @param blobSize      the size of the blob in bytes
+     * @param metadata      optional metadata to be associated with the blob
+     * @param ETag          the expected ETag value for conditional upload
+     * @param etagListener  listener to handle the resulting ETag or error notifications
+     * @throws IOException if an error occurs during upload or if validations fail
+     */
+    void executeSingleUploadIfEtagMatches(
+        final S3BlobStore blobStore,
+        final String blobName,
+        final InputStream input,
+        final long blobSize,
+        final Map<String, String> metadata,
+        final String ETag,
+        ActionListener<String> etagListener
+    ) throws IOException {
+        // Extra safety checks remain the same
+        if (blobSize > MAX_FILE_SIZE.getBytes()) {
+            throw new IllegalArgumentException("Upload request size [" + blobSize + "] can't be larger than " + MAX_FILE_SIZE);
+        }
+        if (blobSize > blobStore.bufferSizeInBytes()) {
+            throw new IllegalArgumentException("Upload request size [" + blobSize + "] can't be larger than buffer size");
+        }
+
+        PutObjectRequest.Builder putObjectRequestBuilder = PutObjectRequest.builder()
+            .bucket(blobStore.bucket())
+            .key(blobName)
+            .contentLength(blobSize)
+            .storageClass(blobStore.getStorageClass())
+            .ifMatch(ETag)
+            .acl(blobStore.getCannedACL())
+            .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().putObjectMetricPublisher));
+
+        if (CollectionUtils.isNotEmpty(metadata)) {
+            putObjectRequestBuilder = putObjectRequestBuilder.metadata(metadata);
+        }
+        if (blobStore.serverSideEncryption()) {
+            putObjectRequestBuilder.serverSideEncryption(ServerSideEncryption.AES256);
+        }
+
+        PutObjectRequest putObjectRequest = putObjectRequestBuilder.build();
+
+        try (AmazonS3Reference clientReference = blobStore.clientReference()) {
+            final InputStream requestInputStream = blobStore.isUploadRetryEnabled()
+                ? new BufferedInputStream(input, (int) (blobSize + 1))
+                : input;
+
+            PutObjectResponse response = SocketAccess.doPrivileged(
+                () -> clientReference.get().putObject(putObjectRequest, RequestBody.fromInputStream(requestInputStream, blobSize))
+            );
+
+            if (response.eTag() != null) {
+                etagListener.onResponse(response.eTag());
+            } else {
+                IOException exception = new IOException(
+                    "S3 upload for [" + blobName + "] returned null ETag, violating data integrity expectations"
+                );
+                etagListener.onFailure(exception);
+                throw exception;
+            }
+
+        } catch (S3Exception e) {
+            if (e.statusCode() == 412) {
+                etagListener.onFailure(new OpenSearchException("stale_primary_shard", e, "Precondition Failed : Etag Mismatch", blobName));
+                throw new IOException("Unable to upload object [" + blobName + "] due to ETag mismatch", e);
+            } else {
+                IOException exception = new IOException(
+                    String.format(Locale.ROOT, "S3 error during upload [%s]: %s", blobName, e.getMessage()),
+                    e
+                );
+                etagListener.onFailure(exception);
+                throw exception;
+            }
+        } catch (SdkException e) {
+            IOException exception = new IOException(String.format(Locale.ROOT, "S3 upload failed for [%s]", blobName), e);
+            etagListener.onFailure(exception);
+            throw exception;
+        }
     }
 
     /**

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -64,6 +64,7 @@ import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Error;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.StorageClass;
@@ -72,6 +73,7 @@ import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Publisher;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobMetadata;
@@ -111,15 +113,19 @@ import java.util.stream.IntStream;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -137,6 +143,40 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
             () -> blobContainer.executeSingleUpload(blobStore, randomAlphaOfLengthBetween(1, 10), null, blobSize, null)
         );
         assertEquals("Upload request size [" + blobSize + "] can't be larger than 5gb", e.getMessage());
+    }
+
+    public void testExecuteSingleUploadIfEtagMatches_BlobSizeTooLarge() {
+        final long maxSizeBytes = ByteSizeUnit.GB.toBytes(5);
+        final long blobSize = maxSizeBytes + 1;
+
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+        when(blobStore.bufferSizeInBytes()).thenReturn(maxSizeBytes);
+
+        final S3BlobContainer blobContainer = new S3BlobContainer(mock(BlobPath.class), blobStore);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+
+        ActionListener<String> dummyListener = new ActionListener<>() {
+            @Override
+            public void onResponse(String s) {}
+
+            @Override
+            public void onFailure(Exception e) {}
+        };
+
+        final IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> blobContainer.executeSingleUploadIfEtagMatches(
+                blobStore,
+                blobName,
+                new ByteArrayInputStream(new byte[0]),
+                blobSize,
+                null,
+                "\"dummy-etag\"",
+                dummyListener
+            )
+        );
+
+        assertEquals("Upload request size [" + blobSize + "] can't be larger than 5gb", exception.getMessage());
     }
 
     public void testExecuteSingleUploadBlobSizeLargerThanBufferSize() {
@@ -157,6 +197,40 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
             )
         );
         assertEquals("Upload request size [2097152] can't be larger than buffer size", e.getMessage());
+    }
+
+    public void testExecuteSingleUploadIfEtagMatches_BlobSizeLargerThanBufferSize() {
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+        when(blobStore.bufferSizeInBytes()).thenReturn(ByteSizeUnit.MB.toBytes(1));
+
+        final S3BlobContainer blobContainer = new S3BlobContainer(mock(BlobPath.class), blobStore);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+        final long invalidBlobSize = ByteSizeUnit.MB.toBytes(2); // 2MB
+
+        final IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> blobContainer.executeSingleUploadIfEtagMatches(
+                blobStore,
+                blobName,
+                new ByteArrayInputStream(new byte[0]),
+                invalidBlobSize,
+                null,
+                "\"dummy-etag\"",
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(String s) {
+                        fail("Should never succeed");
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        fail("Should throw before listener");
+                    }
+                }
+            )
+        );
+
+        assertEquals("Upload request size [2097152] can't be larger than buffer size", exception.getMessage());
     }
 
     public void testBlobExists() {
@@ -253,7 +327,6 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
             for (int i = 0; i < totalPageCount * s3ObjectsPerPage; i++) {
                 keysListed.add(blobPath + UUID.randomUUID().toString());
             }
-            // S3 lists keys in lexicographic order
             keysListed.sort(String::compareTo);
         }
 
@@ -669,6 +742,407 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         if (serverSideEncryption) {
             assertEquals(ServerSideEncryption.AES256, request.serverSideEncryption());
         }
+    }
+
+    public void testExecuteSingleUploadIfEtagMatchesPreconditionFailed() {
+        final String bucketName = randomAlphaOfLengthBetween(1, 10);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+        final String eTag = randomAlphaOfLengthBetween(8, 32);
+
+        final Map<String, String> metadata = new HashMap<>();
+        metadata.put("key1", "value1");
+
+        final BlobPath blobPath = new BlobPath();
+        final int bufferSize = randomIntBetween(1024, 2048);
+        final int blobSize = randomIntBetween(0, bufferSize);
+
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+        when(blobStore.bucket()).thenReturn(bucketName);
+        when(blobStore.bufferSizeInBytes()).thenReturn((long) bufferSize);
+        when(blobStore.getStorageClass()).thenReturn(StorageClass.STANDARD);
+        when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
+        when(blobStore.serverSideEncryption()).thenReturn(false);
+        when(blobStore.isUploadRetryEnabled()).thenReturn(false);
+        when(blobStore.getCannedACL()).thenReturn(null);
+
+        final S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
+
+        final S3Client client = mock(S3Client.class);
+        final AmazonS3Reference clientReference = mock(AmazonS3Reference.class);
+        when(blobStore.clientReference()).thenReturn(clientReference);
+        when(clientReference.get()).thenReturn(client);
+        doNothing().when(clientReference).close();
+
+        S3Exception preconditionFailedException = (S3Exception) S3Exception.builder()
+            .message("Precondition Failed")
+            .statusCode(412)
+            .build();
+        when(client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenThrow(preconditionFailedException);
+
+        final AtomicReference<Exception> capturedException = new AtomicReference<>();
+        ActionListener<String> realListener = ActionListener.wrap(r -> fail("Should have failed"), capturedException::set);
+        ActionListener<String> etagListener = Mockito.spy(realListener);
+
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[blobSize]);
+
+        IOException ioException = expectThrows(
+            IOException.class,
+            () -> blobContainer.executeSingleUploadIfEtagMatches(blobStore, blobName, inputStream, blobSize, metadata, eTag, etagListener)
+        );
+
+        assertEquals("Unable to upload object [" + blobName + "] due to ETag mismatch", ioException.getMessage());
+        assertTrue("IOException cause should be S3Exception", ioException.getCause() instanceof S3Exception);
+        assertEquals(preconditionFailedException, ioException.getCause());
+
+        verify(etagListener, never()).onResponse(any());
+
+        Exception exception = capturedException.get();
+        assertNotNull("Expected an exception to be captured", exception);
+
+        assertTrue(exception instanceof OpenSearchException);
+        OpenSearchException osException = (OpenSearchException) exception;
+
+        assertEquals("stale_primary_shard", osException.getMessage());
+
+        Throwable cause = osException.getCause();
+        assertNotNull("Should have a cause", cause);
+        assertTrue("Cause should be an S3Exception", cause instanceof S3Exception);
+        S3Exception s3Cause = (S3Exception) cause;
+        assertEquals(412, s3Cause.statusCode());
+        assertEquals("Precondition Failed", s3Cause.getMessage());
+        verify(clientReference).close();
+    }
+
+    public void testExecuteSingleUploadIfEtagMatchesS3Exception() {
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+        final String bucketName = randomAlphaOfLengthBetween(1, 10);
+        final String etag = "\"test-etag\"";
+        final int blobSize = 100;
+
+        S3Client s3Client = mock(S3Client.class);
+        S3Exception s3Exception = (S3Exception) S3Exception.builder().message("Access Denied").statusCode(403).build();
+
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenThrow(s3Exception);
+
+        AmazonS3Reference clientReference = mock(AmazonS3Reference.class);
+        when(clientReference.get()).thenReturn(s3Client);
+
+        S3BlobStore blobStore = mock(S3BlobStore.class);
+        when(blobStore.clientReference()).thenReturn(clientReference);
+        when(blobStore.bucket()).thenReturn(bucketName);
+        when(blobStore.bufferSizeInBytes()).thenReturn(1000L);
+
+        StatsMetricPublisher metrics = new StatsMetricPublisher();
+        when(blobStore.getStatsMetricPublisher()).thenReturn(metrics);
+
+        BlobPath blobPath = new BlobPath();
+        S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
+
+        AtomicReference<Exception> capturedError = new AtomicReference<>();
+        AtomicBoolean successCalled = new AtomicBoolean(false);
+
+        ActionListener<String> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(String s) {
+                successCalled.set(true);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                capturedError.set(e);
+            }
+        };
+
+        ByteArrayInputStream input = new ByteArrayInputStream(new byte[blobSize]);
+
+        IOException exception = expectThrows(
+            IOException.class,
+            () -> blobContainer.executeSingleUploadIfEtagMatches(blobStore, blobName, input, blobSize, null, etag, listener)
+        );
+
+        String expectedErrorMessage = "S3 error during upload [" + blobName + "]: Access Denied";
+        assertEquals(expectedErrorMessage, exception.getMessage());
+        assertEquals(s3Exception, exception.getCause());
+
+        verify(clientReference).close();
+        assertFalse("Success callback should not be called", successCalled.get());
+
+        Exception captured = capturedError.get();
+        assertNotNull("Error callback should receive an exception", captured);
+        assertTrue("Exception should be IOException", captured instanceof IOException);
+
+        String errorMessage = captured.getMessage();
+        assertTrue("Error should mention blob name", errorMessage.contains(blobName));
+        assertEquals("Original S3Exception should be the cause", s3Exception, captured.getCause());
+    }
+
+    public void testExecuteSingleUploadIfEtagMatchesSuccess() throws IOException {
+        final String bucketName = randomAlphaOfLengthBetween(1, 10);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+        final String eTag = randomAlphaOfLengthBetween(8, 32);
+        final String returnedETag = randomAlphaOfLengthBetween(8, 32);
+
+        final Map<String, String> metadata = new HashMap<>();
+        metadata.put("key1", "value1");
+        metadata.put("key2", "value2");
+
+        final BlobPath blobPath = new BlobPath();
+        if (randomBoolean()) {
+            IntStream.of(randomIntBetween(1, 5)).forEach(value -> blobPath.add("path_" + value));
+        }
+
+        final int bufferSize = randomIntBetween(1024, 2048);
+        final int blobSize = randomIntBetween(0, bufferSize);
+
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+
+        when(blobStore.bucket()).thenReturn(bucketName);
+        when(blobStore.bufferSizeInBytes()).thenReturn((long) bufferSize);
+        when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
+
+        final S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
+
+        final boolean serverSideEncryption = randomBoolean();
+        when(blobStore.serverSideEncryption()).thenReturn(serverSideEncryption);
+
+        final StorageClass storageClass = randomFrom(StorageClass.values());
+        when(blobStore.getStorageClass()).thenReturn(storageClass);
+
+        final ObjectCannedACL cannedAccessControlList = randomBoolean() ? randomFrom(ObjectCannedACL.values()) : null;
+        if (cannedAccessControlList != null) {
+            when(blobStore.getCannedACL()).thenReturn(cannedAccessControlList);
+        }
+
+        final S3Client client = mock(S3Client.class);
+        final AmazonS3Reference clientReference = mock(AmazonS3Reference.class);
+        when(clientReference.get()).thenReturn(client);
+        when(blobStore.clientReference()).thenReturn(clientReference);
+
+        final boolean isUploadRetryEnabled = randomBoolean();
+        when(blobStore.isUploadRetryEnabled()).thenReturn(isUploadRetryEnabled);
+
+        final ArgumentCaptor<PutObjectRequest> putObjectRequestArgumentCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        final ArgumentCaptor<RequestBody> requestBodyArgumentCaptor = ArgumentCaptor.forClass(RequestBody.class);
+
+        when(client.putObject(putObjectRequestArgumentCaptor.capture(), requestBodyArgumentCaptor.capture())).thenReturn(
+            PutObjectResponse.builder().eTag(returnedETag).build()
+        );
+
+        @SuppressWarnings("unchecked")
+        ActionListener<String> etagListener = mock(ActionListener.class);
+
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[blobSize]);
+        blobContainer.executeSingleUploadIfEtagMatches(blobStore, blobName, inputStream, blobSize, metadata, eTag, etagListener);
+
+        final PutObjectRequest request = putObjectRequestArgumentCaptor.getValue();
+        final RequestBody requestBody = requestBodyArgumentCaptor.getValue();
+        assertEquals(bucketName, request.bucket());
+        assertEquals(blobPath.buildAsString() + blobName, request.key());
+        assertEquals(blobSize, request.contentLength().longValue());
+        assertEquals(storageClass, request.storageClass());
+        assertEquals(cannedAccessControlList, request.acl());
+        assertEquals(metadata, request.metadata());
+
+        assertEquals(eTag, request.ifMatch());
+
+        byte[] expectedBytes = new byte[blobSize];
+        try (InputStream is = requestBody.contentStreamProvider().newStream()) {
+            assertArrayEquals(expectedBytes, is.readAllBytes());
+        }
+
+        if (serverSideEncryption) {
+            assertEquals(ServerSideEncryption.AES256, request.serverSideEncryption());
+        }
+
+        verify(etagListener).onResponse(returnedETag);
+        verify(etagListener, never()).onFailure(any());
+
+        verify(clientReference).close();
+    }
+
+    public void testExecuteSingleUploadIfEtagMatchesSdkException() {
+        final String bucketName = randomAlphaOfLengthBetween(1, 10);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+        final String eTag = randomAlphaOfLengthBetween(8, 32);
+
+        final Map<String, String> metadata = new HashMap<>();
+        metadata.put("key1", "value1");
+
+        final BlobPath blobPath = new BlobPath();
+        final int bufferSize = randomIntBetween(1024, 2048);
+        final int blobSize = randomIntBetween(0, bufferSize);
+
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+
+        when(blobStore.bucket()).thenReturn(bucketName);
+        when(blobStore.bufferSizeInBytes()).thenReturn((long) bufferSize);
+        when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
+        when(blobStore.getStorageClass()).thenReturn(StorageClass.STANDARD);
+        when(blobStore.serverSideEncryption()).thenReturn(false);
+        when(blobStore.isUploadRetryEnabled()).thenReturn(false);
+        when(blobStore.getCannedACL()).thenReturn(null);
+
+        final S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
+
+        final S3Client client = mock(S3Client.class);
+        final AmazonS3Reference clientReference = mock(AmazonS3Reference.class);
+        when(blobStore.clientReference()).thenReturn(clientReference);
+        when(clientReference.get()).thenReturn(client);
+
+        final SdkException sdkException = SdkException.builder().message("Generic Sdk failure").build();
+        when(client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenThrow(sdkException);
+
+        final AtomicReference<Exception> capturedException = new AtomicReference<>();
+        ActionListener<String> realListener = ActionListener.wrap(r -> fail("Should have failed for SdkException"), capturedException::set);
+        ActionListener<String> etagListener = Mockito.spy(realListener);
+
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[blobSize]);
+
+        IOException exception = expectThrows(
+            IOException.class,
+            () -> blobContainer.executeSingleUploadIfEtagMatches(blobStore, blobName, inputStream, blobSize, metadata, eTag, etagListener)
+        );
+
+        assertEquals("S3 upload failed for [" + blobName + "]", exception.getMessage());
+        assertEquals(sdkException, exception.getCause());
+
+        verify(etagListener, never()).onResponse(any());
+        Exception listenerException = capturedException.get();
+        assertNotNull("Expected an exception to be captured", listenerException);
+        assertTrue("Exception should be an IOException", listenerException instanceof IOException);
+
+        IOException listenerIoException = (IOException) listenerException;
+        assertTrue("IOException message should contain the blob name", listenerIoException.getMessage().contains(blobName));
+        assertEquals(sdkException, listenerIoException.getCause());
+
+        verify(clientReference).close();
+    }
+
+    public void testExecuteSingleUploadIfEtagMatchesWithNullETag() {
+        final String bucketName = randomAlphaOfLengthBetween(1, 10);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+        final String providedETag = randomAlphaOfLengthBetween(8, 32);
+
+        final int bufferSize = randomIntBetween(1024, 2048);
+        final int blobSize = randomIntBetween(0, bufferSize);
+
+        final BlobPath blobPath = new BlobPath();
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+
+        when(blobStore.bucket()).thenReturn(bucketName);
+        when(blobStore.bufferSizeInBytes()).thenReturn((long) bufferSize);
+        when(blobStore.getStorageClass()).thenReturn(StorageClass.STANDARD);
+        when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
+        when(blobStore.serverSideEncryption()).thenReturn(false);
+        when(blobStore.isUploadRetryEnabled()).thenReturn(false);
+        when(blobStore.getCannedACL()).thenReturn(null);
+
+        final S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
+
+        final S3Client client = mock(S3Client.class);
+        final AmazonS3Reference clientReference = mock(AmazonS3Reference.class);
+        when(blobStore.clientReference()).thenReturn(clientReference);
+        when(clientReference.get()).thenReturn(client);
+
+        when(client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(
+            PutObjectResponse.builder().eTag(null).build()
+        );
+
+        @SuppressWarnings("unchecked")
+        ActionListener<String> etagListener = mock(ActionListener.class);
+
+        // Use expectThrows to handle the expected exception
+        IOException exception = expectThrows(IOException.class, () -> {
+            try (ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[blobSize])) {
+                blobContainer.executeSingleUploadIfEtagMatches(
+                    blobStore,
+                    blobName,
+                    inputStream,
+                    blobSize,
+                    null,
+                    providedETag,
+                    etagListener
+                );
+            }
+        });
+
+        String expectedMessage = "S3 upload for [" + blobName + "] returned null ETag, violating data integrity expectations";
+        assertEquals(expectedMessage, exception.getMessage());
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(etagListener).onFailure(exceptionCaptor.capture());
+        verify(etagListener, never()).onResponse(anyString());
+
+        Exception listenerException = exceptionCaptor.getValue();
+        assertTrue("Exception should be IOException", listenerException instanceof IOException);
+        assertTrue("Exception message should mention null ETag", listenerException.getMessage().contains("null ETag"));
+
+        verify(clientReference).close();
+    }
+
+    public void testExecuteSingleUploadIfEtagMatchesNullOrEmptyInput() throws IOException {
+        final String bucketName = randomAlphaOfLengthBetween(1, 10);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+
+        final int bufferSize = randomIntBetween(1024, 2048);
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+
+        when(blobStore.bucket()).thenReturn(bucketName);
+        when(blobStore.bufferSizeInBytes()).thenReturn((long) bufferSize);
+        when(blobStore.getStorageClass()).thenReturn(StorageClass.STANDARD);
+        when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
+        when(blobStore.serverSideEncryption()).thenReturn(false);
+        when(blobStore.isUploadRetryEnabled()).thenReturn(false);
+        when(blobStore.getCannedACL()).thenReturn(null);
+
+        final S3BlobContainer blobContainer = new S3BlobContainer(new BlobPath(), blobStore);
+
+        final ByteArrayInputStream inputStreamCase1 = new ByteArrayInputStream(new byte[bufferSize]);
+        @SuppressWarnings("unchecked")
+        ActionListener<String> mockListenerCase1 = mock(ActionListener.class);
+
+        final S3Client client1 = mock(S3Client.class);
+        final AmazonS3Reference clientReference1 = mock(AmazonS3Reference.class);
+
+        when(blobStore.clientReference()).thenReturn(clientReference1);
+        when(clientReference1.get()).thenReturn(client1);
+        when(client1.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(
+            PutObjectResponse.builder().eTag("nullEtagTest").build()
+        );
+
+        blobContainer.executeSingleUploadIfEtagMatches(blobStore, blobName, inputStreamCase1, bufferSize, null, null, mockListenerCase1);
+
+        verify(mockListenerCase1).onResponse("nullEtagTest");
+        verify(mockListenerCase1, never()).onFailure(any());
+        verify(clientReference1).close();
+
+        final ByteArrayInputStream inputStreamCase2 = new ByteArrayInputStream(new byte[0]);
+        @SuppressWarnings("unchecked")
+        ActionListener<String> mockListenerCase2 = mock(ActionListener.class);
+
+        final S3Client client2 = mock(S3Client.class);
+        final AmazonS3Reference clientReference2 = mock(AmazonS3Reference.class);
+
+        when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
+        when(blobStore.clientReference()).thenReturn(clientReference2);
+        when(clientReference2.get()).thenReturn(client2);
+        when(client2.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(
+            PutObjectResponse.builder().eTag("emptyMetadataETag").build()
+        );
+
+        blobContainer.executeSingleUploadIfEtagMatches(
+            blobStore,
+            blobName,
+            inputStreamCase2,
+            0,
+            Collections.emptyMap(),
+            "",
+            mockListenerCase2
+        );
+
+        verify(mockListenerCase2).onResponse("emptyMetadataETag");
+        verify(mockListenerCase2, never()).onFailure(any());
+        verify(clientReference2).close();
     }
 
     public void testExecuteMultipartUploadBlobSizeTooLarge() {


### PR DESCRIPTION
### Description
Adds `executeSingleUploadIfEtagMatches(...)` to `S3BlobStore`, enabling support for conditional single‑part upload via the S3 `If-Match` header.  
- **Success **: invokes `onResponse` with the new ETag.  
- **Precondition Failed (412)**: invokes `onFailure` with an `OpenSearchException("stale_primary_shard")`.  
- **Other S3/SDK errors**: wrapped in `IOException` and passed to `onFailure`.  

![Diag](https://github.com/user-attachments/assets/ca63685d-711a-4f0b-90d0-f8956dba4b63)

### Test Coverage

1. **Precondition Failed (HTTP 412)**  
   **Setup:** Mock `S3Exception` 412  
   **Expectation:**  
   - Throws `IOException("Unable to upload object [<blob>] due to ETag mismatch")`  
   - Listener fails with `OpenSearchException("stale_primary_shard")`  
   - `onResponse` never called  

2. **General S3Exception (HTTP 403)**  
   **Setup:** Mock `S3Exception` 403  
   **Expectation:**  
   - Throws `IOException("S3 error during upload [<blob>]: Access Denied")` (cause is the original `S3Exception`)  
   - Listener’s `onFailure` invoked (message contains blob name)  
   - `onResponse` never called  

3. **Successful Upload**  
   **Setup:** Mock `PutObjectResponse` with non-null ETag  
   **Expectation:**  
   - Listener’s `onResponse` receives that ETag  
   - All request fields (bucket, key, contentLength, storageClass, ACL, metadata, ifMatch, SSE) are correct  
   - `onFailure` never called  

4. **SDK Exception**  
   **Setup:** Mock `SdkException`  
   **Expectation:**  
   - Throws `IOException("S3 upload failed for [<blob>]", sdkException)`  
   - Listener’s `onFailure` receives that `IOException`  

5. **Null ETag in Response**  
   **Setup:** Mock `PutObjectResponse` with `eTag == null`  
   **Expectation:**  
   - Throws `IOException("S3 upload for [<blob>] returned null ETag…")`  
   - Listener’s `onFailure` invoked  
   - `onResponse` never called  

6. **Null or Empty Input/ETag**  
   - **Null ETag, non-empty blob:** upload succeeds → `onResponse` gets returned ETag  
   - **Empty ETag `""`, zero-length blob:** upload succeeds → `onResponse` gets returned ETag  

7. **Blob Size Limits**  
   - **> 5 GB:** Throws `IllegalArgumentException("Upload request size [<size>] can't be larger than 5gb")`  
   - **> bufferSize:** Throws `IllegalArgumentException` before any S3 interaction  
 
### Related Issue
Concerned RFC : [RFC #17763](https://github.com/opensearch-project/OpenSearch/issues/17763)
Parent Meta Issue : [Meta #17859](https://github.com/opensearch-project/OpenSearch/issues/17859)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
