### PR TITLE
Fix flaky TransportMultiSearchActionTests.testCancellation

### DIFF
--- a/server/src/test/java/org/opensearch/action/search/TransportMultiSearchActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/TransportMultiSearchActionTests.java
@@ -293,7 +293,7 @@ public class TransportMultiSearchActionTests extends OpenSearchTestCase {
         assertThat(result, equalTo(1));
     }
 
-    public void testCancellation() {
+    public void testCancellation() throws InterruptedException {
         // Initialize dependencies of TransportMultiSearchAction
         Settings settings = Settings.builder().put("node.name", TransportMultiSearchActionTests.class.getSimpleName()).build();
         ActionFilters actionFilters = mock(ActionFilters.class);
@@ -385,22 +385,35 @@ public class TransportMultiSearchActionTests extends OpenSearchTestCase {
             }
             MultiSearchResponse[] responses = new MultiSearchResponse[1];
             Exception[] exceptions = new Exception[1];
+            CountDownLatch executedLatch = new CountDownLatch(1);
             parentTask[0] = (CancellableTask) action.execute(multiSearchRequest, new TaskListener<>() {
                 @Override
                 public void onResponse(Task task, MultiSearchResponse items) {
                     responses[0] = items;
+                    executedLatch.countDown();
                 }
 
                 @Override
                 public void onFailure(Task task, Exception e) {
                     exceptions[0] = e;
+                    executedLatch.countDown();
                 }
             });
             parentTask[0].cancel("Giving up");
             canceledLatch.countDown();
 
-            assertNull(responses[0]);
-            assertNull(exceptions[0]);
+            if (!executedLatch.await(10, TimeUnit.SECONDS)) {
+                fail("Latch should have counted down");
+            }
+
+            boolean concalled = false;
+            for (MultiSearchResponse.Item item : responses[0].getResponses()) {
+                if (item.isFailure() && item.getFailure().getMessage().contains("Parent task was cancelled")) {
+                    concalled = true;
+                    break;
+                }
+            }
+            assertTrue(concalled);
         } finally {
             assertTrue(OpenSearchTestCase.terminate(threadPool));
         }

--- a/server/src/test/java/org/opensearch/action/search/TransportMultiSearchActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/TransportMultiSearchActionTests.java
@@ -406,14 +406,14 @@ public class TransportMultiSearchActionTests extends OpenSearchTestCase {
                 fail("Latch should have counted down");
             }
 
-            boolean concalled = false;
+            boolean cancelled = false;
             for (MultiSearchResponse.Item item : responses[0].getResponses()) {
                 if (item.isFailure() && item.getFailure().getMessage().contains("Parent task was cancelled")) {
-                    concalled = true;
+                    cancelled = true;
                     break;
                 }
             }
-            assertTrue(concalled);
+            assertTrue(cancelled);
         } finally {
             assertTrue(OpenSearchTestCase.terminate(threadPool));
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
When I put the PR #18069 with the newest `main` branch, the  `ci` throws the exception, as shown in this link: TransportMultiSearchActionTests.testCancellation:
https://build.ci.opensearch.org/job/gradle-check/57253/

Here are two scenarios regarding this issue:
1. If the unit test executes too quickly, the async search might not get a chance to execute, so the unit test seems doesn't work.
2. On the other hand, if the unit test does not execute quickly, it may trigger the exception, which is the case I encountered.
https://github.com/opensearch-project/OpenSearch/blob/main/server/src/test/java/org/opensearch/action/search/TransportMultiSearchActionTests.java#L402

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
