### PR TITLE
Fix IndexServiceTests sort field test cases

### DIFF
--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
@@ -368,6 +368,17 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
         return createIndex(index, createIndexRequestBuilder);
     }
 
+    /**
+     * Creates an index with mappings provided in the format expected by {@link org.opensearch.action.admin.indices.create.CreateIndexRequest#simpleMapping(String...)}
+     */
+    protected IndexService createIndexWithSimpleMappings(String index, Settings settings, String... mappings) {
+        CreateIndexRequestBuilder createIndexRequestBuilder = client().admin().indices().prepareCreate(index).setSettings(settings);
+        if (mappings != null) {
+            createIndexRequestBuilder.setMapping(mappings);
+        }
+        return createIndex(index, createIndexRequestBuilder);
+    }
+
     protected IndexService createIndex(String index, CreateIndexRequestBuilder createIndexRequestBuilder) {
         assertAcked(createIndexRequestBuilder.get());
         // Wait for the index to be allocated so that cluster state updates don't override


### PR DESCRIPTION
As far as I can tell these test cases have never been working as intended. They appear to have been created as a copy-paste error from `testIllegalFsyncInterval`. They passed because the createIndex call was failing due to setting the translog sync interval to an invalid value, which is what the try-catch was expecting. After removing the invalid setting the tests did not work properly for multiple reasons. I believe I have fixed the tests back to the original intent.

The reason for digging into this test was to remove the deprecated `createIndex` calls from OpenSearchSingleNodeTestCase which take the now removed type parameter. I will follow up with a separate PR to do that work, as this was a significant enough change to stand on its own.

### Related Issues
Related to #10045

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
