### PR TITLE
Update Subject interface to use CheckedRunnable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Ability to run Code Coverage with Gradle and produce the jacoco reports locally ([#18509](https://github.com/opensearch-project/OpenSearch/issues/18509))
 
 ### Changed
+- Update Subject interface to use CheckedRunnable ([#18570](https://github.com/opensearch-project/OpenSearch/issues/18570))
 
 ### Dependencies
 - Bump `stefanzweifel/git-auto-commit-action` from 5 to 6 ([#18524](https://github.com/opensearch-project/OpenSearch/pull/18524))

--- a/libs/common/src/main/java/org/opensearch/common/CheckedRunnable.java
+++ b/libs/common/src/main/java/org/opensearch/common/CheckedRunnable.java
@@ -32,11 +32,14 @@
 
 package org.opensearch.common;
 
+import org.opensearch.common.annotation.PublicApi;
+
 /**
  * A {@link Runnable}-like interface which allows throwing checked exceptions.
  *
  * @opensearch.api
  */
+@PublicApi(since = "3.2.0")
 @FunctionalInterface
 public interface CheckedRunnable<E extends Exception> {
     void run() throws E;

--- a/plugins/identity-shiro/src/main/java/org/opensearch/identity/shiro/ShiroPluginSubject.java
+++ b/plugins/identity-shiro/src/main/java/org/opensearch/identity/shiro/ShiroPluginSubject.java
@@ -41,7 +41,7 @@ public class ShiroPluginSubject implements PluginSubject {
     }
 
     @Override
-    public <E extends Exception> void runAs(CheckedRunnable<E> r) throws Exception {
+    public <E extends Exception> void runAs(CheckedRunnable<E> r) throws E {
         try (ThreadContext.StoredContext ctx = threadPool.getThreadContext().stashContext()) {
             r.run();
         }

--- a/plugins/identity-shiro/src/main/java/org/opensearch/identity/shiro/ShiroPluginSubject.java
+++ b/plugins/identity-shiro/src/main/java/org/opensearch/identity/shiro/ShiroPluginSubject.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.identity.shiro;
 
+import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.identity.NamedPrincipal;
@@ -15,7 +16,6 @@ import org.opensearch.identity.PluginSubject;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.security.Principal;
-import java.util.concurrent.Callable;
 
 /**
  * Implementation of subject that is always authenticated
@@ -41,9 +41,9 @@ public class ShiroPluginSubject implements PluginSubject {
     }
 
     @Override
-    public <T> T runAs(Callable<T> callable) throws Exception {
+    public <E extends Exception> void runAs(CheckedRunnable<E> r) throws Exception {
         try (ThreadContext.StoredContext ctx = threadPool.getThreadContext().stashContext()) {
-            return callable.call();
+            r.run();
         }
     }
 }

--- a/server/src/main/java/org/opensearch/identity/Subject.java
+++ b/server/src/main/java/org/opensearch/identity/Subject.java
@@ -24,7 +24,7 @@ public interface Subject {
     Principal getPrincipal();
 
     /**
-     * runAs allows the caller to run a callable function as this subject
+     * runAs allows the caller to run a {@link CheckedRunnable} as this subject
      */
     default <E extends Exception> void runAs(CheckedRunnable<E> r) throws E {
         r.run();

--- a/server/src/main/java/org/opensearch/identity/Subject.java
+++ b/server/src/main/java/org/opensearch/identity/Subject.java
@@ -26,7 +26,7 @@ public interface Subject {
     /**
      * runAs allows the caller to run a callable function as this subject
      */
-    default <E extends Exception> void runAs(CheckedRunnable<E> r) throws Exception {
+    default <E extends Exception> void runAs(CheckedRunnable<E> r) throws E {
         r.run();
     };
 }

--- a/server/src/main/java/org/opensearch/identity/Subject.java
+++ b/server/src/main/java/org/opensearch/identity/Subject.java
@@ -5,10 +5,10 @@
 
 package org.opensearch.identity;
 
+import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.annotation.ExperimentalApi;
 
 import java.security.Principal;
-import java.util.concurrent.Callable;
 
 /**
  * An individual, process, or device that causes information to flow among objects or change to the system state.
@@ -26,7 +26,7 @@ public interface Subject {
     /**
      * runAs allows the caller to run a callable function as this subject
      */
-    default <T> T runAs(Callable<T> callable) throws Exception {
-        return callable.call();
+    default <E extends Exception> void runAs(CheckedRunnable<E> r) throws Exception {
+        r.run();
     };
 }

--- a/server/src/main/java/org/opensearch/identity/noop/NoopPluginSubject.java
+++ b/server/src/main/java/org/opensearch/identity/noop/NoopPluginSubject.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.identity.noop;
 
+import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.annotation.InternalApi;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.identity.NamedPrincipal;
@@ -15,7 +16,6 @@ import org.opensearch.identity.PluginSubject;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.security.Principal;
-import java.util.concurrent.Callable;
 
 /**
  * Implementation of subject that is always authenticated
@@ -41,9 +41,9 @@ public class NoopPluginSubject implements PluginSubject {
     }
 
     @Override
-    public <T> T runAs(Callable<T> callable) throws Exception {
+    public <E extends Exception> void runAs(CheckedRunnable<E> r) throws E {
         try (ThreadContext.StoredContext ctx = threadPool.getThreadContext().stashContext()) {
-            return callable.call();
+            r.run();
         }
     }
 }

--- a/server/src/test/java/org/opensearch/identity/noop/NoopPluginSubjectTests.java
+++ b/server/src/test/java/org/opensearch/identity/noop/NoopPluginSubjectTests.java
@@ -48,10 +48,7 @@ public class NoopPluginSubjectTests extends OpenSearchTestCase {
         assertThat(testPluginSubject.getPrincipal().getName(), equalTo(NamedPrincipal.UNAUTHENTICATED.getName()));
         threadPool.getThreadContext().putHeader("test_header", "foo");
         assertThat(threadPool.getThreadContext().getHeader("test_header"), equalTo("foo"));
-        testPluginSubject.runAs(() -> {
-            assertNull(threadPool.getThreadContext().getHeader("test_header"));
-            return null;
-        });
+        testPluginSubject.runAs(() -> { assertNull(threadPool.getThreadContext().getHeader("test_header")); });
         assertThat(threadPool.getThreadContext().getHeader("test_header"), equalTo("foo"));
         terminate(threadPool);
     }


### PR DESCRIPTION
### Description

Small PR to update the Subject interface to use CheckedRunnable. The return value of the Callable is never used and it propagates a generic Exception which would be cleaner to get the specific exception type instead.

### Related Issues

A bit of cleanup to https://github.com/opensearch-project/OpenSearch/pull/14630

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
