### PR TITLE
Fix seccomp test

### DIFF
--- a/qa/systemd-test/src/test/java/org/opensearch/systemdinteg/SystemdIntegTests.java
+++ b/qa/systemd-test/src/test/java/org/opensearch/systemdinteg/SystemdIntegTests.java
@@ -37,6 +37,7 @@ import java.util.Locale;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 
 
 public class SystemdIntegTests extends LuceneTestCase {
@@ -137,8 +138,9 @@ public class SystemdIntegTests extends LuceneTestCase {
 
     public void testSeccompEnabled() throws IOException, InterruptedException {
         // Check if Seccomp is enabled
-        String seccomp = executeCommand("sudo su -c 'grep Seccomp /proc/" + opensearchPid + "/status'", "Failed to read Seccomp status");
-        assertFalse("Seccomp should be enabled", seccomp.contains("0"));
+        String seccomp = executeCommand("sudo su -c 'grep \"^Seccomp:\" /proc/" + opensearchPid + "/status'", "Failed to read Seccomp status");
+        int seccompValue = Integer.parseInt(seccomp.split(":\\s*")[1].trim());
+        assertNotEquals("Seccomp should be enabled", 0, seccompValue);
     }
 
     public void testRebootSysCall() throws IOException, InterruptedException {


### PR DESCRIPTION
### Description
Fix test that checks if Seccomp is enabled

### Related Issues
```
Suite: Test class org.opensearch.systemdinteg.SystemdIntegTests
  2> May 01, 2025 9:36:29 PM org.apache.lucene.internal.vectorization.VectorizationProvider lookup
  2> WARNING: C2 compiler is disabled; Java vector incubator API can't be enabled
  2> java.lang.AssertionError: Seccomp should be enabled
        at __randomizedtesting.SeedInfo.seed([69E4FBFD7BE9AE21:3DC557472D5D715]:0)
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.assertTrue(Assert.java:42)
        at org.junit.Assert.assertFalse(Assert.java:65)
        at org.opensearch.systemdinteg.SystemdIntegTests.testSeccompEnabled(SystemdIntegTests.java:141)
  2> NOTE: reproduce with: gradlew test --tests SystemdIntegTests.testSeccompEnabled -Dtests.seed=69E4FBFD7BE9AE21 -Dtests.locale=vun-Latn-TZ -Dtests.timezone=Asia/Bishkek -Dtests.asserts=true -Dtests.file.encoding=UTF-8
  2> NOTE: test params are: codec=Asserting(Lucene101): {}, docValues:{}, maxPointsInLeafNode=267, maxMBSortInHeap=7.443377624226953, sim=Asserting(RandomSimilarity(queryNorm=false): {}), locale=vun-Latn-TZ, timezone=Asia/Bishkek
  2> NOTE: Linux 6.1.109-118.189.amzn2023.aarch64 aarch64/Eclipse Adoptium 21.0.7 (64-bit)/cpus=16,threads=1,free=435481744,total=536870912
  2> NOTE: All tests run in this JVM: [SystemdIntegTests]
7 tests completed, 1 failed
```
### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).