### PR TITLE
[BUG FIX] Fix the visit of sub queries for HasParentQuery and HasChildQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Add task cancellation checks in aggregators ([#18426](https://github.com/opensearch-project/OpenSearch/pull/18426))
 - Fix concurrent timings in profiler ([#18540](https://github.com/opensearch-project/OpenSearch/pull/18540))
+- Fix the visit of sub queries for HasParentQuery and HasChildQuery ([#18621](https://github.com/opensearch-project/OpenSearch/pull/18621))
 
 ### Security
 

--- a/modules/parent-join/src/main/java/org/opensearch/join/query/HasChildQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/opensearch/join/query/HasChildQueryBuilder.java
@@ -34,6 +34,7 @@ package org.opensearch.join.query;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.OrdinalMap;
+import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
@@ -58,6 +59,7 @@ import org.opensearch.index.query.InnerHitBuilder;
 import org.opensearch.index.query.InnerHitContextBuilder;
 import org.opensearch.index.query.NestedQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryShardException;
@@ -549,6 +551,14 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
                 children
             );
             innerHits.put(name, innerHitContextBuilder);
+        }
+    }
+
+    @Override
+    public void visit(QueryBuilderVisitor visitor) {
+        visitor.accept(this);
+        if (query != null) {
+            visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(query);
         }
     }
 }

--- a/modules/parent-join/src/main/java/org/opensearch/join/query/HasChildQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/opensearch/join/query/HasChildQueryBuilder.java
@@ -558,7 +558,7 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
         if (query != null) {
-            visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(query);
+            query.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
         }
     }
 }

--- a/modules/parent-join/src/main/java/org/opensearch/join/query/HasChildQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/opensearch/join/query/HasChildQueryBuilder.java
@@ -557,8 +557,6 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
     @Override
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
-        if (query != null) {
-            query.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
-        }
+        query.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
     }
 }

--- a/modules/parent-join/src/main/java/org/opensearch/join/query/HasParentQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/opensearch/join/query/HasParentQueryBuilder.java
@@ -336,9 +336,6 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
     @Override
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
-        if (query != null) {
-            query.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
-        }
+        query.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
     }
-
 }

--- a/modules/parent-join/src/main/java/org/opensearch/join/query/HasParentQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/opensearch/join/query/HasParentQueryBuilder.java
@@ -31,6 +31,7 @@
 
 package org.opensearch.join.query;
 
+import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.ScoreMode;
@@ -48,6 +49,7 @@ import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.InnerHitBuilder;
 import org.opensearch.index.query.InnerHitContextBuilder;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryShardException;
@@ -328,6 +330,14 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
                 children
             );
             innerHits.put(name, innerHitContextBuilder);
+        }
+    }
+
+    @Override
+    public void visit(QueryBuilderVisitor visitor) {
+        visitor.accept(this);
+        if (query != null) {
+            visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(query);
         }
     }
 

--- a/modules/parent-join/src/main/java/org/opensearch/join/query/HasParentQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/opensearch/join/query/HasParentQueryBuilder.java
@@ -337,7 +337,7 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
     public void visit(QueryBuilderVisitor visitor) {
         visitor.accept(this);
         if (query != null) {
-            visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(query);
+            query.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
         }
     }
 

--- a/modules/parent-join/src/test/java/org/opensearch/join/query/HasChildQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/opensearch/join/query/HasChildQueryBuilderTests.java
@@ -69,10 +69,12 @@ import org.opensearch.test.TestGeoShapeFieldMapperPlugin;
 import org.opensearch.test.VersionUtils;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -391,5 +393,14 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
         HasChildQueryBuilder queryBuilder = hasChildQuery(CHILD_DOC, new TermQueryBuilder("custom_string", "value"), ScoreMode.None);
         OpenSearchException e = expectThrows(OpenSearchException.class, () -> queryBuilder.toQuery(queryShardContext));
         assertEquals("[joining] queries cannot be executed when 'search.allow_expensive_queries' is set to false.", e.getMessage());
+    }
+
+    public void testVisit() {
+        HasChildQueryBuilder builder = doCreateTestQueryBuilder();
+
+        List<QueryBuilder> visitedQueries = new ArrayList<>();
+        builder.visit(createTestVisitor(visitedQueries));
+
+        assertEquals(2, visitedQueries.size());
     }
 }

--- a/modules/parent-join/src/test/java/org/opensearch/join/query/HasParentQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/opensearch/join/query/HasParentQueryBuilderTests.java
@@ -294,7 +294,6 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
     }
 
     public void testVisit() {
-
         HasParentQueryBuilder builder = doCreateTestQueryBuilder();
 
         List<QueryBuilder> visitedQueries = new ArrayList<>();

--- a/modules/parent-join/src/test/java/org/opensearch/join/query/HasParentQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/opensearch/join/query/HasParentQueryBuilderTests.java
@@ -58,10 +58,12 @@ import org.opensearch.test.TestGeoShapeFieldMapperPlugin;
 import org.opensearch.test.VersionUtils;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -289,5 +291,15 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
         );
         OpenSearchException e = expectThrows(OpenSearchException.class, () -> queryBuilder.toQuery(queryShardContext));
         assertEquals("[joining] queries cannot be executed when 'search.allow_expensive_queries' is set to false.", e.getMessage());
+    }
+
+    public void testVisit() {
+
+        HasParentQueryBuilder builder = doCreateTestQueryBuilder();
+
+        List<QueryBuilder> visitedQueries = new ArrayList<>();
+        builder.visit(createTestVisitor(visitedQueries));
+
+        assertEquals(2, visitedQueries.size());
     }
 }


### PR DESCRIPTION
### Description
In #13837 AND #14739 i see it fixed many scenarios queries, but we still need Join Query Builder to visit query builders. especially for neural search can visit embedding or other field

### Related Issues

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
