### PR TITLE
Replace Version with RemoteVersion in reindex module

### DIFF
--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteRequestBuilders.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteRequestBuilders.java
@@ -35,7 +35,6 @@ package org.opensearch.index.reindex.remote;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.opensearch.OpenSearchException;
-import org.opensearch.Version;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.client.Request;
 import org.opensearch.common.logging.DeprecationLogger;
@@ -74,7 +73,7 @@ final class RemoteRequestBuilders {
 
     private RemoteRequestBuilders() {}
 
-    static Request initialSearch(SearchRequest searchRequest, BytesReference query, Version remoteVersion) {
+    static Request initialSearch(SearchRequest searchRequest, BytesReference query, RemoteVersion remoteVersion) {
         // It is nasty to build paths with StringBuilder but we'll be careful....
         StringBuilder path = new StringBuilder("/");
         addIndices(path, searchRequest.indices());
@@ -84,7 +83,7 @@ final class RemoteRequestBuilders {
         if (searchRequest.scroll() != null) {
             TimeValue keepAlive = searchRequest.scroll().keepAlive();
             // V_5_0_0
-            if (remoteVersion.before(Version.fromId(5000099))) {
+            if (remoteVersion.before(RemoteVersion.V_5_0_0)) {
                 /* Versions of Elasticsearch before 5.0 couldn't parse nanos or micros
                  * so we toss out that resolution, rounding up because more scroll
                  * timeout seems safer than less. */
@@ -103,7 +102,7 @@ final class RemoteRequestBuilders {
         if (searchRequest.source().sorts() != null) {
             boolean useScan = false;
             // Detect if we should use search_type=scan rather than a sort
-            if (remoteVersion.before(Version.fromId(2010099))) {
+            if (remoteVersion.before(RemoteVersion.V_2_1_0)) {
                 for (SortBuilder<?> sort : searchRequest.source().sorts()) {
                     if (sort instanceof FieldSortBuilder) {
                         FieldSortBuilder f = (FieldSortBuilder) sort;
@@ -124,10 +123,10 @@ final class RemoteRequestBuilders {
                 request.addParameter("sort", sorts.toString());
             }
         }
-        if (remoteVersion.before(Version.fromId(2000099))) {
+        if (remoteVersion.before(RemoteVersion.V_2_0_0)) {
             // Versions before 2.0.0 need prompting to return interesting fields. Note that timestamp isn't available at all....
             searchRequest.source().storedField("_parent").storedField("_routing").storedField("_ttl");
-            if (remoteVersion.before(Version.fromId(1000099))) {
+            if (remoteVersion.before(RemoteVersion.V_1_0_0)) {
                 // Versions before 1.0.0 don't support `"_source": true` so we have to ask for the _source in a funny way.
                 if (false == searchRequest.source().storedFields().fieldNames().contains("_source")) {
                     searchRequest.source().storedField("_source");
@@ -140,11 +139,11 @@ final class RemoteRequestBuilders {
                 fields.append(',').append(searchRequest.source().storedFields().fieldNames().get(i));
             }
             // V_5_0_0
-            String storedFieldsParamName = remoteVersion.before(Version.fromId(5000099)) ? "fields" : "stored_fields";
+            String storedFieldsParamName = remoteVersion.before(RemoteVersion.V_5_0_0) ? "fields" : "stored_fields";
             request.addParameter(storedFieldsParamName, fields.toString());
         }
 
-        if (remoteVersion.onOrAfter(Version.fromId(6030099))) {
+        if (remoteVersion.onOrAfter(RemoteVersion.V_6_3_0)) {
             // allow_partial_results introduced in 6.3, running remote reindex against earlier versions still silently discards RED shards.
             request.addParameter("allow_partial_search_results", "false");
         }
@@ -173,7 +172,7 @@ final class RemoteRequestBuilders {
             if (searchRequest.source().fetchSource() != null) {
                 entity.field("_source", searchRequest.source().fetchSource());
             } else {
-                if (remoteVersion.onOrAfter(Version.fromId(1000099))) {
+                if (remoteVersion.onOrAfter(RemoteVersion.V_1_0_0)) {
                     // Versions before 1.0 don't support `"_source": true` so we have to ask for the source as a stored field.
                     entity.field("_source", true);
                 }
@@ -225,11 +224,10 @@ final class RemoteRequestBuilders {
         throw new IllegalArgumentException("Unsupported sort [" + sort + "]");
     }
 
-    static Request scroll(String scroll, TimeValue keepAlive, Version remoteVersion) {
+    static Request scroll(String scroll, TimeValue keepAlive, RemoteVersion remoteVersion) {
         Request request = new Request("POST", "/_search/scroll");
 
-        // V_5_0_0
-        if (remoteVersion.before(Version.fromId(5000099))) {
+        if (remoteVersion.before(RemoteVersion.V_5_0_0)) {
             /* Versions of Elasticsearch before 5.0 couldn't parse nanos or micros
              * so we toss out that resolution, rounding up so we shouldn't end up
              * with 0s. */
@@ -237,7 +235,7 @@ final class RemoteRequestBuilders {
         }
         request.addParameter("scroll", keepAlive.getStringRep());
 
-        if (remoteVersion.before(Version.fromId(2000099))) {
+        if (remoteVersion.before(RemoteVersion.V_2_0_0)) {
             // Versions before 2.0.0 extract the plain scroll_id from the body
             request.setEntity(new StringEntity(scroll, ContentType.TEXT_PLAIN));
             return request;
@@ -252,10 +250,10 @@ final class RemoteRequestBuilders {
         return request;
     }
 
-    static Request clearScroll(String scroll, Version remoteVersion) {
+    static Request clearScroll(String scroll, RemoteVersion remoteVersion) {
         Request request = new Request("DELETE", "/_search/scroll");
 
-        if (remoteVersion.before(Version.fromId(2000099))) {
+        if (remoteVersion.before(RemoteVersion.V_2_0_0)) {
             // Versions before 2.0.0 extract the plain scroll_id from the body
             request.setEntity(new StringEntity(scroll, ContentType.TEXT_PLAIN));
             return request;

--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteResponseParsers.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteResponseParsers.java
@@ -33,8 +33,6 @@
 package org.opensearch.index.reindex.remote;
 
 import org.apache.lucene.search.TotalHits;
-import org.opensearch.LegacyESVersion;
-import org.opensearch.Version;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.ParsingException;
@@ -294,21 +292,20 @@ final class RemoteResponseParsers {
     }
 
     /**
-     * Parses the main action to return just the {@linkplain Version} that it returns. We throw everything else out.
+     * Parses the main action to return just the {@linkplain RemoteVersion} that it returns. We throw everything else out.
      */
-    public static final ConstructingObjectParser<Version, MediaType> MAIN_ACTION_PARSER = new ConstructingObjectParser<>(
+    public static final ConstructingObjectParser<RemoteVersion, MediaType> MAIN_ACTION_PARSER = new ConstructingObjectParser<>(
         "/",
         true,
-        a -> (Version) a[0]
+        a -> (RemoteVersion) a[0]
     );
     static {
-        ConstructingObjectParser<Version, MediaType> versionParser = new ConstructingObjectParser<>(
-            "version",
-            true,
-            a -> a[0] == null
-                ? LegacyESVersion.fromString(((String) a[1]).replace("-SNAPSHOT", "").replaceFirst("-(alpha\\d+|beta\\d+|rc\\d+)", ""))
-                : Version.fromString(((String) a[1]).replace("-SNAPSHOT", "").replaceFirst("-(alpha\\d+|beta\\d+|rc\\d+)", ""))
-        );
+        ConstructingObjectParser<RemoteVersion, MediaType> versionParser = new ConstructingObjectParser<>("version", true, a -> {
+            String distribution = (String) a[0];
+            String number = (String) a[1];
+            String cleanNumber = number.replace("-SNAPSHOT", "").replaceFirst("-(alpha\\d+|beta\\d+|rc\\d+)", "");
+            return RemoteVersion.fromString(cleanNumber, distribution);
+        });
         versionParser.declareStringOrNull(optionalConstructorArg(), new ParseField("distribution"));
         versionParser.declareString(constructorArg(), new ParseField("number"));
         MAIN_ACTION_PARSER.declareObject(constructorArg(), versionParser, new ParseField("version"));

--- a/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteVersion.java
+++ b/modules/reindex/src/main/java/org/opensearch/index/reindex/remote/RemoteVersion.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.reindex.remote;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Represents a version of a remote Elasticsearch or OpenSearch cluster for reindexing purposes.
+ * This class provides backward compatibility support for communicating with older Elasticsearch versions
+ * without relying on the global Version class.
+ */
+public final class RemoteVersion implements Comparable<RemoteVersion> {
+
+    private final int major;
+    private final int minor;
+    private final int revision;
+    private final String distribution;
+
+    // Common version constants for backward compatibility
+    public static final RemoteVersion V_0_20_5 = new RemoteVersion(0, 20, 5, null);
+    public static final RemoteVersion V_0_90_13 = new RemoteVersion(0, 90, 13, null);
+    public static final RemoteVersion V_1_0_0 = new RemoteVersion(1, 0, 0, null);
+    public static final RemoteVersion V_1_7_5 = new RemoteVersion(1, 7, 5, null);
+    public static final RemoteVersion V_2_0_0 = new RemoteVersion(2, 0, 0, null);
+    public static final RemoteVersion V_2_1_0 = new RemoteVersion(2, 1, 0, null);
+    public static final RemoteVersion V_2_3_3 = new RemoteVersion(2, 3, 3, null);
+    public static final RemoteVersion V_5_0_0 = new RemoteVersion(5, 0, 0, null);
+    public static final RemoteVersion V_6_0_0 = new RemoteVersion(6, 0, 0, null);
+    public static final RemoteVersion V_6_3_0 = new RemoteVersion(6, 3, 0, null);
+    public static final RemoteVersion V_7_0_0 = new RemoteVersion(7, 0, 0, null);
+
+    // OpenSearch versions
+    public static final RemoteVersion OPENSEARCH_1_0_0 = new RemoteVersion(1, 0, 0, "opensearch");
+    public static final RemoteVersion OPENSEARCH_2_0_0 = new RemoteVersion(2, 0, 0, "opensearch");
+    public static final RemoteVersion OPENSEARCH_3_1_0 = new RemoteVersion(3, 1, 0, "opensearch");
+
+    public RemoteVersion(int major, int minor, int revision, String distribution) {
+        this.major = major;
+        this.minor = minor;
+        this.revision = revision;
+        this.distribution = distribution != null ? distribution.toLowerCase(Locale.ROOT) : "elasticsearch";
+    }
+
+    /**
+     * Parse version string like "7.10.2" or "1.0.0"
+     */
+    public static RemoteVersion fromString(String version, String distribution) {
+        if (version == null || version.trim().isEmpty()) {
+            throw new IllegalArgumentException("Version string cannot be null or empty");
+        }
+
+        // Remove snapshot and pre-release qualifiers
+        String cleanVersion = version.replace("-SNAPSHOT", "").replaceFirst("-(alpha\\d+|beta\\d+|rc\\d+)", "");
+
+        String[] parts = cleanVersion.split("\\.");
+        if (parts.length < 2) {
+            throw new IllegalArgumentException("Invalid version format: " + version);
+        }
+
+        try {
+            int major = Integer.parseInt(parts[0]);
+            int minor = Integer.parseInt(parts[1]);
+            int revision = parts.length > 2 ? Integer.parseInt(parts[2]) : 0;
+
+            return new RemoteVersion(major, minor, revision, distribution);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid version format: " + version, e);
+        }
+    }
+
+    public static RemoteVersion fromString(String version) {
+        return fromString(version, "elasticsearch");
+    }
+
+    public boolean before(RemoteVersion other) {
+        return this.compareTo(other) < 0;
+    }
+
+    public boolean onOrAfter(RemoteVersion other) {
+        return this.compareTo(other) >= 0;
+    }
+
+    public boolean onOrBefore(RemoteVersion other) {
+        return this.compareTo(other) <= 0;
+    }
+
+    public boolean after(RemoteVersion other) {
+        return this.compareTo(other) > 0;
+    }
+
+    public boolean isOpenSearch() {
+        return "opensearch".equals(distribution);
+    }
+
+    public boolean isElasticsearch() {
+        return "elasticsearch".equals(distribution);
+    }
+
+    @Override
+    public int compareTo(RemoteVersion other) {
+        if (other == null) {
+            return 1;
+        }
+
+        int result = Integer.compare(this.major, other.major);
+        if (result != 0) {
+            return result;
+        }
+
+        result = Integer.compare(this.minor, other.minor);
+        if (result != 0) {
+            return result;
+        }
+
+        return Integer.compare(this.revision, other.revision);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        RemoteVersion that = (RemoteVersion) obj;
+        return major == that.major && minor == that.minor && revision == that.revision && Objects.equals(distribution, that.distribution);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(major, minor, revision, distribution);
+    }
+
+    @Override
+    public String toString() {
+        return major + "." + minor + "." + revision;
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public int getRevision() {
+        return revision;
+    }
+
+    public String getDistribution() {
+        return distribution;
+    }
+}

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteRequestBuildersTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteRequestBuildersTests.java
@@ -34,7 +34,6 @@ package org.opensearch.index.reindex.remote;
 
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
-import org.opensearch.Version;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.client.Request;
 import org.opensearch.common.io.Streams;
@@ -72,7 +71,7 @@ import static org.hamcrest.Matchers.not;
  */
 public class RemoteRequestBuildersTests extends OpenSearchTestCase {
     public void testIntialSearchPath() {
-        Version remoteVersion = Version.fromId(between(0, Version.CURRENT.id));
+        RemoteVersion remoteVersion = RemoteVersion.V_2_0_0;
         BytesReference query = new BytesArray("{}");
 
         SearchRequest searchRequest = new SearchRequest().source(new SearchSourceBuilder());
@@ -108,7 +107,7 @@ public class RemoteRequestBuildersTests extends OpenSearchTestCase {
     }
 
     private void expectBadStartRequest(SearchRequest searchRequest, String type, String bad, String failed) {
-        Version remoteVersion = Version.fromId(between(0, Version.CURRENT.id));
+        RemoteVersion remoteVersion = RemoteVersion.V_2_0_0;
         BytesReference query = new BytesArray("{}");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> initialSearch(searchRequest, query, remoteVersion));
         assertEquals(type + " containing [" + bad + "] not supported but got [" + failed + "]", e.getMessage());
@@ -119,16 +118,16 @@ public class RemoteRequestBuildersTests extends OpenSearchTestCase {
         SearchRequest searchRequest = new SearchRequest().source(new SearchSourceBuilder());
 
         // Test sort:_doc for versions that support it.
-        Version remoteVersion = Version.fromId(between(2010099, Version.CURRENT.id));
+        RemoteVersion remoteVersion = RemoteVersion.V_2_1_0;
         searchRequest.source().sort("_doc");
         assertThat(initialSearch(searchRequest, query, remoteVersion).getParameters(), hasEntry("sort", "_doc:asc"));
 
         // Test search_type scan for versions that don't support sort:_doc.
-        remoteVersion = Version.fromId(between(0, 2010099 - 1));
+        remoteVersion = RemoteVersion.V_2_0_0;
         assertThat(initialSearch(searchRequest, query, remoteVersion).getParameters(), hasEntry("search_type", "scan"));
 
         // Test sorting by some field. Version doesn't matter.
-        remoteVersion = Version.fromId(between(0, Version.CURRENT.id));
+        remoteVersion = RemoteVersion.OPENSEARCH_2_0_0;
         searchRequest.source().sorts().clear();
         searchRequest.source().sort("foo");
         assertThat(initialSearch(searchRequest, query, remoteVersion).getParameters(), hasEntry("sort", "foo:asc"));
@@ -139,7 +138,7 @@ public class RemoteRequestBuildersTests extends OpenSearchTestCase {
         SearchRequest searchRequest = new SearchRequest().source(new SearchSourceBuilder());
 
         // Test request without any fields
-        Version remoteVersion = Version.fromId(between(2000099, Version.CURRENT.id));
+        RemoteVersion remoteVersion = RemoteVersion.V_2_0_0;
         assertThat(
             initialSearch(searchRequest, query, remoteVersion).getParameters(),
             not(either(hasKey("stored_fields")).or(hasKey("fields")))
@@ -148,21 +147,19 @@ public class RemoteRequestBuildersTests extends OpenSearchTestCase {
         // Test stored_fields for versions that support it
         searchRequest = new SearchRequest().source(new SearchSourceBuilder());
         searchRequest.source().storedField("_source").storedField("_id");
-        // V_5_0_0_alpha4 => current
-        remoteVersion = Version.fromId(between(5000004, Version.CURRENT.id));
+        remoteVersion = RemoteVersion.V_5_0_0;
         assertThat(initialSearch(searchRequest, query, remoteVersion).getParameters(), hasEntry("stored_fields", "_source,_id"));
 
         // Test fields for versions that support it
         searchRequest = new SearchRequest().source(new SearchSourceBuilder());
         searchRequest.source().storedField("_source").storedField("_id");
-        // V_2_0_0 => V_5_0_0_alpha3
-        remoteVersion = Version.fromId(between(2000099, 5000003));
+        remoteVersion = RemoteVersion.V_2_0_0;
         assertThat(initialSearch(searchRequest, query, remoteVersion).getParameters(), hasEntry("fields", "_source,_id"));
 
         // Test extra fields for versions that need it
         searchRequest = new SearchRequest().source(new SearchSourceBuilder());
         searchRequest.source().storedField("_source").storedField("_id");
-        remoteVersion = Version.fromId(between(0, 2000099 - 1));
+        remoteVersion = RemoteVersion.V_1_7_5;
         assertThat(
             initialSearch(searchRequest, query, remoteVersion).getParameters(),
             hasEntry("fields", "_source,_id,_parent,_routing,_ttl")
@@ -171,14 +168,14 @@ public class RemoteRequestBuildersTests extends OpenSearchTestCase {
         // But only versions before 1.0 force _source to be in the list
         searchRequest = new SearchRequest().source(new SearchSourceBuilder());
         searchRequest.source().storedField("_id");
-        remoteVersion = Version.fromId(between(1000099, 2000099 - 1));
+        remoteVersion = RemoteVersion.V_1_7_5;
         assertThat(initialSearch(searchRequest, query, remoteVersion).getParameters(), hasEntry("fields", "_id,_parent,_routing,_ttl"));
     }
 
     public void testInitialSearchParamsMisc() {
         BytesReference query = new BytesArray("{}");
         SearchRequest searchRequest = new SearchRequest().source(new SearchSourceBuilder());
-        Version remoteVersion = Version.fromId(between(0, Version.CURRENT.id));
+        RemoteVersion remoteVersion = RemoteVersion.OPENSEARCH_2_0_0;
 
         TimeValue scroll = null;
         if (randomBoolean()) {
@@ -210,23 +207,21 @@ public class RemoteRequestBuildersTests extends OpenSearchTestCase {
 
     public void testInitialSearchDisallowPartialResults() {
         final String allowPartialParamName = "allow_partial_search_results";
-        final int v6_3 = 6030099;
 
         BytesReference query = new BytesArray("{}");
         SearchRequest searchRequest = new SearchRequest().source(new SearchSourceBuilder());
 
-        Version disallowVersion = Version.fromId(between(v6_3, Version.CURRENT.id));
+        RemoteVersion disallowVersion = RemoteVersion.V_6_3_0;
         Map<String, String> params = initialSearch(searchRequest, query, disallowVersion).getParameters();
         assertEquals("false", params.get(allowPartialParamName));
 
-        Version allowVersion = Version.fromId(between(0, v6_3 - 1));
+        RemoteVersion allowVersion = RemoteVersion.V_6_0_0;
         params = initialSearch(searchRequest, query, allowVersion).getParameters();
         assertThat(params.keySet(), not(contains(allowPartialParamName)));
     }
 
-    private void assertScroll(Version remoteVersion, Map<String, String> params, TimeValue requested) {
-        // V_5_0_0
-        if (remoteVersion.before(Version.fromId(5000099))) {
+    private void assertScroll(RemoteVersion remoteVersion, Map<String, String> params, TimeValue requested) {
+        if (remoteVersion.before(RemoteVersion.V_5_0_0)) {
             // Versions of Elasticsearch prior to 5.0 can't parse nanos or micros in TimeValue.
             assertThat(params.get("scroll"), not(either(endsWith("nanos")).or(endsWith("micros"))));
             if (requested.getStringRep().endsWith("nanos") || requested.getStringRep().endsWith("micros")) {
@@ -239,14 +234,14 @@ public class RemoteRequestBuildersTests extends OpenSearchTestCase {
     }
 
     public void testInitialSearchEntity() throws IOException {
-        Version remoteVersion = Version.fromId(between(0, Version.CURRENT.id));
+        RemoteVersion remoteVersion = RemoteVersion.V_2_0_0;
 
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.source(new SearchSourceBuilder());
         String query = "{\"match_all\":{}}";
         HttpEntity entity = initialSearch(searchRequest, new BytesArray(query), remoteVersion).getEntity();
         assertEquals(ContentType.APPLICATION_JSON.toString(), entity.getContentType());
-        if (remoteVersion.onOrAfter(Version.fromId(1000099))) {
+        if (remoteVersion.onOrAfter(RemoteVersion.V_1_0_0)) {
             assertEquals(
                 "{\"query\":" + query + ",\"_source\":true}",
                 Streams.copyToString(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8))
@@ -279,14 +274,14 @@ public class RemoteRequestBuildersTests extends OpenSearchTestCase {
 
     public void testScrollParams() {
         String scroll = randomAlphaOfLength(30);
-        Version remoteVersion = Version.fromId(between(0, Version.CURRENT.id));
+        RemoteVersion remoteVersion = RemoteVersion.V_2_0_0;
         TimeValue keepAlive = TimeValue.parseTimeValue(randomPositiveTimeValue(), "test");
         assertScroll(remoteVersion, scroll(scroll, keepAlive, remoteVersion).getParameters(), keepAlive);
     }
 
     public void testScrollEntity() throws IOException {
         String scroll = randomAlphaOfLength(30);
-        HttpEntity entity = scroll(scroll, timeValueMillis(between(1, 1000)), Version.fromString("5.0.0")).getEntity();
+        HttpEntity entity = scroll(scroll, timeValueMillis(between(1, 1000)), RemoteVersion.V_5_0_0).getEntity();
         assertEquals(ContentType.APPLICATION_JSON.toString(), entity.getContentType());
         assertThat(
             Streams.copyToString(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8)),
@@ -294,14 +289,14 @@ public class RemoteRequestBuildersTests extends OpenSearchTestCase {
         );
 
         // Test with version < 2.0.0
-        entity = scroll(scroll, timeValueMillis(between(1, 1000)), Version.fromId(1070499)).getEntity();
+        entity = scroll(scroll, timeValueMillis(between(1, 1000)), RemoteVersion.V_1_7_5).getEntity();
         assertEquals(ContentType.TEXT_PLAIN.toString(), entity.getContentType());
         assertEquals(scroll, Streams.copyToString(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8)));
     }
 
     public void testClearScroll() throws IOException {
         String scroll = randomAlphaOfLength(30);
-        Request request = clearScroll(scroll, Version.fromString("5.0.0"));
+        Request request = clearScroll(scroll, RemoteVersion.V_5_0_0);
         assertEquals(ContentType.APPLICATION_JSON.toString(), request.getEntity().getContentType());
         assertThat(
             Streams.copyToString(new InputStreamReader(request.getEntity().getContent(), StandardCharsets.UTF_8)),
@@ -310,7 +305,7 @@ public class RemoteRequestBuildersTests extends OpenSearchTestCase {
         assertThat(request.getParameters().keySet(), empty());
 
         // Test with version < 2.0.0
-        request = clearScroll(scroll, Version.fromId(1070499));
+        request = clearScroll(scroll, RemoteVersion.V_1_7_5);
         assertEquals(ContentType.TEXT_PLAIN.toString(), request.getEntity().getContentType());
         assertEquals(scroll, Streams.copyToString(new InputStreamReader(request.getEntity().getContent(), StandardCharsets.UTF_8)));
         assertThat(request.getParameters().keySet(), empty());

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
@@ -55,9 +55,7 @@ import org.apache.hc.core5.http.nio.HandlerFactory;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.IOReactorStatus;
-import org.opensearch.LegacyESVersion;
 import org.opensearch.OpenSearchStatusException;
-import org.opensearch.Version;
 import org.opensearch.action.bulk.BackoffPolicy;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.client.ResponseException;
@@ -158,18 +156,16 @@ public class RemoteScrollableHitSourceTests extends OpenSearchTestCase {
     }
 
     public void testLookupRemoteVersion() throws Exception {
-        assertLookupRemoteVersion(LegacyESVersion.fromString("0.20.5"), "main/0_20_5.json");
-        assertLookupRemoteVersion(LegacyESVersion.fromString("0.90.13"), "main/0_90_13.json");
-        assertLookupRemoteVersion(LegacyESVersion.fromString("1.7.5"), "main/1_7_5.json");
-        assertLookupRemoteVersion(LegacyESVersion.fromId(2030399), "main/2_3_3.json");
-        // assert for V_5_0_0 (no qualifier) since we no longer consider qualifier in Version since 7
-        assertLookupRemoteVersion(LegacyESVersion.fromId(5000099), "main/5_0_0_alpha_3.json");
-        // V_5_0_0 since we no longer consider qualifier in Version
-        assertLookupRemoteVersion(LegacyESVersion.fromId(5000099), "main/with_unknown_fields.json");
-        assertLookupRemoteVersion(Version.fromId(1000099 ^ Version.MASK), "main/OpenSearch_1_0_0.json");
+        assertLookupRemoteVersion(RemoteVersion.V_0_20_5, "main/0_20_5.json");
+        assertLookupRemoteVersion(RemoteVersion.V_0_90_13, "main/0_90_13.json");
+        assertLookupRemoteVersion(RemoteVersion.V_1_7_5, "main/1_7_5.json");
+        assertLookupRemoteVersion(RemoteVersion.V_2_3_3, "main/2_3_3.json");
+        assertLookupRemoteVersion(RemoteVersion.V_5_0_0, "main/5_0_0_alpha_3.json");
+        assertLookupRemoteVersion(RemoteVersion.V_5_0_0, "main/with_unknown_fields.json");
+        assertLookupRemoteVersion(RemoteVersion.OPENSEARCH_1_0_0, "main/OpenSearch_1_0_0.json");
     }
 
-    private void assertLookupRemoteVersion(Version expected, String s) throws Exception {
+    private void assertLookupRemoteVersion(RemoteVersion expected, String s) throws Exception {
         AtomicBoolean called = new AtomicBoolean();
         sourceWithMockedRemoteCall(false, ContentType.APPLICATION_JSON, s).lookupRemoteVersion(wrapAsListener(v -> {
             assertEquals(expected, v);
@@ -513,7 +509,7 @@ public class RemoteScrollableHitSourceTests extends OpenSearchTestCase {
     public void testNoContentTypeIsError() {
         RuntimeException e = expectListenerFailure(
             RuntimeException.class,
-            (RejectAwareActionListener<Version> listener) -> sourceWithMockedRemoteCall(false, null, "main/0_20_5.json")
+            (RejectAwareActionListener<RemoteVersion> listener) -> sourceWithMockedRemoteCall(false, null, "main/0_20_5.json")
                 .lookupRemoteVersion(listener)
         );
         assertEquals(e.getMessage(), "Response didn't include supported Content-Type, remote is likely not an OpenSearch instance");
@@ -648,16 +644,16 @@ public class RemoteScrollableHitSourceTests extends OpenSearchTestCase {
 
         TestRemoteScrollableHitSource hitSource = new TestRemoteScrollableHitSource(restClient) {
             @Override
-            void lookupRemoteVersion(RejectAwareActionListener<Version> listener) {
+            void lookupRemoteVersion(RejectAwareActionListener<RemoteVersion> listener) {
                 if (mockRemoteVersion) {
-                    listener.onResponse(Version.CURRENT);
+                    listener.onResponse(RemoteVersion.OPENSEARCH_3_1_0);
                 } else {
                     super.lookupRemoteVersion(listener);
                 }
             }
         };
         if (mockRemoteVersion) {
-            hitSource.remoteVersion = Version.CURRENT;
+            hitSource.remoteVersion = RemoteVersion.OPENSEARCH_3_1_0;
         }
         return hitSource;
     }

--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteVersionTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/remote/RemoteVersionTests.java
@@ -1,0 +1,273 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.reindex.remote;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class RemoteVersionTests extends OpenSearchTestCase {
+
+    public void testVersionComparison() {
+        // Test before()
+        assertTrue(RemoteVersion.V_1_0_0.before(RemoteVersion.V_2_0_0));
+        assertFalse(RemoteVersion.V_1_0_0.before(RemoteVersion.V_1_0_0));
+        assertFalse(RemoteVersion.V_2_0_0.before(RemoteVersion.V_1_0_0));
+
+        // Test onOrBefore()
+        assertTrue(RemoteVersion.V_1_0_0.onOrBefore(RemoteVersion.V_2_0_0));
+        assertTrue(RemoteVersion.V_1_0_0.onOrBefore(RemoteVersion.V_1_0_0));
+        assertFalse(RemoteVersion.V_2_0_0.onOrBefore(RemoteVersion.V_1_0_0));
+
+        // Test after()
+        assertFalse(RemoteVersion.V_1_0_0.after(RemoteVersion.V_2_0_0));
+        assertFalse(RemoteVersion.V_1_0_0.after(RemoteVersion.V_1_0_0));
+        assertTrue(RemoteVersion.V_2_0_0.after(RemoteVersion.V_1_0_0));
+
+        // Test onOrAfter()
+        assertFalse(RemoteVersion.V_1_0_0.onOrAfter(RemoteVersion.V_2_0_0));
+        assertTrue(RemoteVersion.V_1_0_0.onOrAfter(RemoteVersion.V_1_0_0));
+        assertTrue(RemoteVersion.V_2_0_0.onOrAfter(RemoteVersion.V_1_0_0));
+
+        // Test compareTo()
+        assertTrue(RemoteVersion.V_1_0_0.compareTo(RemoteVersion.V_2_0_0) < 0);
+        assertTrue(RemoteVersion.V_2_0_0.compareTo(RemoteVersion.V_1_0_0) > 0);
+
+        // Test OpenSearch vs Elasticsearch versions with same numbers
+        assertEquals(0, RemoteVersion.V_2_0_0.compareTo(RemoteVersion.OPENSEARCH_2_0_0)); // Same version numbers should be equal in
+                                                                                          // comparison
+    }
+
+    public void testVersionFromString() {
+        // Test basic version parsing
+        RemoteVersion version = RemoteVersion.fromString("7.10.2");
+        assertEquals(7, version.getMajor());
+        assertEquals(10, version.getMinor());
+        assertEquals(2, version.getRevision());
+        assertEquals("elasticsearch", version.getDistribution());
+
+        // Test version with distribution
+        RemoteVersion opensearchVersion = RemoteVersion.fromString("1.0.0", "opensearch");
+        assertEquals(1, opensearchVersion.getMajor());
+        assertEquals(0, opensearchVersion.getMinor());
+        assertEquals(0, opensearchVersion.getRevision());
+        assertEquals("opensearch", opensearchVersion.getDistribution());
+
+        // Test version without revision
+        RemoteVersion versionNoRevision = RemoteVersion.fromString("2.1");
+        assertEquals(2, versionNoRevision.getMajor());
+        assertEquals(1, versionNoRevision.getMinor());
+        assertEquals(0, versionNoRevision.getRevision());
+
+        // Test version with snapshot qualifier
+        RemoteVersion snapshotVersion = RemoteVersion.fromString("2.0.0-SNAPSHOT");
+        assertEquals(2, snapshotVersion.getMajor());
+        assertEquals(0, snapshotVersion.getMinor());
+        assertEquals(0, snapshotVersion.getRevision());
+
+        // Test version with pre-release qualifiers
+        RemoteVersion alphaVersion = RemoteVersion.fromString("2.0.0-alpha1");
+        assertEquals(2, alphaVersion.getMajor());
+        assertEquals(0, alphaVersion.getMinor());
+        assertEquals(0, alphaVersion.getRevision());
+
+        RemoteVersion betaVersion = RemoteVersion.fromString("2.0.0-beta2");
+        assertEquals(2, betaVersion.getMajor());
+        assertEquals(0, betaVersion.getMinor());
+        assertEquals(0, betaVersion.getRevision());
+
+        RemoteVersion rcVersion = RemoteVersion.fromString("2.0.0-rc1");
+        assertEquals(2, rcVersion.getMajor());
+        assertEquals(0, rcVersion.getMinor());
+        assertEquals(0, rcVersion.getRevision());
+    }
+
+    public void testInvalidVersionFromString() {
+        // Test null version
+        Exception e = expectThrows(IllegalArgumentException.class, () -> RemoteVersion.fromString(null));
+        assertTrue(e.getMessage().contains("Version string cannot be null or empty"));
+
+        // Test empty version
+        e = expectThrows(IllegalArgumentException.class, () -> RemoteVersion.fromString(""));
+        assertTrue(e.getMessage().contains("Version string cannot be null or empty"));
+
+        // Test invalid format
+        e = expectThrows(IllegalArgumentException.class, () -> RemoteVersion.fromString("invalid"));
+        assertTrue(e.getMessage().contains("Invalid version format"));
+
+        // Test non-numeric version
+        e = expectThrows(IllegalArgumentException.class, () -> RemoteVersion.fromString("a.b.c"));
+        assertTrue(e.getMessage().contains("Invalid version format"));
+    }
+
+    public void testVersionConstants() {
+        // Test Elasticsearch versions
+        assertEquals(0, RemoteVersion.V_0_20_5.getMajor());
+        assertEquals(20, RemoteVersion.V_0_20_5.getMinor());
+        assertEquals(5, RemoteVersion.V_0_20_5.getRevision());
+        assertEquals("elasticsearch", RemoteVersion.V_0_20_5.getDistribution());
+
+        assertEquals(7, RemoteVersion.V_7_0_0.getMajor());
+        assertEquals(0, RemoteVersion.V_7_0_0.getMinor());
+        assertEquals(0, RemoteVersion.V_7_0_0.getRevision());
+        assertEquals("elasticsearch", RemoteVersion.V_7_0_0.getDistribution());
+
+        // Test OpenSearch versions
+        assertEquals(1, RemoteVersion.OPENSEARCH_1_0_0.getMajor());
+        assertEquals(0, RemoteVersion.OPENSEARCH_1_0_0.getMinor());
+        assertEquals(0, RemoteVersion.OPENSEARCH_1_0_0.getRevision());
+        assertEquals("opensearch", RemoteVersion.OPENSEARCH_1_0_0.getDistribution());
+
+        assertEquals(2, RemoteVersion.OPENSEARCH_2_0_0.getMajor());
+        assertEquals(0, RemoteVersion.OPENSEARCH_2_0_0.getMinor());
+        assertEquals(0, RemoteVersion.OPENSEARCH_2_0_0.getRevision());
+        assertEquals("opensearch", RemoteVersion.OPENSEARCH_2_0_0.getDistribution());
+
+        assertEquals(3, RemoteVersion.OPENSEARCH_3_1_0.getMajor());
+        assertEquals(1, RemoteVersion.OPENSEARCH_3_1_0.getMinor());
+        assertEquals(0, RemoteVersion.OPENSEARCH_3_1_0.getRevision());
+        assertEquals("opensearch", RemoteVersion.OPENSEARCH_3_1_0.getDistribution());
+    }
+
+    public void testVersionOrdering() {
+        // Test chronological ordering of constants
+        assertTrue(RemoteVersion.V_0_20_5.before(RemoteVersion.V_0_90_13));
+        assertTrue(RemoteVersion.V_0_90_13.before(RemoteVersion.V_1_0_0));
+        assertTrue(RemoteVersion.V_1_0_0.before(RemoteVersion.V_1_7_5));
+        assertTrue(RemoteVersion.V_1_7_5.before(RemoteVersion.V_2_0_0));
+        assertTrue(RemoteVersion.V_2_0_0.before(RemoteVersion.V_2_1_0));
+        assertTrue(RemoteVersion.V_2_1_0.before(RemoteVersion.V_2_3_3));
+        assertTrue(RemoteVersion.V_2_3_3.before(RemoteVersion.V_5_0_0));
+        assertTrue(RemoteVersion.V_5_0_0.before(RemoteVersion.V_6_0_0));
+        assertTrue(RemoteVersion.V_6_0_0.before(RemoteVersion.V_6_3_0));
+        assertTrue(RemoteVersion.V_6_3_0.before(RemoteVersion.V_7_0_0));
+    }
+
+    public void testDistributionChecks() {
+        // Test isElasticsearch()
+        assertTrue(RemoteVersion.V_7_0_0.isElasticsearch());
+        assertFalse(RemoteVersion.OPENSEARCH_1_0_0.isElasticsearch());
+
+        // Test isOpenSearch()
+        assertTrue(RemoteVersion.OPENSEARCH_1_0_0.isOpenSearch());
+        assertFalse(RemoteVersion.V_7_0_0.isOpenSearch());
+
+        // Test custom distribution
+        RemoteVersion customVersion = new RemoteVersion(1, 0, 0, "custom");
+        assertFalse(customVersion.isElasticsearch());
+        assertFalse(customVersion.isOpenSearch());
+        assertEquals("custom", customVersion.getDistribution());
+
+        // Test null distribution defaults to elasticsearch
+        RemoteVersion nullDistVersion = new RemoteVersion(1, 0, 0, null);
+        assertTrue(nullDistVersion.isElasticsearch());
+        assertFalse(nullDistVersion.isOpenSearch());
+    }
+
+    public void testEqualsAndHashCode() {
+        RemoteVersion version1 = new RemoteVersion(2, 0, 0, null);
+        RemoteVersion version2 = new RemoteVersion(2, 0, 0, null);
+        RemoteVersion version3 = new RemoteVersion(2, 0, 0, "opensearch");
+        RemoteVersion version4 = new RemoteVersion(2, 0, 1, null);
+
+        // Test equals
+        assertEquals(version1, version2);
+        assertNotEquals(version1, version3); // Different distribution
+        assertNotEquals(version1, version4); // Different revision
+        assertNotEquals(version1, null);
+        assertNotEquals(version1, "not a version");
+
+        // Test hashCode consistency
+        assertEquals(version1.hashCode(), version2.hashCode());
+        assertNotEquals(version1.hashCode(), version3.hashCode());
+
+        // Test reflexivity
+        assertEquals(version1, version1);
+    }
+
+    /**
+     * Test equals method
+     */
+    public void testEqualsMethodAllBranches() {
+        RemoteVersion baseVersion = new RemoteVersion(2, 1, 3, "elasticsearch");
+
+        // Test same object (reflexivity)
+        assertEquals(baseVersion, baseVersion);
+
+        // Test null
+        assertNotEquals(baseVersion, null);
+
+        // Test different class
+        assertNotEquals(baseVersion, "not a version object");
+
+        // Test different major version
+        RemoteVersion differentMajor = new RemoteVersion(1, 1, 3, "elasticsearch");
+        assertNotEquals(baseVersion, differentMajor);
+
+        // Test different minor version
+        RemoteVersion differentMinor = new RemoteVersion(2, 0, 3, "elasticsearch");
+        assertNotEquals(baseVersion, differentMinor);
+
+        // Test different revision
+        RemoteVersion differentRevision = new RemoteVersion(2, 1, 2, "elasticsearch");
+        assertNotEquals(baseVersion, differentRevision);
+
+        // Test different distribution (null vs non-null) - null becomes "elasticsearch", so they are equal
+        RemoteVersion nullDistribution = new RemoteVersion(2, 1, 3, null);
+        assertEquals(baseVersion, nullDistribution); // null distribution becomes "elasticsearch"
+
+        // Test different distribution (non-null vs non-null)
+        RemoteVersion opensearchDistribution = new RemoteVersion(2, 1, 3, "opensearch");
+        assertNotEquals(baseVersion, opensearchDistribution);
+
+        // Test same distribution (both null)
+        RemoteVersion nullDist1 = new RemoteVersion(2, 1, 3, null);
+        RemoteVersion nullDist2 = new RemoteVersion(2, 1, 3, null);
+        assertEquals(nullDist1, nullDist2);
+
+        // Test identical version (all fields match)
+        RemoteVersion identical = new RemoteVersion(2, 1, 3, "elasticsearch");
+        assertEquals(baseVersion, identical);
+
+        // Test case sensitivity in distribution - both become lowercase, so they are equal
+        RemoteVersion upperCaseDist = new RemoteVersion(2, 1, 3, "ELASTICSEARCH");
+        assertEquals(baseVersion, upperCaseDist); // Both become "elasticsearch" due to toLowerCase()
+    }
+
+    public void testToString() {
+        RemoteVersion version = new RemoteVersion(2, 1, 3, null);
+        assertEquals("2.1.3", version.toString());
+
+        RemoteVersion opensearchVersion = new RemoteVersion(1, 0, 0, "opensearch");
+        assertEquals("1.0.0", opensearchVersion.toString());
+    }
+
+    public void testCompareToWithNull() {
+        RemoteVersion version = RemoteVersion.V_2_0_0;
+        assertTrue(version.compareTo(null) > 0);
+    }
+
+    public void testVersionConstantsAreCorrect() {
+        // Verify that our constants match what fromString would produce
+        assertEquals(RemoteVersion.V_2_0_0, RemoteVersion.fromString("2.0.0"));
+        assertEquals(RemoteVersion.V_7_0_0, RemoteVersion.fromString("7.0.0"));
+        assertEquals(RemoteVersion.OPENSEARCH_1_0_0, RemoteVersion.fromString("1.0.0", "opensearch"));
+        assertEquals(RemoteVersion.OPENSEARCH_2_0_0, RemoteVersion.fromString("2.0.0", "opensearch"));
+    }
+
+    public void testCaseInsensitiveDistribution() {
+        RemoteVersion version1 = new RemoteVersion(1, 0, 0, null);
+        RemoteVersion version2 = new RemoteVersion(1, 0, 0, "elasticsearch");
+        RemoteVersion version3 = new RemoteVersion(1, 0, 0, "ElasticSearch");
+
+        assertEquals(version1, version2);
+        assertEquals(version1, version3);
+        assertTrue(version1.isElasticsearch());
+        assertTrue(version2.isElasticsearch());
+        assertTrue(version3.isElasticsearch());
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Replaces the usage of `Version` class with `RemoteVersion` class in the reindex module's remote components to provide better isolation and backward compatibility for remote reindex operations.

### Related Issues
Resolves #18391 
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
