### PR TITLE
Add Seccomp and Reboot call tests

### DIFF
--- a/qa/systemd-test/src/test/java/org/opensearch/systemdinteg/SystemdIntegTests.java
+++ b/qa/systemd-test/src/test/java/org/opensearch/systemdinteg/SystemdIntegTests.java
@@ -135,6 +135,17 @@ public class SystemdIntegTests extends LuceneTestCase {
                 limits.contains("Max open files            unlimited            unlimited"));
     }
 
+    public void testSeccompEnabled() throws IOException, InterruptedException {
+        // Check if Seccomp is enabled
+        String seccomp = executeCommand("sudo su -c 'grep Seccomp /proc/" + opensearchPid + "/status'", "Failed to read Seccomp status");
+        assertFalse("Seccomp should be enabled", seccomp.contains("0"));
+    }
+
+    public void testRebootSysCall() throws IOException, InterruptedException {
+        String rebootResult = executeCommand("sudo su opensearch -c 'kill -s SIGHUP 1' 2>&1 || echo 'Operation not permitted'", "Failed to test reboot system call");
+        assertTrue("Reboot system call should be blocked", rebootResult.contains("Operation not permitted"));
+    }
+
     public void testOpenSearchProcessCannotExit() throws IOException, InterruptedException {
 
         String scriptPath;


### PR DESCRIPTION
### Description
Adds systemd tests to check if seccomp is enabled and reboot call is blocked

### Related Issues

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
