### PR TITLE
Changes for the Upload Workflow for merged segments

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -336,7 +336,9 @@ public final class RemoteStoreRefreshListener extends ReleasableRetryableRefresh
         ActionListener<Void> segmentUploadsCompletedListener
     ) {
         Collection<String> filteredFiles = localSegmentsPostRefresh.stream().filter(file -> !skipUpload(file)).collect(Collectors.toList());
-        Function<Map<String, Long>, UploadListener> uploadListenerFunction = (Map<String, Long> sizeMap) -> createUploadListener(localSegmentsSizeMap);
+        Function<Map<String, Long>, UploadListener> uploadListenerFunction = (Map<String, Long> sizeMap) -> createUploadListener(
+            localSegmentsSizeMap
+        );
 
         remoteStoreUploader.uploadSegments(
             filteredFiles,

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -9,9 +9,7 @@
 package org.opensearch.index.shard;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
@@ -19,7 +17,6 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.bulk.BackoffPolicy;
-import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.cluster.routing.RecoverySource;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.logging.Loggers;
@@ -30,7 +27,6 @@ import org.opensearch.index.engine.EngineException;
 import org.opensearch.index.engine.InternalEngine;
 import org.opensearch.index.remote.RemoteSegmentTransferTracker;
 import org.opensearch.index.seqno.SequenceNumbers;
-import org.opensearch.index.store.CompositeDirectory;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.remote.metadata.RemoteSegmentMetadata;
 import org.opensearch.index.translog.Translog;
@@ -49,6 +45,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.opensearch.index.seqno.SequenceNumbers.LOCAL_CHECKPOINT_KEY;
@@ -93,6 +90,7 @@ public final class RemoteStoreRefreshListener extends ReleasableRetryableRefresh
     private volatile Iterator<TimeValue> backoffDelayIterator;
     private final SegmentReplicationCheckpointPublisher checkpointPublisher;
     private final RemoteStoreSettings remoteStoreSettings;
+    private final RemoteStoreUploader remoteStoreUploader;
 
     public RemoteStoreRefreshListener(
         IndexShard indexShard,
@@ -106,6 +104,7 @@ public final class RemoteStoreRefreshListener extends ReleasableRetryableRefresh
         this.storeDirectory = indexShard.store().directory();
         this.remoteDirectory = (RemoteSegmentStoreDirectory) ((FilterDirectory) ((FilterDirectory) indexShard.remoteStore().directory())
             .getDelegate()).getDelegate();
+        remoteStoreUploader = new RemoteStoreUploaderService(indexShard, storeDirectory, remoteDirectory);
         localSegmentChecksumMap = new HashMap<>();
         RemoteSegmentMetadata remoteSegmentMetadata = null;
         if (indexShard.routingEntry().primary()) {
@@ -324,6 +323,22 @@ public final class RemoteStoreRefreshListener extends ReleasableRetryableRefresh
         return successful.get();
     }
 
+    private void uploadNewSegments(
+        Collection<String> localSegmentsPostRefresh,
+        Map<String, Long> localSegmentsSizeMap,
+        ActionListener<Void> segmentUploadsCompletedListener
+    ) {
+        Collection<String> filteredFiles = localSegmentsPostRefresh.stream().filter(file -> !skipUpload(file)).collect(Collectors.toList());
+        Function<Map<String, Long>, UploadListener> uploadListenerFunction = this::createUploadListener;
+        remoteStoreUploader.uploadSegments(
+            filteredFiles,
+            localSegmentsSizeMap,
+            segmentUploadsCompletedListener,
+            uploadListenerFunction,
+            isLowPriorityUpload()
+        );
+    }
+
     /**
      * Clears the stale files from the latest local segment checksum map.
      *
@@ -421,45 +436,6 @@ public final class RemoteStoreRefreshListener extends ReleasableRetryableRefresh
                 replicationCheckpoint,
                 indexShard.getNodeId()
             );
-        }
-    }
-
-    private void uploadNewSegments(
-        Collection<String> localSegmentsPostRefresh,
-        Map<String, Long> localSegmentsSizeMap,
-        ActionListener<Void> listener
-    ) {
-        Collection<String> filteredFiles = localSegmentsPostRefresh.stream().filter(file -> !skipUpload(file)).collect(Collectors.toList());
-        if (filteredFiles.size() == 0) {
-            logger.debug("No new segments to upload in uploadNewSegments");
-            listener.onResponse(null);
-            return;
-        }
-
-        logger.debug("Effective new segments files to upload {}", filteredFiles);
-        ActionListener<Collection<Void>> mappedListener = ActionListener.map(listener, resp -> null);
-        GroupedActionListener<Void> batchUploadListener = new GroupedActionListener<>(mappedListener, filteredFiles.size());
-        Directory directory = ((FilterDirectory) (((FilterDirectory) storeDirectory).getDelegate())).getDelegate();
-
-        for (String src : filteredFiles) {
-            // Initializing listener here to ensure that the stats increment operations are thread-safe
-            UploadListener statsListener = createUploadListener(localSegmentsSizeMap);
-            ActionListener<Void> aggregatedListener = ActionListener.wrap(resp -> {
-                statsListener.onSuccess(src);
-                batchUploadListener.onResponse(resp);
-                if (directory instanceof CompositeDirectory) {
-                    ((CompositeDirectory) directory).afterSyncToRemote(src);
-                }
-            }, ex -> {
-                logger.warn(() -> new ParameterizedMessage("Exception: [{}] while uploading segment files", ex), ex);
-                if (ex instanceof CorruptIndexException) {
-                    indexShard.failShard(ex.getMessage(), ex);
-                }
-                statsListener.onFailure(src);
-                batchUploadListener.onFailure(ex);
-            });
-            statsListener.beforeUpload(src);
-            remoteDirectory.copyFrom(storeDirectory, src, IOContext.DEFAULT, aggregatedListener, isLowPriorityUpload());
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -323,13 +323,21 @@ public final class RemoteStoreRefreshListener extends ReleasableRetryableRefresh
         return successful.get();
     }
 
+    /**
+     * Uploads new segment files to the remote store.
+     *
+     * @param localSegmentsPostRefresh collection of segment files present after refresh
+     * @param localSegmentsSizeMap map of segment file names to their sizes
+     * @param segmentUploadsCompletedListener listener to be notified when upload completes
+     */
     private void uploadNewSegments(
         Collection<String> localSegmentsPostRefresh,
         Map<String, Long> localSegmentsSizeMap,
         ActionListener<Void> segmentUploadsCompletedListener
     ) {
         Collection<String> filteredFiles = localSegmentsPostRefresh.stream().filter(file -> !skipUpload(file)).collect(Collectors.toList());
-        Function<Map<String, Long>, UploadListener> uploadListenerFunction = this::createUploadListener;
+        Function<Map<String, Long>, UploadListener> uploadListenerFunction = (Map<String, Long> sizeMap) -> createUploadListener(localSegmentsSizeMap);
+
         remoteStoreUploader.uploadSegments(
             filteredFiles,
             localSegmentsSizeMap,

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreUploader.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreUploader.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.shard;
+
+import org.opensearch.core.action.ActionListener;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Interface to handle the functionality for upload data in the remote store
+ */
+public interface RemoteStoreUploader {
+
+    void syncAndUploadNewSegments(Collection<String> localSegments, Map<String, Long> localSegmentsSizeMap, ActionListener<Void> listener);
+}

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreUploader.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreUploader.java
@@ -8,15 +8,22 @@
 
 package org.opensearch.index.shard;
 
+import org.opensearch.common.util.UploadListener;
 import org.opensearch.core.action.ActionListener;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Interface to handle the functionality for upload data in the remote store
  */
 public interface RemoteStoreUploader {
 
-    void syncAndUploadNewSegments(Collection<String> localSegments, Map<String, Long> localSegmentsSizeMap, ActionListener<Void> listener);
+    void uploadSegments(
+        Collection<String> localSegments,
+        Map<String, Long> localSegmentsSizeMap,
+        ActionListener<Void> listener,
+        Function<Map<String, Long>, UploadListener> uploadListenerFunction
+    );
 }

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreUploader.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreUploader.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * Interface to handle the functionality for upload data in the remote store
+ * Interface to handle the functionality for uploading data in the remote store
  */
 public interface RemoteStoreUploader {
 
@@ -24,6 +24,7 @@ public interface RemoteStoreUploader {
         Collection<String> localSegments,
         Map<String, Long> localSegmentsSizeMap,
         ActionListener<Void> listener,
-        Function<Map<String, Long>, UploadListener> uploadListenerFunction
+        Function<Map<String, Long>, UploadListener> uploadListenerFunction,
+        boolean isLowPriorityUpload
     );
 }

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreUploaderService.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreUploaderService.java
@@ -10,26 +10,21 @@ package org.opensearch.index.shard;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
-import org.apache.lucene.store.IndexInput;
 import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.cluster.routing.RecoverySource;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.util.UploadListener;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.index.remote.RemoteSegmentTransferTracker;
 import org.opensearch.index.store.CompositeDirectory;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 
-import java.io.IOException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
+import java.util.function.Function;
 
 /**
  * The service essentially acts as a bridge between local segment storage and remote storage,
@@ -39,69 +34,56 @@ public class RemoteStoreUploaderService implements RemoteStoreUploader {
 
     private final Logger logger;
 
-    public static final Set<String> EXCLUDE_FILES = Set.of("write.lock");
-
     private final IndexShard indexShard;
     private final Directory storeDirectory;
     private final RemoteSegmentStoreDirectory remoteDirectory;
-    private final Map<String, String> localSegmentChecksumMap;
-    // todo: check if we need to create a separate segment tracker as it is said to be linked to RL
-    private final RemoteSegmentTransferTracker segmentTracker;
 
-    public RemoteStoreUploaderService(
-        IndexShard indexShard,
-        Directory storeDirectory,
-        RemoteSegmentStoreDirectory remoteDirectory,
-        RemoteSegmentTransferTracker segmentTracker
-    ) {
-        this.indexShard = indexShard;
-        // todo: check the prefix to be add for this class
+    public RemoteStoreUploaderService(IndexShard indexShard, Directory storeDirectory, RemoteSegmentStoreDirectory remoteDirectory) {
         logger = Loggers.getLogger(getClass(), indexShard.shardId());
+        this.indexShard = indexShard;
         this.storeDirectory = storeDirectory;
         this.remoteDirectory = remoteDirectory;
-        this.segmentTracker = segmentTracker;
-        this.localSegmentChecksumMap = new HashMap<>();
     }
 
     @Override
-    public void syncAndUploadNewSegments(
+    public void uploadSegments(
         Collection<String> localSegments,
         Map<String, Long> localSegmentsSizeMap,
-        ActionListener<Void> listener
+        ActionListener<Void> listener,
+        Function<Map<String, Long>, UploadListener> uploadListenerFunction
     ) {
-
-        Collection<String> filteredFiles = localSegments.stream().filter(file -> !skipUpload(file)).toList();
-        if (filteredFiles.isEmpty()) {
+        if (localSegments.isEmpty()) {
             logger.debug("No new segments to upload in uploadNewSegments");
             listener.onResponse(null);
             return;
         }
 
-        logger.debug("Effective new segments files to upload {}", filteredFiles);
+        logger.debug("Effective new segments files to upload {}", localSegments);
         ActionListener<Collection<Void>> mappedListener = ActionListener.map(listener, resp -> null);
-        GroupedActionListener<Void> batchUploadListener = new GroupedActionListener<>(mappedListener, filteredFiles.size());
+        GroupedActionListener<Void> batchUploadListener = new GroupedActionListener<>(mappedListener, localSegments.size());
         Directory directory = ((FilterDirectory) (((FilterDirectory) storeDirectory).getDelegate())).getDelegate();
 
-        for (String filteredFile : filteredFiles) {
+        for (String localSegment : localSegments) {
             // Initializing listener here to ensure that the stats increment operations are thread-safe
-            UploadListener statsListener = createUploadListener(localSegmentsSizeMap);
+            UploadListener statsListener = uploadListenerFunction.apply(localSegmentsSizeMap);
             ActionListener<Void> aggregatedListener = ActionListener.wrap(resp -> {
-                statsListener.onSuccess(filteredFile);
+                statsListener.onSuccess(localSegment);
                 batchUploadListener.onResponse(resp);
+                // Once uploaded to Remote, local files become eligible for eviction from FileCache
                 if (directory instanceof CompositeDirectory) {
-                    ((CompositeDirectory) directory).afterSyncToRemote(filteredFile);
+                    ((CompositeDirectory) directory).afterSyncToRemote(localSegment);
                 }
             }, ex -> {
                 logger.warn(() -> new ParameterizedMessage("Exception: [{}] while uploading segment files", ex), ex);
                 if (ex instanceof CorruptIndexException) {
                     indexShard.failShard(ex.getMessage(), ex);
                 }
-                statsListener.onFailure(filteredFile);
+                statsListener.onFailure(localSegment);
                 batchUploadListener.onFailure(ex);
             });
-            statsListener.beforeUpload(filteredFile);
+            statsListener.beforeUpload(localSegment);
             // Place where the actual upload is happening
-            remoteDirectory.copyFrom(storeDirectory, filteredFile, IOContext.DEFAULT, aggregatedListener, isLowPriorityUpload());
+            remoteDirectory.copyFrom(storeDirectory, localSegment, IOContext.DEFAULT, aggregatedListener, isLowPriorityUpload());
         }
     }
 
@@ -118,68 +100,5 @@ public class RemoteStoreUploaderService implements RemoteStoreUploader {
             && (indexShard.recoveryState().getRecoverySource().getType() == RecoverySource.Type.LOCAL_SHARDS
                 || indexShard.recoveryState().getRecoverySource().getType() == RecoverySource.Type.SNAPSHOT
                 || indexShard.shouldSeedRemoteStore());
-    }
-
-    /**
-     * Creates an {@link UploadListener} containing the stats population logic which would be triggered before and after segment upload events
-     *
-     * @param fileSizeMap updated map of current snapshot of local segments to their sizes
-     */
-    private UploadListener createUploadListener(Map<String, Long> fileSizeMap) {
-        return new UploadListener() {
-            private long uploadStartTime = 0;
-
-            @Override
-            public void beforeUpload(String file) {
-                // Start tracking the upload bytes started
-                segmentTracker.addUploadBytesStarted(fileSizeMap.get(file));
-                uploadStartTime = System.currentTimeMillis();
-            }
-
-            @Override
-            public void onSuccess(String file) {
-                // Track upload success
-                segmentTracker.addUploadBytesSucceeded(fileSizeMap.get(file));
-                segmentTracker.addToLatestUploadedFiles(file);
-                segmentTracker.addUploadTimeInMillis(Math.max(1, System.currentTimeMillis() - uploadStartTime));
-            }
-
-            @Override
-            public void onFailure(String file) {
-                // Track upload failure
-                segmentTracker.addUploadBytesFailed(fileSizeMap.get(file));
-                segmentTracker.addUploadTimeInMillis(Math.max(1, System.currentTimeMillis() - uploadStartTime));
-            }
-        };
-    }
-
-    /**
-     * Whether to upload a file or not depending on whether file is in excluded list or has been already uploaded.
-     *
-     * @param file that needs to be uploaded.
-     * @return true if the upload has to be skipped for the file.
-     */
-    private boolean skipUpload(String file) {
-        try {
-            // Exclude files that are already uploaded and the exclude files to come up with the list of files to be uploaded.
-            // todo: Check if we need the second condition or is it just fail safe
-            return EXCLUDE_FILES.contains(file) || remoteDirectory.containsFile(file, getChecksumOfLocalFile(file));
-        } catch (IOException e) {
-            logger.error(
-                "Exception while reading checksum of local segment file: {}, ignoring the exception and re-uploading the file",
-                file
-            );
-        }
-        return false;
-    }
-
-    private String getChecksumOfLocalFile(String file) throws IOException {
-        if (!localSegmentChecksumMap.containsKey(file)) {
-            try (IndexInput indexInput = storeDirectory.openInput(file, IOContext.READONCE)) {
-                String checksum = Long.toString(CodecUtil.retrieveChecksum(indexInput));
-                localSegmentChecksumMap.put(file, checksum);
-            }
-        }
-        return localSegmentChecksumMap.get(file);
     }
 }

--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreUploaderService.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreUploaderService.java
@@ -1,0 +1,185 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.shard;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.opensearch.action.support.GroupedActionListener;
+import org.opensearch.cluster.routing.RecoverySource;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.util.UploadListener;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.remote.RemoteSegmentTransferTracker;
+import org.opensearch.index.store.CompositeDirectory;
+import org.opensearch.index.store.RemoteSegmentStoreDirectory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The service essentially acts as a bridge between local segment storage and remote storage,
+ * ensuring efficient and reliable segment synchronization while providing comprehensive monitoring and error handling.
+ */
+public class RemoteStoreUploaderService implements RemoteStoreUploader {
+
+    private final Logger logger;
+
+    public static final Set<String> EXCLUDE_FILES = Set.of("write.lock");
+
+    private final IndexShard indexShard;
+    private final Directory storeDirectory;
+    private final RemoteSegmentStoreDirectory remoteDirectory;
+    private final Map<String, String> localSegmentChecksumMap;
+    // todo: check if we need to create a separate segment tracker as it is said to be linked to RL
+    private final RemoteSegmentTransferTracker segmentTracker;
+
+    public RemoteStoreUploaderService(
+        IndexShard indexShard,
+        Directory storeDirectory,
+        RemoteSegmentStoreDirectory remoteDirectory,
+        RemoteSegmentTransferTracker segmentTracker
+    ) {
+        this.indexShard = indexShard;
+        // todo: check the prefix to be add for this class
+        logger = Loggers.getLogger(getClass(), indexShard.shardId());
+        this.storeDirectory = storeDirectory;
+        this.remoteDirectory = remoteDirectory;
+        this.segmentTracker = segmentTracker;
+        this.localSegmentChecksumMap = new HashMap<>();
+    }
+
+    @Override
+    public void syncAndUploadNewSegments(
+        Collection<String> localSegments,
+        Map<String, Long> localSegmentsSizeMap,
+        ActionListener<Void> listener
+    ) {
+
+        Collection<String> filteredFiles = localSegments.stream().filter(file -> !skipUpload(file)).toList();
+        if (filteredFiles.isEmpty()) {
+            logger.debug("No new segments to upload in uploadNewSegments");
+            listener.onResponse(null);
+            return;
+        }
+
+        logger.debug("Effective new segments files to upload {}", filteredFiles);
+        ActionListener<Collection<Void>> mappedListener = ActionListener.map(listener, resp -> null);
+        GroupedActionListener<Void> batchUploadListener = new GroupedActionListener<>(mappedListener, filteredFiles.size());
+        Directory directory = ((FilterDirectory) (((FilterDirectory) storeDirectory).getDelegate())).getDelegate();
+
+        for (String filteredFile : filteredFiles) {
+            // Initializing listener here to ensure that the stats increment operations are thread-safe
+            UploadListener statsListener = createUploadListener(localSegmentsSizeMap);
+            ActionListener<Void> aggregatedListener = ActionListener.wrap(resp -> {
+                statsListener.onSuccess(filteredFile);
+                batchUploadListener.onResponse(resp);
+                if (directory instanceof CompositeDirectory) {
+                    ((CompositeDirectory) directory).afterSyncToRemote(filteredFile);
+                }
+            }, ex -> {
+                logger.warn(() -> new ParameterizedMessage("Exception: [{}] while uploading segment files", ex), ex);
+                if (ex instanceof CorruptIndexException) {
+                    indexShard.failShard(ex.getMessage(), ex);
+                }
+                statsListener.onFailure(filteredFile);
+                batchUploadListener.onFailure(ex);
+            });
+            statsListener.beforeUpload(filteredFile);
+            // Place where the actual upload is happening
+            remoteDirectory.copyFrom(storeDirectory, filteredFile, IOContext.DEFAULT, aggregatedListener, isLowPriorityUpload());
+        }
+    }
+
+    boolean isLowPriorityUpload() {
+        return isLocalOrSnapshotRecoveryOrSeeding();
+    }
+
+    boolean isLocalOrSnapshotRecoveryOrSeeding() {
+        // In this case when the primary mode is false, we need to upload segments to Remote Store
+        // This is required in case of remote migration seeding/snapshots/shrink/ split/clone where we need to durable persist
+        // all segments to remote before completing the recovery to ensure durability.
+        return (indexShard.state() == IndexShardState.RECOVERING && indexShard.shardRouting.primary())
+            && indexShard.recoveryState() != null
+            && (indexShard.recoveryState().getRecoverySource().getType() == RecoverySource.Type.LOCAL_SHARDS
+                || indexShard.recoveryState().getRecoverySource().getType() == RecoverySource.Type.SNAPSHOT
+                || indexShard.shouldSeedRemoteStore());
+    }
+
+    /**
+     * Creates an {@link UploadListener} containing the stats population logic which would be triggered before and after segment upload events
+     *
+     * @param fileSizeMap updated map of current snapshot of local segments to their sizes
+     */
+    private UploadListener createUploadListener(Map<String, Long> fileSizeMap) {
+        return new UploadListener() {
+            private long uploadStartTime = 0;
+
+            @Override
+            public void beforeUpload(String file) {
+                // Start tracking the upload bytes started
+                segmentTracker.addUploadBytesStarted(fileSizeMap.get(file));
+                uploadStartTime = System.currentTimeMillis();
+            }
+
+            @Override
+            public void onSuccess(String file) {
+                // Track upload success
+                segmentTracker.addUploadBytesSucceeded(fileSizeMap.get(file));
+                segmentTracker.addToLatestUploadedFiles(file);
+                segmentTracker.addUploadTimeInMillis(Math.max(1, System.currentTimeMillis() - uploadStartTime));
+            }
+
+            @Override
+            public void onFailure(String file) {
+                // Track upload failure
+                segmentTracker.addUploadBytesFailed(fileSizeMap.get(file));
+                segmentTracker.addUploadTimeInMillis(Math.max(1, System.currentTimeMillis() - uploadStartTime));
+            }
+        };
+    }
+
+    /**
+     * Whether to upload a file or not depending on whether file is in excluded list or has been already uploaded.
+     *
+     * @param file that needs to be uploaded.
+     * @return true if the upload has to be skipped for the file.
+     */
+    private boolean skipUpload(String file) {
+        try {
+            // Exclude files that are already uploaded and the exclude files to come up with the list of files to be uploaded.
+            // todo: Check if we need the second condition or is it just fail safe
+            return EXCLUDE_FILES.contains(file) || remoteDirectory.containsFile(file, getChecksumOfLocalFile(file));
+        } catch (IOException e) {
+            logger.error(
+                "Exception while reading checksum of local segment file: {}, ignoring the exception and re-uploading the file",
+                file
+            );
+        }
+        return false;
+    }
+
+    private String getChecksumOfLocalFile(String file) throws IOException {
+        if (!localSegmentChecksumMap.containsKey(file)) {
+            try (IndexInput indexInput = storeDirectory.openInput(file, IOContext.READONCE)) {
+                String checksum = Long.toString(CodecUtil.retrieveChecksum(indexInput));
+                localSegmentChecksumMap.put(file, checksum);
+            }
+        }
+        return localSegmentChecksumMap.get(file);
+    }
+}

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreUploaderServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreUploaderServiceTests.java
@@ -474,4 +474,5 @@ public class RemoteStoreUploaderServiceTests extends OpenSearchTestCase {
             super(in);
         }
     }
+
 }

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreUploaderServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreUploaderServiceTests.java
@@ -474,5 +474,4 @@ public class RemoteStoreUploaderServiceTests extends OpenSearchTestCase {
             super(in);
         }
     }
-
 }

--- a/server/src/test/java/org/opensearch/index/shard/RemoteStoreUploaderServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteStoreUploaderServiceTests.java
@@ -1,0 +1,484 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.shard;
+
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.opensearch.cluster.routing.RecoverySource;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.util.UploadListener;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.store.CompositeDirectory;
+import org.opensearch.index.store.RemoteDirectory;
+import org.opensearch.index.store.RemoteSegmentStoreDirectory;
+import org.opensearch.index.store.lockmanager.RemoteStoreLockManager;
+import org.opensearch.indices.recovery.RecoveryState;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RemoteStoreUploaderServiceTests extends OpenSearchTestCase {
+
+    /**
+     * Helper method to access private fields using reflection
+     */
+    @SuppressWarnings("unchecked")
+    private <T> T getFieldValue(Object object, String fieldName) {
+        try {
+            java.lang.reflect.Field field = object.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return (T) field.get(object);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get field value: " + fieldName, e);
+        }
+    }
+
+    private IndexShard mockIndexShard;
+    private Directory mockStoreDirectory;
+    private RemoteSegmentStoreDirectory mockRemoteDirectory;
+    private RemoteStoreUploaderService uploaderService;
+    private UploadListener mockUploadListener;
+    private Function<Map<String, Long>, UploadListener> mockUploadListenerFunction;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockIndexShard = mock(IndexShard.class);
+        ShardId shardId = new ShardId(new Index("test", "test"), 0);
+        when(mockIndexShard.shardId()).thenReturn(shardId);
+
+        // Create a mock ShardRouting and set it as a field on the IndexShard mock
+        ShardRouting mockShardRouting = mock(ShardRouting.class);
+        try {
+            java.lang.reflect.Field shardRoutingField = IndexShard.class.getDeclaredField("shardRouting");
+            shardRoutingField.setAccessible(true);
+            shardRoutingField.set(mockIndexShard, mockShardRouting);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set shardRouting field", e);
+        }
+        mockStoreDirectory = mock(FilterDirectory.class);
+        // Use a real instance with mocked dependencies instead of mocking the final class
+        mockRemoteDirectory = createMockRemoteDirectory();
+        mockUploadListener = mock(UploadListener.class);
+        mockUploadListenerFunction = mock(Function.class);
+
+        when(mockUploadListenerFunction.apply(any())).thenReturn(mockUploadListener);
+
+        uploaderService = new RemoteStoreUploaderService(mockIndexShard, mockStoreDirectory, mockRemoteDirectory);
+    }
+
+    /**
+     * Creates a real RemoteSegmentStoreDirectory instance with mocked dependencies
+     * instead of trying to mock the final class directly.
+     */
+    private RemoteSegmentStoreDirectory createMockRemoteDirectory() {
+        try {
+            RemoteDirectory remoteDataDirectory = mock(RemoteDirectory.class);
+            RemoteDirectory remoteMetadataDirectory = mock(RemoteDirectory.class);
+            RemoteStoreLockManager lockManager = mock(RemoteStoreLockManager.class);
+            ThreadPool threadPool = mock(ThreadPool.class);
+            ShardId shardId = new ShardId(new Index("test", "test"), 0);
+
+            return new RemoteSegmentStoreDirectory(remoteDataDirectory, remoteMetadataDirectory, lockManager, threadPool, shardId);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create mock RemoteSegmentStoreDirectory", e);
+        }
+    }
+
+    public void testUploadSegmentsWithEmptyCollection() throws Exception {
+        Collection<String> emptySegments = Collections.emptyList();
+        Map<String, Long> segmentSizeMap = new HashMap<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ActionListener<Void> listener = ActionListener.wrap(
+            response -> latch.countDown(),
+            exception -> fail("Should not fail for empty segments")
+        );
+
+        uploaderService.uploadSegments(emptySegments, segmentSizeMap, listener, mockUploadListenerFunction);
+
+        assertTrue(latch.await(1, TimeUnit.SECONDS));
+    }
+
+    public void testUploadSegmentsSuccess() throws Exception {
+        Collection<String> segments = Arrays.asList("segment1", "segment2");
+        Map<String, Long> segmentSizeMap = new HashMap<>();
+        segmentSizeMap.put("segment1", 100L);
+        segmentSizeMap.put("segment2", 200L);
+
+        // Create a fresh mock IndexShard
+        IndexShard freshMockShard = mock(IndexShard.class);
+        ShardId shardId = new ShardId(new Index("test", "test"), 0);
+        when(freshMockShard.shardId()).thenReturn(shardId);
+
+        // Create a mock ShardRouting and set it as a field on the IndexShard mock
+        ShardRouting mockShardRouting = mock(ShardRouting.class);
+        try {
+            java.lang.reflect.Field shardRoutingField = IndexShard.class.getDeclaredField("shardRouting");
+            shardRoutingField.setAccessible(true);
+            shardRoutingField.set(freshMockShard, mockShardRouting);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set shardRouting field", e);
+        }
+
+        // Create a mock directory structure that matches what the code expects
+        Directory innerMockDelegate = mock(Directory.class);
+        FilterDirectory innerFilterDirectory = new TestFilterDirectory(new TestFilterDirectory(innerMockDelegate));
+
+        FilterDirectory outerFilterDirectory = new TestFilterDirectory(new TestFilterDirectory(innerFilterDirectory));
+
+        // Create a new uploader service with the fresh mocks
+        RemoteStoreUploaderService testUploaderService = new RemoteStoreUploaderService(
+            freshMockShard,
+            outerFilterDirectory,
+            mockRemoteDirectory
+        );
+
+        // Setup the real RemoteSegmentStoreDirectory to handle copyFrom calls
+        RemoteDirectory remoteDataDirectory = getFieldValue(mockRemoteDirectory, "remoteDataDirectory");
+        doAnswer(invocation -> {
+            ActionListener<Void> callback = invocation.getArgument(5);
+            callback.onResponse(null);
+            return true;
+        }).when(remoteDataDirectory).copyFrom(any(), any(), any(), any(), any(), any(), any(Boolean.class));
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ActionListener<Void> listener = ActionListener.wrap(
+            response -> latch.countDown(),
+            exception -> fail("Upload should succeed: " + exception.getMessage())
+        );
+
+        testUploaderService.uploadSegments(segments, segmentSizeMap, listener, mockUploadListenerFunction);
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        // Verify the upload listener was called correctly
+        verify(mockUploadListener, times(2)).beforeUpload(any(String.class));
+        verify(mockUploadListener, times(2)).onSuccess(any(String.class));
+    }
+
+    public void testUploadSegmentsWithCompositeDirectory() throws Exception {
+        Collection<String> segments = Arrays.asList("segment1");
+        Map<String, Long> segmentSizeMap = new HashMap<>();
+        segmentSizeMap.put("segment1", 100L);
+
+        // Create a fresh mock IndexShard
+        IndexShard freshMockShard = mock(IndexShard.class);
+        ShardId shardId = new ShardId(new Index("test", "test"), 0);
+        when(freshMockShard.shardId()).thenReturn(shardId);
+
+        // Create a mock ShardRouting and set it as a field on the IndexShard mock
+        ShardRouting mockShardRouting = mock(ShardRouting.class);
+        try {
+            java.lang.reflect.Field shardRoutingField = IndexShard.class.getDeclaredField("shardRouting");
+            shardRoutingField.setAccessible(true);
+            shardRoutingField.set(freshMockShard, mockShardRouting);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set shardRouting field", e);
+        }
+
+        CompositeDirectory mockCompositeDirectory = mock(CompositeDirectory.class);
+        FilterDirectory innerFilterDirectory = new TestFilterDirectory(mockCompositeDirectory);
+        FilterDirectory outerFilterDirectory = new TestFilterDirectory(innerFilterDirectory);
+
+        // Create a new uploader service with the fresh mocks
+        RemoteStoreUploaderService testUploaderService = new RemoteStoreUploaderService(
+            freshMockShard,
+            outerFilterDirectory,
+            mockRemoteDirectory
+        );
+
+        // Setup the real RemoteSegmentStoreDirectory to handle copyFrom calls
+        RemoteDirectory remoteDataDirectory = getFieldValue(mockRemoteDirectory, "remoteDataDirectory");
+        doAnswer(invocation -> {
+            ActionListener<Void> callback = invocation.getArgument(5);
+            callback.onResponse(null);
+            return true;
+        }).when(remoteDataDirectory).copyFrom(any(), any(), any(), any(), any(), any(), any(Boolean.class));
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ActionListener<Void> listener = ActionListener.wrap(
+            response -> latch.countDown(),
+            exception -> fail("Upload should succeed: " + exception.getMessage())
+        );
+
+        testUploaderService.uploadSegments(segments, segmentSizeMap, listener, mockUploadListenerFunction);
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        verify(mockCompositeDirectory).afterSyncToRemote("segment1");
+    }
+
+    public void testUploadSegmentsWithCorruptIndexException() throws Exception {
+        Collection<String> segments = Arrays.asList("segment1");
+        Map<String, Long> segmentSizeMap = new HashMap<>();
+        segmentSizeMap.put("segment1", 100L);
+
+        // Create a fresh mock IndexShard
+        IndexShard freshMockShard = mock(IndexShard.class);
+        ShardId shardId = new ShardId(new Index("test", "test"), 0);
+        when(freshMockShard.shardId()).thenReturn(shardId);
+
+        // Create a mock ShardRouting and set it as a field on the IndexShard mock
+        ShardRouting mockShardRouting = mock(ShardRouting.class);
+        try {
+            java.lang.reflect.Field shardRoutingField = IndexShard.class.getDeclaredField("shardRouting");
+            shardRoutingField.setAccessible(true);
+            shardRoutingField.set(freshMockShard, mockShardRouting);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set shardRouting field", e);
+        }
+
+        Directory innerMockDelegate = mock(Directory.class);
+        FilterDirectory innerFilterDirectory = new TestFilterDirectory(new TestFilterDirectory(innerMockDelegate));
+
+        FilterDirectory outerFilterDirectory = new TestFilterDirectory(new TestFilterDirectory(innerFilterDirectory));
+
+        // Create a new uploader service with the fresh mocks
+        RemoteStoreUploaderService testUploaderService = new RemoteStoreUploaderService(
+            freshMockShard,
+            outerFilterDirectory,
+            mockRemoteDirectory
+        );
+
+        CorruptIndexException corruptException = new CorruptIndexException("Index corrupted", "test");
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Setup the real RemoteSegmentStoreDirectory to handle copyFrom calls
+        RemoteDirectory remoteDataDirectory = getFieldValue(mockRemoteDirectory, "remoteDataDirectory");
+        doAnswer(invocation -> {
+            ActionListener<Void> callback = invocation.getArgument(5);
+            callback.onFailure(corruptException);
+            return true;
+        }).when(remoteDataDirectory).copyFrom(any(), any(), any(), any(), any(), any(), any(Boolean.class));
+
+        ActionListener<Void> listener = ActionListener.wrap(response -> fail("Should not succeed with corrupt index"), exception -> {
+            assertEquals(corruptException, exception);
+            latch.countDown();
+        });
+
+        testUploaderService.uploadSegments(segments, segmentSizeMap, listener, mockUploadListenerFunction);
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        verify(freshMockShard).failShard(eq("Index corrupted (resource=test)"), eq(corruptException));
+        verify(mockUploadListener).onFailure("segment1");
+    }
+
+    public void testUploadSegmentsWithGenericException() throws Exception {
+        Collection<String> segments = Arrays.asList("segment1");
+        Map<String, Long> segmentSizeMap = new HashMap<>();
+        segmentSizeMap.put("segment1", 100L);
+
+        // Create a fresh mock IndexShard
+        IndexShard freshMockShard = mock(IndexShard.class);
+        ShardId shardId = new ShardId(new Index("test", "test"), 0);
+        when(freshMockShard.shardId()).thenReturn(shardId);
+
+        // Create a mock ShardRouting and set it as a field on the IndexShard mock
+        ShardRouting mockShardRouting = mock(ShardRouting.class);
+        try {
+            java.lang.reflect.Field shardRoutingField = IndexShard.class.getDeclaredField("shardRouting");
+            shardRoutingField.setAccessible(true);
+            shardRoutingField.set(freshMockShard, mockShardRouting);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set shardRouting field", e);
+        }
+
+        Directory innerMockDelegate = mock(Directory.class);
+        FilterDirectory innerFilterDirectory = new TestFilterDirectory(new TestFilterDirectory(innerMockDelegate));
+
+        FilterDirectory outerFilterDirectory = new TestFilterDirectory(new TestFilterDirectory(innerFilterDirectory));
+
+        // Create a new uploader service with the fresh mocks
+        RemoteStoreUploaderService testUploaderService = new RemoteStoreUploaderService(
+            freshMockShard,
+            outerFilterDirectory,
+            mockRemoteDirectory
+        );
+
+        RuntimeException genericException = new RuntimeException("Generic error");
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Setup the real RemoteSegmentStoreDirectory to handle copyFrom calls
+        RemoteDirectory remoteDataDirectory = getFieldValue(mockRemoteDirectory, "remoteDataDirectory");
+        doAnswer(invocation -> {
+            ActionListener<Void> callback = invocation.getArgument(5);
+            callback.onFailure(genericException);
+            return true;
+        }).when(remoteDataDirectory).copyFrom(any(), any(), any(), any(), any(), any(), any(Boolean.class));
+
+        ActionListener<Void> listener = ActionListener.wrap(response -> fail("Should not succeed with generic exception"), exception -> {
+            assertEquals(genericException, exception);
+            latch.countDown();
+        });
+
+        testUploaderService.uploadSegments(segments, segmentSizeMap, listener, mockUploadListenerFunction);
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        verify(freshMockShard, never()).failShard(any(), any());
+        verify(mockUploadListener).onFailure("segment1");
+    }
+
+    public void testIsLowPriorityUpload() {
+        when(mockIndexShard.state()).thenReturn(IndexShardState.RECOVERING);
+        try {
+            java.lang.reflect.Field shardRoutingField = IndexShard.class.getDeclaredField("shardRouting");
+            shardRoutingField.setAccessible(true);
+            ShardRouting mockShardRouting = (ShardRouting) shardRoutingField.get(mockIndexShard);
+            when(mockShardRouting.primary()).thenReturn(true);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to access shardRouting field", e);
+        }
+
+        RecoveryState mockRecoveryState = mock(RecoveryState.class);
+        RecoverySource mockRecoverySource = mock(RecoverySource.class);
+        when(mockRecoverySource.getType()).thenReturn(RecoverySource.Type.LOCAL_SHARDS);
+        when(mockRecoveryState.getRecoverySource()).thenReturn(mockRecoverySource);
+        when(mockIndexShard.recoveryState()).thenReturn(mockRecoveryState);
+
+        assertTrue(uploaderService.isLowPriorityUpload());
+    }
+
+    public void testIsLocalOrSnapshotRecoveryOrSeedingWithLocalShards() {
+        when(mockIndexShard.state()).thenReturn(IndexShardState.RECOVERING);
+        try {
+            java.lang.reflect.Field shardRoutingField = IndexShard.class.getDeclaredField("shardRouting");
+            shardRoutingField.setAccessible(true);
+            ShardRouting mockShardRouting = (ShardRouting) shardRoutingField.get(mockIndexShard);
+            when(mockShardRouting.primary()).thenReturn(true);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to access shardRouting field", e);
+        }
+
+        RecoveryState mockRecoveryState = mock(RecoveryState.class);
+        RecoverySource mockRecoverySource = mock(RecoverySource.class);
+        when(mockRecoverySource.getType()).thenReturn(RecoverySource.Type.LOCAL_SHARDS);
+        when(mockRecoveryState.getRecoverySource()).thenReturn(mockRecoverySource);
+        when(mockIndexShard.recoveryState()).thenReturn(mockRecoveryState);
+
+        assertTrue(uploaderService.isLocalOrSnapshotRecoveryOrSeeding());
+    }
+
+    public void testIsLocalOrSnapshotRecoveryOrSeedingWithSnapshot() {
+        when(mockIndexShard.state()).thenReturn(IndexShardState.RECOVERING);
+        try {
+            java.lang.reflect.Field shardRoutingField = IndexShard.class.getDeclaredField("shardRouting");
+            shardRoutingField.setAccessible(true);
+            ShardRouting mockShardRouting = (ShardRouting) shardRoutingField.get(mockIndexShard);
+            when(mockShardRouting.primary()).thenReturn(true);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to access shardRouting field", e);
+        }
+
+        RecoveryState mockRecoveryState = mock(RecoveryState.class);
+        RecoverySource mockRecoverySource = mock(RecoverySource.class);
+        when(mockRecoverySource.getType()).thenReturn(RecoverySource.Type.SNAPSHOT);
+        when(mockRecoveryState.getRecoverySource()).thenReturn(mockRecoverySource);
+        when(mockIndexShard.recoveryState()).thenReturn(mockRecoveryState);
+
+        assertTrue(uploaderService.isLocalOrSnapshotRecoveryOrSeeding());
+    }
+
+    public void testIsLocalOrSnapshotRecoveryOrSeedingWithSeeding() {
+        when(mockIndexShard.state()).thenReturn(IndexShardState.RECOVERING);
+        try {
+            java.lang.reflect.Field shardRoutingField = IndexShard.class.getDeclaredField("shardRouting");
+            shardRoutingField.setAccessible(true);
+            ShardRouting mockShardRouting = (ShardRouting) shardRoutingField.get(mockIndexShard);
+            when(mockShardRouting.primary()).thenReturn(true);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to access shardRouting field", e);
+        }
+
+        RecoveryState mockRecoveryState = mock(RecoveryState.class);
+        RecoverySource mockRecoverySource = mock(RecoverySource.class);
+        when(mockRecoverySource.getType()).thenReturn(RecoverySource.Type.PEER);
+        when(mockRecoveryState.getRecoverySource()).thenReturn(mockRecoverySource);
+        when(mockIndexShard.recoveryState()).thenReturn(mockRecoveryState);
+        when(mockIndexShard.shouldSeedRemoteStore()).thenReturn(true);
+
+        assertTrue(uploaderService.isLocalOrSnapshotRecoveryOrSeeding());
+    }
+
+    public void testIsLocalOrSnapshotRecoveryOrSeedingReturnsFalse() {
+        when(mockIndexShard.state()).thenReturn(IndexShardState.STARTED);
+        try {
+            java.lang.reflect.Field shardRoutingField = IndexShard.class.getDeclaredField("shardRouting");
+            shardRoutingField.setAccessible(true);
+            ShardRouting mockShardRouting = (ShardRouting) shardRoutingField.get(mockIndexShard);
+            when(mockShardRouting.primary()).thenReturn(true);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to access shardRouting field", e);
+        }
+
+        assertFalse(uploaderService.isLocalOrSnapshotRecoveryOrSeeding());
+    }
+
+    public void testIsLocalOrSnapshotRecoveryOrSeedingWithNonPrimary() {
+        when(mockIndexShard.state()).thenReturn(IndexShardState.RECOVERING);
+        try {
+            java.lang.reflect.Field shardRoutingField = IndexShard.class.getDeclaredField("shardRouting");
+            shardRoutingField.setAccessible(true);
+            ShardRouting mockShardRouting = (ShardRouting) shardRoutingField.get(mockIndexShard);
+            when(mockShardRouting.primary()).thenReturn(false);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to access shardRouting field", e);
+        }
+
+        assertFalse(uploaderService.isLocalOrSnapshotRecoveryOrSeeding());
+    }
+
+    public void testIsLocalOrSnapshotRecoveryOrSeedingWithNullRecoveryState() {
+        when(mockIndexShard.state()).thenReturn(IndexShardState.RECOVERING);
+        try {
+            java.lang.reflect.Field shardRoutingField = IndexShard.class.getDeclaredField("shardRouting");
+            shardRoutingField.setAccessible(true);
+            ShardRouting mockShardRouting = (ShardRouting) shardRoutingField.get(mockIndexShard);
+            when(mockShardRouting.primary()).thenReturn(true);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to access shardRouting field", e);
+        }
+        when(mockIndexShard.recoveryState()).thenReturn(null);
+
+        assertFalse(uploaderService.isLocalOrSnapshotRecoveryOrSeeding());
+    }
+
+    public static class TestFilterDirectory extends FilterDirectory {
+
+        /**
+         * Sole constructor, typically called from sub-classes.
+         *
+         * @param in input directory
+         */
+        public TestFilterDirectory(Directory in) {
+            super(in);
+        }
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The PR aims to highlight the changes on how to segregate the syncing segments to Remote Store which is highly coupled to the Refresh workflow. 

The segregation of the code will help to sync the segments at any action. Some are listed below

1. Syncing the segments as soon as it is merged to the remote store.
2. Syncing the segments after the refresh is triggered.

The overall purpose of the above mentioned feature to make the segments available as soon as possible reducing the search latency since the ingestion of the document.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
