### PR TITLE
Set git attributes to union changes in the CHANGELOG to reduce merge conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@
 *.crt binary
 *.p12 binary
 *.txt text=auto
+CHANGELOG.md merge=union


### PR DESCRIPTION
### Description

This is a quality of life PR to drastically reduce the number of merge conflicts and prevent maintainers from having to constantly resolve conflicts only in the CHANGELOG file.

By setting the gitattribute `merge=union`, this tells git to automatically take the union of both sides of the conflicts without maintainers having to manually determine how to perform the merge.

### Related Issues

Resolves https://github.com/opensearch-project/OpenSearch/issues/18475

Related to https://about.gitlab.com/blog/gitlab-reduced-merge-conflicts-by-90-percent-with-changelog-placeholders/

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
