### PR TITLE
Bugfix arrow-flight-rpc plugin dependency injection collision

### DIFF
--- a/plugins/arrow-flight-rpc/README.md
+++ b/plugins/arrow-flight-rpc/README.md
@@ -1,0 +1,31 @@
+# arrow-flight-rpc
+
+Enable this transport with:
+
+```
+setting 'aux.transport.types',                   '[arrow-flight-rpc]'
+setting 'aux.transport.arrow-flight-rpc.port',   '9400-9500' //optional
+```
+
+## Testing
+
+### Unit Tests
+
+```
+./gradlew run \
+    -PinstalledPlugins="['arrow-flight-rpc']" \
+    -Dtests.opensearch.aux.transport.types="[experimental-transport-arrow-flight-rpc]" \
+    -Dtests.opensearch.opensearch.experimental.feature.arrow.streams.enabled=true
+```
+
+### Unit Tests
+
+```
+./gradlew :plugins:arrow-flight-rpc:test
+```
+
+### Integration Tests
+
+```
+./gradlew :plugins:arrow-flight-rpc:internalClusterTest
+```

--- a/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/ArrowFlightServerIT.java
+++ b/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/ArrowFlightServerIT.java
@@ -25,6 +25,7 @@ import org.opensearch.arrow.spi.StreamProducer;
 import org.opensearch.arrow.spi.StreamReader;
 import org.opensearch.arrow.spi.StreamTicket;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -36,10 +37,20 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.opensearch.arrow.flight.bootstrap.FlightService.ARROW_FLIGHT_TRANSPORT_SETTING_KEY;
 import static org.opensearch.common.util.FeatureFlags.ARROW_STREAMS;
+import static org.opensearch.transport.AuxTransport.AUX_TRANSPORT_TYPES_KEY;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 5)
 public class ArrowFlightServerIT extends OpenSearchIntegTestCase {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(AUX_TRANSPORT_TYPES_KEY, ARROW_FLIGHT_TRANSPORT_SETTING_KEY)
+            .build();
+    }
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightStreamPlugin.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightStreamPlugin.java
@@ -115,7 +115,7 @@ public class FlightStreamPlugin extends Plugin
         flightService.setClusterService(clusterService);
         flightService.setThreadPool(threadPool);
         flightService.setClient(client);
-        return List.of(flightService);
+        return Collections.emptyList();
     }
 
     /**


### PR DESCRIPTION
### Description
`arrow-flight-rpc` plugin provides the `FlightService` through both `createComponent` as well as `getAuxTransports`. These two instances collide when Node.java dependency injection framework binds them both to `FlightService.class`.

Removing the `createComponent` instance to resolve this conflict. `createComponent` does not respect aux transport enable settings or port range settings.

Error:
```
»  uncaught exception in thread [main]
»  org.opensearch.common.inject.CreationException: Guice creation errors:
»
»  1) A binding to org.opensearch.arrow.flight.bootstrap.FlightService was already configured at _unknown_.
»    at _unknown_
»
»  1 error
»       at <<<guice>>>
»       at org.opensearch.node.Node.<init>(Node.java:1591)
»       at org.opensearch.node.Node.<init>(Node.java:464)
»       at org.opensearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:249)
...
```

### Related Issues
No issue

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
