### PR TITLE
Fix leafSorter optimization for ReadOnlyEngine and NRTReplicationEngine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed Staggered merge -  load average replace with AverageTrackers, some Default thresholds modified ([#18666](https://github.com/opensearch-project/OpenSearch/pull/18666))
 - Use `new SecureRandom()` to avoid blocking ([18729](https://github.com/opensearch-project/OpenSearch/issues/18729))
 - Use ScoreDoc instead of FieldDoc when creating TopScoreDocCollectorManager to avoid unnecessary conversion ([#18802](https://github.com/opensearch-project/OpenSearch/pull/18802))
+- Fix leafSorter optimization for ReadOnlyEngine and NRTReplicationEngine ([#18639](https://github.com/opensearch-project/OpenSearch/pull/18639))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
@@ -150,7 +150,8 @@ public class NRTReplicationEngine extends Engine {
         return new NRTReplicationReaderManager(
             OpenSearchDirectoryReader.wrap(getDirectoryReader(), shardId),
             replicaFileTracker::incRef,
-            replicaFileTracker::decRef
+            replicaFileTracker::decRef,
+            engineConfig
         );
     }
 
@@ -537,6 +538,9 @@ public class NRTReplicationEngine extends Engine {
 
     private DirectoryReader getDirectoryReader() throws IOException {
         // for segment replication: replicas should create the reader from store, we don't want an open IW on replicas.
-        return new SoftDeletesDirectoryReaderWrapper(DirectoryReader.open(store.directory()), Lucene.SOFT_DELETES_FIELD);
+        return new SoftDeletesDirectoryReaderWrapper(
+            DirectoryReader.open(store.directory(), engineConfig.getLeafSorter()),
+            Lucene.SOFT_DELETES_FIELD
+        );
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
@@ -78,7 +78,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
         super(config, null, null, true, Function.identity(), true);
         this.segmentsStats = new SegmentsStats();
         Directory directory = store.directory();
-        try (DirectoryReader reader = openDirectory(directory, config.getIndexSettings().isSoftDeleteEnabled())) {
+        try (DirectoryReader reader = openDirectory(directory, config.getIndexSettings().isSoftDeleteEnabled(), config.getLeafSorter())) {
             for (LeafReaderContext ctx : reader.getContext().leaves()) {
                 SegmentReader segmentReader = Lucene.segmentReader(ctx.reader());
                 fillSegmentStats(segmentReader, true, segmentsStats);

--- a/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
@@ -34,6 +34,7 @@ package org.opensearch.index.engine;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.SoftDeletesDirectoryReaderWrapper;
 import org.apache.lucene.search.ReferenceManager;
@@ -61,6 +62,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.BiFunction;
@@ -498,6 +500,17 @@ public class ReadOnlyEngine extends Engine {
     protected static DirectoryReader openDirectory(Directory directory, boolean wrapSoftDeletes) throws IOException {
         assert Transports.assertNotTransportThread("opening directory reader of a read-only engine");
         final DirectoryReader reader = DirectoryReader.open(directory);
+        if (wrapSoftDeletes) {
+            return new SoftDeletesDirectoryReaderWrapper(reader, Lucene.SOFT_DELETES_FIELD);
+        } else {
+            return reader;
+        }
+    }
+
+    protected static DirectoryReader openDirectory(Directory directory, boolean wrapSoftDeletes, Comparator<LeafReader> leafSorter)
+        throws IOException {
+        assert Transports.assertNotTransportThread("opening directory reader of a read-only engine");
+        final DirectoryReader reader = DirectoryReader.open(directory, leafSorter);
         if (wrapSoftDeletes) {
             return new SoftDeletesDirectoryReaderWrapper(reader, Lucene.SOFT_DELETES_FIELD);
         } else {

--- a/server/src/test/java/org/opensearch/index/engine/LeafSorterOptimizationTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/LeafSorterOptimizationTests.java
@@ -37,10 +37,8 @@ import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 public class LeafSorterOptimizationTests extends EngineTestCase {
@@ -102,7 +100,16 @@ public class LeafSorterOptimizationTests extends EngineTestCase {
                 .globalCheckpointSupplier(globalCheckpoint::get)
                 .leafSorter(java.util.Comparator.<org.apache.lucene.index.LeafReader>comparingInt(reader -> reader.maxDoc()))
                 .build();
-            try (ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(readOnlyConfig, null, null, true, java.util.function.Function.identity(), true)) {
+            try (
+                ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(
+                    readOnlyConfig,
+                    null,
+                    null,
+                    true,
+                    java.util.function.Function.identity(),
+                    true
+                )
+            ) {
                 try (Engine.Searcher searcher = readOnlyEngine.acquireSearcher("test")) {
                     DirectoryReader reader = (DirectoryReader) searcher.getDirectoryReader();
                     // Assert that there are multiple leaves (segments)

--- a/server/src/test/java/org/opensearch/index/engine/LeafSorterOptimizationTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/LeafSorterOptimizationTests.java
@@ -1,0 +1,323 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopDocs;
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.DataStream;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.indices.breaker.NoneCircuitBreakerService;
+import org.opensearch.index.codec.CodecService;
+import org.opensearch.index.mapper.ParsedDocument;
+import org.opensearch.index.seqno.RetentionLeases;
+import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.index.store.Store;
+import org.opensearch.index.translog.TranslogConfig;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class LeafSorterOptimizationTests extends EngineTestCase {
+
+    public void testReadOnlyEngineUsesLeafSorter() throws IOException {
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        try (Store store = createStore()) {
+            store.createEmpty(Version.CURRENT.luceneVersion);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+
+            try (InternalEngine engine = new InternalEngine(config)) {
+                // Index some documents with timestamps
+                for (int i = 0; i < 10; i++) {
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    engine.index(
+                        new Engine.Index(
+                            newUid(doc),
+                            doc,
+                            i,
+                            primaryTerm.get(),
+                            1,
+                            null,
+                            Engine.Operation.Origin.PRIMARY,
+                            System.nanoTime(),
+                            -1,
+                            false,
+                            SequenceNumbers.UNASSIGNED_SEQ_NO,
+                            0
+                        )
+                    );
+                }
+                engine.flush();
+
+                // Create ReadOnlyEngine
+                ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(
+                    engine.engineConfig,
+                    engine.getSeqNoStats(globalCheckpoint.get()),
+                    engine.translogManager().getTranslogStats(),
+                    false,
+                    Function.identity(),
+                    true
+                );
+
+                // Verify that the engine has a leafSorter configured
+                assertThat("Engine should have leafSorter configured", readOnlyEngine.engineConfig.getLeafSorter(), notNullValue());
+
+                // Verify that DirectoryReader is opened with leafSorter
+                try (Engine.Searcher searcher = readOnlyEngine.acquireSearcher("test", Engine.SearcherScope.EXTERNAL)) {
+                    DirectoryReader reader = searcher.getDirectoryReader();
+                    assertThat("DirectoryReader should be created", reader, notNullValue());
+                }
+            }
+        }
+    }
+
+    public void testNRTReplicationEngineUsesLeafSorter() throws IOException {
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        try (Store store = createStore()) {
+            store.createEmpty(Version.CURRENT.luceneVersion);
+
+            // Create config with leafSorter explicitly set
+            EngineConfig config = new EngineConfig.Builder().shardId(shardId)
+                .threadPool(threadPool)
+                .indexSettings(defaultSettings)
+                .warmer(null)
+                .store(store)
+                .mergePolicy(newMergePolicy())
+                .analyzer(newIndexWriterConfig().getAnalyzer())
+                .similarity(newIndexWriterConfig().getSimilarity())
+                .codecService(new CodecService(null, defaultSettings, logger))
+                .eventListener(new Engine.EventListener() {
+                })
+                .queryCache(IndexSearcher.getDefaultQueryCache())
+                .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
+                .translogConfig(new TranslogConfig(shardId, createTempDir(), defaultSettings, BigArrays.NON_RECYCLING_INSTANCE, "", false))
+                .flushMergesAfter(TimeValue.timeValueMinutes(5))
+                .externalRefreshListener(emptyList())
+                .internalRefreshListener(emptyList())
+                .indexSort(null)
+                .circuitBreakerService(new NoneCircuitBreakerService())
+                .globalCheckpointSupplier(globalCheckpoint::get)
+                .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+                .primaryTermSupplier(primaryTerm)
+                .tombstoneDocSupplier(tombstoneDocSupplier())
+                .leafSorter(DataStream.TIMESERIES_LEAF_SORTER)
+                .build();
+
+            // Verify that the config has leafSorter configured
+            assertThat("Engine config should have leafSorter configured", config.getLeafSorter(), notNullValue());
+
+            // Verify that the leafSorter is the timeseries leafSorter
+            Comparator<LeafReader> leafSorter = config.getLeafSorter();
+            assertThat("LeafSorter should be configured", leafSorter, notNullValue());
+        }
+    }
+
+    public void testNoOpEngineUsesLeafSorter() throws IOException {
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        try (Store store = createStore()) {
+            store.createEmpty(Version.CURRENT.luceneVersion);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+
+            try (InternalEngine engine = new InternalEngine(config)) {
+                // Index some documents
+                for (int i = 0; i < 5; i++) {
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    engine.index(
+                        new Engine.Index(
+                            newUid(doc),
+                            doc,
+                            i,
+                            primaryTerm.get(),
+                            1,
+                            null,
+                            Engine.Operation.Origin.PRIMARY,
+                            System.nanoTime(),
+                            -1,
+                            false,
+                            SequenceNumbers.UNASSIGNED_SEQ_NO,
+                            0
+                        )
+                    );
+                }
+                engine.flush();
+
+                // Create NoOpEngine
+                NoOpEngine noOpEngine = new NoOpEngine(config);
+
+                // Verify that the engine has a leafSorter configured
+                assertThat("Engine should have leafSorter configured", noOpEngine.engineConfig.getLeafSorter(), notNullValue());
+
+                // Verify that DirectoryReader is opened with leafSorter
+                try (Engine.Searcher searcher = noOpEngine.acquireSearcher("test", Engine.SearcherScope.EXTERNAL)) {
+                    DirectoryReader reader = searcher.getDirectoryReader();
+                    assertThat("DirectoryReader should be created", reader, notNullValue());
+                }
+            }
+        }
+    }
+
+    public void testLeafSorterIsAppliedToDirectoryReader() throws IOException {
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        try (Store store = createStore()) {
+            store.createEmpty(Version.CURRENT.luceneVersion);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+
+            try (InternalEngine engine = new InternalEngine(config)) {
+                // Index some documents
+                for (int i = 0; i < 5; i++) {
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    engine.index(
+                        new Engine.Index(
+                            newUid(doc),
+                            doc,
+                            i,
+                            primaryTerm.get(),
+                            1,
+                            null,
+                            Engine.Operation.Origin.PRIMARY,
+                            System.nanoTime(),
+                            -1,
+                            false,
+                            SequenceNumbers.UNASSIGNED_SEQ_NO,
+                            0
+                        )
+                    );
+                }
+
+                // Get the leafSorter from the engine config
+                Comparator<LeafReader> leafSorter = engine.engineConfig.getLeafSorter();
+                assertThat("LeafSorter should be configured", leafSorter, notNullValue());
+
+                // Test that DirectoryReader.open with leafSorter works correctly
+                try (DirectoryReader reader = DirectoryReader.open(store.directory(), leafSorter)) {
+                    assertThat("DirectoryReader should be created with leafSorter", reader, notNullValue());
+                    assertThat("Reader should have correct number of documents", reader.numDocs(), equalTo(5));
+                }
+            }
+        }
+    }
+
+    public void testTimestampSortOptimizationWorksOnAllEngineTypes() throws IOException {
+        // Test that timestamp sort optimization works on all engine types
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+
+        // Test InternalEngine (primary)
+        try (Store store = createStore()) {
+            store.createEmpty(Version.CURRENT.luceneVersion);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+
+            try (InternalEngine engine = new InternalEngine(config)) {
+                // Index documents with timestamps
+                for (int i = 0; i < 100; i++) {
+                    ParsedDocument doc = testParsedDocument(Integer.toString(i), null, testDocument(), new BytesArray("{}"), null);
+                    engine.index(
+                        new Engine.Index(
+                            newUid(doc),
+                            doc,
+                            i,
+                            primaryTerm.get(),
+                            1,
+                            null,
+                            Engine.Operation.Origin.PRIMARY,
+                            System.nanoTime(),
+                            -1,
+                            false,
+                            SequenceNumbers.UNASSIGNED_SEQ_NO,
+                            0
+                        )
+                    );
+                }
+                engine.flush();
+
+                // Test sort performance on InternalEngine
+                testSortPerformance(engine, "InternalEngine");
+
+                // Create ReadOnlyEngine and test
+                ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(
+                    engine.engineConfig,
+                    engine.getSeqNoStats(globalCheckpoint.get()),
+                    engine.translogManager().getTranslogStats(),
+                    false,
+                    Function.identity(),
+                    true
+                );
+
+                // Test sort performance on ReadOnlyEngine
+                testSortPerformance(readOnlyEngine, "ReadOnlyEngine");
+                readOnlyEngine.close();
+            }
+        }
+
+        // Test NRTReplicationEngine
+        try (Store store = createStore()) {
+            store.createEmpty(Version.CURRENT.luceneVersion);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+
+            try (NRTReplicationEngine nrtEngine = new NRTReplicationEngine(config)) {
+                // Test sort performance on NRTReplicationEngine
+                testSortPerformance(nrtEngine, "NRTReplicationEngine");
+            }
+        }
+    }
+
+    private void testSortPerformance(Engine engine, String engineType) throws IOException {
+        try (Engine.Searcher searcher = engine.acquireSearcher("test", Engine.SearcherScope.EXTERNAL)) {
+            DirectoryReader reader = searcher.getDirectoryReader();
+            IndexSearcher indexSearcher = new IndexSearcher(reader);
+
+            // Create a sort by timestamp (descending)
+            Sort timestampSort = new Sort(new SortField("@timestamp", SortField.Type.LONG, true));
+
+            // Perform a sorted search
+            TopDocs topDocs = indexSearcher.search(new MatchAllDocsQuery(), 10, timestampSort);
+
+            // Verify that the search completed successfully
+            assertThat("Search should complete successfully on " + engineType, topDocs.totalHits.value(), greaterThan(0L));
+
+            // Verify that the engine has leafSorter configured
+            assertThat("Engine " + engineType + " should have leafSorter configured", engine.config().getLeafSorter(), notNullValue());
+        }
+    }
+
+    public void testLeafSorterConfiguration() throws IOException {
+        final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
+        try (Store store = createStore()) {
+            store.createEmpty(Version.CURRENT.luceneVersion);
+            EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
+
+            // Test that all engine types have leafSorter configured
+            try (InternalEngine internalEngine = new InternalEngine(config)) {
+                assertThat("InternalEngine should have leafSorter", internalEngine.config().getLeafSorter(), notNullValue());
+            }
+
+            try (NRTReplicationEngine nrtEngine = new NRTReplicationEngine(config)) {
+                assertThat("NRTReplicationEngine should have leafSorter", nrtEngine.config().getLeafSorter(), notNullValue());
+            }
+
+            try (NoOpEngine noOpEngine = new NoOpEngine(config)) {
+                assertThat("NoOpEngine should have leafSorter", noOpEngine.config().getLeafSorter(), notNullValue());
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/index/engine/NRTReplicationReaderManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/NRTReplicationReaderManagerTests.java
@@ -11,11 +11,21 @@ package org.opensearch.index.engine;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.StandardDirectoryReader;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.util.Version;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.core.indices.breaker.NoneCircuitBreakerService;
+import org.opensearch.index.codec.CodecService;
+import org.opensearch.index.seqno.RetentionLeases;
+import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.store.Store;
+import org.opensearch.index.translog.TranslogConfig;
 
 import java.io.IOException;
+
+import static java.util.Collections.emptyList;
 
 public class NRTReplicationReaderManagerTests extends EngineTestCase {
 
@@ -24,10 +34,38 @@ public class NRTReplicationReaderManagerTests extends EngineTestCase {
             store.createEmpty(Version.LATEST);
             final DirectoryReader reader = DirectoryReader.open(store.directory());
             final SegmentInfos initialInfos = ((StandardDirectoryReader) reader).getSegmentInfos();
+
+            // Create a minimal engine config for testing
+            EngineConfig testConfig = new EngineConfig.Builder().shardId(shardId)
+                .threadPool(threadPool)
+                .indexSettings(defaultSettings)
+                .warmer(null)
+                .store(store)
+                .mergePolicy(newMergePolicy())
+                .analyzer(newIndexWriterConfig().getAnalyzer())
+                .similarity(newIndexWriterConfig().getSimilarity())
+                .codecService(new CodecService(null, defaultSettings, logger))
+                .eventListener(new Engine.EventListener() {
+                })
+                .queryCache(IndexSearcher.getDefaultQueryCache())
+                .queryCachingPolicy(IndexSearcher.getDefaultQueryCachingPolicy())
+                .translogConfig(new TranslogConfig(shardId, createTempDir(), defaultSettings, BigArrays.NON_RECYCLING_INSTANCE, "", false))
+                .flushMergesAfter(TimeValue.timeValueMinutes(5))
+                .externalRefreshListener(emptyList())
+                .internalRefreshListener(emptyList())
+                .indexSort(null)
+                .circuitBreakerService(new NoneCircuitBreakerService())
+                .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
+                .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+                .primaryTermSupplier(primaryTerm)
+                .tombstoneDocSupplier(tombstoneDocSupplier())
+                .build();
+
             NRTReplicationReaderManager readerManager = new NRTReplicationReaderManager(
                 OpenSearchDirectoryReader.wrap(reader, shardId),
                 (files) -> {},
-                (files) -> {}
+                (files) -> {},
+                testConfig
             );
             assertEquals(initialInfos, readerManager.getSegmentInfos());
             try (final OpenSearchDirectoryReader acquire = readerManager.acquire()) {


### PR DESCRIPTION
### Description
Timestamp sort optimisations (leafSorter) were not working consistently across all engine types. While InternalEngine (primary shards) correctly applied leafSorter, other engine types like ReadOnlyEngine (searchable snapshots) and NRTReplicationEngine (segment replication) were not passing leafSorter when opening DirectoryReader instances.
This caused inconsistent performance for time-series workloads:

- Primary shards: Fast time-series queries (segments ordered by timestamp)
- Searchable snapshots: Slower time-series queries (segments in arbitrary order)
- Segment replication replicas: Slower time-series queries (segments in arbitrary order)

**Solution**
Apply leafSorter optimisation consistently across all engine types by ensuring `DirectoryReader.open()` calls include the leafSorter parameter.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
#17579 

### Check List
- [X] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
