### PR TITLE
Revert "Avoid invalid retries on multiple replicas when querying"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add composite directory factory ([#17988](https://github.com/opensearch-project/OpenSearch/pull/17988))
 
 ### Changed
-- Avoid invalid retries in multiple replicas when querying [#17370](https://github.com/opensearch-project/OpenSearch/pull/17370)
 
 ### Dependencies
 - Bump `com.google.code.gson:gson` from 2.12.1 to 2.13.0 ([#17923](https://github.com/opensearch-project/OpenSearch/pull/17923))

--- a/libs/core/src/main/java/org/opensearch/OpenSearchException.java
+++ b/libs/core/src/main/java/org/opensearch/OpenSearchException.java
@@ -302,12 +302,8 @@ public class OpenSearchException extends RuntimeException implements Writeable, 
      * Returns the rest status code associated with this exception.
      */
     public RestStatus status() {
-        return status(this);
-    }
-
-    public static RestStatus status(Throwable t) {
-        Throwable cause = ExceptionsHelper.unwrapCause(t);
-        if (cause == t) {
+        Throwable cause = unwrapCause();
+        if (cause == this) {
             return RestStatus.INTERNAL_SERVER_ERROR;
         } else {
             return ExceptionsHelper.status(cause);

--- a/server/src/main/java/org/opensearch/action/support/TransportActions.java
+++ b/server/src/main/java/org/opensearch/action/support/TransportActions.java
@@ -34,11 +34,8 @@ package org.opensearch.action.support;
 
 import org.apache.lucene.store.AlreadyClosedException;
 import org.opensearch.ExceptionsHelper;
-import org.opensearch.OpenSearchException;
 import org.opensearch.action.NoShardAvailableActionException;
 import org.opensearch.action.UnavailableShardsException;
-import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
-import org.opensearch.core.tasks.TaskCancelledException;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.shard.IllegalIndexShardStateException;
 import org.opensearch.index.shard.ShardNotFoundException;
@@ -65,14 +62,6 @@ public class TransportActions {
      */
     public static boolean isReadOverrideException(Exception e) {
         return !isShardNotAvailableException(e);
-    }
-
-    public static boolean isRetryableSearchException(final Exception e) {
-        return (OpenSearchException.status(e).getStatusFamilyCode() != 4) && (e.getCause() instanceof TaskCancelledException == false)
-            // There exists a scenario where a primary shard (0 replicas) relocates and is in POST_RECOVERY on the
-            // target node but already deleted on the source node. Search request should still work.
-            || (e.getCause() instanceof IndexNotFoundException)
-            || (e.getCause() instanceof OpenSearchRejectedExecutionException);
     }
 
 }


### PR DESCRIPTION
This reverts commit eba12faff9a84cc15b083c77e9ecda5f939787f6 from PR #17370

I was able to get a mostly reliable reproduction with the following command:

```
./gradlew ':server:internalClusterTest' --tests "org.opensearch.recovery.RecoveryWhileUnderLoadIT" -Dtests.method='testRecoverWhileUnderLoadAllocateReplicasRelocatePrimariesTest' -Dtests.iters=20 -Dtests.seed=C5861E9C93984071 --rerun
```

Using `git bisect` I was able to find this commit as the culprit to the recent flakiness in RecoveryWhileUnderLoadIT.

FYI @msfroh @kkewwei 

### Related Issues
Resolves #14509

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
