### PR TITLE
[Bug] Star tree indexing - kahan summation fix

### DIFF
--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/AbstractDocumentsFileManager.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/AbstractDocumentsFileManager.java
@@ -21,8 +21,10 @@ import org.opensearch.index.compositeindex.datacube.MetricStat;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeDocument;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeField;
 import org.opensearch.index.compositeindex.datacube.startree.aggregators.MetricAggregatorInfo;
+import org.opensearch.index.compositeindex.datacube.startree.utils.CompensatedSumType;
 import org.opensearch.index.compositeindex.datacube.startree.utils.StarTreeDocumentBitSetUtil;
 import org.opensearch.index.mapper.FieldValueConverter;
+import org.opensearch.search.aggregations.metrics.CompensatedSum;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -120,6 +122,15 @@ public abstract class AbstractDocumentsFileManager implements Closeable {
                 if (isAggregatedDoc) {
                     long val = NumericUtils.doubleToSortableLong(
                         starTreeDocument.metrics[i] == null ? 0.0 : (Double) starTreeDocument.metrics[i]
+                    );
+                    buffer.putLong(val);
+                } else {
+                    buffer.putLong(starTreeDocument.metrics[i] == null ? 0L : (Long) starTreeDocument.metrics[i]);
+                }
+            } else if (aggregatedValueType instanceof CompensatedSumType) {
+                if (isAggregatedDoc) {
+                    long val = NumericUtils.doubleToSortableLong(
+                        starTreeDocument.metrics[i] == null ? 0.0 : ((CompensatedSum) starTreeDocument.metrics[i]).value()
                     );
                     buffer.putLong(val);
                 } else {
@@ -228,6 +239,14 @@ public abstract class AbstractDocumentsFileManager implements Closeable {
                 long val = input.readLong(offset);
                 if (isAggregatedDoc) {
                     metrics[i] = DOUBLE.toDoubleValue(val);
+                } else {
+                    metrics[i] = val;
+                }
+                offset += Long.BYTES;
+            } else if (aggregatedValueType instanceof CompensatedSumType) {
+                long val = input.readLong(offset);
+                if (isAggregatedDoc) {
+                    metrics[i] = new CompensatedSum(DOUBLE.toDoubleValue(val), 0);
                 } else {
                     metrics[i] = val;
                 }

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/BaseStarTreeBuilder.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/BaseStarTreeBuilder.java
@@ -42,6 +42,7 @@ import org.opensearch.index.compositeindex.datacube.startree.fileformats.StarTre
 import org.opensearch.index.compositeindex.datacube.startree.index.StarTreeValues;
 import org.opensearch.index.compositeindex.datacube.startree.node.InMemoryTreeNode;
 import org.opensearch.index.compositeindex.datacube.startree.node.StarTreeNodeType;
+import org.opensearch.index.compositeindex.datacube.startree.utils.CompensatedSumType;
 import org.opensearch.index.compositeindex.datacube.startree.utils.SequentialDocValuesIterator;
 import org.opensearch.index.compositeindex.datacube.startree.utils.iterator.SortedNumericStarTreeValuesIterator;
 import org.opensearch.index.compositeindex.datacube.startree.utils.iterator.SortedSetStarTreeValuesIterator;
@@ -50,6 +51,7 @@ import org.opensearch.index.mapper.FieldMapper;
 import org.opensearch.index.mapper.FieldValueConverter;
 import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.search.aggregations.metrics.CompensatedSum;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -488,6 +490,13 @@ public abstract class BaseStarTreeBuilder implements StarTreeBuilder {
                             ((SortedNumericDocValuesWriterWrapper) (metricWriters.get(i))).addValue(
                                 docId,
                                 NumericUtils.doubleToSortableLong((Double) starTreeDocument.metrics[i])
+                            );
+                        }
+                    } else if (aggregatedValueType instanceof CompensatedSumType) {
+                        if (starTreeDocument.metrics[i] != null) {
+                            ((SortedNumericDocValuesWriterWrapper) (metricWriters.get(i))).addValue(
+                                docId,
+                                NumericUtils.doubleToSortableLong(((CompensatedSum) starTreeDocument.metrics[i]).value())
                             );
                         }
                     } else {

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/CompensatedSumType.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/CompensatedSumType.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.compositeindex.datacube.startree.utils;
+
+import org.opensearch.index.mapper.FieldValueConverter;
+
+import static org.opensearch.index.mapper.NumberFieldMapper.NumberType.DOUBLE;
+
+/**
+ * Field value converter for CompensatedSum - it's just a wrapper over Double
+ *
+ * @opensearch.internal
+ */
+public class CompensatedSumType implements FieldValueConverter {
+
+    public CompensatedSumType() {}
+
+    @Override
+    public double toDoubleValue(long value) {
+        return DOUBLE.toDoubleValue(value);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/CompensatedSum.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/CompensatedSum.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.search.aggregations.metrics;
 
+import java.util.Objects;
+
 /**
  * Used to calculate sums using the Kahan summation algorithm.
  *
@@ -108,6 +110,24 @@ public class CompensatedSum {
         }
 
         return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CompensatedSum that = (CompensatedSum) o;
+        return Double.compare(that.value, value) == 0 && Double.compare(that.delta, delta) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, delta);
+    }
+
+    @Override
+    public String toString() {
+        return value + " " + delta;
     }
 
 }

--- a/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/StarTreeTestUtils.java
+++ b/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/StarTreeTestUtils.java
@@ -21,6 +21,7 @@ import org.opensearch.index.compositeindex.datacube.startree.node.StarTreeNodeTy
 import org.opensearch.index.compositeindex.datacube.startree.utils.SequentialDocValuesIterator;
 import org.opensearch.index.mapper.CompositeMappedFieldType;
 import org.opensearch.index.mapper.FieldValueConverter;
+import org.opensearch.search.aggregations.metrics.CompensatedSum;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -150,6 +151,18 @@ public class StarTreeTestUtils {
             for (int mi = 0; mi < resultStarTreeDocument.metrics.length; mi++) {
                 if (expectedStarTreeDocument.metrics[mi] instanceof Long) {
                     assertEquals(((Long) expectedStarTreeDocument.metrics[mi]).doubleValue(), resultStarTreeDocument.metrics[mi]);
+                } else if (resultStarTreeDocument.metrics[mi] instanceof CompensatedSum) {
+                    if (expectedStarTreeDocument.metrics[mi] instanceof CompensatedSum) {
+                        assertEquals(expectedStarTreeDocument.metrics[mi], resultStarTreeDocument.metrics[mi]);
+                    } else {
+                        assertEquals((expectedStarTreeDocument.metrics[mi]), ((CompensatedSum) resultStarTreeDocument.metrics[mi]).value());
+                    }
+                } else if (expectedStarTreeDocument.metrics[mi] instanceof CompensatedSum) {
+                    if (resultStarTreeDocument.metrics[mi] instanceof CompensatedSum) {
+                        assertEquals(expectedStarTreeDocument.metrics[mi], resultStarTreeDocument.metrics[mi]);
+                    } else {
+                        assertEquals(((CompensatedSum) expectedStarTreeDocument.metrics[mi]).value(), resultStarTreeDocument.metrics[mi]);
+                    }
                 } else {
                     assertEquals(expectedStarTreeDocument.metrics[mi], resultStarTreeDocument.metrics[mi]);
                 }

--- a/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/aggregators/AbstractValueAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/aggregators/AbstractValueAggregatorTests.java
@@ -12,6 +12,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.opensearch.index.mapper.FieldValueConverter;
 import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.search.aggregations.metrics.CompensatedSum;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 
@@ -64,6 +65,10 @@ public abstract class AbstractValueAggregatorTests extends OpenSearchTestCase {
         long randomLong = randomLong();
         if (aggregator instanceof CountValueAggregator) {
             assertEquals(CountValueAggregator.DEFAULT_INITIAL_VALUE, aggregator.getInitialAggregatedValueForSegmentDocValue(randomLong()));
+        } else if (aggregator instanceof SumValueAggregator) {
+            CompensatedSum sum = new CompensatedSum(0, 0);
+            sum.add(fieldValueConverter.toDoubleValue(randomLong));
+            assertEquals(sum, aggregator.getInitialAggregatedValueForSegmentDocValue(randomLong));
         } else {
             assertEquals(fieldValueConverter.toDoubleValue(randomLong), aggregator.getInitialAggregatedValueForSegmentDocValue(randomLong));
         }

--- a/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/aggregators/StaticValueAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/aggregators/StaticValueAggregatorTests.java
@@ -21,28 +21,28 @@ public class StaticValueAggregatorTests extends OpenSearchTestCase {
         double expected = 1;
 
         // initializing our sum aggregator to derive exact sum using kahan summation
-        double aggregatedValue = getAggregatedValue(numbers);
-        assertEquals(expected, aggregatedValue, 0);
+        CompensatedSum aggregatedSum = getAggregatedValue(numbers);
+        assertEquals(expected, aggregatedSum.value(), 0);
 
         // assert kahan summation plain logic with our aggregated value
         double actual = kahanSum(numbers);
-        assertEquals(actual, aggregatedValue, 0);
+        assertEquals(actual, aggregatedSum.value(), 0);
 
         // assert that normal sum fails for this case
         double normalSum = normalSum(numbers);
         assertNotEquals(expected, normalSum, 0);
         assertNotEquals(actual, normalSum, 0);
-        assertNotEquals(aggregatedValue, normalSum, 0);
-
+        assertNotEquals(aggregatedSum.value(), normalSum, 0);
     }
 
-    private static double getAggregatedValue(double[] numbers) {
-        // explicitly took double to test for most precision
-        // hard to run similar tests for different data types dynamically as inputs and precision vary
+    private static CompensatedSum getAggregatedValue(double[] numbers) {
         SumValueAggregator aggregator = new SumValueAggregator(NumberFieldMapper.NumberType.DOUBLE);
-        double aggregatedValue = aggregator.getInitialAggregatedValueForSegmentDocValue(NumericUtils.doubleToSortableLong(numbers[0]));
-        aggregatedValue = aggregator.mergeAggregatedValueAndSegmentValue(aggregatedValue, NumericUtils.doubleToSortableLong(numbers[1]));
-        aggregatedValue = aggregator.mergeAggregatedValueAndSegmentValue(aggregatedValue, NumericUtils.doubleToSortableLong(numbers[2]));
+        long sortableLong1 = NumericUtils.doubleToSortableLong(numbers[0]);
+        CompensatedSum aggregatedValue = aggregator.getInitialAggregatedValueForSegmentDocValue(sortableLong1);
+        long sortableLong2 = NumericUtils.doubleToSortableLong(numbers[1]);
+        aggregatedValue = aggregator.mergeAggregatedValueAndSegmentValue(aggregatedValue, sortableLong2);
+        long sortableLong3 = NumericUtils.doubleToSortableLong(numbers[2]);
+        aggregatedValue = aggregator.mergeAggregatedValueAndSegmentValue(aggregatedValue, sortableLong3);
         return aggregatedValue;
     }
 
@@ -129,5 +129,4 @@ public class StaticValueAggregatorTests extends OpenSearchTestCase {
         }
         assertEquals(expected, aggregatedValue, 0);
     }
-
 }

--- a/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/builder/BaseStarTreeBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/builder/BaseStarTreeBuilderTests.java
@@ -43,6 +43,7 @@ import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.MappingLookup;
 import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.search.aggregations.metrics.CompensatedSum;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.BeforeClass;
 
@@ -236,11 +237,24 @@ public class BaseStarTreeBuilderTests extends OpenSearchTestCase {
         assertEquals(metricAggregatorInfos, expectedMetricAggregatorInfos);
     }
 
-    public void test_reduceStarTreeDocuments() {
-        StarTreeDocument starTreeDocument1 = new StarTreeDocument(new Long[] { 1L, 3L, 5L, 8L }, new Double[] { 4.0, 8.0 });
-        StarTreeDocument starTreeDocument2 = new StarTreeDocument(new Long[] { 1L, 3L, 5L, 8L }, new Double[] { 10.0, 6.0 });
+    private CompensatedSum compensatedSum(Double val) {
+        return new CompensatedSum(val, 0);
+    }
 
-        StarTreeDocument expectedeMergedStarTreeDocument = new StarTreeDocument(new Long[] { 1L, 3L, 5L, 8L }, new Double[] { 14.0, 14.0 });
+    public void test_reduceStarTreeDocuments() {
+        StarTreeDocument starTreeDocument1 = new StarTreeDocument(
+            new Long[] { 1L, 3L, 5L, 8L },
+            new Object[] { compensatedSum(4.0), compensatedSum(8.0) }
+        );
+        StarTreeDocument starTreeDocument2 = new StarTreeDocument(
+            new Long[] { 1L, 3L, 5L, 8L },
+            new Object[] { compensatedSum(10.0), compensatedSum(6.0) }
+        );
+
+        StarTreeDocument expectedeMergedStarTreeDocument = new StarTreeDocument(
+            new Long[] { 1L, 3L, 5L, 8L },
+            new Object[] { compensatedSum(14.0), compensatedSum(14.0) }
+        );
         StarTreeDocument mergedStarTreeDocument = builder.reduceStarTreeDocuments(null, starTreeDocument1);
         StarTreeDocument resultStarTreeDocument = builder.reduceStarTreeDocuments(mergedStarTreeDocument, starTreeDocument2);
 

--- a/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeBuildMetricTests.java
+++ b/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeBuildMetricTests.java
@@ -49,6 +49,7 @@ import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.MappingLookup;
 import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.search.aggregations.metrics.CompensatedSum;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -1021,7 +1022,7 @@ public class StarTreeBuildMetricTests extends StarTreeBuilderTestCase {
                 long dimValue = dimValueToDocIdEntry.getKey();
                 int docId = dimValueToDocIdEntry.getValue();
                 if (map.get(dimValue) != null) {
-                    assertEquals(map.get(dimValue), resultStarTreeDocuments.get(docId).metrics[0]);
+                    assertEquals(map.get(dimValue), ((CompensatedSum) resultStarTreeDocuments.get(docId).metrics[0]).value(), 0);
                 }
             }
         }
@@ -1032,7 +1033,7 @@ public class StarTreeBuildMetricTests extends StarTreeBuilderTestCase {
             assertEquals(expectedStarTreeDocument.dimensions[0], resultStarTreeDocument.dimensions[0]);
             assertEquals(expectedStarTreeDocument.dimensions[1], resultStarTreeDocument.dimensions[1]);
             assertEquals(expectedStarTreeDocument.dimensions[2], resultStarTreeDocument.dimensions[2]);
-            assertEquals(expectedStarTreeDocument.metrics[0], resultStarTreeDocument.metrics[0]);
+            assertEquals(expectedStarTreeDocument.metrics[0], ((CompensatedSum) resultStarTreeDocument.metrics[0]).value());
             assertEquals(expectedStarTreeDocument.metrics[1], resultStarTreeDocument.metrics[1]);
         }
 

--- a/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeBuilderFlushFlowTests.java
+++ b/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeBuilderFlushFlowTests.java
@@ -35,6 +35,7 @@ import org.opensearch.index.compositeindex.datacube.startree.fileformats.meta.St
 import org.opensearch.index.compositeindex.datacube.startree.utils.SequentialDocValuesIterator;
 import org.opensearch.index.compositeindex.datacube.startree.utils.iterator.SortedNumericStarTreeValuesIterator;
 import org.opensearch.index.compositeindex.datacube.startree.utils.iterator.SortedSetStarTreeValuesIterator;
+import org.opensearch.search.aggregations.metrics.CompensatedSum;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -121,11 +122,12 @@ public class StarTreeBuilderFlushFlowTests extends StarTreeBuilderTestCase {
                     starTreeDocument.dimensions[0] == null
                         ? starTreeDocument.dimensions[1] * 1 * 10.0
                         : starTreeDocument.dimensions[0] * 10,
-                    starTreeDocument.metrics[0]
+                    ((CompensatedSum) starTreeDocument.metrics[0]).value(),
+                    0
                 );
                 assertEquals(1L, starTreeDocument.metrics[1]);
             } else {
-                assertEquals(150D, starTreeDocument.metrics[0]);
+                assertEquals(150D, ((CompensatedSum) starTreeDocument.metrics[0]).value(), 0);
                 assertEquals(6L, starTreeDocument.metrics[1]);
             }
         }
@@ -226,7 +228,7 @@ public class StarTreeBuilderFlushFlowTests extends StarTreeBuilderTestCase {
                 if (starTreeDocument.dimensions[0] != null) {
                     assertEquals(count, (long) starTreeDocument.dimensions[0]);
                 }
-                assertEquals(starTreeDocument.dimensions[1] * 10.0, starTreeDocument.metrics[0]);
+                assertEquals(starTreeDocument.dimensions[1] * 10.0, ((CompensatedSum) starTreeDocument.metrics[0]).value(), 0);
                 assertEquals(1L, starTreeDocument.metrics[1]);
             }
         }
@@ -333,7 +335,7 @@ public class StarTreeBuilderFlushFlowTests extends StarTreeBuilderTestCase {
         int count = 0;
         for (StarTreeDocument starTreeDocument : starTreeDocuments) {
             if (count < 6) {
-                assertEquals(expectedSumMetrics[count], starTreeDocument.metrics[0]);
+                assertEquals(expectedSumMetrics[count], ((CompensatedSum) starTreeDocument.metrics[0]).value(), 0);
                 assertEquals(expectedCountMetric, starTreeDocument.metrics[1]);
 
                 Long dim1 = starTreeDocument.dimensions[0];
@@ -446,7 +448,8 @@ public class StarTreeBuilderFlushFlowTests extends StarTreeBuilderTestCase {
         for (StarTreeDocument starTreeDocument : starTreeDocuments) {
             assertEquals(
                 starTreeDocument.dimensions[1] != null ? starTreeDocument.dimensions[1] * 10.0 : 49500.0,
-                starTreeDocument.metrics[0]
+                ((CompensatedSum) starTreeDocument.metrics[0]).value(),
+                0
             );
         }
         validateStarTree(builder.getRootNode(), 2, 1, builder.getStarTreeDocuments());
@@ -525,7 +528,7 @@ public class StarTreeBuilderFlushFlowTests extends StarTreeBuilderTestCase {
         while (starTreeDocumentIterator.hasNext()) {
             count++;
             StarTreeDocument starTreeDocument = starTreeDocumentIterator.next();
-            assertEquals(starTreeDocument.dimensions[3] * 1 * 10.0, starTreeDocument.metrics[1]);
+            assertEquals(starTreeDocument.dimensions[3] * 1 * 10.0, ((CompensatedSum) starTreeDocument.metrics[1]).value(), 0);
             assertEquals(1L, starTreeDocument.metrics[0]);
         }
         assertEquals(6, count);
@@ -600,11 +603,12 @@ public class StarTreeBuilderFlushFlowTests extends StarTreeBuilderTestCase {
                     starTreeDocument.dimensions[0] == null
                         ? starTreeDocument.dimensions[1] * 1 * 10.0
                         : starTreeDocument.dimensions[0] * 10,
-                    starTreeDocument.metrics[0]
+                    ((CompensatedSum) starTreeDocument.metrics[0]).value(),
+                    0
                 );
                 assertEquals(1L, starTreeDocument.metrics[1]);
             } else {
-                assertEquals(150D, starTreeDocument.metrics[0]);
+                assertEquals(150D, ((CompensatedSum) starTreeDocument.metrics[0]).value(), 0);
                 assertEquals(6L, starTreeDocument.metrics[1]);
             }
         }

--- a/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeBuilderMergeFlowTests.java
+++ b/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeBuilderMergeFlowTests.java
@@ -38,6 +38,7 @@ import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MappingLookup;
 import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.search.aggregations.metrics.CompensatedSum;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -216,7 +217,7 @@ public class StarTreeBuilderMergeFlowTests extends StarTreeBuilderTestCase {
         int count = 0;
         for (StarTreeDocument starTreeDocument : builder.getStarTreeDocuments()) {
             if (count < 1000) {
-                assertEquals(starTreeDocument.dimensions[0] * 20.0, starTreeDocument.metrics[0]);
+                assertEquals(starTreeDocument.dimensions[0] * 20.0, ((CompensatedSum) starTreeDocument.metrics[0]).value(), 0);
                 assertEquals(2L, starTreeDocument.metrics[2]);
             }
             count++;
@@ -530,7 +531,8 @@ public class StarTreeBuilderMergeFlowTests extends StarTreeBuilderTestCase {
             if (count <= 6) {
                 assertEquals(
                     starTreeDocument.dimensions[0] != null ? starTreeDocument.dimensions[0] * 2 * 10.0 : 40.0,
-                    starTreeDocument.metrics[0]
+                    ((CompensatedSum) starTreeDocument.metrics[0]).value(),
+                    0
                 );
             }
         }
@@ -616,7 +618,8 @@ public class StarTreeBuilderMergeFlowTests extends StarTreeBuilderTestCase {
             if (count <= 6) {
                 assertEquals(
                     starTreeDocument.dimensions[0] != null ? starTreeDocument.dimensions[0] * 2 * 10.0 : 40.0,
-                    starTreeDocument.metrics[0]
+                    ((CompensatedSum) starTreeDocument.metrics[0]).value(),
+                    0
                 );
             }
         }
@@ -1405,13 +1408,13 @@ public class StarTreeBuilderMergeFlowTests extends StarTreeBuilderTestCase {
          */
         for (StarTreeDocument starTreeDocument : starTreeDocuments) {
             if (starTreeDocument.dimensions[3] == null) {
-                assertEquals(sum, starTreeDocument.metrics[0]);
+                assertEquals(sum, ((CompensatedSum) starTreeDocument.metrics[0]).value(), 0);
                 assertEquals(2495000L, (long) starTreeDocument.metrics[1]);
             } else {
                 if (starTreeDocument.dimensions[0] != null) {
-                    sum += (double) starTreeDocument.metrics[0];
+                    sum += ((CompensatedSum) starTreeDocument.metrics[0]).value();
                 }
-                assertEquals(starTreeDocument.dimensions[3] * 500 + 200.0, starTreeDocument.metrics[0]);
+                assertEquals(starTreeDocument.dimensions[3] * 500 + 200.0, ((CompensatedSum) starTreeDocument.metrics[0]).value(), 0);
                 assertEquals(starTreeDocument.dimensions[3] * 500 + 200L, (long) starTreeDocument.metrics[1]);
 
             }
@@ -2047,7 +2050,7 @@ public class StarTreeBuilderMergeFlowTests extends StarTreeBuilderTestCase {
         builder.appendDocumentsToStarTree(starTreeDocumentIterator);
         for (StarTreeDocument starTreeDocument : builder.getStarTreeDocuments()) {
             count++;
-            assertEquals(starTreeDocument.dimensions[3] * 10.0, (double) starTreeDocument.metrics[1], 0);
+            assertEquals(starTreeDocument.dimensions[3] * 10.0, (Double) ((CompensatedSum) starTreeDocument.metrics[1]).value(), 0);
             assertEquals(starTreeDocument.dimensions[3], starTreeDocument.metrics[0]);
         }
         assertEquals(10, count);
@@ -2148,10 +2151,10 @@ public class StarTreeBuilderMergeFlowTests extends StarTreeBuilderTestCase {
             count++;
             if (count <= 4) {
                 assertEquals(starTreeDocument.dimensions[0] * 2, (long) starTreeDocument.metrics[0], 0);
-                assertEquals(starTreeDocument.dimensions[0] * 20.0, (double) starTreeDocument.metrics[1], 0);
+                assertEquals(starTreeDocument.dimensions[0] * 20.0, ((CompensatedSum) starTreeDocument.metrics[1]).value(), 0);
             } else {
                 assertEquals(starTreeDocument.dimensions[0], (long) starTreeDocument.metrics[0], 0);
-                assertEquals(starTreeDocument.dimensions[0] * 10.0, (double) starTreeDocument.metrics[1], 0);
+                assertEquals(starTreeDocument.dimensions[0] * 10.0, ((CompensatedSum) starTreeDocument.metrics[1]).value(), 0);
             }
         }
         assertEquals(6, count);

--- a/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeBuilderSortAndAggregateTests.java
+++ b/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeBuilderSortAndAggregateTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.NumericUtils;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeDocument;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeFieldConfiguration;
 import org.opensearch.index.compositeindex.datacube.startree.utils.SequentialDocValuesIterator;
+import org.opensearch.search.aggregations.metrics.CompensatedSum;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -102,8 +103,8 @@ public class StarTreeBuilderSortAndAggregateTests extends StarTreeBuilderTestCas
             assertEquals(expectedStarTreeDocument.dimensions[1], resultStarTreeDocument.dimensions[1]);
             assertEquals(expectedStarTreeDocument.dimensions[2], resultStarTreeDocument.dimensions[2]);
             assertEquals(expectedStarTreeDocument.dimensions[3], resultStarTreeDocument.dimensions[3]);
-            assertEquals(expectedStarTreeDocument.metrics[0], resultStarTreeDocument.metrics[0]);
-            assertEquals(expectedStarTreeDocument.metrics[1], resultStarTreeDocument.metrics[1]);
+            assertEquals(expectedStarTreeDocument.metrics[0], ((CompensatedSum) resultStarTreeDocument.metrics[0]).value());
+            assertEquals(expectedStarTreeDocument.metrics[1], ((CompensatedSum) resultStarTreeDocument.metrics[1]).value());
             assertEquals(expectedStarTreeDocument.metrics[2], resultStarTreeDocument.metrics[2]);
             assertEquals(expectedStarTreeDocument.metrics[3], resultStarTreeDocument.metrics[3]);
             assertEquals(expectedStarTreeDocument.metrics[4], resultStarTreeDocument.metrics[4]);
@@ -177,8 +178,8 @@ public class StarTreeBuilderSortAndAggregateTests extends StarTreeBuilderTestCas
             assertEquals(expectedStarTreeDocument.dimensions[1], resultStarTreeDocument.dimensions[1]);
             assertEquals(expectedStarTreeDocument.dimensions[2], resultStarTreeDocument.dimensions[2]);
             assertEquals(expectedStarTreeDocument.dimensions[3], resultStarTreeDocument.dimensions[3]);
-            assertEquals(expectedStarTreeDocument.metrics[0], resultStarTreeDocument.metrics[0]);
-            assertEquals(expectedStarTreeDocument.metrics[1], resultStarTreeDocument.metrics[1]);
+            assertEquals(expectedStarTreeDocument.metrics[0], ((CompensatedSum) resultStarTreeDocument.metrics[0]).value());
+            assertEquals(expectedStarTreeDocument.metrics[1], ((CompensatedSum) resultStarTreeDocument.metrics[1]).value());
             assertEquals(expectedStarTreeDocument.metrics[2], resultStarTreeDocument.metrics[2]);
             assertEquals(expectedStarTreeDocument.metrics[3], resultStarTreeDocument.metrics[3]);
             assertEquals(expectedStarTreeDocument.metrics[4], resultStarTreeDocument.metrics[4]);
@@ -253,8 +254,8 @@ public class StarTreeBuilderSortAndAggregateTests extends StarTreeBuilderTestCas
             assertEquals(expectedStarTreeDocument.dimensions[1], resultStarTreeDocument.dimensions[1]);
             assertEquals(expectedStarTreeDocument.dimensions[2], resultStarTreeDocument.dimensions[2]);
             assertEquals(expectedStarTreeDocument.dimensions[3], resultStarTreeDocument.dimensions[3]);
-            assertEquals(expectedStarTreeDocument.metrics[0], resultStarTreeDocument.metrics[0]);
-            assertEquals(expectedStarTreeDocument.metrics[1], resultStarTreeDocument.metrics[1]);
+            assertEquals(expectedStarTreeDocument.metrics[0], ((CompensatedSum) resultStarTreeDocument.metrics[0]).value());
+            assertEquals(expectedStarTreeDocument.metrics[1], ((CompensatedSum) resultStarTreeDocument.metrics[1]).value());
             assertEquals(expectedStarTreeDocument.metrics[2], resultStarTreeDocument.metrics[2]);
             assertEquals(expectedStarTreeDocument.metrics[3], resultStarTreeDocument.metrics[3]);
             assertEquals(expectedStarTreeDocument.metrics[4], resultStarTreeDocument.metrics[4]);
@@ -312,8 +313,8 @@ public class StarTreeBuilderSortAndAggregateTests extends StarTreeBuilderTestCas
             assertEquals(expectedStarTreeDocument.dimensions[1], resultStarTreeDocument.dimensions[1]);
             assertEquals(expectedStarTreeDocument.dimensions[2], resultStarTreeDocument.dimensions[2]);
             assertEquals(expectedStarTreeDocument.dimensions[3], resultStarTreeDocument.dimensions[3]);
-            assertEquals(expectedStarTreeDocument.metrics[0], resultStarTreeDocument.metrics[0]);
-            assertEquals(expectedStarTreeDocument.metrics[1], resultStarTreeDocument.metrics[1]);
+            assertEquals(expectedStarTreeDocument.metrics[0], ((CompensatedSum) resultStarTreeDocument.metrics[0]).value());
+            assertEquals(expectedStarTreeDocument.metrics[1], ((CompensatedSum) resultStarTreeDocument.metrics[1]).value());
             assertEquals(expectedStarTreeDocument.metrics[2], resultStarTreeDocument.metrics[2]);
             assertEquals(expectedStarTreeDocument.metrics[3], resultStarTreeDocument.metrics[3]);
             assertEquals(expectedStarTreeDocument.metrics[4], resultStarTreeDocument.metrics[4]);
@@ -383,8 +384,8 @@ public class StarTreeBuilderSortAndAggregateTests extends StarTreeBuilderTestCas
             assertEquals(expectedStarTreeDocument.dimensions[1], resultStarTreeDocument.dimensions[1]);
             assertEquals(expectedStarTreeDocument.dimensions[2], resultStarTreeDocument.dimensions[2]);
             assertEquals(expectedStarTreeDocument.dimensions[3], resultStarTreeDocument.dimensions[3]);
-            assertEquals(expectedStarTreeDocument.metrics[0], resultStarTreeDocument.metrics[0]);
-            assertEquals(expectedStarTreeDocument.metrics[1], resultStarTreeDocument.metrics[1]);
+            assertEquals(expectedStarTreeDocument.metrics[0], ((CompensatedSum) resultStarTreeDocument.metrics[0]).value());
+            assertEquals(expectedStarTreeDocument.metrics[1], ((CompensatedSum) resultStarTreeDocument.metrics[1]).value());
             assertEquals(expectedStarTreeDocument.metrics[2], resultStarTreeDocument.metrics[2]);
             assertEquals(expectedStarTreeDocument.metrics[3], resultStarTreeDocument.metrics[3]);
             assertEquals(expectedStarTreeDocument.metrics[4], resultStarTreeDocument.metrics[4]);
@@ -454,8 +455,8 @@ public class StarTreeBuilderSortAndAggregateTests extends StarTreeBuilderTestCas
             assertEquals(expectedStarTreeDocument.dimensions[1], resultStarTreeDocument.dimensions[1]);
             assertEquals(expectedStarTreeDocument.dimensions[2], resultStarTreeDocument.dimensions[2]);
             assertEquals(expectedStarTreeDocument.dimensions[3], resultStarTreeDocument.dimensions[3]);
-            assertEquals(expectedStarTreeDocument.metrics[0], resultStarTreeDocument.metrics[0]);
-            assertEquals(expectedStarTreeDocument.metrics[1], resultStarTreeDocument.metrics[1]);
+            assertEquals(expectedStarTreeDocument.metrics[0], ((CompensatedSum) resultStarTreeDocument.metrics[0]).value());
+            assertEquals(expectedStarTreeDocument.metrics[1], ((CompensatedSum) resultStarTreeDocument.metrics[1]).value());
             assertEquals(expectedStarTreeDocument.metrics[2], resultStarTreeDocument.metrics[2]);
             assertEquals(expectedStarTreeDocument.metrics[3], resultStarTreeDocument.metrics[3]);
             assertEquals(expectedStarTreeDocument.metrics[4], resultStarTreeDocument.metrics[4]);
@@ -535,8 +536,8 @@ public class StarTreeBuilderSortAndAggregateTests extends StarTreeBuilderTestCas
             assertEquals(expectedStarTreeDocument.dimensions[1], resultStarTreeDocument.dimensions[1]);
             assertEquals(expectedStarTreeDocument.dimensions[2], resultStarTreeDocument.dimensions[2]);
             assertEquals(expectedStarTreeDocument.dimensions[3], resultStarTreeDocument.dimensions[3]);
-            assertEquals(expectedStarTreeDocument.metrics[0], resultStarTreeDocument.metrics[0]);
-            assertEquals(expectedStarTreeDocument.metrics[1], resultStarTreeDocument.metrics[1]);
+            assertEquals(expectedStarTreeDocument.metrics[0], ((CompensatedSum) resultStarTreeDocument.metrics[0]).value());
+            assertEquals(expectedStarTreeDocument.metrics[1], ((CompensatedSum) resultStarTreeDocument.metrics[1]).value());
             assertEquals(expectedStarTreeDocument.metrics[2], resultStarTreeDocument.metrics[2]);
             assertEquals(expectedStarTreeDocument.metrics[3], resultStarTreeDocument.metrics[3]);
             assertEquals(expectedStarTreeDocument.metrics[4], resultStarTreeDocument.metrics[4]);
@@ -612,8 +613,8 @@ public class StarTreeBuilderSortAndAggregateTests extends StarTreeBuilderTestCas
             assertEquals(expectedStarTreeDocument.dimensions[1], resultStarTreeDocument.dimensions[1]);
             assertEquals(expectedStarTreeDocument.dimensions[2], resultStarTreeDocument.dimensions[2]);
             assertEquals(expectedStarTreeDocument.dimensions[3], resultStarTreeDocument.dimensions[3]);
-            assertEquals(expectedStarTreeDocument.metrics[0], resultStarTreeDocument.metrics[0]);
-            assertEquals(expectedStarTreeDocument.metrics[1], resultStarTreeDocument.metrics[1]);
+            assertEquals(expectedStarTreeDocument.metrics[0], ((CompensatedSum) resultStarTreeDocument.metrics[0]).value());
+            assertEquals(expectedStarTreeDocument.metrics[1], ((CompensatedSum) resultStarTreeDocument.metrics[1]).value());
             assertEquals(expectedStarTreeDocument.metrics[2], resultStarTreeDocument.metrics[2]);
             assertEquals(expectedStarTreeDocument.metrics[3], resultStarTreeDocument.metrics[3]);
             assertEquals(expectedStarTreeDocument.metrics[4], resultStarTreeDocument.metrics[4]);
@@ -684,8 +685,8 @@ public class StarTreeBuilderSortAndAggregateTests extends StarTreeBuilderTestCas
             assertEquals(expectedStarTreeDocument.dimensions[1], resultStarTreeDocument.dimensions[1]);
             assertEquals(expectedStarTreeDocument.dimensions[2], resultStarTreeDocument.dimensions[2]);
             assertEquals(expectedStarTreeDocument.dimensions[3], resultStarTreeDocument.dimensions[3]);
-            assertEquals(expectedStarTreeDocument.metrics[0], resultStarTreeDocument.metrics[0]);
-            assertEquals(expectedStarTreeDocument.metrics[1], resultStarTreeDocument.metrics[1]);
+            assertEquals(expectedStarTreeDocument.metrics[0], ((CompensatedSum) resultStarTreeDocument.metrics[0]).value());
+            assertEquals(expectedStarTreeDocument.metrics[1], ((CompensatedSum) resultStarTreeDocument.metrics[1]).value());
             assertEquals(expectedStarTreeDocument.metrics[2], resultStarTreeDocument.metrics[2]);
             assertEquals(expectedStarTreeDocument.metrics[3], resultStarTreeDocument.metrics[3]);
             assertEquals(expectedStarTreeDocument.metrics[4], resultStarTreeDocument.metrics[4]);

--- a/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeBuilderTestCase.java
+++ b/server/src/test/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeBuilderTestCase.java
@@ -55,6 +55,7 @@ import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.MappingLookup;
 import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.search.aggregations.metrics.CompensatedSum;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 
@@ -320,8 +321,8 @@ public abstract class StarTreeBuilderTestCase extends OpenSearchTestCase {
             assertEquals(expectedStarTreeDocument.dimensions[1], resultStarTreeDocument.dimensions[1]);
             assertEquals(expectedStarTreeDocument.dimensions[2], resultStarTreeDocument.dimensions[2]);
             assertEquals(expectedStarTreeDocument.dimensions[3], resultStarTreeDocument.dimensions[3]);
-            assertEquals(expectedStarTreeDocument.metrics[0], resultStarTreeDocument.metrics[0]);
-            assertEquals(expectedStarTreeDocument.metrics[1], resultStarTreeDocument.metrics[1]);
+            assertEquals(expectedStarTreeDocument.metrics[0], ((CompensatedSum) resultStarTreeDocument.metrics[0]).value());
+            assertEquals(expectedStarTreeDocument.metrics[1], ((CompensatedSum) resultStarTreeDocument.metrics[1]).value());
             assertEquals(expectedStarTreeDocument.metrics[2], resultStarTreeDocument.metrics[2]);
             assertEquals(expectedStarTreeDocument.metrics[3], resultStarTreeDocument.metrics[3]);
             assertEquals(expectedStarTreeDocument.metrics[4], resultStarTreeDocument.metrics[4]);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Star tree's SumValueAggregator today stores kahan summation state which gets reused and we found an edge case where the children node's value gets set in the kahan summation that gets used in the parent nodes which results in incorrect results.

As part of this PR removing the state from the SumValueAggregator and using `CompensatedSum` as the `SumAggregator` type.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/18463
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
