### PR TITLE
Mute WarmIndexSegmentReplicationIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/WarmIndexSegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/WarmIndexSegmentReplicationIT.java
@@ -20,6 +20,7 @@ import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.action.admin.cluster.stats.ClusterStatsResponse;
@@ -110,6 +111,7 @@ import static org.hamcrest.Matchers.is;
 /**
  * This class runs Segment Replication Integ test suite with partial locality indices (warm indices).
  */
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/18157")
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 @ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
 public class WarmIndexSegmentReplicationIT extends SegmentReplicationBaseIT {


### PR DESCRIPTION
This is a new test that is pretty flaky. Muting it now while the feature is still under development.

@gbbafna @skumawat2025 Please take a look. If there's a quick fix we can discard this PR, but otherwise I'd prefer to merge this in the meantime to stabilize the tests.

Related to #18157

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
