### PR TITLE
Fix assertion in RemoteStatePublicationIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteStatePublicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/remote/RemoteStatePublicationIT.java
@@ -89,6 +89,7 @@ import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_ST
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT;
 import static org.opensearch.node.remotestore.RemoteStoreNodeAttribute.REMOTE_STORE_ROUTING_TABLE_REPOSITORY_NAME_ATTRIBUTE_KEY;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
@@ -589,7 +590,10 @@ public class RemoteStatePublicationIT extends RemoteStoreBaseIntegTestCase {
         assertEquals(0, dataNodeDiscoveryStats.getClusterStateStats().getUpdateSuccess());
         assertTrue(dataNodeDiscoveryStats.getClusterStateStats().getPersistenceStats().get(0).getSuccessCount() > 0);
         assertEquals(0, dataNodeDiscoveryStats.getClusterStateStats().getPersistenceStats().get(0).getFailedCount());
-        assertTrue(dataNodeDiscoveryStats.getClusterStateStats().getPersistenceStats().get(0).getTotalTimeInMillis() > 0);
+        assertThat(
+            dataNodeDiscoveryStats.getClusterStateStats().getPersistenceStats().get(0).getTotalTimeInMillis(),
+            greaterThanOrEqualTo(0L)
+        );
         assertEquals(
             0,
             dataNodeDiscoveryStats.getClusterStateStats()
@@ -602,7 +606,10 @@ public class RemoteStatePublicationIT extends RemoteStoreBaseIntegTestCase {
 
         assertTrue(dataNodeDiscoveryStats.getClusterStateStats().getPersistenceStats().get(1).getSuccessCount() > 0);
         assertEquals(0, dataNodeDiscoveryStats.getClusterStateStats().getPersistenceStats().get(1).getFailedCount());
-        assertTrue(dataNodeDiscoveryStats.getClusterStateStats().getPersistenceStats().get(1).getTotalTimeInMillis() > 0);
+        assertThat(
+            dataNodeDiscoveryStats.getClusterStateStats().getPersistenceStats().get(1).getTotalTimeInMillis(),
+            greaterThanOrEqualTo(0L)
+        );
         assertEquals(
             0,
             dataNodeDiscoveryStats.getClusterStateStats()


### PR DESCRIPTION
I believe it's a mistake to assume that an operation will take more than zero milliseconds. We don't necessarily know the resolution of the clocks on the test machines, and a sufficently fast download in the test environment can be truncated to zero millis.

### Related Issues
I've observed this failure in my local testing (see #18108) and it's easy to reproduce, but I haven't observed it fail in CI.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
