### PR TITLE
Flaky MetricAggregatorTests

### DIFF
--- a/server/src/test/java/org/opensearch/search/aggregations/startree/MetricAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/startree/MetricAggregatorTests.java
@@ -559,6 +559,7 @@ public class MetricAggregatorTests extends AggregatorTestCase {
                 .includeLower(randomBoolean())
                 .includeUpper(randomBoolean());
         }
+        //HI
 
         public QueryBuilder getBoolQueryBuilder() {
             // MUST only

--- a/server/src/test/java/org/opensearch/search/aggregations/startree/MetricAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/startree/MetricAggregatorTests.java
@@ -554,17 +554,15 @@ public class MetricAggregatorTests extends AggregatorTestCase {
         }
 
         public QueryBuilder getRangeQueryBuilder() {
-            RangeQueryBuilder qb = new RangeQueryBuilder(fieldName).from(valueSupplier.get())
+            return new RangeQueryBuilder(fieldName).from(valueSupplier.get())
                 .to(valueSupplier.get())
                 .includeLower(randomBoolean())
                 .includeUpper(randomBoolean());
-            return qb;
         }
 
         public QueryBuilder getBoolQueryBuilder() {
             // MUST only
             BoolQueryBuilder mustOnly = new BoolQueryBuilder().must(getTermQueryBuilder());
-            // Keyword terms are not always supported for range queries.
             if (fieldType.equals(DimensionTypes.KEYWORD.name().toLowerCase(Locale.ROOT))) {
                 mustOnly.must(getTermQueryBuilder());
             } else {
@@ -578,7 +576,6 @@ public class MetricAggregatorTests extends AggregatorTestCase {
             // SHOULD only on same dimension
             BoolQueryBuilder shouldOnly = new BoolQueryBuilder().should(getTermQueryBuilder());
 
-            // Keyword terms are not always supported for range queries.
             if (fieldType.equals(DimensionTypes.KEYWORD.name().toLowerCase(Locale.ROOT))) {
                 shouldOnly.should(getTermQueryBuilder());
             } else {

--- a/server/src/test/java/org/opensearch/search/aggregations/startree/MetricAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/startree/MetricAggregatorTests.java
@@ -137,7 +137,6 @@ public class MetricAggregatorTests extends AggregatorTestCase {
         return new Composite101Codec(Lucene101Codec.Mode.BEST_SPEED, mapperService, testLogger);
     }
 
-    // @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/18110")
     public void testStarTreeDocValues() throws IOException {
         final List<Supplier<Integer>> MAX_LEAF_DOC_VARIATIONS = List.of(
             () -> 1,
@@ -559,32 +558,32 @@ public class MetricAggregatorTests extends AggregatorTestCase {
                 .to(valueSupplier.get())
                 .includeLower(randomBoolean())
                 .includeUpper(randomBoolean());
-            // Keyword terms are not always supported for range queries.
-            if (fieldType.equals(DimensionTypes.KEYWORD.name().toLowerCase(Locale.ROOT))) {
-                // This is essentially a match none query because the value of the keyword will
-                // never have the string value of "-1". Just using a match none query is not possible
-                // because the match none query does not correspond with a fieldname, making star tree
-                // precomputation unavailable in boolean queries as the queries must be on the same
-                // dimension.
-                return new TermQueryBuilder(fieldName, String.valueOf(-1));
-            }
             return qb;
         }
 
         public QueryBuilder getBoolQueryBuilder() {
             // MUST only
-            BoolQueryBuilder mustOnly = new BoolQueryBuilder().must(getTermQueryBuilder()).must(getRangeQueryBuilder());
+            BoolQueryBuilder mustOnly = new BoolQueryBuilder().must(getTermQueryBuilder());
+            // Keyword terms are not always supported for range queries.
+            if (fieldType.equals(DimensionTypes.KEYWORD.name().toLowerCase(Locale.ROOT))) {
+                mustOnly.must(getTermQueryBuilder());
+            } else {
+                mustOnly.must(getRangeQueryBuilder());
+            }
 
             // MUST with nested SHOULD on same dimension
             BoolQueryBuilder mustWithShould = new BoolQueryBuilder().must(getTermQueryBuilder())
-                .must(
-                    new BoolQueryBuilder().should(new TermQueryBuilder(fieldName, valueSupplier.get()))
-                        .should(new TermQueryBuilder(fieldName, valueSupplier.get()))
-                );
+                .must(new BoolQueryBuilder().should(getTermQueryBuilder()).should(getTermQueryBuilder()));
 
             // SHOULD only on same dimension
-            BoolQueryBuilder shouldOnly = new BoolQueryBuilder().should(new TermQueryBuilder(fieldName, valueSupplier.get()))
-                .should(getRangeQueryBuilder());
+            BoolQueryBuilder shouldOnly = new BoolQueryBuilder().should(getTermQueryBuilder());
+
+            // Keyword terms are not always supported for range queries.
+            if (fieldType.equals(DimensionTypes.KEYWORD.name().toLowerCase(Locale.ROOT))) {
+                shouldOnly.should(getTermQueryBuilder());
+            } else {
+                shouldOnly.should(getRangeQueryBuilder());
+            }
 
             return randomFrom(mustOnly, mustWithShould, shouldOnly);
         }

--- a/server/src/test/java/org/opensearch/search/aggregations/startree/MetricAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/startree/MetricAggregatorTests.java
@@ -559,7 +559,6 @@ public class MetricAggregatorTests extends AggregatorTestCase {
                 .includeLower(randomBoolean())
                 .includeUpper(randomBoolean());
         }
-        //HI
 
         public QueryBuilder getBoolQueryBuilder() {
             // MUST only

--- a/server/src/test/java/org/opensearch/search/aggregations/startree/MetricAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/startree/MetricAggregatorTests.java
@@ -137,7 +137,7 @@ public class MetricAggregatorTests extends AggregatorTestCase {
         return new Composite101Codec(Lucene101Codec.Mode.BEST_SPEED, mapperService, testLogger);
     }
 
-    //@AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/18110")
+    // @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/18110")
     public void testStarTreeDocValues() throws IOException {
         final List<Supplier<Integer>> MAX_LEAF_DOC_VARIATIONS = List.of(
             () -> 1,
@@ -559,12 +559,12 @@ public class MetricAggregatorTests extends AggregatorTestCase {
                 .to(valueSupplier.get())
                 .includeLower(randomBoolean())
                 .includeUpper(randomBoolean());
-            // Keyword terms are not always supported for range queries. 
+            // Keyword terms are not always supported for range queries.
             if (fieldType.equals(DimensionTypes.KEYWORD.name().toLowerCase(Locale.ROOT))) {
                 // This is essentially a match none query because the value of the keyword will
                 // never have the string value of "-1". Just using a match none query is not possible
                 // because the match none query does not correspond with a fieldname, making star tree
-                // precomputation unavailable in boolean queries as the queries must be on the same 
+                // precomputation unavailable in boolean queries as the queries must be on the same
                 // dimension.
                 return new TermQueryBuilder(fieldName, String.valueOf(-1));
             }


### PR DESCRIPTION
### Description
This change will make sure that the MetricAggregatorTests does not fail on the range query. What happened was that in the test, the range query was applied on a terms, but the difference between the expected aggregation and the actual aggregation was not zero. On a field called "keyword_field", the boolean query had 2 should queries (range from 18 to 0) and (exact match of 37). 

In the expected aggregation, only the documents which matched on 37 were added together, but in the actual aggregation, more documents which somehow satisfied the range from 18 to 0 were added together. I think what happened was that the "keyword_field" was a string value, and in the range query, the values are interpreted as mapped ordinals in the star tree filters (https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/startree/filter/RangeMatchDimFilter.java), but it seems like in the expected query which does not use star tree filters, the strings are compared as its byte ref value (https://lucene.apache.org/core/6_6_0/core/org/apache/lucene/search/TermRangeQuery.html). At least for now, I think that we should avoid using keyword strings for a range query.  

### Related Issues
Resolves #18110
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
