### PR TITLE
[refs #18606] Use the same thread for a mock invocation

### DIFF
--- a/modules/autotagging-commons/src/test/java/org/opensearch/rule/action/TransportGetRuleActionTests.java
+++ b/modules/autotagging-commons/src/test/java/org/opensearch/rule/action/TransportGetRuleActionTests.java
@@ -8,15 +8,13 @@
 
 package org.opensearch.rule.action;
 
+import org.apache.lucene.util.SameThreadExecutorService;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.rule.RulePersistenceService;
 import org.opensearch.rule.RulePersistenceServiceRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
-
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -39,11 +37,9 @@ public class TransportGetRuleActionTests extends OpenSearchTestCase {
         when(rulePersistenceServiceRegistry.getRulePersistenceService(any())).thenReturn(rulePersistenceService);
         doNothing().when(rulePersistenceService).getRule(any(), any());
         ThreadPool threadPool = mock(ThreadPool.class);
-        ExecutorService mockExecutor = Executors.newSingleThreadExecutor();
-        when(threadPool.executor(any())).thenReturn(mockExecutor);
+        when(threadPool.executor(any())).thenReturn(new SameThreadExecutorService());
         sut = new TransportGetRuleAction(transportService, threadPool, actionFilters, rulePersistenceServiceRegistry);
         sut.doExecute(null, getRuleRequest, null);
         verify(rulePersistenceService, times(1)).getRule(any(), any());
-        mockExecutor.shutdownNow();
     }
 }


### PR DESCRIPTION
### Description
Changed `TransportGetRuleActionTests.testExecute` to use `SameThreadExecutorService` to avoid race conditions

### Related Issues
Resolves #18606

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
