### PR TITLE
Remove clone holder and add Cleaner logic to clean up clones in FullFileCachedIndexInput

### DIFF
--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
 
+@ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
 public class FileCacheTests extends OpenSearchTestCase {
     // need concurrency level to be static to make these tests more deterministic because capacity per segment is dependent on
     // (total capacity) / (concurrency level) so having high concurrency level might trigger early evictions which is tolerable in real life

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.index.store.remote.filecache;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
@@ -18,6 +20,7 @@ import org.opensearch.core.common.breaker.CircuitBreakingException;
 import org.opensearch.core.common.breaker.NoopCircuitBreaker;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.store.remote.directory.RemoteSnapshotDirectoryFactory;
+import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
 import org.opensearch.index.store.remote.utils.FileTypeUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCachedIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCachedIndexInputTests.java
@@ -8,12 +8,15 @@
 
 package org.opensearch.index.store.remote.filecache;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.breaker.NoopCircuitBreaker;
+import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
 

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCachedIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCachedIndexInputTests.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import java.io.IOException;
 import java.nio.file.Path;
 
+@ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
 public class FileCachedIndexInputTests extends OpenSearchTestCase {
 
     protected FileCache fileCache;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Remove clone holder and add Cleaner logic to clean up clones in FullFileCachedIndexInput

### Related Issues
Resolves #18659 
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
