### PR TITLE
Make HASHED_PREFIX as the default path type for remote store and snapshot

### DIFF
--- a/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
+++ b/server/src/main/java/org/opensearch/indices/RemoteStoreSettings.java
@@ -75,7 +75,7 @@ public class RemoteStoreSettings {
     @ExperimentalApi
     public static final Setting<RemoteStoreEnums.PathType> CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING = new Setting<>(
         "cluster.remote_store.index.path.type",
-        RemoteStoreEnums.PathType.FIXED.toString(),
+        RemoteStoreEnums.PathType.HASHED_PREFIX.toString(),
         RemoteStoreEnums.PathType::parseString,
         Property.NodeScope,
         Property.Dynamic

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -362,7 +362,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     public static final Setting<PathType> SHARD_PATH_TYPE = new Setting<>(
         "shard_path_type",
-        PathType.FIXED.toString(),
+        PathType.HASHED_PREFIX.toString(),
         PathType::parseString
     );
 

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreCustomMetadataResolverTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreCustomMetadataResolverTests.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.when;
 public class RemoteStoreCustomMetadataResolverTests extends OpenSearchTestCase {
 
     RepositoriesService repositoriesService = mock(RepositoriesService.class);
-    Settings settings = Settings.EMPTY;
 
     public void testGetPathStrategyMinVersionOlder() {
         Settings settings = Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), randomFrom(PathType.values())).build();
@@ -138,6 +137,12 @@ public class RemoteStoreCustomMetadataResolverTests extends OpenSearchTestCase {
             () -> repositoriesService,
             settings
         );
+        assertEquals(PathType.HASHED_PREFIX, resolver.getPathStrategy().getType());
+        assertNotNull(resolver.getPathStrategy().getHashAlgorithm());
+        assertEquals(PathHashAlgorithm.FNV_1A_COMPOSITE_1, resolver.getPathStrategy().getHashAlgorithm());
+
+        // Set FIXED with null hash algorithm
+        clusterSettings.applySettings(Settings.builder().put(CLUSTER_REMOTE_STORE_PATH_TYPE_SETTING.getKey(), PathType.FIXED).build());
         assertEquals(PathType.FIXED, resolver.getPathStrategy().getType());
         assertNull(resolver.getPathStrategy().getHashAlgorithm());
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

1. The default value for `cluster.remote_store.index.path.type` has been changed from `FIXED` to `HASHED_PREFIX`. This setting determines the path type used for data stored in the remote store. The `HASHED_PREFIX` option provides better distribution of keys and has been known to scale better with growing data size.
 
2. The default value for `shard_path_type` has been changed from `FIXED` to `HASHED_PREFIX`. This setting determines the path type used for shard files in the blob store repository. Similar to the remote store settings, the `HASHED_PREFIX` option provides better distribution of shard files.

These changes are intended to improve the default performance and reliability of remote store and snapshot functionality in OpenSearch.

Let me know if you would like me to modify or expand on anything in this PR description.
### Check List
- [x] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
