### PR TITLE
Null check field names in QueryStringQueryBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove package org.opensearch.transport.grpc and replace with org.opensearch.plugin.transport.grpc ([#18031](https://github.com/opensearch-project/OpenSearch/pull/18031))
 - Fix the native plugin installation error cause by the pgp public key change ([#18147](https://github.com/opensearch-project/OpenSearch/pull/18147))
 - Fix object field exists query ([#17843](https://github.com/opensearch-project/OpenSearch/pull/17843))
+- Null check field names in QueryStringQueryBuilder ([#18194](https://github.com/opensearch-project/OpenSearch/pull/18194))
 
 ### Security
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/50_multi_match.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/50_multi_match.yml
@@ -33,3 +33,18 @@
   - match: { hits.total.value: 3 }
   - match: { hits.hits.0._id: "2" }
   - gt: { hits.hits.2._score: 0.0 }
+
+  # Test that query with null field fails appropriately
+  - do:
+      catch: bad_request
+      search:
+        index: test
+        body:
+          query:
+            query_string:
+              query: "red"
+              fields: ["color", null, "shape"]
+
+  - match: { status: 400 }
+  - match: { error.type: parsing_exception }
+  - match: { error.reason: "[query_string] field name in [fields] cannot be null" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/50_multi_match.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/50_multi_match.yml
@@ -1,7 +1,4 @@
-"Cross fields do not return negative scores":
-  - skip:
-      version: " - 2.99.99"
-      reason: "This fix is in 2.15. Until we do the BWC dance, we need to skip all pre-3.0, though."
+setup:
   - do:
       index:
         index: test
@@ -19,6 +16,12 @@
         body: { "color" : "orange red yellow purple" }
   - do:
       indices.refresh: { }
+
+---
+"Cross fields do not return negative scores":
+  - skip:
+      version: " - 2.14.99"
+      reason: "This fix is in 2.15.0"
   - do:
       search:
         index: test
@@ -34,7 +37,11 @@
   - match: { hits.hits.0._id: "2" }
   - gt: { hits.hits.2._score: 0.0 }
 
-  # Test that query with null field fails appropriately
+---
+"Query string with null field throws 400":
+  - skip:
+      version: " - 3.0.99"
+      reason: "This fix is in 3.1.0"
   - do:
       catch: bad_request
       search:

--- a/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
@@ -685,6 +685,12 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
                 if (FIELDS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     List<String> fields = new ArrayList<>();
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                            throw new ParsingException(
+                                parser.getTokenLocation(),
+                                "[" + QueryStringQueryBuilder.NAME + "] field name in [" + currentFieldName + "] cannot be null"
+                            );
+                        }
                         fields.add(parser.text());
                     }
                     fieldsAndWeights = QueryParserHelper.parseFieldsAndWeights(fields);

--- a/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
@@ -71,6 +71,7 @@ import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.Fuzziness;
 import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.ParsingException;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.mapper.FieldNamesFieldMapper;
 import org.opensearch.index.mapper.MapperService;
@@ -1011,6 +1012,18 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .add(new MatchNoDocsQuery("empty fields"), Occur.SHOULD)
             .build();
         assertThat(expectedQuery, equalTo(query));
+    }
+
+    public void testNullFieldInFieldsArray() throws IOException {
+        String queryAsString = "{\n"
+            + "  \"query_string\" : {\n"
+            + "    \"query\" : \"test\",\n"
+            + "    \"fields\" : [ \"field1\", null, \"field2\" ]\n"
+            + "  }\n"
+            + "}";
+
+        ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(queryAsString));
+        assertEquals("[query_string] field name in [fields] cannot be null", e.getMessage());
     }
 
     public void testToQueryTextParsing() throws IOException {


### PR DESCRIPTION
### Description

Adds a check for a null value before getting text on a field name, which would otherwise throw an `IllegalStateException`.  This results in a (useful) Parsing exception and 400 rest status describing the error, rather than a 500 error.

### Related Issues
Fixes  #18131 (together with #18161)

### Check List
- [X] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
