### PR TITLE
Increase default percentiles agg compression to 200

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/PercentilesConfig.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/PercentilesConfig.java
@@ -129,7 +129,7 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
      * @opensearch.internal
      */
     public static class TDigest extends PercentilesConfig {
-        static final double DEFAULT_COMPRESSION = 100.0;
+        static final double DEFAULT_COMPRESSION = 200.0;
         private double compression;
 
         public TDigest() {


### PR DESCRIPTION
### Description
Changes default percentiles aggregation compression from 100 to 200, increasing accuracy. 

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/18458

### Check List
- [x] Functionality includes testing.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
