### PR TITLE
Adding support for multifields in startree

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/mapper/StarTreeMapperIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/mapper/StarTreeMapperIT.java
@@ -149,6 +149,12 @@ public class StarTreeMapperIT extends OpenSearchIntegTestCase {
                 .startObject()
                 .field("name", "nested.nested1.keyword_dv")
                 .endObject()
+                .startObject()
+                .field("name", "nested.nested1.name.keyword1")
+                .endObject()
+                .startObject()
+                .field("name", "nested.nested1.name.keyword2")
+                .endObject()
                 .endArray()
                 .startArray("metrics")
                 .startObject()
@@ -181,6 +187,19 @@ public class StarTreeMapperIT extends OpenSearchIntegTestCase {
                 .startObject("status")
                 .field("type", "integer")
                 .field("doc_values", true)
+                .endObject()
+                .startObject("name")
+                .field("type", "text")
+                .startObject("fields")
+                .startObject("keyword1")
+                .field("type", "keyword")
+                .field("ignore_above", 512)
+                .endObject()
+                .startObject("keyword2")
+                .field("type", "keyword")
+                .field("ignore_above", 512)
+                .endObject()
+                .endObject()
                 .endObject()
                 .startObject("keyword_dv")
                 .field("type", "keyword")
@@ -694,6 +713,10 @@ public class StarTreeMapperIT extends OpenSearchIntegTestCase {
                     assertTrue(starTreeFieldType.getDimensions().get(1) instanceof NumericDimension);
                     assertEquals("nested.nested1.keyword_dv", starTreeFieldType.getDimensions().get(2).getField());
                     assertTrue(starTreeFieldType.getDimensions().get(2) instanceof OrdinalDimension);
+                    assertEquals("nested.nested1.name.keyword1", starTreeFieldType.getDimensions().get(3).getField());
+                    assertTrue(starTreeFieldType.getDimensions().get(3) instanceof OrdinalDimension);
+                    assertEquals("nested.nested1.name.keyword2", starTreeFieldType.getDimensions().get(4).getField());
+                    assertTrue(starTreeFieldType.getDimensions().get(4) instanceof OrdinalDimension);
                     assertEquals("nested3.numeric_dv", starTreeFieldType.getMetrics().get(0).getField());
                     List<MetricStat> expectedMetrics = Arrays.asList(MetricStat.VALUE_COUNT, MetricStat.SUM, MetricStat.AVG);
                     assertEquals(expectedMetrics, starTreeFieldType.getMetrics().get(0).getMetrics());
@@ -823,7 +846,7 @@ public class StarTreeMapperIT extends OpenSearchIntegTestCase {
         // here nested.nested1.status is part of the composite field but "nested" field itself is an array
         prepareCreate(TEST_INDEX).setSettings(settings).setMapping(createNestedTestMapping()).get();
         // Attempt to index a document with an array field
-        XContentBuilder doc = jsonBuilder().startObject()
+        final XContentBuilder doc = jsonBuilder().startObject()
             .field("timestamp", "2023-06-01T12:00:00Z")
             .startArray("nested")
             .startObject()
@@ -835,7 +858,7 @@ public class StarTreeMapperIT extends OpenSearchIntegTestCase {
             .field("status", 10)
             .endObject()
             .startObject()
-            .field("status", 10)
+            .field("name", "this is name")
             .endObject()
             .endArray()
             .endObject()
@@ -850,6 +873,35 @@ public class StarTreeMapperIT extends OpenSearchIntegTestCase {
             "object mapping for [_doc] with array for [nested] cannot be accepted, as the field is also part of composite index mapping which does not accept arrays",
             ex.getMessage()
         );
+
+        // Attempt to index a document with an array field
+        final XContentBuilder doc1 = jsonBuilder().startObject()
+            .field("timestamp", "2023-06-01T12:00:00Z")
+            .startArray("nested")
+            .startObject()
+            .startArray("nested1")
+            .startObject()
+            .field("status", 10)
+            .endObject()
+            .startObject()
+            .field("name", "this is name")
+            .endObject()
+            .startObject()
+            .field("name", "this is name 1")
+            .endObject()
+            .endArray()
+            .endObject()
+            .endArray()
+            .endObject();
+        // Index the document and refresh
+        MapperParsingException ex1 = expectThrows(
+            MapperParsingException.class,
+            () -> client().prepareIndex(TEST_INDEX).setSource(doc1).get()
+        );
+        assertEquals(
+            "object mapping for [_doc] with array for [nested] cannot be accepted, as the field is also part of composite index mapping which does not accept arrays",
+            ex1.getMessage()
+        );
     }
 
     public void testCompositeIndexWithArraysInChildNestedCompositeField() throws IOException {
@@ -863,10 +915,10 @@ public class StarTreeMapperIT extends OpenSearchIntegTestCase {
             .field("status", 10)
             .endObject()
             .startObject()
-            .field("status", 10)
+            .field("name", "this is name")
             .endObject()
             .startObject()
-            .field("status", 10)
+            .field("name", "this is name1")
             .endObject()
             .endArray()
             .endObject()
@@ -878,6 +930,32 @@ public class StarTreeMapperIT extends OpenSearchIntegTestCase {
         );
         assertEquals(
             "object mapping for [nested] with array for [nested1] cannot be accepted, as the field is also part of composite index mapping which does not accept arrays",
+            ex.getMessage()
+        );
+    }
+
+    public void testCompositeIndexWithArraysInNestedMultiFields() throws IOException {
+        prepareCreate(TEST_INDEX).setSettings(settings).setMapping(createNestedTestMapping()).get();
+        // here nested.nested1.status is part of the composite field but "nested.nested1" field is an array
+        XContentBuilder doc = jsonBuilder().startObject()
+            .field("timestamp", "2023-06-01T12:00:00Z")
+            .startObject("nested")
+            .startObject("nested1")
+            .field("status", 10)
+            .startArray("name")
+            .value("this is name")
+            .value("this is name1")
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject();
+        // Index the document and refresh
+        MapperParsingException ex = expectThrows(
+            MapperParsingException.class,
+            () -> client().prepareIndex(TEST_INDEX).setSource(doc).get()
+        );
+        assertEquals(
+            "object mapping for [nested.nested1] with array for [name] cannot be accepted, as the field is also part of composite index mapping which does not accept arrays",
             ex.getMessage()
         );
     }

--- a/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
@@ -725,6 +725,10 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                     return new MultiFields(mappers);
                 }
             }
+
+            public Map<String, Mapper.Builder> getMapperBuilders() {
+                return mapperBuilders;
+            }
         }
 
         private final Map<String, FieldMapper> mappers;

--- a/server/src/test/java/org/opensearch/index/mapper/StarTreeMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/StarTreeMapperTests.java
@@ -286,7 +286,7 @@ public class StarTreeMapperTests extends MapperTestCase {
         }
     }
 
-    public void testValidStarTreeNestedFields() throws IOException {
+    public void testValidStarTreeNestedFieldsAndMultiFields() throws IOException {
         MapperService mapperService = createMapperService(getMinMappingWithNestedField());
         Set<CompositeMappedFieldType> compositeFieldTypes = mapperService.getCompositeFieldTypes();
         for (CompositeMappedFieldType type : compositeFieldTypes) {
@@ -304,6 +304,11 @@ public class StarTreeMapperTests extends MapperTestCase {
                 assertEquals(expectedTimeUnits.get(i).shortName(), dateDim.getSortedCalendarIntervals().get(i).shortName());
             }
             assertEquals("nested.status", starTreeFieldType.getDimensions().get(1).getField());
+            assertEquals("nested.name.keyword1", starTreeFieldType.getDimensions().get(2).getField());
+            assertEquals("nested.name.keyword2", starTreeFieldType.getDimensions().get(3).getField());
+            assertEquals("name.keyword1", starTreeFieldType.getDimensions().get(4).getField());
+            assertEquals("name.keyword2", starTreeFieldType.getDimensions().get(5).getField());
+
             assertEquals("nested.status", starTreeFieldType.getMetrics().get(0).getField());
             List<MetricStat> expectedMetrics = Arrays.asList(MetricStat.VALUE_COUNT, MetricStat.SUM, MetricStat.AVG);
             assertEquals(expectedMetrics, starTreeFieldType.getMetrics().get(0).getMetrics());
@@ -1162,6 +1167,18 @@ public class StarTreeMapperTests extends MapperTestCase {
             b.startObject();
             b.field("name", "nested.status");
             b.endObject();
+            b.startObject();
+            b.field("name", "nested.name.keyword1");
+            b.endObject();
+            b.startObject();
+            b.field("name", "nested.name.keyword2");
+            b.endObject();
+            b.startObject();
+            b.field("name", "name.keyword1");
+            b.endObject();
+            b.startObject();
+            b.field("name", "name.keyword2");
+            b.endObject();
             b.endArray();
 
             b.startArray("metrics");
@@ -1186,6 +1203,19 @@ public class StarTreeMapperTests extends MapperTestCase {
             b.startObject("status");
             b.field("type", "integer");
             b.endObject();
+            b.startObject("name");
+            b.field("type", "text");
+            b.startObject("fields");
+            b.startObject("keyword1");
+            b.field("type", "keyword");
+            b.field("ignore_above", 512);
+            b.endObject();
+            b.startObject("keyword2");
+            b.field("type", "keyword");
+            b.field("ignore_above", 512);
+            b.endObject();
+            b.endObject();
+            b.endObject();
             b.endObject();
             b.endObject();
             b.startObject("metric_field");
@@ -1193,6 +1223,19 @@ public class StarTreeMapperTests extends MapperTestCase {
             b.endObject();
             b.startObject("keyword1");
             b.field("type", "keyword");
+            b.endObject();
+            b.startObject("name");
+            b.field("type", "text");
+            b.startObject("fields");
+            b.startObject("keyword1");
+            b.field("type", "keyword");
+            b.field("ignore_above", 512);
+            b.endObject();
+            b.startObject("keyword2");
+            b.field("type", "keyword");
+            b.field("ignore_above", 512);
+            b.endObject();
+            b.endObject();
             b.endObject();
             b.endObject();
         });


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adding support for multi-fields with star tree.
For example we'll be able to support `text_field.keyword` as part of star tree
```
"text_field": {
                "type": "text",
                "fields": {
                    "keyword": {
                        "type": "keyword",
                        "ignore_above": 512
                    }
                }
            }
```

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/18688
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
