### PR TITLE
Introduce SecureHttpTransportParameters experimental API (to complement SecureTransportParameters counterpart)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Add support for Warm Indices Write Block on Flood Watermark breach ([#18375](https://github.com/opensearch-project/OpenSearch/pull/18375))
 - Ability to run Code Coverage with Gradle and produce the jacoco reports locally ([#18509](https://github.com/opensearch-project/OpenSearch/issues/18509))
+- Introduce SecureHttpTransportParameters experimental API (to complement SecureTransportParameters counterpart) ([#18572](https://github.com/opensearch-project/OpenSearch/issues/18572))
 
 ### Changed
 

--- a/server/src/main/java/org/opensearch/plugins/DefaultSecureHttpTransportParameters.java
+++ b/server/src/main/java/org/opensearch/plugins/DefaultSecureHttpTransportParameters.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Default implementation of {@link SecureHttpTransportSettingsProvider.SecureHttpTransportParameters}.
+ */
+class DefaultSecureHttpTransportParameters implements SecureHttpTransportSettingsProvider.SecureHttpTransportParameters {
+    @Override
+    public Optional<KeyManagerFactory> keyManagerFactory() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> sslProvider() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> clientAuth() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Collection<String> protocols() {
+        return List.of();
+    }
+
+    @Override
+    public Collection<String> cipherSuites() {
+        return List.of();
+    }
+
+    @Override
+    public Optional<TrustManagerFactory> trustManagerFactory() {
+        return Optional.empty();
+    }
+}

--- a/server/src/main/java/org/opensearch/plugins/SecureHttpTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureHttpTransportSettingsProvider.java
@@ -13,8 +13,10 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.http.HttpServerTransport;
 import org.opensearch.transport.TransportAdapterProvider;
 
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManagerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -38,12 +40,64 @@ public interface SecureHttpTransportSettingsProvider {
     final String REQUEST_DECOMPRESSOR = "RequestDecompressor";
 
     /**
+     * Dynamic parameters that can be provided by the {@link SecureHttpTransportParameters}
+     */
+    @ExperimentalApi
+    interface SecureHttpTransportParameters {
+        /**
+         * Provides the instance of {@link KeyManagerFactory}
+         * @return instance of {@link KeyManagerFactory}
+         */
+        Optional<KeyManagerFactory> keyManagerFactory();
+
+        /**
+         * Provides the SSL provider (JDK, OpenSsl, ...) if supported by transport
+         * @return SSL provider
+         */
+        Optional<String> sslProvider();
+
+        /**
+         * Provides desired client authentication level
+         * @return client authentication level
+         */
+        Optional<String> clientAuth();
+
+        /**
+         * Provides the list of supported protocols
+         * @return list of supported protocols
+         */
+        Collection<String> protocols();
+
+        /**
+         * Provides the list of supported cipher suites
+         * @return list of supported cipher suites
+         */
+        Collection<String> cipherSuites();
+
+        /**
+         * Provides the instance of {@link TrustManagerFactory}
+         * @return instance of {@link TrustManagerFactory}
+         */
+        Optional<TrustManagerFactory> trustManagerFactory();
+    }
+
+    /**
      * Collection of additional {@link TransportAdapterProvider}s that are specific to particular HTTP transport
      * @param settings settings
      * @return a collection of additional {@link TransportAdapterProvider}s
      */
     default Collection<TransportAdapterProvider<HttpServerTransport>> getHttpTransportAdapterProviders(Settings settings) {
         return Collections.emptyList();
+    }
+
+    /**
+     * Returns parameters that can be dynamically provided by a plugin providing a {@link SecureHttpTransportParameters}
+     * implementation
+     * @param settings settings
+     * @return an instance of {@link SecureHttpTransportParameters}
+     */
+    default Optional<SecureHttpTransportParameters> parameters(Settings settings) {
+        return Optional.of(new DefaultSecureHttpTransportParameters());
     }
 
     /**

--- a/server/src/main/java/org/opensearch/plugins/SecureTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureTransportSettingsProvider.java
@@ -53,18 +53,46 @@ public interface SecureTransportSettingsProvider {
      */
     @ExperimentalApi
     interface SecureTransportParameters {
+        /**
+         * Enable / Disable dual model (if supported by transport)
+         * @return dual model enabled or not
+         */
         boolean dualModeEnabled();
 
+        /**
+         * Provides the instance of {@link KeyManagerFactory}
+         * @return instance of {@link KeyManagerFactory}
+         */
         Optional<KeyManagerFactory> keyManagerFactory();
 
+        /**
+         * Provides the SSL provider (JDK, OpenSsl, ...) if supported by transport
+         * @return SSL provider
+         */
         Optional<String> sslProvider();
 
+        /**
+         * Provides desired client authentication level
+         * @return client authentication level
+         */
         Optional<String> clientAuth();
 
+        /**
+         * Provides the list of supported protocols
+         * @return list of supported protocols
+         */
         Collection<String> protocols();
 
+        /**
+         * Provides the list of supported cipher suites
+         * @return list of supported cipher suites
+         */
         Collection<String> cipherSuites();
 
+        /**
+         * Provides the instance of {@link TrustManagerFactory}
+         * @return instance of {@link TrustManagerFactory}
+         */
         Optional<TrustManagerFactory> trustManagerFactory();
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Introduce `SecureHttpTransportParameters` experimental API (to complement `SecureTransportParameters` counterpart). The way we configure SSL Context in Reactor Netty 4 transport is not very clean and turned out to be fragile. By introducing  `SecureHttpTransportParameters` (similarly with  `SecureTransportParameters`), the transport could be configured in straightforward way.

### Related Issues
Towards https://github.com/opensearch-project/OpenSearch/issues/18559

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
