### PR TITLE
[Rule based auto-tagging] add rule sync service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Update API of Message in index to add the timestamp for lag calculation in ingestion polling ([#17977](https://github.com/opensearch-project/OpenSearch/pull/17977/))
 - Add Warm Disk Threshold Allocation Decider for Warm shards ([#18082](https://github.com/opensearch-project/OpenSearch/pull/18082))
 - Add composite directory factory ([#17988](https://github.com/opensearch-project/OpenSearch/pull/17988))
+- [Rule based auto-tagging] Add refresh based synchronization service for `Rule`s ([#18128](https://github.com/opensearch-project/OpenSearch/pull/18128))
 - Add pull-based ingestion error metrics and make internal queue size configurable ([#18088](https://github.com/opensearch-project/OpenSearch/pull/18088))
 - Adding support for derive source feature and implementing it for various type of field mappers ([#17759](https://github.com/opensearch-project/OpenSearch/pull/17759))
 - [Security Manager Replacement] Enhance Java Agent to intercept newByteChannel ([#17989](https://github.com/opensearch-project/OpenSearch/pull/17989))

--- a/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/storage/DefaultAttributeValueStore.java
+++ b/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/storage/DefaultAttributeValueStore.java
@@ -109,7 +109,12 @@ public class DefaultAttributeValueStore<K extends String, V> implements Attribut
 
     @Override
     public void clear() {
-        trie.clear();
+        writeLock.lock();
+        try {
+            trie.clear();
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     @Override

--- a/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/action/GetRuleRequestTests.java
+++ b/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/action/GetRuleRequestTests.java
@@ -64,4 +64,65 @@ public class GetRuleRequestTests extends OpenSearchTestCase {
         request = new GetRuleRequest(_ID_ONE, ATTRIBUTE_MAP, "", RuleTestUtils.MockRuleFeatureType.INSTANCE);
         assertThrows(IllegalArgumentException.class, request::validate);
     }
+
+    public static final String _ID_ONE = "id_1";
+    public static final String SEARCH_AFTER = "search_after";
+    public static final String _ID_TWO = "G5iIq84j7eK1qIAAAAIH53=1";
+    public static final String FEATURE_VALUE_ONE = "feature_value_one";
+    public static final String FEATURE_VALUE_TWO = "feature_value_two";
+    public static final String ATTRIBUTE_VALUE_ONE = "mock_attribute_one";
+    public static final String ATTRIBUTE_VALUE_TWO = "mock_attribute_two";
+    public static final String DESCRIPTION_ONE = "description_1";
+    public static final String DESCRIPTION_TWO = "description_2";
+    public static final String TIMESTAMP_ONE = "2024-01-26T08:58:57.558Z";
+    public static final String TIMESTAMP_TWO = "2023-01-26T08:58:57.558Z";
+    public static final Map<Attribute, Set<String>> ATTRIBUTE_MAP = Map.of(
+        RuleTestUtils.MockRuleAttributes.MOCK_RULE_ATTRIBUTE_ONE,
+        Set.of(ATTRIBUTE_VALUE_ONE)
+    );
+
+    public static final Rule ruleOne = Rule.builder()
+        .id(_ID_ONE)
+        .description(DESCRIPTION_ONE)
+        .featureType(RuleTestUtils.MockRuleFeatureType.INSTANCE)
+        .featureValue(FEATURE_VALUE_ONE)
+        .attributeMap(ATTRIBUTE_MAP)
+        .updatedAt(TIMESTAMP_ONE)
+        .build();
+
+    public static final Rule ruleTwo = Rule.builder()
+        .id(_ID_TWO)
+        .description(DESCRIPTION_TWO)
+        .featureType(RuleTestUtils.MockRuleFeatureType.INSTANCE)
+        .featureValue(FEATURE_VALUE_TWO)
+        .attributeMap(Map.of(RuleTestUtils.MockRuleAttributes.MOCK_RULE_ATTRIBUTE_TWO, Set.of(ATTRIBUTE_VALUE_TWO)))
+        .updatedAt(TIMESTAMP_TWO)
+        .build();
+
+    public static Map<String, Rule> ruleMap() {
+        return Map.of(_ID_ONE, ruleOne, _ID_TWO, ruleTwo);
+    }
+
+    public static void assertEqualRules(Map<String, Rule> mapOne, Map<String, Rule> mapTwo, boolean ruleUpdated) {
+        assertEquals(mapOne.size(), mapTwo.size());
+        for (Map.Entry<String, Rule> entry : mapOne.entrySet()) {
+            String id = entry.getKey();
+            assertTrue(mapTwo.containsKey(id));
+            Rule one = mapOne.get(id);
+            Rule two = mapTwo.get(id);
+            assertEqualRule(one, two, ruleUpdated);
+        }
+    }
+
+    public static void assertEqualRule(Rule one, Rule two, boolean ruleUpdated) {
+        if (ruleUpdated) {
+            assertEquals(one.getDescription(), two.getDescription());
+            assertEquals(one.getFeatureType(), two.getFeatureType());
+            assertEquals(one.getFeatureValue(), two.getFeatureValue());
+            assertEquals(one.getAttributeMap(), two.getAttributeMap());
+            assertEquals(one.getAttributeMap(), two.getAttributeMap());
+        } else {
+            assertEquals(one, two);
+        }
+    }
 }

--- a/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/action/GetRuleRequestTests.java
+++ b/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/action/GetRuleRequestTests.java
@@ -11,15 +11,15 @@ package org.opensearch.rule.action;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.rule.GetRuleRequest;
+import org.opensearch.rule.autotagging.Attribute;
+import org.opensearch.rule.autotagging.Rule;
 import org.opensearch.rule.utils.RuleTestUtils;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 import java.util.HashMap;
-
-import static org.opensearch.rule.utils.RuleTestUtils.ATTRIBUTE_MAP;
-import static org.opensearch.rule.utils.RuleTestUtils.SEARCH_AFTER;
-import static org.opensearch.rule.utils.RuleTestUtils._ID_ONE;
+import java.util.Map;
+import java.util.Set;
 
 public class GetRuleRequestTests extends OpenSearchTestCase {
     /**

--- a/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/action/GetRuleResponseTests.java
+++ b/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/action/GetRuleResponseTests.java
@@ -41,6 +41,7 @@ public class GetRuleResponseTests extends OpenSearchTestCase {
     );
 
     public static final Rule ruleOne = Rule.builder()
+        .id(_ID_ONE)
         .description(DESCRIPTION_ONE)
         .featureType(RuleTestUtils.MockRuleFeatureType.INSTANCE)
         .featureValue(FEATURE_VALUE_ONE)

--- a/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/autotagging/RuleTests.java
+++ b/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/autotagging/RuleTests.java
@@ -47,7 +47,7 @@ public class RuleTests extends AbstractSerializingTestCase<Rule> {
         String description = randomAlphaOfLength(10);
         String featureValue = randomAlphaOfLength(5);
         String updatedAt = Instant.now().toString();
-        return new Rule(description, ATTRIBUTE_MAP, FEATURE_TYPE, featureValue, updatedAt);
+        return new Rule("test_id", description, ATTRIBUTE_MAP, FEATURE_TYPE, featureValue, updatedAt);
     }
 
     @Override

--- a/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/autotagging/RuleTests.java
+++ b/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/autotagging/RuleTests.java
@@ -123,6 +123,7 @@ public class RuleTests extends AbstractSerializingTestCase<Rule> {
         String description
     ) {
         return Rule.builder()
+            .id(_ID)
             .featureValue(featureValue)
             .featureType(featureType)
             .description(description)

--- a/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/utils/RuleTestUtils.java
+++ b/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/utils/RuleTestUtils.java
@@ -42,6 +42,7 @@ public class RuleTestUtils {
     );
 
     public static final Rule ruleOne = Rule.builder()
+        .id(_ID_ONE)
         .description(DESCRIPTION_ONE)
         .featureType(RuleTestUtils.MockRuleFeatureType.INSTANCE)
         .featureValue(FEATURE_VALUE_ONE)
@@ -50,6 +51,7 @@ public class RuleTestUtils {
         .build();
 
     public static final Rule ruleTwo = Rule.builder()
+        .id(_ID_TWO)
         .description(DESCRIPTION_TWO)
         .featureType(RuleTestUtils.MockRuleFeatureType.INSTANCE)
         .featureValue(FEATURE_VALUE_TWO)

--- a/modules/autotagging-commons/src/main/java/org/opensearch/rule/InMemoryRuleProcessingService.java
+++ b/modules/autotagging-commons/src/main/java/org/opensearch/rule/InMemoryRuleProcessingService.java
@@ -27,6 +27,7 @@ import java.util.function.BiConsumer;
  */
 public class InMemoryRuleProcessingService {
 
+    public static final String WILDCARD = "*";
     private final AttributeValueStoreFactory attributeValueStoreFactory;
 
     /**
@@ -69,7 +70,7 @@ public class InMemoryRuleProcessingService {
     private void addOperation(Map.Entry<Attribute, Set<String>> attributeEntry, Rule rule) {
         AttributeValueStore<String, String> valueStore = attributeValueStoreFactory.getAttributeValueStore(attributeEntry.getKey());
         for (String value : attributeEntry.getValue()) {
-            valueStore.put(value, rule.getFeatureValue());
+            valueStore.put(value.replace(WILDCARD, ""), rule.getFeatureValue());
         }
     }
 

--- a/modules/autotagging-commons/src/main/java/org/opensearch/rule/InMemoryRuleProcessingService.java
+++ b/modules/autotagging-commons/src/main/java/org/opensearch/rule/InMemoryRuleProcessingService.java
@@ -10,7 +10,6 @@ package org.opensearch.rule;
 
 import org.opensearch.rule.attribute_extractor.AttributeExtractor;
 import org.opensearch.rule.autotagging.Attribute;
-import org.opensearch.rule.autotagging.FeatureType;
 import org.opensearch.rule.autotagging.Rule;
 import org.opensearch.rule.storage.AttributeValueStore;
 import org.opensearch.rule.storage.AttributeValueStoreFactory;
@@ -20,7 +19,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.Supplier;
 
 /**
  * This class is responsible for managing in-memory view of Rules and Find matching Rule for the request
@@ -32,15 +30,11 @@ public class InMemoryRuleProcessingService {
     private final AttributeValueStoreFactory attributeValueStoreFactory;
 
     /**
-     *  Constrcutor
-     * @param featureType
-     * @param attributeValueStoreSupplier
+     *  Constructor
+     * @param attributeValueStoreFactory
      */
-    public InMemoryRuleProcessingService(
-        FeatureType featureType,
-        Supplier<AttributeValueStore<String, String>> attributeValueStoreSupplier
-    ) {
-        attributeValueStoreFactory = new AttributeValueStoreFactory(featureType, attributeValueStoreSupplier);
+    public InMemoryRuleProcessingService(AttributeValueStoreFactory attributeValueStoreFactory) {
+        this.attributeValueStoreFactory = attributeValueStoreFactory;
     }
 
     /**
@@ -111,5 +105,13 @@ public class InMemoryRuleProcessingService {
             }
         }
         return result;
+    }
+
+    /**
+     * AttributeValueStoreFactory getter
+     * @return
+     */
+    public AttributeValueStoreFactory getAttributeValueStoreFactory() {
+        return attributeValueStoreFactory;
     }
 }

--- a/modules/autotagging-commons/src/main/java/org/opensearch/rule/InMemoryRuleProcessingService.java
+++ b/modules/autotagging-commons/src/main/java/org/opensearch/rule/InMemoryRuleProcessingService.java
@@ -27,6 +27,9 @@ import java.util.function.BiConsumer;
  */
 public class InMemoryRuleProcessingService {
 
+    /**
+     * Wildcard character which will be removed as we only support prefix based search rather than pattern match based
+     */
     public static final String WILDCARD = "*";
     private final AttributeValueStoreFactory attributeValueStoreFactory;
 

--- a/modules/autotagging-commons/src/main/java/org/opensearch/rule/InMemoryRuleProcessingService.java
+++ b/modules/autotagging-commons/src/main/java/org/opensearch/rule/InMemoryRuleProcessingService.java
@@ -107,12 +107,4 @@ public class InMemoryRuleProcessingService {
         }
         return result;
     }
-
-    /**
-     * AttributeValueStoreFactory getter
-     * @return
-     */
-    public AttributeValueStoreFactory getAttributeValueStoreFactory() {
-        return attributeValueStoreFactory;
-    }
 }

--- a/modules/autotagging-commons/src/test/java/org/opensearch/rule/InMemoryRuleProcessingServiceTests.java
+++ b/modules/autotagging-commons/src/test/java/org/opensearch/rule/InMemoryRuleProcessingServiceTests.java
@@ -13,6 +13,7 @@ import org.opensearch.rule.autotagging.Attribute;
 import org.opensearch.rule.autotagging.AutoTaggingRegistry;
 import org.opensearch.rule.autotagging.FeatureType;
 import org.opensearch.rule.autotagging.Rule;
+import org.opensearch.rule.storage.AttributeValueStoreFactory;
 import org.opensearch.rule.storage.DefaultAttributeValueStore;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -26,7 +27,11 @@ public class InMemoryRuleProcessingServiceTests extends OpenSearchTestCase {
 
     public void setUp() throws Exception {
         super.setUp();
-        sut = new InMemoryRuleProcessingService(WLMFeatureType.WLM, DefaultAttributeValueStore::new);
+        AttributeValueStoreFactory attributeValueStoreFactory = new AttributeValueStoreFactory(
+            WLMFeatureType.WLM,
+            DefaultAttributeValueStore::new
+        );
+        sut = new InMemoryRuleProcessingService(attributeValueStoreFactory);
     }
 
     public void testAdd() {

--- a/modules/autotagging-commons/src/test/java/org/opensearch/rule/InMemoryRuleProcessingServiceTests.java
+++ b/modules/autotagging-commons/src/test/java/org/opensearch/rule/InMemoryRuleProcessingServiceTests.java
@@ -102,6 +102,7 @@ public class InMemoryRuleProcessingServiceTests extends OpenSearchTestCase {
 
     private static Rule getRule(Set<String> attributeValues, String label) {
         return new Rule(
+            randomAlphaOfLength(5),
             "test description",
             Map.of(TestAttribute.TEST_ATTRIBUTE, attributeValues),
             WLMFeatureType.WLM,

--- a/plugins/workload-management/build.gradle
+++ b/plugins/workload-management/build.gradle
@@ -8,12 +8,10 @@
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
-
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.yaml-rest-test'
 apply plugin: 'opensearch.java-rest-test'
 apply plugin: 'opensearch.internal-cluster-test'
-
 opensearchplugin {
   description = 'OpenSearch Workload Management Plugin.'
   classname = 'org.opensearch.plugin.wlm.WorkloadManagementPlugin'

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/WorkloadManagementPlugin.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/WorkloadManagementPlugin.java
@@ -136,6 +136,7 @@ public class WorkloadManagementPlugin extends Plugin implements ActionPlugin, Sy
             clusterService.getSettings(),
             clusterService.getClusterSettings(),
             parser,
+            ruleProcessingService,
             featureType,
             rulePersistenceService,
             new RuleEventClassifier(Collections.emptySet(), ruleProcessingService)

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/WorkloadManagementPlugin.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/WorkloadManagementPlugin.java
@@ -43,6 +43,7 @@ import org.opensearch.plugin.wlm.rule.WorkloadGroupFeatureType;
 import org.opensearch.plugin.wlm.rule.WorkloadGroupFeatureValueValidator;
 import org.opensearch.plugin.wlm.rule.WorkloadGroupRuleRoutingService;
 import org.opensearch.plugin.wlm.rule.sync.RefreshBasedSyncMechanism;
+import org.opensearch.plugin.wlm.rule.sync.detect.RuleEventClassifier;
 import org.opensearch.plugin.wlm.service.WorkloadGroupPersistenceService;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.DiscoveryPlugin;
@@ -124,20 +125,21 @@ public class WorkloadManagementPlugin extends Plugin implements ActionPlugin, Sy
             client,
             clusterService,
             MAX_RULES_PER_PAGE,
-            new XContentRuleParser(featureType),
+            parser,
             new IndexBasedRuleQueryMapper()
         );
 
         ruleRoutingService = new WorkloadGroupRuleRoutingService(client, clusterService);
 
         RefreshBasedSyncMechanism refreshMechanism = new RefreshBasedSyncMechanism(
-            client,
             threadPool,
             clusterService.getSettings(),
             clusterService.getClusterSettings(),
             parser,
             ruleProcessingService,
-            featureType
+            featureType,
+            rulePersistenceService,
+            new RuleEventClassifier(Collections.emptySet(), ruleProcessingService)
         );
 
         autoTaggingActionFilter = new AutoTaggingActionFilter(ruleProcessingService, threadPool);

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/WorkloadManagementPlugin.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/WorkloadManagementPlugin.java
@@ -136,7 +136,6 @@ public class WorkloadManagementPlugin extends Plugin implements ActionPlugin, Sy
             clusterService.getSettings(),
             clusterService.getClusterSettings(),
             parser,
-            ruleProcessingService,
             featureType,
             rulePersistenceService,
             new RuleEventClassifier(Collections.emptySet(), ruleProcessingService)

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
@@ -82,6 +82,7 @@ public class RefreshBasedSyncMechanism extends AbstractLifecycleComponent {
      * @param clusterSettings
      * @param parser
      * @param ruleProcessingService
+     * @param featureType
      * @param rulePersistenceService
      * @param ruleEventClassifier
      */

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
@@ -132,7 +132,7 @@ public class RefreshBasedSyncMechanism extends AbstractLifecycleComponent {
     public void setRefreshInterval(long refreshInterval) {
         if (refreshInterval < MIN_SYNC_REFRESH_INTERVAL) {
             logger.warn("Refresh interval must be at least 1000ms. Neglecting this change");
-            return;
+            throw new IllegalArgumentException("Refresh interval must be at least 1000ms");
         }
         this.refreshInterval = refreshInterval;
     }

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
@@ -37,23 +37,23 @@ public class RefreshBasedSyncMechanism extends AbstractLifecycleComponent {
     /**
      * Setting name to control the refresh interval of synchronization service
      */
-    public static final String RULE_SYNC_REFRESH_INTERVAL_SETTING_NAME = "wlm.rule.sync_refresh_interval";
+    public static final String RULE_SYNC_REFRESH_INTERVAL_SETTING_NAME = "wlm.rule.sync_refresh_interval_ms";
     /**
      * Default value for refresh interval
      */
-    public static final long RULE_SYNC_REFRESH_INTERVAL_DEFAULT = 5000;
+    public static final long RULE_SYNC_REFRESH_INTERVAL_DEFAULT_MS = 5000;
     /**
      * Minimum value for refresh interval
      */
-    public static final int MIN_SYNC_REFRESH_INTERVAL = 1000;
+    public static final int MIN_SYNC_REFRESH_INTERVAL_MS = 1000;
 
     /**
      * Setting to control the run interval of synchronization service
      */
     public static final Setting<Long> RULE_SYNC_REFRESH_INTERVAL_SETTING = Setting.longSetting(
         RULE_SYNC_REFRESH_INTERVAL_SETTING_NAME,
-        RULE_SYNC_REFRESH_INTERVAL_DEFAULT,
-        MIN_SYNC_REFRESH_INTERVAL,
+        RULE_SYNC_REFRESH_INTERVAL_DEFAULT_MS,
+        MIN_SYNC_REFRESH_INTERVAL_MS,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -150,9 +150,9 @@ public class RefreshBasedSyncMechanism extends AbstractLifecycleComponent {
      * @param refreshInterval
      */
     public void setRefreshInterval(long refreshInterval) {
-        if (refreshInterval < MIN_SYNC_REFRESH_INTERVAL) {
-            logger.warn("Refresh interval must be at least 1000ms. Neglecting this change");
-            throw new IllegalArgumentException("Refresh interval must be at least 1000ms");
+        if (refreshInterval < MIN_SYNC_REFRESH_INTERVAL_MS) {
+            logger.warn("Refresh interval must be at least {}ms. Neglecting this change", MIN_SYNC_REFRESH_INTERVAL_MS);
+            throw new IllegalArgumentException("Refresh interval must be at least " + MIN_SYNC_REFRESH_INTERVAL_MS+ "ms");
         }
         this.refreshInterval = refreshInterval;
     }

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
@@ -1,0 +1,139 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.sync;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.lifecycle.AbstractLifecycleComponent;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.plugin.wlm.WorkloadManagementPlugin;
+import org.opensearch.rule.InMemoryRuleProcessingService;
+import org.opensearch.rule.RuleEntityParser;
+import org.opensearch.rule.autotagging.FeatureType;
+import org.opensearch.rule.storage.AttributeValueStore;
+import org.opensearch.rule.storage.AttributeValueStoreFactory;
+import org.opensearch.threadpool.Scheduler;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * This class pulls the latest rules from the RULES system index to update the in-memory view
+ */
+public class RefreshBasedSyncMechanism extends AbstractLifecycleComponent {
+    public static final String RULE_SYNC_REFRESH_INTERVAL_SETTING_NAME = "wlm.rule.sync_refresh_interval";
+    public static final long RULE_SYNC_REFRESH_INTERVAL_DEFAULT = 5000;
+
+    /**
+     * Setting to control the run interval of Query Group Service
+     */
+    public static final Setting<Long> RULE_SYNC_REFRESH_INTERVAL_SETTING = Setting.longSetting(
+        RULE_SYNC_REFRESH_INTERVAL_SETTING_NAME,
+        RULE_SYNC_REFRESH_INTERVAL_DEFAULT,
+        1000,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+    public static final int MIN_SYNC_REFRESH_INTERVAL = 1000;
+
+    private final Client client;
+    private final ThreadPool threadPool;
+    private long refreshInterval;
+    private volatile Scheduler.Cancellable scheduledFuture;
+    private final RuleEntityParser parser;
+    private final InMemoryRuleProcessingService ruleProcessingService;
+    private final FeatureType featureType;
+    private static final Logger logger = LogManager.getLogger(RefreshBasedSyncMechanism.class);
+
+    public RefreshBasedSyncMechanism(
+        Client client,
+        ThreadPool threadPool,
+        Settings settings,
+        ClusterSettings clusterSettings,
+        RuleEntityParser parser,
+        InMemoryRuleProcessingService ruleProcessingService,
+        FeatureType featureType
+    ) {
+        this.client = client;
+        this.threadPool = threadPool;
+        refreshInterval = RULE_SYNC_REFRESH_INTERVAL_SETTING.get(settings);
+        this.parser = parser;
+        this.ruleProcessingService = ruleProcessingService;
+        this.featureType = featureType;
+        clusterSettings.addSettingsUpdateConsumer(RULE_SYNC_REFRESH_INTERVAL_SETTING, this::setRefreshInterval);
+    }
+
+    void doRun() {
+        clearRulesFromInMemoryService();
+        client.prepareSearch(WorkloadManagementPlugin.INDEX_NAME).execute(new ActionListener<SearchResponse>() {
+            @Override
+            public void onResponse(SearchResponse searchResponse) {
+                Arrays.stream(searchResponse.getHits().getHits())
+                    .forEach(hit -> { ruleProcessingService.add(parser.parse(hit.getSourceAsString())); });
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.info("Failed to refresh rules from in-memory service.");
+            }
+        });
+    }
+
+    private void clearRulesFromInMemoryService() {
+        final AttributeValueStoreFactory attributeValueStoreFactory = ruleProcessingService.getAttributeValueStoreFactory();
+        featureType.getAllowedAttributesRegistry().values().stream().forEach(attribute -> {
+            final AttributeValueStore<String, String> attributeValueStore = attributeValueStoreFactory.getAttributeValueStore(attribute);
+            if (attributeValueStore != null) {
+                attributeValueStore.clear();
+            }
+        });
+    }
+
+    @Override
+    protected void doStart() {
+        scheduledFuture = threadPool.scheduleWithFixedDelay(
+            this::doRun,
+            TimeValue.timeValueMillis(refreshInterval),
+            ThreadPool.Names.GENERIC
+        );
+    }
+
+    @Override
+    protected void doStop() {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel();
+        }
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel();
+        }
+    }
+
+    /**
+     * sets the refresh interval for the rule sync mechanism
+     * @param refreshInterval
+     */
+    public void setRefreshInterval(long refreshInterval) {
+        if (refreshInterval < MIN_SYNC_REFRESH_INTERVAL) {
+            logger.warn("Refresh interval must be at least 1000ms. Neglecting this change");
+            return;
+        }
+        this.refreshInterval = refreshInterval;
+    }
+}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
@@ -157,7 +157,7 @@ public class RefreshBasedSyncMechanism extends AbstractLifecycleComponent {
         }
     }
 
-    public void setWlmMode(WlmMode mode) {
+    void setWlmMode(WlmMode mode) {
         this.wlmMode = mode;
     }
 }

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
@@ -34,20 +34,29 @@ import java.util.Arrays;
  * This class pulls the latest rules from the RULES system index to update the in-memory view
  */
 public class RefreshBasedSyncMechanism extends AbstractLifecycleComponent {
+    /**
+     * Setting name to control the refresh interval of synchronization service
+     */
     public static final String RULE_SYNC_REFRESH_INTERVAL_SETTING_NAME = "wlm.rule.sync_refresh_interval";
+    /**
+     * Default value for refresh interval
+     */
     public static final long RULE_SYNC_REFRESH_INTERVAL_DEFAULT = 5000;
+    /**
+     * Minimum value for refresh interval
+     */
+    public static final int MIN_SYNC_REFRESH_INTERVAL = 1000;
 
     /**
-     * Setting to control the run interval of Query Group Service
+     * Setting to control the run interval of synchronization service
      */
     public static final Setting<Long> RULE_SYNC_REFRESH_INTERVAL_SETTING = Setting.longSetting(
         RULE_SYNC_REFRESH_INTERVAL_SETTING_NAME,
         RULE_SYNC_REFRESH_INTERVAL_DEFAULT,
-        1000,
+        MIN_SYNC_REFRESH_INTERVAL,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
-    public static final int MIN_SYNC_REFRESH_INTERVAL = 1000;
 
     private final Client client;
     private final ThreadPool threadPool;
@@ -58,6 +67,17 @@ public class RefreshBasedSyncMechanism extends AbstractLifecycleComponent {
     private final FeatureType featureType;
     private static final Logger logger = LogManager.getLogger(RefreshBasedSyncMechanism.class);
 
+    /**
+     * Constructor
+     *
+     * @param client
+     * @param threadPool
+     * @param settings
+     * @param clusterSettings
+     * @param parser
+     * @param ruleProcessingService
+     * @param featureType
+     */
     public RefreshBasedSyncMechanism(
         Client client,
         ThreadPool threadPool,

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
@@ -34,7 +34,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-
 /**
  * This class pulls the latest rules from the RULES system index to update the in-memory view
  */

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
@@ -121,7 +121,7 @@ public class RefreshBasedSyncMechanism extends AbstractLifecycleComponent {
                     final Set<Rule> newRules = new HashSet<>(response.getRules().values());
                     ruleEventClassifier.setPreviousRules(lastRunIndexedRules);
 
-                    ruleEventClassifier.getRuleEvents(newRules).forEach(event -> { event.process(ruleProcessingService); });
+                    ruleEventClassifier.getRuleEvents(newRules).forEach(event -> { event.process(); });
 
                     lastRunIndexedRules = newRules;
                 }

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
@@ -16,6 +16,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.plugin.wlm.rule.sync.detect.RuleEvent;
 import org.opensearch.plugin.wlm.rule.sync.detect.RuleEventClassifier;
 import org.opensearch.rule.GetRuleRequest;
 import org.opensearch.rule.GetRuleResponse;
@@ -125,7 +126,7 @@ public class RefreshBasedSyncMechanism extends AbstractLifecycleComponent {
                     final Set<Rule> newRules = new HashSet<>(response.getRules().values());
                     ruleEventClassifier.setPreviousRules(lastRunIndexedRules);
 
-                    ruleEventClassifier.getRuleEvents(newRules).forEach(event -> { event.process(); });
+                    ruleEventClassifier.getRuleEvents(newRules).forEach(RuleEvent::process);
 
                     lastRunIndexedRules = newRules;
                 }

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/AddRuleEvent.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/AddRuleEvent.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.sync.detect;
+
+import org.opensearch.rule.InMemoryRuleProcessingService;
+import org.opensearch.rule.autotagging.Rule;
+
+/**
+ * This class represents an add rule event which can be consumed by {@link org.opensearch.plugin.wlm.rule.sync.RefreshBasedSyncMechanism}
+ */
+public class AddRuleEvent implements RuleEvent {
+    private final Rule newRule;
+
+    /**
+     * Constructor
+     * @param newRule
+     */
+    public AddRuleEvent(Rule newRule) {
+        this.newRule = newRule;
+    }
+
+    @Override
+    public void process(InMemoryRuleProcessingService inMemoryRuleProcessingService) {
+        inMemoryRuleProcessingService.add(newRule);
+    }
+}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/AddRuleEvent.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/AddRuleEvent.java
@@ -16,17 +16,19 @@ import org.opensearch.rule.autotagging.Rule;
  */
 public class AddRuleEvent implements RuleEvent {
     private final Rule newRule;
+    private final InMemoryRuleProcessingService ruleProcessingService;
 
     /**
      * Constructor
      * @param newRule
      */
-    public AddRuleEvent(Rule newRule) {
+    public AddRuleEvent(Rule newRule, InMemoryRuleProcessingService ruleProcessingService) {
         this.newRule = newRule;
+        this.ruleProcessingService = ruleProcessingService;
     }
 
     @Override
-    public void process(InMemoryRuleProcessingService inMemoryRuleProcessingService) {
-        inMemoryRuleProcessingService.add(newRule);
+    public void process() {
+        ruleProcessingService.add(newRule);
     }
 }

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/AddRuleEvent.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/AddRuleEvent.java
@@ -21,6 +21,7 @@ public class AddRuleEvent implements RuleEvent {
     /**
      * Constructor
      * @param newRule
+     * @param ruleProcessingService
      */
     public AddRuleEvent(Rule newRule, InMemoryRuleProcessingService ruleProcessingService) {
         this.newRule = newRule;

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/DeleteRuleEvent.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/DeleteRuleEvent.java
@@ -21,6 +21,7 @@ public class DeleteRuleEvent implements RuleEvent {
     /**
      * Constructor
      * @param deletedRule
+     * @param ruleProcessingService
      */
     public DeleteRuleEvent(Rule deletedRule, InMemoryRuleProcessingService ruleProcessingService) {
         this.deletedRule = deletedRule;

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/DeleteRuleEvent.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/DeleteRuleEvent.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.sync.detect;
+
+import org.opensearch.rule.InMemoryRuleProcessingService;
+import org.opensearch.rule.autotagging.Rule;
+
+/**
+ * This class represents a delete rule event which can be consumed by {@link org.opensearch.plugin.wlm.rule.sync.RefreshBasedSyncMechanism}
+ */
+public class DeleteRuleEvent implements RuleEvent {
+    private Rule deletedRule;
+
+    /**
+     * Constructor
+     * @param deletedRule
+     */
+    public DeleteRuleEvent(Rule deletedRule) {
+        this.deletedRule = deletedRule;
+    }
+
+    @Override
+    public void process(InMemoryRuleProcessingService inMemoryRuleProcessingService) {
+        inMemoryRuleProcessingService.remove(deletedRule);
+    }
+}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/DeleteRuleEvent.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/DeleteRuleEvent.java
@@ -16,17 +16,19 @@ import org.opensearch.rule.autotagging.Rule;
  */
 public class DeleteRuleEvent implements RuleEvent {
     private Rule deletedRule;
+    private final InMemoryRuleProcessingService ruleProcessingService;
 
     /**
      * Constructor
      * @param deletedRule
      */
-    public DeleteRuleEvent(Rule deletedRule) {
+    public DeleteRuleEvent(Rule deletedRule, InMemoryRuleProcessingService ruleProcessingService) {
         this.deletedRule = deletedRule;
+        this.ruleProcessingService = ruleProcessingService;
     }
 
     @Override
-    public void process(InMemoryRuleProcessingService inMemoryRuleProcessingService) {
-        inMemoryRuleProcessingService.remove(deletedRule);
+    public void process() {
+        ruleProcessingService.remove(deletedRule);
     }
 }

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEvent.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEvent.java
@@ -8,8 +8,6 @@
 
 package org.opensearch.plugin.wlm.rule.sync.detect;
 
-import org.opensearch.rule.InMemoryRuleProcessingService;
-
 /**
  * This interface represents a rule event which can be consumed by {@link org.opensearch.plugin.wlm.rule.sync.RefreshBasedSyncMechanism}
  */
@@ -17,7 +15,6 @@ public interface RuleEvent {
     /**
      * This method is used to consume this event
      *
-     * @param inMemoryRuleProcessingService
      */
-    void process(InMemoryRuleProcessingService inMemoryRuleProcessingService);
+    void process();
 }

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEvent.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEvent.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.sync.detect;
+
+import org.opensearch.rule.InMemoryRuleProcessingService;
+
+/**
+ * This interface represents a rule event which can be consumed by {@link org.opensearch.plugin.wlm.rule.sync.RefreshBasedSyncMechanism}
+ */
+public interface RuleEvent {
+    /**
+     * This method is used to consume this event
+     *
+     * @param inMemoryRuleProcessingService
+     */
+    void process(InMemoryRuleProcessingService inMemoryRuleProcessingService);
+}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEventClassifier.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEventClassifier.java
@@ -32,6 +32,7 @@ public class RuleEventClassifier {
      * Constructor
      *
      * @param previousRules
+     * @param ruleProcessingService
      */
     public RuleEventClassifier(Set<Rule> previousRules, InMemoryRuleProcessingService ruleProcessingService) {
         this.previousRules = previousRules;

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEventClassifier.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEventClassifier.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.sync.detect;
+
+import org.opensearch.plugin.wlm.rule.sync.RefreshBasedSyncMechanism;
+import org.opensearch.rule.autotagging.Rule;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This class is responsible for determining new {@link RuleEvent}s based on the previous snapshot of {@link Rule}s
+ */
+public class RuleEventClassifier {
+    private Set<Rule> previousRules;
+    private Map<String, Rule> previousRuleMap;
+    private Map<String, Rule> newRuleMap;
+
+    /**
+     * Constructor
+     *
+     * @param previousRules
+     */
+    public RuleEventClassifier(Set<Rule> previousRules) {
+        this.previousRules = previousRules;
+        this.previousRuleMap = previousRules.stream().collect(Collectors.toMap(Rule::getId, rule -> rule));
+    }
+
+    /**
+     * This method classifies the rules based on the previous and new rules
+     * and returns the appropriate rule events.
+     * @param newRules Set of new rules
+     * @return List of rule events
+     */
+    public List<RuleEvent> getRuleEvents(Set<Rule> newRules) {
+        this.newRuleMap = newRules.stream().collect(Collectors.toMap(Rule::getId, rule -> rule));
+        List<RuleEvent> ruleEvents = new ArrayList<>();
+
+        // handles updates and add
+        for (Rule newRule : newRules) {
+            if (isPotentialNewRule(newRule)) {
+                if (isRuleUpdated(newRule)) {
+                    ruleEvents.add(new UpdateRuleEvent(previousRuleMap.get(newRule.getId()), newRule));
+                } else {
+                    ruleEvents.add(new AddRuleEvent(newRule));
+                }
+            }
+        }
+
+        // handles deletes
+        for (Rule previousRule : previousRules) {
+            if (isRuleDeleted(previousRule)) {
+                ruleEvents.add(new DeleteRuleEvent(previousRule));
+            }
+        }
+        return ruleEvents;
+    }
+
+    private boolean isPotentialNewRule(Rule rule) {
+        return !previousRules.contains(rule);
+    }
+
+    private boolean isRuleUpdated(Rule rule) {
+        return previousRuleMap.containsKey(rule.getId());
+    }
+
+    private boolean isRuleDeleted(Rule rule) {
+        return !newRuleMap.containsKey(rule.getId());
+    }
+
+    /**
+     * Sets the previous rules and updates the previous rule map
+     * which will be used to compute rule change events during next {@link RefreshBasedSyncMechanism} run
+     * @param previousRules
+     */
+    public void setPreviousRules(Set<Rule> previousRules) {
+        this.previousRules = previousRules;
+        this.previousRuleMap = previousRules.stream().collect(Collectors.toMap(Rule::getId, rule -> rule));
+    }
+}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEventClassifier.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEventClassifier.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 
 /**
  * This class is responsible for determining new {@link RuleEvent}s based on the previous snapshot of {@link Rule}s
+ * <b>Warning:</b>  This class is not thread-safe and is expected to be called from a single thread only
  */
 public class RuleEventClassifier {
     private Set<Rule> previousRules;

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/UpdateRuleEvent.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/UpdateRuleEvent.java
@@ -17,20 +17,22 @@ import org.opensearch.rule.autotagging.Rule;
 public class UpdateRuleEvent implements RuleEvent {
     private final Rule previousRule;
     private final Rule newRule;
+    private final InMemoryRuleProcessingService ruleProcessingService;
 
     /**
      * Constructor
      * @param previousRule
      * @param newRule
      */
-    public UpdateRuleEvent(Rule previousRule, Rule newRule) {
+    public UpdateRuleEvent(Rule previousRule, Rule newRule, InMemoryRuleProcessingService ruleProcessingService) {
         this.previousRule = previousRule;
         this.newRule = newRule;
+        this.ruleProcessingService = ruleProcessingService;
     }
 
     @Override
-    public void process(InMemoryRuleProcessingService inMemoryRuleProcessingService) {
-        inMemoryRuleProcessingService.remove(previousRule);
-        inMemoryRuleProcessingService.add(newRule);
+    public void process() {
+        ruleProcessingService.remove(previousRule);
+        ruleProcessingService.add(newRule);
     }
 }

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/UpdateRuleEvent.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/UpdateRuleEvent.java
@@ -23,6 +23,7 @@ public class UpdateRuleEvent implements RuleEvent {
      * Constructor
      * @param previousRule
      * @param newRule
+     * @param ruleProcessingService
      */
     public UpdateRuleEvent(Rule previousRule, Rule newRule, InMemoryRuleProcessingService ruleProcessingService) {
         this.previousRule = previousRule;

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/UpdateRuleEvent.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/UpdateRuleEvent.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.sync.detect;
+
+import org.opensearch.rule.InMemoryRuleProcessingService;
+import org.opensearch.rule.autotagging.Rule;
+
+/**
+ * This class represents an update rule event which can be consumed by {@link org.opensearch.plugin.wlm.rule.sync.RefreshBasedSyncMechanism}
+ */
+public class UpdateRuleEvent implements RuleEvent {
+    private final Rule previousRule;
+    private final Rule newRule;
+
+    /**
+     * Constructor
+     * @param previousRule
+     * @param newRule
+     */
+    public UpdateRuleEvent(Rule previousRule, Rule newRule) {
+        this.previousRule = previousRule;
+        this.newRule = newRule;
+    }
+
+    @Override
+    public void process(InMemoryRuleProcessingService inMemoryRuleProcessingService) {
+        inMemoryRuleProcessingService.remove(previousRule);
+        inMemoryRuleProcessingService.add(newRule);
+    }
+}

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/package-info.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/detect/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+/**
+ * This package contains constructs to detect and handle rule changes between index and in memory view of indices
+ * This package will facilitate detecting, add, update, delete events during current and previous {@link org.opensearch.plugin.wlm.rule.sync.RefreshBasedSyncMechanism}
+ * run and then apply these events to in memory view of Rules
+ */
+package org.opensearch.plugin.wlm.rule.sync.detect;

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/package-info.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/package-info.java
@@ -6,6 +6,6 @@
  * compatible open source license.
  */
 /**
- * This package contains synchronization related constructs
+ * This package contains constructs to enable synchronization between index and in memory view of Rules
  */
 package org.opensearch.plugin.wlm.rule.sync;

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/package-info.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+/**
+ * This package contains synchronization related constructs
+ */
+package org.opensearch.plugin.wlm.rule.sync;

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/AutoTaggingActionFilterTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/AutoTaggingActionFilterTests.java
@@ -19,6 +19,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.rule.InMemoryRuleProcessingService;
 import org.opensearch.rule.autotagging.Attribute;
 import org.opensearch.rule.autotagging.FeatureType;
+import org.opensearch.rule.storage.AttributeValueStoreFactory;
 import org.opensearch.rule.storage.DefaultAttributeValueStore;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
@@ -46,7 +47,11 @@ public class AutoTaggingActionFilterTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         threadPool = new TestThreadPool("AutoTaggingActionFilterTests");
-        ruleProcessingService = spy(new InMemoryRuleProcessingService(WLMFeatureType.WLM, DefaultAttributeValueStore::new));
+        AttributeValueStoreFactory attributeValueStoreFactory = new AttributeValueStoreFactory(
+            WLMFeatureType.WLM,
+            DefaultAttributeValueStore::new
+        );
+        ruleProcessingService = spy(new InMemoryRuleProcessingService(attributeValueStoreFactory));
         autoTaggingActionFilter = new AutoTaggingActionFilter(ruleProcessingService, threadPool);
     }
 

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/WorkloadManagementPluginTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/WorkloadManagementPluginTests.java
@@ -123,7 +123,7 @@ public class WorkloadManagementPluginTests extends OpenSearchTestCase {
     public void testGetFeatureTypeReturnsWorkloadGroupFeatureType() {
         plugin.createComponents(
             mock(Client.class),
-            mock(ClusterService.class),
+            mockClusterService,
             mock(ThreadPool.class),
             mock(ResourceWatcherService.class),
             mock(ScriptService.class),

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/WorkloadManagementPluginTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/WorkloadManagementPluginTests.java
@@ -49,6 +49,21 @@ import static org.mockito.Mockito.when;
 
 public class WorkloadManagementPluginTests extends OpenSearchTestCase {
     WorkloadManagementPlugin plugin = new WorkloadManagementPlugin();
+    ClusterService mockClusterService;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockClusterService = mock(ClusterService.class);
+        Settings settings = Settings.builder().put(RefreshBasedSyncMechanism.RULE_SYNC_REFRESH_INTERVAL_SETTING_NAME, 1000).build();
+        when(mockClusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, new HashSet<>(plugin.getSettings())));
+        when(mockClusterService.getSettings()).thenReturn(settings);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
 
     public void testGetActionsReturnsHandlers() {
         List<ActionPlugin.ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = plugin.getActions();
@@ -78,7 +93,7 @@ public class WorkloadManagementPluginTests extends OpenSearchTestCase {
         Client mockClient = mock(Client.class);
         plugin.createComponents(
             mockClient,
-            mock(ClusterService.class),
+            mockClusterService,
             mock(ThreadPool.class),
             mock(ResourceWatcherService.class),
             mock(ScriptService.class),
@@ -138,7 +153,6 @@ public class WorkloadManagementPluginTests extends OpenSearchTestCase {
      */
     public void testCreateComponentsReturnsRefreshMechanism() {
         Client mockClient = mock(Client.class);
-        ClusterService mockClusterService = mock(ClusterService.class);
         ThreadPool mockThreadPool = mock(ThreadPool.class);
         ResourceWatcherService mockResourceWatcherService = mock(ResourceWatcherService.class);
         ScriptService mockScriptService = mock(ScriptService.class);
@@ -147,9 +161,6 @@ public class WorkloadManagementPluginTests extends OpenSearchTestCase {
         NamedWriteableRegistry mockNamedWriteableRegistry = mock(NamedWriteableRegistry.class);
         IndexNameExpressionResolver mockIndexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
         Supplier<RepositoriesService> mockRepositoriesServiceSupplier = () -> mock(RepositoriesService.class);
-        Settings settings = Settings.builder().put(RefreshBasedSyncMechanism.RULE_SYNC_REFRESH_INTERVAL_SETTING_NAME, 1000).build();
-        when(mockClusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, new HashSet<>(plugin.getSettings())));
-        when(mockClusterService.getSettings()).thenReturn(settings);
 
         Collection<Object> components = plugin.createComponents(
             mockClient,

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/WorkloadManagementPluginTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/WorkloadManagementPluginTests.java
@@ -38,6 +38,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 import org.opensearch.watcher.ResourceWatcherService;
+import org.opensearch.wlm.WorkloadManagementSettings;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -56,7 +57,9 @@ public class WorkloadManagementPluginTests extends OpenSearchTestCase {
         super.setUp();
         mockClusterService = mock(ClusterService.class);
         Settings settings = Settings.builder().put(RefreshBasedSyncMechanism.RULE_SYNC_REFRESH_INTERVAL_SETTING_NAME, 1000).build();
-        when(mockClusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, new HashSet<>(plugin.getSettings())));
+        ClusterSettings clusterSettings = new ClusterSettings(settings, new HashSet<>(plugin.getSettings()));
+        clusterSettings.registerSetting(WorkloadManagementSettings.WLM_MODE_SETTING);
+        when(mockClusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(mockClusterService.getSettings()).thenReturn(settings);
     }
 

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanismTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanismTests.java
@@ -1,0 +1,163 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.sync;
+
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.action.search.SearchRequestBuilder;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.plugin.wlm.WorkloadManagementPlugin;
+import org.opensearch.plugin.wlm.rule.WorkloadGroupFeatureType;
+import org.opensearch.rule.InMemoryRuleProcessingService;
+import org.opensearch.rule.RuleEntityParser;
+import org.opensearch.rule.autotagging.FeatureType;
+import org.opensearch.rule.storage.AttributeValueStoreFactory;
+import org.opensearch.rule.storage.DefaultAttributeValueStore;
+import org.opensearch.rule.storage.XContentRuleParser;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.Scheduler;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Locale;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RefreshBasedSyncMechanismTests extends OpenSearchTestCase {
+    public static final String VALID_JSON = String.format(Locale.ROOT, """
+        {
+            "description": "%s",
+            "workload_group": "feature value",
+            "index_pattern": ["attribute_value_one", "attribute_value_two"],
+            "updated_at": "%s"
+        }
+        """, "test description", Instant.now().toString());
+
+    RefreshBasedSyncMechanism sut;
+
+    Client mockClient;
+    InMemoryRuleProcessingService ruleProcessingService;
+    FeatureType featureType;
+    AttributeValueStoreFactory attributeValueStoreFactory;
+    ThreadPool mockThreadPool;
+    Scheduler.Cancellable scheduledFuture;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        try (WorkloadManagementPlugin plugin = new WorkloadManagementPlugin()) {
+            Settings settings = Settings.builder().put(RefreshBasedSyncMechanism.RULE_SYNC_REFRESH_INTERVAL_SETTING_NAME, 1000).build();
+            ClusterSettings clusterSettings = new ClusterSettings(settings, new HashSet<>(plugin.getSettings()));
+            mockThreadPool = mock(ThreadPool.class);
+            attributeValueStoreFactory = new AttributeValueStoreFactory(WorkloadGroupFeatureType.INSTANCE, DefaultAttributeValueStore::new);
+            RuleEntityParser parser = new XContentRuleParser(WorkloadGroupFeatureType.INSTANCE);
+            ruleProcessingService = mock(InMemoryRuleProcessingService.class);
+            mockClient = mock(Client.class);
+            when(ruleProcessingService.getAttributeValueStoreFactory()).thenReturn(attributeValueStoreFactory);
+            scheduledFuture = mock(Scheduler.Cancellable.class);
+            when(mockThreadPool.scheduleWithFixedDelay(any(), any(), any())).thenReturn(scheduledFuture);
+
+            sut = new RefreshBasedSyncMechanism(
+                mockClient,
+                mockThreadPool,
+                settings,
+                clusterSettings,
+                parser,
+                ruleProcessingService,
+                WorkloadGroupFeatureType.INSTANCE
+            );
+        }
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    public void testDoStart() {
+        sut.doStart();
+        verify(mockThreadPool, times(1)).scheduleWithFixedDelay(any(), any(), any());
+    }
+
+    public void testDoStop() {
+        sut.doStart();
+        sut.doStop();
+        verify(scheduledFuture, times(1)).cancel();
+    }
+
+    public void testDoClose() throws IOException {
+        sut.doStart();
+        sut.doClose();
+        verify(scheduledFuture, times(1)).cancel();
+    }
+
+    /**
+     * Tests the behavior of doRun when the search operation fails.
+     * This test verifies that the method handles the failure case correctly
+     * by logging the failure without throwing an exception.
+     */
+    @SuppressWarnings("unchecked")
+    public void testDoRunSearchFailure() {
+        SearchRequestBuilder requestBuilder = mock(SearchRequestBuilder.class);
+        when(mockClient.prepareSearch(eq(WorkloadManagementPlugin.INDEX_NAME))).thenReturn(requestBuilder);
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(0);
+            listener.onFailure(new RuntimeException("Search failed"));
+            return null;
+        }).when(requestBuilder).execute(any(ActionListener.class));
+
+        sut.doRun();
+
+        verify(mockClient).prepareSearch(eq(WorkloadManagementPlugin.INDEX_NAME));
+        verify(ruleProcessingService, times(1)).getAttributeValueStoreFactory();
+    }
+
+    /**
+     * Test case for the doRun() method.
+     * This test verifies that the doRun() method clears rules from the in-memory service
+     * and attempts to refresh rules by executing a search request.
+     */
+    @SuppressWarnings("unchecked")
+    public void test_doRun_clearsAndRefreshesRules() {
+        SearchRequestBuilder requestBuilder = mock(SearchRequestBuilder.class);
+        SearchResponse searchResponse = mock(SearchResponse.class);
+
+        SearchHits searchHits = new SearchHits(new SearchHit[] { new SearchHit(1) }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchHit hit = searchHits.getHits()[0];
+        hit.sourceRef(new BytesArray(VALID_JSON));
+        when(searchResponse.getHits()).thenReturn(searchHits);
+
+        when(mockClient.prepareSearch(eq(WorkloadManagementPlugin.INDEX_NAME))).thenReturn(requestBuilder);
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(0);
+            listener.onResponse(searchResponse);
+            return null;
+        }).when(requestBuilder).execute(any(ActionListener.class));
+
+        sut.doRun();
+
+        verify(ruleProcessingService, times(1)).getAttributeValueStoreFactory();
+        verify(ruleProcessingService, times(1)).add(any());
+        verify(mockClient, times(1)).prepareSearch(WorkloadManagementPlugin.INDEX_NAME);
+    }
+}

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanismTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanismTests.java
@@ -70,11 +70,11 @@ public class RefreshBasedSyncMechanismTests extends OpenSearchTestCase {
             ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, new HashSet<>(plugin.getSettings()));
             clusterSettings.registerSetting(WorkloadManagementSettings.WLM_MODE_SETTING);
             mockThreadPool = mock(ThreadPool.class);
+            ruleProcessingService = mock(InMemoryRuleProcessingService.class);
             rulePersistenceService = mock(RulePersistenceService.class);
-            ruleEventClassifier = new RuleEventClassifier(Collections.emptySet());
+            ruleEventClassifier = new RuleEventClassifier(Collections.emptySet(), ruleProcessingService);
             attributeValueStoreFactory = new AttributeValueStoreFactory(WorkloadGroupFeatureType.INSTANCE, DefaultAttributeValueStore::new);
             RuleEntityParser parser = new XContentRuleParser(WorkloadGroupFeatureType.INSTANCE);
-            ruleProcessingService = mock(InMemoryRuleProcessingService.class);
             mockClient = mock(Client.class);
             scheduledFuture = mock(Scheduler.Cancellable.class);
             when(mockThreadPool.scheduleWithFixedDelay(any(), any(), any())).thenReturn(scheduledFuture);

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEventClassifierTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEventClassifierTests.java
@@ -8,8 +8,7 @@
 
 package org.opensearch.plugin.wlm.rule.sync.detect;
 
-import org.opensearch.plugin.wlm.rule.WorkloadGroupFeatureType;
-import org.opensearch.rule.RuleAttribute;
+import org.opensearch.plugin.wlm.AutoTaggingActionFilterTests;
 import org.opensearch.rule.autotagging.Rule;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -78,14 +77,14 @@ public class RuleEventClassifierTests extends OpenSearchTestCase {
 
     }
 
-    Rule getRandomRule(String id) {
+    public static Rule getRandomRule(String id) {
         return Rule.builder()
             .id(id)
             .description("description")
-            .attributeMap(Map.of(RuleAttribute.INDEX_PATTERN, Set.of(randomAlphaOfLengthBetween(2, 10))))
+            .attributeMap(Map.of(AutoTaggingActionFilterTests.TestAttribute.TEST_ATTRIBUTE, Set.of(randomAlphaOfLengthBetween(2, 10))))
             .featureValue(randomAlphaOfLengthBetween(2, 10))
             .updatedAt("2025-05-27T08:58:57.558Z")
-            .featureType(WorkloadGroupFeatureType.INSTANCE)
+            .featureType(AutoTaggingActionFilterTests.WLMFeatureType.WLM)
             .build();
     }
 }

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEventClassifierTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEventClassifierTests.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.wlm.rule.sync.detect;
+
+import org.opensearch.plugin.wlm.rule.WorkloadGroupFeatureType;
+import org.opensearch.rule.RuleAttribute;
+import org.opensearch.rule.autotagging.Rule;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class RuleEventClassifierTests extends OpenSearchTestCase {
+    public static final int TOTAL_RULE_COUNT = 10;
+    RuleEventClassifier sut;
+
+    public void testGetRuleEventsForAddRuleEvents() {
+        sut = new RuleEventClassifier(Collections.emptySet());
+        Set<Rule> newRules = new HashSet<>();
+        for (int i = 0; i < TOTAL_RULE_COUNT; i++) {
+            newRules.add(getRandomRule(String.valueOf(i)));
+        }
+
+        List<RuleEvent> addRuleEvents = sut.getRuleEvents(newRules);
+        assertEquals(TOTAL_RULE_COUNT, addRuleEvents.size());
+        assertTrue(addRuleEvents.stream().allMatch(ruleEvent -> ruleEvent instanceof AddRuleEvent));
+    }
+
+    public void testDeleteRuleEvents() {
+        Set<Rule> previousRules = new HashSet<>();
+        for (int i = 0; i < TOTAL_RULE_COUNT; i++) {
+            previousRules.add(getRandomRule(String.valueOf(i)));
+        }
+        final int EXISTING_RULE_COUNT = 3;
+        Set<Rule> newRules = new HashSet<>();
+        Iterator<Rule> ruleIterator = previousRules.iterator();
+        for (int i = 0; i < EXISTING_RULE_COUNT; i++) {
+            newRules.add(ruleIterator.next());
+        }
+        sut = new RuleEventClassifier(previousRules);
+        List<RuleEvent> deleteRuleEvents = sut.getRuleEvents(newRules);
+
+        assertEquals(TOTAL_RULE_COUNT - EXISTING_RULE_COUNT, deleteRuleEvents.size());
+        assertTrue(deleteRuleEvents.stream().allMatch(ruleEvent -> ruleEvent instanceof DeleteRuleEvent));
+
+    }
+
+    public void testUpdateRuleEvents() {
+        Set<Rule> previousRules = new HashSet<>();
+        Set<Rule> newRules = new HashSet<>();
+        final int EXISTING_RULE_COUNT = 3;
+        for (int i = 0; i < TOTAL_RULE_COUNT; i++) {
+            Rule randomRule = getRandomRule(String.valueOf(i));
+            previousRules.add(randomRule);
+            if (i < EXISTING_RULE_COUNT) {
+                newRules.add(randomRule);
+            }
+        }
+
+        for (int i = EXISTING_RULE_COUNT; i < TOTAL_RULE_COUNT; i++) {
+            newRules.add(getRandomRule(String.valueOf(i)));
+        }
+        sut = new RuleEventClassifier(previousRules);
+        List<RuleEvent> deleteRuleEvents = sut.getRuleEvents(newRules);
+
+        assertEquals(TOTAL_RULE_COUNT - EXISTING_RULE_COUNT, deleteRuleEvents.size());
+        assertTrue(deleteRuleEvents.stream().allMatch(ruleEvent -> ruleEvent instanceof UpdateRuleEvent));
+
+    }
+
+    Rule getRandomRule(String id) {
+        return Rule.builder()
+            .id(id)
+            .description("description")
+            .attributeMap(Map.of(RuleAttribute.INDEX_PATTERN, Set.of(randomAlphaOfLengthBetween(2, 10))))
+            .featureValue(randomAlphaOfLengthBetween(2, 10))
+            .updatedAt("2025-05-27T08:58:57.558Z")
+            .featureType(WorkloadGroupFeatureType.INSTANCE)
+            .build();
+    }
+}

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEventClassifierTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/rule/sync/detect/RuleEventClassifierTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.plugin.wlm.rule.sync.detect;
 
 import org.opensearch.plugin.wlm.AutoTaggingActionFilterTests;
+import org.opensearch.rule.InMemoryRuleProcessingService;
 import org.opensearch.rule.autotagging.Rule;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -19,12 +20,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.mockito.Mockito.mock;
+
 public class RuleEventClassifierTests extends OpenSearchTestCase {
     public static final int TOTAL_RULE_COUNT = 10;
     RuleEventClassifier sut;
 
+    InMemoryRuleProcessingService ruleProcessingService = mock(InMemoryRuleProcessingService.class);
+
     public void testGetRuleEventsForAddRuleEvents() {
-        sut = new RuleEventClassifier(Collections.emptySet());
+        sut = new RuleEventClassifier(Collections.emptySet(), ruleProcessingService);
         Set<Rule> newRules = new HashSet<>();
         for (int i = 0; i < TOTAL_RULE_COUNT; i++) {
             newRules.add(getRandomRule(String.valueOf(i)));
@@ -46,7 +51,7 @@ public class RuleEventClassifierTests extends OpenSearchTestCase {
         for (int i = 0; i < EXISTING_RULE_COUNT; i++) {
             newRules.add(ruleIterator.next());
         }
-        sut = new RuleEventClassifier(previousRules);
+        sut = new RuleEventClassifier(previousRules, ruleProcessingService);
         List<RuleEvent> deleteRuleEvents = sut.getRuleEvents(newRules);
 
         assertEquals(TOTAL_RULE_COUNT - EXISTING_RULE_COUNT, deleteRuleEvents.size());
@@ -69,7 +74,7 @@ public class RuleEventClassifierTests extends OpenSearchTestCase {
         for (int i = EXISTING_RULE_COUNT; i < TOTAL_RULE_COUNT; i++) {
             newRules.add(getRandomRule(String.valueOf(i)));
         }
-        sut = new RuleEventClassifier(previousRules);
+        sut = new RuleEventClassifier(previousRules, ruleProcessingService);
         List<RuleEvent> deleteRuleEvents = sut.getRuleEvents(newRules);
 
         assertEquals(TOTAL_RULE_COUNT - EXISTING_RULE_COUNT, deleteRuleEvents.size());


### PR DESCRIPTION
### Description
This change adds a periodically running thread to refresh the current in-memory `Rule`s view from `RULES` system index.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/16797#issuecomment-2594284060%3E
https://github.com/opensearch-project/OpenSearch/issues/13341

### Check List
- [X] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
