### PR TITLE
Expose method for getting reference count of entry in FileCache 

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
@@ -123,6 +123,11 @@ public class FileCache implements RefCountedCache<Path, CachedIndexInput> {
     }
 
     @Override
+    public Integer getRef(Path key) {
+        return theCache.getRef(key);
+    }
+
+    @Override
     public long prune() {
         return theCache.prune();
     }

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/cache/LRUCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/cache/LRUCache.java
@@ -263,6 +263,21 @@ class LRUCache<K, V> implements RefCountedCache<K, V> {
     }
 
     @Override
+    public Integer getRef(K key) {
+        Objects.requireNonNull(key);
+        lock.lock();
+        try {
+            Node<K, V> node = data.get(key);
+            if (node != null) {
+                return node.refCount;
+            }
+            return null;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
     public long prune(Predicate<K> keyPredicate) {
         long sum = 0L;
         lock.lock();

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/cache/RefCountedCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/cache/RefCountedCache.java
@@ -76,6 +76,12 @@ public interface RefCountedCache<K, V> {
      */
     void decRef(K key);
 
+
+    /**
+     * get the reference count for key {@code key}.
+     */
+    Integer getRef(K key);
+
     /**
      * Removes all cache entries with a reference count of zero, regardless of current capacity.
      *

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/cache/RefCountedCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/cache/RefCountedCache.java
@@ -76,7 +76,6 @@ public interface RefCountedCache<K, V> {
      */
     void decRef(K key);
 
-
     /**
      * get the reference count for key {@code key}.
      */

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/cache/SegmentedCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/cache/SegmentedCache.java
@@ -134,6 +134,12 @@ public class SegmentedCache<K, V> implements RefCountedCache<K, V> {
     }
 
     @Override
+    public Integer getRef(K key) {
+        if (key == null) throw new NullPointerException();
+        return segmentFor(key).getRef(key);
+    }
+
+    @Override
     public long prune() {
         long sum = 0L;
         for (RefCountedCache<K, V> cache : table) {

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
@@ -157,12 +157,16 @@ public class FileCacheTests extends OpenSearchTestCase {
         // IndexInput with refcount greater than 0 will not be evicted
         for (int i = 0; i < 4; i++) {
             assertNotNull(fileCache.get(createPath(Integer.toString(i))));
+            assertNotNull(fileCache.getRef(createPath(Integer.toString(i))));
+            assertEquals(2, (int) fileCache.getRef(createPath(Integer.toString(i))));
             fileCache.decRef(createPath(Integer.toString(i)));
         }
 
         // decrease ref
         for (int i = 0; i < 4; i++) {
             fileCache.decRef(createPath(Integer.toString(i)));
+            assertNotNull(fileCache.getRef(createPath(Integer.toString(i))));
+            assertEquals(0, (int) fileCache.getRef(createPath(Integer.toString(i))));
         }
 
         // try to evict previous IndexInput again
@@ -172,6 +176,7 @@ public class FileCacheTests extends OpenSearchTestCase {
 
         for (int i = 0; i < 4; i++) {
             assertNull(fileCache.get(createPath(Integer.toString(i))));
+            assertNull(fileCache.getRef(createPath(Integer.toString(i))));
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/store/remote/utils/cache/RefCountedCacheTestCase.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/utils/cache/RefCountedCacheTestCase.java
@@ -31,14 +31,25 @@ abstract class RefCountedCacheTestCase extends OpenSearchTestCase {
         refCountedCache.put("1", 10L);
         assertEquals(10L, refCountedCache.usage().usage());
         assertEquals(10L, refCountedCache.usage().activeUsage());
+        assertNotNull(refCountedCache.getRef("1"));
+        assertEquals(1, (int) refCountedCache.getRef("1"));
 
         refCountedCache.decRef("1");
         assertEquals(10L, refCountedCache.usage().usage());
         assertEquals(0L, refCountedCache.usage().activeUsage());
+        assertNotNull(refCountedCache.getRef("1"));
+        assertEquals(0, (int) refCountedCache.getRef("1"));
 
         refCountedCache.incRef("1");
         assertEquals(10L, refCountedCache.usage().usage());
         assertEquals(10L, refCountedCache.usage().activeUsage());
+        assertNotNull(refCountedCache.getRef("1"));
+        assertEquals(1, (int) refCountedCache.getRef("1"));
+
+        refCountedCache.decRef("1");
+        refCountedCache.prune();
+        assertNull(refCountedCache.getRef("1"));
+
     }
 
     public void testEviction() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Expose method for getting reference count of entry in FileCache 

### Related Issues
Resolves #[18258](https://github.com/opensearch-project/OpenSearch/issues/18258)

### Check List
- [x] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
