### PR TITLE
Replace wrapper-validation-action GitHub action

### DIFF
--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -8,4 +8,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/wrapper-validation@v3


### PR DESCRIPTION
The wrapper-validation-action has been superceded by gradle/actions/wrapper-validation.

https://github.com/gradle/wrapper-validation-action?tab=readme-ov-file

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
