### PR TITLE
Use Bad Request status for InputCoercionException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove package org.opensearch.transport.grpc and replace with org.opensearch.plugin.transport.grpc ([#18031](https://github.com/opensearch-project/OpenSearch/pull/18031))
 - Fix the native plugin installation error cause by the pgp public key change ([#18147](https://github.com/opensearch-project/OpenSearch/pull/18147))
 - Fix object field exists query ([#17843](https://github.com/opensearch-project/OpenSearch/pull/17843))
+- Use Bad Request status for InputCoercionEcception ([#18161](https://github.com/opensearch-project/OpenSearch/pull/18161))
 
 ### Security
 

--- a/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
+++ b/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
@@ -33,6 +33,7 @@
 package org.opensearch;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.exc.InputCoercionException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -98,6 +99,8 @@ public final class ExceptionsHelper {
                 return ((OpenSearchException) t).status();
             } else if (t instanceof IllegalArgumentException) {
                 return RestStatus.BAD_REQUEST;
+            } else if (t instanceof InputCoercionException) {
+                return RestStatus.BAD_REQUEST;
             } else if (t instanceof JsonParseException) {
                 return RestStatus.BAD_REQUEST;
             } else if (t instanceof OpenSearchRejectedExecutionException) {
@@ -115,6 +118,8 @@ public final class ExceptionsHelper {
                 return getExceptionSimpleClassName(t) + "[" + t.getMessage() + "]";
             } else if (t instanceof IllegalArgumentException) {
                 return "Invalid argument";
+            } else if (t instanceof InputCoercionException) {
+                return "Incompatible JSON value";
             } else if (t instanceof JsonParseException) {
                 return "Failed to parse JSON";
             } else if (t instanceof OpenSearchRejectedExecutionException) {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yml
@@ -46,6 +46,9 @@ setup:
 
 ---
 "Request with size exceeding max integer value":
+  - skip:
+      version: "- 3.0.99"
+      reason: "returns 500 before 3.1.0"
   - do:
       catch:      /Numeric value \(2147483648\) out of range of int/
       search:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yml
@@ -45,6 +45,21 @@ setup:
         size: 10010
 
 ---
+"Request with size exceeding max integer value":
+  - do:
+      catch:      /Numeric value \(2147483648\) out of range of int/
+      search:
+        rest_total_hits_as_int: true
+        index: test_1
+        body:
+          query:
+            match_all: {}
+          size: 2147483648
+
+  - match: { status: 400 }
+  - match: { error.type: input_coercion_exception }
+
+---
 "Rescore window limits":
   - do:
       catch:      /Rescore window \[10001\] is too large\. It must be less than \[10000\]\./

--- a/server/src/test/java/org/opensearch/ExceptionsHelperTests.java
+++ b/server/src/test/java/org/opensearch/ExceptionsHelperTests.java
@@ -33,6 +33,7 @@
 package org.opensearch;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.exc.InputCoercionException;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.lucene.index.CorruptIndexException;
@@ -110,12 +111,17 @@ public class ExceptionsHelperTests extends OpenSearchTestCase {
 
     public void testStatus() {
         assertThat(ExceptionsHelper.status(new IllegalArgumentException("illegal")), equalTo(RestStatus.BAD_REQUEST));
+        assertThat(ExceptionsHelper.status(new InputCoercionException(null, "illegal", null, null)), equalTo(RestStatus.BAD_REQUEST));
         assertThat(ExceptionsHelper.status(new JsonParseException(null, "illegal")), equalTo(RestStatus.BAD_REQUEST));
         assertThat(ExceptionsHelper.status(new OpenSearchRejectedExecutionException("rejected")), equalTo(RestStatus.TOO_MANY_REQUESTS));
     }
 
     public void testSummaryMessage() {
         assertThat(ExceptionsHelper.summaryMessage(new IllegalArgumentException("illegal")), equalTo("Invalid argument"));
+        assertThat(
+            ExceptionsHelper.summaryMessage(new InputCoercionException(null, "illegal", null, null)),
+            equalTo("Incompatible JSON value")
+        );
         assertThat(ExceptionsHelper.summaryMessage(new JsonParseException(null, "illegal")), equalTo("Failed to parse JSON"));
         assertThat(ExceptionsHelper.summaryMessage(new OpenSearchRejectedExecutionException("rejected")), equalTo("Too many requests"));
     }


### PR DESCRIPTION
### Description

The Jackson [InputCoercionException](https://fasterxml.github.io/jackson-core/javadoc/2.11/com/fasterxml/jackson/core/exc/InputCoercionException.html) is thrown for a "valid but incompatible input value"
> Exception type for read-side problems that are not direct decoding ("parsing") problems (those would be reported as [JsonParseException](https://fasterxml.github.io/jackson-core/javadoc/2.11/com/fasterxml/jackson/core/JsonParseException.html)s), but rather result from failed attempts to convert specific Java value out of valid but incompatible input value. One example is numeric coercions where target number type's range does not allow mapping of too large/too small input value.

As an exception caused by user input, a 400 (Bad Request) REST status is appropriate.  Currently parsing XContent that encounters this error (such as an integer out of range) returns an inappropriate 500 status.

### Related Issues

One of two problems reported in #18131

### Check List
- [x] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
