### PR TITLE
Ability to run Code Coverage locally with Gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Approximation Framework Enhancement: Update the BKD traversal logic to improve the performance on skewed data ([#18439](https://github.com/opensearch-project/OpenSearch/issues/18439))
 - Support system generated ingest pipelines for bulk update operations ([#18277](https://github.com/opensearch-project/OpenSearch/pull/18277)))
 - Added FS Health Check Failure metric ([#18435](https://github.com/opensearch-project/OpenSearch/pull/18435))
+- Ability to run Code Coverage with Gradle and produce the jacoco reports locally ([#18509](https://github.com/opensearch-project/OpenSearch/issues/18509))
 
 ### Changed
 - Create generic DocRequest to better categorize ActionRequests ([#18269](https://github.com/opensearch-project/OpenSearch/pull/18269)))

--- a/TESTING.md
+++ b/TESTING.md
@@ -522,15 +522,12 @@ The code coverage report can be generated through Gradle with [JaCoCo plugin](ht
 
 For unit test:
 
-    ./gradlew codeCoverageReportForUnitTest
+    ./gradlew jacocoTestReport
 
 For integration test:
 
-    ./gradlew codeCoverageReportForIntegrationTest
+    ./gradlew :server:jacocoTestReport
 
-For the combined tests (unit and integration):
-
-    ./gradlew codeCoverageReport
 
 To generate coverage report for the combined tests after `check` task:
 
@@ -546,7 +543,7 @@ The report will be in XML format only by default, but you can add the following 
 
 For example, to generate code coverage report in HTML format and not in XML format:
 
-    ./gradlew codeCoverageReport -Dtests.coverage.report.html=true -Dtests.coverage.report.xml=false
+    ./gradlew jacocoTestReport -Dtests.coverage.report.html=true -Dtests.coverage.report.xml=false
 
 Apart from using Gradle, it is also possible to gain insight in code coverage using IntelliJ’s built-in coverage analysis tool that can measure coverage upon executing specific tests. Eclipse may also be able to do the same using the EclEmma plugin.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -518,22 +518,48 @@ Example:
 
 # Test coverage analysis
 
-The code coverage report can be generated through Gradle with [JaCoCo plugin](https://docs.gradle.org/current/userguide/jacoco_plugin.html).
+The code coverage report can be generated through Gradle with [JaCoCo plugin](https://docs.gradle.org/current/userguide/jacoco_plugin.html). Following are some of the ways to generate the code coverage reports locally.
 
 For unit test:
 
+    ./gradlew test
     ./gradlew jacocoTestReport
+
+For unit test inside a specific module:
+
+    ./gradlew :server:test
+    ./gradlew :server:jacocoTestReport
+
+For specific unit test inside a specific module:
+
+    ./gradlew :server:test --tests "org.opensearch.search.approximate.ApproximatePointRangeQueryTests.testNycTaxiDataDistribution"
+    ./gradlew :server:jacocoTestReport -Dtests.coverage.report.html=true
 
 For integration test:
 
+    ./gradlew internalClusterTest
+    ./gradlew jacocoTestReport
+
+For integration test inside a specific module:
+
+    ./gradlew :server:internalClusterTest
     ./gradlew :server:jacocoTestReport
 
+For specific integration test inside a specific module:
+
+    ./gradlew :server:internalClusterTest --tests "org.opensearch.action.admin.ClientTimeoutIT.testNodesInfoTimeout"
+    ./gradlew :server:jacocoTestReport
+
+For modules with javaRestTest:
+
+    ./gradlew :qa:die-with-dignity:javaRestTest
+    ./gradlew :qa:die-with-dignity:jacocoTestReport -Dtests.coverage.report.html=true
 
 To generate coverage report for the combined tests after `check` task:
 
     ./gradlew check -Dtests.coverage=true
 
-The code coverage report will be generated in `build/codeCoverageReport`, `build/codeCoverageReportForUnitTest` or `build/codeCoverageReportForIntegrationTest` correspondingly.
+The code coverage report will be generated in `$buildDir/build/reports/jacoco/test/html/`.
 
 The report will be in XML format only by default, but you can add the following parameter for HTML and CSV format.
 
@@ -543,7 +569,7 @@ The report will be in XML format only by default, but you can add the following 
 
 For example, to generate code coverage report in HTML format and not in XML format:
 
-    ./gradlew jacocoTestReport -Dtests.coverage.report.html=true -Dtests.coverage.report.xml=false
+    ./gradlew internalClusterTest -Dtests.coverage.report.html=true -Dtests.coverage.report.xml=false
 
 Apart from using Gradle, it is also possible to gain insight in code coverage using IntelliJ’s built-in coverage analysis tool that can measure coverage upon executing specific tests. Eclipse may also be able to do the same using the EclEmma plugin.
 

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -34,6 +34,47 @@ tasks.withType(JacocoReport).configureEach {
   }
 }
 
+// Enhance jacoco report tasks to include all test types
+allprojects {
+  plugins.withId('jacoco') {
+    // Configure both jacocoTestReport and testCodeCoverageReport tasks
+    tasks.matching { it.name == 'jacocoTestReport' || it.name == 'testCodeCoverageReport' }.configureEach {
+      // Collect execution data files from all available test tasks
+      def executionDataFiles = []
+      def sourceSetsList = []
+      
+      if (tasks.findByName('test')) {
+        executionDataFiles.add("$buildDir/jacoco/test.exec")
+        sourceSetsList.add(sourceSets.test)
+      }
+
+      if (tasks.findByName('internalClusterTest')) {
+        executionDataFiles.add("$buildDir/jacoco/internalClusterTest.exec")
+        sourceSetsList.add(sourceSets.internalClusterTest)
+      }
+
+      if (tasks.findByName('javaRestTest')) {
+        executionDataFiles.add("$buildDir/jacoco/javaRestTest.exec")
+        sourceSetsList.add(sourceSets.javaRestTest)
+      }
+      
+      // Set execution data and source sets
+      if (!executionDataFiles.isEmpty()) {
+        executionData.setFrom(files(executionDataFiles).filter { it.exists() })
+        sourceSets(*sourceSetsList)
+      }
+
+      // Only run if at least one execution data file exists
+      onlyIf {
+        file("$buildDir/jacoco/test.exec").exists() ||
+          file("$buildDir/jacoco/internalClusterTest.exec").exists() ||
+          file("$buildDir/jacoco/javaRestTest.exec").exists()
+      }
+    }
+  }
+}
+
+
 if (System.getProperty("tests.coverage")) {
   reporting {
     reports {

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -71,20 +71,17 @@ if (System.getProperty("tests.coverage")) {
       testCodeCoverageReport(JacocoCoverageReport) {
         testSuiteName = "test"
       }
+      testCodeCoverageReportJavaRestTest(JacocoCoverageReport) {
+        testSuiteName = "javaRestTest"
+      }
     }
   }
 
   // Attach code coverage report task to Gradle check task
   project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure {
-    dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
-  }
-  
-  // To include javaRestTest in code coverage
-  allprojects {
-    plugins.withId('opensearch.java-rest-test') {
-      rootProject.tasks.named('testCodeCoverageReport').configure {
-        dependsOn tasks.named('javaRestTest')
-      }
-    }
+    dependsOn(
+      tasks.named('testCodeCoverageReport', JacocoReport),
+      tasks.named('testCodeCoverageReportJavaRestTest', JacocoReport)
+    )
   }
 }

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -34,37 +34,28 @@ tasks.withType(JacocoReport).configureEach {
   }
 }
 
-// Enhance jacoco report tasks to include all test types
+// Enhance jacocoTestReport task to include all test types
 allprojects {
   plugins.withId('jacoco') {
-    // Configure both jacocoTestReport and testCodeCoverageReport tasks
-    tasks.matching { it.name == 'jacocoTestReport' || it.name == 'testCodeCoverageReport' }.configureEach {
-      // Collect execution data files from all available test tasks
+    tasks.matching { it.name == 'jacocoTestReport' }.configureEach {
       def executionDataFiles = []
       def sourceSetsList = []
-      
       if (tasks.findByName('test')) {
         executionDataFiles.add("$buildDir/jacoco/test.exec")
         sourceSetsList.add(sourceSets.test)
       }
-
       if (tasks.findByName('internalClusterTest')) {
         executionDataFiles.add("$buildDir/jacoco/internalClusterTest.exec")
         sourceSetsList.add(sourceSets.internalClusterTest)
       }
-
       if (tasks.findByName('javaRestTest')) {
         executionDataFiles.add("$buildDir/jacoco/javaRestTest.exec")
         sourceSetsList.add(sourceSets.javaRestTest)
       }
-      
-      // Set execution data and source sets
       if (!executionDataFiles.isEmpty()) {
         executionData.setFrom(files(executionDataFiles).filter { it.exists() })
         sourceSets(*sourceSetsList)
       }
-
-      // Only run if at least one execution data file exists
       onlyIf {
         file("$buildDir/jacoco/test.exec").exists() ||
           file("$buildDir/jacoco/internalClusterTest.exec").exists() ||
@@ -73,7 +64,6 @@ allprojects {
     }
   }
 }
-
 
 if (System.getProperty("tests.coverage")) {
   reporting {
@@ -87,5 +77,14 @@ if (System.getProperty("tests.coverage")) {
   // Attach code coverage report task to Gradle check task
   project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure {
     dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
+  }
+  
+  // To include javaRestTest in code coverage
+  allprojects {
+    plugins.withId('opensearch.java-rest-test') {
+      rootProject.tasks.named('testCodeCoverageReport').configure {
+        dependsOn tasks.named('javaRestTest')
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

- Ability to run code coverage locally.
- Run code coverage for integrationTest, test and javaRestTest (coming from this https://github.com/opensearch-project/OpenSearch/pull/18376 looks like javaRestTest is not added)
- Run for specific Gradle module.
- Run for specific test class and method.

### Related Issues
While I'm working on this PR https://github.com/opensearch-project/OpenSearch/pull/18358, I noticed that GitHub reports code coverage only after the Gradle Check workflow passes. Being able to run coverage reports locally using Gradle can help test and improve coverage earlier in the development cycle. Although IntelliJ provides some insights, using Gradle with the JaCoCo plugin ensures consistency with the coverage reported by GitHub.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
