### PR TITLE
Improve failure message in AbstractSimpleTransportTestCase

### DIFF
--- a/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/transport/AbstractSimpleTransportTestCase.java
@@ -2074,7 +2074,7 @@ public abstract class AbstractSimpleTransportTestCase extends OpenSearchTestCase
                 logger.debug((Supplier<?>) () -> new ParameterizedMessage("---> received exception for id {}", id), exp);
                 allRequestsDone.countDown();
                 Throwable unwrap = ExceptionsHelper.unwrap(exp, IOException.class);
-                assertNotNull(unwrap);
+                assertNotNull("Expected an IOException somewhere in causal chain: " + exp, unwrap);
                 assertEquals(IOException.class, unwrap.getClass());
                 assertEquals("forced failure", unwrap.getMessage());
             }


### PR DESCRIPTION
This assertion is failing in #18071. I can't reproduce it but improving the message on failure may help debug it.

### Related Issues
Related #18071

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
