### PR TITLE
Add tolerance for matrix stats agg variance value assertion

### DIFF
--- a/client/rest-high-level/src/test/java/org/opensearch/client/SearchIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/SearchIT.java
@@ -567,12 +567,12 @@ public class SearchIT extends OpenSearchRestHighLevelClientTestCase {
         MatrixStats matrixStats = searchResponse.getAggregations().get("agg1");
         assertEquals(5, matrixStats.getFieldCount("num"));
         assertEquals(56d, matrixStats.getMean("num"), 0d);
-        assertEquals(1830.0000000000002, matrixStats.getVariance("num"), 0d);
+        assertEquals(1830.0000000000002, matrixStats.getVariance("num"), 1.0e-12);
         assertEquals(0.09340198804973039, matrixStats.getSkewness("num"), 0d);
         assertEquals(1.2741646510794589, matrixStats.getKurtosis("num"), 0d);
         assertEquals(5, matrixStats.getFieldCount("num2"));
         assertEquals(29d, matrixStats.getMean("num2"), 0d);
-        assertEquals(330d, matrixStats.getVariance("num2"), 0d);
+        assertEquals(330d, matrixStats.getVariance("num2"), 1.0e-12);
         assertEquals(-0.13568039346585542, matrixStats.getSkewness("num2"), 1.0e-16);
         assertEquals(1.3517561983471071, matrixStats.getKurtosis("num2"), 0d);
         assertEquals(-767.5, matrixStats.getCovariance("num", "num2"), 0d);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
After enabling the concurrent segment search by default, the variance result from matrix stats starts to flaky around the asserting value a little bit which seems coming from precision loss of float data. 

The parallel search and randomness of segment layout are considered to be the cause of this flaky.

A quick look into how variance is calculated and a conversation with AI say "floating-point arithmetic not being perfectly associative", (A + B) + (C + D) `slices group` may not be same as A + B + C + D `default sequential segment`. Seem reasonable to me.

Tolerance is choosed based on the failed tests. Mismatch happens at the last digit
0.0000000000002
So choose
0.000000000001 to be the tolerance.

### Related Issues
Resolves #18129 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
