### PR TITLE
Fix flaky RepositoriesServiceIT.testCreatSnapAndUpdateReposityCauseInfiniteLoop

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/repositories/RepositoriesServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/repositories/RepositoriesServiceIT.java
@@ -127,7 +127,6 @@ public class RepositoriesServiceIT extends OpenSearchIntegTestCase {
         assertThrows(RepositoryException.class, () -> createRepository(repositoryName, FsRepository.TYPE, repoSettings));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/15842")
     public void testCreatSnapAndUpdateReposityCauseInfiniteLoop() throws InterruptedException {
         // create index
         internalCluster();
@@ -173,16 +172,20 @@ public class RepositoriesServiceIT extends OpenSearchIntegTestCase {
         });
         thread.start();
 
-        logger.info("--> begin to reset repository");
-        repoSettings = Settings.builder().put("location", randomRepoPath()).put("max_snapshot_bytes_per_sec", "300mb");
-        OpenSearchIntegTestCase.putRepositoryWithNoSettingOverrides(
-            client().admin().cluster(),
-            repositoryName,
-            FsRepository.TYPE,
-            true,
-            repoSettings
-        );
-        logger.info("--> finish to reset repository");
+        try {
+            logger.info("--> begin to reset repository");
+            repoSettings = Settings.builder().put("location", randomRepoPath()).put("max_snapshot_bytes_per_sec", "300mb");
+            OpenSearchIntegTestCase.putRepositoryWithNoSettingOverrides(
+                client().admin().cluster(),
+                repositoryName,
+                FsRepository.TYPE,
+                true,
+                repoSettings
+            );
+            logger.info("--> finish to reset repository");
+        } catch (IllegalStateException e) {
+            assertThat(e, hasToString(containsString(("trying to modify or unregister repository that is currently used"))));
+        }
 
         // after updating repository, snapshot should be success
         createSnapshot.run();


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #15842
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
