### PR TITLE
Support/fix for star-tree keyword aggregation dfs mode

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/TermsAggregator.java
@@ -291,11 +291,7 @@ public abstract class TermsAggregator extends DeferableBucketAggregator {
 
     @Override
     protected boolean shouldDefer(Aggregator aggregator) {
-        if (context.getQueryShardContext().getStarTreeQueryContext() == null) {
-            return collectMode == SubAggCollectionMode.BREADTH_FIRST && !aggsUsedForSorting.contains(aggregator);
-        } else {
-            // when pre-computing using star-tree - return false (don't defer) for BREADTH_FIRST case
-            return collectMode != SubAggCollectionMode.BREADTH_FIRST;
-        }
+        return context.getQueryShardContext().getStarTreeQueryContext() == null
+            && (collectMode == SubAggCollectionMode.BREADTH_FIRST && !aggsUsedForSorting.contains(aggregator));
     }
 }

--- a/server/src/test/java/org/opensearch/search/aggregations/startree/KeywordTermsAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/startree/KeywordTermsAggregatorTests.java
@@ -45,7 +45,7 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
-import org.opensearch.search.aggregations.Aggregator;
+import org.opensearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.opensearch.search.aggregations.AggregatorTestCase;
 import org.opensearch.search.aggregations.bucket.terms.InternalTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -66,6 +66,8 @@ import static org.opensearch.search.aggregations.AggregationBuilders.max;
 import static org.opensearch.search.aggregations.AggregationBuilders.min;
 import static org.opensearch.search.aggregations.AggregationBuilders.sum;
 import static org.opensearch.search.aggregations.AggregationBuilders.terms;
+import static org.opensearch.search.aggregations.Aggregator.SubAggCollectionMode.BREADTH_FIRST;
+import static org.opensearch.search.aggregations.Aggregator.SubAggCollectionMode.DEPTH_FIRST;
 import static org.opensearch.test.InternalAggregationTestCase.DEFAULT_MAX_BUCKETS;
 
 public class KeywordTermsAggregatorTests extends AggregatorTestCase {
@@ -155,8 +157,7 @@ public class KeywordTermsAggregatorTests extends AggregatorTestCase {
 
         Query query = new MatchAllDocsQuery();
         QueryBuilder queryBuilder = null;
-        TermsAggregationBuilder termsAggregationBuilder = terms("terms_agg").field(CLIENTIP)
-            .collectMode(Aggregator.SubAggCollectionMode.BREADTH_FIRST);
+        TermsAggregationBuilder termsAggregationBuilder = terms("terms_agg").field(CLIENTIP);
         testCase(indexSearcher, query, queryBuilder, termsAggregationBuilder, starTree, supportedDimensions);
 
         ValuesSourceAggregationBuilder[] aggBuilders = {
@@ -170,9 +171,7 @@ public class KeywordTermsAggregatorTests extends AggregatorTestCase {
             query = new MatchAllDocsQuery();
             queryBuilder = null;
 
-            termsAggregationBuilder = terms("terms_agg").field(CLIENTIP)
-                .subAggregation(aggregationBuilder)
-                .collectMode(Aggregator.SubAggCollectionMode.BREADTH_FIRST);
+            termsAggregationBuilder = terms("terms_agg").field(CLIENTIP).subAggregation(aggregationBuilder);
             testCase(indexSearcher, query, queryBuilder, termsAggregationBuilder, starTree, supportedDimensions);
 
             // Numeric-terms query with keyword terms aggregation
@@ -204,43 +203,47 @@ public class KeywordTermsAggregatorTests extends AggregatorTestCase {
         CompositeIndexFieldInfo starTree,
         LinkedHashMap<Dimension, MappedFieldType> supportedDimensions
     ) throws IOException {
-        InternalTerms starTreeAggregation = searchAndReduceStarTree(
-            createIndexSettings(),
-            indexSearcher,
-            query,
-            queryBuilder,
-            termsAggregationBuilder,
-            starTree,
-            supportedDimensions,
-            null,
-            DEFAULT_MAX_BUCKETS,
-            false,
-            null,
-            true,
-            STATUS_FIELD_TYPE,
-            SIZE_FIELD_NAME,
-            CLIENTIP_FIELD_NAME
-        );
+        for (SubAggCollectionMode collectionMode : List.of(DEPTH_FIRST, BREADTH_FIRST)) {
+            termsAggregationBuilder.collectMode(collectionMode);
 
-        InternalTerms defaultAggregation = searchAndReduceStarTree(
-            createIndexSettings(),
-            indexSearcher,
-            query,
-            queryBuilder,
-            termsAggregationBuilder,
-            null,
-            null,
-            null,
-            DEFAULT_MAX_BUCKETS,
-            false,
-            null,
-            false,
-            STATUS_FIELD_TYPE,
-            SIZE_FIELD_NAME,
-            CLIENTIP_FIELD_NAME
-        );
+            InternalTerms starTreeAggregation = searchAndReduceStarTree(
+                createIndexSettings(),
+                indexSearcher,
+                query,
+                queryBuilder,
+                termsAggregationBuilder,
+                starTree,
+                supportedDimensions,
+                null,
+                DEFAULT_MAX_BUCKETS,
+                false,
+                null,
+                true,
+                STATUS_FIELD_TYPE,
+                SIZE_FIELD_NAME,
+                CLIENTIP_FIELD_NAME
+            );
 
-        assertEquals(defaultAggregation.getBuckets().size(), starTreeAggregation.getBuckets().size());
-        assertEquals(defaultAggregation.getBuckets(), starTreeAggregation.getBuckets());
+            InternalTerms defaultAggregation = searchAndReduceStarTree(
+                createIndexSettings(),
+                indexSearcher,
+                query,
+                queryBuilder,
+                termsAggregationBuilder,
+                null,
+                null,
+                null,
+                DEFAULT_MAX_BUCKETS,
+                false,
+                null,
+                false,
+                STATUS_FIELD_TYPE,
+                SIZE_FIELD_NAME,
+                CLIENTIP_FIELD_NAME
+            );
+
+            assertEquals(defaultAggregation.getBuckets().size(), starTreeAggregation.getBuckets().size());
+            assertEquals(defaultAggregation.getBuckets(), starTreeAggregation.getBuckets());
+        }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

**TLDR**: DFS flow in keyword terms was returing empty buckets, this PR fixes the flow for DFS case.

**Detailed Explanation of Changes:**
The existing strategy where we fetch which bucketOrd to update:
```
long bucketOrd = collectionStrategy.globalOrdToBucketOrd(0, ord);
```


For DenseGlobalOrds (used by breadth-first flow) implementation: would return the bucket in for correctly
```
 @Override
        long globalOrdToBucketOrd(long owningBucketOrd, long globalOrd) {
            assert owningBucketOrd == 0;
            return globalOrd;
        }
        
```


For RemapGlobalOrds (used by depth-first flow) implementation: was returning `-1` when it was trying to find a bucket, and hence bucket was not getting initialized properly with correct values.

```
@Override
        long globalOrdToBucketOrd(long owningBucketOrd, long globalOrd) {
            return bucketOrds.find(owningBucketOrd, globalOrd);
        }
```

We needed a new utility to find or create bucket if not available so I have introduced a new utility to resolve the same:

```
 abstract long getOrAddBucketOrd(long owningBucketOrd, long globalOrd) throws IOException;
```

 
 This change ensures that both the cases. bfs/dfs are handled correctly.
 
 Added test cases to handle the same.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
