### PR TITLE
[Backport 2.19] Use Bad Request status for InputCoercionException (#18161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
-- Use Bad Request status for InputCoercionEcception ([#18161](https://github.com/opensearch-project/OpenSearch/pull/18161))
+- Use Bad Request status for InputCoercionException ([#18161](https://github.com/opensearch-project/OpenSearch/pull/18161))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Use Bad Request status for InputCoercionEcception ([#18161](https://github.com/opensearch-project/OpenSearch/pull/18161))
 
 ### Security
 

--- a/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
+++ b/libs/core/src/main/java/org/opensearch/ExceptionsHelper.java
@@ -33,6 +33,7 @@
 package org.opensearch;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.exc.InputCoercionException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -97,6 +98,8 @@ public final class ExceptionsHelper {
                 return ((OpenSearchException) t).status();
             } else if (t instanceof IllegalArgumentException) {
                 return RestStatus.BAD_REQUEST;
+            } else if (t instanceof InputCoercionException) {
+                return RestStatus.BAD_REQUEST;
             } else if (t instanceof JsonParseException) {
                 return RestStatus.BAD_REQUEST;
             } else if (t instanceof OpenSearchRejectedExecutionException) {
@@ -112,6 +115,8 @@ public final class ExceptionsHelper {
                 return getExceptionSimpleClassName(t) + "[" + t.getMessage() + "]";
             } else if (t instanceof IllegalArgumentException) {
                 return "Invalid argument";
+            } else if (t instanceof InputCoercionException) {
+                return "Incompatible JSON value";
             } else if (t instanceof JsonParseException) {
                 return "Failed to parse JSON";
             } else if (t instanceof OpenSearchRejectedExecutionException) {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/30_limits.yml
@@ -45,6 +45,24 @@ setup:
         size: 10010
 
 ---
+"Request with size exceeding max integer value":
+  - skip:
+      version: "- 3.0.99"
+      reason: "returns 500 before 3.1.0"
+  - do:
+      catch:      /Numeric value \(2147483648\) out of range of int/
+      search:
+        rest_total_hits_as_int: true
+        index: test_1
+        body:
+          query:
+            match_all: {}
+          size: 2147483648
+
+  - match: { status: 400 }
+  - match: { error.type: input_coercion_exception }
+
+---
 "Rescore window limits":
   - do:
       catch:      /Rescore window \[10001\] is too large\. It must be less than \[10000\]\./

--- a/server/src/test/java/org/opensearch/ExceptionsHelperTests.java
+++ b/server/src/test/java/org/opensearch/ExceptionsHelperTests.java
@@ -33,6 +33,7 @@
 package org.opensearch;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.exc.InputCoercionException;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.lucene.index.CorruptIndexException;
@@ -110,12 +111,17 @@ public class ExceptionsHelperTests extends OpenSearchTestCase {
 
     public void testStatus() {
         assertThat(ExceptionsHelper.status(new IllegalArgumentException("illegal")), equalTo(RestStatus.BAD_REQUEST));
+        assertThat(ExceptionsHelper.status(new InputCoercionException(null, "illegal", null, null)), equalTo(RestStatus.BAD_REQUEST));
         assertThat(ExceptionsHelper.status(new JsonParseException(null, "illegal")), equalTo(RestStatus.BAD_REQUEST));
         assertThat(ExceptionsHelper.status(new OpenSearchRejectedExecutionException("rejected")), equalTo(RestStatus.TOO_MANY_REQUESTS));
     }
 
     public void testSummaryMessage() {
         assertThat(ExceptionsHelper.summaryMessage(new IllegalArgumentException("illegal")), equalTo("Invalid argument"));
+        assertThat(
+            ExceptionsHelper.summaryMessage(new InputCoercionException(null, "illegal", null, null)),
+            equalTo("Incompatible JSON value")
+        );
         assertThat(ExceptionsHelper.summaryMessage(new JsonParseException(null, "illegal")), equalTo("Failed to parse JSON"));
         assertThat(ExceptionsHelper.summaryMessage(new OpenSearchRejectedExecutionException("rejected")), equalTo("Too many requests"));
     }


### PR DESCRIPTION
Backport 4ce638c06fe5a937bee30321f3c609927089de16 from #18161 