### PR TITLE
Fix the version increment workflow with the branching strategy update

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -29,7 +29,7 @@ jobs:
           fi
           CURRENT_VERSION_ARRAY=($(echo "$TAG" | tr . '\n'))
           BASE=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:2}")
-          BASE_X=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:1}.x")
+          MAIN_BRANCH="main"
           CURRENT_VERSION=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}")
           CURRENT_VERSION_UNDERSCORE=$(IFS=_ ; echo "V_${CURRENT_VERSION_ARRAY[*]:0:3}")
           CURRENT_VERSION_ARRAY[2]=$((CURRENT_VERSION_ARRAY[2]+1))
@@ -42,7 +42,7 @@ jobs:
           fi
           echo "TAG=$TAG" >> $GITHUB_ENV
           echo "BASE=$BASE" >> $GITHUB_ENV
-          echo "BASE_X=$BASE_X" >> $GITHUB_ENV
+          echo "MAIN_BRANCH=$MAIN_BRANCH" >> $GITHUB_ENV
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
           echo "CURRENT_VERSION_UNDERSCORE=$CURRENT_VERSION_UNDERSCORE" >> $GITHUB_ENV
           echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
@@ -77,33 +77,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.BASE_X }}
-
-      - name: Add Patch Version on Major.X branch
-        uses: peternied/opensearch-core-version-updater@v1
-        with:
-          previous-version: ${{ env.CURRENT_VERSION }}
-          new-version: ${{ env.NEXT_VERSION }}
-          update-current: false
-
-      - name: Create PR for BASE_X
-        id: base_x_pr
-        uses: peter-evans/create-pull-request@v7
-        with:
-          base: ${{ env.BASE_X }}
-          branch: 'create-pull-request/patch-${{ env.BASE_X }}'
-          commit-message: Add bwc version ${{ env.NEXT_VERSION }}
-          signoff: true
-          delete-branch: true
-          labels: |
-            autocut
-          title: '[AUTO] [${{ env.BASE_X }}] Add bwc version ${{ env.NEXT_VERSION }}.'
-          body: |
-            I've noticed that a new tag ${{ env.TAG }} was pushed, and added a bwc version ${{ env.NEXT_VERSION }}.
-
-      - uses: actions/checkout@v4
-        with:
-          ref: main
+          ref: ${{ env.MAIN_BRANCH }}
 
       - name: Add Patch Version on main branch
         uses: peternied/opensearch-core-version-updater@v1
@@ -112,18 +86,18 @@ jobs:
           new-version: ${{ env.NEXT_VERSION }}
           update-current: false
 
-      - name: Create PR for main
-        id: main_pr
+      - name: Create PR for MAIN_BRANCH
+        id: main_branch_pr
         uses: peter-evans/create-pull-request@v7
         with:
-          base: main
-          branch: 'create-pull-request/patch-main'
+          base: ${{ env.MAIN_BRANCH }}
+          branch: 'create-pull-request/patch-${{ env.MAIN_BRANCH }}'
           commit-message: Add bwc version ${{ env.NEXT_VERSION }}
           signoff: true
           delete-branch: true
           labels: |
             autocut
-          title: '[AUTO] [main] Add bwc version ${{ env.NEXT_VERSION }}.'
+          title: '[AUTO] [${{ env.MAIN_BRANCH }}] Add bwc version ${{ env.NEXT_VERSION }}.'
           body: |
             I've noticed that a new tag ${{ env.TAG }} was pushed, and added a bwc version ${{ env.NEXT_VERSION }}.
 
@@ -139,8 +113,7 @@ jobs:
              ### Exit Criteria
              Review and merged the following pull requests
              - [ ] ${{ steps.base_pr.outputs.pull-request-url }}
-             - [ ] ${{ steps.base_x_pr.outputs.pull-request-url }}
-             - [ ] ${{ steps.main_pr.outputs.pull-request-url }}
+             - [ ] ${{ steps.main_branch_pr.outputs.pull-request-url }}
 
              ### Additional Context
              See project wide guidance on branching and versions [[link]](https://github.com/opensearch-project/.github/blob/main/RELEASING.md).


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Coming from https://github.com/opensearch-project/OpenSearch/pull/18544, an attempt to fix the workflow to continue with the version increment automation.
Since we eliminated `.x` branch, we only need 2 PR's upon tag creation, example when `3.1.0` tag is created:
- PR on 3.1 branch: [AUTO] Increment version to 3.1.1.
- PR on main branch: [AUTO] [main] Add bwc version 3.1.1.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
