### PR TITLE
Fix flaky failures in PitMultiNodeIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/pit/PitMultiNodeIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/pit/PitMultiNodeIT.java
@@ -117,7 +117,12 @@ public class PitMultiNodeIT extends ParameterizedStaticSettingsOpenSearchIntegTe
                 ActionFuture<CreatePitResponse> execute = client().execute(CreatePitAction.INSTANCE, request);
                 ExecutionException ex = expectThrows(ExecutionException.class, execute::get);
                 assertTrue(ex.getMessage().contains("Failed to execute phase [create_pit]"));
-                validatePitStats("index", 0, 0);
+                // If the search must make a transport call to start the search then a
+                // PIT context may be temporarily created on a separate thread. The test
+                // will end up racing with the PIT decrement call and can very briefly
+                // observe non-zero PIT stats, so we poll here and wait for stats to eventually
+                // resolve to zero. In almost all cases the first call will observe zero stats.
+                assertBusy(() -> validatePitStats("index", 0, 0));
                 return super.onNodeStopped(nodeName);
             }
         });


### PR DESCRIPTION
Add polling to test case that can briefly return non-zero PIT stats when a PIT request is rejected.

I could manually force the race condition to happen by adding a sleep for a couple seconds here: https://github.com/opensearch-project/OpenSearch/blob/f2cc3d8ea314b2d49a8b6ea5f57de5b6aff4faf9/server/src/main/java/org/opensearch/index/search/stats/ShardSearchStats.java#L189

I validated this fix causes the test to pass reliably even with the sleep injected.

### Related Issues
Resolves #14525

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
