### PR TITLE
Initialize FileCache for warm index on node boot-up/restart

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/WritableWarmIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/WritableWarmIT.java
@@ -189,19 +189,9 @@ public class WritableWarmIT extends RemoteStoreBaseIntegTestCase {
         Settings settings = Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-            .put(IndexModule.INDEX_STORE_LOCALITY_SETTING.getKey(), IndexModule.DataLocalityType.PARTIAL.name())
             .build();
 
         assertAcked(client().admin().indices().prepareCreate(INDEX_NAME_2).setSettings(settings).get());
-
-        // Verify from the cluster settings if the data locality is partial
-        GetIndexResponse getIndexResponse = client().admin()
-            .indices()
-            .getIndex(new GetIndexRequest().indices(INDEX_NAME_2).includeDefaults(true))
-            .get();
-
-        Settings indexSettings = getIndexResponse.settings().get(INDEX_NAME_2);
-        assertEquals(IndexModule.DataLocalityType.PARTIAL.name(), indexSettings.get(IndexModule.INDEX_STORE_LOCALITY_SETTING.getKey()));
 
         // Ingesting docs again before force merge
         indexBulk(INDEX_NAME_2, NUM_DOCS_IN_BULK);

--- a/server/src/main/java/org/opensearch/common/cache/RemovalReason.java
+++ b/server/src/main/java/org/opensearch/common/cache/RemovalReason.java
@@ -21,5 +21,6 @@ public enum RemovalReason {
     INVALIDATED,
     EVICTED,
     EXPLICIT,
-    CAPACITY
+    CAPACITY,
+    RESTARTED // This is used by testing framework to close the CachedIndexInput during node restart.
 }

--- a/server/src/main/java/org/opensearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/opensearch/env/NodeEnvironment.java
@@ -1291,6 +1291,11 @@ public final class NodeEnvironment implements Closeable {
         return indexSubPaths;
     }
 
+    @Deprecated(forRemoval = true)
+    public static List<Path> collectFileCacheDataPath(NodePath fileCacheNodePath) throws IOException {
+        return collectFileCacheDataPath(fileCacheNodePath, Settings.EMPTY);
+    }
+
     private static void processDirectory(Path directoryPath, List<Path> indexSubPaths) throws IOException {
         if (Files.isDirectory(directoryPath)) {
             try (DirectoryStream<Path> indexStream = Files.newDirectoryStream(directoryPath)) {

--- a/server/src/main/java/org/opensearch/env/NodeRepurposeCommand.java
+++ b/server/src/main/java/org/opensearch/env/NodeRepurposeCommand.java
@@ -137,7 +137,7 @@ public class NodeRepurposeCommand extends OpenSearchNodeCommand {
 
         if (repurposeSearch) {
             terminal.println(Terminal.Verbosity.VERBOSE, "Collecting file cache data paths");
-            fileCacheDataPaths = NodeEnvironment.collectFileCacheDataPath(fileCacheNodePath);
+            fileCacheDataPaths = NodeEnvironment.collectFileCacheDataPath(fileCacheNodePath, env.settings());
             fileCachePaths = uniqueParentPaths(fileCacheDataPaths, indexMetadataPaths);
         }
 
@@ -227,7 +227,7 @@ public class NodeRepurposeCommand extends OpenSearchNodeCommand {
 
         if (repurposeSearch) {
             terminal.println(Terminal.Verbosity.VERBOSE, "Collecting file cache data paths");
-            fileCacheDataPaths = NodeEnvironment.collectFileCacheDataPath(fileCacheNodePath);
+            fileCacheDataPaths = NodeEnvironment.collectFileCacheDataPath(fileCacheNodePath, env.settings());
             fileCachePaths = uniqueParentPaths(fileCacheDataPaths);
         }
 

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/AggregateFileCacheStats.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/AggregateFileCacheStats.java
@@ -116,6 +116,11 @@ public class AggregateFileCacheStats implements Writeable, ToXContentFragment {
         return overallFileCacheStats.getCacheMisses();
     }
 
+    // visible for testing.
+    public FileCacheStats getBlockFileCacheStats() {
+        return blockFileCacheStats;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.AGGREGATE_FILE_CACHE);

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCache.java
@@ -28,8 +28,10 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import static org.opensearch.index.store.remote.directory.RemoteSnapshotDirectoryFactory.LOCAL_STORE_LOCATION;
+import static org.opensearch.index.store.remote.utils.FileTypeUtils.INDICES_FOLDER_IDENTIFIER;
 
 /**
  * File Cache (FC) is introduced to solve the problem that the local disk cannot hold
@@ -192,6 +194,11 @@ public class FileCache implements RefCountedCache<Path, CachedIndexInput> {
         theCache.logCurrentState();
     }
 
+    // To be used only in testing framework.
+    public void closeIndexInputReferences() {
+        theCache.closeIndexInputReferences();
+    }
+
     /**
      * Ensures that the PARENT breaker is not tripped when an entry is added to the cache
      * @param filePath the path key for which entry is added
@@ -216,32 +223,29 @@ public class FileCache implements RefCountedCache<Path, CachedIndexInput> {
      * directory within the provided file cache path.
      */
     public void restoreFromDirectory(List<Path> fileCacheDataPaths) {
-        fileCacheDataPaths.stream()
-            .filter(Files::isDirectory)
-            .map(path -> path.resolve(LOCAL_STORE_LOCATION))
-            .filter(Files::isDirectory)
-            .flatMap(dir -> {
-                try {
-                    return Files.list(dir);
-                } catch (IOException e) {
-                    throw new UncheckedIOException(
-                        "Unable to process file cache directory. Please clear the file cache for node startup.",
-                        e
-                    );
-                }
-            })
-            .filter(Files::isRegularFile)
-            .forEach(path -> {
-                try {
-                    put(path.toAbsolutePath(), new RestoredCachedIndexInput(Files.size(path)));
-                    decRef(path.toAbsolutePath());
-                } catch (IOException e) {
-                    throw new UncheckedIOException(
-                        "Unable to retrieve cache file details. Please clear the file cache for node startup.",
-                        e
-                    );
-                }
-            });
+        Stream.concat(
+            fileCacheDataPaths.stream()
+                .filter(Files::isDirectory)
+                .map(path -> path.resolve(LOCAL_STORE_LOCATION))
+                .filter(Files::isDirectory),
+            fileCacheDataPaths.stream()
+                .filter(Files::isDirectory)
+                .map(path -> path.resolve(INDICES_FOLDER_IDENTIFIER))
+                .filter(Files::isDirectory)
+        ).flatMap(dir -> {
+            try {
+                return Files.list(dir);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Unable to process file cache directory. Please clear the file cache for node startup.", e);
+            }
+        }).filter(Files::isRegularFile).forEach(path -> {
+            try {
+                put(path.toAbsolutePath(), new RestoredCachedIndexInput(Files.size(path)));
+                decRef(path.toAbsolutePath());
+            } catch (IOException e) {
+                throw new UncheckedIOException("Unable to retrieve cache file details. Please clear the file cache for node startup.", e);
+            }
+        });
     }
 
     /**
@@ -308,10 +312,10 @@ public class FileCache implements RefCountedCache<Path, CachedIndexInput> {
      * These entries are eligible for eviction so if nothing needs to reference
      * them they will be deleted when the disk-based local cache fills up.
      */
-    private static class RestoredCachedIndexInput implements CachedIndexInput {
+    public static class RestoredCachedIndexInput implements CachedIndexInput {
         private final long length;
 
-        private RestoredCachedIndexInput(long length) {
+        public RestoredCachedIndexInput(long length) {
             this.length = length;
         }
 

--- a/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheFactory.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/filecache/FileCacheFactory.java
@@ -55,7 +55,11 @@ public class FileCacheFactory {
                 Path key = removalNotification.getKey();
                 if (removalReason != RemovalReason.REPLACED) {
                     catchAsRuntimeException(value::close);
-                    catchAsRuntimeException(() -> Files.deleteIfExists(key));
+                    // On RESTARTED removal, we close the IndexInput but preserve the files on disk as this scenario only occurs during
+                    // tests
+                    if (removalReason != RemovalReason.RESTARTED) {
+                        catchAsRuntimeException(() -> Files.deleteIfExists(key));
+                    }
                 }
             });
     }

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/FileTypeUtils.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/FileTypeUtils.java
@@ -19,6 +19,7 @@ import org.opensearch.common.annotation.ExperimentalApi;
 public class FileTypeUtils {
 
     public static String BLOCK_FILE_IDENTIFIER = "_block_";
+    public static String INDICES_FOLDER_IDENTIFIER = "index";
 
     public static boolean isTempFile(String name) {
         return name.endsWith(".tmp");

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/cache/LRUCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/cache/LRUCache.java
@@ -184,6 +184,24 @@ class LRUCache<K, V> implements RefCountedCache<K, V> {
         }
     }
 
+    // To be used only in testing framework.
+    public void closeIndexInputReferences() {
+        lock.lock();
+        try {
+            int closedEntries = 0;
+            final Iterator<Node<K, V>> iterator = data.values().iterator();
+            while (iterator.hasNext()) {
+                closedEntries++;
+                Node<K, V> node = iterator.next();
+                iterator.remove();
+                listener.onRemoval(new RemovalNotification<>(node.key, node.value, RemovalReason.RESTARTED));
+            }
+            logger.trace("Reference cleanup completed - Total entries: {}", closedEntries);
+        } finally {
+            lock.unlock();
+        }
+    }
+
     @Override
     public void clear() {
         lock.lock();
@@ -411,6 +429,8 @@ class LRUCache<K, V> implements RefCountedCache<K, V> {
                     .append(entry.getValue().refCount)
                     .append(" , Weight: ")
                     .append(entry.getValue().weight)
+                    .append(" , Pinned: ")
+                    .append(entry.getValue().pinned)
                     .append(" ]\n");
             }
             if (allFiles.length() > 1) {

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/cache/LRUCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/cache/LRUCache.java
@@ -429,8 +429,6 @@ class LRUCache<K, V> implements RefCountedCache<K, V> {
                     .append(entry.getValue().refCount)
                     .append(" , Weight: ")
                     .append(entry.getValue().weight)
-                    .append(" , Pinned: ")
-                    .append(entry.getValue().pinned)
                     .append(" ]\n");
             }
             if (allFiles.length() > 1) {

--- a/server/src/main/java/org/opensearch/index/store/remote/utils/cache/SegmentedCache.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/cache/SegmentedCache.java
@@ -244,6 +244,13 @@ public class SegmentedCache<K, V> implements RefCountedCache<K, V> {
         }
     }
 
+    // To be used only in testing framework.
+    public void closeIndexInputReferences() {
+        for (RefCountedCache<K, V> cache : table) {
+            ((LRUCache<K, V>) cache).closeIndexInputReferences();
+        }
+    }
+
     enum SingletonWeigher implements Weigher<Object> {
         INSTANCE;
 

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -2252,7 +2252,7 @@ public class Node implements Closeable {
 
         this.fileCache = FileCacheFactory.createConcurrentLRUFileCache(capacity, circuitBreaker);
         fileCacheNodePath.fileCacheReservedSize = new ByteSizeValue(this.fileCache.capacity(), ByteSizeUnit.BYTES);
-        List<Path> fileCacheDataPaths = collectFileCacheDataPath(fileCacheNodePath);
+        List<Path> fileCacheDataPaths = collectFileCacheDataPath(fileCacheNodePath, settings);
         this.fileCache.restoreFromDirectory(fileCacheDataPaths);
     }
 

--- a/server/src/test/java/org/opensearch/index/store/CompositeDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/CompositeDirectoryTests.java
@@ -19,7 +19,9 @@ import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.breaker.NoopCircuitBreaker;
 import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
 import org.opensearch.index.store.remote.file.OnDemandBlockSnapshotIndexInput;
+import org.opensearch.index.store.remote.filecache.CachedIndexInput;
 import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.index.store.remote.filecache.FileCache.RestoredCachedIndexInput;
 import org.opensearch.index.store.remote.filecache.FileCacheFactory;
 import org.opensearch.index.store.remote.filecache.FileCachedIndexInput;
 import org.opensearch.index.store.remote.utils.FileTypeUtils;
@@ -188,6 +190,54 @@ public class CompositeDirectoryTests extends BaseRemoteSegmentStoreDirectoryTest
         assertFalse(existsInLocalDirectory(FILE_PRESENT_LOCALLY));
         // Asserting file is not present in FileCache
         assertNull(fileCache.get(getFilePath(FILE_PRESENT_LOCALLY)));
+    }
+
+    public void testOpenInputWithClosedCachedInput() throws Exception {
+        // Setup: Create a file and get it into cache
+        try (IndexOutput indexOutput = compositeDirectory.createOutput(NEW_FILE, IOContext.DEFAULT)) {
+            indexOutput.writeString("test data");
+        }
+
+        // Get the cached input and close it
+        Path key = getFilePath(NEW_FILE);
+        RestoredCachedIndexInput restoredCachedIndexInput = new RestoredCachedIndexInput(0);
+        CachedIndexInput cachedInput = fileCache.get(key);
+        cachedInput.close();
+        // replace the original index input with RestoredCachedIndexInput
+        fileCache.put(key, restoredCachedIndexInput);
+
+        // Verify that we can still open the file and get a valid input
+        IndexInput input = compositeDirectory.openInput(NEW_FILE, IOContext.DEFAULT);
+        assertNotNull(input);
+        assertTrue(input instanceof FileCachedIndexInput);
+        input.close();
+    }
+
+    public void testOpenInputAfterFileCacheEviction() throws IOException {
+        // First create and cache the file locally
+        try (IndexOutput indexOutput = compositeDirectory.createOutput(FILE_PRESENT_IN_REMOTE_ONLY, IOContext.DEFAULT)) {
+            indexOutput.writeString("test data");
+        }
+
+        // Clear the file cache
+        fileCache.clear();
+
+        // Should still be able to open input, now from remote
+        IndexInput input = compositeDirectory.openInput(FILE_PRESENT_IN_REMOTE_ONLY, IOContext.DEFAULT);
+        assertNotNull(input);
+        assertTrue(input instanceof OnDemandBlockSnapshotIndexInput);
+        input.close();
+    }
+
+    public void testOpenInputThrowsIOException() throws IOException {
+        // Use FILE_PRESENT_LOCALLY ("_1.cfe") which is already set up locally
+        // Corrupt the local file to cause IOException
+        Path filePath = getFilePath(NEW_FILE);
+        try (IndexOutput output = localDirectory.createOutput(NEW_FILE, IOContext.DEFAULT)) {
+            output.writeString("corrupted data");
+        }
+
+        assertThrows(IOException.class, () -> compositeDirectory.openInput(NEW_FILE, IOContext.DEFAULT));
     }
 
     private void addFilesToDirectory(String[] files) throws IOException {

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheCleanerTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheCleanerTests.java
@@ -8,16 +8,21 @@
 
 package org.opensearch.index.store.remote.filecache;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.routing.AllocationId;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.breaker.NoopCircuitBreaker;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.env.NodeEnvironment;
+import org.opensearch.gateway.WriteStateException;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.ShardPath;
+import org.opensearch.index.shard.ShardStateMetadata;
 import org.opensearch.test.OpenSearchTestCase;
 import org.hamcrest.MatcherAssert;
 import org.junit.After;
@@ -26,10 +31,14 @@ import org.junit.Before;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
+import static org.opensearch.index.IndexModule.IS_WARM_INDEX_SETTING;
 import static org.opensearch.index.store.remote.directory.RemoteSnapshotDirectoryFactory.LOCAL_STORE_LOCATION;
+import static org.opensearch.index.store.remote.utils.FileTypeUtils.INDICES_FOLDER_IDENTIFIER;
 import static org.hamcrest.Matchers.equalTo;
 
 public class FileCacheCleanerTests extends OpenSearchTestCase {
@@ -46,6 +55,28 @@ public class FileCacheCleanerTests extends OpenSearchTestCase {
         SETTINGS
     );
 
+    private static final ShardId WARM_SHARD_0 = new ShardId("warm-index-0", "warm-uuid-0", 0);
+    private static final ShardId WARM_SHARD_1 = new ShardId("warm-index-1", "warm-uuid-1", 1);
+
+    private static final Settings WARM_SETTINGS = Settings.builder()
+        .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+        .put(IS_WARM_INDEX_SETTING.getKey(), true)
+        .build();
+
+    private static final IndexSettings WARM_INDEX_SETTINGS_0 = new IndexSettings(
+        IndexMetadata.builder("warm-index-0").settings(WARM_SETTINGS).build(),
+        WARM_SETTINGS
+    );
+
+    private static final IndexSettings WARM_INDEX_SETTINGS_1 = new IndexSettings(
+        IndexMetadata.builder("warm-index-1").settings(WARM_SETTINGS).build(),
+        WARM_SETTINGS
+    );
+
+    private static final Logger logger = LogManager.getLogger(FileCache.class);
+
     private final FileCache fileCache = FileCacheFactory.createConcurrentLRUFileCache(
         1024 * 1024,
         1,
@@ -61,7 +92,25 @@ public class FileCacheCleanerTests extends OpenSearchTestCase {
         cleaner = new FileCacheCleaner(() -> fileCache);
         files.put(SHARD_0, addFile(fileCache, env, SHARD_0));
         files.put(SHARD_1, addFile(fileCache, env, SHARD_1));
-        MatcherAssert.assertThat(fileCache.size(), equalTo(2L));
+
+        // add files in filecache for warm index shards.
+        Path[] paths0 = env.availableShardPaths(WARM_SHARD_0);
+        Path[] paths1 = env.availableShardPaths(WARM_SHARD_1);
+        Path path1 = randomFrom(paths0);
+        Path path2 = randomFrom(paths1);
+        writeShardStateMetadata("warm-uuid-0", path1);
+        writeShardStateMetadata("warm-uuid-1", path2);
+        files.put(WARM_SHARD_0, addFileForWarmIndex(fileCache, env, WARM_SHARD_0));
+        files.put(WARM_SHARD_1, addFileForWarmIndex(fileCache, env, WARM_SHARD_1));
+
+        MatcherAssert.assertThat(fileCache.size(), equalTo(4L));
+    }
+
+    private static void writeShardStateMetadata(String indexUUID, Path... paths) throws WriteStateException {
+        ShardStateMetadata.FORMAT.writeAndCleanup(
+            new ShardStateMetadata(true, indexUUID, AllocationId.newInitializing(), ShardStateMetadata.IndexDataLocation.LOCAL),
+            paths
+        );
     }
 
     private static Path addFile(FileCache fileCache, NodeEnvironment env, ShardId shardId) throws IOException {
@@ -69,6 +118,39 @@ public class FileCacheCleanerTests extends OpenSearchTestCase {
         final Path localStorePath = shardPath.getDataPath().resolve(LOCAL_STORE_LOCATION);
         Files.createDirectories(localStorePath);
         final Path file = Files.createFile(localStorePath.resolve("file"));
+        fileCache.put(file, new CachedIndexInput() {
+            @Override
+            public IndexInput getIndexInput() {
+                return null;
+            }
+
+            @Override
+            public long length() {
+                return 1024;
+            }
+
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+
+            @Override
+            public void close() {
+
+            }
+        });
+        return file;
+    }
+
+    private static Path addFileForWarmIndex(FileCache fileCache, NodeEnvironment env, ShardId shardId) throws IOException {
+        final ShardPath shardPath = ShardPath.loadShardPath(logger, env, shardId, "");
+        final Path localStorePath = shardPath.getDataPath().resolve(INDICES_FOLDER_IDENTIFIER);
+
+        logger.info("warm index local store location [{}]", localStorePath);
+
+        Files.createDirectories(localStorePath);
+        final Path file = Files.createFile(localStorePath.resolve("file"));
+
         fileCache.put(file, new CachedIndexInput() {
             @Override
             public IndexInput getIndexInput() {
@@ -101,13 +183,103 @@ public class FileCacheCleanerTests extends OpenSearchTestCase {
     public void testShardRemoved() {
         final Path cachePath = ShardPath.loadFileCachePath(env, SHARD_0).getDataPath();
         assertTrue(Files.exists(cachePath));
-
+        // Initially 4 files exits in fileCache.
+        MatcherAssert.assertThat(fileCache.size(), equalTo(4L));
+        // cleanup shard_0 files.
         cleaner.beforeShardPathDeleted(SHARD_0, INDEX_SETTINGS, env);
-        MatcherAssert.assertThat(fileCache.size(), equalTo(1L));
+        // assert fileCache has 3 files.
+        MatcherAssert.assertThat(fileCache.size(), equalTo(3L));
         assertNull(fileCache.get(files.get(SHARD_0)));
         assertFalse(Files.exists(files.get(SHARD_0)));
         assertTrue(Files.exists(files.get(SHARD_1)));
         assertFalse(Files.exists(cachePath));
+    }
+
+    public void testShardRemovedForWarmIndex() throws IOException {
+        final Path indexFilePath0 = ShardPath.loadShardPath(logger, env, WARM_SHARD_0, "").getDataPath();
+        final Path indexFilePath1 = ShardPath.loadShardPath(logger, env, WARM_SHARD_1, "").getDataPath();
+        assertTrue(Files.exists(indexFilePath0));
+        // Initially 4 files exits in fileCache.
+        MatcherAssert.assertThat(fileCache.size(), equalTo(4L));
+        // clean warm_shard_0 files
+        cleaner.beforeShardPathDeleted(WARM_SHARD_0, WARM_INDEX_SETTINGS_0, env);
+        MatcherAssert.assertThat(fileCache.size(), equalTo(3L));
+        assertNull(fileCache.get(files.get(WARM_SHARD_0)));
+        assertFalse(Files.exists(files.get(WARM_SHARD_0)));
+        assertTrue(Files.exists(files.get(WARM_SHARD_1)));
+        assertFalse(Files.exists(indexFilePath0));
+
+        // clean warm_shard_1 files as well.
+        cleaner.beforeShardPathDeleted(WARM_SHARD_1, WARM_INDEX_SETTINGS_1, env);
+        MatcherAssert.assertThat(fileCache.size(), equalTo(2L));
+        assertNull(fileCache.get(files.get(WARM_SHARD_1)));
+        assertFalse(Files.exists(files.get(WARM_SHARD_1)));
+        assertFalse(Files.exists(indexFilePath1));
+    }
+
+    public void testIndexRemovedForWarmIndexWhenShardPathDeletedFirst() throws IOException {
+        final Path indexFilePath = ShardPath.loadShardPath(logger, env, WARM_SHARD_0, "").getDataPath();
+        assertTrue(Files.exists(indexFilePath));
+        // assert filecache contains 4 files
+        MatcherAssert.assertThat(fileCache.size(), equalTo(4L));
+        // clean shard path files first.
+        cleaner.beforeShardPathDeleted(WARM_SHARD_0, WARM_INDEX_SETTINGS_0, env);
+        // now clean the index path.
+        cleaner.beforeIndexPathDeleted(WARM_INDEX_SETTINGS_0.getIndex(), WARM_INDEX_SETTINGS_0, env);
+        // Assert that index path deleted and fileCache also doesn't have files for that index shard.
+        MatcherAssert.assertThat(fileCache.size(), equalTo(3L));
+        assertFalse(Files.exists(indexFilePath));
+    }
+
+    public void testIndexNotRemovedForWarmIndexWhenShardPathNotDeletedFirst() throws IOException {
+        final Path indexFilePath = ShardPath.loadShardPath(logger, env, WARM_SHARD_0, "").getDataPath();
+        assertTrue(Files.exists(indexFilePath));
+        // assert filecache contains 4 files
+        MatcherAssert.assertThat(fileCache.size(), equalTo(4L));
+        // Try to not clean the index path without calling beforeShardPathDeleted method
+        cleaner.beforeIndexPathDeleted(WARM_INDEX_SETTINGS_0.getIndex(), WARM_INDEX_SETTINGS_0, env);
+        // Assert that index path should exists and fileCache also have files for that index shard.
+        MatcherAssert.assertThat(fileCache.size(), equalTo(4L));
+        assertTrue(Files.exists(indexFilePath));
+    }
+
+    public void testFileCacheNotClearedAndWithFileAlreadyDeleted() throws IOException {
+        // Delete the shard path to simulate IOException when trying to load shard path
+        Path shardPath = ShardPath.loadShardPath(logger, env, WARM_SHARD_0, "").getDataPath();
+        Path shardFilePath = shardPath.resolve(INDICES_FOLDER_IDENTIFIER).resolve("file");
+        assertTrue(Files.exists(shardFilePath));
+        Files.delete(shardFilePath);
+
+        // Initially 4 files exist in fileCache
+        MatcherAssert.assertThat(fileCache.size(), equalTo(4L));
+
+        // Try to clean up the deleted shard path
+        cleaner.beforeShardPathDeleted(WARM_SHARD_0, WARM_INDEX_SETTINGS_0, env);
+
+        // Verify fileCache still contains all files as remove operation won't get executed.
+        MatcherAssert.assertThat(fileCache.size(), equalTo(4L));
+        // Shard path is still deleted
+        assertFalse(Files.exists(shardPath));
+    }
+
+    public void testShardRemovedForWarmIndexWithIOExceptionOnDirectoryStream() throws IOException {
+        Path shardPath = ShardPath.loadShardPath(logger, env, WARM_SHARD_0, "").getDataPath();
+        Path indicesPath = shardPath.resolve(INDICES_FOLDER_IDENTIFIER);
+
+        // Make the indices directory non-readable to cause IOException during directory stream
+        Files.setPosixFilePermissions(indicesPath, new HashSet<>());
+
+        // Initially 4 files exist in fileCache
+        MatcherAssert.assertThat(fileCache.size(), equalTo(4L));
+
+        // Try to clean up with non-readable directory
+        cleaner.beforeShardPathDeleted(WARM_SHARD_0, WARM_INDEX_SETTINGS_0, env);
+
+        // Restore permissions for cleanup
+        Files.setPosixFilePermissions(indicesPath, PosixFilePermissions.fromString("rwxrwxrwx"));
+
+        // Verify fileCache still contains all files as operation failed
+        MatcherAssert.assertThat(fileCache.size(), equalTo(4L));
     }
 
     public void testIndexRemoved() {
@@ -117,7 +289,7 @@ public class FileCacheCleanerTests extends OpenSearchTestCase {
         cleaner.beforeShardPathDeleted(SHARD_0, INDEX_SETTINGS, env);
         cleaner.beforeShardPathDeleted(SHARD_1, INDEX_SETTINGS, env);
         cleaner.beforeIndexPathDeleted(SHARD_0.getIndex(), INDEX_SETTINGS, env);
-        MatcherAssert.assertThat(fileCache.size(), equalTo(0L));
+        MatcherAssert.assertThat(fileCache.size(), equalTo(2L));
         assertFalse(Files.exists(indexCachePath));
     }
 }

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
@@ -18,12 +18,14 @@ import org.opensearch.core.common.breaker.CircuitBreakingException;
 import org.opensearch.core.common.breaker.NoopCircuitBreaker;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.store.remote.directory.RemoteSnapshotDirectoryFactory;
+import org.opensearch.index.store.remote.utils.FileTypeUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
 
 public class FileCacheTests extends OpenSearchTestCase {
@@ -60,6 +62,18 @@ public class FileCacheTests extends OpenSearchTestCase {
             .resolve(indexName)
             .resolve(shardId)
             .resolve(RemoteSnapshotDirectoryFactory.LOCAL_STORE_LOCATION);
+        Path filePath = folderPath.resolve(fileName);
+        Files.createDirectories(folderPath);
+        Files.createFile(filePath);
+        Files.write(filePath, "test-data".getBytes());
+    }
+
+    @SuppressForbidden(reason = "creating a test file for cache")
+    private void createWarmIndexFile(String indexName, String shardId, String fileName) throws IOException {
+        Path folderPath = path.resolve(NodeEnvironment.INDICES_FOLDER)
+            .resolve(indexName)
+            .resolve(shardId)
+            .resolve(FileTypeUtils.INDICES_FOLDER_IDENTIFIER);
         Path filePath = folderPath.resolve(fileName);
         Files.createDirectories(folderPath);
         Files.createFile(filePath);
@@ -355,6 +369,114 @@ public class FileCacheTests extends OpenSearchTestCase {
         fileCache.restoreFromDirectory(List.of(fileCachePath));
         assertTrue(fileCache.usage() > 0);
         assertEquals(0, fileCache.activeUsage());
+    }
+
+    public void testCloseIndexInputReferences() throws IOException {
+        FileCache fileCache = createFileCache(MEGA_BYTES);
+        // Add some entries to cache
+        int numEntries = 2;
+        Path tempDir = createTempDir();
+        Path path1 = tempDir.resolve("test1.tmp");
+        Path path2 = tempDir.resolve("test2.tmp");
+
+        // Create the files
+        Files.createFile(path1);
+        Files.createFile(path2);
+
+        try {
+            fileCache.put(path1, new StubCachedIndexInput(8 * MEGA_BYTES));
+            fileCache.incRef(path1); // Increase reference count
+            fileCache.put(path2, new StubCachedIndexInput(8 * MEGA_BYTES));
+            fileCache.incRef(path2); // Increase reference count
+            // Verify initial state
+            assertEquals(numEntries, fileCache.size());
+            // Close all references
+            fileCache.closeIndexInputReferences();
+            // Verify cache is empty
+            assertEquals(0, fileCache.size());
+            // Verify all entries are removed
+            assertNull(fileCache.get(path1));
+            assertNull(fileCache.get(path2));
+            // Verify path still exists
+            assertTrue(Files.exists(path1));
+            assertTrue(Files.exists(path2));
+        } finally {
+            Files.deleteIfExists(path1);
+            Files.deleteIfExists(path2);
+        }
+    }
+
+    public void testRestoreFromEmptyDirectory() throws IOException {
+        FileCache fileCache = createFileCache(MEGA_BYTES);
+        Path emptyDir = createTempDir();
+        fileCache.restoreFromDirectory(List.of(emptyDir));
+        assertEquals(0, fileCache.usage());
+        assertEquals(0, fileCache.activeUsage());
+    }
+
+    public void testRestoreWithNonExistentDirectory() {
+        FileCache fileCache = createFileCache(MEGA_BYTES);
+        Path nonExistentPath = path.resolve("non-existent");
+
+        fileCache.restoreFromDirectory(List.of(nonExistentPath));
+        assertEquals(0, fileCache.usage());
+    }
+
+    public void testWarmIndexCacheRestore() throws IOException {
+        String indexName = "test-warm-index";
+        String shardId = "0";
+        createWarmIndexFile(indexName, shardId, "test.0");
+        FileCache fileCache = createFileCache(MEGA_BYTES);
+        assertEquals(0, fileCache.usage());
+        Path indicesCachePath = path.resolve(NodeEnvironment.INDICES_FOLDER).resolve(indexName).resolve(shardId);
+        fileCache.restoreFromDirectory(List.of(indicesCachePath));
+        assertTrue(fileCache.usage() > 0);
+        assertEquals(0, fileCache.activeUsage());
+    }
+
+    public void testRestoreFromMultipleDirectories() throws IOException {
+        String index1 = "test-index-1";
+        String index2 = "test-warm-index-2";
+        String shardId = "0";
+
+        // Create files in both cache and indices directories
+        createFile(index1, shardId, "test1.0");
+        createWarmIndexFile(index2, shardId, "test2.0");
+
+        FileCache fileCache = createFileCache(MEGA_BYTES);
+        Path cachePath = path.resolve(NodeEnvironment.CACHE_FOLDER).resolve(index1).resolve(shardId);
+        Path indicesPath = path.resolve(NodeEnvironment.INDICES_FOLDER).resolve(index2).resolve(shardId);
+
+        fileCache.restoreFromDirectory(List.of(cachePath, indicesPath));
+        assertTrue(fileCache.usage() > 0);
+        assertEquals(0, fileCache.activeUsage());
+    }
+
+    public void testRestoreWithInvalidWarmIndexFiles() throws IOException {
+        String indexName = "test-warm-index";
+        String shardId = "0";
+
+        // Create a valid warm index file
+        createWarmIndexFile(indexName, shardId, "valid.0");
+
+        // Create an invalid/corrupt warm index file
+        Path invalidFilePath = path.resolve(NodeEnvironment.INDICES_FOLDER)
+            .resolve(indexName)
+            .resolve(shardId)
+            .resolve(FileTypeUtils.INDICES_FOLDER_IDENTIFIER)
+            .resolve("invalid.0");
+        Files.createDirectories(invalidFilePath.getParent());
+        Files.createFile(invalidFilePath);
+        // Make file unreadable
+        Files.setPosixFilePermissions(invalidFilePath, PosixFilePermissions.fromString("---------"));
+
+        FileCache fileCache = createFileCache(MEGA_BYTES);
+        Path indicesPath = path.resolve(NodeEnvironment.INDICES_FOLDER).resolve(indexName).resolve(shardId);
+
+        // Should handle the invalid file gracefully
+        fileCache.restoreFromDirectory(List.of(indicesPath));
+        assertTrue("File cache should contain at least the valid file", fileCache.usage() > 0);
+        assertEquals("No files should be actively used", 0, fileCache.activeUsage());
     }
 
     private void putAndDecRef(FileCache cache, int path, long indexInputSize) {

--- a/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/InternalTestCluster.java
@@ -1982,6 +1982,12 @@ public final class InternalTestCluster extends TestCluster {
         assert Thread.holdsLock(this);
         logger.info("Restarting node [{}] ", nodeAndClient.name);
 
+        FileCache fileCache = nodeAndClient.node().fileCache();
+        // Close IndexInput reference file to avoid file leaks during node restart
+        if (fileCache != null && WARM_NODE_PREDICATE.test(nodeAndClient)) {
+            fileCache.closeIndexInputReferences();
+        }
+
         if (activeDisruptionScheme != null) {
             activeDisruptionScheme.removeFromNode(nodeAndClient.name, this);
         }


### PR DESCRIPTION
### Description
This PR:
- Implements local file scanning to warm up fileCache during node startup, reducing remote store downloads
- Logic to cleans up index and shard paths during warm index deletion. Reference [PR](https://github.com/opensearch-project/OpenSearch/pull/11443).
- Fixes flaky tests in WarmIndexSegmentReplicationIT

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/17526, https://github.com/opensearch-project/OpenSearch/issues/18157

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
