### PR TITLE
[Pull-based Ingestion] Support cluster write blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Apply cluster state metadata and routing table diff when building cluster state from remote([#18256](https://github.com/opensearch-project/OpenSearch/pull/18256))
 - Support create mode in pull-based ingestion and add retries for transient failures ([#18250](https://github.com/opensearch-project/OpenSearch/pull/18250)))
 - Decouple the init of Crypto Plugin and KeyProvider in CryptoRegistry ([18270](https://github.com/opensearch-project/OpenSearch/pull18270)))
+- Support cluster write block in pull-based ingestion ([#18280](https://github.com/opensearch-project/OpenSearch/pull/18280)))
 
 ### Changed
 

--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/KafkaIngestionBaseIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/KafkaIngestionBaseIT.java
@@ -204,4 +204,12 @@ public class KafkaIngestionBaseIT extends OpenSearchIntegTestCase {
         cleanup();
         setupKafka(numKafkaPartitions);
     }
+
+    protected void setWriteBlock(String indexName, boolean isWriteBlockEnabled) {
+        client().admin()
+            .indices()
+            .prepareUpdateSettings(indexName)
+            .setSettings(Settings.builder().put("index.blocks.write", isWriteBlockEnabled))
+            .get();
+    }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
@@ -662,6 +662,7 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
             wrapper,
             getInstanceFromNode(CircuitBreakerService.class),
             env.nodeId(),
+            getInstanceFromNode(ClusterService.class),
             listener
         );
         shardRef.set(newShard);
@@ -688,6 +689,7 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
         CheckedFunction<DirectoryReader, DirectoryReader, IOException> wrapper,
         final CircuitBreakerService cbs,
         final String nodeId,
+        final ClusterService clusterService,
         final IndexingOperationListener... listeners
     ) throws IOException {
         ShardRouting initializingShardRouting = getInitializingShardRouting(shard.routingEntry());
@@ -726,7 +728,8 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
             false,
             OpenSearchTestCase::randomBoolean,
             () -> indexService.getIndexSettings().getRefreshInterval(),
-            indexService.getRefreshMutex()
+            indexService.getRefreshMutex(),
+            clusterService
         );
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
@@ -729,7 +729,7 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
             OpenSearchTestCase::randomBoolean,
             () -> indexService.getIndexSettings().getRefreshInterval(),
             indexService.getRefreshMutex(),
-            clusterService
+            clusterService.getClusterApplierService()
         );
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/state/ShardIngestionState.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/state/ShardIngestionState.java
@@ -28,22 +28,21 @@ import java.util.Map;
  * @opensearch.experimental
  */
 @ExperimentalApi
-public record ShardIngestionState(String index, int shardId, String pollerState, String errorPolicy, boolean isPollerPaused)
-    implements
-        Writeable,
-        ToXContentFragment {
+public record ShardIngestionState(String index, int shardId, String pollerState, String errorPolicy, boolean isPollerPaused,
+    boolean isWriteBlockEnabled) implements Writeable, ToXContentFragment {
 
     private static final String SHARD = "shard";
     private static final String POLLER_STATE = "poller_state";
     private static final String ERROR_POLICY = "error_policy";
     private static final String POLLER_PAUSED = "poller_paused";
+    private static final String WRITE_BLOCK_ENABLED = "write_block_enabled";
 
     public ShardIngestionState() {
-        this("", -1, "", "", false);
+        this("", -1, "", "", false, false);
     }
 
     public ShardIngestionState(StreamInput in) throws IOException {
-        this(in.readString(), in.readVInt(), in.readOptionalString(), in.readOptionalString(), in.readBoolean());
+        this(in.readString(), in.readVInt(), in.readOptionalString(), in.readOptionalString(), in.readBoolean(), in.readBoolean());
     }
 
     public ShardIngestionState(
@@ -51,13 +50,15 @@ public record ShardIngestionState(String index, int shardId, String pollerState,
         int shardId,
         @Nullable String pollerState,
         @Nullable String errorPolicy,
-        boolean isPollerPaused
+        boolean isPollerPaused,
+        boolean isWriteBlockEnabled
     ) {
         this.index = index;
         this.shardId = shardId;
         this.pollerState = pollerState;
         this.errorPolicy = errorPolicy;
         this.isPollerPaused = isPollerPaused;
+        this.isWriteBlockEnabled = isWriteBlockEnabled;
     }
 
     @Override
@@ -67,6 +68,7 @@ public record ShardIngestionState(String index, int shardId, String pollerState,
         out.writeOptionalString(pollerState);
         out.writeOptionalString(errorPolicy);
         out.writeBoolean(isPollerPaused);
+        out.writeBoolean(isWriteBlockEnabled);
     }
 
     @Override
@@ -76,6 +78,7 @@ public record ShardIngestionState(String index, int shardId, String pollerState,
         builder.field(POLLER_STATE, pollerState);
         builder.field(ERROR_POLICY, errorPolicy);
         builder.field(POLLER_PAUSED, isPollerPaused);
+        builder.field(WRITE_BLOCK_ENABLED, isWriteBlockEnabled);
         builder.endObject();
         return builder;
     }

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -728,7 +728,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 fixedRefreshIntervalSchedulingEnabled,
                 this::getRefreshInterval,
                 refreshMutex,
-                clusterService
+                clusterService.getClusterApplierService()
             );
             eventListener.indexShardStateChanged(indexShard, null, indexShard.state(), "shard created");
             eventListener.afterIndexShardCreated(indexShard);

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -727,7 +727,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 shardLevelRefreshEnabled,
                 fixedRefreshIntervalSchedulingEnabled,
                 this::getRefreshInterval,
-                refreshMutex
+                refreshMutex,
+                clusterService
             );
             eventListener.indexShardStateChanged(indexShard, null, indexShard.state(), "shard created");
             eventListener.afterIndexShardCreated(indexShard);

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -41,7 +41,7 @@ import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.similarities.Similarity;
-import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.cluster.service.ClusterApplierService;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.settings.Setting;
@@ -114,7 +114,7 @@ public final class EngineConfig {
     private final BooleanSupplier startedPrimarySupplier;
     private final Comparator<LeafReader> leafSorter;
     private final Supplier<DocumentMapperForType> documentMapperForTypeSupplier;
-    private final ClusterService clusterService;
+    private final ClusterApplierService clusterApplierService;
 
     /**
      * A supplier of the outstanding retention leases. This is used during merged operations to determine which operations that have been
@@ -305,7 +305,7 @@ public final class EngineConfig {
         this.leafSorter = builder.leafSorter;
         this.documentMapperForTypeSupplier = builder.documentMapperForTypeSupplier;
         this.indexReaderWarmer = builder.indexReaderWarmer;
-        this.clusterService = builder.clusterService;
+        this.clusterApplierService = builder.clusterApplierService;
     }
 
     /**
@@ -580,10 +580,10 @@ public final class EngineConfig {
     }
 
     /**
-     * Returns the ClusterService instance.
+     * Returns the ClusterApplierService instance.
      */
-    public ClusterService getClusterService() {
-        return this.clusterService;
+    public ClusterApplierService getClusterApplierService() {
+        return this.clusterApplierService;
     }
 
     /**
@@ -621,7 +621,7 @@ public final class EngineConfig {
         private Supplier<DocumentMapperForType> documentMapperForTypeSupplier;
         Comparator<LeafReader> leafSorter;
         private IndexWriter.IndexReaderWarmer indexReaderWarmer;
-        private ClusterService clusterService;
+        private ClusterApplierService clusterApplierService;
 
         public Builder shardId(ShardId shardId) {
             this.shardId = shardId;
@@ -768,8 +768,8 @@ public final class EngineConfig {
             return this;
         }
 
-        public Builder clusterService(ClusterService clusterService) {
-            this.clusterService = clusterService;
+        public Builder clusterApplierService(ClusterApplierService clusterApplierService) {
+            this.clusterApplierService = clusterApplierService;
             return this;
         }
 

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -41,6 +41,7 @@ import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.similarities.Similarity;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.settings.Setting;
@@ -113,6 +114,7 @@ public final class EngineConfig {
     private final BooleanSupplier startedPrimarySupplier;
     private final Comparator<LeafReader> leafSorter;
     private final Supplier<DocumentMapperForType> documentMapperForTypeSupplier;
+    private final ClusterService clusterService;
 
     /**
      * A supplier of the outstanding retention leases. This is used during merged operations to determine which operations that have been
@@ -303,6 +305,7 @@ public final class EngineConfig {
         this.leafSorter = builder.leafSorter;
         this.documentMapperForTypeSupplier = builder.documentMapperForTypeSupplier;
         this.indexReaderWarmer = builder.indexReaderWarmer;
+        this.clusterService = builder.clusterService;
     }
 
     /**
@@ -577,6 +580,13 @@ public final class EngineConfig {
     }
 
     /**
+     * Returns the ClusterService instance.
+     */
+    public ClusterService getClusterService() {
+        return this.clusterService;
+    }
+
+    /**
      * Builder for EngineConfig class
      *
      * @opensearch.internal
@@ -611,6 +621,7 @@ public final class EngineConfig {
         private Supplier<DocumentMapperForType> documentMapperForTypeSupplier;
         Comparator<LeafReader> leafSorter;
         private IndexWriter.IndexReaderWarmer indexReaderWarmer;
+        private ClusterService clusterService;
 
         public Builder shardId(ShardId shardId) {
             this.shardId = shardId;
@@ -754,6 +765,11 @@ public final class EngineConfig {
 
         public Builder indexReaderWarmer(IndexWriter.IndexReaderWarmer indexReaderWarmer) {
             this.indexReaderWarmer = indexReaderWarmer;
+            return this;
+        }
+
+        public Builder clusterService(ClusterService clusterService) {
+            this.clusterService = clusterService;
             return this;
         }
 

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfigFactory.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfigFactory.java
@@ -18,6 +18,7 @@ import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.similarities.Similarity;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.index.shard.ShardId;
@@ -158,7 +159,8 @@ public class EngineConfigFactory {
         TranslogFactory translogFactory,
         Comparator<LeafReader> leafSorter,
         Supplier<DocumentMapperForType> documentMapperForTypeSupplier,
-        IndexWriter.IndexReaderWarmer indexReaderWarmer
+        IndexWriter.IndexReaderWarmer indexReaderWarmer,
+        ClusterService clusterService
     ) {
         CodecService codecServiceToUse = codecService;
         if (codecService == null && this.codecServiceFactory != null) {
@@ -194,6 +196,7 @@ public class EngineConfigFactory {
             .leafSorter(leafSorter)
             .documentMapperForTypeSupplier(documentMapperForTypeSupplier)
             .indexReaderWarmer(indexReaderWarmer)
+            .clusterService(clusterService)
             .build();
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfigFactory.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfigFactory.java
@@ -18,7 +18,7 @@ import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.similarities.Similarity;
-import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.cluster.service.ClusterApplierService;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.index.shard.ShardId;
@@ -160,7 +160,7 @@ public class EngineConfigFactory {
         Comparator<LeafReader> leafSorter,
         Supplier<DocumentMapperForType> documentMapperForTypeSupplier,
         IndexWriter.IndexReaderWarmer indexReaderWarmer,
-        ClusterService clusterService
+        ClusterApplierService clusterApplierService
     ) {
         CodecService codecServiceToUse = codecService;
         if (codecService == null && this.codecServiceFactory != null) {
@@ -196,7 +196,7 @@ public class EngineConfigFactory {
             .leafSorter(leafSorter)
             .documentMapperForTypeSupplier(documentMapperForTypeSupplier)
             .indexReaderWarmer(indexReaderWarmer)
-            .clusterService(clusterService)
+            .clusterApplierService(clusterApplierService)
             .build();
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -136,9 +136,9 @@ public class IngestionEngine extends InternalEngine {
 
         // Register the poller with the ClusterService for receiving cluster state updates.
         // Also initialize cluster write block state in the poller.
-        if (engineConfig.getClusterService() != null) {
-            engineConfig.getClusterService().addStateApplier(streamPoller);
-            boolean isWriteBlockEnabled = engineConfig.getClusterService()
+        if (engineConfig.getClusterApplierService() != null) {
+            engineConfig.getClusterApplierService().addListener(streamPoller);
+            boolean isWriteBlockEnabled = engineConfig.getClusterApplierService()
                 .state()
                 .blocks()
                 .indexBlocked(ClusterBlockLevel.WRITE, engineConfig.getIndexSettings().getIndex().getName());

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.admin.indices.streamingingestion.state.ShardIngestionState;
+import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IngestionSource;
 import org.opensearch.common.lease.Releasable;
@@ -132,6 +133,19 @@ public class IngestionEngine extends InternalEngine {
             ingestionSource.getNumProcessorThreads(),
             ingestionSource.getBlockingQueueSize()
         );
+
+        // Register the poller with the ClusterService for receiving cluster state updates.
+        // Also initialize cluster write block state in the poller.
+        if (engineConfig.getClusterService() != null) {
+            engineConfig.getClusterService().addStateApplier(streamPoller);
+            boolean isWriteBlockEnabled = engineConfig.getClusterService()
+                .state()
+                .blocks()
+                .indexBlocked(ClusterBlockLevel.WRITE, engineConfig.getIndexSettings().getIndex().getName());
+            streamPoller.setWriteBlockEnabled(isWriteBlockEnabled);
+        }
+
+        // start the polling loop
         streamPoller.start();
     }
 
@@ -512,7 +526,9 @@ public class IngestionEngine extends InternalEngine {
             engineConfig.getShardId().getId(),
             streamPoller.getState().toString(),
             streamPoller.getErrorStrategy().getName(),
-            streamPoller.isPaused()
+            streamPoller.isPaused(),
+            streamPoller.isWriteBlockEnabled()
+
         );
     }
 }

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -76,7 +76,7 @@ import org.opensearch.cluster.routing.RecoverySource;
 import org.opensearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;
-import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.cluster.service.ClusterApplierService;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.CheckedFunction;
@@ -376,7 +376,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     private final Supplier<TimeValue> refreshInterval;
     private final Object refreshMutex;
     private volatile AsyncShardRefreshTask refreshTask;
-    private final ClusterService clusterService;
+    private final ClusterApplierService clusterApplierService;
 
     public IndexShard(
         final ShardRouting shardRouting,
@@ -414,7 +414,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         final Supplier<Boolean> fixedRefreshIntervalSchedulingEnabled,
         final Supplier<TimeValue> refreshInterval,
         final Object refreshMutex,
-        final ClusterService clusterService
+        final ClusterApplierService clusterApplierService
     ) throws IOException {
         super(shardRouting.shardId(), indexSettings);
         assert shardRouting.initializing();
@@ -521,7 +521,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         this.fixedRefreshIntervalSchedulingEnabled = fixedRefreshIntervalSchedulingEnabled;
         this.refreshInterval = refreshInterval;
         this.refreshMutex = Objects.requireNonNull(refreshMutex);
-        this.clusterService = clusterService;
+        this.clusterApplierService = clusterApplierService;
         synchronized (this.refreshMutex) {
             if (shardLevelRefreshEnabled) {
                 startRefreshTask();
@@ -4132,7 +4132,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             // timeseries
             () -> docMapper(),
             mergedSegmentWarmerFactory.get(this),
-            clusterService
+            clusterApplierService
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -76,6 +76,7 @@ import org.opensearch.cluster.routing.RecoverySource;
 import org.opensearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardRoutingState;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.CheckedFunction;
@@ -375,6 +376,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     private final Supplier<TimeValue> refreshInterval;
     private final Object refreshMutex;
     private volatile AsyncShardRefreshTask refreshTask;
+    private final ClusterService clusterService;
 
     public IndexShard(
         final ShardRouting shardRouting,
@@ -411,7 +413,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         final boolean shardLevelRefreshEnabled,
         final Supplier<Boolean> fixedRefreshIntervalSchedulingEnabled,
         final Supplier<TimeValue> refreshInterval,
-        final Object refreshMutex
+        final Object refreshMutex,
+        final ClusterService clusterService
     ) throws IOException {
         super(shardRouting.shardId(), indexSettings);
         assert shardRouting.initializing();
@@ -518,6 +521,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         this.fixedRefreshIntervalSchedulingEnabled = fixedRefreshIntervalSchedulingEnabled;
         this.refreshInterval = refreshInterval;
         this.refreshMutex = Objects.requireNonNull(refreshMutex);
+        this.clusterService = clusterService;
         synchronized (this.refreshMutex) {
             if (shardLevelRefreshEnabled) {
                 startRefreshTask();
@@ -4127,7 +4131,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             isTimeSeriesDescSortOptimizationEnabled() ? DataStream.TIMESERIES_LEAF_SORTER : null, // DESC @timestamp default order for
             // timeseries
             () -> docMapper(),
-            mergedSegmentWarmerFactory.get(this)
+            mergedSegmentWarmerFactory.get(this),
+            clusterService
         );
     }
 

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -441,8 +441,12 @@ public class DefaultStreamPoller implements StreamPoller {
     }
 
     @Override
-    public void applyClusterState(final ClusterChangedEvent event) {
+    public void clusterChanged(ClusterChangedEvent event) {
         try {
+            if (event.blocksChanged() == false) {
+                return;
+            }
+
             final ClusterState state = event.state();
             isWriteBlockEnabled = state.blocks().indexBlocked(ClusterBlockLevel.WRITE, indexName);
 

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -10,8 +10,12 @@ package org.opensearch.indices.pollingingest;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.ClusterChangedEvent;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.metrics.CounterMetric;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.index.IngestionShardConsumer;
 import org.opensearch.index.IngestionShardPointer;
 import org.opensearch.index.Message;
@@ -30,6 +34,7 @@ import java.util.concurrent.Executors;
  */
 public class DefaultStreamPoller implements StreamPoller {
     private static final Logger logger = LogManager.getLogger(DefaultStreamPoller.class);
+    private static final int DEFAULT_POLLER_SLEEP_PERIOD_MS = 100;
 
     private volatile State state = State.NONE;
 
@@ -38,6 +43,9 @@ public class DefaultStreamPoller implements StreamPoller {
     private volatile boolean closed;
     private volatile boolean paused;
     private volatile IngestionErrorStrategy errorStrategy;
+
+    // indicates if a local or global cluster write block is in effect
+    private volatile boolean isWriteBlockEnabled;
 
     private volatile long lastPolledMessageTimestamp = 0;
 
@@ -56,6 +64,7 @@ public class DefaultStreamPoller implements StreamPoller {
     private int pollTimeout;
 
     private Set<IngestionShardPointer> persistedPointers;
+    private final String indexName;
 
     private final CounterMetric totalPolledCount = new CounterMetric();
     private final CounterMetric totalConsumerErrorCount = new CounterMetric();
@@ -98,7 +107,8 @@ public class DefaultStreamPoller implements StreamPoller {
             errorStrategy,
             initialState,
             maxPollSize,
-            pollTimeout
+            pollTimeout,
+            ingestionEngine.config().getIndexSettings()
         );
     }
 
@@ -112,7 +122,8 @@ public class DefaultStreamPoller implements StreamPoller {
         IngestionErrorStrategy errorStrategy,
         State initialState,
         long maxPollSize,
-        int pollTimeout
+        int pollTimeout,
+        IndexSettings indexSettings
     ) {
         this.consumer = Objects.requireNonNull(consumer);
         this.resetState = resetState;
@@ -133,6 +144,8 @@ public class DefaultStreamPoller implements StreamPoller {
             )
         );
         this.errorStrategy = errorStrategy;
+        this.indexName = indexSettings.getIndex().getName();
+
     }
 
     @Override
@@ -199,11 +212,10 @@ public class DefaultStreamPoller implements StreamPoller {
                     resetState = ResetState.NONE;
                 }
 
-                if (paused) {
+                if (paused || isWriteBlockEnabled) {
                     state = State.PAUSED;
                     try {
-                        // TODO: make sleep time configurable
-                        Thread.sleep(100);
+                        Thread.sleep(DEFAULT_POLLER_SLEEP_PERIOD_MS);
                     } catch (Throwable e) {
                         logger.error("Error in pausing the poller of shard {}: {}", consumer.getShardId(), e);
                     }
@@ -416,5 +428,27 @@ public class DefaultStreamPoller implements StreamPoller {
     public void updateErrorStrategy(IngestionErrorStrategy errorStrategy) {
         this.errorStrategy = errorStrategy;
         blockingQueueContainer.updateErrorStrategy(errorStrategy);
+    }
+
+    @Override
+    public boolean isWriteBlockEnabled() {
+        return isWriteBlockEnabled;
+    }
+
+    @Override
+    public void setWriteBlockEnabled(boolean isWriteBlockEnabled) {
+        this.isWriteBlockEnabled = isWriteBlockEnabled;
+    }
+
+    @Override
+    public void applyClusterState(final ClusterChangedEvent event) {
+        try {
+            final ClusterState state = event.state();
+            isWriteBlockEnabled = state.blocks().indexBlocked(ClusterBlockLevel.WRITE, indexName);
+
+        } catch (Exception e) {
+            logger.error("Error applying cluster state in stream poller", e);
+            throw e;
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
@@ -8,7 +8,7 @@
 
 package org.opensearch.indices.pollingingest;
 
-import org.opensearch.cluster.ClusterStateApplier;
+import org.opensearch.cluster.ClusterStateListener;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.IngestionShardPointer;
 
@@ -17,7 +17,7 @@ import java.io.Closeable;
 /**
  * A poller for reading messages from an ingestion shard. This is used in the ingestion engine.
  */
-public interface StreamPoller extends Closeable, ClusterStateApplier {
+public interface StreamPoller extends Closeable, ClusterStateListener {
 
     String BATCH_START = "batch_start";
 

--- a/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/StreamPoller.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.indices.pollingingest;
 
+import org.opensearch.cluster.ClusterStateApplier;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.IngestionShardPointer;
 
@@ -16,7 +17,7 @@ import java.io.Closeable;
 /**
  * A poller for reading messages from an ingestion shard. This is used in the ingestion engine.
  */
-public interface StreamPoller extends Closeable {
+public interface StreamPoller extends Closeable, ClusterStateApplier {
 
     String BATCH_START = "batch_start";
 
@@ -60,6 +61,16 @@ public interface StreamPoller extends Closeable {
      * Update the error strategy for the poller.
      */
     void updateErrorStrategy(IngestionErrorStrategy errorStrategy);
+
+    /**
+     * Returns if write block is active for the poller.
+     */
+    boolean isWriteBlockEnabled();
+
+    /**
+     * Sets write block status for the poller.
+     */
+    void setWriteBlockEnabled(boolean isWriteBlockEnabled);
 
     /**
      * a state to indicate the current state of the poller

--- a/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/GetIngestionStateResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/GetIngestionStateResponseTests.java
@@ -19,8 +19,8 @@ public class GetIngestionStateResponseTests extends OpenSearchTestCase {
 
     public void testSerialization() throws IOException {
         ShardIngestionState[] shardStates = new ShardIngestionState[] {
-            new ShardIngestionState("index1", 0, "POLLING", "DROP", false),
-            new ShardIngestionState("index1", 1, "PAUSED", "BLOCK", true) };
+            new ShardIngestionState("index1", 0, "POLLING", "DROP", false, false),
+            new ShardIngestionState("index1", 1, "PAUSED", "BLOCK", true, false) };
         GetIngestionStateResponse response = new GetIngestionStateResponse(shardStates, 2, 2, 0, null, Collections.emptyList());
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {

--- a/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/ShardIngestionStateTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/ShardIngestionStateTests.java
@@ -19,7 +19,7 @@ import java.util.Map;
 public class ShardIngestionStateTests extends OpenSearchTestCase {
 
     public void testSerialization() throws IOException {
-        ShardIngestionState state = new ShardIngestionState("index1", 0, "POLLING", "DROP", false);
+        ShardIngestionState state = new ShardIngestionState("index1", 0, "POLLING", "DROP", false, false);
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             state.writeTo(out);
@@ -30,12 +30,13 @@ public class ShardIngestionStateTests extends OpenSearchTestCase {
                 assertEquals(state.shardId(), deserializedState.shardId());
                 assertEquals(state.pollerState(), deserializedState.pollerState());
                 assertEquals(state.isPollerPaused(), deserializedState.isPollerPaused());
+                assertEquals(state.isWriteBlockEnabled(), deserializedState.isWriteBlockEnabled());
             }
         }
     }
 
     public void testSerializationWithNullValues() throws IOException {
-        ShardIngestionState state = new ShardIngestionState("index1", 0, null, null, false);
+        ShardIngestionState state = new ShardIngestionState("index1", 0, null, null, false, false);
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             state.writeTo(out);
@@ -52,9 +53,9 @@ public class ShardIngestionStateTests extends OpenSearchTestCase {
 
     public void testGroupShardStateByIndex() {
         ShardIngestionState[] states = new ShardIngestionState[] {
-            new ShardIngestionState("index1", 0, "POLLING", "DROP", true),
-            new ShardIngestionState("index1", 1, "PAUSED", "DROP", false),
-            new ShardIngestionState("index2", 0, "POLLING", "DROP", true) };
+            new ShardIngestionState("index1", 0, "POLLING", "DROP", true, false),
+            new ShardIngestionState("index1", 1, "PAUSED", "DROP", false, false),
+            new ShardIngestionState("index2", 0, "POLLING", "DROP", true, false) };
 
         Map<String, List<ShardIngestionState>> groupedStates = ShardIngestionState.groupShardStateByIndex(states);
 

--- a/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/TransportGetIngestionStateActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/TransportGetIngestionStateActionTests.java
@@ -117,7 +117,7 @@ public class TransportGetIngestionStateActionTests extends OpenSearchTestCase {
         ShardRouting shardRouting = mock(ShardRouting.class);
         IndexService indexService = mock(IndexService.class);
         IndexShard indexShard = mock(IndexShard.class);
-        ShardIngestionState expectedState = new ShardIngestionState("test-index", 0, "POLLING", "DROP", true);
+        ShardIngestionState expectedState = new ShardIngestionState("test-index", 0, "POLLING", "DROP", true, false);
 
         when(shardRouting.shardId()).thenReturn(mock(ShardId.class));
         when(shardRouting.shardId().getIndex()).thenReturn(mock(Index.class));
@@ -166,7 +166,9 @@ public class TransportGetIngestionStateActionTests extends OpenSearchTestCase {
 
     public void testNewResponse() {
         GetIngestionStateRequest request = new GetIngestionStateRequest(new String[] { "test-index" });
-        List<ShardIngestionState> responses = Collections.singletonList(new ShardIngestionState("test-index", 0, "POLLING", "DROP", true));
+        List<ShardIngestionState> responses = Collections.singletonList(
+            new ShardIngestionState("test-index", 0, "POLLING", "DROP", true, false)
+        );
         List<DefaultShardOperationFailedException> shardFailures = Collections.emptyList();
         ClusterState clusterState = mock(ClusterState.class);
 

--- a/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/TransportUpdateIngestionStateActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/TransportUpdateIngestionStateActionTests.java
@@ -112,7 +112,7 @@ public class TransportUpdateIngestionStateActionTests extends OpenSearchTestCase
         ShardRouting shardRouting = mock(ShardRouting.class);
         IndexService indexService = mock(IndexService.class);
         IndexShard indexShard = mock(IndexShard.class);
-        ShardIngestionState expectedState = new ShardIngestionState("test-index", 0, "PAUSED", "DROP", true);
+        ShardIngestionState expectedState = new ShardIngestionState("test-index", 0, "PAUSED", "DROP", true, false);
 
         when(shardRouting.shardId()).thenReturn(mock(ShardId.class));
         when(shardRouting.shardId().getIndex()).thenReturn(mock(Index.class));
@@ -161,7 +161,9 @@ public class TransportUpdateIngestionStateActionTests extends OpenSearchTestCase
 
     public void testNewResponse() {
         UpdateIngestionStateRequest request = new UpdateIngestionStateRequest(new String[] { "test-index" }, new int[] { 0 });
-        List<ShardIngestionState> responses = Collections.singletonList(new ShardIngestionState("test-index", 0, "PAUSED", "DROP", true));
+        List<ShardIngestionState> responses = Collections.singletonList(
+            new ShardIngestionState("test-index", 0, "PAUSED", "DROP", true, false)
+        );
         List<DefaultShardOperationFailedException> shardFailures = Collections.emptyList();
         ClusterState clusterState = mock(ClusterState.class);
 

--- a/server/src/test/java/org/opensearch/index/engine/EngineConfigFactoryTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/EngineConfigFactoryTests.java
@@ -72,6 +72,7 @@ public class EngineConfigFactoryTests extends OpenSearchTestCase {
             new InternalTranslogFactory(),
             null,
             null,
+            null,
             null
         );
 
@@ -152,6 +153,7 @@ public class EngineConfigFactoryTests extends OpenSearchTestCase {
             false,
             () -> Boolean.TRUE,
             new InternalTranslogFactory(),
+            null,
             null,
             null,
             null

--- a/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.index.engine;
 
 import org.apache.lucene.index.NoMergePolicy;
+import org.opensearch.action.admin.indices.streamingingestion.state.ShardIngestionState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.settings.Settings;
@@ -114,6 +115,13 @@ public class IngestionEngineTests extends EngineTestCase {
             );
             Assert.assertEquals(2, persistedPointers.size());
         }
+
+        // validate ingestion state on successful engine creation
+        ShardIngestionState ingestionState = ingestionEngine.getIngestionState();
+        assertEquals("test", ingestionState.index());
+        assertEquals("DROP", ingestionState.errorPolicy());
+        assertFalse(ingestionState.isPollerPaused());
+        assertFalse(ingestionState.isWriteBlockEnabled());
     }
 
     public void testRecovery() throws IOException {

--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -504,14 +504,24 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             .build();
 
         ClusterChangedEvent event1 = new ClusterChangedEvent("test", state2, state1);
-        poller.applyClusterState(event1);
+        poller.clusterChanged(event1);
         assertTrue(poller.isWriteBlockEnabled());
 
         // remove write block
         ClusterState state3 = ClusterState.builder(ClusterName.DEFAULT).build();
         ClusterChangedEvent event2 = new ClusterChangedEvent("test", state3, state2);
-        poller.applyClusterState(event2);
+        poller.clusterChanged(event2);
         assertFalse(poller.isWriteBlockEnabled());
 
+        // test no block change
+        ClusterChangedEvent event3 = new ClusterChangedEvent("test", state3, state3);
+        poller.clusterChanged(event3);
+        assertFalse(poller.isWriteBlockEnabled());
+    }
+
+    public void testErrorApplyingClusterChange() {
+        ClusterChangedEvent event = mock(ClusterChangedEvent.class);
+        doThrow(new RuntimeException()).when(event).blocksChanged();
+        assertThrows(RuntimeException.class, () -> poller.clusterChanged(event));
     }
 }

--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -8,9 +8,20 @@
 
 package org.opensearch.indices.pollingingest;
 
+import org.opensearch.cluster.ClusterChangedEvent;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlock;
+import org.opensearch.cluster.block.ClusterBlockLevel;
+import org.opensearch.cluster.block.ClusterBlocks;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.index.IngestionShardConsumer;
 import org.opensearch.index.IngestionShardPointer;
 import org.opensearch.index.engine.FakeIngestionSource;
+import org.opensearch.index.engine.IngestionEngine;
+import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -18,6 +29,7 @@ import org.junit.Before;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -52,6 +64,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     private final int sleepTime = 300;
     private DropIngestionErrorStrategy errorStrategy;
     private PartitionedBlockingQueueContainer partitionedBlockingQueueContainer;
+    private IngestionEngine engine;
+    private IndexSettings indexSettings;
 
     @Before
     public void setUp() throws Exception {
@@ -65,6 +79,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         processorRunnable = new MessageProcessorRunnable(new ArrayBlockingQueue<>(5), processor, errorStrategy);
         persistedPointers = new HashSet<>();
         partitionedBlockingQueueContainer = new PartitionedBlockingQueueContainer(processorRunnable, 0);
+        engine = mock(IngestionEngine.class);
+        indexSettings = IndexSettingsModule.newIndexSettings("index", Settings.EMPTY);
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
             persistedPointers,
@@ -75,7 +91,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             errorStrategy,
             StreamPoller.State.NONE,
             1000,
-            1000
+            1000,
+            indexSettings
         );
         partitionedBlockingQueueContainer.startProcessorThreads();
     }
@@ -136,7 +153,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             errorStrategy,
             StreamPoller.State.NONE,
             1000,
-            1000
+            1000,
+            indexSettings
         );
 
         CountDownLatch latch = new CountDownLatch(2);
@@ -176,7 +194,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             errorStrategy,
             StreamPoller.State.NONE,
             1000,
-            1000
+            1000,
+            indexSettings
         );
         CountDownLatch latch = new CountDownLatch(2);
         doAnswer(invocation -> {
@@ -202,7 +221,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             errorStrategy,
             StreamPoller.State.NONE,
             1000,
-            1000
+            1000,
+            indexSettings
         );
 
         poller.start();
@@ -224,7 +244,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             errorStrategy,
             StreamPoller.State.NONE,
             1000,
-            1000
+            1000,
+            indexSettings
         );
         CountDownLatch latch = new CountDownLatch(1);
         doAnswer(invocation -> {
@@ -302,7 +323,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             errorStrategy,
             StreamPoller.State.NONE,
             1000,
-            1000
+            1000,
+            indexSettings
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -358,7 +380,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             errorStrategy,
             StreamPoller.State.NONE,
             1000,
-            1000
+            1000,
+            indexSettings
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -391,7 +414,8 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             mockErrorStrategy,
             StreamPoller.State.NONE,
             1000,
-            1000
+            1000,
+            indexSettings
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -457,12 +481,37 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             errorStrategy,
             StreamPoller.State.NONE,
             1000,
-            1000
+            1000,
+            indexSettings
         );
         poller.start();
         Thread.sleep(sleepTime);
 
         assertEquals(new FakeIngestionSource.FakeIngestionShardPointer(0), poller.getBatchStartPointer());
         blockingQueueContainer.close();
+    }
+
+    public void testClusterStateChange() {
+        // set write block
+        ClusterState state1 = ClusterState.builder(ClusterName.DEFAULT).build();
+        ClusterState state2 = ClusterState.builder(ClusterName.DEFAULT)
+            .blocks(
+                ClusterBlocks.builder()
+                    .addGlobalBlock(
+                        new ClusterBlock(1, "description", true, true, true, RestStatus.ACCEPTED, EnumSet.allOf((ClusterBlockLevel.class)))
+                    )
+            )
+            .build();
+
+        ClusterChangedEvent event1 = new ClusterChangedEvent("test", state2, state1);
+        poller.applyClusterState(event1);
+        assertTrue(poller.isWriteBlockEnabled());
+
+        // remove write block
+        ClusterState state3 = ClusterState.builder(ClusterName.DEFAULT).build();
+        ClusterChangedEvent event2 = new ClusterChangedEvent("test", state3, state2);
+        poller.applyClusterState(event2);
+        assertFalse(poller.isWriteBlockEnabled());
+
     }
 }

--- a/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
@@ -68,6 +68,7 @@ import org.opensearch.action.support.replication.ReplicationResponse;
 import org.opensearch.cluster.ClusterModule;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.AllocationId;
+import org.opensearch.cluster.service.ClusterApplierService;
 import org.opensearch.common.CheckedBiFunction;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Randomness;
@@ -991,7 +992,11 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
     /**
      * Override config with ingestion engine configs
      */
-    protected EngineConfig config(EngineConfig config, Supplier<DocumentMapperForType> documentMapperForTypeSupplier) {
+    protected EngineConfig config(
+        EngineConfig config,
+        Supplier<DocumentMapperForType> documentMapperForTypeSupplier,
+        ClusterApplierService clusterApplierService
+    ) {
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
             "test",
             Settings.builder().put(config.getIndexSettings().getSettings()).build()
@@ -1019,6 +1024,7 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
             .primaryTermSupplier(config.getPrimaryTermSupplier())
             .tombstoneDocSupplier(config.getTombstoneDocSupplier())
             .documentMapperForTypeSupplier(documentMapperForTypeSupplier)
+            .clusterApplierService(clusterApplierService)
             .build();
     }
 

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -729,7 +729,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 () -> Boolean.FALSE,
                 indexSettings::getRefreshInterval,
                 new Object(),
-                clusterService
+                clusterService.getClusterApplierService()
             );
             indexShard.addShardFailureCallback(DEFAULT_SHARD_FAILURE_HANDLER);
             if (remoteStoreStatsTrackerFactory != null) {

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -728,7 +728,8 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 false,
                 () -> Boolean.FALSE,
                 indexSettings::getRefreshInterval,
-                new Object()
+                new Object(),
+                clusterService
             );
             indexShard.addShardFailureCallback(DEFAULT_SHARD_FAILURE_HANDLER);
             if (remoteStoreStatsTrackerFactory != null) {


### PR DESCRIPTION
### Description
This PR adds support for cluster write blocks in pull-based ingestion flow. The stream poller is enhanced to listen to cluster state changes and the poller is paused when a write block is active, and resumed when the write block is removed. 

GetIngestionState API is also enhanced to reflect the write block status of the poller.

### Related Issues
Resolves #18279

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
