### PR TITLE
Fix incorrect constructor param ordering in ShardRouting

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/ShardRouting.java
@@ -122,8 +122,8 @@ public class ShardRouting implements Writeable, ToXContentObject {
 
     protected ShardRouting(
         ShardId shardId,
-        String relocatingNodeId,
         String currentNodeId,
+        String relocatingNodeId,
         boolean primary,
         ShardRoutingState shardRoutingState,
         RecoverySource recoverySource,
@@ -133,8 +133,8 @@ public class ShardRouting implements Writeable, ToXContentObject {
     ) {
         this(
             shardId,
-            relocatingNodeId,
             currentNodeId,
+            relocatingNodeId,
             primary,
             false,
             shardRoutingState,


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The [default](https://github.com/opensearch-project/OpenSearch/blob/cc875c6f8cc966538945687662bf1a6334c5cb44/server/src/main/java/org/opensearch/cluster/routing/ShardRouting.java#L85) ctor for ShardRouting has currentNodeId before relocatingNodeId.  A new ctor to add support for the search only flag was added with this order swapped.  There is no actual bug surfaced because it then passes the relocating as the current. Further there is only one caller of this ctor [here](https://github.com/opensearch-project/OpenSearch/blob/cc875c6f8cc966538945687662bf1a6334c5cb44/server/src/main/java/org/opensearch/cluster/routing/ShardRouting.java#L670), that passes the current as the relocated... anyway this cleans it up.

### Related Issues
N/A

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
