### PR TITLE
[Bug Fix] Fix the backward compatibility regression with `COMPLEMENT` for Regexp queries introduced in OpenSearch 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Autotagging] Fix delete rule event consumption in InMemoryRuleProcessingService ([#18628](https://github.com/opensearch-project/OpenSearch/pull/18628))
 - Cannot communicate with HTTP/2 when reactor-netty is enabled ([#18599](https://github.com/opensearch-project/OpenSearch/pull/18599))
 - Fix the visit of sub queries for HasParentQuery and HasChildQuery ([#18621](https://github.com/opensearch-project/OpenSearch/pull/18621))
+- Fix the backward compatibility regression with COMPLEMENT for Regexp queries introduced in OpenSearch 3.0 ([#18640](https://github.com/opensearch-project/OpenSearch/pull/18640))
 
 
 ### Security

--- a/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
@@ -49,6 +49,8 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.ConstantScoreQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.RegexpFlag;
+import org.opensearch.index.query.RegexpQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.search.rescore.QueryRescorerBuilder;
 import org.opensearch.search.sort.SortOrder;
@@ -59,7 +61,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
@@ -762,5 +766,20 @@ public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTe
                 "This limit can be set by changing the [" + IndexSettings.MAX_RESCORE_WINDOW_SETTING.getKey() + "] index level setting."
             )
         );
+    }
+
+    public void testRegexQueryWithComplementFlag() {
+        createIndex("test_regex");
+        client().prepareIndex("test_regex").setId("1").setSource("text", "abc").get();
+        client().prepareIndex("test_regex").setId("2").setSource("text", "adc").get();
+        client().prepareIndex("test_regex").setId("3").setSource("text", "acc").get();
+        refresh();
+        RegexpQueryBuilder query = new RegexpQueryBuilder("text.keyword", "a~bc");
+        query.flags(RegexpFlag.COMPLEMENT);
+        SearchResponse response = client().prepareSearch("test_regex").setQuery(query).get();
+        assertEquals("COMPLEMENT should match 2 documents", 2L, response.getHits().getTotalHits().value());
+        Set<String> matchedIds = Arrays.stream(response.getHits().getHits()).map(hit -> hit.getId()).collect(Collectors.toSet());
+        assertEquals("Should match exactly 2 documents", 2, matchedIds.size());
+        assertTrue("Should match documents 2 and 3", matchedIds.containsAll(Arrays.asList("2", "3")));
     }
 }

--- a/server/src/main/java/org/opensearch/index/query/RegexpQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/RegexpQueryBuilder.java
@@ -38,6 +38,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
+import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.lucene.BytesRefs;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.core.ParseField;
@@ -60,6 +61,9 @@ import java.util.Objects;
  * @opensearch.internal
  */
 public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder> implements MultiTermQueryBuilder {
+
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RegexpQueryBuilder.class);
+
     public static final String NAME = "regexp";
 
     public static final int DEFAULT_FLAGS_VALUE = RegexpFlag.ALL.value();
@@ -294,6 +298,18 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
                     + "] index level setting."
             );
         }
+
+        // Check if COMPLEMENT flag is being used
+        // The COMPLEMENT flag maps to Lucene's DEPRECATED_COMPLEMENT which is marked for removal in Lucene 11
+        // This deprecation warning helps users migrate their queries before the feature is completely removed
+        if ((syntaxFlagsValue & RegexpFlag.COMPLEMENT.value()) != 0) {
+            deprecationLogger.deprecate(
+                "regexp_complement_operator",
+                "The complement operator (~) for arbitrary patterns in regexp queries is deprecated and will be removed in a future version. "
+                    + "Consider rewriting your query to use character class negation [^...] or other query types."
+            );
+        }
+
         MultiTermQuery.RewriteMethod method = QueryParsers.parseRewriteMethod(rewrite, null, LoggingDeprecationHandler.INSTANCE);
 
         int matchFlagsValue = caseInsensitive ? RegExp.ASCII_CASE_INSENSITIVE : 0;

--- a/server/src/main/java/org/opensearch/index/query/RegexpQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/RegexpQueryBuilder.java
@@ -299,7 +299,8 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
         int matchFlagsValue = caseInsensitive ? RegExp.ASCII_CASE_INSENSITIVE : 0;
         Query query = null;
         // For BWC we mask irrelevant bits (RegExp changed ALL from 0xffff to 0xff)
-        int sanitisedSyntaxFlag = syntaxFlagsValue & RegExp.ALL;
+        // The hexadecimal for DEPRECATED_COMPLEMENT is 0x10000. The OR condition ensures COMPLEMENT ~ is preserved
+        int sanitisedSyntaxFlag = syntaxFlagsValue & (RegExp.ALL | RegExp.DEPRECATED_COMPLEMENT);
 
         MappedFieldType fieldType = context.fieldMapper(fieldName);
         if (fieldType != null) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Coming from @msfroh suggestion https://github.com/opensearch-project/OpenSearch/issues/18397#issuecomment-2950840604 I can see the issue where the `COMPLEMENT` is dropped and `sanitisedSyntaxFlag` returns as 0. With this change I see the value as 65536 (`0x10000`) which works as expected.

Added an IT test as I assume we cannot test this with existing unit tests in `RegexpQueryBuilderTests`.

Background, the `COMPLEMENT(RegExp.DEPRECATED_COMPLEMENT),` is updated as part of https://github.com/opensearch-project/OpenSearch/pull/16366

### Note

When we upgrade to Lucene 11 (OpenSearch 4.0), we should:
- Remove `COMPLEMENT(RegExp.DEPRECATED_COMPLEMENT)`, from OpenSearch `RegexpFlag` class.
- Handle the `RegexpQueryBuilder.java`
- Update Documentation https://docs.opensearch.org/docs/latest/query-dsl/regex-syntax/ by removing all references to the `~` operator and remove COMPLEMENT from the flags list

CC: @getsaurabh02 

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/18397

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
