### PR TITLE
Add support for SSE-KMS and bucket owner verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use QueryCoordinatorContext for the rewrite in validate API. ([#18272](https://github.com/opensearch-project/OpenSearch/pull/18272))
 - Upgrade crypto kms plugin dependencies for AWS SDK v2.x. ([#18268](https://github.com/opensearch-project/OpenSearch/pull/18268))
 - Add support for `matched_fields` with the unified highlighter ([#18164](https://github.com/opensearch-project/OpenSearch/issues/18164))
+- [repository-s3] Add support for SSE-KMS and S3 bucket owner verification ([#18312](https://github.com/opensearch-project/OpenSearch/pull/18312))
 
 ### Changed
 - Create generic DocRequest to better categorize ActionRequests ([#18269](https://github.com/opensearch-project/OpenSearch/pull/18269)))
@@ -51,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Deprecated
 
 ### Removed
+- [repository-s3] Removed existing ineffective `server_side_encryption` setting ([#18312](https://github.com/opensearch-project/OpenSearch/pull/18312))
 
 ### Fixed
 - Fix simultaneously creating a snapshot and updating the repository can potentially trigger an infinite loop ([#17532](https://github.com/opensearch-project/OpenSearch/pull/17532))

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
@@ -53,7 +53,6 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectAttributes;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
@@ -110,6 +109,7 @@ import org.reactivestreams.Subscription;
 import static org.opensearch.repositories.s3.S3Repository.MAX_FILE_SIZE;
 import static org.opensearch.repositories.s3.S3Repository.MAX_FILE_SIZE_USING_MULTIPART;
 import static org.opensearch.repositories.s3.S3Repository.MIN_PART_SIZE_USING_MULTIPART;
+import static org.opensearch.repositories.s3.utils.SseKmsUtil.configureEncryptionSettings;
 
 class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamBlobContainer {
 
@@ -129,7 +129,13 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
             SocketAccess.doPrivileged(
                 () -> clientReference.get()
-                    .headObject(HeadObjectRequest.builder().bucket(blobStore.bucket()).key(buildKey(blobName)).build())
+                    .headObject(
+                        HeadObjectRequest.builder()
+                            .bucket(blobStore.bucket())
+                            .key(buildKey(blobName))
+                            .expectedBucketOwner(blobStore.expectedBucketOwner())
+                            .build()
+                    )
             );
             return true;
         } catch (NoSuchKeyException e) {
@@ -214,7 +220,12 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             writeContext.doRemoteDataIntegrityCheck(),
             writeContext.getExpectedChecksum(),
             blobStore.isUploadRetryEnabled(),
-            writeContext.getMetadata()
+            writeContext.getMetadata(),
+            blobStore.serverSideEncryptionType(),
+            blobStore.serverSideEncryptionKmsKey(),
+            blobStore.serverSideEncryptionBucketKey(),
+            blobStore.serverSideEncryptionEncryptionContext(),
+            blobStore.expectedBucketOwner()
         );
         try {
             // If file size is greater than the queue capacity than SizeBasedBlockingQ will always reject the upload.
@@ -498,6 +509,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             .prefix(keyPath)
             .delimiter("/")
             .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().listObjectsMetricPublisher))
+            .expectedBucketOwner(blobStore.expectedBucketOwner())
             .build();
     }
 
@@ -534,14 +546,13 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             .contentLength(blobSize)
             .storageClass(blobStore.getStorageClass())
             .acl(blobStore.getCannedACL())
-            .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().putObjectMetricPublisher));
+            .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().putObjectMetricPublisher))
+            .expectedBucketOwner(blobStore.expectedBucketOwner());
 
         if (CollectionUtils.isNotEmpty(metadata)) {
             putObjectRequestBuilder = putObjectRequestBuilder.metadata(metadata);
         }
-        if (blobStore.serverSideEncryption()) {
-            putObjectRequestBuilder.serverSideEncryption(ServerSideEncryption.AES256);
-        }
+        configureEncryptionSettings(putObjectRequestBuilder, blobStore);
 
         PutObjectRequest putObjectRequest = putObjectRequestBuilder.build();
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
@@ -591,15 +602,14 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             .key(blobName)
             .storageClass(blobStore.getStorageClass())
             .acl(blobStore.getCannedACL())
-            .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector));
+            .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector))
+            .expectedBucketOwner(blobStore.expectedBucketOwner());
 
         if (CollectionUtils.isNotEmpty(metadata)) {
             createMultipartUploadRequestBuilder.metadata(metadata);
         }
 
-        if (blobStore.serverSideEncryption()) {
-            createMultipartUploadRequestBuilder.serverSideEncryption(ServerSideEncryption.AES256);
-        }
+        configureEncryptionSettings(createMultipartUploadRequestBuilder, blobStore);
 
         final InputStream requestInputStream;
         if (blobStore.isUploadRetryEnabled()) {
@@ -628,6 +638,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
                     .partNumber(i)
                     .contentLength((i < nbParts) ? partSize : lastPartSize)
                     .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector))
+                    .expectedBucketOwner(blobStore.expectedBucketOwner())
                     .build();
 
                 bytesCount += uploadPartRequest.contentLength();
@@ -650,6 +661,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
                 .uploadId(uploadId.get())
                 .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build())
                 .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector))
+                .expectedBucketOwner(blobStore.expectedBucketOwner())
                 .build();
 
             SocketAccess.doPrivilegedVoid(() -> clientReference.get().completeMultipartUpload(completeMultipartUploadRequest));
@@ -663,6 +675,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
                     .bucket(bucketName)
                     .key(blobName)
                     .uploadId(uploadId.get())
+                    .expectedBucketOwner(blobStore.expectedBucketOwner())
                     .build();
                 try (AmazonS3Reference clientReference = blobStore.clientReference()) {
                     SocketAccess.doPrivilegedVoid(() -> clientReference.get().abortMultipartUpload(abortRequest));
@@ -729,12 +742,14 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
         @Nullable Integer partNumber
     ) {
         final boolean isMultipartObject = partNumber != null;
-        final GetObjectRequest.Builder getObjectRequestBuilder = GetObjectRequest.builder().bucket(bucketName).key(blobKey);
+        final GetObjectRequest.Builder getObjectRequestBuilder = GetObjectRequest.builder()
+            .bucket(bucketName)
+            .key(blobKey)
+            .expectedBucketOwner(blobStore.expectedBucketOwner());
 
         if (isMultipartObject) {
             getObjectRequestBuilder.partNumber(partNumber);
         }
-
         return SocketAccess.doPrivileged(
             () -> s3AsyncClient.getObject(getObjectRequestBuilder.build(), AsyncResponseTransformer.toBlockingInputStream())
                 .thenApply(response -> transformResponseToInputStreamContainer(response, isMultipartObject))
@@ -775,6 +790,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             .bucket(bucketName)
             .key(blobName)
             .objectAttributes(ObjectAttributes.CHECKSUM, ObjectAttributes.OBJECT_SIZE, ObjectAttributes.OBJECT_PARTS)
+            .expectedBucketOwner(blobStore.expectedBucketOwner())
             .build();
 
         return SocketAccess.doPrivileged(() -> s3AsyncClient.getObjectAttributes(getObjectAttributesRequest));

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobStore.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobStore.java
@@ -48,6 +48,8 @@ import org.opensearch.repositories.s3.async.AsyncTransferManager;
 import org.opensearch.repositories.s3.async.SizeBasedBlockingQ;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
@@ -57,9 +59,13 @@ import static org.opensearch.repositories.s3.S3Repository.BUCKET_SETTING;
 import static org.opensearch.repositories.s3.S3Repository.BUFFER_SIZE_SETTING;
 import static org.opensearch.repositories.s3.S3Repository.BULK_DELETE_SIZE;
 import static org.opensearch.repositories.s3.S3Repository.CANNED_ACL_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.EXPECTED_BUCKET_OWNER_SETTING;
 import static org.opensearch.repositories.s3.S3Repository.PERMIT_BACKED_TRANSFER_ENABLED;
 import static org.opensearch.repositories.s3.S3Repository.REDIRECT_LARGE_S3_UPLOAD;
-import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_ENCRYPTION_CONTEXT_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_KMS_KEY_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_TYPE_SETTING;
 import static org.opensearch.repositories.s3.S3Repository.STORAGE_CLASS_SETTING;
 import static org.opensearch.repositories.s3.S3Repository.UPLOAD_RETRY_ENABLED;
 
@@ -81,7 +87,11 @@ public class S3BlobStore implements BlobStore {
 
     private volatile boolean permitBackedTransferEnabled;
 
-    private volatile boolean serverSideEncryption;
+    private volatile String serverSideEncryptionType;
+    private volatile String serverSideEncryptionKmsKey;
+    private volatile boolean serverSideEncryptionBucketKey;
+    private volatile String serverSideEncryptionEncryptionContext;
+    private volatile String expectedBucketOwner;
 
     private volatile ObjectCannedACL cannedACL;
 
@@ -107,7 +117,6 @@ public class S3BlobStore implements BlobStore {
         S3AsyncService s3AsyncService,
         boolean multipartUploadEnabled,
         String bucket,
-        boolean serverSideEncryption,
         ByteSizeValue bufferSize,
         String cannedACL,
         String storageClass,
@@ -119,13 +128,17 @@ public class S3BlobStore implements BlobStore {
         AsyncExecutorContainer normalExecutorBuilder,
         SizeBasedBlockingQ normalPrioritySizeBasedBlockingQ,
         SizeBasedBlockingQ lowPrioritySizeBasedBlockingQ,
-        GenericStatsMetricPublisher genericStatsMetricPublisher
+        GenericStatsMetricPublisher genericStatsMetricPublisher,
+        String serverSideEncryptionType,
+        String serverSideEncryptionKmsKey,
+        boolean serverSideEncryptionBucketKey,
+        String serverSideEncryptionEncryptionContext,
+        String expectedBucketOwner
     ) {
         this.service = service;
         this.s3AsyncService = s3AsyncService;
         this.multipartUploadEnabled = multipartUploadEnabled;
         this.bucket = bucket;
-        this.serverSideEncryption = serverSideEncryption;
         this.bufferSize = bufferSize;
         this.cannedACL = initCannedACL(cannedACL);
         this.storageClass = initStorageClass(storageClass);
@@ -142,13 +155,17 @@ public class S3BlobStore implements BlobStore {
         this.lowPrioritySizeBasedBlockingQ = lowPrioritySizeBasedBlockingQ;
         this.genericStatsMetricPublisher = genericStatsMetricPublisher;
         this.permitBackedTransferEnabled = PERMIT_BACKED_TRANSFER_ENABLED.get(repositoryMetadata.settings());
+        this.serverSideEncryptionType = serverSideEncryptionType;
+        this.serverSideEncryptionKmsKey = serverSideEncryptionKmsKey;
+        this.serverSideEncryptionBucketKey = serverSideEncryptionBucketKey;
+        this.serverSideEncryptionEncryptionContext = serverSideEncryptionEncryptionContext;
+        this.expectedBucketOwner = expectedBucketOwner;
     }
 
     @Override
     public void reload(RepositoryMetadata repositoryMetadata) {
         this.repositoryMetadata = repositoryMetadata;
         this.bucket = BUCKET_SETTING.get(repositoryMetadata.settings());
-        this.serverSideEncryption = SERVER_SIDE_ENCRYPTION_SETTING.get(repositoryMetadata.settings());
         this.bufferSize = BUFFER_SIZE_SETTING.get(repositoryMetadata.settings());
         this.cannedACL = initCannedACL(CANNED_ACL_SETTING.get(repositoryMetadata.settings()));
         this.storageClass = initStorageClass(STORAGE_CLASS_SETTING.get(repositoryMetadata.settings()));
@@ -156,6 +173,11 @@ public class S3BlobStore implements BlobStore {
         this.redirectLargeUploads = REDIRECT_LARGE_S3_UPLOAD.get(repositoryMetadata.settings());
         this.uploadRetryEnabled = UPLOAD_RETRY_ENABLED.get(repositoryMetadata.settings());
         this.permitBackedTransferEnabled = PERMIT_BACKED_TRANSFER_ENABLED.get(repositoryMetadata.settings());
+        this.serverSideEncryptionType = SERVER_SIDE_ENCRYPTION_TYPE_SETTING.get(repositoryMetadata.settings());
+        this.serverSideEncryptionKmsKey = SERVER_SIDE_ENCRYPTION_KMS_KEY_SETTING.get(repositoryMetadata.settings());
+        this.serverSideEncryptionBucketKey = SERVER_SIDE_ENCRYPTION_BUCKET_KEY_SETTING.get(repositoryMetadata.settings());
+        this.serverSideEncryptionEncryptionContext = SERVER_SIDE_ENCRYPTION_ENCRYPTION_CONTEXT_SETTING.get(repositoryMetadata.settings());
+        this.expectedBucketOwner = EXPECTED_BUCKET_OWNER_SETTING.get(repositoryMetadata.settings());
     }
 
     @Override
@@ -191,8 +213,33 @@ public class S3BlobStore implements BlobStore {
         return bucket;
     }
 
-    public boolean serverSideEncryption() {
-        return serverSideEncryption;
+    public String serverSideEncryptionType() {
+        return serverSideEncryptionType;
+    }
+
+    public String serverSideEncryptionKmsKey() {
+        return serverSideEncryptionKmsKey;
+    }
+
+    public boolean serverSideEncryptionBucketKey() {
+        return serverSideEncryptionBucketKey;
+    }
+
+    /**
+     * Returns the SSE encryption context base64 UTF8 encoded, as required by S3 SDK. If the encryption context is empty return
+     * null as the S3 client ignores null header values
+     */
+    public String serverSideEncryptionEncryptionContext() {
+        return serverSideEncryptionEncryptionContext.isEmpty()
+            ? null
+            : Base64.getEncoder().encodeToString(serverSideEncryptionEncryptionContext.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Returns the expected bucket owner if set, else null as the S3 client ignores null header values
+     */
+    public String expectedBucketOwner() {
+        return expectedBucketOwner.isEmpty() ? null : expectedBucketOwner;
     }
 
     public long bufferSizeInBytes() {

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RetryingInputStream.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RetryingInputStream.java
@@ -106,7 +106,8 @@ class S3RetryingInputStream extends InputStream {
             final GetObjectRequest.Builder getObjectRequest = GetObjectRequest.builder()
                 .bucket(blobStore.bucket())
                 .key(blobKey)
-                .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().getObjectMetricPublisher));
+                .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().getObjectMetricPublisher))
+                .expectedBucketOwner(blobStore.expectedBucketOwner());
             if (currentOffset > 0 || start > 0 || end < Long.MAX_VALUE - 1) {
                 assert start + currentOffset <= end : "requesting beyond end, start = "
                     + start

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/AsyncPartsHandler.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/AsyncPartsHandler.java
@@ -95,7 +95,8 @@ public class AsyncPartsHandler {
                     .key(uploadRequest.getKey())
                     .uploadId(uploadId)
                     .overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector))
-                    .contentLength(inputStreamContainer.getContentLength());
+                    .contentLength(inputStreamContainer.getContentLength())
+                    .expectedBucketOwner(uploadRequest.getExpectedBucketOwner());
                 if (uploadRequest.doRemoteDataIntegrityCheck()) {
                     uploadPartRequestBuilder.checksumAlgorithm(ChecksumAlgorithm.CRC32);
                 }
@@ -136,6 +137,7 @@ public class AsyncPartsHandler {
             .bucket(uploadRequest.getBucket())
             .key(uploadRequest.getKey())
             .uploadId(uploadId)
+            .expectedBucketOwner(uploadRequest.getExpectedBucketOwner())
             .build();
         SocketAccess.doPrivileged(() -> s3AsyncClient.abortMultipartUpload(abortMultipartUploadRequest).exceptionally(throwable -> {
             log.warn(

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/S3AsyncDeleteHelper.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/S3AsyncDeleteHelper.java
@@ -90,6 +90,7 @@ public class S3AsyncDeleteHelper {
                     .build()
             )
             .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().getDeleteObjectsMetricPublisher()))
+            .expectedBucketOwner(blobStore.expectedBucketOwner())
             .build();
     }
 }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/UploadRequest.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/UploadRequest.java
@@ -28,6 +28,11 @@ public class UploadRequest {
     private final Long expectedChecksum;
     private final Map<String, String> metadata;
     private final boolean uploadRetryEnabled;
+    private volatile String serverSideEncryptionType;
+    private volatile String serverSideEncryptionKmsKey;
+    private volatile boolean serverSideEncryptionBucketKey;
+    private volatile String serverSideEncryptionEncryptionContext;
+    private final String expectedBucketOwner;
 
     /**
      * Construct a new UploadRequest object
@@ -50,7 +55,12 @@ public class UploadRequest {
         boolean doRemoteDataIntegrityCheck,
         Long expectedChecksum,
         boolean uploadRetryEnabled,
-        @Nullable Map<String, String> metadata
+        @Nullable Map<String, String> metadata,
+        String serverSideEncryptionType,
+        String serverSideEncryptionKmsKey,
+        boolean serverSideEncryptionBucketKey,
+        @Nullable String serverSideEncryptionEncryptionContext,
+        @Nullable String expectedBucketOwner
     ) {
         this.bucket = bucket;
         this.key = key;
@@ -61,6 +71,11 @@ public class UploadRequest {
         this.expectedChecksum = expectedChecksum;
         this.uploadRetryEnabled = uploadRetryEnabled;
         this.metadata = metadata;
+        this.serverSideEncryptionType = serverSideEncryptionType;
+        this.serverSideEncryptionKmsKey = serverSideEncryptionKmsKey;
+        this.serverSideEncryptionBucketKey = serverSideEncryptionBucketKey;
+        this.serverSideEncryptionEncryptionContext = serverSideEncryptionEncryptionContext;
+        this.expectedBucketOwner = expectedBucketOwner;
     }
 
     public String getBucket() {
@@ -100,5 +115,25 @@ public class UploadRequest {
      */
     public Map<String, String> getMetadata() {
         return metadata;
+    }
+
+    public String getServerSideEncryptionType() {
+        return serverSideEncryptionType;
+    }
+
+    public String getServerSideEncryptionKmsKey() {
+        return serverSideEncryptionKmsKey;
+    }
+
+    public boolean getServerSideEncryptionBucketKey() {
+        return serverSideEncryptionBucketKey;
+    }
+
+    public String getServerSideEncryptionEncryptionContext() {
+        return serverSideEncryptionEncryptionContext;
+    }
+
+    public String getExpectedBucketOwner() {
+        return expectedBucketOwner;
     }
 }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/utils/SseKmsUtil.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/utils/SseKmsUtil.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.repositories.s3.utils;
+
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+
+import org.opensearch.repositories.s3.S3BlobStore;
+import org.opensearch.repositories.s3.async.UploadRequest;
+
+public class SseKmsUtil {
+
+    public static void configureEncryptionSettings(CreateMultipartUploadRequest.Builder builder, S3BlobStore blobStore) {
+        if (blobStore.serverSideEncryptionType().equals(ServerSideEncryption.AES256.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AES256);
+        } else if (blobStore.serverSideEncryptionType().equals(ServerSideEncryption.AWS_KMS.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AWS_KMS);
+            builder.ssekmsKeyId(blobStore.serverSideEncryptionKmsKey());
+            builder.bucketKeyEnabled(blobStore.serverSideEncryptionBucketKey());
+            builder.ssekmsEncryptionContext(blobStore.serverSideEncryptionEncryptionContext());
+        }
+    }
+
+    public static void configureEncryptionSettings(PutObjectRequest.Builder builder, S3BlobStore blobStore) {
+        if (blobStore.serverSideEncryptionType().equals(ServerSideEncryption.AES256.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AES256);
+        } else if (blobStore.serverSideEncryptionType().equals(ServerSideEncryption.AWS_KMS.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AWS_KMS);
+            builder.ssekmsKeyId(blobStore.serverSideEncryptionKmsKey());
+            builder.bucketKeyEnabled(blobStore.serverSideEncryptionBucketKey());
+            builder.ssekmsEncryptionContext(blobStore.serverSideEncryptionEncryptionContext());
+        }
+    }
+
+    public static void configureEncryptionSettings(CreateMultipartUploadRequest.Builder builder, UploadRequest uploadRequest) {
+        if (uploadRequest.getServerSideEncryptionType().equals(ServerSideEncryption.AES256.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AES256);
+        } else if (uploadRequest.getServerSideEncryptionType().equals(ServerSideEncryption.AWS_KMS.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AWS_KMS);
+            builder.ssekmsKeyId(uploadRequest.getServerSideEncryptionKmsKey());
+            builder.bucketKeyEnabled(uploadRequest.getServerSideEncryptionBucketKey());
+            builder.ssekmsEncryptionContext(uploadRequest.getServerSideEncryptionEncryptionContext());
+        }
+    }
+
+    public static void configureEncryptionSettings(PutObjectRequest.Builder builder, UploadRequest uploadRequest) {
+        if (uploadRequest.getServerSideEncryptionType().equals(ServerSideEncryption.AES256.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AES256);
+        } else if (uploadRequest.getServerSideEncryptionType().equals(ServerSideEncryption.AWS_KMS.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AWS_KMS);
+            builder.ssekmsKeyId(uploadRequest.getServerSideEncryptionKmsKey());
+            builder.bucketKeyEnabled(uploadRequest.getServerSideEncryptionBucketKey());
+            builder.ssekmsEncryptionContext(uploadRequest.getServerSideEncryptionEncryptionContext());
+        }
+    }
+}

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -103,6 +103,11 @@ import static org.opensearch.repositories.s3.S3ClientSettings.MAX_RETRIES_SETTIN
 import static org.opensearch.repositories.s3.S3ClientSettings.READ_TIMEOUT_SETTING;
 import static org.opensearch.repositories.s3.S3ClientSettings.REGION;
 import static org.opensearch.repositories.s3.S3Repository.BULK_DELETE_SIZE;
+import static org.opensearch.repositories.s3.S3Repository.EXPECTED_BUCKET_OWNER_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_ENCRYPTION_CONTEXT_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_KMS_KEY_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_TYPE_SETTING;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -244,7 +249,6 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
                 asyncService,
                 true,
                 "bucket",
-                S3Repository.SERVER_SIDE_ENCRYPTION_SETTING.getDefault(Settings.EMPTY),
                 bufferSize == null ? S3Repository.BUFFER_SIZE_SETTING.getDefault(Settings.EMPTY) : bufferSize,
                 S3Repository.CANNED_ACL_SETTING.getDefault(Settings.EMPTY),
                 S3Repository.STORAGE_CLASS_SETTING.getDefault(Settings.EMPTY),
@@ -268,7 +272,12 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
                 asyncExecutorContainer,
                 normalPrioritySizeBasedBlockingQ,
                 lowPrioritySizeBasedBlockingQ,
-                genericStatsMetricPublisher
+                genericStatsMetricPublisher,
+                SERVER_SIDE_ENCRYPTION_TYPE_SETTING.getDefault(Settings.EMPTY),
+                SERVER_SIDE_ENCRYPTION_KMS_KEY_SETTING.getDefault(Settings.EMPTY),
+                SERVER_SIDE_ENCRYPTION_BUCKET_KEY_SETTING.getDefault(Settings.EMPTY),
+                SERVER_SIDE_ENCRYPTION_ENCRYPTION_CONTEXT_SETTING.getDefault(Settings.EMPTY),
+                EXPECTED_BUCKET_OWNER_SETTING.getDefault(Settings.EMPTY)
             )
         ) {
             @Override

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -630,8 +630,19 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
 
         final S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
 
-        final boolean serverSideEncryption = randomBoolean();
-        when(blobStore.serverSideEncryption()).thenReturn(serverSideEncryption);
+        final boolean useSseKms = randomBoolean();
+        final String kmsKeyId = randomAlphaOfLength(10);
+        final String kmsContext = randomAlphaOfLength(10);
+        final boolean useBucketKey = randomBoolean();
+        if (useSseKms) {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AWS_KMS.toString());
+            when(blobStore.serverSideEncryptionKmsKey()).thenReturn(kmsKeyId);
+            when(blobStore.serverSideEncryptionBucketKey()).thenReturn(useBucketKey);
+            when(blobStore.serverSideEncryptionEncryptionContext()).thenReturn(kmsContext);
+        } else {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AES256.toString());
+        }
+        when(blobStore.expectedBucketOwner()).thenReturn(randomAlphaOfLength(12));
 
         final StorageClass storageClass = randomFrom(StorageClass.values());
         when(blobStore.getStorageClass()).thenReturn(storageClass);
@@ -666,7 +677,12 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         assertEquals(storageClass, request.storageClass());
         assertEquals(cannedAccessControlList, request.acl());
         assertEquals(metadata, request.metadata());
-        if (serverSideEncryption) {
+        if (useSseKms) {
+            assertEquals(ServerSideEncryption.AWS_KMS, request.serverSideEncryption());
+            assertEquals(kmsKeyId, request.ssekmsKeyId());
+            assertEquals(kmsContext, request.ssekmsEncryptionContext());
+            assertEquals(useBucketKey, request.bucketKeyEnabled());
+        } else {
             assertEquals(ServerSideEncryption.AES256, request.serverSideEncryption());
         }
     }
@@ -716,8 +732,19 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
         when(blobStore.bufferSizeInBytes()).thenReturn(bufferSize);
 
-        final boolean serverSideEncryption = randomBoolean();
-        when(blobStore.serverSideEncryption()).thenReturn(serverSideEncryption);
+        final boolean useSseKms = randomBoolean();
+        final String kmsKeyId = randomAlphaOfLength(10);
+        final String kmsContext = randomAlphaOfLength(10);
+        final boolean useBucketKey = randomBoolean();
+        if (useSseKms) {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AWS_KMS.toString());
+            when(blobStore.serverSideEncryptionKmsKey()).thenReturn(kmsKeyId);
+            when(blobStore.serverSideEncryptionBucketKey()).thenReturn(useBucketKey);
+            when(blobStore.serverSideEncryptionEncryptionContext()).thenReturn(kmsContext);
+        } else {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AES256.toString());
+        }
+        when(blobStore.expectedBucketOwner()).thenReturn(randomAlphaOfLength(12));
 
         final StorageClass storageClass = randomFrom(StorageClass.values());
         when(blobStore.getStorageClass()).thenReturn(storageClass);
@@ -776,7 +803,12 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         assertEquals(cannedAccessControlList, initRequest.acl());
         assertEquals(metadata, initRequest.metadata());
 
-        if (serverSideEncryption) {
+        if (useSseKms) {
+            assertEquals(ServerSideEncryption.AWS_KMS, initRequest.serverSideEncryption());
+            assertEquals(kmsKeyId, initRequest.ssekmsKeyId());
+            assertEquals(kmsContext, initRequest.ssekmsEncryptionContext());
+            assertEquals(useBucketKey, initRequest.bucketKeyEnabled());
+        } else {
             assertEquals(ServerSideEncryption.AES256, initRequest.serverSideEncryption());
         }
 
@@ -827,6 +859,20 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         when(blobStore.bufferSizeInBytes()).thenReturn(bufferSize);
         when(blobStore.getStorageClass()).thenReturn(randomFrom(StorageClass.values()));
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
+
+        final boolean useSseKms = randomBoolean();
+        final String kmsKeyId = randomAlphaOfLength(10);
+        final String kmsContext = randomAlphaOfLength(10);
+        final boolean useBucketKey = randomBoolean();
+        if (useSseKms) {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AWS_KMS.toString());
+            when(blobStore.serverSideEncryptionKmsKey()).thenReturn(kmsKeyId);
+            when(blobStore.serverSideEncryptionBucketKey()).thenReturn(useBucketKey);
+            when(blobStore.serverSideEncryptionEncryptionContext()).thenReturn(kmsContext);
+        } else {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AES256.toString());
+        }
+        when(blobStore.expectedBucketOwner()).thenReturn(randomAlphaOfLength(12));
 
         final S3Client client = mock(S3Client.class);
         final AmazonS3Reference clientReference = new AmazonS3Reference(client);
@@ -1144,8 +1190,21 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
 
         when(blobStore.bucket()).thenReturn(bucketName);
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
-        when(blobStore.serverSideEncryption()).thenReturn(false);
         when(blobStore.asyncClientReference()).thenReturn(amazonAsyncS3Reference);
+
+        final boolean useSseKms = randomBoolean();
+        final String kmsKeyId = randomAlphaOfLength(10);
+        final String kmsContext = randomAlphaOfLength(10);
+        final boolean useBucketKey = randomBoolean();
+        if (useSseKms) {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AWS_KMS.toString());
+            when(blobStore.serverSideEncryptionKmsKey()).thenReturn(kmsKeyId);
+            when(blobStore.serverSideEncryptionBucketKey()).thenReturn(useBucketKey);
+            when(blobStore.serverSideEncryptionEncryptionContext()).thenReturn(kmsContext);
+        } else {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AES256.toString());
+        }
+        when(blobStore.expectedBucketOwner()).thenReturn(null);
 
         CompletableFuture<GetObjectAttributesResponse> getObjectAttributesResponseCompletableFuture = new CompletableFuture<>();
         getObjectAttributesResponseCompletableFuture.complete(
@@ -1201,8 +1260,21 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
 
         when(blobStore.bucket()).thenReturn(bucketName);
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
-        when(blobStore.serverSideEncryption()).thenReturn(false);
         when(blobStore.asyncClientReference()).thenReturn(amazonAsyncS3Reference);
+
+        final boolean useSseKms = randomBoolean();
+        final String kmsKeyId = randomAlphaOfLength(10);
+        final String kmsContext = randomAlphaOfLength(10);
+        final boolean useBucketKey = randomBoolean();
+        if (useSseKms) {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AWS_KMS.toString());
+            when(blobStore.serverSideEncryptionKmsKey()).thenReturn(kmsKeyId);
+            when(blobStore.serverSideEncryptionBucketKey()).thenReturn(useBucketKey);
+            when(blobStore.serverSideEncryptionEncryptionContext()).thenReturn(kmsContext);
+        } else {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AES256.toString());
+        }
+        when(blobStore.expectedBucketOwner()).thenReturn(null);
 
         CompletableFuture<GetObjectAttributesResponse> getObjectAttributesResponseCompletableFuture = new CompletableFuture<>();
         getObjectAttributesResponseCompletableFuture.complete(
@@ -1257,7 +1329,6 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
 
         when(blobStore.bucket()).thenReturn(bucketName);
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
-        when(blobStore.serverSideEncryption()).thenReturn(false);
         when(blobStore.asyncClientReference()).thenReturn(amazonAsyncS3Reference);
 
         CompletableFuture<GetObjectAttributesResponse> getObjectAttributesResponseCompletableFuture = new CompletableFuture<>();
@@ -1300,7 +1371,6 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
 
         when(blobStore.bucket()).thenReturn(bucketName);
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
-        when(blobStore.serverSideEncryption()).thenReturn(false);
         when(blobStore.asyncClientReference()).thenReturn(amazonAsyncS3Reference);
 
         CompletableFuture<GetObjectAttributesResponse> getObjectAttributesResponseCompletableFuture = new CompletableFuture<>();
@@ -1339,7 +1409,6 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         final BlobPath blobPath = new BlobPath();
         when(blobStore.bucket()).thenReturn(bucketName);
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
-        when(blobStore.serverSideEncryption()).thenReturn(false);
         final S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
 
         CompletableFuture<GetObjectAttributesResponse> getObjectAttributesResponseCompletableFuture = new CompletableFuture<>();
@@ -1374,7 +1443,6 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         final BlobPath blobPath = new BlobPath();
         when(blobStore.bucket()).thenReturn(bucketName);
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
-        when(blobStore.serverSideEncryption()).thenReturn(false);
         final S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
 
         GetObjectResponse getObjectResponse = GetObjectResponse.builder().contentLength(contentLength).contentRange(contentRange).build();
@@ -1389,6 +1457,8 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
                 ArgumentMatchers.<AsyncResponseTransformer<GetObjectResponse, ResponseInputStream<GetObjectResponse>>>any()
             )
         ).thenReturn(getObjectPartResponse);
+
+        when(blobStore.expectedBucketOwner()).thenReturn(randomAlphaOfLength(12));
 
         // Header based offset in case of a multi part object request
         InputStreamContainer inputStreamContainer = blobContainer.getBlobPartInputStreamContainer(s3AsyncClient, bucketName, blobName, 0)

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/async/AsyncTransferManagerTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/async/AsyncTransferManagerTests.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
@@ -97,7 +98,7 @@ public class AsyncTransferManagerTests extends OpenSearchTestCase {
             s3AsyncClient,
             new UploadRequest("bucket", "key", ByteSizeUnit.MB.toBytes(1), WritePriority.HIGH, uploadSuccess -> {
                 // do nothing
-            }, false, null, true, metadata),
+            }, false, null, true, metadata, ServerSideEncryption.AWS_KMS.toString(), randomAlphaOfLength(10), true, null, null),
             new StreamContext((partIdx, partSize, position) -> {
                 streamRef.set(new ZeroInputStream(partSize));
                 return new InputStreamContainer(streamRef.get(), partSize, position);
@@ -146,7 +147,7 @@ public class AsyncTransferManagerTests extends OpenSearchTestCase {
             s3AsyncClient,
             new UploadRequest("bucket", "key", ByteSizeUnit.MB.toBytes(1), WritePriority.HIGH, uploadSuccess -> {
                 // do nothing
-            }, false, null, true, metadata),
+            }, false, null, true, metadata, ServerSideEncryption.AWS_KMS.toString(), randomAlphaOfLength(10), true, null, null),
             new StreamContext(
                 (partIdx, partSize, position) -> new InputStreamContainer(new ZeroInputStream(partSize), partSize, position),
                 ByteSizeUnit.MB.toBytes(1),
@@ -203,7 +204,7 @@ public class AsyncTransferManagerTests extends OpenSearchTestCase {
             s3AsyncClient,
             new UploadRequest("bucket", "key", ByteSizeUnit.MB.toBytes(5), WritePriority.HIGH, uploadSuccess -> {
                 // do nothing
-            }, true, 3376132981L, true, metadata),
+            }, true, 3376132981L, true, metadata, ServerSideEncryption.AWS_KMS.toString(), randomAlphaOfLength(10), true, null, null),
             new StreamContext((partIdx, partSize, position) -> {
                 InputStream stream = new ZeroInputStream(partSize);
                 streams.add(stream);
@@ -267,7 +268,7 @@ public class AsyncTransferManagerTests extends OpenSearchTestCase {
             s3AsyncClient,
             new UploadRequest("bucket", "key", ByteSizeUnit.MB.toBytes(5), WritePriority.HIGH, uploadSuccess -> {
                 // do nothing
-            }, true, 0L, true, metadata),
+            }, true, 0L, true, metadata, ServerSideEncryption.AWS_KMS.toString(), randomAlphaOfLength(10), true, null, null),
             new StreamContext(
                 (partIdx, partSize, position) -> new InputStreamContainer(new ZeroInputStream(partSize), partSize, position),
                 ByteSizeUnit.MB.toBytes(1),


### PR DESCRIPTION
### Description
This PR makes 3 main changes
#### 1. Remove the repository-s3 setting `server_side_encryption`
As of January 5, 2023, S3 now applies SSE-S3 as the base level of encryption (the `AES256` encryption type), and there is no way to disable this. This means regardless of whether or not this setting is set or whatever value the setting is set to, it makes no difference in how objects are uploaded to S3. 

For more details, see: https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html

Fortunately, repository settings are fully backwards compatible ever after being removed, which means that even after removing the setting, I can still register a repository like so:
```
curl -XPUT "http://localhost:9200/_snapshot/vector-repo" -H 'Content-Type: application/json' -d'                                            
{
  "type": "s3",
  "settings": {
    "bucket": "sse-tester",
    "base_path": "test_sse_with_enc_ctx",
    "region": "us-east-1",
    "expected_bucket_owner": "759512025873",
    "server_side_encryption": true
  }
}
'
```

#### 2. Add settings to support SSE-KMS

There are 4 new settings introduced:
- `server_side_encryption_type`
- `server_side_encryption_kms_key_id`
- `server_side_encryption_bucket_key_enabled`
- `server_side_encryption_encryption_context`

The `server_side_encryption_type` setting supports 3 values:
- `AES256` -- SSE-S3)
- `aws:kms` -- SSE-KMS)
- `bucket_default` -- this will make the request use the default encryption configuration on the S3 bucket

Example repository:
```
curl -XPUT "http://localhost:9200/_snapshot/vector-repo" -H 'Content-Type: application/json' -d'                                            
{
  "type": "s3",
  "settings": {
    "bucket": "sse-tester",
    "base_path": "test_sse_with_enc_ctx",
    "region": "us-east-1",
    "expected_bucket_owner": "759512025873",
    "server_side_encryption_type": "aws:kms",
    "server_side_encryption_kms_key_id": "arn:aws:kms:us-east-1:XXXXXX:key/XXXXXX",
    "server_side_encryption_encryption_context": "{\"domainARN\": \"my-test-domain\"}"
  }
}
'
```

#### 3. Add bucket owner verification
The new setting `expected_bucket_owner`, when set, will be passed in *all* S3 bucket operation requests to verify that the bucket owner is the expected account.

See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-owner-condition.html#bucket-owner-condition-when-to-use

---

### Testing
Added the new setting/fields to the existing SSE unit tests, but we are pretty limited without being able to actually call S3.

***Note: Pasted actual KMS key in the test results below, but the key used for testing has been deleted for security purposes***

Manual testing:
1. Register repo with valid kms values, take snapshot, check S3 getObject request for encryption values
```
curl -XPUT "http://localhost:9200/_snapshot/vector-repo" -H 'Content-Type: application/json' -d'                                            
{
  "type": "s3",
  "settings": {
    "bucket": "sse-tester",
    "base_path": "test_sse_with_enc_ctx",
    "region": "us-east-1",
    "expected_bucket_owner": "759512025873",
    "server_side_encryption": true,
    "server_side_encryption_type": "aws:kms",
    "server_side_encryption_kms_key_id": "arn:aws:kms:us-east-1:209972747865:key/b74e2711-1b42-4f5f-9831-aa8519f58dc8",
    "server_side_encryption_encryption_context": "{\"domainARN\": \"my-test-domain\"}",
    "server_side_encryption_bucket_key_enabled": true
  }
}
'

aws s3api get-object --bucket sse-tester --key test_sse_with_enc_ctx/snap-IzNPHJG8RUWOZWPtUWINpQ.dat ./tmp/downloadedFile.file
{
    "AcceptRanges": "bytes",
    "LastModified": "2025-05-20T01:19:04+00:00",
    "ContentLength": 306,
    "ETag": "\"04c6d13cd4c99c504db07b52d5865c95\"",
    "ChecksumCRC32": "OveSuA==",
    "ChecksumType": "FULL_OBJECT",
    "ContentType": "application/octet-stream",
    "ServerSideEncryption": "aws:kms",
    "Metadata": {},
    "SSEKMSKeyId": "arn:aws:kms:us-east-1:209972747865:key/b74e2711-1b42-4f5f-9831-aa8519f58dc8",
    "BucketKeyEnabled": true
}
```
2. Register repo with invalid KMS key
```
curl -XPUT "http://localhost:9200/_snapshot/vector-repo" -H 'Content-Type: application/json' -d'                                            
{
  "type": "s3",
  "settings": {
    "bucket": "sse-tester",
    "base_path": "test_sse_with_enc_ctx",
    "region": "us-east-1",
    "expected_bucket_owner": "759512025873",
    "server_side_encryption": true,
    "server_side_encryption_type": "aws:kms",
    "server_side_encryption_kms_key_id": "arn:aws:kms:us-east-1:209972747865:key/b74e2711-1b42-4f5f-9831-aa8519f58dc0",
    "server_side_encryption_encryption_context": "{\"domainARN\": \"my-test-domain\"}",
    "server_side_encryption_bucket_key_enabled": true
  }
}
'
{
    "error": {
        "root_cause": [{
            "type": "repository_verification_exception",
            "reason": "[vector-repo] path [test_sse_with_enc_ctx] is not accessible on cluster-manager node"
        }],
        "type": "repository_verification_exception",
        "reason": "[vector-repo] path [test_sse_with_enc_ctx] is not accessible on cluster-manager node",
        "caused_by": {
            "type": "i_o_exception",
            "reason": "Unable to upload object [test_sse_with_enc_ctx/tests-9lw1TTwWQjasbYQfuqhx3w/master.dat] using a single upload",
            "caused_by": {
                "type": "s3_exception",
                "reason": "User: ----- is not authorized to perform: kms:GenerateDataKey on this resource because the resource does not exist in this Region, no resource-based policies allow access, or a resource-based policy explicitly denies access (Service: S3, Status Code: 403, Request ID: H7MDGSGQG5JXZ1RN, Extended Request ID: TZzLwOcEl5ZvgF0PlKA9sWaRb6Ejkopr5CA9UeWhp9188GxSo3afo+CpGHW7pshersXYAdFMaxY=) (SDK Attempt Count: 1)"
            }
        }
    },
    "status": 500
}
```
3. Register repo with invalid encryption context
```
curl -XPUT "http://localhost:9200/_snapshot/vector-repo" -H 'Content-Type: application/json' -d'                                            
{
  "type": "s3",
  "settings": {
    "bucket": "sse-tester",
    "base_path": "test_sse_with_enc_ctx",
    "region": "us-east-1",
    "expected_bucket_owner": "759512025873",
    "server_side_encryption": true,
    "server_side_encryption_type": "aws:kms",
    "server_side_encryption_kms_key_id": "arn:aws:kms:us-east-1:209972747865:key/b74e2711-1b42-4f5f-9831-aa8519f58dc8",
    "server_side_encryption_encryption_context": "{\"domainARN\": \"my-test-domain\"}INVALID",
    "server_side_encryption_bucket_key_enabled": true
  }
}
'
{
    "error": {
        "root_cause": [{
            "type": "repository_verification_exception",
            "reason": "[vector-repo] path [test_sse_with_enc_ctx] is not accessible on cluster-manager node"
        }],
        "type": "repository_verification_exception",
        "reason": "[vector-repo] path [test_sse_with_enc_ctx] is not accessible on cluster-manager node",
        "caused_by": {
            "type": "i_o_exception",
            "reason": "Unable to upload object [test_sse_with_enc_ctx/tests-bv7KdLsNT-isoYU7xnYEBg/master.dat] using a single upload",
            "caused_by": {
                "type": "s3_exception",
                "reason": "The header 'x-amz-server-side-encryption-context' shall be Base64-encoded UTF-8 string holding JSON which represents a string-string map (Service: S3, Status Code: 400, Request ID: ECVM877F8ABXS1RX, Extended Request ID: 00vaUW6siUaCXv5y0YToPXZUyLc3sb9/lrIpE9FTKwzN0wrvnGoUTNZwUzGGAbutO9yLkzLu3v0=) (SDK Attempt Count: 1)"
            }
        }
    },
    "status": 500
} 
```
4. Register repo with invalid bucket owner
```
curl -XPUT "http://localhost:9200/_snapshot/vector-repo" -H 'Content-Type: application/json' -d'                                            
{
  "type": "s3",
  "settings": {
    "bucket": "sse-tester",
    "base_path": "test_sse_with_enc_ctx",
    "region": "us-east-1",
    "expected_bucket_owner": "209972747865",
    "server_side_encryption": true,
    "server_side_encryption_type": "aws:kms",
    "server_side_encryption_kms_key_id": "arn:aws:kms:us-east-1:209972747865:key/b74e2711-1b42-4f5f-9831-aa8519f58dc8",
    "server_side_encryption_encryption_context": "{\"domainARN\": \"my-test-domain\"}",
    "server_side_encryption_bucket_key_enabled": true
  }
}
'
{
    "error": {
        "root_cause": [{
            "type": "repository_verification_exception",
            "reason": "[vector-repo] path [test_sse_with_enc_ctx] is not accessible on cluster-manager node"
        }],
        "type": "repository_verification_exception",
        "reason": "[vector-repo] path [test_sse_with_enc_ctx] is not accessible on cluster-manager node",
        "caused_by": {
            "type": "i_o_exception",
            "reason": "Unable to upload object [test_sse_with_enc_ctx/tests-wpGzDNqqSD-5z_t3qNoJrA/master.dat] using a single upload",
            "caused_by": {
                "type": "s3_exception",
                "reason": "Access Denied (Service: S3, Status Code: 403, Request ID: 59TPC5JJDGHR3J89, Extended Request ID: /yqpUj0dG4UhSsAmYnPEejJmWOpHdcy2hjv/hIYrRZjG0sSlPhG20fM9zUCHMnW7SDzdwBTEUJE=) (SDK Attempt Count: 1)"
            }
        }
    },
    "status": 500
}
```
5. Register repo with invalid encryption type
```
curl -XPUT "http://localhost:9200/_snapshot/vector-repo" -H 'Content-Type: application/json' -d'                                            
{
  "type": "s3",
  "settings": {
    "bucket": "sse-tester",
    "base_path": "test_sse_with_enc_ctx",
    "region": "us-east-1",
    "expected_bucket_owner": "759512025873",
    "server_side_encryption": true,
    "server_side_encryption_type": "invalid",
    "server_side_encryption_kms_key_id": "arn:aws:kms:us-east-1:209972747865:key/b74e2711-1b42-4f5f-9831-aa8519f58dc8",
    "server_side_encryption_encryption_context": "{\"domainARN\": \"my-test-domain\"}",
    "server_side_encryption_bucket_key_enabled": true
  }
}
'
{
    "error": {
        "root_cause": [{
            "type": "repository_exception",
            "reason": "[vector-repo] failed to create repository"
        }],
        "type": "repository_exception",
        "reason": "[vector-repo] failed to create repository",
        "caused_by": {
            "type": "illegal_argument_exception",
            "reason": "server_side_encryption_type must be one of [AES256, aws:kms, bucket_default]"
        }
    },
    "status": 500
}
```
6. Check that default encryption settings are used when `default` setting is set
```
aws s3api get-bucket-encryption --bucket sse-tester                                                                           
{
    "ServerSideEncryptionConfiguration": {
        "Rules": [
            {
                "ApplyServerSideEncryptionByDefault": {
                    "SSEAlgorithm": "aws:kms",
                    "KMSMasterKeyID": "arn:aws:kms:us-east-1:759512025873:alias/aws/s3"
                },
                "BucketKeyEnabled": true
            }
        ]
    }
}

curl -XPUT "http://localhost:9200/_snapshot/vector-repo" -H 'Content-Type: application/json' -d'                                            
{
  "type": "s3",
  "settings": {
    "bucket": "sse-tester",
    "base_path": "test_sse_with_enc_ctx",
    "region": "us-east-1",
    "expected_bucket_owner": "759512025873",
    "server_side_encryption": true,
    "server_side_encryption_type": "bucket_default" 
  }
}
'

aws s3api get-object --bucket sse-tester --key test_sse_with_enc_ctx/snap-GQmFCVglSPWzgntQWC08sA.dat ./tmp/downloadedFile.file
{
    "AcceptRanges": "bytes",
    "LastModified": "2025-05-20T01:27:57+00:00",
    "ContentLength": 306,
    "ETag": "\"7dd0810991c09eb7a2f6eb5e4e379913\"",
    "ChecksumCRC32": "kB1bXQ==",
    "ChecksumType": "FULL_OBJECT",
    "ContentType": "application/octet-stream",
    "ServerSideEncryption": "aws:kms",
    "Metadata": {},
    "SSEKMSKeyId": "arn:aws:kms:us-east-1:759512025873:key/2826bcd9-2686-4d65-8cf6-aa5846c0c36f",
    "BucketKeyEnabled": true
}
```
7. Check that setting bucket key enabled to false disables bucket key
```
curl -XPUT "http://localhost:9200/_snapshot/vector-repo" -H 'Content-Type: application/json' -d'                                            
{
  "type": "s3",
  "settings": {
    "bucket": "sse-tester",
    "base_path": "test_sse_with_enc_ctx",
    "region": "us-east-1",
    "expected_bucket_owner": "759512025873",
    "server_side_encryption": true,
    "server_side_encryption_type": "aws:kms",       
    "server_side_encryption_kms_key_id": "arn:aws:kms:us-east-1:209972747865:key/b74e2711-1b42-4f5f-9831-aa8519f58dc8",
    "server_side_encryption_encryption_context": "{\"domainARN\": \"my-test-domain\"}",
    "server_side_encryption_bucket_key_enabled": false
  }
}
'

aws s3api get-object --bucket sse-tester --key test_sse_with_enc_ctx/snap-8di6_WPiQeqOjh0IgnG5Fg.dat ./tmp/downloadedFile.file
{
    "AcceptRanges": "bytes",
    "LastModified": "2025-05-20T01:31:41+00:00",
    "ContentLength": 306,
    "ETag": "\"c9f4cdd1460751d676ace612c95a7ffe\"",
    "ChecksumCRC32": "LSLcpg==",
    "ChecksumType": "FULL_OBJECT",
    "ContentType": "application/octet-stream",
    "ServerSideEncryption": "aws:kms",
    "Metadata": {},
    "SSEKMSKeyId": "arn:aws:kms:us-east-1:209972747865:key/b74e2711-1b42-4f5f-9831-aa8519f58dc8"
}
```
`BucketKeyEnabled` is not present in the response above.

8. Check that `AES256` encryption type still uses to SSE-S3
```
curl -XPUT "http://localhost:9200/_snapshot/vector-repo" -H 'Content-Type: application/json' -d'                                            
{
  "type": "s3",
  "settings": {
    "bucket": "sse-tester",
    "base_path": "test_sse_with_enc_ctx",
    "region": "us-east-1",
    "expected_bucket_owner": "759512025873",
    "server_side_encryption": true,
    "server_side_encryption_type": "AES256"        
  }                                                                                                                    
}                                                                                      
' 

aws s3api get-object --bucket sse-tester --key test_sse_with_enc_ctx/snap-D2HjatDxRhqWA6rJWFI0Og.dat ./tmp/downloadedFile.file
{
    "AcceptRanges": "bytes",
    "LastModified": "2025-05-20T01:34:56+00:00",
    "ContentLength": 306,
    "ETag": "\"e7545a369280ab6c6277f2a208629fdb\"",
    "ChecksumCRC32": "HusXpQ==",
    "ChecksumType": "FULL_OBJECT",
    "ContentType": "application/octet-stream",
    "ServerSideEncryption": "AES256",
    "Metadata": {}
}
```
9. Valid encryption settings on async multi-part upload
I used the kNN plugin's implementation for this, as it was a little easier to set up than remote store (ref: https://github.com/opensearch-project/k-NN/blob/b7fc5dd98072ea157a9b301e7f93d79e9700984d/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/DefaultVectorRepositoryAccessor.java#L81)
```
curl -XPUT "http://localhost:9200/_snapshot/vector-repo" -H 'Content-Type: application/json' -d'                                            
{
  "type": "s3",
  "settings": {
    "bucket": "sse-tester",
    "base_path": "test_sse_with_enc_ctx",
    "region": "us-east-1",
    "expected_bucket_owner": "759512025873",
    "server_side_encryption": true,
    "server_side_encryption_type": "aws:kms",
    "server_side_encryption_kms_key_id": "arn:aws:kms:us-east-1:209972747865:key/b74e2711-1b42-4f5f-9831-aa8519f58dc8",
    "server_side_encryption_encryption_context": "{\"domainARN\": \"my-test-domain\"}",
    "server_side_encryption_bucket_key_enabled": true
  }
}


aws s3api get-object --bucket sse-tester --key test_sse_vector_repo/l4bvV1PlQXiKOUE4EdefDQ_vectors/NI3v9JYBAeI-CJ5ZSygX_target_field__53.knnvec downloadedFile.file 
{
    "AcceptRanges": "bytes",
    "LastModified": "2025-05-21T22:20:46+00:00",
    "ContentLength": 307200000,
    "ETag": "\"05dff410cf57ca43906a34914cc62d04-19\"",
    "ChecksumCRC64NVME": "s3ZEszslDh8=",
    "ChecksumType": "FULL_OBJECT",
    "ContentType": "binary/octet-stream",
    "ServerSideEncryption": "aws:kms",
    "Metadata": {},
    "SSEKMSKeyId": "arn:aws:kms:us-east-1:209972747865:key/b74e2711-1b42-4f5f-9831-aa8519f58dc8",
    "BucketKeyEnabled": true
}

aws s3api get-object-attributes --bucket sse-tester --key test_sse_vector_repo/l4bvV1PlQXiKOUE4EdefDQ_vectors/NI3v9JYBAeI-CJ5ZSygX_target_field__53.knnvec --object-attributes ObjectParts
{
    "LastModified": "2025-05-21T22:20:46+00:00",
    "ObjectParts": {
        "TotalPartsCount": 19
    }
}
```

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/14606

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
  - https://github.com/opensearch-project/documentation-website/issues/9929

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
