### PR TITLE
[Approximation Framework] Extend approximation to single clause boolean queries

### DIFF
--- a/server/src/main/java/org/opensearch/index/query/BoolQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/BoolQueryBuilder.java
@@ -51,6 +51,8 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.search.approximate.ApproximateBooleanQuery;
+import org.opensearch.search.approximate.ApproximateScoreQuery;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -344,7 +346,12 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
         }
 
         Query query = Queries.applyMinimumShouldMatch(booleanQuery, minimumShouldMatch);
-        return adjustPureNegative ? fixNegativeQueryIfNeeded(query) : query;
+
+        if (adjustPureNegative) {
+            query = fixNegativeQueryIfNeeded(query);
+        }
+
+        return new ApproximateScoreQuery(query, new ApproximateBooleanQuery((BooleanQuery) query));
     }
 
     private static void addBooleanClauses(

--- a/server/src/main/java/org/opensearch/search/approximate/ApproximateBooleanQuery.java
+++ b/server/src/main/java/org/opensearch/search/approximate/ApproximateBooleanQuery.java
@@ -26,17 +26,15 @@ import java.util.List;
 public class ApproximateBooleanQuery extends ApproximateQuery {
     public final BooleanQuery boolQuery;
     private final int size;
-    private final SortOrder sortOrder;
     private final List<BooleanClause> clauses;
 
     public ApproximateBooleanQuery(BooleanQuery boolQuery) {
-        this(boolQuery, SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO, null);
+        this(boolQuery, SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO);
     }
 
-    protected ApproximateBooleanQuery(BooleanQuery boolQuery, int size, SortOrder sortOrder) {
+    protected ApproximateBooleanQuery(BooleanQuery boolQuery, int size) {
         this.boolQuery = boolQuery;
         this.size = size;
-        this.sortOrder = sortOrder;
         this.clauses = boolQuery.clauses();
     }
 
@@ -105,7 +103,7 @@ public class ApproximateBooleanQuery extends ApproximateQuery {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ApproximateBooleanQuery that = (ApproximateBooleanQuery) o;
-        return size == that.size && sortOrder == that.sortOrder && boolQuery.equals(that.boolQuery);
+        return size == that.size && boolQuery.equals(that.boolQuery);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/approximate/ApproximateBooleanQuery.java
+++ b/server/src/main/java/org/opensearch/search/approximate/ApproximateBooleanQuery.java
@@ -26,7 +26,6 @@ public class ApproximateBooleanQuery extends ApproximateQuery {
     public final BooleanQuery boolQuery;
     private final int size;
     private final List<BooleanClause> clauses;
-    private SearchContext context;
 
     public ApproximateBooleanQuery(BooleanQuery boolQuery) {
         this(boolQuery, SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO);
@@ -40,8 +39,6 @@ public class ApproximateBooleanQuery extends ApproximateQuery {
 
     @Override
     protected boolean canApproximate(SearchContext context) {
-        // Store the context for use in rewrite
-        this.context = context;
 
         if (context == null) {
             return false;
@@ -62,8 +59,9 @@ public class ApproximateBooleanQuery extends ApproximateQuery {
             BooleanClause singleClause = clauses.get(0);
             Query clauseQuery = singleClause.query();
 
-            // If the clause is already an ApproximateScoreQuery, we can approximate
-            if (clauseQuery instanceof ApproximateScoreQuery) {
+            // If the clause is already an ApproximateScoreQuery, we can approximate + set context
+            if (clauseQuery instanceof ApproximateScoreQuery approximateScoreQuery) {
+                approximateScoreQuery.setContext(context);
                 return true;
             }
         }
@@ -80,12 +78,6 @@ public class ApproximateBooleanQuery extends ApproximateQuery {
 
             // If the single clause is an ApproximateScoreQuery, set its context
             if (clauseQuery instanceof ApproximateScoreQuery approximateQuery) {
-
-                // If we have a context, set it on the query
-                if (context != null) {
-                    approximateQuery.setContext(context);
-                }
-
                 return approximateQuery;
             }
 

--- a/server/src/main/java/org/opensearch/search/approximate/ApproximateBooleanQuery.java
+++ b/server/src/main/java/org/opensearch/search/approximate/ApproximateBooleanQuery.java
@@ -79,8 +79,7 @@ public class ApproximateBooleanQuery extends ApproximateQuery {
             Query clauseQuery = singleClause.query();
 
             // If the single clause is an ApproximateScoreQuery, set its context
-            if (clauseQuery instanceof ApproximateScoreQuery) {
-                ApproximateScoreQuery approximateQuery = (ApproximateScoreQuery) clauseQuery;
+            if (clauseQuery instanceof ApproximateScoreQuery approximateQuery) {
 
                 // If we have a context, set it on the query
                 if (context != null) {

--- a/server/src/main/java/org/opensearch/search/approximate/ApproximateBooleanQuery.java
+++ b/server/src/main/java/org/opensearch/search/approximate/ApproximateBooleanQuery.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.approximate;
+
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.QueryVisitor;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.sort.SortOrder;
+
+import java.util.List;
+
+public class ApproximateBooleanQuery extends ApproximateQuery {
+    public final BooleanQuery boolQuery;
+    private final int size;
+    private final SortOrder sortOrder;
+    private final List<BooleanClause> clauses;
+
+    public ApproximateBooleanQuery(BooleanQuery boolQuery) {
+        this(boolQuery, SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO, null);
+    }
+
+    protected ApproximateBooleanQuery(BooleanQuery boolQuery, int size, SortOrder sortOrder) {
+        this.boolQuery = boolQuery;
+        this.size = size;
+        this.sortOrder = sortOrder;
+        this.clauses = boolQuery.clauses();
+    }
+
+    @Override
+    protected boolean canApproximate(SearchContext context) {
+        return false;
+    }
+
+    @Override
+    public String toString(String s) {
+        return "ApproximateBooleanQuery(" + boolQuery.toString(s) + ")";
+    }
+
+    @Override
+    public void visit(QueryVisitor queryVisitor) {
+        boolQuery.visit(queryVisitor);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ApproximateBooleanQuery that = (ApproximateBooleanQuery) o;
+        return size == that.size && sortOrder == that.sortOrder && boolQuery.equals(that.boolQuery);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = boolQuery.hashCode();
+        result = 31 * result + size;
+        result = 31 * result + (sortOrder != null ? sortOrder.hashCode() : 0);
+        return result;
+    }
+}


### PR DESCRIPTION
### Description
Implements ApproximateBooleanQuery which flattens and rewrites to single clause queries at the OpenSearch level and applies approximation if possible.

### Related Issues
Resolves #18692

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
