### PR TITLE
Switch ingest-geoip and lang-painless modules to use the gradle version catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Create generic DocRequest to better categorize ActionRequests ([#18269](https://github.com/opensearch-project/OpenSearch/pull/18269)))
+- Switch ingest-geoip and lang-painless modules to use the gradle version catalog ([#18316](https://github.com/opensearch-project/OpenSearch/pull/18316)))
 
 ### Dependencies
 - Bump `com.google.code.gson:gson` from 2.12.1 to 2.13.1 ([#17923](https://github.com/opensearch-project/OpenSearch/pull/17923), [#18266](https://github.com/opensearch-project/OpenSearch/pull/18266))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Create generic DocRequest to better categorize ActionRequests ([#18269](https://github.com/opensearch-project/OpenSearch/pull/18269)))
-- Switch ingest-geoip and lang-painless modules to use the gradle version catalog ([#18316](https://github.com/opensearch-project/OpenSearch/pull/18316)))
 
 ### Dependencies
 - Bump `com.google.code.gson:gson` from 2.12.1 to 2.13.1 ([#17923](https://github.com/opensearch-project/OpenSearch/pull/17923), [#18266](https://github.com/opensearch-project/OpenSearch/pull/18266))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,8 +93,17 @@ arrow                 = "18.1.0"
 flatbuffers           = "2.0.0"
 
 [libraries]
+antlr4-runtime = { group = "org.antlr", name = "antlr4-runtime", version.ref = "antlr4" }
+asm-analysis = { group = "org.ow2.asm", name = "asm-analysis", version.ref = "asm" }
+asm-commons = { group = "org.ow2.asm", name = "asm-commons", version.ref = "asm" }
+asm-core = { group = "org.ow2.asm", name = "asm", version.ref = "asm" }
+asm-tree = { group = "org.ow2.asm", name = "asm-tree", version.ref = "asm" }
+asm-util = { group = "org.ow2.asm", name = "asm-util", version.ref = "asm" }
 hamcrest = { group = "org.hamcrest", name = "hamcrest", version.ref = "hamcrest" }
 hdrhistogram = { group = "org.hdrhistogram", name = "HdrHistogram", version.ref = "hdrhistogram" }
+jackson-annotation = { group = "com.fasterxml.jackson.core", name = "jackson-annotations", version.ref = "jackson" }
+jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson_databind" }
+jackson-datatype-jsr310 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version.ref = "jackson" }
 jakartaannotation = { group = "jakarta.annotation", name = "jakarta.annotation-api", version.ref = "jakarta_annotation" }
 jodatime = { group = "joda-time", name = "joda-time", version.ref = "joda" }
 jna = { group = "net.java.dev.jna", name = "jna", version.ref = "jna" }
@@ -142,6 +151,13 @@ spatial4j = { group = "org.locationtech.spatial4j", name = "spatial4j", version.
 tdigest = { group = "com.tdunning", name = "t-digest", version.ref = "tdigest" }
 
 [bundles]
+asm = [
+    "asm-analysis",
+    "asm-commons",
+    "asm-core",
+    "asm-tree",
+    "asm-util"
+]
 lucene = [
     "lucene-core",
     "lucene-analysis-common",

--- a/modules/ingest-geoip/build.gradle
+++ b/modules/ingest-geoip/build.gradle
@@ -42,9 +42,9 @@ dependencies {
   api('com.maxmind.geoip2:geoip2:4.3.0')
   // geoip2 dependencies:
   api('com.maxmind.db:maxmind-db:3.1.1')
-  api("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
-  api("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
-  api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}")
+  api(libs.jackson.annotation)
+  api(libs.jackson.databind)
+  api(libs.jackson.datatype.jsr310)
 
   testImplementation 'org.elasticsearch:geolite2-databases:20191119'
 }

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -54,12 +54,8 @@ testClusters.all {
 }
 
 dependencies {
-  api "org.antlr:antlr4-runtime:${versions.antlr4}"
-  api "org.ow2.asm:asm-util:${versions.asm}"
-  api "org.ow2.asm:asm-tree:${versions.asm}"
-  api "org.ow2.asm:asm-commons:${versions.asm}"
-  api "org.ow2.asm:asm-analysis:${versions.asm}"
-  api "org.ow2.asm:asm:${versions.asm}"
+  api(libs.antlr4.runtime)
+  api(libs.bundles.asm)
   api project('spi')
 }
 


### PR DESCRIPTION
### Description

This PR continues to convert more modules to using the gradle version catalog. Its important to have references to libraries in the version catalog because then dependabot can monitor for version updates.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
