### PR TITLE
[Backport 2.19] Disabling _close API invocation during remote migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 2.x]
 ### Added
+- Reject close index requests, while remote store migration is in progress.([#18327](https://github.com/opensearch-project/OpenSearch/pull/18327))
 
 ### Dependencies
 - Bump `netty` from 4.1.118.Final to 4.1.121.Final ([#18192](https://github.com/opensearch-project/OpenSearch/pull/18192))

--- a/server/src/internalClusterTest/java/org/opensearch/remotemigration/CloseIndexMigrationTestCase.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotemigration/CloseIndexMigrationTestCase.java
@@ -11,8 +11,10 @@ package org.opensearch.remotemigration;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.action.admin.indices.close.CloseIndexRequest;
 import org.opensearch.action.support.ActiveShardCount;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MetadataIndexStateService;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
@@ -29,16 +31,11 @@ public class CloseIndexMigrationTestCase extends MigrationBaseTestCase {
     private final static String REMOTE_STORE_DIRECTION = "remote_store";
     private final static String MIXED_MODE = "mixed";
 
-    @Override
-    protected Settings featureFlagSettings() {
-        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.REMOTE_STORE_MIGRATION_EXPERIMENTAL, "true").build();
-    }
-
     /*
      * This test will verify the close request failure, when cluster mode is mixed
      * and migration to remote store is in progress.
      * */
-    public void testFailCloseIndexWhileDocRepToRemoteStoreMigration() throws IllegalStateException {
+    public void testFailCloseIndexWhileDocRepToRemoteStoreMigration() {
         setAddRemote(false);
         // create a docrep cluster
         internalCluster().startClusterManagerOnlyNode();
@@ -86,5 +83,56 @@ public class CloseIndexMigrationTestCase extends MigrationBaseTestCase {
 
         );
         assertEquals("Cannot close index while remote migration is ongoing", ex.getCause().getMessage());
+    }
+
+    /*
+     * Verify that index closes if compatibility mode is MIXED, and direction is set to NONE
+     * */
+    public void testCloseIndexRequestWithMixedCompatibilityModeAndNoDirection() {
+        setAddRemote(false);
+        // create a docrep cluster
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().validateClusterFormed();
+
+        // add a non-remote node
+        String nonRemoteNodeName = internalCluster().startDataOnlyNode();
+        internalCluster().validateClusterFormed();
+
+        // create index in cluster
+        Settings.Builder builder = Settings.builder().put(SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT);
+        internalCluster().client()
+            .admin()
+            .indices()
+            .prepareCreate(TEST_INDEX)
+            .setSettings(
+                builder.put("index.number_of_shards", 2)
+                    .put("index.number_of_replicas", 0)
+                    .put("index.routing.allocation.include._name", nonRemoteNodeName)
+            )
+            .setWaitForActiveShards(ActiveShardCount.ALL)
+            .execute()
+            .actionGet();
+
+        // set mixed mode
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder().put(REMOTE_STORE_COMPATIBILITY_MODE_SETTING.getKey(), MIXED_MODE));
+        assertAcked(internalCluster().client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        ensureGreen(TEST_INDEX);
+
+        // perform close action
+        assertAcked(internalCluster().client().admin().indices().close(new CloseIndexRequest(TEST_INDEX)).actionGet());
+
+        // verify that index has been closed
+        final ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+
+        final IndexMetadata indexMetadata = clusterState.metadata().indices().get(TEST_INDEX);
+        assertEquals(IndexMetadata.State.CLOSE, indexMetadata.getState());
+        final Settings indexSettings = indexMetadata.getSettings();
+        assertTrue(indexSettings.hasValue(MetadataIndexStateService.VERIFIED_BEFORE_CLOSE_SETTING.getKey()));
+        assertEquals(true, indexSettings.getAsBoolean(MetadataIndexStateService.VERIFIED_BEFORE_CLOSE_SETTING.getKey(), false));
+        assertNotNull(clusterState.routingTable().index(TEST_INDEX));
+        assertTrue(clusterState.blocks().hasIndexBlock(TEST_INDEX, MetadataIndexStateService.INDEX_CLOSED_BLOCK));
+
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/remotemigration/CloseIndexMigrationTestCase.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotemigration/CloseIndexMigrationTestCase.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.remotemigration;
+
+import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.opensearch.action.admin.indices.close.CloseIndexRequest;
+import org.opensearch.action.support.ActiveShardCount;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
+import static org.opensearch.node.remotestore.RemoteStoreNodeService.MIGRATION_DIRECTION_SETTING;
+import static org.opensearch.node.remotestore.RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class CloseIndexMigrationTestCase extends MigrationBaseTestCase {
+    private static final String TEST_INDEX = "ind";
+    private final static String REMOTE_STORE_DIRECTION = "remote_store";
+    private final static String MIXED_MODE = "mixed";
+
+    @Override
+    protected Settings featureFlagSettings() {
+        return Settings.builder().put(super.featureFlagSettings()).put(FeatureFlags.REMOTE_STORE_MIGRATION_EXPERIMENTAL, "true").build();
+    }
+
+    /*
+     * This test will verify the close request failure, when cluster mode is mixed
+     * and migration to remote store is in progress.
+     * */
+    public void testFailCloseIndexWhileDocRepToRemoteStoreMigration() throws IllegalStateException {
+        setAddRemote(false);
+        // create a docrep cluster
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().validateClusterFormed();
+
+        // add a non-remote node
+        String nonRemoteNodeName = internalCluster().startDataOnlyNode();
+        internalCluster().validateClusterFormed();
+
+        // create index in cluster
+        Settings.Builder builder = Settings.builder().put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT);
+        internalCluster().client()
+            .admin()
+            .indices()
+            .prepareCreate(TEST_INDEX)
+            .setSettings(
+                builder.put("index.number_of_shards", 2)
+                    .put("index.number_of_replicas", 0)
+                    .put("index.routing.allocation.include._name", nonRemoteNodeName)
+            )
+            .setWaitForActiveShards(ActiveShardCount.ALL)
+            .execute()
+            .actionGet();
+
+        // set mixed mode
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder().put(REMOTE_STORE_COMPATIBILITY_MODE_SETTING.getKey(), MIXED_MODE));
+        assertAcked(internalCluster().client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        // add a remote node
+        addRemote = true;
+        internalCluster().startDataOnlyNode();
+        internalCluster().validateClusterFormed();
+
+        // set remote store migration direction
+        updateSettingsRequest.persistentSettings(Settings.builder().put(MIGRATION_DIRECTION_SETTING.getKey(), REMOTE_STORE_DIRECTION));
+        assertAcked(internalCluster().client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        ensureGreen(TEST_INDEX);
+
+        // Try closing the index, expecting failure.
+        ExecutionException ex = expectThrows(
+            ExecutionException.class,
+            () -> internalCluster().client().admin().indices().close(new CloseIndexRequest(TEST_INDEX)).get()
+
+        );
+        assertEquals("Cannot close index while remote migration is ongoing", ex.getCause().getMessage());
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -52,6 +52,9 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.index.Index;
+import org.opensearch.node.remotestore.RemoteStoreNodeService;
+import org.opensearch.node.remotestore.RemoteStoreNodeService.CompatibilityMode;
+import org.opensearch.node.remotestore.RemoteStoreNodeService.Direction;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -130,6 +133,7 @@ public class TransportCloseIndexAction extends TransportClusterManagerNodeAction
                     + ": true] to enable it. NOTE: closed indices still consume a significant amount of diskspace"
             );
         }
+        validateRemoteMigration();
         super.doExecute(task, request, listener);
     }
 
@@ -171,5 +175,21 @@ public class TransportCloseIndexAction extends TransportClusterManagerNodeAction
             logger.debug(() -> new ParameterizedMessage("failed to close indices [{}]", (Object) concreteIndices), t);
             delegatedListener.onFailure(t);
         }));
+    }
+
+    /**
+     * Reject close index request if cluster mode is [MIXED] and migration direction is [RemoteStore]
+     * @throws IllegalStateException if cluster mode is [MIXED] and migration direction is [RemoteStore]
+     */
+    private void validateRemoteMigration() {
+        ClusterSettings clusterSettings = clusterService.getClusterSettings();
+        CompatibilityMode compatibilityMode = clusterSettings.get(RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING);
+        Direction migrationDirection = clusterSettings.get(RemoteStoreNodeService.MIGRATION_DIRECTION_SETTING);
+        if (compatibilityMode == CompatibilityMode.MIXED) {
+            boolean isRemoteMigration = migrationDirection == Direction.REMOTE_STORE;
+            if (isRemoteMigration) {
+                throw new IllegalStateException("Cannot close index while remote migration is ongoing");
+            }
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -185,11 +185,8 @@ public class TransportCloseIndexAction extends TransportClusterManagerNodeAction
         ClusterSettings clusterSettings = clusterService.getClusterSettings();
         CompatibilityMode compatibilityMode = clusterSettings.get(RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING);
         Direction migrationDirection = clusterSettings.get(RemoteStoreNodeService.MIGRATION_DIRECTION_SETTING);
-        if (compatibilityMode == CompatibilityMode.MIXED) {
-            boolean isRemoteMigration = migrationDirection == Direction.REMOTE_STORE;
-            if (isRemoteMigration) {
-                throw new IllegalStateException("Cannot close index while remote migration is ongoing");
-            }
+        if (compatibilityMode == CompatibilityMode.MIXED && migrationDirection == Direction.REMOTE_STORE) {
+            throw new IllegalStateException("Cannot close index while remote migration is ongoing");
         }
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/indices/close/TransportCloseIndexActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/close/TransportCloseIndexActionTests.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.close;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.DestructiveOperations;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.MetadataIndexStateService;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.node.remotestore.RemoteStoreNodeService.MIGRATION_DIRECTION_SETTING;
+import static org.opensearch.node.remotestore.RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TransportCloseIndexActionTests extends OpenSearchTestCase {
+    private static ThreadPool threadPool;
+    private ClusterService clusterService;
+    private final static String MIXED_MODE = "mixed";
+    private final static String REMOTE_STORE_DIRECTION = "remote_store";
+    private ClusterSettings clusterSettings;
+    private final static String TEST_IND = "ind";
+
+    @BeforeClass
+    public static void beforeClass() {
+        threadPool = new TestThreadPool(getTestClass().getName());
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        clusterService = mock(ClusterService.class);
+        Settings settings = Settings.builder()
+            .put(REMOTE_STORE_COMPATIBILITY_MODE_SETTING.getKey(), MIXED_MODE)
+            .put(MIGRATION_DIRECTION_SETTING.getKey(), REMOTE_STORE_DIRECTION)
+            .build();
+        ClusterSettings clusSet = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        when(clusterService.getClusterSettings()).thenReturn(clusSet);
+        clusterSettings = clusterService.getClusterSettings();
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        clusterService.close();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+        threadPool = null;
+    }
+
+    private TransportCloseIndexAction createAction() {
+        return new TransportCloseIndexAction(
+            Settings.EMPTY,
+            mock(TransportService.class),
+            clusterService,
+            threadPool,
+            mock(MetadataIndexStateService.class),
+            clusterSettings,
+            mock(ActionFilters.class),
+            mock(IndexNameExpressionResolver.class),
+            new DestructiveOperations(Settings.EMPTY, clusterSettings)
+        );
+    }
+
+    // Test if validateRemoteMigration throws illegal exception when compatibility mode is MIXED and migration Direction is REMOTE_STORE
+    public void testRemoteValidation() {
+        TransportCloseIndexAction action = createAction();
+
+        Exception e = expectThrows(IllegalStateException.class, () -> action.doExecute(null, new CloseIndexRequest(TEST_IND), null));
+
+        assertEquals("Cannot close index while remote migration is ongoing", e.getMessage());
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
We want to disallow API which are involved in closing index, when Document-Replication type to Segment-Replication type migration is happening.

- Disallow if cluster settings has REMOTE_STORE_COMPATIBILITY_MODE_SETTING as MIXED and MIGRATION_DIRECTION_SETTING as REMOTE_STORE.

### Related Issues
Resolves #18328 
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
