### PR TITLE
Composite Directory - silently fail instead of throwing error for non-existent file in deleteFile() call

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/CompositeDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/CompositeDirectory.java
@@ -143,7 +143,12 @@ public class CompositeDirectory extends FilterDirectory {
         if (FileTypeUtils.isTempFile(name)) {
             localDirectory.deleteFile(name);
         } else if (Arrays.asList(listAll()).contains(name) == false) {
-            throw new NoSuchFileException("File " + name + " not found in directory");
+            /*
+             We can run into scenarios where stale files are evicted locally (zero refCount in FileCache) and
+             not present in remote as well (due to metadata refresh). In such scenarios listAll() of composite directory
+             will not show the file. Hence, we need to silently fail deleteFile operation for such files.
+             */
+            return;
         } else {
             List<String> blockFiles = listBlockFiles(name);
             if (blockFiles.isEmpty()) {

--- a/server/src/test/java/org/opensearch/index/store/CompositeDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/CompositeDirectoryTests.java
@@ -80,8 +80,14 @@ public class CompositeDirectoryTests extends BaseRemoteSegmentStoreDirectoryTest
         compositeDirectory.deleteFile(FILE_PRESENT_LOCALLY);
         assertFalse(existsInCompositeDirectory(FILE_PRESENT_LOCALLY));
         assertFalse(existsInCompositeDirectory(BLOCK_FILE_PRESENT_LOCALLY));
-        // Reading deleted file from directory should result in NoSuchFileException
-        assertThrows(NoSuchFileException.class, () -> compositeDirectory.openInput(FILE_PRESENT_LOCALLY, IOContext.DEFAULT));
+        // Deletion of non-existent file should fail silently without throwing any error
+        Exception exception = null;
+        try {
+            compositeDirectory.deleteFile(NON_EXISTENT_FILE);
+        } catch (Exception e) {
+            exception = e;
+        }
+        assertNull(exception);
     }
 
     public void testFileLength() throws IOException {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
In composite directory for deleteFile method, we currently throw a NoSuchFileException if the file is not found in the directory.

In this PR we are adding a modification that instead of throwing a NoSuchFileException we simply fail silently.
This is needed because we can run into scenarios where stale files are evicted locally (zero refCount in FileCache) and not present in remote as well (due to metadata refresh). In such scenarios listAll() of composite directory will not show the file and operations such as refresh/merge where we calling this deleteFile method will fail.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
