### PR TITLE
Add Prudhvi Godithi (GH: prudhvigodithi) as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,7 +5,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 ## Current Maintainers
 
 | Maintainer        | GitHub ID                                               | Affiliation |
-| ----------------- | ------------------------------------------------------- | ----------- |
+|-------------------| ------------------------------------------------------- | ----------- |
 | Anas Alkouz       | [anasalkouz](https://github.com/anasalkouz)             | Amazon      |
 | Andrew Ross       | [andrross](https://github.com/andrross)                 | Amazon      |
 | Andriy Redko      | [reta](https://github.com/reta)                         | Independent |
@@ -28,6 +28,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Owais Kazi        | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
 | Pan Guixin        | [bugmakerrrrrr](https://github.com/bugmakerrrrrr)       | ByteDance   |
 | Peter Nied        | [peternied](https://github.com/peternied)               | Amazon      |
+| Prudhvi Godithi   | [prudhvigodithi](https://github.com/prudhvigodithi)               | Amazon      |
 | Rishabh Maurya    | [rishabhmaurya](https://github.com/rishabhmaurya)       | Amazon      |
 | Rishikesh Pasham  | [Rishikesh1159](https://github.com/Rishikesh1159)       | Amazon      |
 | Sachin Kale       | [sachinpkale](https://github.com/sachinpkale)           | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -28,7 +28,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Owais Kazi        | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
 | Pan Guixin        | [bugmakerrrrrr](https://github.com/bugmakerrrrrr)       | ByteDance   |
 | Peter Nied        | [peternied](https://github.com/peternied)               | Amazon      |
-| Prudhvi Godithi   | [prudhvigodithi](https://github.com/prudhvigodithi)               | Amazon      |
+| Prudhvi Godithi   | [prudhvigodithi](https://github.com/prudhvigodithi)     | Amazon      |
 | Rishabh Maurya    | [rishabhmaurya](https://github.com/rishabhmaurya)       | Amazon      |
 | Rishikesh Pasham  | [Rishikesh1159](https://github.com/Rishikesh1159)       | Amazon      |
 | Sachin Kale       | [sachinpkale](https://github.com/sachinpkale)           | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,7 +5,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 ## Current Maintainers
 
 | Maintainer        | GitHub ID                                               | Affiliation |
-|-------------------| ------------------------------------------------------- | ----------- |
+| ----------------- | ------------------------------------------------------- | ----------- |
 | Anas Alkouz       | [anasalkouz](https://github.com/anasalkouz)             | Amazon      |
 | Andrew Ross       | [andrross](https://github.com/andrross)                 | Amazon      |
 | Andriy Redko      | [reta](https://github.com/reta)                         | Independent |


### PR DESCRIPTION
Following the [nomination process](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer), I have nominated and other maintainers have agreed to add [prudhvigodithi](https://github.com/prudhvigodithi) as a co-maintainer of the OpenSearch repository. He has kindly accepted the invitation.

Prudhvi has been an excellent steward of the OpenSearch Project as a whole through his work on engineering efficiency and has been trusted as an admin for the project for the last few years. More recently, Prudhvi has been contributing in significant ways to the core repo through code contributions, reviews, opening up issues and engaging with the OpenSearch community on issues.
 
Prudhvi has been a contributor since 2022 and has 48 PRs merged into the core repo that include features like Reader-Writer separation, bug fixes, search enhancements and improvements to the build for OpenSearch.
 
See all code contributions (Open + Closed) from Prudhvi here: https://github.com/opensearch-project/opensearch/commits?author=prudhvigodithi
 
Some notable contributions include:
 
- Search only replicas (scale to zero) with Reader/Writer Separation: https://github.com/opensearch-project/OpenSearch/pull/17299
- Approximation Framework Enhancement: Update the BKD traversal logic to improve the performance on skewed data: https://github.com/opensearch-project/OpenSearch/pull/18439
- Created opensearch.pluginzip gradle plugin to simplify plugin zip publishing across the plugins: https://github.com/opensearch-project/OpenSearch/pull/2988
- Improve sort-query performance by retaining the default totalHitsThreshold for approximated match_all queries: https://github.com/opensearch-project/OpenSearch/pull/18189
- Engineering efficiency improvements:
  - Add ability to run Code Coverage locally with Gradle: https://github.com/opensearch-project/OpenSearch/pull/18509
  - Gradle check metrics dashboard: https://github.com/opensearch-project/OpenSearch/pull/13919
- Many flaky test fixes: https://github.com/opensearch-project/OpenSearch/pull/17866, https://github.com/opensearch-project/OpenSearch/pull/18235, https://github.com/opensearch-project/OpenSearch/pull/17848
- JPMS Support:
  - Refactor the codebase to eliminate top level split packages: https://github.com/opensearch-project/OpenSearch/pull/17153
  - Refactor :libs module bootstrap package to eliminate top level split packages: https://github.com/opensearch-project/OpenSearch/pull/17117
 
Prudhvi actively engages in code reviews for community contributions and in total has engaged on 114 PRs as a reviewer.
 
See all PRs where Prudhvi has engaged as a commenter: https://github.com/opensearch-project/opensearch/pulls?q=is%3Apr+commenter%3Aprudhvigodithi
 
Some recent review examples:
 
- https://github.com/opensearch-project/OpenSearch/pull/18511
- https://github.com/opensearch-project/OpenSearch/pull/18337
- https://github.com/opensearch-project/OpenSearch/pull/3656
 
Prudhvi also routinely opens up issues on the OpenSearch repo with valuable feature requests and reports of deficiencies (20 in total):
 
See issues submitted by Prudhvi here: https://github.com/opensearch-project/OpenSearch/issues?q=is%3Aissue+author%3Aprudhvigodithi
 
Notable issue submissions include:
 
- Add additional details on Gradle Check failures autocut issues: https://github.com/opensearch-project/OpenSearch/issues/13950
- Integration/BWC tests for OpenSearch native plugins: https://github.com/opensearch-project/OpenSearch/issues/5208
- [BUG] Range query with now on date fields skips Approximation Path: https://github.com/opensearch-project/OpenSearch/issues/18503
- [Feature Request] Approximation Framework for queries with search_after: https://github.com/opensearch-project/OpenSearch/issues/18546
 
Prudhvi regularly contributes to conversation on Github issues (including RFCs). In total, Prudhvi has engaged on 89 issues on the core repo:
 
See all issues where Prudhvi has engaged as a commenter: https://github.com/opensearch-project/opensearch/issues?q=is%3Aissue+commenter%3Aprudhvigodithi
 
Additionally, Prudhvi is active in the community as an admin for the project. Find blog posts that Prudhvi has authored here: https://opensearch.org/author/prudhvi-godithi/