### PR TITLE
Added support for range version support in semver

### DIFF
--- a/libs/core/src/main/java/org/opensearch/semver/SemverRange.java
+++ b/libs/core/src/main/java/org/opensearch/semver/SemverRange.java
@@ -53,9 +53,6 @@ public class SemverRange implements ToXContentFragment {
         this.rangeVersion = rangeVersion;
         this.rangeOperator = rangeOperator;
         this.expression = rangeOperator.expression;
-        if (this.expression == null && rangeOperator != RangeOperator.RANGE) {
-            throw new IllegalStateException("Expression cannot be null for non-RANGE operators");
-        }
     }
 
     /**
@@ -68,10 +65,12 @@ public class SemverRange implements ToXContentFragment {
         Matcher matcher = RANGE_PATTERN.matcher(range);
         if (matcher.matches()) {
             char leftBracket = matcher.group(1).charAt(0);
-            Version lowerVersion = Version.fromString(matcher.group(2));
-            Version upperVersion = Version.fromString(matcher.group(3));
+            String lowerVersionStr = matcher.group(2);
+            String upperVersionStr = matcher.group(3);
             char rightBracket = matcher.group(4).charAt(0);
 
+            Version lowerVersion = Version.fromString(matcher.group(2));
+            Version upperVersion = Version.fromString(matcher.group(3));
             boolean includeLower = leftBracket == '[';
             boolean includeUpper = rightBracket == ']';
 
@@ -87,7 +86,7 @@ public class SemverRange implements ToXContentFragment {
         return new SemverRange(Version.fromString(version), rangeOperator);
     }
 
-    private SemverRange(Version rangeVersion, RangeOperator operator, Expression customExpression) {
+    public SemverRange(Version rangeVersion, RangeOperator operator, Expression customExpression) {
         this.rangeVersion = rangeVersion;
         this.rangeOperator = operator;
         this.expression = customExpression;
@@ -177,7 +176,7 @@ public class SemverRange implements ToXContentFragment {
         EQ("=", new Equal()),
         TILDE("~", new Tilde()),
         CARET("^", new Caret()),
-        RANGE("range", null),
+        RANGE("range", new Range()),
         DEFAULT("", new Equal());
 
         private final String operator;

--- a/libs/core/src/main/java/org/opensearch/semver/expr/Range.java
+++ b/libs/core/src/main/java/org/opensearch/semver/expr/Range.java
@@ -21,6 +21,13 @@ public class Range implements Expression {
     private final boolean includeLower;
     private final boolean includeUpper;
 
+    public Range() {
+        this.lowerBound = Version.fromString("0.0.0");  // Minimum version
+        this.upperBound = Version.fromString("999.999.999"); // Maximum version
+        this.includeLower = true;  // Default to inclusive bounds
+        this.includeUpper = true;
+    }
+
     public Range(Version lowerBound, Version upperBound, boolean includeLower, boolean includeUpper) {
         if (lowerBound == null) {
             throw new IllegalArgumentException("Lower bound cannot be null");

--- a/libs/core/src/main/java/org/opensearch/semver/expr/Range.java
+++ b/libs/core/src/main/java/org/opensearch/semver/expr/Range.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.semver.expr;
+
+import org.opensearch.Version;
+
+import java.util.Objects;
+
+/**
+ * Expression to evaluate version compatibility within a specified range with configurable bounds.
+ */
+public class Range implements Expression {
+    private final Version lowerBound;
+    private final Version upperBound;
+    private final boolean includeLower;
+    private final boolean includeUpper;
+
+    public Range(Version lowerBound, Version upperBound, boolean includeLower, boolean includeUpper) {
+        if (lowerBound == null) {
+            throw new IllegalArgumentException("Lower bound cannot be null");
+        }
+        if (upperBound == null) {
+            throw new IllegalArgumentException("Upper bound cannot be null");
+        }
+        if (lowerBound.after(upperBound)) {
+            throw new IllegalArgumentException("Lower bound must be less than or equal to upper bound");
+        }
+        this.lowerBound = lowerBound;
+        this.upperBound = upperBound;
+        this.includeLower = includeLower;
+        this.includeUpper = includeUpper;
+    }
+
+    public void updateRange(Range other) {
+        if (other == null) {
+            throw new IllegalArgumentException("Range cannot be null");
+        }
+    }
+
+    @Override
+    public boolean evaluate(final Version rangeVersion, final Version versionToEvaluate) {
+
+        boolean satisfiesLower = includeLower ? versionToEvaluate.onOrAfter(lowerBound) : versionToEvaluate.after(lowerBound);
+
+        boolean satisfiesUpper = includeUpper ? versionToEvaluate.onOrBefore(upperBound) : versionToEvaluate.before(upperBound);
+
+        return satisfiesLower && satisfiesUpper;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Range range = (Range) o;
+        return includeLower == range.includeLower
+            && includeUpper == range.includeUpper
+            && Objects.equals(lowerBound, range.lowerBound)
+            && Objects.equals(upperBound, range.upperBound);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lowerBound, upperBound, includeLower, includeUpper);
+    }
+
+    public boolean isIncludeLower() {
+        return includeLower;
+    }
+
+    public boolean isIncludeUpper() {
+        return includeUpper;
+    }
+
+    public Version getLowerBound() {
+        return lowerBound;
+    }
+
+    public Version getUpperBound() {
+        return upperBound;
+    }
+
+}

--- a/libs/core/src/test/java/org/opensearch/semver/SemverRangeTests.java
+++ b/libs/core/src/test/java/org/opensearch/semver/SemverRangeTests.java
@@ -101,5 +101,93 @@ public class SemverRangeTests extends OpenSearchTestCase {
         assertTrue(ex.getMessage().contains("the version needs to contain major, minor, and revision, and optionally the build"));
 
         expectThrows(NumberFormatException.class, () -> SemverRange.fromString("$1.2.3"));
+
+        assertThrows(IllegalArgumentException.class, () -> SemverRange.fromString("[2.3.0]"));
+        assertThrows(IllegalArgumentException.class, () -> SemverRange.fromString("[2.3.0,]"));
+        assertThrows(IllegalArgumentException.class, () -> SemverRange.fromString("[,2.7.0]"));
+        assertThrows(IllegalArgumentException.class, () -> SemverRange.fromString("2.3.0,2.7.0"));
+        assertThrows(IllegalArgumentException.class, () -> SemverRange.fromString("[2.7.0,2.3.0]"));
     }
+
+    public void testInclusiveRange() {
+        SemverRange range = SemverRange.fromString("[2.3.0,2.7.0]");
+
+        // Test lower bound
+        assertTrue("Should include lower bound", range.isSatisfiedBy("2.3.0"));
+
+        // Test upper bound
+        assertTrue("Should include upper bound", range.isSatisfiedBy("2.7.0"));
+
+        // Test middle values
+        assertTrue("Should include values in range", range.isSatisfiedBy("2.5.0"));
+        assertTrue("Should include patch versions", range.isSatisfiedBy("2.4.1"));
+
+        // Test out of range values
+        assertFalse("Should exclude values below range", range.isSatisfiedBy("2.2.9"));
+        assertFalse("Should exclude values above range", range.isSatisfiedBy("2.7.1"));
+    }
+
+    public void testExclusiveRange() {
+        SemverRange range = SemverRange.fromString("(2.3.0,2.7.0)");
+
+        // Test bounds
+        assertFalse("Should exclude lower bound", range.isSatisfiedBy("2.3.0"));
+        assertFalse("Should exclude upper bound", range.isSatisfiedBy("2.7.0"));
+
+        // Test middle values
+        assertTrue("Should include values in range", range.isSatisfiedBy("2.5.0"));
+        assertTrue("Should include values near lower bound", range.isSatisfiedBy("2.3.1"));
+        assertTrue("Should include values near upper bound", range.isSatisfiedBy("2.6.9"));
+
+        // Test out of range values
+        assertFalse("Should exclude values below range", range.isSatisfiedBy("2.2.9"));
+        assertFalse("Should exclude values above range", range.isSatisfiedBy("2.7.1"));
+    }
+
+    public void testMixedRanges() {
+        // Test inclusive lower bound, exclusive upper bound
+        SemverRange range1 = SemverRange.fromString("[2.3.0,2.7.0)");
+        assertTrue("Should include lower bound", range1.isSatisfiedBy("2.3.0"));
+        assertFalse("Should exclude upper bound", range1.isSatisfiedBy("2.7.0"));
+        assertTrue("Should include values in range", range1.isSatisfiedBy("2.6.9"));
+
+        // Test exclusive lower bound, inclusive upper bound
+        SemverRange range2 = SemverRange.fromString("(2.3.0,2.7.0]");
+        assertFalse("Should exclude lower bound", range2.isSatisfiedBy("2.3.0"));
+        assertTrue("Should include upper bound", range2.isSatisfiedBy("2.7.0"));
+        assertTrue("Should include values in range", range2.isSatisfiedBy("2.3.1"));
+    }
+
+    public void testRangeToString() {
+        // Test that toString produces the same string that was parsed
+        String[] ranges = { "[2.3.0,2.7.0]", "(2.3.0,2.7.0)", "[2.3.0,2.7.0)", "(2.3.0,2.7.0]" };
+
+        for (String rangeStr : ranges) {
+            SemverRange range = SemverRange.fromString(rangeStr);
+            assertEquals("toString should match original string", rangeStr, range.toString());
+        }
+    }
+
+    public void testRangeEquality() {
+        SemverRange range1 = SemverRange.fromString("[2.3.0,2.7.0]");
+        SemverRange range2 = SemverRange.fromString("[2.3.0,2.7.0]");
+        SemverRange range3 = SemverRange.fromString("(2.3.0,2.7.0]");
+
+        assertEquals("Identical ranges should be equal", range1, range2);
+        assertNotEquals("Different ranges should not be equal", range1, range3);
+        assertNotEquals("Range should not equal null", null, range1);
+    }
+
+    public void testVersionEdgeCases() {
+        SemverRange range = SemverRange.fromString("[2.0.0,3.0.0]");
+
+        // Test major version boundaries
+        assertTrue(range.isSatisfiedBy("2.0.0"));
+        assertTrue(range.isSatisfiedBy("2.99.99"));
+        assertTrue(range.isSatisfiedBy("3.0.0"));
+        assertFalse(range.isSatisfiedBy("1.99.99"));
+        assertFalse(range.isSatisfiedBy("3.0.1"));
+
+    }
+
 }

--- a/libs/core/src/test/java/org/opensearch/semver/expr/RangeTests.java
+++ b/libs/core/src/test/java/org/opensearch/semver/expr/RangeTests.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.semver.expr;
+
+import org.opensearch.Version;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class RangeTests extends OpenSearchTestCase {
+
+    public void testRangeEvaluation() {
+        Version lowerBound = Version.fromString("2.3.0");
+        Version upperBound = Version.fromString("2.7.0");
+
+        // Test inclusive range
+        Range inclusiveRange = new Range(lowerBound, upperBound, true, true);
+        assertTrue(inclusiveRange.evaluate(null, Version.fromString("2.3.0")));
+        assertTrue(inclusiveRange.evaluate(null, Version.fromString("2.5.0")));
+        assertTrue(inclusiveRange.evaluate(null, Version.fromString("2.7.0")));
+        assertFalse(inclusiveRange.evaluate(null, Version.fromString("2.2.9")));
+        assertFalse(inclusiveRange.evaluate(null, Version.fromString("2.7.1")));
+
+        // Test exclusive range
+        Range exclusiveRange = new Range(lowerBound, upperBound, false, false);
+        assertFalse(exclusiveRange.evaluate(null, Version.fromString("2.3.0")));
+        assertTrue(exclusiveRange.evaluate(null, Version.fromString("2.5.0")));
+        assertFalse(exclusiveRange.evaluate(null, Version.fromString("2.7.0")));
+        assertFalse(exclusiveRange.evaluate(null, Version.fromString("2.2.9")));
+        assertFalse(exclusiveRange.evaluate(null, Version.fromString("2.7.1")));
+    }
+
+    public void testInvalidRanges() {
+        Version lowerBound = Version.fromString("2.3.0");
+        Version upperBound = Version.fromString("2.7.0");
+
+        // Test null bounds
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> new Range(null, upperBound, true, true));
+        assertEquals("Lower bound cannot be null", ex.getMessage());
+
+        ex = expectThrows(IllegalArgumentException.class, () -> new Range(lowerBound, null, true, true));
+        assertEquals("Upper bound cannot be null", ex.getMessage());
+
+        // Test invalid range (upper < lower)
+        ex = expectThrows(IllegalArgumentException.class, () -> new Range(upperBound, lowerBound, true, true));
+        assertEquals("Lower bound must be less than or equal to upper bound", ex.getMessage());
+    }
+
+    public void testMixedBoundTypes() {
+        Version lowerBound = Version.fromString("2.3.0");
+        Version upperBound = Version.fromString("2.7.0");
+
+        // Test inclusive lower, exclusive upper
+        Range mixedRange1 = new Range(lowerBound, upperBound, true, false);
+        assertTrue(mixedRange1.evaluate(null, Version.fromString("2.3.0")));
+        assertTrue(mixedRange1.evaluate(null, Version.fromString("2.6.9")));
+        assertFalse(mixedRange1.evaluate(null, Version.fromString("2.7.0")));
+
+        // Test exclusive lower, inclusive upper
+        Range mixedRange2 = new Range(lowerBound, upperBound, false, true);
+        assertFalse(mixedRange2.evaluate(null, Version.fromString("2.3.0")));
+        assertTrue(mixedRange2.evaluate(null, Version.fromString("2.3.1")));
+        assertTrue(mixedRange2.evaluate(null, Version.fromString("2.7.0")));
+    }
+
+    public void testRangeAccessors() {
+        Version lowerBound = Version.fromString("2.3.0");
+        Version upperBound = Version.fromString("2.7.0");
+        Range range = new Range(lowerBound, upperBound, true, false);
+
+        assertEquals("Lower bound should match", lowerBound, range.getLowerBound());
+        assertEquals("Upper bound should match", upperBound, range.getUpperBound());
+        assertTrue("Should be inclusive lower", range.isIncludeLower());
+        assertFalse("Should be exclusive upper", range.isIncludeUpper());
+    }
+}

--- a/libs/core/src/test/java/org/opensearch/semver/expr/RangeTests.java
+++ b/libs/core/src/test/java/org/opensearch/semver/expr/RangeTests.java
@@ -13,6 +13,15 @@ import org.opensearch.test.OpenSearchTestCase;
 
 public class RangeTests extends OpenSearchTestCase {
 
+    public void testDefaultConstructor() {
+        Range range = new Range();
+        assertEquals(Version.fromString("0.0.0"), range.getLowerBound());
+        assertEquals(Version.fromString("999.999.999"), range.getUpperBound());
+        assertTrue(range.isIncludeLower());
+        assertTrue(range.isIncludeUpper());
+
+    }
+
     public void testRangeEvaluation() {
         Version lowerBound = Version.fromString("2.3.0");
         Version upperBound = Version.fromString("2.7.0");
@@ -77,4 +86,18 @@ public class RangeTests extends OpenSearchTestCase {
         assertTrue("Should be inclusive lower", range.isIncludeLower());
         assertFalse("Should be exclusive upper", range.isIncludeUpper());
     }
+
+    public void testUpdateRangeNullCheck() {
+        Range range = new Range(
+            Version.fromString("1.0.0"),
+            Version.fromString("2.0.0"),
+            true,  // includeLower
+            true   // includeUpper
+        );
+
+        // Test that updateRange throws IllegalArgumentException for null input
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> range.updateRange(null));
+        assertEquals("Range cannot be null", ex.getMessage());
+    }
+
 }


### PR DESCRIPTION
### Description
This PR fixes the SemverRange implementation to properly handle version range expressions and comparisons. The changes include:

1. Proper implementation of range parsing and validation
2. Correct handling of inclusive/exclusive bounds in version ranges
4. Added proper validation for invalid inputs
5. Ensured correct version comparisons within ranges


### Related Issues
Resolves #18554 

<!-- List any other related issues here -->
N/A

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
