### PR TITLE
Change single shard assignment log message from warn to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- Lower down the log level to DEBUG ([#18186](https://github.com/opensearch-project/OpenSearch/pull/18186))
+- Change single shard assignment log message from warn to debug ([#18186](https://github.com/opensearch-project/OpenSearch/pull/18186))
 
 [Unreleased 2.19.x]: https://github.com/opensearch-project/OpenSearch/compare/fd9a9d90df25bea1af2c6a85039692e815b894f5...2.19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Security
 
+### Changed
+
+- Lower down the log level to DEBUG ([#18186](https://github.com/opensearch-project/OpenSearch/pull/18186))
+
 [Unreleased 2.19.x]: https://github.com/opensearch-project/OpenSearch/compare/fd9a9d90df25bea1af2c6a85039692e815b894f5...2.19

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/AllocationService.java
@@ -598,7 +598,7 @@ public class AllocationService {
             allocateAllUnassignedShards(allocation);
             return;
         }
-        logger.warn("Falling back to single shard assignment since batch mode disable or multiple custom allocators set");
+        logger.debug("Falling back to single shard assignment since batch mode disable or multiple custom allocators set");
 
         final RoutingNodes.UnassignedShards.UnassignedIterator primaryIterator = allocation.routingNodes().unassigned().iterator();
         while (primaryIterator.hasNext()) {


### PR DESCRIPTION
### Description

This logging message is relevant to experimental feature that is not yet turned on by default. When this code runs in production then this logging message is confusing OPS because there is nothing they can do to address this WARN level message.

### Related Issues

Resolves #18137

### Check List
- ~[ ] Functionality includes testing.~
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
