### PR TITLE
Fix sync method to account for block files in Composite Directory

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/CompositeDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/CompositeDirectory.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.opensearch.index.store.remote.utils.FileTypeUtils.BLOCK_FILE_IDENTIFIER;
+import static org.opensearch.index.store.remote.utils.FileTypeUtils.isBlockFile;
 import static org.apache.lucene.index.IndexFileNames.SEGMENTS;
 
 /**
@@ -102,6 +103,24 @@ public class CompositeDirectory extends FilterDirectory {
     protected List<String> listBlockFiles(String fileName) throws IOException {
         return Stream.of(listLocalFiles())
             .filter(file -> file.equals(fileName) || file.startsWith(fileName + FileTypeUtils.BLOCK_FILE_IDENTIFIER))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a list of names of all block files stored in the local directory for a given set of files,
+     * including the original file names itself if present.
+     *
+     * @param fileNames The set of files to search for, along with its associated block files.
+     * @return A list of file names, including the original file (if present) and all its block files.
+     * @throws IOException in case of I/O error while listing files.
+     */
+    protected List<String> listBlockFiles(String[] fileNames) throws IOException {
+        Set<String> files = Set.of(fileNames);
+        return Stream.of(listLocalFiles())
+            .filter(
+                file -> files.contains(file)
+                    || (isBlockFile(file) && files.contains(file.substring(0, file.indexOf(BLOCK_FILE_IDENTIFIER))))
+            )
             .collect(Collectors.toList());
     }
 
@@ -249,8 +268,15 @@ public class CompositeDirectory extends FilterDirectory {
     public void sync(Collection<String> names) throws IOException {
         ensureOpen();
         logger.trace("Composite Directory[{}]: sync() called {}", this::toString, () -> names);
-        Collection<String> remoteFiles = Arrays.asList(getRemoteFiles());
-        Collection<String> filesToSync = names.stream().filter(name -> remoteFiles.contains(name) == false).collect(Collectors.toList());
+        Set<String> remoteFiles = Set.of(getRemoteFiles());
+        Set<String> localFiles = Arrays.stream(listLocalFiles())
+            .map(file -> isBlockFile(file) ? file.substring(0, file.indexOf(BLOCK_FILE_IDENTIFIER)) : file)
+            .collect(Collectors.toSet());
+        String[] fullFilesToSync = names.stream().filter(name -> remoteFiles.contains(name) == false).toArray(String[]::new);
+        for (String fullFileToSync : fullFilesToSync) {
+            if (localFiles.contains(fullFileToSync) == false) throw new NoSuchFileException("Unable to sync file " + fullFileToSync);
+        }
+        List<String> filesToSync = listBlockFiles(fullFilesToSync);
         logger.trace("Composite Directory[{}]: Synced files : {}", this::toString, () -> filesToSync);
         localDirectory.sync(filesToSync);
     }

--- a/server/src/test/java/org/opensearch/index/store/CompositeDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/CompositeDirectoryTests.java
@@ -132,6 +132,12 @@ public class CompositeDirectoryTests extends BaseRemoteSegmentStoreDirectoryTest
         // All the files in the below list are present either locally or on remote, so sync should work as expected
         Collection<String> names = List.of("_0.cfe", "_0.cfs", "_0.si", "_1.cfe", "_2.cfe", "segments_1");
         compositeDirectory.sync(names);
+        // Deleting file _1.cfe and then adding its blocks locally so that full file is not present but block files are present in local
+        // State of _1.cfe file after these operations - not present in remote, full file not present locally but blocks present in local
+        compositeDirectory.deleteFile("_1.cfe");
+        addFilesToDirectory(new String[] { "_1.cfe_block_0", "_1.cfe_block_2" });
+        // Sync should work as expected since blocks are present in local
+        compositeDirectory.sync(List.of("_1.cfe"));
         // Below list contains a non-existent file, hence will throw an error
         Collection<String> names1 = List.of("_0.cfe", "_0.cfs", "_0.si", "_1.cfe", "_2.cfe", "segments_1", "non_existent_file");
         assertThrows(NoSuchFileException.class, () -> compositeDirectory.sync(names1));


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix sync method to account for block files in Composite Directory

### Related Issues
Resolves #18657 
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
