### PR TITLE
[BUG] Cannot communicate with http2 when reactor-netty is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Add task cancellation checks in aggregators ([#18426](https://github.com/opensearch-project/OpenSearch/pull/18426))
 - Fix concurrent timings in profiler ([#18540](https://github.com/opensearch-project/OpenSearch/pull/18540))
+- Cannot communicate with HTTP/2 when reactor-netty is enabled ([#18599](https://github.com/opensearch-project/OpenSearch/pull/18599))
 
 ### Security
 

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.http.reactor.netty4;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.network.NetworkService;
 import org.opensearch.common.settings.ClusterSettings;
@@ -27,6 +28,7 @@ import org.opensearch.http.HttpReadTimeoutException;
 import org.opensearch.http.HttpServerChannel;
 import org.opensearch.http.reactor.netty4.ssl.SslUtils;
 import org.opensearch.plugins.SecureHttpTransportSettingsProvider;
+import org.opensearch.plugins.SecureHttpTransportSettingsProvider.SecureHttpTransportParameters;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.telemetry.tracing.Tracer;
@@ -34,28 +36,27 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.reactor.SharedGroupFactory;
 import org.opensearch.transport.reactor.netty4.Netty4Utils;
 
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.KeyManagerFactory;
 
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.ssl.ApplicationProtocolNegotiator;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.timeout.ReadTimeoutException;
-import io.netty.util.ReferenceCountUtil;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
@@ -306,59 +307,33 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
 
         // Configure SSL context if available
         if (secureHttpTransportSettingsProvider != null) {
-            final SSLEngine engine = secureHttpTransportSettingsProvider.buildSecureHttpServerEngine(settings, this)
-                .orElseGet(SslUtils::createDefaultServerSSLEngine);
+            final Optional<SecureHttpTransportParameters> parameters = secureHttpTransportSettingsProvider.parameters(settings);
 
-            try {
-                final List<String> cipherSuites = Arrays.asList(engine.getEnabledCipherSuites());
-                final List<String> applicationProtocols = Arrays.asList(engine.getSSLParameters().getApplicationProtocols());
+            final KeyManagerFactory keyManagerFactory = parameters.flatMap(SecureHttpTransportParameters::keyManagerFactory)
+                .orElseThrow(() -> new OpenSearchException("The KeyManagerFactory instance is not provided"));
 
-                configured = configured.secure(spec -> spec.sslContext(new SslContext() {
-                    @Override
-                    public SSLSessionContext sessionContext() {
-                        throw new UnsupportedOperationException(); /* server only, should never be called */
-                    }
+            final SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(keyManagerFactory);
+            parameters.flatMap(SecureHttpTransportParameters::trustManagerFactory).ifPresent(sslContextBuilder::trustManager);
+            parameters.map(SecureHttpTransportParameters::cipherSuites)
+                .ifPresent(ciphers -> sslContextBuilder.ciphers(ciphers, SupportedCipherSuiteFilter.INSTANCE));
 
-                    @Override
-                    public SSLEngine newEngine(ByteBufAllocator alloc, String peerHost, int peerPort) {
-                        throw new UnsupportedOperationException(); /* server only, should never be called */
-                    }
+            final SslContext sslContext = sslContextBuilder.protocols(
+                parameters.map(SecureHttpTransportParameters::protocols).orElseGet(() -> Arrays.asList(SslUtils.DEFAULT_SSL_PROTOCOLS))
+            )
+                .applicationProtocolConfig(
+                    new ApplicationProtocolConfig(
+                        ApplicationProtocolConfig.Protocol.ALPN,
+                        // NO_ADVERTISE is currently the only mode supported by both OpenSsl and JDK providers.
+                        ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+                        // ACCEPT is currently the only mode supported by both OpenSsl and JDK providers.
+                        ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+                        ApplicationProtocolNames.HTTP_2,
+                        ApplicationProtocolNames.HTTP_1_1
+                    )
+                )
+                .build();
 
-                    @Override
-                    public SSLEngine newEngine(ByteBufAllocator alloc) {
-                        try {
-                            return secureHttpTransportSettingsProvider.buildSecureHttpServerEngine(
-                                settings,
-                                ReactorNetty4HttpServerTransport.this
-                            ).orElseGet(SslUtils::createDefaultServerSSLEngine);
-                        } catch (final SSLException ex) {
-                            throw new UnsupportedOperationException("Unable to create SSLEngine", ex);
-                        }
-                    }
-
-                    @Override
-                    public boolean isClient() {
-                        return false; /* server only */
-                    }
-
-                    @Override
-                    public List<String> cipherSuites() {
-                        return cipherSuites;
-                    }
-
-                    @Override
-                    public ApplicationProtocolNegotiator applicationProtocolNegotiator() {
-                        return new ApplicationProtocolNegotiator() {
-                            @Override
-                            public List<String> protocols() {
-                                return applicationProtocols;
-                            }
-                        };
-                    }
-                }).build()).protocol(HttpProtocol.HTTP11, HttpProtocol.H2);
-            } finally {
-                ReferenceCountUtil.release(engine);
-            }
+            configured = configured.secure(spec -> spec.sslContext(sslContext)).protocol(HttpProtocol.HTTP11, HttpProtocol.H2);
         } else {
             configured = configured.protocol(HttpProtocol.HTTP11, HttpProtocol.H2C);
         }
@@ -373,6 +348,12 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
      * @return response publisher
      */
     protected Publisher<Void> incomingRequest(HttpServerRequest request, HttpServerResponse response) {
+        // At least now, Reactor Netty does not respect maxInitialLineLength setting for HTTP/2 (but
+        // does respect it for H2C and HTTP/1.1)
+        if (request.uri().length() > maxInitialLineLength.bytesAsInt()) {
+            return response.status(HttpResponseStatus.REQUEST_URI_TOO_LONG).send();
+        }
+
         final Method method = HttpConversionUtil.convertMethod(request.method());
         final Optional<RestHandler> dispatchHandlerOpt = dispatcher.dispatchHandler(
             request.uri(),

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ssl/SslUtils.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ssl/SslUtils.java
@@ -21,7 +21,10 @@ import java.security.NoSuchAlgorithmException;
  * Helper class for creating default SSL engines
  */
 public class SslUtils {
-    private static final String[] DEFAULT_SSL_PROTOCOLS = { "TLSv1.3", "TLSv1.2", "TLSv1.1" };
+    /**
+     * Default support TLS protocols
+     */
+    public static final String[] DEFAULT_SSL_PROTOCOLS = { "TLSv1.3", "TLSv1.2", "TLSv1.1" };
 
     private SslUtils() {}
 

--- a/plugins/transport-reactor-netty4/src/test/java/org/opensearch/http/reactor/netty4/ReactorHttpClient.java
+++ b/plugins/transport-reactor-netty4/src/test/java/org/opensearch/http/reactor/netty4/ReactorHttpClient.java
@@ -54,6 +54,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.ParallelFlux;
 import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.Http2SslContextSpec;
+import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.client.HttpClient;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
@@ -65,6 +66,7 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 public class ReactorHttpClient implements Closeable {
     private final boolean compression;
     private final boolean secure;
+    private final boolean useHttp11Only;
 
     static Collection<String> returnHttpResponseBodies(Collection<FullHttpResponse> responses) {
         List<String> list = new ArrayList<>(responses.size());
@@ -85,6 +87,7 @@ public class ReactorHttpClient implements Closeable {
     public ReactorHttpClient(boolean compression, boolean secure) {
         this.compression = compression;
         this.secure = secure;
+        this.useHttp11Only = OpenSearchTestCase.randomBoolean();
     }
 
     public static ReactorHttpClient create() {
@@ -265,25 +268,36 @@ public class ReactorHttpClient implements Closeable {
             .runOn(eventLoopGroup)
             .host(remoteAddress.getHostString())
             .port(remoteAddress.getPort())
-            .compress(compression);
+            .compress(compression)
+            .protocol(HttpProtocol.H2, HttpProtocol.HTTP11);
 
         if (secure) {
-            return client.secure(
-                spec -> spec.sslContext(
-                    OpenSearchTestCase.randomBoolean()
-                        /* switch between HTTP 1.1/HTTP 2 randomly, both are supported */ ? Http11SslContextSpec.forClient()
-                            .configure(s -> s.clientAuth(ClientAuth.NONE).trustManager(InsecureTrustManagerFactory.INSTANCE))
-                        : Http2SslContextSpec.forClient()
-                            .configure(s -> s.clientAuth(ClientAuth.NONE).trustManager(InsecureTrustManagerFactory.INSTANCE))
-                )
+            return client.protocol(
+                useHttp11Only ? new HttpProtocol[] { HttpProtocol.HTTP11 } : new HttpProtocol[] { HttpProtocol.HTTP11, HttpProtocol.H2 }
+            )
+                .secure(
+                    spec -> spec.sslContext(
+                        useHttp11Only
+                            /* switch between HTTP 1.1/HTTP 2 randomly, both are supported */
+                            ? Http11SslContextSpec.forClient()
+                                .configure(s -> s.clientAuth(ClientAuth.NONE).trustManager(InsecureTrustManagerFactory.INSTANCE))
+                            : Http2SslContextSpec.forClient()
+                                .configure(s -> s.clientAuth(ClientAuth.NONE).trustManager(InsecureTrustManagerFactory.INSTANCE))
+                    )
+                );
+        } else {
+            return client.protocol(
+                useHttp11Only ? new HttpProtocol[] { HttpProtocol.HTTP11 } : new HttpProtocol[] { HttpProtocol.HTTP11, HttpProtocol.H2C }
             );
         }
-
-        return client;
     }
 
     @Override
     public void close() {
 
+    }
+
+    public boolean useHttp11only() {
+        return useHttp11Only;
     }
 }

--- a/plugins/transport-reactor-netty4/src/test/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransportTests.java
+++ b/plugins/transport-reactor-netty4/src/test/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransportTests.java
@@ -208,8 +208,13 @@ public class ReactorNetty4HttpServerTransportTests extends OpenSearchTestCase {
                 final HttpContent continuationRequest = new DefaultHttpContent(Unpooled.EMPTY_BUFFER);
                 final FullHttpResponse continuationResponse = client.send(remoteAddress.address(), request, continuationRequest);
                 try {
-                    assertThat(continuationResponse.status(), is(HttpResponseStatus.OK));
-                    assertThat(new String(ByteBufUtil.getBytes(continuationResponse.content()), StandardCharsets.UTF_8), is("done"));
+                    if (expectedStatus == HttpResponseStatus.EXPECTATION_FAILED && client.useHttp11only() == false) {
+                        assertThat(continuationResponse.status(), is(HttpResponseStatus.EXPECTATION_FAILED));
+                        assertThat(new String(ByteBufUtil.getBytes(continuationResponse.content()), StandardCharsets.UTF_8), is(""));
+                    } else {
+                        assertThat(continuationResponse.status(), is(HttpResponseStatus.OK));
+                        assertThat(new String(ByteBufUtil.getBytes(continuationResponse.content()), StandardCharsets.UTF_8), is("done"));
+                    }
                 } finally {
                     continuationResponse.release();
                 }

--- a/plugins/transport-reactor-netty4/src/test/java/org/opensearch/http/reactor/netty4/ssl/SecureReactorNetty4HttpServerTransportTests.java
+++ b/plugins/transport-reactor-netty4/src/test/java/org/opensearch/http/reactor/netty4/ssl/SecureReactorNetty4HttpServerTransportTests.java
@@ -48,8 +48,11 @@ import org.junit.Before;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManagerFactory;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
@@ -80,6 +83,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 
@@ -108,7 +112,45 @@ public class SecureReactorNetty4HttpServerTransportTests extends OpenSearchTestC
         bigArrays = new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService());
         clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
+        var keyManagerFactory = KeyManagerFactory.getInstance("PKIX");
+        keyManagerFactory.init(KeyStoreUtils.createServerKeyStore(), KEYSTORE_PASSWORD);
+
         secureHttpTransportSettingsProvider = new SecureHttpTransportSettingsProvider() {
+            @Override
+            public Optional<SecureHttpTransportParameters> parameters(Settings settings) {
+                return Optional.of(new SecureHttpTransportParameters() {
+                    @Override
+                    public Optional<KeyManagerFactory> keyManagerFactory() {
+                        return Optional.of(keyManagerFactory);
+                    }
+
+                    @Override
+                    public Optional<String> sslProvider() {
+                        return Optional.empty();
+                    }
+
+                    @Override
+                    public Optional<String> clientAuth() {
+                        return Optional.empty();
+                    }
+
+                    @Override
+                    public Collection<String> protocols() {
+                        return Arrays.asList(SslUtils.DEFAULT_SSL_PROTOCOLS);
+                    }
+
+                    @Override
+                    public Collection<String> cipherSuites() {
+                        return Http2SecurityUtil.CIPHERS;
+                    }
+
+                    @Override
+                    public Optional<TrustManagerFactory> trustManagerFactory() {
+                        return Optional.of(InsecureTrustManagerFactory.INSTANCE);
+                    }
+                });
+            }
+
             @Override
             public Optional<TransportExceptionHandler> buildHttpServerExceptionHandler(Settings settings, HttpServerTransport transport) {
                 return Optional.empty();
@@ -117,8 +159,6 @@ public class SecureReactorNetty4HttpServerTransportTests extends OpenSearchTestC
             @Override
             public Optional<SSLEngine> buildSecureHttpServerEngine(Settings settings, HttpServerTransport transport) throws SSLException {
                 try {
-                    var keyManagerFactory = KeyManagerFactory.getInstance("PKIX");
-                    keyManagerFactory.init(KeyStoreUtils.createServerKeyStore(), KEYSTORE_PASSWORD);
                     SSLEngine engine = SslContextBuilder.forServer(keyManagerFactory)
                         .trustManager(InsecureTrustManagerFactory.INSTANCE)
                         .build()


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
When an OpenSearch cluster is setup up http.type as reactor-netty-secure, the curl invocation of any endpoints fails. The reason is the client(curl) and the server try to communicate via http2. When http1.1 is forced we do not see the error, indicating the server fails to support http2 when reactor netty is enabled.

### Related Issues
Closes https://github.com/opensearch-project/OpenSearch/issues/18559

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
