### PR TITLE
Standardize setting key for aux transports

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightService.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightService.java
@@ -38,6 +38,8 @@ import java.util.Objects;
  * as well as managing the stream operations through a FlightStreamManager.
  */
 public class FlightService extends AuxTransport {
+    public static final String ARROW_FLIGHT_TRANSPORT_SETTING_KEY = "experimental-transport-arrow-flight-rpc";
+
     private static final Logger logger = LogManager.getLogger(FlightService.class);
     private final ServerComponents serverComponents;
     private FlightStreamManager streamManager;
@@ -60,6 +62,11 @@ public class FlightService extends AuxTransport {
         }
         this.serverComponents = new ServerComponents(settings);
         this.streamManager = new FlightStreamManager();
+    }
+
+    @Override
+    public String enableKey() {
+        return ARROW_FLIGHT_TRANSPORT_SETTING_KEY;
     }
 
     void setClusterService(ClusterService clusterService) {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightService.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightService.java
@@ -38,7 +38,12 @@ import java.util.Objects;
  * as well as managing the stream operations through a FlightStreamManager.
  */
 public class FlightService extends AuxTransport {
-    private static final String ARROW_FLIGHT_TRANSPORT_SETTING_KEY = "experimental-transport-arrow-flight-rpc";
+    /**
+     * Setting identifier for this transport.
+     * Public for testing.
+     */
+    public static final String ARROW_FLIGHT_TRANSPORT_SETTING_KEY = "experimental-transport-arrow-flight-rpc";
+
     private static final Logger logger = LogManager.getLogger(FlightService.class);
     private final ServerComponents serverComponents;
     private FlightStreamManager streamManager;

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightService.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightService.java
@@ -65,7 +65,7 @@ public class FlightService extends AuxTransport {
     }
 
     @Override
-    public String enableKey() {
+    public String settingKey() {
         return ARROW_FLIGHT_TRANSPORT_SETTING_KEY;
     }
 

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightService.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightService.java
@@ -38,8 +38,7 @@ import java.util.Objects;
  * as well as managing the stream operations through a FlightStreamManager.
  */
 public class FlightService extends AuxTransport {
-    public static final String ARROW_FLIGHT_TRANSPORT_SETTING_KEY = "experimental-transport-arrow-flight-rpc";
-
+    private static final String ARROW_FLIGHT_TRANSPORT_SETTING_KEY = "experimental-transport-arrow-flight-rpc";
     private static final Logger logger = LogManager.getLogger(FlightService.class);
     private final ServerComponents serverComponents;
     private FlightStreamManager streamManager;
@@ -64,6 +63,9 @@ public class FlightService extends AuxTransport {
         this.streamManager = new FlightStreamManager();
     }
 
+    /**
+     * Identifier for enabling and configuring this transport in settings.
+     */
     @Override
     public String settingKey() {
         return ARROW_FLIGHT_TRANSPORT_SETTING_KEY;

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightService.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightService.java
@@ -23,9 +23,9 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.network.NetworkService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.transport.BoundTransportAddress;
-import org.opensearch.plugins.NetworkPlugin;
 import org.opensearch.plugins.SecureTransportSettingsProvider;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.AuxTransport;
 import org.opensearch.transport.client.Client;
 
 import java.security.AccessController;
@@ -37,7 +37,7 @@ import java.util.Objects;
  * It handles the initialization, startup, and shutdown of the Flight server and client,
  * as well as managing the stream operations through a FlightStreamManager.
  */
-public class FlightService extends NetworkPlugin.AuxTransport {
+public class FlightService extends AuxTransport {
     private static final Logger logger = LogManager.getLogger(FlightService.class);
     private final ServerComponents serverComponents;
     private FlightStreamManager streamManager;

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightStreamPlugin.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightStreamPlugin.java
@@ -171,7 +171,7 @@ public class FlightStreamPlugin extends Plugin
             return Collections.emptyMap();
         }
         flightService.setNetworkService(networkService);
-        return Collections.singletonMap(FlightService.AUX_TRANSPORT_TYPES_KEY, () -> flightService);
+        return Collections.singletonMap(flightService.settingKey(), () -> flightService);
     }
 
     /**

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightStreamPlugin.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightStreamPlugin.java
@@ -43,6 +43,7 @@ import org.opensearch.script.ScriptService;
 import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.threadpool.ExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.AuxTransport;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.client.Client;
 import org.opensearch.watcher.ResourceWatcherService;

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/ServerComponents.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/ServerComponents.java
@@ -49,7 +49,7 @@ import io.netty.util.concurrent.Future;
 import static java.util.Collections.emptyList;
 import static org.opensearch.common.settings.Setting.intSetting;
 import static org.opensearch.common.settings.Setting.listSetting;
-import static org.opensearch.plugins.NetworkPlugin.AuxTransport.AUX_TRANSPORT_PORT;
+import static org.opensearch.transport.AuxTransport.AUX_TRANSPORT_PORT;
 import static org.opensearch.transport.Transport.resolveTransportPublishPort;
 
 @SuppressWarnings("removal")

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/FlightStreamPluginTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/FlightStreamPluginTests.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 
 import static org.opensearch.arrow.flight.bootstrap.FlightService.ARROW_FLIGHT_TRANSPORT_SETTING_KEY;
 import static org.opensearch.common.util.FeatureFlags.ARROW_STREAMS;
-import static org.opensearch.transport.AuxTransport.AUX_TRANSPORT_TYPES_KEY;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/FlightStreamPluginTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/FlightStreamPluginTests.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import static org.opensearch.arrow.flight.bootstrap.FlightService.ARROW_FLIGHT_TRANSPORT_SETTING_KEY;
 import static org.opensearch.common.util.FeatureFlags.ARROW_STREAMS;
 import static org.opensearch.transport.AuxTransport.AUX_TRANSPORT_TYPES_KEY;
 import static org.mockito.Mockito.mock;
@@ -87,7 +88,7 @@ public class FlightStreamPluginTests extends OpenSearchTestCase {
 
         assertTrue(
             plugin.getAuxTransports(null, null, null, new NetworkService(List.of()), null, null)
-                .get(AUX_TRANSPORT_TYPES_KEY)
+                .get(ARROW_FLIGHT_TRANSPORT_SETTING_KEY)
                 .get() instanceof FlightService
         );
         assertEquals(1, plugin.getRestHandlers(null, null, null, null, null, null, null).size());

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/FlightStreamPluginTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/FlightStreamPluginTests.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.opensearch.common.util.FeatureFlags.ARROW_STREAMS;
-import static org.opensearch.plugins.NetworkPlugin.AuxTransport.AUX_TRANSPORT_TYPES_KEY;
+import static org.opensearch.transport.AuxTransport.AUX_TRANSPORT_TYPES_KEY;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/plugins/transport-grpc/src/internalClusterTest/java/org/opensearch/plugin/transport/grpc/GrpcTransportBaseIT.java
+++ b/plugins/transport-grpc/src/internalClusterTest/java/org/opensearch/plugin/transport/grpc/GrpcTransportBaseIT.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 import io.grpc.health.v1.HealthCheckResponse;
 
 import static org.opensearch.plugin.transport.grpc.Netty4GrpcServerTransport.GRPC_TRANSPORT_SETTING_KEY;
-import static org.opensearch.plugins.NetworkPlugin.AuxTransport.AUX_TRANSPORT_TYPES_KEY;
+import static org.opensearch.transport.AuxTransport.AUX_TRANSPORT_TYPES_KEY;
 
 /**
  * Base test class for gRPC transport integration tests.

--- a/plugins/transport-grpc/src/internalClusterTest/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransportIT.java
+++ b/plugins/transport-grpc/src/internalClusterTest/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransportIT.java
@@ -32,7 +32,7 @@ import static org.opensearch.plugin.transport.grpc.ssl.SecureNetty4GrpcServerTra
 import static org.opensearch.plugin.transport.grpc.ssl.SecureSettingsHelpers.getServerClientAuthNone;
 import static org.opensearch.plugin.transport.grpc.ssl.SecureSettingsHelpers.getServerClientAuthOptional;
 import static org.opensearch.plugin.transport.grpc.ssl.SecureSettingsHelpers.getServerClientAuthRequired;
-import static org.opensearch.plugins.NetworkPlugin.AuxTransport.AUX_TRANSPORT_TYPES_KEY;
+import static org.opensearch.transport.AuxTransport.AUX_TRANSPORT_TYPES_KEY;
 
 public abstract class SecureNetty4GrpcServerTransportIT extends OpenSearchIntegTestCase {
 

--- a/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/GrpcPlugin.java
+++ b/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/GrpcPlugin.java
@@ -28,6 +28,7 @@ import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.AuxTransport;
 import org.opensearch.transport.client.Client;
 import org.opensearch.watcher.ResourceWatcherService;
 

--- a/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/Netty4GrpcServerTransport.java
+++ b/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/Netty4GrpcServerTransport.java
@@ -232,6 +232,11 @@ public class Netty4GrpcServerTransport extends AuxTransport {
         this.portSettingKey = SETTING_GRPC_PORT.getKey();
     }
 
+    @Override
+    public String enableKey() {
+        return GRPC_TRANSPORT_SETTING_KEY;
+    }
+
     // public for tests
     @Override
     public BoundTransportAddress getBoundAddress() {

--- a/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/Netty4GrpcServerTransport.java
+++ b/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/Netty4GrpcServerTransport.java
@@ -21,7 +21,7 @@ import org.opensearch.core.common.transport.BoundTransportAddress;
 import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
-import org.opensearch.plugins.NetworkPlugin;
+import org.opensearch.transport.AuxTransport;
 import org.opensearch.transport.BindTransportException;
 
 import java.io.IOException;
@@ -56,7 +56,7 @@ import static org.opensearch.transport.Transport.resolveTransportPublishPort;
  * Netty4 gRPC server implemented as a LifecycleComponent.
  * Services injected through BindableService list.
  */
-public class Netty4GrpcServerTransport extends NetworkPlugin.AuxTransport {
+public class Netty4GrpcServerTransport extends AuxTransport {
     private static final Logger logger = LogManager.getLogger(Netty4GrpcServerTransport.class);
 
     /**

--- a/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/Netty4GrpcServerTransport.java
+++ b/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/Netty4GrpcServerTransport.java
@@ -233,7 +233,7 @@ public class Netty4GrpcServerTransport extends AuxTransport {
     }
 
     @Override
-    public String enableKey() {
+    public String settingKey() {
         return GRPC_TRANSPORT_SETTING_KEY;
     }
 

--- a/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransport.java
+++ b/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransport.java
@@ -92,6 +92,11 @@ public class SecureNetty4GrpcServerTransport extends Netty4GrpcServerTransport {
         }
     }
 
+    @Override
+    public String enableKey() {
+        return GRPC_SECURE_TRANSPORT_SETTING_KEY;
+    }
+
     /**
      * Construct JdkSslContext, wrapping javax SSLContext as supplied by SecureAuxTransportSettingsProvider with applied
      * configurations settings in SecureAuxTransportParameters for this transport.

--- a/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransport.java
+++ b/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransport.java
@@ -93,7 +93,7 @@ public class SecureNetty4GrpcServerTransport extends Netty4GrpcServerTransport {
     }
 
     @Override
-    public String enableKey() {
+    public String settingKey() {
         return GRPC_SECURE_TRANSPORT_SETTING_KEY;
     }
 

--- a/plugins/transport-grpc/src/test/java/org/opensearch/plugin/transport/grpc/GrpcPluginTests.java
+++ b/plugins/transport-grpc/src/test/java/org/opensearch/plugin/transport/grpc/GrpcPluginTests.java
@@ -14,10 +14,10 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.indices.breaker.CircuitBreakerService;
 import org.opensearch.plugin.transport.grpc.ssl.SecureNetty4GrpcServerTransport;
-import org.opensearch.plugins.NetworkPlugin;
 import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.AuxTransport;
 import org.opensearch.transport.client.Client;
 import org.junit.Before;
 
@@ -116,7 +116,7 @@ public class GrpcPluginTests extends OpenSearchTestCase {
     public void testGetAuxTransports() {
         Settings settings = Settings.builder().put(SETTING_GRPC_PORT.getKey(), "9200-9300").build();
 
-        Map<String, Supplier<NetworkPlugin.AuxTransport>> transports = plugin.getAuxTransports(
+        Map<String, Supplier<AuxTransport>> transports = plugin.getAuxTransports(
             settings,
             threadPool,
             circuitBreakerService,
@@ -129,14 +129,14 @@ public class GrpcPluginTests extends OpenSearchTestCase {
         assertTrue("Should contain GRPC_TRANSPORT_SETTING_KEY", transports.containsKey(GRPC_TRANSPORT_SETTING_KEY));
 
         // Verify that the supplier returns a Netty4GrpcServerTransport instance
-        NetworkPlugin.AuxTransport transport = transports.get(GRPC_TRANSPORT_SETTING_KEY).get();
+        AuxTransport transport = transports.get(GRPC_TRANSPORT_SETTING_KEY).get();
         assertTrue("Should return a Netty4GrpcServerTransport instance", transport instanceof Netty4GrpcServerTransport);
     }
 
     public void testGetSecureAuxTransports() {
         Settings settings = Settings.builder().put(SETTING_GRPC_SECURE_PORT.getKey(), "9200-9300").build();
 
-        Map<String, Supplier<NetworkPlugin.AuxTransport>> transports = plugin.getSecureAuxTransports(
+        Map<String, Supplier<AuxTransport>> transports = plugin.getSecureAuxTransports(
             settings,
             threadPool,
             circuitBreakerService,
@@ -150,7 +150,7 @@ public class GrpcPluginTests extends OpenSearchTestCase {
         assertTrue("Should contain GRPC_SECURE_TRANSPORT_SETTING_KEY", transports.containsKey(GRPC_SECURE_TRANSPORT_SETTING_KEY));
 
         // Verify that the supplier returns a Netty4GrpcServerTransport instance
-        NetworkPlugin.AuxTransport transport = transports.get(GRPC_SECURE_TRANSPORT_SETTING_KEY).get();
+        AuxTransport transport = transports.get(GRPC_SECURE_TRANSPORT_SETTING_KEY).get();
         assertTrue("Should return a SecureNetty4GrpcServerTransport instance", transport instanceof SecureNetty4GrpcServerTransport);
     }
 }

--- a/plugins/transport-grpc/src/test/java/org/opensearch/plugin/transport/grpc/ssl/SecureSettingsHelpers.java
+++ b/plugins/transport-grpc/src/test/java/org/opensearch/plugin/transport/grpc/ssl/SecureSettingsHelpers.java
@@ -9,8 +9,8 @@
 package org.opensearch.plugin.transport.grpc.ssl;
 
 import org.opensearch.common.settings.Settings;
-import org.opensearch.plugins.NetworkPlugin;
 import org.opensearch.plugins.SecureAuxTransportSettingsProvider;
+import org.opensearch.transport.AuxTransport;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -110,7 +110,7 @@ public class SecureSettingsHelpers {
     ) {
         return new SecureAuxTransportSettingsProvider() {
             @Override
-            public Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, NetworkPlugin.AuxTransport transport)
+            public Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, AuxTransport transport)
                 throws SSLException {
                 // Choose a random protocol from among supported test defaults
                 String protocol = randomFrom(DEFAULT_SSL_PROTOCOLS);

--- a/server/src/main/java/org/opensearch/bootstrap/Security.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Security.java
@@ -74,9 +74,9 @@ import java.util.regex.Pattern;
 
 import static org.opensearch.bootstrap.FilePermissionUtils.addDirectoryPath;
 import static org.opensearch.bootstrap.FilePermissionUtils.addSingleFilePath;
-import static org.opensearch.plugins.NetworkPlugin.AuxTransport.AUX_PORT_DEFAULTS;
-import static org.opensearch.plugins.NetworkPlugin.AuxTransport.AUX_TRANSPORT_PORT;
-import static org.opensearch.plugins.NetworkPlugin.AuxTransport.AUX_TRANSPORT_TYPES_SETTING;
+import static org.opensearch.transport.AuxTransport.AUX_PORT_DEFAULTS;
+import static org.opensearch.transport.AuxTransport.AUX_TRANSPORT_PORT;
+import static org.opensearch.transport.AuxTransport.AUX_TRANSPORT_TYPES_SETTING;
 
 /**
  * Initializes SecurityManager with necessary permissions.

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -147,7 +147,6 @@ import org.opensearch.node.remotestore.RemoteStoreNodeService;
 import org.opensearch.node.resource.tracker.ResourceTrackerSettings;
 import org.opensearch.persistent.PersistentTasksClusterService;
 import org.opensearch.persistent.decider.EnableAssignmentDecider;
-import org.opensearch.plugins.NetworkPlugin;
 import org.opensearch.plugins.PluginsService;
 import org.opensearch.ratelimitting.admissioncontrol.AdmissionControlSettings;
 import org.opensearch.ratelimitting.admissioncontrol.settings.CpuBasedAdmissionControllerSettings;

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -171,6 +171,7 @@ import org.opensearch.tasks.TaskResourceTrackingService;
 import org.opensearch.tasks.consumer.TopNSearchTasksLogger;
 import org.opensearch.telemetry.TelemetrySettings;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.AuxTransport;
 import org.opensearch.transport.ProxyConnectionStrategy;
 import org.opensearch.transport.RemoteClusterService;
 import org.opensearch.transport.RemoteConnectionStrategy;
@@ -362,7 +363,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 NetworkModule.TRANSPORT_SSL_DUAL_MODE_ENABLED,
                 NetworkModule.TRANSPORT_SSL_ENFORCE_HOSTNAME_VERIFICATION,
                 NetworkModule.TRANSPORT_SSL_ENFORCE_HOSTNAME_VERIFICATION_RESOLVE_HOST_NAME,
-                NetworkPlugin.AuxTransport.AUX_TRANSPORT_TYPES_SETTING,
+                AuxTransport.AUX_TRANSPORT_TYPES_SETTING,
                 HttpTransportSettings.SETTING_CORS_ALLOW_CREDENTIALS,
                 HttpTransportSettings.SETTING_CORS_ENABLED,
                 HttpTransportSettings.SETTING_CORS_MAX_AGE,

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -271,6 +271,7 @@ import org.opensearch.telemetry.tracing.TracerFactory;
 import org.opensearch.threadpool.ExecutorBuilder;
 import org.opensearch.threadpool.RunnableTaskExecutionListener;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.AuxTransport;
 import org.opensearch.transport.RemoteClusterService;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportInterceptor;
@@ -2174,7 +2175,7 @@ public class Node implements Closeable {
         return networkModule.getHttpServerTransportSupplier().get();
     }
 
-    protected List<NetworkPlugin.AuxTransport> newAuxTransports(NetworkModule networkModule) {
+    protected List<AuxTransport> newAuxTransports(NetworkModule networkModule) {
         return networkModule.getAuxServerTransportList();
     }
 

--- a/server/src/main/java/org/opensearch/plugins/NetworkPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/NetworkPlugin.java
@@ -48,6 +48,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.http.HttpServerTransport;
 import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.AuxTransport;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportInterceptor;
 
@@ -66,38 +67,6 @@ import static org.opensearch.common.settings.Setting.affixKeySetting;
  * @opensearch.api
  */
 public interface NetworkPlugin {
-
-    /**
-     * Auxiliary transports are lifecycle components with an associated port range.
-     * These pluggable client/server transport implementations have their lifecycle managed by Node.
-     *
-     * Auxiliary transports are additionally defined by a port range on which they bind. Opening permissions on these
-     * ports is awkward as {@link org.opensearch.bootstrap.Security} is configured previous to Node initialization during
-     * bootstrap. To allow pluggable AuxTransports access to configurable port ranges we require the port range be provided
-     * through an {@link org.opensearch.common.settings.Setting.AffixSetting} of the form 'AUX_SETTINGS_PREFIX.{aux-transport-key}.ports'.
-     */
-    @ExperimentalApi
-    abstract class AuxTransport extends AbstractLifecycleComponent {
-        public static final String AUX_SETTINGS_PREFIX = "aux.transport.";
-        public static final String AUX_TRANSPORT_TYPES_KEY = AUX_SETTINGS_PREFIX + "types";
-        public static final String AUX_PORT_DEFAULTS = "9400-9500";
-        public static final Setting.AffixSetting<PortsRange> AUX_TRANSPORT_PORT = affixKeySetting(
-            AUX_SETTINGS_PREFIX,
-            "port",
-            key -> new Setting<>(key, AUX_PORT_DEFAULTS, PortsRange::new, Setting.Property.NodeScope)
-        );
-
-        public static final Setting<List<String>> AUX_TRANSPORT_TYPES_SETTING = Setting.listSetting(
-            AUX_TRANSPORT_TYPES_KEY,
-            emptyList(),
-            Function.identity(),
-            Setting.Property.NodeScope
-        );
-
-        // public for tests
-        public abstract BoundTransportAddress getBoundAddress();
-    }
-
     /**
      * Auxiliary transports are optional and run in parallel to the default HttpServerTransport.
      * Returns a map of AuxTransport suppliers.
@@ -166,7 +135,7 @@ public interface NetworkPlugin {
 
     /**
      * Returns a map of secure {@link AuxTransport} suppliers.
-     * See {@link org.opensearch.plugins.NetworkPlugin.AuxTransport#AUX_TRANSPORT_TYPES_SETTING} to configure a specific implementation.
+     * See {@link org.opensearch.transport.AuxTransport#AUX_TRANSPORT_TYPES_SETTING} to configure a specific implementation.
      */
     @ExperimentalApi
     default Map<String, Supplier<AuxTransport>> getSecureAuxTransports(

--- a/server/src/main/java/org/opensearch/plugins/NetworkPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/NetworkPlugin.java
@@ -32,17 +32,13 @@
 package org.opensearch.plugins;
 
 import org.opensearch.common.annotation.ExperimentalApi;
-import org.opensearch.common.lifecycle.AbstractLifecycleComponent;
 import org.opensearch.common.network.NetworkService;
 import org.opensearch.common.settings.ClusterSettings;
-import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.transport.PortsRange;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.common.util.PageCacheRecycler;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
-import org.opensearch.core.common.transport.BoundTransportAddress;
 import org.opensearch.core.indices.breaker.CircuitBreakerService;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.http.HttpServerTransport;
@@ -55,11 +51,7 @@ import org.opensearch.transport.TransportInterceptor;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.function.Supplier;
-
-import static java.util.Collections.emptyList;
-import static org.opensearch.common.settings.Setting.affixKeySetting;
 
 /**
  * Plugin for extending network and transport related classes

--- a/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
@@ -10,6 +10,7 @@ package org.opensearch.plugins;
 
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.transport.AuxTransport;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
@@ -27,7 +28,7 @@ public interface SecureAuxTransportSettingsProvider {
      * Fetch an SSLContext as managed by pluggable security provider.
      * @return an instance of SSLContext.
      */
-    default Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, NetworkPlugin.AuxTransport transport)
+    default Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, AuxTransport transport)
         throws SSLException {
         return Optional.empty();
     }

--- a/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
@@ -28,8 +28,7 @@ public interface SecureAuxTransportSettingsProvider {
      * Fetch an SSLContext as managed by pluggable security provider.
      * @return an instance of SSLContext.
      */
-    default Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, AuxTransport transport)
-        throws SSLException {
+    default Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, AuxTransport transport) throws SSLException {
         return Optional.empty();
     }
 

--- a/server/src/main/java/org/opensearch/transport/AuxTransport.java
+++ b/server/src/main/java/org/opensearch/transport/AuxTransport.java
@@ -39,13 +39,18 @@ public abstract class AuxTransport extends AbstractLifecycleComponent {
         "port",
         key -> new Setting<>(key, AUX_PORT_DEFAULTS, PortsRange::new, Setting.Property.NodeScope)
     );
-
     public static final Setting<List<String>> AUX_TRANSPORT_TYPES_SETTING = Setting.listSetting(
         AUX_TRANSPORT_TYPES_KEY,
         emptyList(),
         Function.identity(),
         Setting.Property.NodeScope
     );
+
+    /**
+     * @return unique key for enabling this transport per AUX_TRANSPORT_TYPES_KEY.
+     * This key is used to identify the aux transport in settings across plugins.
+     */
+    public abstract String enableKey();
 
     // public for tests
     public abstract BoundTransportAddress getBoundAddress();

--- a/server/src/main/java/org/opensearch/transport/AuxTransport.java
+++ b/server/src/main/java/org/opensearch/transport/AuxTransport.java
@@ -47,10 +47,10 @@ public abstract class AuxTransport extends AbstractLifecycleComponent {
     );
 
     /**
-     * @return unique key for enabling this transport per AUX_TRANSPORT_TYPES_KEY.
-     * This key is used to identify the aux transport in settings across plugins.
+     * @return unique name for which this transport is identified in settings.
+     * This should identify your transport for the purposes of enabling with AUX_TRANSPORT_TYPES_KEY setting.
      */
-    public abstract String enableKey();
+    public abstract String settingKey();
 
     // public for tests
     public abstract BoundTransportAddress getBoundAddress();

--- a/server/src/main/java/org/opensearch/transport/AuxTransport.java
+++ b/server/src/main/java/org/opensearch/transport/AuxTransport.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.transport;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.lifecycle.AbstractLifecycleComponent;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.transport.PortsRange;
+import org.opensearch.core.common.transport.BoundTransportAddress;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static java.util.Collections.emptyList;
+import static org.opensearch.common.settings.Setting.affixKeySetting;
+
+/**
+ * Auxiliary transports are lifecycle components with an associated port range.
+ * These pluggable client/server transport implementations have their lifecycle managed by Node.
+ *
+ * Auxiliary transports are additionally defined by a port range on which they bind. Opening permissions on these
+ * ports is awkward as {@link org.opensearch.bootstrap.Security} is configured previous to Node initialization during
+ * bootstrap. To allow pluggable AuxTransports access to configurable port ranges we require the port range be provided
+ * through an {@link org.opensearch.common.settings.Setting.AffixSetting} of the form 'AUX_SETTINGS_PREFIX.{aux-transport-key}.ports'.
+ */
+@ExperimentalApi
+public abstract class AuxTransport extends AbstractLifecycleComponent {
+    public static final String AUX_SETTINGS_PREFIX = "aux.transport.";
+    public static final String AUX_TRANSPORT_TYPES_KEY = AUX_SETTINGS_PREFIX + "types";
+    public static final String AUX_PORT_DEFAULTS = "9400-9500";
+    public static final Setting.AffixSetting<PortsRange> AUX_TRANSPORT_PORT = affixKeySetting(
+        AUX_SETTINGS_PREFIX,
+        "port",
+        key -> new Setting<>(key, AUX_PORT_DEFAULTS, PortsRange::new, Setting.Property.NodeScope)
+    );
+
+    public static final Setting<List<String>> AUX_TRANSPORT_TYPES_SETTING = Setting.listSetting(
+        AUX_TRANSPORT_TYPES_KEY,
+        emptyList(),
+        Function.identity(),
+        Setting.Property.NodeScope
+    );
+
+    // public for tests
+    public abstract BoundTransportAddress getBoundAddress();
+}


### PR DESCRIPTION
### Description
Adds a few changes with the goal of making AuxTransport settings more easily configured/extended.

- Moves `AuxTransport` out of `NetworkPlugin` into `org.opensearch.transport.AuxTransport`.
Minor refactor. All other transport base classes are in this package and AuxTransport a bit out of place in `NetworkPlugin`.
- Adds a `settingKey` accessor to AuxTransport.
Forward looking change for plugins which want to identify the namespace of AuxTransports.
(https://github.com/opensearch-project/security/pull/5375)
- Bugfix for `FlightStreamPlugin` which registers the `FlightService` AuxTransport under key `aux.transport.types`.
Moved this to `experimental-transport-arrow-flight-rpc` which users will need to include under `aux.transport.types` setting to enable this transport.
 
### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
