### PR TITLE
Replace the deprecated construction method of TopScoreDocCollectorManager with the new method in Lucene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Avoid NPE if on SnapshotInfo if 'shallow' boolean not present ([#18187](https://github.com/opensearch-project/OpenSearch/issues/18187))
 - Fix 'system call filter not installed' caused when network.host: 0.0.0.0 ([#18309](https://github.com/opensearch-project/OpenSearch/pull/18309))
 - Fix MatrixStatsAggregator reuse when mode parameter changes ([#18242](https://github.com/opensearch-project/OpenSearch/issues/18242))
-- Replace the deprecated construction method of TopScoreDocCollectorManager with the new method
+- Replace the deprecated construction method of TopScoreDocCollectorManager with the new method ([#18395](https://github.com/opensearch-project/OpenSearch/pull/18395))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Avoid NPE if on SnapshotInfo if 'shallow' boolean not present ([#18187](https://github.com/opensearch-project/OpenSearch/issues/18187))
 - Fix 'system call filter not installed' caused when network.host: 0.0.0.0 ([#18309](https://github.com/opensearch-project/OpenSearch/pull/18309))
 - Fix MatrixStatsAggregator reuse when mode parameter changes ([#18242](https://github.com/opensearch-project/OpenSearch/issues/18242))
+- Replace the deprecated construction method of TopScoreDocCollectorManager with the new method
 
 ### Security
 

--- a/modules/parent-join/src/main/java/org/opensearch/join/query/ParentChildInnerHitContextBuilder.java
+++ b/modules/parent-join/src/main/java/org/opensearch/join/query/ParentChildInnerHitContextBuilder.java
@@ -175,7 +175,7 @@ class ParentChildInnerHitContextBuilder extends InnerHitContextBuilder {
                         maxScoreCollector = new MaxScoreCollector();
                     }
                 } else {
-                    topDocsCollector = new TopScoreDocCollectorManager(topN, null, Integer.MAX_VALUE, false).newCollector();
+                    topDocsCollector = new TopScoreDocCollectorManager(topN, null, Integer.MAX_VALUE).newCollector();
                     maxScoreCollector = new MaxScoreCollector();
                 }
                 for (LeafReaderContext ctx : context.searcher().getIndexReader().leaves()) {

--- a/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/NestedQueryBuilder.java
@@ -495,7 +495,7 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
                         maxScoreCollector = new MaxScoreCollector();
                     }
                 } else {
-                    topDocsCollector = new TopScoreDocCollectorManager(topN, null, Integer.MAX_VALUE, false).newCollector();
+                    topDocsCollector = new TopScoreDocCollectorManager(topN, null, Integer.MAX_VALUE).newCollector();
                     maxScoreCollector = new MaxScoreCollector();
                 }
                 intersect(weight, innerHitQueryWeight, MultiCollector.wrap(topDocsCollector, maxScoreCollector), ctx);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/sampler/BestDocsDeferringCollector.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/sampler/BestDocsDeferringCollector.java
@@ -124,7 +124,7 @@ public class BestDocsDeferringCollector extends DeferringBucketCollector impleme
     // Designed to be overridden by subclasses that may score docs by criteria
     // other than Lucene score
     protected TopDocsCollector<? extends ScoreDoc> createTopDocsCollector(int size) throws IOException {
-        return new TopScoreDocCollectorManager(size, null, Integer.MAX_VALUE, false).newCollector();
+        return new TopScoreDocCollectorManager(size, null, Integer.MAX_VALUE).newCollector();
     }
 
     // Can be overridden by subclasses that have a different priority queue implementation

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/TopHitsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/TopHitsAggregator.java
@@ -158,10 +158,7 @@ class TopHitsAggregator extends MetricsAggregator {
                     // but here we create collectors ourselves and we need prevent OOM because of crazy an offset and size.
                     topN = Math.min(topN, subSearchContext.searcher().getIndexReader().maxDoc());
                     if (sort == null) {
-                        collectors = new Collectors(
-                            new TopScoreDocCollectorManager(topN, null, Integer.MAX_VALUE, false).newCollector(),
-                            null
-                        );
+                        collectors = new Collectors(new TopScoreDocCollectorManager(topN, null, Integer.MAX_VALUE).newCollector(), null);
                     } else {
                         // TODO: can we pass trackTotalHits=subSearchContext.trackTotalHits(){
                         // Note that this would require to catch CollectionTerminatedException

--- a/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
@@ -348,10 +348,9 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
             int hitCountThreshold
         ) {
             if (sortAndFormats == null) {
-                return new TopScoreDocCollectorManager(numHits, searchAfter, hitCountThreshold, false).newCollector();
+                return new TopScoreDocCollectorManager(numHits, searchAfter, hitCountThreshold).newCollector();
             } else {
-                return new TopFieldCollectorManager(sortAndFormats.sort, numHits, (FieldDoc) searchAfter, hitCountThreshold, false)
-                    .newCollector();
+                return new TopFieldCollectorManager(sortAndFormats.sort, numHits, (FieldDoc) searchAfter, hitCountThreshold).newCollector();
             }
         }
 
@@ -364,17 +363,12 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
             if (sortAndFormats == null) {
                 // See please https://github.com/apache/lucene/pull/450, should be fixed in 9.x
                 if (searchAfter != null) {
-                    return new TopScoreDocCollectorManager(
-                        numHits,
-                        new FieldDoc(searchAfter.doc, searchAfter.score),
-                        hitCountThreshold,
-                        true
-                    );
+                    return new TopScoreDocCollectorManager(numHits, new FieldDoc(searchAfter.doc, searchAfter.score), hitCountThreshold);
                 } else {
-                    return new TopScoreDocCollectorManager(numHits, null, hitCountThreshold, true);
+                    return new TopScoreDocCollectorManager(numHits, null, hitCountThreshold);
                 }
             } else {
-                return new TopFieldCollectorManager(sortAndFormats.sort, numHits, (FieldDoc) searchAfter, hitCountThreshold, true);
+                return new TopFieldCollectorManager(sortAndFormats.sort, numHits, (FieldDoc) searchAfter, hitCountThreshold);
             }
         }
 


### PR DESCRIPTION
### Description
Replace the deprecated construction method of TopScoreDocCollectorManager with the new method in Lucene 10.1.0.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/18394.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
