### PR TITLE
[Backport 2.19] Fix checkpoint handling to prevent segment replication infinite loop

### DIFF
--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicationTargetService.java
@@ -50,6 +50,7 @@ import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -340,7 +341,10 @@ public class SegmentReplicationTargetService extends AbstractLifecycleComponent 
 
                         // if we received a checkpoint during the copy event that is ahead of this
                         // try and process it.
-                        processLatestReceivedCheckpoint(replicaShard, thread);
+                        ReplicationCheckpoint lastReceivedCheckpoint = latestReceivedCheckpoint.get(replicaShard.shardId());
+                        if (Objects.nonNull(lastReceivedCheckpoint) && lastReceivedCheckpoint.isAheadOf(receivedCheckpoint)) {
+                            processLatestReceivedCheckpoint(replicaShard, thread);
+                        }
                     }
 
                     @Override

--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
@@ -506,6 +506,7 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
 
         latch.await(2, TimeUnit.SECONDS);
         verify(spy, (atLeastOnce())).updateVisibleCheckpoint(eq(0L), eq(replicaShard));
+        verify(spy, times(1)).processLatestReceivedCheckpoint(any(), any());
     }
 
     public void testStartReplicationListenerFailure() throws InterruptedException {
@@ -736,4 +737,5 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
         spy.clusterChanged(new ClusterChangedEvent("ignored", oldState, newState));
         verify(spy, times(1)).processLatestReceivedCheckpoint(eq(replicaShard), any());
     }
+
 }


### PR DESCRIPTION
Backports https://github.com/opensearch-project/OpenSearch/commit/46a0045a2301b3bc51e2da9c5e853f69ac6342c2 from https://github.com/opensearch-project/OpenSearch/pull/18636/