### PR TITLE
Add syscalls for merge operation error

### DIFF
--- a/distribution/packages/src/common/systemd/opensearch.service
+++ b/distribution/packages/src/common/systemd/opensearch.service
@@ -100,6 +100,8 @@ LockPersonality=yes
 # System call filterings which restricts which system calls a process can make
 # @ means allowed
 # ~ means not allowed
+# These syscalls are related to mmap which is needed for OpenSearch Services
+SystemCallFilter=madvise mincore mlock mlock2 munlock get_mempolicy sched_getaffinity sched_setaffinity fcntl
 SystemCallFilter=@system-service
 SystemCallFilter=~@reboot
 SystemCallFilter=~@swap
@@ -138,7 +140,7 @@ ReadWritePaths=-/etc/opensearch
 ReadWritePaths=-/mnt/snapshots
 
 ## Allow read access to system files
-ReadOnlyPaths=/etc/os-release /usr/lib/os-release /etc/system-release
+ReadOnlyPaths=-/etc/os-release -/usr/lib/os-release -/etc/system-release
 
 ## Allow read access to Linux IO stats
 ReadOnlyPaths=/proc/self/mountinfo /proc/diskstats


### PR DESCRIPTION
### Description
Add syscalls for merge operation error

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/18083
```
[2025-04-29T18:29:29,191][WARN ][o.o.i.c.IndicesClusterStateService] [node_name_9200] [security-auditlog-2025.04.29][0] marking and sending shard failed due to [shard failure, reason [merge failed]]
org.apache.lucene.index.MergePolicy$MergeException: java.lang.IllegalStateException: this writer hit an unrecoverable error; cannot merge
```

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
