### PR TITLE
[Bugfix] Fix flakiness in TieredSpilloverCacheStatsIT.testClosingShard()

### DIFF
--- a/modules/cache-common/src/internalClusterTest/java/org/opensearch/cache/common/tier/TieredSpilloverCacheStatsIT.java
+++ b/modules/cache-common/src/internalClusterTest/java/org/opensearch/cache/common/tier/TieredSpilloverCacheStatsIT.java
@@ -430,8 +430,7 @@ public class TieredSpilloverCacheStatsIT extends TieredSpilloverCacheBaseIT {
 
         // Closing the index should close the shard
         assertAcked(client().admin().indices().delete(new DeleteIndexRequest("index")).get());
-        Thread.sleep(50); // Ensure the cache cleanup has finished before we check
-        assertEquals(new ImmutableCacheStats(0, 0, 0, 0, 0), getTotalStats(client));
+        assertBusy(() -> assertEquals(new ImmutableCacheStats(0, 0, 0, 0, 0), getTotalStats(client)));
     }
 
     private void startIndex(Client client, String indexName) throws InterruptedException {


### PR DESCRIPTION
### Description
Fixes flakiness in TieredSpilloverCacheStatsIT.testClosingShard() by adding a 50 ms sleep before doing a check. This should ensure the asynchronous cache cleanup logic is always finished before the check. 

I'm not totally sure why this only started flaking recently, around April 14. As far as I can tell no relevant code changed around then. Did something change about the way we run tests in Jenkins that might have slowed down the cache cleanup logic? 

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/14300

### Check List
- [x] Functionality includes testing.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
