### PR TITLE
feat: Add epsilon tolerance for numeric matches in YAML REST tests

### DIFF
--- a/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/MatchAssertionTests.java
+++ b/test/framework/src/test/java/org/opensearch/test/rest/yaml/section/MatchAssertionTests.java
@@ -32,7 +32,11 @@
 package org.opensearch.test.rest.yaml.section;
 
 import org.opensearch.core.xcontent.XContentLocation;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
@@ -63,5 +67,59 @@ public class MatchAssertionTests extends OpenSearchTestCase {
         matchAssertion.doAssert(singletonMap("a", null), matchAssertion.getExpectedValue());
         AssertionError e = expectThrows(AssertionError.class, () -> matchAssertion.doAssert(emptyMap(), matchAssertion.getExpectedValue()));
         assertThat(e.getMessage(), containsString("expected [null] but not found"));
+    }
+
+    public void testEpsilon() {
+        XContentLocation xContentLocation = new XContentLocation(0, 0);
+        MatchAssertion matchAssertion = new MatchAssertion(xContentLocation, "field", 0.95, 0.01);
+        matchAssertion.doAssert(0.955, 0.95);
+        matchAssertion.doAssert(0.945, 0.95);
+        expectThrows(AssertionError.class, () -> matchAssertion.doAssert(0.965, 0.95));
+        expectThrows(AssertionError.class, () -> matchAssertion.doAssert(0.935, 0.95));
+    }
+
+    public void testEpsilonWithDifferentTypes() {
+        XContentLocation xContentLocation = new XContentLocation(0, 0);
+        MatchAssertion matchAssertion = new MatchAssertion(xContentLocation, "field", 100L, 1.0);
+        matchAssertion.doAssert(100.5, 100L);
+        matchAssertion.doAssert(99.5, 100L);
+        MatchAssertion matchAssertion2 = new MatchAssertion(xContentLocation, "field", 100.0, 1.0);
+        matchAssertion2.doAssert(100, 100.0);
+        matchAssertion2.doAssert(99, 100.0);
+
+        expectThrows(AssertionError.class, () -> matchAssertion.doAssert(101.1, 100L));
+        expectThrows(AssertionError.class, () -> matchAssertion2.doAssert(98, 100.0));
+    }
+
+    public void testEpsilonIsZero() {
+        XContentLocation location = new XContentLocation(0, 0);
+        MatchAssertion matchAssertion = new MatchAssertion(location, "field", 5.0, 0.0);
+        matchAssertion.doAssert(5.0, 5.0);
+
+        expectThrows(AssertionError.class, () -> matchAssertion.doAssert(5.0000000001, 5.0));
+        expectThrows(AssertionError.class, () -> matchAssertion.doAssert(4.9999999999, 5.0));
+
+        MatchAssertion intMatchAssertion = new MatchAssertion(location, "field", 5, 0.0);
+        intMatchAssertion.doAssert(5, 5);
+        intMatchAssertion.doAssert(5.0, 5);
+        expectThrows(AssertionError.class, () -> intMatchAssertion.doAssert(6, 5));
+    }
+
+    public void testNegativeEpsilon() {
+        XContentLocation location = new XContentLocation(0, 0);
+        MatchAssertion matchAssertion = new MatchAssertion(location, "field", 5.0, -0.01);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> matchAssertion.doAssert(5.0, 5.0));
+        assertThat(e.getMessage(), containsString("epsilon must be non-negative, but was: " + -0.01));
+    }
+
+    public void testParseEpsilonNotANumber() throws IOException {
+        String jsonContent = "{ \"field_to_match\": 42.0, \"epsilon\": \"invalid_epsilon_value\" }";
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), jsonContent)) {
+            parser.nextToken();
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> MatchAssertion.parse(parser));
+            assertThat(e.getMessage(), containsString("epsilon must be a number"));
+        }
     }
 }


### PR DESCRIPTION
This commit introduces an epsilon parameter to the match assertion in YAML REST tests. This allows for specifying a tolerance when comparing numerical values

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
