### PR TITLE
[Pull-based Ingestion] Create ingestion-fs plugin for simpler local testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Introduce SecureHttpTransportParameters experimental API (to complement SecureTransportParameters counterpart) ([#18572](https://github.com/opensearch-project/OpenSearch/issues/18572))
 - Create equivalents of JSM's AccessController in the java agent ([#18346](https://github.com/opensearch-project/OpenSearch/issues/18346))
 - Introduced a new cluster-level API to fetch remote store metadata (segments and translogs) for each shard of an index. ([#18257](https://github.com/opensearch-project/OpenSearch/pull/18257))
+- Introduce a new pull-based ingestion plugin for file-based indexing (for local testing) ([#18591](https://github.com/opensearch-project/OpenSearch/pull/18591))
 
 ### Changed
 - Update Subject interface to use CheckedRunnable ([#18570](https://github.com/opensearch-project/OpenSearch/issues/18570))

--- a/plugins/ingestion-fs/README.md
+++ b/plugins/ingestion-fs/README.md
@@ -1,0 +1,64 @@
+# ingestion-fs plugin
+
+The ingestion-fs plugin enables pull-based ingestion from the local file system into OpenSearch. It is primarily intended for local testing and development purposes to facilitate testing without setting up Kafka/Kinesis.
+
+## Overview
+
+This plugin implements a custom ingestion source for the [pull-based ingestion framework](https://docs.opensearch.org/docs/latest/api-reference/document-apis/pull-based-ingestion/). It allows OpenSearch to ingest documents from `.ndjson` files on the file system.
+
+Each shard-specific file is expected to follow the path:
+```
+${base_directory}/${topic}/${shard_id}.ndjson
+```
+
+## Usage
+
+### 1. Prepare test data
+
+Create the `ndjson` files with sample data following the format mentioned [here](https://docs.opensearch.org/docs/latest/api-reference/document-apis/pull-based-ingestion/).
+For example, create a file `${base_directory}/test-topic/0.ndjson` with data
+
+```
+{"_id":"1","_version":"1","_op_type":"index","_source":{"name":"name1", "age": 30}}
+{"_id":"2","_version":"1","_op_type":"index","_source":{"name":"name2", "age": 31}}
+```
+
+### 2. Start OpenSearch with the Plugin
+
+```
+./gradlew run -PinstalledPlugins="['ingestion-fs']"
+```
+
+### 3. Create a pull-based index
+
+Create an index by specifying ingestion source settings as follows
+
+<pre>
+PUT /test-index
+{
+  "settings": {
+    "ingestion_source": {
+      "type": "file",
+      "param": {
+        "topic": "test_topic",
+        "base_directory": "path to the base directory"
+      }
+    },
+    "index.number_of_shards": 1,
+    "index.number_of_replicas": 0,
+    "index": {
+      "replication.type": "SEGMENT"
+    }
+  },
+  "mappings": {
+    "properties": {
+      "name": {
+        "type": "text"
+      },
+      "age": {
+        "type": "integer"
+      }
+    }
+  }
+}
+</pre>

--- a/plugins/ingestion-fs/README.md
+++ b/plugins/ingestion-fs/README.md
@@ -8,7 +8,7 @@ This plugin implements a custom ingestion source for the [pull-based ingestion f
 
 Each shard-specific file is expected to follow the path:
 ```
-${base_directory}/${topic}/${shard_id}.ndjson
+${base_directory}/${stream}/${shard_id}.ndjson
 ```
 
 ## Usage
@@ -16,7 +16,7 @@ ${base_directory}/${topic}/${shard_id}.ndjson
 ### 1. Prepare test data
 
 Create the `ndjson` files with sample data following the format mentioned [here](https://docs.opensearch.org/docs/latest/api-reference/document-apis/pull-based-ingestion/).
-For example, create a file `${base_directory}/test-topic/0.ndjson` with data
+For example, create a file `${base_directory}/test-stream/0.ndjson` with data
 
 ```
 {"_id":"1","_version":"1","_op_type":"index","_source":{"name":"name1", "age": 30}}
@@ -40,7 +40,7 @@ PUT /test-index
     "ingestion_source": {
       "type": "file",
       "param": {
-        "topic": "test_topic",
+        "stream": "test_stream",
         "base_directory": "path to the base directory"
       }
     },

--- a/plugins/ingestion-fs/build.gradle
+++ b/plugins/ingestion-fs/build.gradle
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+apply plugin: 'opensearch.internal-cluster-test'
+
+opensearchplugin {
+  description = 'Pull-based ingestion plugin to read from local files for testing'
+  classname = 'org.opensearch.plugin.ingestion.fs.FilePlugin'
+}

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileConsumerFactory.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileConsumerFactory.java
@@ -19,6 +19,9 @@ public class FileConsumerFactory implements IngestionConsumerFactory<FilePartiti
 
     private FileSourceConfig config;
 
+    /**
+     * Initialize a FileConsumerFactory for file-based indexing.
+     */
     public FileConsumerFactory() {}
 
     @Override

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileConsumerFactory.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileConsumerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.ingestion.fs;
+
+import org.opensearch.index.IngestionConsumerFactory;
+
+import java.util.Map;
+
+/**
+ * Factory for creating file-based ingestion consumers.
+ */
+public class FileConsumerFactory implements IngestionConsumerFactory<FilePartitionConsumer, FileOffset> {
+
+    private FileSourceConfig config;
+
+    public FileConsumerFactory() {}
+
+    @Override
+    public void initialize(Map<String, Object> params) {
+        this.config = new FileSourceConfig(params);
+    }
+
+    @Override
+    public FilePartitionConsumer createShardConsumer(String clientId, int shardId) {
+        assert config != null;
+        return new FilePartitionConsumer(config, shardId);
+    }
+
+    @Override
+    public FileOffset parsePointerFromString(String pointer) {
+        return new FileOffset(Long.parseLong(pointer));
+    }
+}

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileMessage.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileMessage.java
@@ -15,14 +15,14 @@ import org.opensearch.index.Message;
  */
 public class FileMessage implements Message<byte[]> {
     private final byte[] payload;
-    private final long timestamp;
+    private final Long timestamp;
 
     /**
      * Create a file message.
      * @param payload Line contents from the file, as a byte array.
      * @param timestamp Millisecond timestamp for when the line was read.
      */
-    public FileMessage(byte[] payload, long timestamp) {
+    public FileMessage(byte[] payload, Long timestamp) {
         this.payload = payload;
         this.timestamp = timestamp;
     }

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileMessage.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileMessage.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.ingestion.fs;
+
+import org.opensearch.index.Message;
+
+/**
+ * Message abstraction for file-based ingestion.
+ */
+public class FileMessage implements Message<byte[]> {
+    private final byte[] payload;
+    private final long timestamp;
+
+    /**
+     * Create a file message.
+     * @param payload Line contents from the file, as a byte array.
+     * @param timestamp Millisecond timestamp for when the line was read.
+     */
+    public FileMessage(byte[] payload, long timestamp) {
+        this.payload = payload;
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public byte[] getPayload() {
+        return payload;
+    }
+
+    @Override
+    public Long getTimestamp() {
+        return timestamp;
+    }
+}

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileOffset.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileOffset.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.ingestion.fs;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.search.Query;
+import org.opensearch.index.IngestionShardPointer;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Offset for a file-based ingestion source (line number).
+ */
+public class FileOffset implements IngestionShardPointer {
+
+    private final long line;
+
+    public FileOffset(long line) {
+        assert line >= 0;
+        this.line = line;
+    }
+
+    public long getLine() {
+        return line;
+    }
+
+    @Override
+    public byte[] serialize() {
+        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+        buffer.putLong(line);
+        return buffer.array();
+    }
+
+    @Override
+    public String asString() {
+        return Long.toString(line);
+    }
+
+    @Override
+    public Field asPointField(String fieldName) {
+        return new LongPoint(fieldName, line);
+    }
+
+    @Override
+    public Query newRangeQueryGreaterThan(String fieldName) {
+        return LongPoint.newRangeQuery(fieldName, line, Long.MAX_VALUE);
+    }
+
+    @Override
+    public int compareTo(IngestionShardPointer o) {
+        if (o == null || !(o instanceof FileOffset)) {
+            throw new IllegalArgumentException("Incompatible pointer type: " + (o == null ? "null" : o.getClass()));
+        }
+        return Long.compare(this.line, ((FileOffset) o).line);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FileOffset)) return false;
+        return this.line == ((FileOffset) o).line;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(line);
+    }
+
+    @Override
+    public String toString() {
+        return "FileOffset{" + "line=" + line + '}';
+    }
+}

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileOffset.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileOffset.java
@@ -22,11 +22,18 @@ public class FileOffset implements IngestionShardPointer {
 
     private final long line;
 
+    /**
+     * Create a new file offset based on line number.
+     * @param line line number (offset)
+     */
     public FileOffset(long line) {
         assert line >= 0;
         this.line = line;
     }
 
+    /**
+     * Returns the line number (offset).
+     */
     public long getLine() {
         return line;
     }

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FilePartitionConsumer.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FilePartitionConsumer.java
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.ingestion.fs;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.io.PathUtils;
+import org.opensearch.index.IngestionShardConsumer;
+import org.opensearch.index.IngestionShardPointer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * File-based consumer for testing ingestion. Reads from ${baseDir}/${topic}/${shardId}.ndjson.
+ */
+@SuppressForbidden(reason = "uses user provided path to read files for local testing")
+public class FilePartitionConsumer implements IngestionShardConsumer<FileOffset, FileMessage> {
+    private static final Logger logger = LogManager.getLogger(FilePartitionConsumer.class);
+
+    private final Path shardFilePath;
+    private final int shardId;
+
+    private BufferedReader reader = null;
+    private long currentLineInReader = 0;
+    private long lastReadLine = -1;
+
+    public FilePartitionConsumer(FileSourceConfig config, int shardId) {
+        String baseDir = config.getBaseDirectory();
+        String topic = config.getTopic();
+
+        this.shardFilePath = PathUtils.get(baseDir, topic, shardId + ".ndjson");
+        this.shardId = shardId;
+
+        if (!Files.exists(shardFilePath)) {
+            logger.warn("FilePartitionConsumer: File {} does not exist.", shardFilePath.toAbsolutePath());
+        } else {
+            logger.info("Initialized FilePartitionConsumer for shard {} with file: {}", shardId, shardFilePath.toAbsolutePath());
+        }
+    }
+
+    @Override
+    public List<ReadResult<FileOffset, FileMessage>> readNext(FileOffset offset, boolean includeStart, long maxMessages, int timeoutMillis)
+        throws TimeoutException {
+        long startLine = includeStart ? offset.getLine() : offset.getLine() + 1;
+        return readFromFile(startLine, maxMessages);
+    }
+
+    @Override
+    public List<ReadResult<FileOffset, FileMessage>> readNext(long maxMessages, int timeoutMillis) throws TimeoutException {
+        return readFromFile(lastReadLine + 1, maxMessages);
+    }
+
+    private synchronized List<ReadResult<FileOffset, FileMessage>> readFromFile(long startLine, long maxLines) throws TimeoutException {
+        List<ReadResult<FileOffset, FileMessage>> results = new ArrayList<>();
+
+        if (!Files.exists(shardFilePath)) {
+            return results;
+        }
+
+        try {
+            if (reader == null) {
+                reader = Files.newBufferedReader(shardFilePath, StandardCharsets.UTF_8);
+                currentLineInReader = 0;
+            }
+
+            if (startLine < currentLineInReader) {
+                reader.close();
+                reader = Files.newBufferedReader(shardFilePath, StandardCharsets.UTF_8);
+                currentLineInReader = 0;
+            }
+
+            while (currentLineInReader < startLine && reader.readLine() != null) {
+                currentLineInReader++;
+            }
+
+            String line;
+            while (results.size() < maxLines && (line = reader.readLine()) != null) {
+                FileOffset offset = new FileOffset(currentLineInReader);
+                FileMessage message = new FileMessage(line.getBytes(StandardCharsets.UTF_8), System.currentTimeMillis());
+                results.add(new ReadResult<>(offset, message));
+                lastReadLine = currentLineInReader;
+                currentLineInReader++;
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read from file: " + shardFilePath.toAbsolutePath(), e);
+        }
+
+        return results;
+    }
+
+    @Override
+    public IngestionShardPointer earliestPointer() {
+        return new FileOffset(0);
+    }
+
+    @Override
+    public IngestionShardPointer latestPointer() {
+        if (!Files.exists(shardFilePath)) {
+            return new FileOffset(0);
+        }
+
+        try (
+            LineNumberReader lineNumberReader = new LineNumberReader(
+                new InputStreamReader(Files.newInputStream(shardFilePath), StandardCharsets.UTF_8)
+            )
+        ) {
+            lineNumberReader.skip(Long.MAX_VALUE);
+            return new FileOffset(lineNumberReader.getLineNumber());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to compute latest pointer", e);
+        }
+    }
+
+    /**
+     * Timestamp based pointer is not supported in file mode. Defaults to earliest pointer.
+     */
+    @Override
+    public IngestionShardPointer pointerFromTimestampMillis(long timestampMillis) {
+        return earliestPointer();
+    }
+
+    @Override
+    public IngestionShardPointer pointerFromOffset(String offset) {
+        return new FileOffset(Long.parseLong(offset));
+    }
+
+    @Override
+    public int getShardId() {
+        return shardId;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (reader != null) {
+            reader.close();
+        }
+    }
+}

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FilePlugin.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FilePlugin.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.ingestion.fs;
+
+import org.opensearch.index.IngestionConsumerFactory;
+import org.opensearch.plugins.IngestionConsumerPlugin;
+import org.opensearch.plugins.Plugin;
+
+import java.util.Map;
+
+/**
+ * A plugin for file-based ingestion (used for local testing).
+ */
+public class FilePlugin extends Plugin implements IngestionConsumerPlugin {
+
+    /**
+     * The type of the ingestion source.
+     */
+    public static final String TYPE = "FILE";
+
+    public FilePlugin() {}
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Map<String, IngestionConsumerFactory> getIngestionConsumerFactories() {
+        return Map.of(TYPE, new FileConsumerFactory());
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+}

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FilePlugin.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FilePlugin.java
@@ -24,6 +24,9 @@ public class FilePlugin extends Plugin implements IngestionConsumerPlugin {
      */
     public static final String TYPE = "FILE";
 
+    /**
+     * Initialize FilePlugin for file-based indexing.
+     */
     public FilePlugin() {}
 
     @SuppressWarnings("rawtypes")

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileSourceConfig.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileSourceConfig.java
@@ -20,15 +20,25 @@ public class FileSourceConfig {
     private final String topic;
     private final String baseDirectory;
 
+    /**
+     * Initialize a new file-based source config.
+     * @param params parameters for file-based indexing
+     */
     public FileSourceConfig(Map<String, Object> params) {
         this.topic = (String) params.get(TOPIC);
         this.baseDirectory = (String) params.get(BASE_DIR);
     }
 
+    /**
+     * Returns the topic name.
+     */
     public String getTopic() {
         return topic;
     }
 
+    /**
+     * Returns the base directory in which topic and shard specific files will be present.
+     */
     public String getBaseDirectory() {
         return baseDirectory;
     }

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileSourceConfig.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileSourceConfig.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.ingestion.fs;
+
+import java.util.Map;
+
+/**
+ * Configuration holder for file-based ingestion source.
+ */
+public class FileSourceConfig {
+    private static final String TOPIC = "topic";
+    private static final String BASE_DIR = "base_directory";
+
+    private final String topic;
+    private final String baseDirectory;
+
+    public FileSourceConfig(Map<String, Object> params) {
+        this.topic = (String) params.get(TOPIC);
+        this.baseDirectory = (String) params.get(BASE_DIR);
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public String getBaseDirectory() {
+        return baseDirectory;
+    }
+}

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileSourceConfig.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FileSourceConfig.java
@@ -14,10 +14,10 @@ import java.util.Map;
  * Configuration holder for file-based ingestion source.
  */
 public class FileSourceConfig {
-    private static final String TOPIC = "topic";
+    private static final String STREAM = "stream";
     private static final String BASE_DIR = "base_directory";
 
-    private final String topic;
+    private final String stream;
     private final String baseDirectory;
 
     /**
@@ -25,19 +25,19 @@ public class FileSourceConfig {
      * @param params parameters for file-based indexing
      */
     public FileSourceConfig(Map<String, Object> params) {
-        this.topic = (String) params.get(TOPIC);
+        this.stream = (String) params.get(STREAM);
         this.baseDirectory = (String) params.get(BASE_DIR);
     }
 
     /**
-     * Returns the topic name.
+     * Returns the stream name.
      */
-    public String getTopic() {
-        return topic;
+    public String getStream() {
+        return stream;
     }
 
     /**
-     * Returns the base directory in which topic and shard specific files will be present.
+     * Returns the base directory in which stream and shard specific files will be present.
      */
     public String getBaseDirectory() {
         return baseDirectory;

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/package-info.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** package for file-based ingestion plugin */
+package org.opensearch.plugin.ingestion.fs;

--- a/plugins/ingestion-fs/src/test/java/org/opensearch/plugin/ingestion/fs/FileBasedIngestionSingleNodeTests.java
+++ b/plugins/ingestion-fs/src/test/java/org/opensearch/plugin/ingestion/fs/FileBasedIngestionSingleNodeTests.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.ingestion.fs;
+
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+import org.junit.Before;
+
+import java.io.BufferedWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collection;
+import java.util.Collections;
+
+public class FileBasedIngestionSingleNodeTests extends OpenSearchSingleNodeTestCase {
+    private Path ingestionDir;
+    private final String topic = "test_topic";
+    private final String index = "test_index";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.singleton(FilePlugin.class);
+    }
+
+    @Before
+    public void setupIngestionFile() throws Exception {
+        ingestionDir = createTempDir().resolve("fs_ingestion");
+        Path topicDir = ingestionDir.resolve(topic);
+        Files.createDirectories(topicDir);
+
+        Path shardFile = topicDir.resolve("0.ndjson");
+        try (BufferedWriter writer = Files.newBufferedWriter(shardFile, StandardCharsets.UTF_8, StandardOpenOption.CREATE)) {
+            writer.write("{\"_id\":\"1\",\"_version\":\"1\",\"_op_type\":\"index\",\"_source\":{\"name\":\"alice\", \"age\": 30}}\n");
+            writer.write("{\"_id\":\"2\",\"_version\":\"1\",\"_op_type\":\"index\",\"_source\":{\"name\":\"bob\", \"age\": 35}}\n");
+        }
+    }
+
+    public void testFileIngestion() throws Exception {
+        String mappings = """
+            {
+              "properties": {
+                "name": { "type": "text" },
+                "age": { "type": "integer" }
+              }
+            }
+            """;
+
+        createIndexWithMappingSource(
+            index,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put("ingestion_source.type", "FILE")
+                .put("ingestion_source.pointer.init.reset", "earliest")
+                .put("ingestion_source.param.topic", topic)
+                .put("ingestion_source.param.base_directory", ingestionDir.toString())
+                .put("index.replication.type", "SEGMENT")
+                .build(),
+            mappings
+        );
+        ensureGreen(index);
+
+        assertBusy(() -> {
+            RangeQueryBuilder query = new RangeQueryBuilder("age").gte(0);
+            SearchResponse response = client().prepareSearch(index).setQuery(query).get();
+            assertEquals(2, response.getHits().getTotalHits().value());
+        });
+
+        // cleanup the test index
+        client().admin().indices().delete(new DeleteIndexRequest(index)).actionGet();
+    }
+}

--- a/plugins/ingestion-fs/src/test/java/org/opensearch/plugin/ingestion/fs/FileMessageTests.java
+++ b/plugins/ingestion-fs/src/test/java/org/opensearch/plugin/ingestion/fs/FileMessageTests.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.ingestion.fs;
+
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Assert;
+
+public class FileMessageTests extends OpenSearchTestCase {
+    public void testConstructorAndGetters() {
+        byte[] payload = { 1, 2, 3 };
+        FileMessage message = new FileMessage(payload, 1000L);
+
+        Assert.assertArrayEquals("Payload should be correctly initialized and returned", payload, message.getPayload());
+        Assert.assertEquals(1000L, message.getTimestamp().longValue());
+    }
+
+    public void testConstructorWithNullPayload() {
+        FileMessage message = new FileMessage(null, null);
+
+        Assert.assertNull("Payload should be null", message.getPayload());
+        Assert.assertNull("Timestamp should be null", message.getTimestamp());
+    }
+}

--- a/plugins/ingestion-fs/src/test/java/org/opensearch/plugin/ingestion/fs/FileOffsetTests.java
+++ b/plugins/ingestion-fs/src/test/java/org/opensearch/plugin/ingestion/fs/FileOffsetTests.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.ingestion.fs;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.nio.ByteBuffer;
+
+public class FileOffsetTests extends OpenSearchTestCase {
+
+    public void testFileOffset() {
+        FileOffset offset = new FileOffset(42L);
+        byte[] serialized = offset.serialize();
+        long deserialized = ByteBuffer.wrap(serialized).getLong();
+        assertEquals(offset.getLine(), deserialized);
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a new pull-based ingestion plugin, for indexing documents from the file system. More details can be found in the attached issue. This is only meant for local testing purpose, with the motivation to enable users to index documents from their local machine without having to setup Kafka or Kinesis.

### Related Issues
Resolves #18590

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
