### PR TITLE
Provide aux transport to SecureAuxTransportSettingsProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Update Subject interface to use CheckedRunnable ([#18570](https://github.com/opensearch-project/OpenSearch/issues/18570))
+- Update SecureAuxTransportSettingsProvider to distinguish between aux transport types ([#18616](https://github.com/opensearch-project/OpenSearch/pull/18616))
 
 ### Dependencies
 - Bump `stefanzweifel/git-auto-commit-action` from 5 to 6 ([#18524](https://github.com/opensearch-project/OpenSearch/pull/18524))

--- a/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransport.java
+++ b/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransport.java
@@ -106,7 +106,7 @@ public class SecureNetty4GrpcServerTransport extends Netty4GrpcServerTransport {
      * @param provider for SSLContext and SecureAuxTransportParameters (ClientAuth and enabled ciphers).
      */
     private JdkSslContext getSslContext(Settings settings, SecureAuxTransportSettingsProvider provider) throws SSLException {
-        Optional<SSLContext> sslContext = provider.buildSecureAuxServerTransportContext(settings, this);
+        Optional<SSLContext> sslContext = provider.buildSecureAuxServerTransportContext(settings, this.settingKey());
         if (sslContext.isEmpty()) {
             try {
                 sslContext = Optional.of(SSLContext.getDefault());
@@ -114,7 +114,7 @@ public class SecureNetty4GrpcServerTransport extends Netty4GrpcServerTransport {
                 throw new SSLException("Failed to build default SSLContext for " + SecureNetty4GrpcServerTransport.class.getName(), e);
             }
         }
-        SecureAuxTransportSettingsProvider.SecureAuxTransportParameters params = provider.parameters(this)
+        SecureAuxTransportSettingsProvider.SecureAuxTransportParameters params = provider.parameters(settings, this.settingKey())
             .orElseGet(DefaultParameters::new);
         ClientAuth clientAuth = ClientAuth.valueOf(params.clientAuth().orElseThrow().toUpperCase(Locale.ROOT));
         return new JdkSslContext(

--- a/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransport.java
+++ b/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransport.java
@@ -114,7 +114,7 @@ public class SecureNetty4GrpcServerTransport extends Netty4GrpcServerTransport {
                 throw new SSLException("Failed to build default SSLContext for " + SecureNetty4GrpcServerTransport.class.getName(), e);
             }
         }
-        SecureAuxTransportSettingsProvider.SecureAuxTransportParameters params = provider.parameters().orElseGet(DefaultParameters::new);
+        SecureAuxTransportSettingsProvider.SecureAuxTransportParameters params = provider.parameters(this).orElseGet(DefaultParameters::new);
         ClientAuth clientAuth = ClientAuth.valueOf(params.clientAuth().orElseThrow().toUpperCase(Locale.ROOT));
         return new JdkSslContext(
             sslContext.get(),

--- a/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransport.java
+++ b/plugins/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransport.java
@@ -114,7 +114,8 @@ public class SecureNetty4GrpcServerTransport extends Netty4GrpcServerTransport {
                 throw new SSLException("Failed to build default SSLContext for " + SecureNetty4GrpcServerTransport.class.getName(), e);
             }
         }
-        SecureAuxTransportSettingsProvider.SecureAuxTransportParameters params = provider.parameters(this).orElseGet(DefaultParameters::new);
+        SecureAuxTransportSettingsProvider.SecureAuxTransportParameters params = provider.parameters(this)
+            .orElseGet(DefaultParameters::new);
         ClientAuth clientAuth = ClientAuth.valueOf(params.clientAuth().orElseThrow().toUpperCase(Locale.ROOT));
         return new JdkSslContext(
             sslContext.get(),

--- a/plugins/transport-grpc/src/test/java/org/opensearch/plugin/transport/grpc/ssl/SecureSettingsHelpers.java
+++ b/plugins/transport-grpc/src/test/java/org/opensearch/plugin/transport/grpc/ssl/SecureSettingsHelpers.java
@@ -126,7 +126,7 @@ public class SecureSettingsHelpers {
             }
 
             @Override
-            public Optional<SecureAuxTransportParameters> parameters() {
+            public Optional<SecureAuxTransportParameters> parameters(AuxTransport transport) {
                 return Optional.of(new SecureAuxTransportParameters() {
                     @Override
                     public Optional<String> clientAuth() {

--- a/plugins/transport-grpc/src/test/java/org/opensearch/plugin/transport/grpc/ssl/SecureSettingsHelpers.java
+++ b/plugins/transport-grpc/src/test/java/org/opensearch/plugin/transport/grpc/ssl/SecureSettingsHelpers.java
@@ -109,7 +109,7 @@ public class SecureSettingsHelpers {
     ) {
         return new SecureAuxTransportSettingsProvider() {
             @Override
-            public Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, String auxEnableSettingKey)
+            public Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, String auxTransportType)
                 throws SSLException {
                 // Choose a random protocol from among supported test defaults
                 String protocol = randomFrom(DEFAULT_SSL_PROTOCOLS);
@@ -125,7 +125,7 @@ public class SecureSettingsHelpers {
             }
 
             @Override
-            public Optional<SecureAuxTransportParameters> parameters(Settings settings, String auxEnableSettingKey) {
+            public Optional<SecureAuxTransportParameters> parameters(Settings settings, String auxTransportType) {
                 return Optional.of(new SecureAuxTransportParameters() {
                     @Override
                     public Optional<String> clientAuth() {

--- a/plugins/transport-grpc/src/test/java/org/opensearch/plugin/transport/grpc/ssl/SecureSettingsHelpers.java
+++ b/plugins/transport-grpc/src/test/java/org/opensearch/plugin/transport/grpc/ssl/SecureSettingsHelpers.java
@@ -10,7 +10,6 @@ package org.opensearch.plugin.transport.grpc.ssl;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.plugins.SecureAuxTransportSettingsProvider;
-import org.opensearch.transport.AuxTransport;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -110,7 +109,7 @@ public class SecureSettingsHelpers {
     ) {
         return new SecureAuxTransportSettingsProvider() {
             @Override
-            public Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, AuxTransport transport)
+            public Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, String auxEnableSettingKey)
                 throws SSLException {
                 // Choose a random protocol from among supported test defaults
                 String protocol = randomFrom(DEFAULT_SSL_PROTOCOLS);
@@ -126,7 +125,7 @@ public class SecureSettingsHelpers {
             }
 
             @Override
-            public Optional<SecureAuxTransportParameters> parameters(AuxTransport transport) {
+            public Optional<SecureAuxTransportParameters> parameters(Settings settings, String auxEnableSettingKey) {
                 return Optional.of(new SecureAuxTransportParameters() {
                     @Override
                     public Optional<String> clientAuth() {

--- a/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
@@ -26,6 +26,8 @@ import java.util.Optional;
 public interface SecureAuxTransportSettingsProvider {
     /**
      * Fetch an SSLContext as managed by pluggable security provider.
+     * @param settings for providing additional configuration options when building the ssl context.
+     * @param transport the auxiliary transport for which an SSLContext is built.
      * @return an instance of SSLContext.
      */
     default Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, AuxTransport transport) throws SSLException {
@@ -34,6 +36,7 @@ public interface SecureAuxTransportSettingsProvider {
 
     /**
      * Additional params required for configuring ALPN.
+     * @param transport the auxiliary transport to be provided SecureAuxTransportParameters.
      * @return an instance of {@link SecureAuxTransportSettingsProvider.SecureAuxTransportParameters}
      */
     default Optional<SecureAuxTransportSettingsProvider.SecureAuxTransportParameters> parameters(AuxTransport transport) {

--- a/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
@@ -26,10 +26,10 @@ public interface SecureAuxTransportSettingsProvider {
     /**
      * Fetch an SSLContext as managed by pluggable security provider.
      * @param settings for providing additional configuration options when building the ssl context.
-     * @param auxTransportSettingKey key for enabling this transport with AUX_TRANSPORT_TYPES_SETTING.
+     * @param auxTransportType key for enabling this transport with AUX_TRANSPORT_TYPES_SETTING.
      * @return an instance of SSLContext.
      */
-    default Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, String auxTransportSettingKey)
+    default Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, String auxTransportType)
         throws SSLException {
         return Optional.empty();
     }
@@ -37,12 +37,12 @@ public interface SecureAuxTransportSettingsProvider {
     /**
      * Additional params required for configuring ALPN.
      * @param settings for providing additional configuration options when building secure params.
-     * @param auxTransportSettingKey key for enabling this transport with AUX_TRANSPORT_TYPES_SETTING.
+     * @param auxTransportType key for enabling this transport with AUX_TRANSPORT_TYPES_SETTING.
      * @return an instance of {@link SecureAuxTransportSettingsProvider.SecureAuxTransportParameters}
      */
     default Optional<SecureAuxTransportSettingsProvider.SecureAuxTransportParameters> parameters(
         Settings settings,
-        String auxTransportSettingKey
+        String auxTransportType
     ) throws SSLException {
         return Optional.empty();
     }

--- a/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
@@ -10,7 +10,6 @@ package org.opensearch.plugins;
 
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.transport.AuxTransport;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
@@ -27,19 +26,24 @@ public interface SecureAuxTransportSettingsProvider {
     /**
      * Fetch an SSLContext as managed by pluggable security provider.
      * @param settings for providing additional configuration options when building the ssl context.
-     * @param transport the auxiliary transport for which an SSLContext is built.
+     * @param auxTransportSettingKey key for enabling this transport with AUX_TRANSPORT_TYPES_SETTING.
      * @return an instance of SSLContext.
      */
-    default Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, AuxTransport transport) throws SSLException {
+    default Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, String auxTransportSettingKey)
+        throws SSLException {
         return Optional.empty();
     }
 
     /**
      * Additional params required for configuring ALPN.
-     * @param transport the auxiliary transport to be provided SecureAuxTransportParameters.
+     * @param settings for providing additional configuration options when building secure params.
+     * @param auxTransportSettingKey key for enabling this transport with AUX_TRANSPORT_TYPES_SETTING.
      * @return an instance of {@link SecureAuxTransportSettingsProvider.SecureAuxTransportParameters}
      */
-    default Optional<SecureAuxTransportSettingsProvider.SecureAuxTransportParameters> parameters(AuxTransport transport) {
+    default Optional<SecureAuxTransportSettingsProvider.SecureAuxTransportParameters> parameters(
+        Settings settings,
+        String auxTransportSettingKey
+    ) throws SSLException {
         return Optional.empty();
     }
 

--- a/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
@@ -36,7 +36,7 @@ public interface SecureAuxTransportSettingsProvider {
      * Additional params required for configuring ALPN.
      * @return an instance of {@link SecureAuxTransportSettingsProvider.SecureAuxTransportParameters}
      */
-    default Optional<SecureAuxTransportSettingsProvider.SecureAuxTransportParameters> parameters() {
+    default Optional<SecureAuxTransportSettingsProvider.SecureAuxTransportParameters> parameters(AuxTransport transport) {
         return Optional.empty();
     }
 

--- a/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
+++ b/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java
@@ -29,8 +29,7 @@ public interface SecureAuxTransportSettingsProvider {
      * @param auxTransportType key for enabling this transport with AUX_TRANSPORT_TYPES_SETTING.
      * @return an instance of SSLContext.
      */
-    default Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, String auxTransportType)
-        throws SSLException {
+    default Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, String auxTransportType) throws SSLException {
         return Optional.empty();
     }
 
@@ -40,10 +39,8 @@ public interface SecureAuxTransportSettingsProvider {
      * @param auxTransportType key for enabling this transport with AUX_TRANSPORT_TYPES_SETTING.
      * @return an instance of {@link SecureAuxTransportSettingsProvider.SecureAuxTransportParameters}
      */
-    default Optional<SecureAuxTransportSettingsProvider.SecureAuxTransportParameters> parameters(
-        Settings settings,
-        String auxTransportType
-    ) throws SSLException {
+    default Optional<SecureAuxTransportSettingsProvider.SecureAuxTransportParameters> parameters(Settings settings, String auxTransportType)
+        throws SSLException {
         return Optional.empty();
     }
 


### PR DESCRIPTION
### Description
Similar to `SecureAuxTransportSettingsProvider::buildSecureAuxServerTransportContext`, `SecureAuxTransportSettingsProvider::parameters` must be provided the `AuxTransport` instance so it knows which transport to fetch security settings for.

### Related Issues
Prerequisite for introducing security plugin settings for aux transports:
https://github.com/opensearch-project/security/pull/5375

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
