### PR TITLE
Add shared memory access

### DIFF
--- a/distribution/packages/src/common/systemd/opensearch.service
+++ b/distribution/packages/src/common/systemd/opensearch.service
@@ -130,6 +130,7 @@ RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
 
 ReadWritePaths=/var/log/opensearch
 ReadWritePaths=/var/lib/opensearch
+ReadWritePaths=/dev/shm/performanceanalyzer
 ReadWritePaths=-/etc/opensearch
 ReadWritePaths=-/mnt/snapshots
 


### PR DESCRIPTION

### Description
Adds /dev/shm/perfomanceanalyzer to ReadWritePaths in systemd unit file.

### Related Issues
- https://github.com/opensearch-project/OpenSearch/issues/18083#issuecomment-2836324239

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
