### PR TITLE
Execute `:libs:opensearch-agent-sm:agent` tests in separate JVMs

### DIFF
--- a/libs/agent-sm/agent/build.gradle
+++ b/libs/agent-sm/agent/build.gradle
@@ -74,6 +74,7 @@ tasks.named('validateNebulaPom') {
 tasks.test {
   dependsOn prepareAgent
   jvmArgs += ["-javaagent:" + project.jar.archiveFile.get()]
+  forkEvery = 1
 }
 
 tasks.check {


### PR DESCRIPTION
### Description
Re-submitting #18429 with a proper branch

Since there's no way to remove an `AgentPolicy` once it set, the only way to avoid conflicts described in #18428 is to fork a new JVM per test

### Related Issues
Resolves #18428


### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).