### PR TITLE
Use single quotes in reproduction command

### DIFF
--- a/test/framework/src/main/java/org/opensearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/opensearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -93,20 +93,20 @@ public class ReproduceInfoPrinter extends RunListener {
 
         // append Gradle test runner test filter string
         b.append("'" + task + "'");
-        b.append(" --tests \"");
+        b.append(" --tests '");
         b.append(failure.getDescription().getClassName());
         final String methodName = failure.getDescription().getMethodName();
         if (methodName != null) {
             // fallback to system property filter when tests contain "."
             if (methodName.contains(".")) {
-                b.append("\" -Dtests.method=\"");
+                b.append("' -Dtests.method='");
                 b.append(methodName);
             } else {
                 b.append(".");
                 b.append(methodName);
             }
         }
-        b.append("\"");
+        b.append("'");
 
         GradleMessageBuilder gradleMessageBuilder = new GradleMessageBuilder(b);
         gradleMessageBuilder.appendAllOpts(failure.getDescription());


### PR DESCRIPTION
Parameterized tests will output test names that include double quotes in the test case, such as:

```
./gradlew ':server:internalClusterTest' --tests "org.opensearch.recovery.RecoveryWhileUnderLoadIT" -Dtests.method="testRecoverWhileUnderLoadWithDerivedSource {p0={"cluster.indices.replication.strategy":"SEGMENT"}}"
```

The nested double quotes do not work appropriately when trying to run the command. This avoids that problem by using single quotes.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
