### PR TITLE
Fix credentials format in manifest triggering workflow

### DIFF
--- a/.github/workflows/trigger-manifest-generation.yml
+++ b/.github/workflows/trigger-manifest-generation.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Trigger manifest-update workflow
         run: |
             echo "Triggering manifest-update workflow at https://build.ci.opensearch.org/job/manifest-update/"
-            curl -f -X POST https://build.ci.opensearch.org/job/manifest-update/build --user "${{ secrets.JENKINS_GITHUB_USER}}:${{ secrets.JENKINS_GITHUB_USER_TOKEN}}"
+            curl -f -X POST https://build.ci.opensearch.org/job/manifest-update/build --user ${{ secrets.JENKINS_GITHUB_USER}}:${{ secrets.JENKINS_GITHUB_USER_TOKEN}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change removes the quotes around credentials in the workflow used to trigger manifest workflow.
See failure https://github.com/opensearch-project/OpenSearch/actions/runs/15980541354

Tested in my fork: https://github.com/gaiksaya/OpenSearch/actions/runs/15981189769

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-build/issues/4225
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
