### PR TITLE
Replaced Thread::getId() with Thread::threadId()

### DIFF
--- a/libs/common/src/main/java/org/opensearch/common/recycler/Recyclers.java
+++ b/libs/common/src/main/java/org/opensearch/common/recycler/Recyclers.java
@@ -151,7 +151,7 @@ public enum Recyclers {
             }
 
             int slot() {
-                final long id = Thread.currentThread().getId();
+                final long id = Thread.currentThread().threadId();
                 // don't trust Thread.hashCode to have equiprobable low bits
                 int slot = (int) BitMixer.mix64(id);
                 // make positive, otherwise % may return negative numbers

--- a/modules/lang-expression/src/main/java/org/opensearch/script/expression/PerThreadReplaceableConstDoubleValueSource.java
+++ b/modules/lang-expression/src/main/java/org/opensearch/script/expression/PerThreadReplaceableConstDoubleValueSource.java
@@ -57,7 +57,7 @@ final class PerThreadReplaceableConstDoubleValueSource extends DoubleValuesSourc
 
     @Override
     public DoubleValues getValues(LeafReaderContext ctx, DoubleValues scores) throws IOException {
-        return perThreadDoubleValues.computeIfAbsent(Thread.currentThread().getId(), threadId -> new ReplaceableConstDoubleValues());
+        return perThreadDoubleValues.computeIfAbsent(Thread.currentThread().threadId(), threadId -> new ReplaceableConstDoubleValues());
     }
 
     @Override
@@ -68,7 +68,7 @@ final class PerThreadReplaceableConstDoubleValueSource extends DoubleValuesSourc
     @Override
     public Explanation explain(LeafReaderContext ctx, int docId, Explanation scoreExplanation) throws IOException {
         final ReplaceableConstDoubleValues currentFv = perThreadDoubleValues.computeIfAbsent(
-            Thread.currentThread().getId(),
+            Thread.currentThread().threadId(),
             threadId -> new ReplaceableConstDoubleValues()
         );
         if (currentFv.advanceExact(docId)) return Explanation.match((float) currentFv.doubleValue(), "ReplaceableConstDoubleValues");
@@ -87,7 +87,7 @@ final class PerThreadReplaceableConstDoubleValueSource extends DoubleValuesSourc
 
     public void setValue(double v) {
         final ReplaceableConstDoubleValues currentFv = perThreadDoubleValues.computeIfAbsent(
-            Thread.currentThread().getId(),
+            Thread.currentThread().threadId(),
             threadId -> new ReplaceableConstDoubleValues()
         );
         currentFv.setValue(v);

--- a/server/src/main/java/org/opensearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/HotThreads.java
@@ -160,7 +160,7 @@ public class HotThreads {
         Map<Long, MyThreadInfo> threadInfos = new HashMap<>();
         for (long threadId : threadBean.getAllThreadIds()) {
             // ignore our own thread...
-            if (Thread.currentThread().getId() == threadId) {
+            if (Thread.currentThread().threadId() == threadId) {
                 continue;
             }
             long cpu = threadBean.getThreadCpuTime(threadId);
@@ -176,7 +176,7 @@ public class HotThreads {
         Thread.sleep(interval.millis());
         for (long threadId : threadBean.getAllThreadIds()) {
             // ignore our own thread...
-            if (Thread.currentThread().getId() == threadId) {
+            if (Thread.currentThread().threadId() == threadId) {
                 continue;
             }
             long cpu = threadBean.getThreadCpuTime(threadId);

--- a/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfiler.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/ConcurrentQueryProfiler.java
@@ -129,6 +129,6 @@ public final class ConcurrentQueryProfiler extends QueryProfiler {
     }
 
     private long getCurrentThreadId() {
-        return Thread.currentThread().getId();
+        return Thread.currentThread().threadId();
     }
 }

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
@@ -127,7 +127,7 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
         logger.debug("Stopping resource tracking for task: {}", task.getId());
         try {
             if (isCurrentThreadWorkingOnTask(task)) {
-                taskExecutionFinishedOnThread(task.getId(), Thread.currentThread().getId());
+                taskExecutionFinishedOnThread(task.getId(), Thread.currentThread().threadId());
             }
         } catch (Exception e) {
             logger.warn("Failed while trying to mark the task execution on current thread completed.", e);
@@ -234,7 +234,7 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
     }
 
     private boolean isCurrentThreadWorkingOnTask(Task task) {
-        long threadId = Thread.currentThread().getId();
+        long threadId = Thread.currentThread().threadId();
         List<ThreadResourceInfo> threadResourceInfos = task.getResourceStats().getOrDefault(threadId, Collections.emptyList());
 
         for (ThreadResourceInfo threadResourceInfo : threadResourceInfos) {
@@ -284,7 +284,7 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
         try {
             // Get resource usages from when the task started
             ThreadResourceInfo threadResourceInfo = task.getActiveThreadResourceInfo(
-                Thread.currentThread().getId(),
+                Thread.currentThread().threadId(),
                 ResourceStatsType.WORKER_STATS
             );
             if (threadResourceInfo == null) {
@@ -295,7 +295,7 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
                 return;
             }
             // Get current resource usages
-            ResourceUsageMetric[] endValues = getResourceUsageMetricsForThread(Thread.currentThread().getId());
+            ResourceUsageMetric[] endValues = getResourceUsageMetricsForThread(Thread.currentThread().threadId());
             long cpu = -1, mem = -1;
             for (ResourceUsageMetric endValue : endValues) {
                 if (endValue.getStats() == ResourceStats.MEMORY) {

--- a/server/src/main/java/org/opensearch/threadpool/TaskAwareRunnable.java
+++ b/server/src/main/java/org/opensearch/threadpool/TaskAwareRunnable.java
@@ -70,7 +70,7 @@ public class TaskAwareRunnable extends AbstractRunnable implements WrappedRunnab
         assert runnableTaskListener.get() != null : "Listener should be attached";
         Long taskId = threadContext.getTransient(TASK_ID);
         if (Objects.nonNull(taskId)) {
-            runnableTaskListener.get().taskExecutionStartedOnThread(taskId, currentThread().getId());
+            runnableTaskListener.get().taskExecutionStartedOnThread(taskId, currentThread().threadId());
         } else {
             logger.debug("Task Id not available in thread context. Skipping update. Thread Info: {}", Thread.currentThread());
         }
@@ -78,7 +78,7 @@ public class TaskAwareRunnable extends AbstractRunnable implements WrappedRunnab
             original.run();
         } finally {
             if (Objects.nonNull(taskId)) {
-                runnableTaskListener.get().taskExecutionFinishedOnThread(taskId, currentThread().getId());
+                runnableTaskListener.get().taskExecutionFinishedOnThread(taskId, currentThread().threadId());
             }
         }
     }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/ResourceAwareTasksTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/ResourceAwareTasksTests.java
@@ -179,9 +179,9 @@ public class ResourceAwareTasksTests extends TaskManagerTestCase {
                 @SuppressForbidden(reason = "ThreadMXBean#getThreadAllocatedBytes")
                 protected void doRun() {
                     taskTestContext.memoryConsumptionWhenExecutionStarts = threadMXBean.getThreadAllocatedBytes(
-                        Thread.currentThread().getId()
+                        Thread.currentThread().threadId()
                     );
-                    threadId.set(Thread.currentThread().getId());
+                    threadId.set(Thread.currentThread().threadId());
 
                     // operationStartValidator will be called just before the task execution.
                     if (taskTestContext.operationStartValidator != null) {

--- a/server/src/test/java/org/opensearch/tasks/TaskResourceTrackingServiceTests.java
+++ b/server/src/test/java/org/opensearch/tasks/TaskResourceTrackingServiceTests.java
@@ -87,7 +87,7 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
         taskResourceTrackingService.setTaskResourceTrackingEnabled(true);
         Task task = new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>());
         ThreadContext.StoredContext storedContext = taskResourceTrackingService.startTracking(task);
-        long threadId = Thread.currentThread().getId();
+        long threadId = Thread.currentThread().threadId();
         taskResourceTrackingService.taskExecutionStartedOnThread(task.getId(), threadId);
 
         assertTrue(task.getResourceStats().get(threadId).get(0).isActive());
@@ -111,7 +111,7 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
         int numTasks = randomIntBetween(2, 100);
         for (int i = 0; i < numTasks; i++) {
             executor.execute(() -> {
-                long threadId = Thread.currentThread().getId();
+                long threadId = Thread.currentThread().threadId();
                 taskResourceTrackingService.taskExecutionStartedOnThread(task.getId(), threadId);
                 // The same thread may pick up multiple runnables for the same task id
                 assertEquals(1, task.getResourceStats().get(threadId).stream().filter(ThreadResourceInfo::isActive).count());
@@ -152,7 +152,7 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
         taskResourceTrackingService.setTaskResourceTrackingEnabled(true);
         taskResourceTrackingService.startTracking(task);
         task.startThreadResourceTracking(
-            Thread.currentThread().getId(),
+            Thread.currentThread().threadId(),
             ResourceStatsType.WORKER_STATS,
             new ResourceUsageMetric(CPU, 100),
             new ResourceUsageMetric(MEMORY, 100)


### PR DESCRIPTION
### Description
Replaces deprecated usages of `Thread::getId()` with `Thread::threadId()` introduced in Java 19. This change ensures compatibility with newer Java versions and eliminates deprecation warnings. The updates are scoped to actual `Thread` usage and do not affect domain-specific `getId()` calls on objects like `Task`, `Node`, etc.

### Related Issues
Resolves #18205

### Check List
- [x] Functionality includes testing. *(Existing tests cover the change, and local builds were verified.)*
- [ ] API changes companion pull request created, if applicable. *(Not applicable — no API changes involved.)*
- [ ] Public documentation issue/PR created, if applicable. *(Not applicable — internal code cleanup only.)*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.