### PR TITLE
add cancellation check in FetchPhase for Agg reductions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix the visit of sub queries for HasParentQuery and HasChildQuery ([#18621](https://github.com/opensearch-project/OpenSearch/pull/18621))
 - Fix the backward compatibility regression with COMPLEMENT for Regexp queries introduced in OpenSearch 3.0 ([#18640](https://github.com/opensearch-project/OpenSearch/pull/18640))
 - Fix Replication lag computation ([#18602](https://github.com/opensearch-project/OpenSearch/pull/18602))
+- Add task cancellation checks in FetchPhase in aggregation reductions ([18673](https://github.com/opensearch-project/OpenSearch/pull/18673))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix the visit of sub queries for HasParentQuery and HasChildQuery ([#18621](https://github.com/opensearch-project/OpenSearch/pull/18621))
 - Fix the backward compatibility regression with COMPLEMENT for Regexp queries introduced in OpenSearch 3.0 ([#18640](https://github.com/opensearch-project/OpenSearch/pull/18640))
 - Fix Replication lag computation ([#18602](https://github.com/opensearch-project/OpenSearch/pull/18602))
-- Add task cancellation checks in FetchPhase in aggregation reductions ([18673](https://github.com/opensearch-project/OpenSearch/pull/18673))
+- Add task cancellation checks in FetchPhase during aggregation reductions ([18673](https://github.com/opensearch-project/OpenSearch/pull/18673))
 
 ### Security
 

--- a/benchmarks/src/main/java/org/opensearch/benchmark/search/aggregations/TermsReduceBenchmark.java
+++ b/benchmarks/src/main/java/org/opensearch/benchmark/search/aggregations/TermsReduceBenchmark.java
@@ -229,7 +229,8 @@ public class TermsReduceBenchmark {
             SearchProgressListener.NOOP,
             namedWriteableRegistry,
             shards.size(),
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         CountDownLatch latch = new CountDownLatch(shards.size());
         for (int i = 0; i < shards.size(); i++) {

--- a/modules/geo/src/main/java/org/opensearch/geo/search/aggregations/bucket/geogrid/BaseGeoGrid.java
+++ b/modules/geo/src/main/java/org/opensearch/geo/search/aggregations/bucket/geogrid/BaseGeoGrid.java
@@ -114,6 +114,7 @@ public abstract class BaseGeoGrid<B extends BaseGeoGridBucket> extends InternalM
         final int size = Math.toIntExact(reduceContext.isFinalReduce() == false ? buckets.size() : Math.min(requiredSize, buckets.size()));
         BucketPriorityQueue<BaseGeoGridBucket> ordered = new BucketPriorityQueue<>(size);
         for (LongObjectPagedHashMap.Cursor<List<BaseGeoGridBucket>> cursor : buckets) {
+            reduceContext.checkCancelled();
             List<BaseGeoGridBucket> sameCellBuckets = cursor.value;
             ordered.insertWithOverflow(reduceBucket(sameCellBuckets, reduceContext));
         }

--- a/modules/geo/src/main/java/org/opensearch/geo/search/aggregations/metrics/InternalGeoBounds.java
+++ b/modules/geo/src/main/java/org/opensearch/geo/search/aggregations/metrics/InternalGeoBounds.java
@@ -119,6 +119,7 @@ public class InternalGeoBounds extends InternalAggregation implements GeoBounds 
         double negRight = Double.NEGATIVE_INFINITY;
 
         for (InternalAggregation aggregation : aggregations) {
+            reduceContext.checkCancelled();
             InternalGeoBounds bounds = (InternalGeoBounds) aggregation;
 
             if (bounds.top > top) {

--- a/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
@@ -566,11 +566,14 @@ public final class SearchPhaseController {
         List<InternalAggregations> toReduce,
         BooleanSupplier isTaskCancelled
     ) {
+        if (toReduce.isEmpty()) {
+            return null;
+        }
         final ReduceContext reduceContext = performFinalReduce
             ? aggReduceContextBuilder.forFinalReduction()
             : aggReduceContextBuilder.forPartialReduction();
         reduceContext.setIsTaskCancelled(isTaskCancelled);
-        return toReduce.isEmpty() ? null : InternalAggregations.topLevelReduce(toReduce, reduceContext);
+        return InternalAggregations.topLevelReduce(toReduce, reduceContext);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -1045,6 +1045,7 @@ final class DefaultSearchContext extends SearchContext {
     @Override
     public InternalAggregation.ReduceContext partialOnShard() {
         InternalAggregation.ReduceContext rc = requestToAggReduceContextBuilder.apply(request.source()).forPartialReduction();
+        rc.setIsTaskCancelled(this::isCancelled);
         rc.setSliceLevel(shouldUseConcurrentSearch());
         return rc;
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/InternalAggregations.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/InternalAggregations.java
@@ -168,6 +168,7 @@ public final class InternalAggregations extends Aggregations implements Writeabl
         Map<String, List<InternalAggregation>> aggByName = new HashMap<>();
         for (InternalAggregations aggregations : aggregationsList) {
             for (Aggregation aggregation : aggregations.aggregations) {
+                context.checkCancelled();
                 List<InternalAggregation> aggs = aggByName.computeIfAbsent(
                     aggregation.getName(),
                     k -> new ArrayList<>(aggregationsList.size())

--- a/server/src/main/java/org/opensearch/search/aggregations/InternalMultiBucketAggregation.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/InternalMultiBucketAggregation.java
@@ -215,6 +215,7 @@ public abstract class InternalMultiBucketAggregation<
         for (B bucket : getBuckets()) {
             List<InternalAggregation> aggs = new ArrayList<>();
             for (Aggregation agg : bucket.getAggregations()) {
+                reduceContext.checkCancelled();
                 PipelineTree subTree = pipelineTree.subTree(agg.getName());
                 aggs.add(((InternalAggregation) agg).reducePipelines((InternalAggregation) agg, reduceContext, subTree));
             }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
@@ -119,6 +119,7 @@ public abstract class InternalSingleBucketAggregation extends InternalAggregatio
         long docCount = 0L;
         List<InternalAggregations> subAggregationsList = new ArrayList<>(aggregations.size());
         for (InternalAggregation aggregation : aggregations) {
+            reduceContext.checkCancelled();
             assert aggregation.getName().equals(getName());
             docCount += ((InternalSingleBucketAggregation) aggregation).docCount;
             subAggregationsList.add(((InternalSingleBucketAggregation) aggregation).aggregations);

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/filter/InternalFilters.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/filter/InternalFilters.java
@@ -213,6 +213,7 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
         List<List<InternalBucket>> bucketsList = null;
         for (InternalAggregation aggregation : aggregations) {
+            reduceContext.checkCancelled();
             InternalFilters filters = (InternalFilters) aggregation;
             if (bucketsList == null) {
                 bucketsList = new ArrayList<>(filters.buckets.size());

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalAutoDateHistogram.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalAutoDateHistogram.java
@@ -308,7 +308,7 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
      * is the same and they can be reduced together.
      */
     private BucketReduceResult reduceBuckets(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
-
+        reduceContext.checkCancelled();
         // First we need to find the highest level rounding used across all the
         // shards
         int reduceRoundingIdx = 0;
@@ -421,6 +421,7 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
 
     @Override
     protected Bucket reduceBucket(List<Bucket> buckets, ReduceContext context) {
+        context.checkCancelled();
         assert buckets.size() > 0;
         List<InternalAggregations> aggregations = new ArrayList<>(buckets.size());
         long docCount = 0;
@@ -542,6 +543,7 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
 
     @Override
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
+        reduceContext.checkCancelled();
         BucketReduceResult reducedBucketsResult = reduceBuckets(aggregations, reduceContext);
 
         if (reduceContext.isFinalReduce()) {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -330,6 +330,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
             }
         };
         for (InternalAggregation aggregation : aggregations) {
+            reduceContext.checkCancelled();
             InternalDateHistogram histogram = (InternalDateHistogram) aggregation;
             if (histogram.buckets.isEmpty() == false) {
                 pq.add(new IteratorAndCurrent(histogram.buckets.iterator()));
@@ -456,6 +457,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
 
     @Override
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
+        reduceContext.checkCancelled();
         List<Bucket> reducedBuckets = reduceBuckets(aggregations, reduceContext);
         if (reduceContext.isFinalReduce()) {
             if (minDocCount == 0) {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -313,6 +313,7 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
             }
         };
         for (InternalAggregation aggregation : aggregations) {
+            reduceContext.checkCancelled();
             InternalHistogram histogram = (InternalHistogram) aggregation;
             if (histogram.buckets.isEmpty() == false) {
                 pq.add(new IteratorAndCurrent(histogram.buckets.iterator()));

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/range/InternalRange.java
@@ -348,6 +348,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
             rangeList[i] = new ArrayList<>();
         }
         for (InternalAggregation aggregation : aggregations) {
+            reduceContext.checkCancelled();
             InternalRange<B, R> ranges = (InternalRange<B, R>) aggregation;
             int i = 0;
             for (B range : ranges.ranges) {

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -219,6 +219,7 @@ public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bu
 
     @Override
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
+        reduceContext.checkCancelled();
         boolean promoteToDouble = false;
         for (InternalAggregation agg : aggregations) {
             if (agg instanceof LongTerms

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
@@ -240,6 +240,7 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
         // Compute the overall result set size and the corpus size using the
         // top-level Aggregations from each shard
         for (InternalAggregation aggregation : aggregations) {
+            reduceContext.checkCancelled();
             @SuppressWarnings("unchecked")
             InternalSignificantTerms<A, B> terms = (InternalSignificantTerms<A, B>) aggregation;
             globalSubsetSize += terms.getSubsetSize();

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -395,6 +395,7 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
         long otherDocCount = 0;
         InternalTerms<A, B> referenceTerms = null;
         for (InternalAggregation aggregation : aggregations) {
+            reduceContext.checkCancelled();
             @SuppressWarnings("unchecked")
             InternalTerms<A, B> terms = (InternalTerms<A, B>) aggregation;
             // For Concurrent Segment Search the aggregation will have a computed doc count error coming from the shards.

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
@@ -146,6 +146,7 @@ abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggr
     public AbstractInternalHDRPercentiles reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
         DoubleHistogram merged = null;
         for (InternalAggregation aggregation : aggregations) {
+            reduceContext.checkCancelled();
             final AbstractInternalHDRPercentiles percentiles = (AbstractInternalHDRPercentiles) aggregation;
             if (merged == null) {
                 merged = new DoubleHistogram(percentiles.state);

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
@@ -129,6 +129,7 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
     public AbstractInternalTDigestPercentiles reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
         TDigestState merged = null;
         for (InternalAggregation aggregation : aggregations) {
+            reduceContext.checkCancelled();
             final AbstractInternalTDigestPercentiles percentiles = (AbstractInternalTDigestPercentiles) aggregation;
             if (merged == null) {
                 merged = new TDigestState(percentiles.state.compression());

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalScriptedMetric.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalScriptedMetric.java
@@ -99,6 +99,7 @@ public class InternalScriptedMetric extends InternalAggregation implements Scrip
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
         List<Object> aggregationObjects = new ArrayList<>();
         for (InternalAggregation aggregation : aggregations) {
+            reduceContext.checkCancelled();
             InternalScriptedMetric mapReduceAggregation = (InternalScriptedMetric) aggregation;
             aggregationObjects.addAll(mapReduceAggregation.aggregations);
         }

--- a/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
@@ -814,7 +814,8 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             task.getProgressListener(),
             writableRegistry(),
             shardsIter.size(),
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         AtomicReference<Exception> exception = new AtomicReference<>();
         ActionListener<SearchResponse> listener = ActionListener.wrap(response -> fail("onResponse should not be called"), exception::set);
@@ -869,7 +870,8 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             task.getProgressListener(),
             writableRegistry(),
             shardsIter.size(),
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         AtomicReference<Exception> exception = new AtomicReference<>();
         ActionListener<SearchResponse> listener = ActionListener.wrap(response -> fail("onResponse should not be called"), exception::set);
@@ -926,7 +928,8 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             mockSearchPhaseContext.getRequest(),
             1,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         return new FetchSearchPhase(
             results,

--- a/server/src/test/java/org/opensearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -675,7 +675,8 @@ public class CanMatchPreFilterSearchPhaseTests extends OpenSearchTestCase {
             task.getProgressListener(),
             writableRegistry(),
             shardsIter.size(),
-            exc -> {}
+            exc -> {},
+            () -> false
         );
 
         CanMatchPreFilterSearchPhase canMatchPhase = new CanMatchPreFilterSearchPhase(

--- a/server/src/test/java/org/opensearch/action/search/DfsQueryPhaseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/DfsQueryPhaseTests.java
@@ -141,7 +141,8 @@ public class DfsQueryPhaseTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             mockSearchPhaseContext.searchRequest,
             results.length(),
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         DfsQueryPhase phase = new DfsQueryPhase(results.asList(), null, consumer, (response) -> new SearchPhase("test") {
             @Override
@@ -226,7 +227,8 @@ public class DfsQueryPhaseTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             mockSearchPhaseContext.searchRequest,
             results.length(),
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         DfsQueryPhase phase = new DfsQueryPhase(results.asList(), null, consumer, (response) -> new SearchPhase("test") {
             @Override
@@ -313,7 +315,8 @@ public class DfsQueryPhaseTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             mockSearchPhaseContext.searchRequest,
             results.length(),
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         DfsQueryPhase phase = new DfsQueryPhase(results.asList(), null, consumer, (response) -> new SearchPhase("test") {
             @Override

--- a/server/src/test/java/org/opensearch/action/search/FetchSearchPhaseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/FetchSearchPhaseTests.java
@@ -72,7 +72,8 @@ public class FetchSearchPhaseTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             mockSearchPhaseContext.getRequest(),
             1,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         boolean hasHits = randomBoolean();
         final int numHits;
@@ -133,7 +134,8 @@ public class FetchSearchPhaseTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             mockSearchPhaseContext.getRequest(),
             2,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         int resultSetSize = randomIntBetween(2, 10);
         ShardSearchContextId ctx1 = new ShardSearchContextId(UUIDs.base64UUID(), 123);
@@ -229,7 +231,8 @@ public class FetchSearchPhaseTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             mockSearchPhaseContext.getRequest(),
             2,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         int resultSetSize = randomIntBetween(2, 10);
         final ShardSearchContextId ctx = new ShardSearchContextId(UUIDs.base64UUID(), 123);
@@ -327,7 +330,8 @@ public class FetchSearchPhaseTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             mockSearchPhaseContext.getRequest(),
             numHits,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         for (int i = 0; i < numHits; i++) {
             QuerySearchResult queryResult = new QuerySearchResult(
@@ -417,7 +421,8 @@ public class FetchSearchPhaseTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             mockSearchPhaseContext.getRequest(),
             2,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         int resultSetSize = randomIntBetween(2, 10);
         QuerySearchResult queryResult = new QuerySearchResult(
@@ -509,7 +514,8 @@ public class FetchSearchPhaseTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             mockSearchPhaseContext.getRequest(),
             2,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         int resultSetSize = 1;
         final ShardSearchContextId ctx1 = new ShardSearchContextId(UUIDs.base64UUID(), 123);

--- a/server/src/test/java/org/opensearch/action/search/QueryPhaseResultConsumerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/QueryPhaseResultConsumerTests.java
@@ -130,7 +130,8 @@ public class QueryPhaseResultConsumerTests extends OpenSearchTestCase {
             e -> onPartialMergeFailure.accumulateAndGet(e, (prev, curr) -> {
                 curr.addSuppressed(prev);
                 return curr;
-            })
+            }),
+            () -> false
         );
 
         CountDownLatch partialReduceLatch = new CountDownLatch(10);

--- a/server/src/test/java/org/opensearch/action/search/SearchPhaseControllerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchPhaseControllerTests.java
@@ -340,7 +340,8 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
                 0,
                 true,
                 InternalAggregationTestCase.emptyReduceContextBuilder(),
-                true
+                true,
+                () -> false
             );
             AtomicArray<SearchPhaseResult> fetchResults = generateFetchResults(
                 nShards,
@@ -668,7 +669,8 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             request,
             3 + numEmptyResponses,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         if (numEmptyResponses == 0) {
             assertEquals(0, reductions.size());
@@ -776,7 +778,8 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             request,
             expectedNumResults,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         AtomicInteger max = new AtomicInteger();
         Thread[] threads = new Thread[expectedNumResults];
@@ -840,7 +843,8 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             request,
             expectedNumResults,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         AtomicInteger max = new AtomicInteger();
         CountDownLatch latch = new CountDownLatch(expectedNumResults);
@@ -893,7 +897,8 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             request,
             expectedNumResults,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         AtomicInteger max = new AtomicInteger();
         CountDownLatch latch = new CountDownLatch(expectedNumResults);
@@ -951,7 +956,8 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             request,
             4,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         int score = 100;
         CountDownLatch latch = new CountDownLatch(4);
@@ -1000,7 +1006,8 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             request,
             expectedNumResults,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         AtomicInteger max = new AtomicInteger();
         SortField[] sortFields = { new SortField("field", SortField.Type.INT, true) };
@@ -1047,7 +1054,8 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             request,
             expectedNumResults,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         SortField[] sortFields = { new SortField("field", SortField.Type.STRING) };
         BytesRef a = new BytesRef("a");
@@ -1097,7 +1105,8 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             request,
             expectedNumResults,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         int maxScoreTerm = -1;
         int maxScorePhrase = -1;
@@ -1235,7 +1244,8 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
                 progressListener,
                 request,
                 expectedNumResults,
-                exc -> {}
+                exc -> {},
+                () -> false
             );
             AtomicInteger max = new AtomicInteger();
             Thread[] threads = new Thread[expectedNumResults];
@@ -1324,7 +1334,8 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             request,
             expectedNumResults,
-            exc -> hasConsumedFailure.set(true)
+            exc -> hasConsumedFailure.set(true),
+            () -> false
         );
         CountDownLatch latch = new CountDownLatch(expectedNumResults);
         Thread[] threads = new Thread[expectedNumResults];

--- a/server/src/test/java/org/opensearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -219,7 +219,8 @@ public class SearchQueryThenFetchAsyncActionTests extends OpenSearchTestCase {
             task.getProgressListener(),
             writableRegistry(),
             shardsIter.size(),
-            exc -> {}
+            exc -> {},
+            () -> false
         );
         SearchQueryThenFetchAsyncAction action = new SearchQueryThenFetchAsyncAction(
             logger,

--- a/server/src/test/java/org/opensearch/action/search/SearchResponseMergerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchResponseMergerTests.java
@@ -139,7 +139,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 new SearchRequest(),
                 () -> null
-            )
+            ),
+            () -> false
         );
         assertEquals(TimeUnit.NANOSECONDS.toMillis(currentRelativeTime), searchResponse.getTook().millis());
     }
@@ -198,7 +199,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 new SearchRequest(),
                 () -> null
-            )
+            ),
+            () -> false
         );
         assertSame(clusters, mergedResponse.getClusters());
         assertEquals(numResponses, mergedResponse.getTotalShards());
@@ -256,7 +258,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 new SearchRequest(),
                 () -> null
-            )
+            ),
+            () -> false
         );
         assertSame(clusters, mergedResponse.getClusters());
         assertEquals(numResponses, mergedResponse.getTotalShards());
@@ -309,7 +312,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 new SearchRequest(),
                 () -> null
-            )
+            ),
+            () -> false
         ).getShardFailures();
         assertThat(Arrays.asList(shardFailures), containsInAnyOrder(expectedFailures.toArray(ShardSearchFailure.EMPTY_ARRAY)));
     }
@@ -350,7 +354,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 new SearchRequest(),
                 () -> null
-            )
+            ),
+            () -> false
         );
         assertSame(clusters, mergedResponse.getClusters());
         assertEquals(numResponses, mergedResponse.getTotalShards());
@@ -419,7 +424,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 new SearchRequest(),
                 () -> null
-            )
+            ),
+            () -> false
         );
         assertSame(clusters, mergedResponse.getClusters());
         assertEquals(numResponses, mergedResponse.getTotalShards());
@@ -498,7 +504,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 new SearchRequest(),
                 () -> null
-            )
+            ),
+            () -> false
         );
         assertSame(clusters, mergedResponse.getClusters());
         assertEquals(numResponses, mergedResponse.getTotalShards());
@@ -579,7 +586,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 new SearchRequest(),
                 () -> null
-            )
+            ),
+            () -> false
         );
         assertSame(clusters, mergedResponse.getClusters());
         assertEquals(numResponses, mergedResponse.getTotalShards());
@@ -743,7 +751,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 new SearchRequest(),
                 () -> null
-            )
+            ),
+            () -> false
         );
 
         assertEquals(TimeUnit.NANOSECONDS.toMillis(currentRelativeTime), searchResponse.getTook().millis());
@@ -810,7 +819,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 new SearchRequest(),
                 () -> null
-            )
+            ),
+            () -> false
         );
         assertSame(clusters, response.getClusters());
         assertEquals(TimeUnit.NANOSECONDS.toMillis(currentRelativeTime), response.getTook().millis());
@@ -890,7 +900,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 new SearchRequest(),
                 () -> null
-            )
+            ),
+            () -> false
         );
         assertEquals(10, mergedResponse.getHits().getTotalHits().value());
         assertEquals(10, mergedResponse.getHits().getHits().length);
@@ -939,7 +950,8 @@ public class SearchResponseMergerTests extends OpenSearchTestCase {
                 new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                 new SearchRequest(),
                 () -> null
-            )
+            ),
+            () -> false
         );
         assertEquals(expectedTotalHits, mergedResponse.getHits().getTotalHits());
     }

--- a/server/src/test/java/org/opensearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/TransportSearchActionTests.java
@@ -489,7 +489,8 @@ public class TransportSearchActionTests extends OpenSearchTestCase {
                     new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                     searchRequest,
                     () -> null
-                )
+                ),
+                () -> false
             );
             if (localIndices == null) {
                 assertNull(setOnce.get());
@@ -552,7 +553,8 @@ public class TransportSearchActionTests extends OpenSearchTestCase {
                         new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                         searchRequest,
                         () -> null
-                    )
+                    ),
+                    () -> false
                 );
                 if (localIndices == null) {
                     assertNull(setOnce.get());
@@ -594,7 +596,8 @@ public class TransportSearchActionTests extends OpenSearchTestCase {
                         new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                         searchRequest,
                         () -> null
-                    )
+                    ),
+                    () -> false
                 );
                 if (localIndices == null) {
                     assertNull(setOnce.get());
@@ -657,7 +660,8 @@ public class TransportSearchActionTests extends OpenSearchTestCase {
                         new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                         searchRequest,
                         () -> null
-                    )
+                    ),
+                    () -> false
                 );
                 if (localIndices == null) {
                     assertNull(setOnce.get());
@@ -702,7 +706,8 @@ public class TransportSearchActionTests extends OpenSearchTestCase {
                         new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                         searchRequest,
                         () -> null
-                    )
+                    ),
+                    () -> false
                 );
                 if (localIndices == null) {
                     assertNull(setOnce.get());
@@ -758,7 +763,8 @@ public class TransportSearchActionTests extends OpenSearchTestCase {
                         new SearchRequestOperationsListener.CompositeListener(List.of(), LogManager.getLogger()),
                         searchRequest,
                         () -> null
-                    )
+                    ),
+                    () -> false
                 );
                 if (localIndices == null) {
                     assertNull(setOnce.get());

--- a/server/src/test/java/org/opensearch/search/aggregations/AggregationCancellationTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/AggregationCancellationTests.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.core.common.breaker.CircuitBreaker;
+import org.opensearch.core.indices.breaker.NoneCircuitBreakerService;
+import org.opensearch.core.tasks.TaskCancelledException;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.StatsAggregationBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+
+public class AggregationCancellationTests extends AggregatorTestCase {
+
+    public void testCancellationDuringReduce() throws IOException {
+        // Create test index and data
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory);
+
+            // Index enough documents to make reduce phase substantial
+            int numDocs = 1000;
+            for (int i = 0; i < numDocs; i++) {
+                Document document = new Document();
+                document.add(new NumericDocValuesField("value", i));
+                document.add(new SortedSetDocValuesField("keyword", new BytesRef("value" + (i % 100))));
+                indexWriter.addDocument(document);
+            }
+            indexWriter.close();
+
+            try (IndexReader reader = DirectoryReader.open(directory)) {
+                IndexSearcher searcher = newSearcher(reader);
+
+                // Create a complex aggregation with nested terms to make reduce phase longer
+                TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("keywords").field("keyword")
+                    .size(100)
+                    .subAggregation(
+                        new TermsAggregationBuilder("nested_keywords").field("keyword")
+                            .size(100)
+                            .subAggregation(new StatsAggregationBuilder("stats").field("value"))
+                    );
+
+                BooleanSupplier cancellationChecker = () -> true;
+
+                // Execute aggregation
+                List<InternalAggregation> aggs = new ArrayList<>();
+                MultiBucketConsumerService.MultiBucketConsumer bucketConsumer = new MultiBucketConsumerService.MultiBucketConsumer(
+                    100000,
+                    new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                );
+
+                Query query = new MatchAllDocsQuery();
+
+                Aggregator agg = createAggregator(query, aggregationBuilder, searcher, bucketConsumer);
+
+                // Collect
+                agg.preCollection();
+                searcher.search(query, agg);
+                agg.postCollection();
+                aggs.add(agg.buildTopLevel());
+
+                // Create reduce context with cancellation checker
+                InternalAggregation.ReduceContext reduceContext = InternalAggregation.ReduceContext.forFinalReduction(
+                    agg.context().bigArrays(),
+                    null,
+                    bucketConsumer,
+                    aggregationBuilder.buildPipelineTree()
+                );
+
+                reduceContext.setIsTaskCancelled(cancellationChecker);
+
+                // Perform reduce - should throw TaskCancelledException
+                expectThrows(
+                    TaskCancelledException.class,
+                    () -> { InternalAggregations.reduce(List.of(InternalAggregations.from(aggs)), reduceContext); }
+                );
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
@@ -759,7 +759,8 @@ public class SearchPipelineServiceTests extends OpenSearchTestCase {
             SearchProgressListener.NOOP,
             writableRegistry(),
             2,
-            exc -> {}
+            exc -> {},
+            () -> false
         );
 
         final QuerySearchResult querySearchResult = new QuerySearchResult();


### PR DESCRIPTION
### Description
This change introduces cancellation checks for early termination in FetchPhase during shard level reduce and co-ordinator level reduce.

### Check List
- [X] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
