### PR TITLE
Update FipsMode check to catch NoSuchMethodError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Create generic DocRequest to better categorize ActionRequests ([#18269](https://github.com/opensearch-project/OpenSearch/pull/18269)))
-- Change implementation for `percentiles` aggregation for latency improvement [#18124](https://github.com/opensearch-project/OpenSearch/pull/18124)
+- Change implementation for `percentiles` aggregation for latency improvement ([#18124](https://github.com/opensearch-project/OpenSearch/pull/18124))
+- Update FipsMode check to catch NoSuchMethodError ([#18427](https://github.com/opensearch-project/OpenSearch/pull/18427))
 
 ### Dependencies
 - Update Apache Lucene from 10.1.0 to 10.2.1 ([#17961](https://github.com/opensearch-project/OpenSearch/pull/17961))

--- a/test/framework/src/main/java/org/opensearch/fips/FipsMode.java
+++ b/test/framework/src/main/java/org/opensearch/fips/FipsMode.java
@@ -15,7 +15,7 @@ public class FipsMode {
     public static Check CHECK = () -> {
         try {
             return CryptoServicesRegistrar.isInApprovedOnlyMode();
-        } catch (NoClassDefFoundError e) {
+        } catch (NoClassDefFoundError | NoSuchMethodError e) {
             return false;
         }
     };


### PR DESCRIPTION
### Description

This PR resolves an error seen in the security plugin here: https://github.com/opensearch-project/security/actions/runs/15408478290/job/43355642640?pr=5370

The error is really a timing issue as the security plugin has not yet converted to BCFIPS jars because of [incompatibility with OpenSAML](https://github.com/opensearch-project/security/issues/4915) which is a library used for SAML authentication. 

The existing check has a catch block for NoSuchClassDef, but in the case of the security plugin the class exists, but the method does not.

### Related Issues

Resolves https://github.com/opensearch-project/security/actions/runs/15408478290/job/43355642640?pr=5370

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
