### PR TITLE
Skip KafkaSingleNodeTests.testPauseAndResumeAPIs it if docker is not available

### DIFF
--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSingleNodeTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSingleNodeTests.java
@@ -27,6 +27,7 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.transport.client.Requests;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 
 import java.util.Arrays;
@@ -37,6 +38,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -55,6 +57,7 @@ public class KafkaSingleNodeTests extends OpenSearchSingleNodeTestCase {
 
     @Before
     public void setup() {
+        Assume.assumeTrue("Docker is not available", DockerClientFactory.instance().isDockerAvailable());
         setupKafka();
     }
 


### PR DESCRIPTION
### Description
When `./gradlew test` is executed on a system without Docker all the test pass except `KafkaSingleNodeTests.testPauseAndResumeAPIs` test, which uses Testcontainers.

I understand that Docker is required for some phases (like `assemble`), but there's no reson to fail the `test` phase because of that. We should ignore that test instead

To reproduce just run `./gradlew test` or `./gradlew :plugins:ingestion-kafka:test --tests KafkaSingleNodeTests` on a system without Docker

### Related Issues
#18527 

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
