### PR TITLE
Use a random FeatureType name in AutoTaggingRegistryTests

### DIFF
--- a/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/autotagging/AutoTaggingRegistryTests.java
+++ b/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/autotagging/AutoTaggingRegistryTests.java
@@ -20,16 +20,19 @@ import static org.mockito.Mockito.when;
 
 public class AutoTaggingRegistryTests extends OpenSearchTestCase {
 
+    private static String TEST_FEATURE_TYPE_NAME;
+
     @BeforeClass
     public static void setUpOnce() {
+        TEST_FEATURE_TYPE_NAME = TEST_FEATURE_TYPE + randomAlphaOfLength(2);
         FeatureType featureType = mock(FeatureType.class);
-        when(featureType.getName()).thenReturn(TEST_FEATURE_TYPE);
+        when(featureType.getName()).thenReturn(TEST_FEATURE_TYPE_NAME);
         AutoTaggingRegistry.registerFeatureType(featureType);
     }
 
     public void testGetFeatureType_Success() {
-        FeatureType retrievedFeatureType = AutoTaggingRegistry.getFeatureType(TEST_FEATURE_TYPE);
-        assertEquals(TEST_FEATURE_TYPE, retrievedFeatureType.getName());
+        FeatureType retrievedFeatureType = AutoTaggingRegistry.getFeatureType(TEST_FEATURE_TYPE_NAME);
+        assertEquals(TEST_FEATURE_TYPE_NAME, retrievedFeatureType.getName());
     }
 
     public void testRuntimeException() {
@@ -39,7 +42,7 @@ public class AutoTaggingRegistryTests extends OpenSearchTestCase {
     public void testIllegalStateExceptionException() {
         assertThrows(IllegalStateException.class, () -> AutoTaggingRegistry.registerFeatureType(null));
         FeatureType featureType = mock(FeatureType.class);
-        when(featureType.getName()).thenReturn(TEST_FEATURE_TYPE);
+        when(featureType.getName()).thenReturn(TEST_FEATURE_TYPE_NAME);
         assertThrows(IllegalStateException.class, () -> AutoTaggingRegistry.registerFeatureType(featureType));
         when(featureType.getName()).thenReturn(randomAlphaOfLength(MAX_FEATURE_TYPE_NAME_LENGTH + 1));
         assertThrows(IllegalStateException.class, () -> AutoTaggingRegistry.registerFeatureType(featureType));


### PR DESCRIPTION
### Description
Use a random FeatureType name in AutoTaggingRegistryTests

### Related Issues
Resolves #18441 

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
