### PR TITLE
Add workflow to automatically trigger manifest generation process

### DIFF
--- a/.github/workflows/trigger-manifest-generation.yml
+++ b/.github/workflows/trigger-manifest-generation.yml
@@ -1,0 +1,17 @@
+name: Trigger manifest generation workflow
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - buildSrc/version.properties
+
+jobs:
+  trigger-manifest-workflow:
+    if: github.repository == 'opensearch-project/OpenSearch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger manifest-update workflow
+        run: |
+            echo "Triggering manifest-update workflow at https://build.ci.opensearch.org/job/manifest-update/"
+            curl -f -X POST https://build.ci.opensearch.org/job/manifest-update/build --user "${{ secrets.JENKINS_GITHUB_USER}}:${{ secrets.JENKINS_GITHUB_USER_TOKEN}}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds a workflow to immediately trigger (instead of waiting for the cronjob to schedule the workflow run) manifest generation workflow that needs OpenSearch version bump PR to be merged. Since `buildSrc/version.properties` only contains OpenSearch version, it seemed like a right trigger for this job. 
See the related issue for more details. 

### Related Issues 
https://github.com/opensearch-project/opensearch-build/issues/4225

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
