### PR TITLE
[ref #18085] Allow READ access to `/sys/fs/cgroup/memory.swap.current`

### DIFF
--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -240,6 +240,7 @@ grant {
   permission java.io.FilePermission "/sys/fs/cgroup/memory/-", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/user.slice/-", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/memory.swap.max", "read";
+  permission java.io.FilePermission "/sys/fs/cgroup/memory.swap.current", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/memory.max", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/memory.current", "read";
 


### PR DESCRIPTION
### Description
Allow READ access to `/sys/fs/cgroup/memory.swap.current`.
See https://github.com/opensearch-project/OpenSearch/pull/18085#discussion_r2153517660

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
