### PR TITLE
Replace usage of deprecated createIndex() method in tests

### DIFF
--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/DisableGraphQueryTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/DisableGraphQueryTests.java
@@ -93,10 +93,9 @@ public class DisableGraphQueryTests extends OpenSearchSingleNodeTestCase {
             .put("index.analysis.analyzer.text_shingle_unigram.tokenizer", "whitespace")
             .put("index.analysis.analyzer.text_shingle_unigram.filter", "lowercase, shingle_unigram")
             .build();
-        indexService = createIndex(
+        indexService = createIndexWithSimpleMappings(
             "test",
             settings,
-            "t",
             "text_shingle",
             "type=text,analyzer=text_shingle",
             "text_shingle_unigram",

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/NeedsScoreTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/NeedsScoreTests.java
@@ -52,7 +52,7 @@ import java.util.Map;
 public class NeedsScoreTests extends OpenSearchSingleNodeTestCase {
 
     public void testNeedsScores() {
-        IndexService index = createIndex("test", Settings.EMPTY, "type", "d", "type=double");
+        IndexService index = createIndexWithSimpleMappings("test", Settings.EMPTY, "d", "type=double");
 
         Map<ScriptContext<?>, List<Allowlist>> contexts = new HashMap<>();
         contexts.put(NumberSortScript.CONTEXT, Allowlist.BASE_ALLOWLISTS);

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/action/PainlessExecuteApiTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/action/PainlessExecuteApiTests.java
@@ -89,7 +89,7 @@ public class PainlessExecuteApiTests extends OpenSearchSingleNodeTestCase {
 
     public void testFilterExecutionContext() throws IOException {
         ScriptService scriptService = getInstanceFromNode(ScriptService.class);
-        IndexService indexService = createIndex("index", Settings.EMPTY, "doc", "field", "type=long");
+        IndexService indexService = createIndexWithSimpleMappings("index", Settings.EMPTY, "field", "type=long");
 
         Request.ContextSetup contextSetup = new Request.ContextSetup("index", new BytesArray("{\"field\": 3}"), null);
         contextSetup.setXContentType(MediaTypeRegistry.JSON);
@@ -120,7 +120,7 @@ public class PainlessExecuteApiTests extends OpenSearchSingleNodeTestCase {
 
     public void testScoreExecutionContext() throws IOException {
         ScriptService scriptService = getInstanceFromNode(ScriptService.class);
-        IndexService indexService = createIndex("index", Settings.EMPTY, "doc", "rank", "type=long", "text", "type=text");
+        IndexService indexService = createIndexWithSimpleMappings("index", Settings.EMPTY, "rank", "type=long", "text", "type=text");
 
         Request.ContextSetup contextSetup = new Request.ContextSetup(
             "index",

--- a/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorQuerySearchTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorQuerySearchTests.java
@@ -281,7 +281,7 @@ public class PercolatorQuerySearchTests extends OpenSearchSingleNodeTestCase {
 
     public void testMapUnmappedFieldAsText() throws IOException {
         Settings.Builder settings = Settings.builder().put("index.percolator.map_unmapped_fields_as_text", true);
-        createIndex("test", settings.build(), "query", "query", "type=percolator");
+        createIndexWithSimpleMappings("test", settings.build(), "query", "type=percolator");
         client().prepareIndex("test")
             .setId("1")
             .setSource(jsonBuilder().startObject().field("query", matchQuery("field1", "value")).endObject())
@@ -302,10 +302,9 @@ public class PercolatorQuerySearchTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testRangeQueriesWithNow() throws Exception {
-        IndexService indexService = createIndex(
+        IndexService indexService = createIndexWithSimpleMappings(
             "test",
             Settings.builder().put("index.number_of_shards", 1).build(),
-            "_doc",
             "field1",
             "type=keyword",
             "field2",

--- a/plugins/mapper-size/src/internalClusterTest/java/org/opensearch/index/mapper/size/SizeMappingTests.java
+++ b/plugins/mapper-size/src/internalClusterTest/java/org/opensearch/index/mapper/size/SizeMappingTests.java
@@ -60,7 +60,7 @@ public class SizeMappingTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testSizeEnabled() throws Exception {
-        IndexService service = createIndex("test", Settings.EMPTY, "type", "_size", "enabled=true");
+        IndexService service = createIndexWithSimpleMappings("test", Settings.EMPTY, "_size", "enabled=true");
         DocumentMapper docMapper = service.mapperService().documentMapper();
 
         BytesReference source = BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", "value").endObject());
@@ -77,7 +77,7 @@ public class SizeMappingTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testSizeDisabled() throws Exception {
-        IndexService service = createIndex("test", Settings.EMPTY, "type", "_size", "enabled=false");
+        IndexService service = createIndexWithSimpleMappings("test", Settings.EMPTY, "_size", "enabled=false");
         DocumentMapper docMapper = service.mapperService().documentMapper();
 
         BytesReference source = BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", "value").endObject());
@@ -87,7 +87,7 @@ public class SizeMappingTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testSizeNotSet() throws Exception {
-        IndexService service = createIndex("test", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME);
+        IndexService service = createIndexWithSimpleMappings("test", Settings.EMPTY);
         DocumentMapper docMapper = service.mapperService().documentMapper();
 
         BytesReference source = BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("field", "value").endObject());
@@ -97,7 +97,7 @@ public class SizeMappingTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testThatDisablingWorksWhenMerging() throws Exception {
-        IndexService service = createIndex("test", Settings.EMPTY, "type", "_size", "enabled=true");
+        IndexService service = createIndexWithSimpleMappings("test", Settings.EMPTY, "_size", "enabled=true");
         DocumentMapper docMapper = service.mapperService().documentMapper();
         assertThat(docMapper.metadataMapper(SizeFieldMapper.class).enabled(), is(true));
 

--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
@@ -77,7 +77,6 @@ import org.opensearch.index.engine.Engine;
 import org.opensearch.index.engine.MergedSegmentWarmerFactory;
 import org.opensearch.index.engine.NoOpEngine;
 import org.opensearch.index.flush.FlushStats;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.SourceToParse;
 import org.opensearch.index.seqno.RetentionLeaseSyncer;
 import org.opensearch.index.seqno.SequenceNumbers;
@@ -477,7 +476,7 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
             .put("index.number_of_shards", 1)
             .put("index.translog.generation_threshold_size", generationThreshold + "b")
             .build();
-        createIndex("test", settings, MapperService.SINGLE_MAPPING_NAME);
+        createIndexWithSimpleMappings("test", settings);
         ensureGreen("test");
         final IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         final IndexService test = indicesService.indexService(resolveIndex("test"));
@@ -813,7 +812,7 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
             .put("index.translog.flush_threshold_size", "512mb") // do not flush
             .put("index.soft_deletes.enabled", true)
             .build();
-        IndexService indexService = createIndex("index", settings, "user_doc", "title", "type=keyword");
+        IndexService indexService = createIndexWithSimpleMappings("index", settings, "title", "type=keyword");
         int numOps = between(1, 10);
         for (int i = 0; i < numOps; i++) {
             if (randomBoolean()) {

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/FiltersAggsRewriteIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/FiltersAggsRewriteIT.java
@@ -51,7 +51,7 @@ import java.util.Map;
 public class FiltersAggsRewriteIT extends OpenSearchSingleNodeTestCase {
 
     public void testWrapperQueryIsRewritten() throws IOException {
-        createIndex("test", Settings.EMPTY, "test", "title", "type=text");
+        createIndexWithSimpleMappings("test", Settings.EMPTY, "title", "type=text");
         client().prepareIndex("test").setId("1").setSource("title", "foo bar baz").get();
         client().prepareIndex("test").setId("2").setSource("title", "foo foo foo").get();
         client().prepareIndex("test").setId("3").setSource("title", "bar baz bax").get();

--- a/server/src/test/java/org/opensearch/action/termvectors/GetTermVectorsTests.java
+++ b/server/src/test/java/org/opensearch/action/termvectors/GetTermVectorsTests.java
@@ -184,7 +184,7 @@ public class GetTermVectorsTests extends OpenSearchSingleNodeTestCase {
             .put("index.analysis.filter.my_delimited_payload.encoding", encodingString)
             .put("index.analysis.filter.my_delimited_payload.type", "mock_payload_filter")
             .build();
-        createIndex("test", setting, "type1", mapping);
+        createIndex("test", setting, mapping);
 
         client().prepareIndex("test")
             .setId(Integer.toString(1))

--- a/server/src/test/java/org/opensearch/index/analysis/PreBuiltAnalyzerTests.java
+++ b/server/src/test/java/org/opensearch/index/analysis/PreBuiltAnalyzerTests.java
@@ -127,7 +127,7 @@ public class PreBuiltAnalyzerTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        MapperService mapperService = createIndex("test", indexSettings, "type", mapping).mapperService();
+        MapperService mapperService = createIndex("test", indexSettings, mapping).mapperService();
 
         MappedFieldType fieldType = mapperService.fieldType("field");
         assertThat(fieldType.getTextSearchInfo().getSearchAnalyzer(), instanceOf(NamedAnalyzer.class));

--- a/server/src/test/java/org/opensearch/index/mapper/ConstantKeywordFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ConstantKeywordFieldMapperTests.java
@@ -156,7 +156,7 @@ public class ConstantKeywordFieldMapperTests extends OpenSearchSingleNodeTestCas
     }
 
     private ConstantKeywordFieldMapper getMapper(FieldMapper.CopyTo copyTo) {
-        indexService = createIndex("test-index", Settings.EMPTY, "constant_keyword", "field", "type=constant_keyword,value=default_value");
+        indexService = createIndexWithSimpleMappings("test-index", Settings.EMPTY, "field", "type=constant_keyword,value=default_value");
         ConstantKeywordFieldMapper mapper = (ConstantKeywordFieldMapper) indexService.mapperService()
             .documentMapper()
             .mappers()

--- a/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/MapperServiceTests.java
@@ -235,10 +235,10 @@ public class MapperServiceTests extends OpenSearchSingleNodeTestCase {
         Settings settings = settings(Version.V_3_0_0).put("index.sort.field", "foo").build();
         IllegalArgumentException invalidNestedException = expectThrows(
             IllegalArgumentException.class,
-            () -> createIndex("test", settings, "t", "nested_field", "type=nested", "foo", "type=keyword")
+            () -> createIndexWithSimpleMappings("test", settings, "nested_field", "type=nested", "foo", "type=keyword")
         );
         assertThat(invalidNestedException.getMessage(), containsString("cannot have nested fields when index sort is activated"));
-        IndexService indexService = createIndex("test", settings, "t", "foo", "type=keyword");
+        IndexService indexService = createIndexWithSimpleMappings("test", settings, "foo", "type=keyword");
         CompressedXContent nestedFieldMapping = new CompressedXContent(
             BytesReference.bytes(
                 XContentFactory.jsonBuilder()

--- a/server/src/test/java/org/opensearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/NestedObjectMapperTests.java
@@ -881,7 +881,6 @@ public class NestedObjectMapperTests extends OpenSearchSingleNodeTestCase {
         MapperService mapperService = createIndex(
             "index1",
             Settings.EMPTY,
-            "_doc",
             jsonBuilder().startObject()
                 .startObject("properties")
                 .startObject("comments")
@@ -901,7 +900,6 @@ public class NestedObjectMapperTests extends OpenSearchSingleNodeTestCase {
         mapperService = createIndex(
             "index2",
             Settings.EMPTY,
-            "_doc",
             jsonBuilder().startObject()
                 .startObject("properties")
                 .startObject("comments")
@@ -1107,7 +1105,6 @@ public class NestedObjectMapperTests extends OpenSearchSingleNodeTestCase {
         MapperService mapperService = createIndex(
             "index1",
             Settings.EMPTY,
-            MapperService.SINGLE_MAPPING_NAME,
             jsonBuilder().startObject()
                 .startObject("properties")
                 .startObject("nested1")

--- a/server/src/test/java/org/opensearch/index/mapper/UpdateMappingTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/UpdateMappingTests.java
@@ -83,7 +83,7 @@ public class UpdateMappingTests extends OpenSearchSingleNodeTestCase {
     }
 
     protected void testConflictWhileMergingAndMappingUnchanged(XContentBuilder mapping, XContentBuilder mappingUpdate) throws IOException {
-        IndexService indexService = createIndex("test", Settings.builder().build(), MapperService.SINGLE_MAPPING_NAME, mapping);
+        IndexService indexService = createIndex("test", Settings.builder().build(), mapping);
         CompressedXContent mappingBeforeUpdate = indexService.mapperService().documentMapper().mappingSource();
         // simulate like in MetadataMappingService#putMapping
         try {
@@ -111,8 +111,7 @@ public class UpdateMappingTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        MapperService mapperService = createIndex("test", Settings.builder().build(), MapperService.SINGLE_MAPPING_NAME, mapping)
-            .mapperService();
+        MapperService mapperService = createIndex("test", Settings.builder().build(), mapping).mapperService();
 
         XContentBuilder update = XContentFactory.jsonBuilder()
             .startObject()
@@ -158,8 +157,7 @@ public class UpdateMappingTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        MapperService mapperService = createIndex("test", Settings.builder().build(), MapperService.SINGLE_MAPPING_NAME, mapping)
-            .mapperService();
+        MapperService mapperService = createIndex("test", Settings.builder().build(), mapping).mapperService();
 
         XContentBuilder update = XContentFactory.jsonBuilder()
             .startObject()

--- a/server/src/test/java/org/opensearch/index/search/NestedHelperTests.java
+++ b/server/src/test/java/org/opensearch/index/search/NestedHelperTests.java
@@ -117,7 +117,7 @@ public class NestedHelperTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        indexService = createIndex("index", Settings.EMPTY, "type", mapping);
+        indexService = createIndex("index", Settings.EMPTY, mapping);
         mapperService = indexService.mapperService();
     }
 

--- a/server/src/test/java/org/opensearch/index/search/nested/NestedSortingTests.java
+++ b/server/src/test/java/org/opensearch/index/search/nested/NestedSortingTests.java
@@ -466,7 +466,7 @@ public class NestedSortingTests extends AbstractFieldDataTestCase {
             mapping.endObject();
         }
         mapping.endObject();
-        IndexService indexService = createIndex("nested_sorting", Settings.EMPTY, "_doc", mapping);
+        IndexService indexService = createIndex("nested_sorting", Settings.EMPTY, mapping);
 
         List<List<Document>> books = new ArrayList<>();
         {

--- a/server/src/test/java/org/opensearch/index/similarity/SimilarityTests.java
+++ b/server/src/test/java/org/opensearch/index/similarity/SimilarityTests.java
@@ -102,7 +102,7 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
 
-        MapperService mapperService = createIndex("foo", settings, "type", mapping).mapperService();
+        MapperService mapperService = createIndex("foo", settings, mapping).mapperService();
         assertThat(mapperService.fieldType("dummy").getTextSearchInfo().getSimilarity().get(), instanceOf(LegacyBM25Similarity.class));
     }
 
@@ -136,7 +136,7 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
             .put("index.similarity.my_similarity.b", 0.5f)
             .put("index.similarity.my_similarity.discount_overlaps", false)
             .build();
-        MapperService mapperService = createIndex("foo", indexSettings, "type", mapping).mapperService();
+        MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
         assertThat(mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get(), instanceOf(BM25Similarity.class));
 
         BM25Similarity similarity = (BM25Similarity) mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get();
@@ -156,7 +156,7 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
 
-        MapperService mapperService = createIndex("foo", Settings.EMPTY, "type", mapping).mapperService();
+        MapperService mapperService = createIndex("foo", Settings.EMPTY, mapping).mapperService();
         assertThat(mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get(), instanceOf(BooleanSimilarity.class));
     }
 
@@ -178,7 +178,7 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
             .put("index.similarity.my_similarity.normalization", "h2")
             .put("index.similarity.my_similarity.normalization.h2.c", 3f)
             .build();
-        MapperService mapperService = createIndex("foo", indexSettings, "type", mapping).mapperService();
+        MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
         assertThat(mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get(), instanceOf(DFRSimilarity.class));
 
         DFRSimilarity similarity = (DFRSimilarity) mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get();
@@ -206,7 +206,7 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
             .put("index.similarity.my_similarity.normalization", "h2")
             .put("index.similarity.my_similarity.normalization.h2.c", 3f)
             .build();
-        MapperService mapperService = createIndex("foo", indexSettings, "type", mapping).mapperService();
+        MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
         assertThat(mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get(), instanceOf(IBSimilarity.class));
 
         IBSimilarity similarity = (IBSimilarity) mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get();
@@ -231,7 +231,7 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
             .put("index.similarity.my_similarity.type", "DFI")
             .put("index.similarity.my_similarity.independence_measure", "chisquared")
             .build();
-        MapperService mapperService = createIndex("foo", indexSettings, "type", mapping).mapperService();
+        MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
         MappedFieldType fieldType = mapperService.fieldType("field1");
 
         assertThat(fieldType.getTextSearchInfo().getSimilarity().get(), instanceOf(DFISimilarity.class));
@@ -255,7 +255,7 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
             .put("index.similarity.my_similarity.mu", 3000f)
             .build();
 
-        MapperService mapperService = createIndex("foo", indexSettings, "type", mapping).mapperService();
+        MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
         assertThat(mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get(), instanceOf(LMDirichletSimilarity.class));
 
         LMDirichletSimilarity similarity = (LMDirichletSimilarity) mapperService.fieldType("field1")
@@ -280,7 +280,7 @@ public class SimilarityTests extends OpenSearchSingleNodeTestCase {
             .put("index.similarity.my_similarity.type", "LMJelinekMercer")
             .put("index.similarity.my_similarity.lambda", 0.7f)
             .build();
-        MapperService mapperService = createIndex("foo", indexSettings, "type", mapping).mapperService();
+        MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
         assertThat(
             mapperService.fieldType("field1").getTextSearchInfo().getSimilarity().get(),
             instanceOf(LMJelinekMercerSimilarity.class)

--- a/server/src/test/java/org/opensearch/index/termvectors/TermVectorsServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/termvectors/TermVectorsServiceTests.java
@@ -67,7 +67,7 @@ public class TermVectorsServiceTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        createIndex("test", Settings.EMPTY, "type1", mapping);
+        createIndex("test", Settings.EMPTY, mapping);
         ensureGreen();
 
         client().prepareIndex("test").setId("0").setSource("field", "foo bar").setRefreshPolicy(IMMEDIATE).get();
@@ -96,7 +96,7 @@ public class TermVectorsServiceTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
         Settings settings = Settings.builder().put("number_of_shards", 1).build();
-        createIndex("test", settings, "_doc", mapping);
+        createIndex("test", settings, mapping);
         ensureGreen();
 
         int max = between(3, 10);
@@ -135,7 +135,7 @@ public class TermVectorsServiceTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
         Settings settings = Settings.builder().put("number_of_shards", 1).build();
-        createIndex("test", settings, "_doc", mapping);
+        createIndex("test", settings, mapping);
         ensureGreen();
 
         int max = between(3, 10);

--- a/server/src/test/java/org/opensearch/search/aggregations/AggregatorBaseTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/AggregatorBaseTests.java
@@ -144,7 +144,7 @@ public class AggregatorBaseTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testShortcutIsApplicable() throws IOException {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type", "bytes", "type=keyword");
+        IndexService indexService = createIndexWithSimpleMappings("index", Settings.EMPTY, "bytes", "type=keyword");
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
             QueryShardContext context = indexService.newQueryShardContext(0, searcher, () -> 42L, null);

--- a/server/src/test/java/org/opensearch/search/aggregations/support/ValuesSourceConfigTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/support/ValuesSourceConfigTests.java
@@ -42,7 +42,6 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.fielddata.SortedBinaryDocValues;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
@@ -50,7 +49,7 @@ import org.opensearch.test.OpenSearchSingleNodeTestCase;
 public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
 
     public void testKeyword() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type", "bytes", "type=keyword");
+        IndexService indexService = createIndexWithSimpleMappings("index", Settings.EMPTY, "bytes", "type=keyword");
         client().prepareIndex("index").setId("1").setSource("bytes", "abc").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
@@ -76,7 +75,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testEmptyKeyword() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type", "bytes", "type=keyword");
+        IndexService indexService = createIndexWithSimpleMappings("index", Settings.EMPTY, "bytes", "type=keyword");
         client().prepareIndex("index").setId("1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
@@ -107,7 +106,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testUnmappedKeyword() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type");
+        IndexService indexService = createIndex("index", Settings.EMPTY);
         client().prepareIndex("index").setId("1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
@@ -137,7 +136,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testLong() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type", "long", "type=long");
+        IndexService indexService = createIndexWithSimpleMappings("index", Settings.EMPTY, "long", "type=long");
         client().prepareIndex("index").setId("1").setSource("long", 42).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
@@ -163,7 +162,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testEmptyLong() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type", "long", "type=long");
+        IndexService indexService = createIndexWithSimpleMappings("index", Settings.EMPTY, "long", "type=long");
         client().prepareIndex("index").setId("1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
@@ -194,7 +193,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testUnmappedLong() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type");
+        IndexService indexService = createIndex("index", Settings.EMPTY);
         client().prepareIndex("index").setId("1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
@@ -225,7 +224,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testBoolean() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type", "bool", "type=boolean");
+        IndexService indexService = createIndexWithSimpleMappings("index", Settings.EMPTY, "bool", "type=boolean");
         client().prepareIndex("index").setId("1").setSource("bool", true).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
@@ -251,7 +250,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testEmptyBoolean() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type", "bool", "type=boolean");
+        IndexService indexService = createIndexWithSimpleMappings("index", Settings.EMPTY, "bool", "type=boolean");
         client().prepareIndex("index").setId("1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
@@ -282,7 +281,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testUnmappedBoolean() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type");
+        IndexService indexService = createIndex("index", Settings.EMPTY);
         client().prepareIndex("index").setId("1").setSource().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
@@ -313,7 +312,14 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
     }
 
     public void testFieldAlias() throws Exception {
-        IndexService indexService = createIndex("index", Settings.EMPTY, "type", "field", "type=keyword", "alias", "type=alias,path=field");
+        IndexService indexService = createIndexWithSimpleMappings(
+            "index",
+            Settings.EMPTY,
+            "field",
+            "type=keyword",
+            "alias",
+            "type=alias,path=field"
+        );
         client().prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
@@ -354,7 +360,7 @@ public class ValuesSourceConfigTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        IndexService indexService = createIndex("index", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping);
+        IndexService indexService = createIndex("index", Settings.EMPTY, mapping);
         client().prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {

--- a/server/src/test/java/org/opensearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/subphase/FieldFetcherTests.java
@@ -277,7 +277,7 @@ public class FieldFetcherTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
 
-        IndexService indexService = createIndex("index", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping);
+        IndexService indexService = createIndex("index", Settings.EMPTY, mapping);
         MapperService mapperService = indexService.mapperService();
 
         XContentBuilder source = XContentFactory.jsonBuilder()
@@ -307,7 +307,7 @@ public class FieldFetcherTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
 
-        IndexService indexService = createIndex("index", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping);
+        IndexService indexService = createIndex("index", Settings.EMPTY, mapping);
         MapperService mapperService = indexService.mapperService();
 
         XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("field", "value").endObject();
@@ -341,7 +341,7 @@ public class FieldFetcherTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
 
-        IndexService indexService = createIndex("index", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping);
+        IndexService indexService = createIndex("index", Settings.EMPTY, mapping);
         MapperService mapperService = indexService.mapperService();
 
         XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("field", 42).endObject();
@@ -374,7 +374,7 @@ public class FieldFetcherTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
 
-        IndexService indexService = createIndex("index", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping);
+        IndexService indexService = createIndex("index", Settings.EMPTY, mapping);
         MapperService mapperService = indexService.mapperService();
 
         XContentBuilder source = XContentFactory.jsonBuilder()
@@ -420,7 +420,7 @@ public class FieldFetcherTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
 
-        IndexService indexService = createIndex("index", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping);
+        IndexService indexService = createIndex("index", Settings.EMPTY, mapping);
         MapperService mapperService = indexService.mapperService();
 
         XContentBuilder source = XContentFactory.jsonBuilder().startObject().array("field", "some text").endObject();
@@ -484,7 +484,7 @@ public class FieldFetcherTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
 
-        IndexService indexService = createIndex("index", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping);
+        IndexService indexService = createIndex("index", Settings.EMPTY, mapping);
         return indexService.mapperService();
     }
 

--- a/server/src/test/java/org/opensearch/search/fetch/subphase/highlight/DerivedFieldFetchAndHighlightTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/subphase/highlight/DerivedFieldFetchAndHighlightTests.java
@@ -124,7 +124,7 @@ public class DerivedFieldFetchAndHighlightTests extends OpenSearchSingleNodeTest
             .endObject();
 
         int docId = 0;
-        IndexService indexService = createIndex("test_index", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping);
+        IndexService indexService = createIndex("test_index", Settings.EMPTY, mapping);
         MapperService mapperService = indexService.mapperService();
 
         try (
@@ -260,7 +260,7 @@ public class DerivedFieldFetchAndHighlightTests extends OpenSearchSingleNodeTest
         // Create index and mapper service
         // We are not defining derived fields in index mapping here
         XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().endObject();
-        IndexService indexService = createIndex("test_index", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping);
+        IndexService indexService = createIndex("test_index", Settings.EMPTY, mapping);
         MapperService mapperService = indexService.mapperService();
 
         try (

--- a/server/src/test/java/org/opensearch/search/geo/GeoShapeQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/geo/GeoShapeQueryTests.java
@@ -365,7 +365,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
 
     public void testGeometryCollectionRelations() throws Exception {
         XContentBuilder mapping = createDefaultMapping();
-        createIndex("test", Settings.builder().put("index.number_of_shards", 1).build(), "doc", mapping);
+        createIndex("test", Settings.builder().put("index.number_of_shards", 1).build(), mapping);
 
         EnvelopeBuilder envelopeBuilder = new EnvelopeBuilder(new Coordinate(-10, 10), new Coordinate(10, -10));
 
@@ -490,7 +490,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
     public void testIndexedShapeReferenceSourceDisabled() throws Exception {
         XContentBuilder mapping = createDefaultMapping();
         client().admin().indices().prepareCreate("test").setMapping(mapping).get();
-        createIndex("shapes", Settings.EMPTY, "shape_type", "_source", "enabled=false");
+        createIndexWithSimpleMappings("shapes", Settings.EMPTY, "_source", "enabled=false");
         ensureGreen();
 
         EnvelopeBuilder shape = new EnvelopeBuilder(new Coordinate(-45, 45), new Coordinate(45, -45));
@@ -749,7 +749,7 @@ public class GeoShapeQueryTests extends GeoQueryTests {
             .endObject()
             .endObject();
 
-        createIndex("test", Settings.EMPTY, "type", mapping);
+        createIndex("test", Settings.EMPTY, mapping);
 
         ShapeBuilder shape = RandomShapeGenerator.createShape(random(), RandomShapeGenerator.ShapeType.MULTIPOINT);
         client().prepareIndex("test")

--- a/server/src/test/java/org/opensearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/server/src/test/java/org/opensearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -787,7 +787,7 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
 
-        MapperService mapperService = createIndex("test", Settings.EMPTY, "type1", mapping).mapperService();
+        MapperService mapperService = createIndex("test", Settings.EMPTY, mapping).mapperService();
         CompletionFieldType completionFieldType = (CompletionFieldType) mapperService.fieldType("completion");
 
         Exception e = expectThrows(IllegalArgumentException.class, () -> completionFieldType.getContextMappings().get("brand"));

--- a/server/src/test/java/org/opensearch/search/suggest/completion/GeoContextMappingTests.java
+++ b/server/src/test/java/org/opensearch/search/suggest/completion/GeoContextMappingTests.java
@@ -77,7 +77,7 @@ public class GeoContextMappingTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
 
-        MapperService mapperService = createIndex("test", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping).mapperService();
+        MapperService mapperService = createIndex("test", Settings.EMPTY, mapping).mapperService();
         MappedFieldType completionFieldType = mapperService.fieldType("completion");
         ParsedDocument parsedDocument = mapperService.documentMapper()
             .parse(
@@ -124,7 +124,7 @@ public class GeoContextMappingTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
 
-        MapperService mapperService = createIndex("test", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping).mapperService();
+        MapperService mapperService = createIndex("test", Settings.EMPTY, mapping).mapperService();
         MappedFieldType completionFieldType = mapperService.fieldType("completion");
         ParsedDocument parsedDocument = mapperService.documentMapper()
             .parse(
@@ -169,7 +169,7 @@ public class GeoContextMappingTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
 
-        MapperService mapperService = createIndex("test", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping).mapperService();
+        MapperService mapperService = createIndex("test", Settings.EMPTY, mapping).mapperService();
         MappedFieldType completionFieldType = mapperService.fieldType("completion");
         ParsedDocument parsedDocument = mapperService.documentMapper()
             .parse(
@@ -222,7 +222,7 @@ public class GeoContextMappingTests extends OpenSearchSingleNodeTestCase {
             .endObject()
             .endObject();
 
-        MapperService mapperService = createIndex("test", Settings.EMPTY, MapperService.SINGLE_MAPPING_NAME, mapping).mapperService();
+        MapperService mapperService = createIndex("test", Settings.EMPTY, mapping).mapperService();
         MappedFieldType completionFieldType = mapperService.fieldType("completion");
         XContentBuilder builder = jsonBuilder().startObject()
             .startArray("completion")
@@ -268,10 +268,7 @@ public class GeoContextMappingTests extends OpenSearchSingleNodeTestCase {
         mapping.endObject();
         mapping.endObject();
 
-        OpenSearchParseException ex = expectThrows(
-            OpenSearchParseException.class,
-            () -> createIndex("test", Settings.EMPTY, "type1", mapping)
-        );
+        OpenSearchParseException ex = expectThrows(OpenSearchParseException.class, () -> createIndex("test", Settings.EMPTY, mapping));
 
         assertThat(ex.getMessage(), equalTo("field [pin] referenced in context [st] must be mapped to geo_point, found [" + type + "]"));
     }
@@ -298,10 +295,7 @@ public class GeoContextMappingTests extends OpenSearchSingleNodeTestCase {
         mapping.endObject();
         mapping.endObject();
 
-        OpenSearchParseException ex = expectThrows(
-            OpenSearchParseException.class,
-            () -> createIndex("test", Settings.EMPTY, "type1", mapping)
-        );
+        OpenSearchParseException ex = expectThrows(OpenSearchParseException.class, () -> createIndex("test", Settings.EMPTY, mapping));
 
         assertThat(ex.getMessage(), equalTo("field [pin] referenced in context [st] is not defined in the mapping"));
     }

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
@@ -339,33 +339,36 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
      * Create a new index on the singleton node with the provided index settings.
      */
     protected IndexService createIndex(String index, Settings settings) {
-        return createIndex(index, settings, null, (XContentBuilder) null);
+        return createIndex(index, settings, null);
     }
 
     /**
-     * Create a new index on the singleton node with the provided index settings.
-     * @deprecated types are being removed
+     * Create a new index on the singleton node with the provided index settings and mappings.
      */
-    @Deprecated
-    protected IndexService createIndex(String index, Settings settings, String type, XContentBuilder mappings) {
-        CreateIndexRequestBuilder createIndexRequestBuilder = client().admin().indices().prepareCreate(index).setSettings(settings);
-        if (type != null && mappings != null) {
-            createIndexRequestBuilder.setMapping(mappings);
-        }
-        return createIndex(index, createIndexRequestBuilder);
-    }
-
-    /**
-     * Create a new index on the singleton node with the provided index settings.
-     * @deprecated types are being removed
-     */
-    @Deprecated
-    protected IndexService createIndex(String index, Settings settings, String type, String... mappings) {
+    protected IndexService createIndex(String index, Settings settings, XContentBuilder mappings) {
         CreateIndexRequestBuilder createIndexRequestBuilder = client().admin().indices().prepareCreate(index).setSettings(settings);
         if (mappings != null) {
             createIndexRequestBuilder.setMapping(mappings);
         }
         return createIndex(index, createIndexRequestBuilder);
+    }
+
+    /**
+     * Create a new index on the singleton node with the provided index settings.
+     * @deprecated types have been removed
+     */
+    @Deprecated
+    protected IndexService createIndex(String index, Settings settings, String type, XContentBuilder mappings) {
+        return createIndex(index, settings, mappings);
+    }
+
+    /**
+     * Create a new index on the singleton node with the provided index settings.
+     * @deprecated types have been removed
+     */
+    @Deprecated
+    protected IndexService createIndex(String index, Settings settings, String type, String... mappings) {
+        return createIndexWithSimpleMappings(index, settings, mappings);
     }
 
     /**


### PR DESCRIPTION
The deprecated versions of this method take a type parameter, support for which was removed back in 2.0. The parameter is not used. I have kept the deprecated methods so as to not break downstream components that may be using them but changed all the code in server to stop passing in a type parameter.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
