### PR TITLE
[segment replication] support local merged segment warmer

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/MergedSegmentWarmerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/MergedSegmentWarmerIT.java
@@ -1,0 +1,199 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.admin.indices.forcemerge.ForceMergeRequest;
+import org.opensearch.action.admin.indices.segments.IndexShardSegments;
+import org.opensearch.action.admin.indices.segments.IndicesSegmentResponse;
+import org.opensearch.action.admin.indices.segments.ShardSegments;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.common.util.set.Sets;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.TieredMergePolicyProvider;
+import org.opensearch.index.engine.Segment;
+import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.TransportService;
+
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * This class runs Segment Replication Integ test suite with merged segment warmer enabled.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class MergedSegmentWarmerIT extends SegmentReplicationIT {
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal)).build();
+    }
+
+    @Override
+    protected Settings featureFlagSettings() {
+        Settings.Builder featureSettings = Settings.builder();
+        featureSettings.put(FeatureFlags.MERGED_SEGMENT_WARMER_EXPERIMENTAL_FLAG, true);
+        return featureSettings.build();
+    }
+
+    public void testMergeSegmentWarmer() throws Exception {
+        final String primaryNode = internalCluster().startDataOnlyNode();
+        final String replicaNode = internalCluster().startDataOnlyNode();
+        createIndex(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        for (int i = 0; i < 30; i++) {
+            client().prepareIndex(INDEX_NAME)
+                .setId(String.valueOf(i))
+                .setSource("foo" + i, "bar" + i)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .get();
+        }
+
+        waitForSearchableDocs(30, primaryNode, replicaNode);
+
+        MockTransportService primaryTransportService = ((MockTransportService) internalCluster().getInstance(
+            TransportService.class,
+            primaryNode
+        ));
+
+        primaryTransportService.addRequestHandlingBehavior(
+            SegmentReplicationSourceService.Actions.GET_SEGMENT_FILES,
+            (handler, request, channel, task) -> {
+                logger.info(
+                    "replicationId {}, get segment files {}",
+                    ((GetSegmentFilesRequest) request).getReplicationId(),
+                    ((GetSegmentFilesRequest) request).getFilesToFetch().stream().map(StoreFileMetadata::name).collect(Collectors.toList())
+                );
+                // After the pre-copy merged segment is complete, the merged segment files is to reuse, so the files to fetch is empty.
+                assertEquals(0, ((GetSegmentFilesRequest) request).getFilesToFetch().size());
+                handler.messageReceived(request, channel, task);
+            }
+        );
+
+        client().admin().indices().forceMerge(new ForceMergeRequest(INDEX_NAME).maxNumSegments(2));
+
+        waitForSegmentCount(INDEX_NAME, 2, logger);
+        primaryTransportService.clearAllRules();
+    }
+
+    public void testConcurrentMergeSegmentWarmer() throws Exception {
+        final String primaryNode = internalCluster().startDataOnlyNode();
+        createIndex(
+            INDEX_NAME,
+            Settings.builder()
+                .put(indexSettings())
+                .put(TieredMergePolicyProvider.INDEX_MERGE_POLICY_SEGMENTS_PER_TIER_SETTING.getKey(), 5)
+                .put(TieredMergePolicyProvider.INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_SETTING.getKey(), 5)
+                .put(IndexSettings.INDEX_MERGE_ON_FLUSH_ENABLED.getKey(), false)
+                .build()
+        );
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        final String replicaNode = internalCluster().startDataOnlyNode();
+        ensureGreen(INDEX_NAME);
+
+        // ensure pre-copy merge segment concurrent execution
+        AtomicInteger getMergeSegmentFilesActionCount = new AtomicInteger(0);
+        MockTransportService primaryTransportService = ((MockTransportService) internalCluster().getInstance(
+            TransportService.class,
+            primaryNode
+        ));
+
+        CountDownLatch blockFileCopy = new CountDownLatch(1);
+        primaryTransportService.addRequestHandlingBehavior(
+            SegmentReplicationSourceService.Actions.GET_MERGED_SEGMENT_FILES,
+            (handler, request, channel, task) -> {
+                logger.info(
+                    "replicationId {}, get merge segment files {}",
+                    ((GetSegmentFilesRequest) request).getReplicationId(),
+                    ((GetSegmentFilesRequest) request).getFilesToFetch().stream().map(StoreFileMetadata::name).collect(Collectors.toList())
+                );
+                getMergeSegmentFilesActionCount.incrementAndGet();
+                if (getMergeSegmentFilesActionCount.get() > 2) {
+                    blockFileCopy.countDown();
+                }
+                handler.messageReceived(request, channel, task);
+            }
+        );
+
+        primaryTransportService.addSendBehavior(
+            internalCluster().getInstance(TransportService.class, replicaNode),
+            (connection, requestId, action, request, options) -> {
+                if (action.equals(SegmentReplicationTargetService.Actions.MERGED_SEGMENT_FILE_CHUNK)) {
+                    try {
+                        blockFileCopy.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                connection.sendRequest(requestId, action, request, options);
+            }
+        );
+
+        for (int i = 0; i < 30; i++) {
+            client().prepareIndex(INDEX_NAME)
+                .setId(String.valueOf(i))
+                .setSource("foo" + i, "bar" + i)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .get();
+        }
+
+        client().admin().indices().forceMerge(new ForceMergeRequest(INDEX_NAME).maxNumSegments(2));
+
+        waitForSegmentCount(INDEX_NAME, 2, logger);
+        primaryTransportService.clearAllRules();
+    }
+
+    public void testMergeSegmentWarmerWithInactiveReplica() throws Exception {
+        internalCluster().startDataOnlyNode();
+        createIndex(INDEX_NAME);
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+
+        for (int i = 0; i < 30; i++) {
+            client().prepareIndex(INDEX_NAME)
+                .setId(String.valueOf(i))
+                .setSource("foo" + i, "bar" + i)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .get();
+        }
+
+        client().admin().indices().forceMerge(new ForceMergeRequest(INDEX_NAME).maxNumSegments(1)).get();
+        final IndicesSegmentResponse response = client().admin().indices().prepareSegments(INDEX_NAME).get();
+        assertEquals(1, response.getIndices().get(INDEX_NAME).getShards().values().size());
+    }
+
+    public static void waitForSegmentCount(String indexName, int segmentCount, Logger logger) throws Exception {
+        assertBusy(() -> {
+            Set<String> primarySegments = Sets.newHashSet();
+            Set<String> replicaSegments = Sets.newHashSet();
+            final IndicesSegmentResponse response = client().admin().indices().prepareSegments(indexName).get();
+            for (IndexShardSegments indexShardSegments : response.getIndices().get(indexName).getShards().values()) {
+                for (ShardSegments shardSegment : indexShardSegments.getShards()) {
+                    for (Segment segment : shardSegment.getSegments()) {
+                        if (shardSegment.getShardRouting().primary()) {
+                            primarySegments.add(segment.getName());
+                        } else {
+                            replicaSegments.add(segment.getName());
+                        }
+                    }
+                }
+            }
+            logger.info("primary segments: {}, replica segments: {}", primarySegments, replicaSegments);
+            assertEquals(segmentCount, primarySegments.size());
+            assertEquals(segmentCount, replicaSegments.size());
+        }, 1, TimeUnit.MINUTES);
+    }
+}

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -314,6 +314,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 ShardLimitValidator.SETTING_CLUSTER_IGNORE_DOT_INDEXES,
                 RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING,
                 RecoverySettings.INDICES_REPLICATION_MAX_BYTES_PER_SEC_SETTING,
+                RecoverySettings.INDICES_MERGED_SEGMENT_REPLICATION_MAX_BYTES_PER_SEC_SETTING,
+                RecoverySettings.INDICES_MERGED_SEGMENT_REPLICATION_TIMEOUT_SETTING,
                 RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC_SETTING,
                 RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_NETWORK_SETTING,
                 RecoverySettings.INDICES_RECOVERY_ACTIVITY_TIMEOUT_SETTING,

--- a/server/src/main/java/org/opensearch/index/engine/LocalMergedSegmentWarmer.java
+++ b/server/src/main/java/org/opensearch/index/engine/LocalMergedSegmentWarmer.java
@@ -32,13 +32,33 @@
 
 package org.opensearch.index.engine;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentReader;
+import org.opensearch.action.ActionListenerResponseHandler;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.indices.recovery.RecoverySettings;
+import org.opensearch.indices.replication.SegmentReplicationTargetService;
+import org.opensearch.indices.replication.checkpoint.PublishMergedSegmentRequest;
+import org.opensearch.indices.replication.checkpoint.ReplicationSegmentCheckpoint;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Implementation of a {@link IndexWriter.IndexReaderWarmer} when local on-disk segment replication is enabled.
@@ -46,18 +66,74 @@ import java.io.IOException;
  * @opensearch.internal
  */
 public class LocalMergedSegmentWarmer implements IndexWriter.IndexReaderWarmer {
+    private static final Logger logger = LogManager.getLogger(LocalMergedSegmentWarmer.class);
     private final TransportService transportService;
     private final RecoverySettings recoverySettings;
     private final ClusterService clusterService;
+    private final IndexShard indexShard;
 
-    public LocalMergedSegmentWarmer(TransportService transportService, RecoverySettings recoverySettings, ClusterService clusterService) {
+    public LocalMergedSegmentWarmer(
+        TransportService transportService,
+        RecoverySettings recoverySettings,
+        ClusterService clusterService,
+        IndexShard indexShard
+    ) {
         this.transportService = transportService;
         this.recoverySettings = recoverySettings;
         this.clusterService = clusterService;
+        this.indexShard = indexShard;
     }
 
     @Override
     public void warm(LeafReader leafReader) throws IOException {
-        // TODO: node-node segment replication merged segment warmer
+        SegmentCommitInfo segmentCommitInfo = ((SegmentReader) leafReader).getSegmentInfo();
+        ReplicationSegmentCheckpoint mergedSegment = indexShard.computeReplicationSegmentCheckpoint(segmentCommitInfo);
+        PublishMergedSegmentRequest request = new PublishMergedSegmentRequest(mergedSegment);
+
+        DiscoveryNodes nodes = clusterService.state().nodes();
+        List<ShardRouting> replicaShards = indexShard.getReplicationGroup().getRoutingTable().replicaShards();
+        List<DiscoveryNode> activeReplicaNodes = replicaShards.stream()
+            .filter(ShardRouting::active)
+            .map(s -> nodes.get(s.currentNodeId()))
+            .toList();
+
+        if (activeReplicaNodes.isEmpty()) {
+            logger.trace("There are no active replicas, skip pre copy merged segment [{}]", segmentCommitInfo.info.name);
+            return;
+        }
+
+        CountDownLatch countDownLatch = new CountDownLatch(activeReplicaNodes.size());
+        AtomicInteger successfulCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+        for (DiscoveryNode replicaNode : activeReplicaNodes) {
+            ActionListener<TransportResponse> listener = ActionListener.wrap(r -> {
+                successfulCount.incrementAndGet();
+                countDownLatch.countDown();
+            }, e -> {
+                failureCount.incrementAndGet();
+                countDownLatch.countDown();
+            });
+            transportService.sendRequest(
+                replicaNode,
+                SegmentReplicationTargetService.Actions.PUBLISH_MERGED_SEGMENT,
+                request,
+                new ActionListenerResponseHandler<>(listener, (in) -> TransportResponse.Empty.INSTANCE, ThreadPool.Names.GENERIC)
+            );
+        }
+        try {
+            countDownLatch.await(recoverySettings.getMergedSegmentReplicationTimeout().seconds(), TimeUnit.SECONDS);
+            logger.trace(
+                "pre copy merged segment [{}] to [{}] active replicas, [{}] successful, [{}] failed",
+                segmentCommitInfo.info.name,
+                activeReplicaNodes.size(),
+                successfulCount,
+                failureCount
+            );
+        } catch (InterruptedException e) {
+            logger.warn(
+                () -> new ParameterizedMessage("Interrupted while waiting for pre copy merged segment [{}]", segmentCommitInfo.info.name),
+                e
+            );
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/MergedSegmentWarmerFactory.java
+++ b/server/src/main/java/org/opensearch/index/engine/MergedSegmentWarmerFactory.java
@@ -61,7 +61,7 @@ public class MergedSegmentWarmerFactory {
         if (shard.indexSettings().isAssignedOnRemoteNode()) {
             return new RemoteStoreMergedSegmentWarmer(transportService, recoverySettings, clusterService);
         } else if (shard.indexSettings().isSegRepLocalEnabled()) {
-            return new LocalMergedSegmentWarmer(transportService, recoverySettings, clusterService);
+            return new LocalMergedSegmentWarmer(transportService, recoverySettings, clusterService, shard);
         } else if (shard.indexSettings().isDocumentReplication()) {
             // MergedSegmentWarmerFactory#get is called when IndexShard is initialized. In scenario document replication,
             // IndexWriter.IndexReaderWarmer should be null.

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -390,6 +390,21 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     }
 
     /**
+     * Segment Replication method - Fetch a map of StoreFileMetadata for segmentCommitInfo.
+     * @param segmentCommitInfo {@link SegmentCommitInfo} from which to compute metadata.
+     * @return {@link Map} map file name to {@link StoreFileMetadata}.
+     */
+    public Map<String, StoreFileMetadata> getSegmentMetadataMap(SegmentCommitInfo segmentCommitInfo) throws IOException {
+        failIfCorrupted();
+        try {
+            return loadMetadata(segmentCommitInfo, directory, logger);
+        } catch (NoSuchFileException | CorruptIndexException | IndexFormatTooOldException | IndexFormatTooNewException ex) {
+            markStoreCorrupted(ex);
+            throw ex;
+        }
+    }
+
+    /**
      * Segment Replication method
      * Returns a diff between the Maps of StoreFileMetadata that can be used for getting list of files to copy over to a replica for segment replication. The returned diff will hold a list of files that are:
      * <ul>
@@ -1191,6 +1206,26 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                 checksumFromLuceneFile(directory, segmentsFile, builder, logger, maxVersion, true);
             }
             return new LoadedMetadata(unmodifiableMap(builder), unmodifiableMap(commitUserDataBuilder), numDocs);
+        }
+
+        static Map<String, StoreFileMetadata> loadMetadata(SegmentCommitInfo info, Directory directory, Logger logger) throws IOException {
+            Map<String, StoreFileMetadata> builder = new HashMap<>();
+            final Version version = info.info.getVersion();
+            if (version == null) {
+                // version is written since 3.1+: we should have already hit IndexFormatTooOld.
+                throw new IllegalArgumentException("expected valid version value: " + info.info.toString());
+            }
+            for (String file : info.files()) {
+                checksumFromLuceneFile(
+                    directory,
+                    file,
+                    builder,
+                    logger,
+                    version,
+                    SEGMENT_INFO_EXTENSION.equals(IndexFileNames.getExtension(file))
+                );
+            }
+            return unmodifiableMap(builder);
         }
 
         private static void checksumFromLuceneFile(

--- a/server/src/main/java/org/opensearch/indices/replication/MergedSegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/MergedSegmentReplicationTarget.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.action.StepListener;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.util.CancellableThreads;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.indices.replication.common.ReplicationListener;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+
+/**
+ * Represents the target of a merged segment replication event.
+ *
+ * @opensearch.internal
+ */
+public class MergedSegmentReplicationTarget extends SegmentReplicationTarget {
+    public final static String MERGE_REPLICATION_PREFIX = "merge.";
+
+    public MergedSegmentReplicationTarget(
+        IndexShard indexShard,
+        ReplicationCheckpoint checkpoint,
+        SegmentReplicationSource source,
+        ReplicationListener listener
+    ) {
+        super(indexShard, checkpoint, source, listener);
+    }
+
+    @Override
+    protected String getPrefix() {
+        return MERGE_REPLICATION_PREFIX + UUIDs.randomBase64UUID() + ".";
+    }
+
+    @Override
+    public void startReplication(ActionListener<Void> listener, BiConsumer<ReplicationCheckpoint, IndexShard> checkpointUpdater) {
+        state.setStage(SegmentReplicationState.Stage.REPLICATING);
+        cancellableThreads.setOnCancel((reason, beforeCancelEx) -> {
+            throw new CancellableThreads.ExecutionCancelledException("merge replication was canceled reason [" + reason + "]");
+        });
+
+        final StepListener<GetSegmentFilesResponse> getFilesListener = new StepListener<>();
+
+        logger.trace(new ParameterizedMessage("Starting Merge Replication Target: {}", description()));
+
+        state.setStage(SegmentReplicationState.Stage.GET_CHECKPOINT_INFO);
+        List<StoreFileMetadata> filesToFetch;
+        try {
+            filesToFetch = getFiles(new CheckpointInfoResponse(checkpoint, checkpoint.getMetadataMap(), null));
+        } catch (Exception e) {
+            listener.onFailure(e);
+            return;
+        }
+        state.setStage(SegmentReplicationState.Stage.GET_FILES);
+        cancellableThreads.checkForCancel();
+        source.getMergedSegmentFiles(getId(), checkpoint, filesToFetch, indexShard, this::updateFileRecoveryBytes, getFilesListener);
+        getFilesListener.whenComplete(response -> {
+            state.setStage(SegmentReplicationState.Stage.FINALIZE_REPLICATION);
+            cancellableThreads.checkForCancel();
+            multiFileWriter.renameAllTempFiles();
+            listener.onResponse(null);
+        }, listener::onFailure);
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSource.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationSource.java
@@ -58,6 +58,25 @@ public interface SegmentReplicationSource {
     );
 
     /**
+     * Fetch the merged segment files.  Passes a listener that completes when files are stored locally.
+     *
+     * @param replicationId long - ID of the replication event.
+     * @param checkpoint    {@link ReplicationCheckpoint} Checkpoint to fetch metadata for.
+     * @param filesToFetch  {@link List} List of files to fetch.
+     * @param indexShard    {@link IndexShard} Reference to the IndexShard.
+     * @param fileProgressTracker {@link BiConsumer} A consumer that updates the replication progress for shard files.
+     * @param listener      {@link ActionListener} Listener that completes with the list of files copied.
+     */
+    default void getMergedSegmentFiles(
+        long replicationId,
+        ReplicationCheckpoint checkpoint,
+        List<StoreFileMetadata> filesToFetch,
+        IndexShard indexShard,
+        BiConsumer<String, Long> fileProgressTracker,
+        ActionListener<GetSegmentFilesResponse> listener
+    ) {};
+
+    /**
      * Get the source description
      */
     String getDescription();

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTarget.java
@@ -50,9 +50,9 @@ import java.util.stream.Collectors;
  */
 public class SegmentReplicationTarget extends ReplicationTarget {
 
-    private final ReplicationCheckpoint checkpoint;
-    private final SegmentReplicationSource source;
-    private final SegmentReplicationState state;
+    protected final ReplicationCheckpoint checkpoint;
+    protected final SegmentReplicationSource source;
+    protected final SegmentReplicationState state;
     protected final MultiFileWriter multiFileWriter;
 
     public final static String REPLICATION_PREFIX = "replication.";
@@ -200,7 +200,7 @@ public class SegmentReplicationTarget extends ReplicationTarget {
         }, listener::onFailure);
     }
 
-    private List<StoreFileMetadata> getFiles(CheckpointInfoResponse checkpointInfo) throws IOException {
+    protected List<StoreFileMetadata> getFiles(CheckpointInfoResponse checkpointInfo) throws IOException {
         cancellableThreads.checkForCancel();
         state.setStage(SegmentReplicationState.Stage.FILE_DIFF);
 
@@ -282,7 +282,7 @@ public class SegmentReplicationTarget extends ReplicationTarget {
      * @param fileName Name of the file being downloaded
      * @param bytesRecovered Number of bytes recovered
      */
-    private void updateFileRecoveryBytes(String fileName, long bytesRecovered) {
+    protected void updateFileRecoveryBytes(String fileName, long bytesRecovered) {
         ReplicationLuceneIndex index = state.getIndex();
         if (index != null) {
             index.addRecoveredBytesToFile(fileName, bytesRecovered);

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicator.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicator.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.index.CorruptIndexException;
 import org.opensearch.OpenSearchCorruptionException;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.SetOnce;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.AbstractRunnable;
@@ -30,11 +31,14 @@ import org.opensearch.indices.replication.common.ReplicationListener;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
+
+import reactor.util.annotation.NonNull;
 
 /**
  * This class is responsible for managing segment replication events on replicas.
@@ -48,6 +52,7 @@ public class SegmentReplicator {
     private static final Logger logger = LogManager.getLogger(SegmentReplicator.class);
 
     private final ReplicationCollection<SegmentReplicationTarget> onGoingReplications;
+    private final ReplicationCollection<MergedSegmentReplicationTarget> onGoingMergedSegmentReplications;
     private final Map<ShardId, SegmentReplicationState> completedReplications = ConcurrentCollections.newConcurrentMap();
     private final ConcurrentMap<ShardId, ConcurrentNavigableMap<Long, ReplicationCheckpointStats>> replicationCheckpointStats =
         ConcurrentCollections.newConcurrentMap();
@@ -58,6 +63,7 @@ public class SegmentReplicator {
 
     public SegmentReplicator(ThreadPool threadPool) {
         this.onGoingReplications = new ReplicationCollection<>(logger, threadPool);
+        this.onGoingMergedSegmentReplications = new ReplicationCollection<>(logger, threadPool);
         this.threadPool = threadPool;
         this.sourceFactory = new SetOnce<>();
     }
@@ -109,6 +115,37 @@ public class SegmentReplicator {
         final SegmentReplicationTarget target = new SegmentReplicationTarget(indexShard, checkpoint, source, listener);
         startReplication(target, indexShard.getRecoverySettings().activityTimeout());
         return target;
+    }
+
+    /**
+     * Start a round of replication merged segment.
+     * @param indexShard - {@link IndexShard} replica shard
+     * @param checkpoint - {@link ReplicationCheckpoint} merged segment to replicate
+     * @param listener - {@link ReplicationListener}
+     */
+    public void startMergedSegmentReplication(
+        final IndexShard indexShard,
+        final ReplicationCheckpoint checkpoint,
+        final SegmentReplicationSource source,
+        final SegmentReplicationTargetService.SegmentReplicationListener listener
+    ) {
+        final MergedSegmentReplicationTarget target = new MergedSegmentReplicationTarget(indexShard, checkpoint, source, listener);
+        startMergedSegmentReplication(target, indexShard.getRecoverySettings().activityTimeout());
+    }
+
+    void startMergedSegmentReplication(final MergedSegmentReplicationTarget target, TimeValue timeout) {
+        final long replicationId;
+        try {
+            replicationId = onGoingMergedSegmentReplications.start(target, timeout);
+        } catch (ReplicationFailedException e) {
+            // replication already running for shard.
+            target.fail(e, false);
+            return;
+        }
+        logger.info(() -> new ParameterizedMessage("Added new merged segment replication to collection {}", target.description()));
+        // Currently, we have not counted the completion information of the pre-copy merged segment, so the completedReplications parameter
+        // is null.
+        threadPool.generic().execute(new ReplicationRunner(replicationId, onGoingMergedSegmentReplications, null));
     }
 
     /**
@@ -243,12 +280,20 @@ public class SegmentReplicator {
     /**
      * Runnable implementation to trigger a replication event.
      */
-    private class ReplicationRunner extends AbstractRunnable {
+    private class ReplicationRunner<R extends SegmentReplicationTarget> extends AbstractRunnable {
 
         final long replicationId;
+        final ReplicationCollection<R> onGoingReplications;
+        final Map<ShardId, SegmentReplicationState> completedReplications;
 
-        public ReplicationRunner(long replicationId) {
+        public ReplicationRunner(
+            long replicationId,
+            @NonNull ReplicationCollection<R> onGoingReplications,
+            @Nullable Map<ShardId, SegmentReplicationState> completedReplications
+        ) {
             this.replicationId = replicationId;
+            this.onGoingReplications = onGoingReplications;
+            this.completedReplications = completedReplications;
         }
 
         @Override
@@ -258,16 +303,24 @@ public class SegmentReplicator {
 
         @Override
         public void doRun() {
-            start(replicationId);
+            start(replicationId, onGoingReplications, completedReplications);
         }
     }
 
-    private void start(final long replicationId) {
+    private void start(
+        final long replicationId,
+        ReplicationCollection<? extends SegmentReplicationTarget> onGoingReplications,
+        Map<ShardId, SegmentReplicationState> completedReplications
+    ) {
         final SegmentReplicationTarget target;
-        try (ReplicationCollection.ReplicationRef<SegmentReplicationTarget> replicationRef = onGoingReplications.get(replicationId)) {
+        logger.info("onGoingReplications size {}, id {}", onGoingReplications.size(), replicationId);
+        try (
+            ReplicationCollection.ReplicationRef<? extends SegmentReplicationTarget> replicationRef = onGoingReplications.get(replicationId)
+        ) {
             // This check is for handling edge cases where the reference is removed before the ReplicationRunner is started by the
             // threadpool.
             if (replicationRef == null) {
+                logger.info("replicationRef is null");
                 return;
             }
             target = replicationRef.get();
@@ -278,7 +331,9 @@ public class SegmentReplicator {
                 logger.debug(() -> new ParameterizedMessage("Finished replicating {} marking as done.", target.description()));
                 pruneCheckpointsUpToLastSync(target.indexShard());
                 onGoingReplications.markAsDone(replicationId);
-                if (target.state().getIndex().recoveredFileCount() != 0 && target.state().getIndex().recoveredBytes() != 0) {
+                if (target.state().getIndex().recoveredFileCount() != 0
+                    && target.state().getIndex().recoveredBytes() != 0
+                    && null != completedReplications) {
                     completedReplications.put(target.shardId(), target.state());
                 }
             }
@@ -306,7 +361,7 @@ public class SegmentReplicator {
             return;
         }
         logger.trace(() -> new ParameterizedMessage("Added new replication to collection {}", target.description()));
-        threadPool.generic().execute(new ReplicationRunner(replicationId));
+        threadPool.generic().execute(new ReplicationRunner(replicationId, onGoingReplications, completedReplications));
     }
 
     private boolean isStoreCorrupt(SegmentReplicationTarget target) {
@@ -336,12 +391,17 @@ public class SegmentReplicator {
 
     void cancel(ShardId shardId, String reason) {
         onGoingReplications.cancelForShard(shardId, reason);
+        onGoingMergedSegmentReplications.cancelForShard(shardId, reason);
         replicationCheckpointStats.remove(shardId);
         primaryCheckpoint.remove(shardId);
     }
 
     SegmentReplicationTarget get(ShardId shardId) {
         return onGoingReplications.getOngoingReplicationTarget(shardId);
+    }
+
+    List<MergedSegmentReplicationTarget> getMergedSegmentReplicationTarget(ShardId shardId) {
+        return onGoingMergedSegmentReplications.getOngoingReplicationTargetList(shardId);
     }
 
     ReplicationCheckpoint getPrimaryCheckpoint(ShardId shardId) {
@@ -358,5 +418,13 @@ public class SegmentReplicator {
 
     ReplicationCollection.ReplicationRef<SegmentReplicationTarget> get(long id, ShardId shardId) {
         return onGoingReplications.getSafe(id, shardId);
+    }
+
+    ReplicationCollection.ReplicationRef<MergedSegmentReplicationTarget> getMergeReplicationRef(long id) {
+        return onGoingMergedSegmentReplications.get(id);
+    }
+
+    ReplicationCollection.ReplicationRef<MergedSegmentReplicationTarget> getMergeReplicationRef(long id, ShardId shardId) {
+        return onGoingMergedSegmentReplications.getSafe(id, shardId);
     }
 }

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishMergedSegmentRequest.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishMergedSegmentRequest.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.indices.replication.checkpoint;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Request object for publish merged segment
+ *
+ * @opensearch.internal
+ */
+public class PublishMergedSegmentRequest extends ActionRequest {
+    private final ReplicationSegmentCheckpoint mergedSegment;
+
+    public PublishMergedSegmentRequest(ReplicationSegmentCheckpoint mergedSegment) {
+        this.mergedSegment = mergedSegment;
+    }
+
+    public PublishMergedSegmentRequest(StreamInput in) throws IOException {
+        super(in);
+        this.mergedSegment = new ReplicationSegmentCheckpoint(in);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        mergedSegment.writeTo(out);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PublishMergedSegmentRequest that)) return false;
+        return Objects.equals(mergedSegment, that.mergedSegment);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mergedSegment);
+    }
+
+    @Override
+    public String toString() {
+        return "PublishMergedSegmentRequest{" + "mergedSegment=" + mergedSegment + '}';
+    }
+
+    public ReplicationSegmentCheckpoint getMergedSegment() {
+        return mergedSegment;
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/ReplicationSegmentCheckpoint.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/ReplicationSegmentCheckpoint.java
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.indices.replication.checkpoint;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.index.store.StoreFileMetadata;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a Pre-copy merged segment which is sent to a replica shard.
+ * Inherit {@link ReplicationCheckpoint}, but the segmentsGen and segmentInfosVersion will not be used.
+ *
+ * @opensearch.internal
+ */
+@ExperimentalApi
+public class ReplicationSegmentCheckpoint extends ReplicationCheckpoint {
+    private final String segmentName;
+
+    public ReplicationSegmentCheckpoint(
+        ShardId shardId,
+        long primaryTerm,
+        long length,
+        String codec,
+        Map<String, StoreFileMetadata> metadataMap,
+        String segmentName
+    ) {
+        super(shardId, primaryTerm, SequenceNumbers.NO_OPS_PERFORMED, SequenceNumbers.NO_OPS_PERFORMED, length, codec, metadataMap);
+        this.segmentName = segmentName;
+    }
+
+    public ReplicationSegmentCheckpoint(StreamInput in) throws IOException {
+        super(in);
+        segmentName = in.readString();
+    }
+
+    /**
+     * The segmentName
+     *
+     * @return the segmentCommitInfo name
+     */
+    public String getSegmentName() {
+        return segmentName;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(segmentName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReplicationSegmentCheckpoint that = (ReplicationSegmentCheckpoint) o;
+        return getPrimaryTerm() == that.getPrimaryTerm()
+            && segmentName.equals(that.segmentName)
+            && Objects.equals(getShardId(), that.getShardId())
+            && getCodec().equals(that.getCodec());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getShardId(), getPrimaryTerm(), segmentName);
+    }
+
+    @Override
+    public String toString() {
+        return "ReplicationCheckpoint{"
+            + "shardId="
+            + getShardId()
+            + ", primaryTerm="
+            + getPrimaryTerm()
+            + ", segmentsGen="
+            + getSegmentsGen()
+            + ", version="
+            + getSegmentInfosVersion()
+            + ", size="
+            + getLength()
+            + ", codec="
+            + getCodec()
+            + ", timestamp="
+            + getCreatedTimeStamp()
+            + ", segmentName="
+            + segmentName
+            + '}';
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/replication/common/ReplicationCollection.java
+++ b/server/src/main/java/org/opensearch/indices/replication/common/ReplicationCollection.java
@@ -286,6 +286,16 @@ public class ReplicationCollection<T extends ReplicationTarget> {
     }
 
     /**
+     * Get targets for shard
+     *
+     * @param shardId      shardId
+     * @return ReplicationTarget list for input shardId
+     */
+    public List<T> getOngoingReplicationTargetList(ShardId shardId) {
+        return onGoingTargetEvents.values().stream().filter(t -> t.indexShard.shardId().equals(shardId)).collect(Collectors.toList());
+    }
+
+    /**
      * a reference to {@link ReplicationTarget}, which implements {@link AutoCloseable}. closing the reference
      * causes {@link ReplicationTarget#decRef()} to be called. This makes sure that the underlying resources
      * will not be freed until {@link ReplicationRef#close()} is called.

--- a/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java
@@ -45,6 +45,7 @@ import org.opensearch.test.CorruptionUtils;
 import org.opensearch.test.junit.annotations.TestLogging;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
+import org.junit.Ignore;
 
 import java.io.IOException;
 import java.nio.channels.FileChannel;
@@ -60,6 +61,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
+import static org.opensearch.common.util.FeatureFlags.MERGED_SEGMENT_WARMER_EXPERIMENTAL_FLAG;
 import static org.opensearch.index.engine.EngineTestCase.assertAtMostOneLuceneDocumentPerSequenceNumber;
 import static org.opensearch.index.shard.RemoteStoreRefreshListener.EXCLUDE_FILES;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -626,6 +628,14 @@ public class RemoteIndexShardTests extends SegmentReplicationIndexShardTests {
                 assertEquals(IndexShardSnapshotStatus.Stage.DONE, stage);
             });
         }
+    }
+
+    @LockFeatureFlag(MERGED_SEGMENT_WARMER_EXPERIMENTAL_FLAG)
+    @Override
+    @Ignore
+    public void testMergedSegmentReplication() throws Exception {
+        // TODO: wait for remote store to support merged segment warmer
+        super.testMergedSegmentReplication();
     }
 
     private RemoteStoreReplicationSource getRemoteStoreReplicationSource(IndexShard shard, Runnable postGetFilesRunnable) {

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationWithNodeToNodeIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationWithNodeToNodeIndexShardTests.java
@@ -421,6 +421,7 @@ public class SegmentReplicationWithNodeToNodeIndexShardTests extends SegmentRepl
             SegmentReplicationSource segmentReplicationSource = getSegmentReplicationSource(
                 primaryShard,
                 (repId) -> targetService.get(repId),
+                (repId) -> targetService.getMergedSegmentReplicationRef(repId),
                 runnablePostGetFiles
             );
             when(sourceFactory.get(any())).thenReturn(segmentReplicationSource);

--- a/server/src/test/java/org/opensearch/indices/recovery/RecoverySettingsDynamicUpdateTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/RecoverySettingsDynamicUpdateTests.java
@@ -54,6 +54,10 @@ public class RecoverySettingsDynamicUpdateTests extends OpenSearchTestCase {
             Settings.builder().put(RecoverySettings.INDICES_REPLICATION_MAX_BYTES_PER_SEC_SETTING.getKey(), 0).build()
         );
         assertNull(recoverySettings.replicationRateLimiter());
+        clusterSettings.applySettings(
+            Settings.builder().put(RecoverySettings.INDICES_MERGED_SEGMENT_REPLICATION_MAX_BYTES_PER_SEC_SETTING.getKey(), 0).build()
+        );
+        assertNull(recoverySettings.mergedSegmentReplicationRateLimiter());
     }
 
     public void testSetReplicationMaxBytesPerSec() {
@@ -70,6 +74,44 @@ public class RecoverySettingsDynamicUpdateTests extends OpenSearchTestCase {
                 .build()
         );
         assertEquals(80, (int) recoverySettings.replicationRateLimiter().getMBPerSec());
+    }
+
+    public void testSetMergedSegmentReplicationMaxBytesPerSec() {
+        assertEquals(40, (int) recoverySettings.mergedSegmentReplicationRateLimiter().getMBPerSec());
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put(
+                    RecoverySettings.INDICES_MERGED_SEGMENT_REPLICATION_MAX_BYTES_PER_SEC_SETTING.getKey(),
+                    new ByteSizeValue(60, ByteSizeUnit.MB)
+                )
+                .build()
+        );
+        assertEquals(60, (int) recoverySettings.mergedSegmentReplicationRateLimiter().getMBPerSec());
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put(
+                    RecoverySettings.INDICES_MERGED_SEGMENT_REPLICATION_MAX_BYTES_PER_SEC_SETTING.getKey(),
+                    new ByteSizeValue(80, ByteSizeUnit.MB)
+                )
+                .build()
+        );
+        assertEquals(80, (int) recoverySettings.mergedSegmentReplicationRateLimiter().getMBPerSec());
+    }
+
+    public void testMergedSegmentReplicationTimeout() {
+        assertEquals(15, (int) recoverySettings.getMergedSegmentReplicationTimeout().minutes());
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put(RecoverySettings.INDICES_MERGED_SEGMENT_REPLICATION_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMinutes(5))
+                .build()
+        );
+        assertEquals(5, (int) recoverySettings.getMergedSegmentReplicationTimeout().minutes());
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put(RecoverySettings.INDICES_MERGED_SEGMENT_REPLICATION_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMinutes(25))
+                .build()
+        );
+        assertEquals(25, (int) recoverySettings.getMergedSegmentReplicationTimeout().minutes());
     }
 
     public void testRetryDelayStateSync() {

--- a/server/src/test/java/org/opensearch/indices/replication/MergedSegmentReplicationTargetTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/MergedSegmentReplicationTargetTests.java
@@ -1,0 +1,250 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication;
+
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.apache.lucene.util.Version;
+import org.opensearch.OpenSearchCorruptionException;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.engine.NRTReplicationEngineFactory;
+import org.opensearch.index.replication.TestReplicationSource;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexShardTestCase;
+import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.indices.replication.checkpoint.ReplicationSegmentCheckpoint;
+import org.opensearch.indices.replication.common.ReplicationFailedException;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.junit.Assert;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class MergedSegmentReplicationTargetTests extends IndexShardTestCase {
+
+    private MergedSegmentReplicationTarget mergedSegmentReplicationTarget;
+    private IndexShard indexShard, spyIndexShard;
+    private ReplicationSegmentCheckpoint mergedSegment;
+    private ByteBuffersDataOutput buffer;
+
+    private static final String SEGMENT_NAME = "_0.si";
+    private static final StoreFileMetadata SEGMENT_FILE = new StoreFileMetadata(SEGMENT_NAME, 1L, "0", Version.LATEST);
+    private static final StoreFileMetadata SEGMENT_FILE_DIFF = new StoreFileMetadata(SEGMENT_NAME, 5L, "different", Version.LATEST);
+
+    private static final Map<String, StoreFileMetadata> SI_SNAPSHOT = Map.of(SEGMENT_FILE.name(), SEGMENT_FILE);
+
+    private static final Map<String, StoreFileMetadata> SI_SNAPSHOT_DIFFERENT = Map.of(SEGMENT_FILE_DIFF.name(), SEGMENT_FILE_DIFF);
+
+    private SegmentInfos testSegmentInfos;
+
+    @Override
+    public void setUp() throws Exception {
+
+        super.setUp();
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, org.opensearch.Version.CURRENT)
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .build();
+
+        indexShard = newStartedShard(false, indexSettings, new NRTReplicationEngineFactory());
+        spyIndexShard = spy(indexShard);
+
+        testSegmentInfos = spyIndexShard.store().readLastCommittedSegmentsInfo();
+        buffer = new ByteBuffersDataOutput();
+        try (ByteBuffersIndexOutput indexOutput = new ByteBuffersIndexOutput(buffer, "", null)) {
+            testSegmentInfos.write(indexOutput);
+        }
+        mergedSegment = new ReplicationSegmentCheckpoint(
+            spyIndexShard.shardId(),
+            spyIndexShard.getPendingPrimaryTerm(),
+            1,
+            indexShard.getLatestReplicationCheckpoint().getCodec(),
+            SI_SNAPSHOT,
+            IndexFileNames.parseSegmentName(SEGMENT_NAME)
+        );
+    }
+
+    public void testSuccessfulResponse_startReplication() {
+
+        SegmentReplicationSource segrepSource = new TestReplicationSource() {
+            @Override
+            public void getCheckpointMetadata(
+                long replicationId,
+                ReplicationCheckpoint checkpoint,
+                ActionListener<CheckpointInfoResponse> listener
+            ) {}
+
+            @Override
+            public void getSegmentFiles(
+                long replicationId,
+                ReplicationCheckpoint checkpoint,
+                List<StoreFileMetadata> filesToFetch,
+                IndexShard indexShard,
+                BiConsumer<String, Long> fileProgressTracker,
+                ActionListener<GetSegmentFilesResponse> listener
+            ) {}
+
+            @Override
+            public void getMergedSegmentFiles(
+                long replicationId,
+                ReplicationCheckpoint checkpoint,
+                List<StoreFileMetadata> filesToFetch,
+                IndexShard indexShard,
+                BiConsumer<String, Long> fileProgressTracker,
+                ActionListener<GetSegmentFilesResponse> listener
+            ) {
+                assertEquals(1, filesToFetch.size());
+                assert (filesToFetch.contains(SEGMENT_FILE));
+                listener.onResponse(new GetSegmentFilesResponse(filesToFetch));
+            }
+        };
+
+        SegmentReplicationTargetService.SegmentReplicationListener segRepListener = mock(
+            SegmentReplicationTargetService.SegmentReplicationListener.class
+        );
+        mergedSegmentReplicationTarget = new MergedSegmentReplicationTarget(spyIndexShard, mergedSegment, segrepSource, segRepListener);
+
+        mergedSegmentReplicationTarget.startReplication(new ActionListener<Void>() {
+            @Override
+            public void onResponse(Void replicationResponse) {
+                mergedSegmentReplicationTarget.markAsDone();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.error("Unexpected onFailure", e);
+                Assert.fail();
+            }
+        }, (ReplicationCheckpoint checkpoint, IndexShard indexShard) -> {
+            assertEquals(mergedSegment, checkpoint);
+            assertEquals(indexShard, spyIndexShard);
+        });
+    }
+
+    public void testFailureResponse_getMergedSegmentFiles() {
+
+        Exception exception = new Exception("dummy failure");
+        SegmentReplicationSource segrepSource = new TestReplicationSource() {
+            @Override
+            public void getCheckpointMetadata(
+                long replicationId,
+                ReplicationCheckpoint checkpoint,
+                ActionListener<CheckpointInfoResponse> listener
+            ) {}
+
+            @Override
+            public void getSegmentFiles(
+                long replicationId,
+                ReplicationCheckpoint checkpoint,
+                List<StoreFileMetadata> filesToFetch,
+                IndexShard indexShard,
+                BiConsumer<String, Long> fileProgressTracker,
+                ActionListener<GetSegmentFilesResponse> listener
+            ) {}
+
+            @Override
+            public void getMergedSegmentFiles(
+                long replicationId,
+                ReplicationCheckpoint checkpoint,
+                List<StoreFileMetadata> filesToFetch,
+                IndexShard indexShard,
+                BiConsumer<String, Long> fileProgressTracker,
+                ActionListener<GetSegmentFilesResponse> listener
+            ) {
+                listener.onFailure(exception);
+            }
+        };
+        SegmentReplicationTargetService.SegmentReplicationListener segRepListener = mock(
+            SegmentReplicationTargetService.SegmentReplicationListener.class
+        );
+        mergedSegmentReplicationTarget = new MergedSegmentReplicationTarget(spyIndexShard, mergedSegment, segrepSource, segRepListener);
+
+        mergedSegmentReplicationTarget.startReplication(new ActionListener<Void>() {
+            @Override
+            public void onResponse(Void replicationResponse) {
+                Assert.fail();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assertEquals(exception, e.getCause().getCause());
+                mergedSegmentReplicationTarget.fail(new ReplicationFailedException(e), false);
+            }
+        }, mock(BiConsumer.class));
+    }
+
+    public void testFailure_differentSegmentFiles() throws IOException {
+
+        SegmentReplicationSource segrepSource = new TestReplicationSource() {
+            @Override
+            public void getCheckpointMetadata(
+                long replicationId,
+                ReplicationCheckpoint checkpoint,
+                ActionListener<CheckpointInfoResponse> listener
+            ) {}
+
+            @Override
+            public void getSegmentFiles(
+                long replicationId,
+                ReplicationCheckpoint checkpoint,
+                List<StoreFileMetadata> filesToFetch,
+                IndexShard indexShard,
+                BiConsumer<String, Long> fileProgressTracker,
+                ActionListener<GetSegmentFilesResponse> listener
+            ) {}
+
+            @Override
+            public void getMergedSegmentFiles(
+                long replicationId,
+                ReplicationCheckpoint checkpoint,
+                List<StoreFileMetadata> filesToFetch,
+                IndexShard indexShard,
+                BiConsumer<String, Long> fileProgressTracker,
+                ActionListener<GetSegmentFilesResponse> listener
+            ) {
+                listener.onResponse(new GetSegmentFilesResponse(filesToFetch));
+            }
+        };
+        SegmentReplicationTargetService.SegmentReplicationListener segRepListener = mock(
+            SegmentReplicationTargetService.SegmentReplicationListener.class
+        );
+        mergedSegmentReplicationTarget = new MergedSegmentReplicationTarget(spyIndexShard, mergedSegment, segrepSource, segRepListener);
+        when(spyIndexShard.getSegmentMetadataMap()).thenReturn(SI_SNAPSHOT_DIFFERENT);
+        mergedSegmentReplicationTarget.startReplication(new ActionListener<Void>() {
+            @Override
+            public void onResponse(Void replicationResponse) {
+                Assert.fail();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assertTrue(e instanceof OpenSearchCorruptionException);
+                assertTrue(e.getMessage().contains("has local copies of segments that differ from the primary"));
+                mergedSegmentReplicationTarget.fail(new ReplicationFailedException(e), false);
+            }
+        }, mock(BiConsumer.class));
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        closeShards(spyIndexShard, indexShard);
+    }
+}

--- a/server/src/test/java/org/opensearch/indices/replication/PrimaryShardReplicationSourceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/PrimaryShardReplicationSourceTests.java
@@ -22,6 +22,7 @@ import org.opensearch.index.shard.IndexShardTestCase;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
+import org.opensearch.indices.replication.checkpoint.ReplicationSegmentCheckpoint;
 import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.transport.CapturingTransport;
@@ -29,6 +30,7 @@ import org.opensearch.transport.TransportService;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 
@@ -132,6 +134,32 @@ public class PrimaryShardReplicationSourceTests extends IndexShardTestCase {
         assertTrue(capturedRequest.request instanceof GetSegmentFilesRequest);
     }
 
+    public void testGetMergedSegmentFiles() {
+        StoreFileMetadata testMetadata = new StoreFileMetadata("testFile", 1L, "checksum", Version.LATEST);
+        final ReplicationCheckpoint checkpoint = new ReplicationSegmentCheckpoint(
+            indexShard.shardId(),
+            PRIMARY_TERM,
+            1,
+            Codec.getDefault().getName(),
+            Map.of("testFile", testMetadata),
+            "_0"
+        );
+        replicationSource.getMergedSegmentFiles(
+            REPLICATION_ID,
+            checkpoint,
+            Arrays.asList(testMetadata),
+            mock(IndexShard.class),
+            (fileName, bytesRecovered) -> {},
+            mock(ActionListener.class)
+        );
+        CapturingTransport.CapturedRequest[] requestList = transport.getCapturedRequestsAndClear();
+        assertEquals(1, requestList.length);
+        CapturingTransport.CapturedRequest capturedRequest = requestList[0];
+        assertEquals(SegmentReplicationSourceService.Actions.GET_MERGED_SEGMENT_FILES, capturedRequest.action);
+        assertEquals(sourceNode, capturedRequest.node);
+        assertTrue(capturedRequest.request instanceof GetSegmentFilesRequest);
+    }
+
     /**
      * This test verifies the transport request timeout value for fetching the segment files.
      */
@@ -159,6 +187,36 @@ public class PrimaryShardReplicationSourceTests extends IndexShardTestCase {
         assertEquals(SegmentReplicationSourceService.Actions.GET_SEGMENT_FILES, capturedRequest.action);
         assertEquals(sourceNode, capturedRequest.node);
         assertEquals(recoverySettings.internalActionLongTimeout(), capturedRequest.options.timeout());
+    }
+
+    /**
+     * This test verifies the transport request timeout value for fetching the merged segment files.
+     */
+    public void testTransportTimeoutForGetMergedSegmentFilesAction() {
+        long fileSize = (long) (Math.pow(10, 9));
+        StoreFileMetadata testMetadata = new StoreFileMetadata("testFile", fileSize, "checksum", Version.LATEST);
+        final ReplicationCheckpoint checkpoint = new ReplicationSegmentCheckpoint(
+            indexShard.shardId(),
+            PRIMARY_TERM,
+            1,
+            Codec.getDefault().getName(),
+            Map.of("testFile", testMetadata),
+            "_0"
+        );
+        replicationSource.getMergedSegmentFiles(
+            REPLICATION_ID,
+            checkpoint,
+            Arrays.asList(testMetadata),
+            mock(IndexShard.class),
+            (fileName, bytesRecovered) -> {},
+            mock(ActionListener.class)
+        );
+        CapturingTransport.CapturedRequest[] requestList = transport.getCapturedRequestsAndClear();
+        assertEquals(1, requestList.length);
+        CapturingTransport.CapturedRequest capturedRequest = requestList[0];
+        assertEquals(SegmentReplicationSourceService.Actions.GET_MERGED_SEGMENT_FILES, capturedRequest.action);
+        assertEquals(sourceNode, capturedRequest.node);
+        assertEquals(recoverySettings.getMergedSegmentReplicationTimeout(), capturedRequest.options.timeout());
     }
 
     private DiscoveryNode newDiscoveryNode(String nodeName) {

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationSourceServiceTests.java
@@ -20,9 +20,12 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexShardClosedException;
+import org.opensearch.index.shard.IndexShardState;
 import org.opensearch.index.shard.ReplicationGroup;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.recovery.RecoverySettings;
@@ -38,6 +41,7 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
+import org.junit.Assert;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -61,6 +65,7 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
     private SegmentReplicationSourceService segmentReplicationSourceService;
     private OngoingSegmentReplications ongoingSegmentReplications;
     private IndexShard mockIndexShard;
+    private IndicesService mockIndicesService;
 
     @Override
     public void setUp() throws Exception {
@@ -68,7 +73,7 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
         // setup mocks
         mockIndexShard = CopyStateTests.createMockIndexShard();
         ShardId testShardId = mockIndexShard.shardId();
-        IndicesService mockIndicesService = mock(IndicesService.class);
+        mockIndicesService = mock(IndicesService.class);
         IndexService mockIndexService = mock(IndexService.class);
         when(mockIndicesService.iterator()).thenReturn(List.of(mockIndexService).iterator());
         when(mockIndicesService.indexServiceSafe(testShardId.getIndex())).thenReturn(mockIndexService);
@@ -85,6 +90,7 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
         when(mockIndexShard.isPrimaryMode()).thenReturn(true);
         final ReplicationGroup replicationGroup = mock(ReplicationGroup.class);
         when(mockIndexShard.getReplicationGroup()).thenReturn(replicationGroup);
+        when(mockIndexShard.state()).thenReturn(IndexShardState.STARTED);
         when(replicationGroup.getInSyncAllocationIds()).thenReturn(Collections.emptySet());
         // This mirrors the creation of the ReplicationCheckpoint inside CopyState
         testCheckpoint = new ReplicationCheckpoint(
@@ -112,6 +118,8 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
         final Settings settings = Settings.builder().put("node.name", SegmentReplicationTargetServiceTests.class.getSimpleName()).build();
         final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
+        when(mockIndexShard.getRecoverySettings()).thenReturn(recoverySettings);
+        when(mockIndexShard.getThreadPool()).thenReturn(testThreadPool);
 
         ongoingSegmentReplications = spy(new OngoingSegmentReplications(mockIndicesService, recoverySettings));
         segmentReplicationSourceService = new SegmentReplicationSourceService(
@@ -146,6 +154,115 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
             @Override
             public void onFailure(Exception e) {
                 fail("unexpected exception: " + e);
+            }
+        });
+    }
+
+    public void testGetMergedSegmentFiles() {
+        final GetSegmentFilesRequest request = new GetSegmentFilesRequest(
+            1,
+            "allocationId",
+            localNode,
+            Collections.emptyList(),
+            testCheckpoint
+        );
+        executeGetMergedSegmentFiles(request, new ActionListener<>() {
+            @Override
+            public void onResponse(GetSegmentFilesResponse response) {
+                assertEquals(0, response.files.size());
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("unexpected exception: " + e);
+            }
+        });
+    }
+
+    public void testGetMergedSegmentFiles_indexNotFound() {
+        when(mockIndicesService.indexServiceSafe(mockIndexShard.shardId().getIndex())).thenReturn(null);
+        final GetSegmentFilesRequest request = new GetSegmentFilesRequest(
+            1,
+            "allocationId",
+            localNode,
+            Collections.emptyList(),
+            testCheckpoint
+        );
+        executeGetMergedSegmentFiles(request, new ActionListener<>() {
+            @Override
+            public void onResponse(GetSegmentFilesResponse response) {
+                Assert.fail("Test should succeed");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assert e.getCause() instanceof IndexNotFoundException;
+            }
+        });
+    }
+
+    public void testGetMergedSegmentFiles_shardClosed() {
+        when(mockIndexShard.state()).thenReturn(IndexShardState.CLOSED);
+        final GetSegmentFilesRequest request = new GetSegmentFilesRequest(
+            1,
+            "allocationId",
+            localNode,
+            Collections.emptyList(),
+            testCheckpoint
+        );
+        executeGetMergedSegmentFiles(request, new ActionListener<>() {
+            @Override
+            public void onResponse(GetSegmentFilesResponse response) {
+                Assert.fail("Test should succeed");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assert e.getCause() instanceof IndexShardClosedException;
+            }
+        });
+    }
+
+    public void testGetMergedSegmentFiles_shardNonPrimary() {
+        when(mockIndexShard.isPrimaryMode()).thenReturn(false);
+        final GetSegmentFilesRequest request = new GetSegmentFilesRequest(
+            1,
+            "allocationId",
+            localNode,
+            Collections.emptyList(),
+            testCheckpoint
+        );
+        executeGetMergedSegmentFiles(request, new ActionListener<>() {
+            @Override
+            public void onResponse(GetSegmentFilesResponse response) {
+                Assert.fail("Test should succeed");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assert e.getCause() instanceof IllegalArgumentException;
+            }
+        });
+    }
+
+    public void testGetMergedSegmentFiles_receiveLowerPrimaryTermRequest() {
+        final GetSegmentFilesRequest request = new GetSegmentFilesRequest(
+            1,
+            "allocationId",
+            localNode,
+            Collections.emptyList(),
+            testCheckpoint
+        );
+        when(mockIndexShard.getOperationPrimaryTerm()).thenReturn(request.getCheckpoint().getPrimaryTerm() + 1);
+        executeGetMergedSegmentFiles(request, new ActionListener<>() {
+            @Override
+            public void onResponse(GetSegmentFilesResponse response) {
+                Assert.fail("Test should succeed");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assert e.getCause() instanceof IllegalArgumentException;
             }
         });
     }
@@ -228,6 +345,35 @@ public class SegmentReplicationSourceServiceTests extends OpenSearchTestCase {
         transportService.sendRequest(
             localNode,
             SegmentReplicationSourceService.Actions.GET_SEGMENT_FILES,
+            request,
+            new TransportResponseHandler<GetSegmentFilesResponse>() {
+                @Override
+                public void handleResponse(GetSegmentFilesResponse response) {
+                    listener.onResponse(response);
+                }
+
+                @Override
+                public void handleException(TransportException e) {
+                    listener.onFailure(e);
+                }
+
+                @Override
+                public String executor() {
+                    return ThreadPool.Names.SAME;
+                }
+
+                @Override
+                public GetSegmentFilesResponse read(StreamInput in) throws IOException {
+                    return new GetSegmentFilesResponse(in);
+                }
+            }
+        );
+    }
+
+    private void executeGetMergedSegmentFiles(GetSegmentFilesRequest request, ActionListener<GetSegmentFilesResponse> listener) {
+        transportService.sendRequest(
+            localNode,
+            SegmentReplicationSourceService.Actions.GET_MERGED_SEGMENT_FILES,
             request,
             new TransportResponseHandler<GetSegmentFilesResponse>() {
                 @Override

--- a/server/src/test/java/org/opensearch/recovery/ReplicationCollectionTests.java
+++ b/server/src/test/java/org/opensearch/recovery/ReplicationCollectionTests.java
@@ -144,6 +144,7 @@ public class ReplicationCollectionTests extends OpenSearchIndexLevelReplicationT
             final IndexShard shard2 = shards.addReplica();
             final long recoveryId = startRecovery(collection, shards.getPrimaryNode(), shard1);
             final long recoveryId2 = startRecovery(collection, shards.getPrimaryNode(), shard2);
+            assertEquals(2, collection.getOngoingReplicationTargetList(shard1.shardId()).size());
             try {
                 collection.getOngoingReplicationTarget(shard1.shardId());
             } catch (AssertionError e) {

--- a/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/replication/OpenSearchIndexLevelReplicationTestCase.java
@@ -377,6 +377,8 @@ public abstract class OpenSearchIndexLevelReplicationTestCase extends IndexShard
                     }
                 }
             }
+            // Update the status of the replicas in the routing table to IndexShardState.STARTED.
+            updateAllocationIDsOnPrimary();
             return started;
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR is based on [[17881](https://github.com/opensearch-project/OpenSearch/pull/17881)]'s follow-up work. It implements the main process of local merged segment warmer, and the main modifications are as follows:

- During the `IndexReaderWarmer#warm`, the primary shard will send send a `PublishMergedSegmentRequest` request containing information about the merged segment (`ReplicationSegmentCheckpoint` is introduced to represent the information of a merged segment) to all active state replicas.
- The replica shard introduces `MergedSegmentReplicationTarget` to pull segment from the primary shard. It has to reuse most of the capabilities in `SegmentReplicationTarget`. The `IndexReaderWarmer#warm` process will not end until all active state replicas have completed pulling merged segment.
- Use separate rate limiter and timeout controls for the merged segments pre-copy.
- Added relevant UT and IT testing.

There are also some orthogonal work that needs to be supported in the future, summarized as follows: 

- Repilica shard cleaning up residual merged segments. For example, after the primary shard fail, the pre-copy merged segment of the previous term needs to be cleaned up, or some segments are no longer referenced after continuous merging.
- Remote store support

### Related Issues
Resolves #[[17528](https://github.com/opensearch-project/OpenSearch/issues/17528)]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
