### PR TITLE
Fail fast if initial delete call fails in CreateIndexIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/CreateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/CreateIndexIT.java
@@ -73,6 +73,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS;
@@ -257,6 +258,7 @@ public class CreateIndexIT extends OpenSearchIntegTestCase {
         synchronized (indexVersionLock) { // not necessarily needed here but for completeness we lock here too
             indexVersion.incrementAndGet();
         }
+        final AtomicReference<Exception> deleteFailure = new AtomicReference<>();
         client().admin().indices().prepareDelete("test").execute(new ActionListener<AcknowledgedResponse>() { // this happens async!!!
             @Override
             public void onResponse(AcknowledgedResponse deleteIndexResponse) {
@@ -284,7 +286,8 @@ public class CreateIndexIT extends OpenSearchIntegTestCase {
 
             @Override
             public void onFailure(Exception e) {
-                throw new RuntimeException(e);
+                deleteFailure.set(e);
+                latch.countDown();
             }
         });
         numDocs = randomIntBetween(100, 200);
@@ -304,6 +307,7 @@ public class CreateIndexIT extends OpenSearchIntegTestCase {
             }
         }
         latch.await();
+        assertNull(deleteFailure.get());
         refresh();
 
         // we only really assert that we never reuse segments of old indices or anything like this here and that nothing fails with


### PR DESCRIPTION
Previously if the delete call failed then the test would block indefinitely on the latch as nothing would count it down. The test would then hit the overall timeout and report thread leak failures. This change captures the exception and fails immediately in the test thread if the delete call fails.

I'm not totally sure this is where the test is occasionally failing, but here is a case where the overall test timeout was reached: https://github.com/opensearch-project/OpenSearch/issues/14312#issuecomment-2843139457

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
