### PR TITLE
[fixes #16599] Field-level `ignore_malformed` should override index-level setting

### DIFF
--- a/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/ScaledFloatFieldMapper.java
@@ -395,8 +395,9 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
         return coerce.value();
     }
 
-    boolean ignoreMalformed() {
-        return ignoreMalformed.value();
+    @Override
+    protected Explicit<Boolean> ignoreMalformed() {
+        return ignoreMalformed;
     }
 
     @Override

--- a/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldMapperTests.java
@@ -90,7 +90,7 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
         checker.registerUpdateCheck(b -> b.field("coerce", false), m -> assertFalse(((ScaledFloatFieldMapper) m).coerce()));
         checker.registerUpdateCheck(
             b -> b.field("ignore_malformed", true),
-            m -> assertTrue(((ScaledFloatFieldMapper) m).ignoreMalformed())
+            m -> assertTrue(((ScaledFloatFieldMapper) m).ignoreMalformed().value())
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -452,7 +452,8 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
         }
     }
 
-    public Explicit<Boolean> ignoreMalformed() {
+    @Override
+    protected Explicit<Boolean> ignoreMalformed() {
         return ignoreMalformed;
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
@@ -51,6 +51,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.Version;
+import org.opensearch.common.Explicit;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.logging.DeprecationLogger;
@@ -103,7 +104,7 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
         private final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).stored, false);
 
-        private final Parameter<Boolean> ignoreMalformed;
+        private final Parameter<Explicit<Boolean>> ignoreMalformed;
         private final Parameter<String> nullValue = Parameter.stringParam("null_value", false, m -> toType(m).nullValueAsString, null)
             .acceptsNull();
 
@@ -116,7 +117,12 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
             super(name);
             this.ignoreMalformedByDefault = ignoreMalformedByDefault;
             this.indexCreatedVersion = indexCreatedVersion;
-            this.ignoreMalformed = Parameter.boolParam("ignore_malformed", true, m -> toType(m).ignoreMalformed, ignoreMalformedByDefault);
+            this.ignoreMalformed = Parameter.explicitBoolParam(
+                "ignore_malformed",
+                true,
+                m -> toType(m).ignoreMalformed,
+                ignoreMalformedByDefault
+            );
         }
 
         Builder nullValue(String nullValue) {
@@ -585,7 +591,7 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
     private final boolean indexed;
     private final boolean hasDocValues;
     private final boolean stored;
-    private final boolean ignoreMalformed;
+    private final Explicit<Boolean> ignoreMalformed;
 
     private final InetAddress nullValue;
     private final String nullValueAsString;
@@ -605,7 +611,8 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
         this.indexCreatedVersion = builder.indexCreatedVersion;
     }
 
-    boolean ignoreMalformed() {
+    @Override
+    protected Explicit<Boolean> ignoreMalformed() {
         return ignoreMalformed;
     }
 
@@ -649,7 +656,7 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
             try {
                 address = InetAddresses.forString(addressAsString);
             } catch (IllegalArgumentException e) {
-                if (ignoreMalformed) {
+                if (ignoreMalformed().value()) {
                     context.addIgnoredField(fieldType().name());
                     return;
                 } else {

--- a/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
@@ -1886,8 +1886,9 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
         return coerce.value();
     }
 
-    boolean ignoreMalformed() {
-        return ignoreMalformed.value();
+    @Override
+    protected Explicit<Boolean> ignoreMalformed() {
+        return ignoreMalformed;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RangeFieldMapper.java
@@ -135,7 +135,7 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
         private final RangeType type;
         private final Version indexCreatedVersion;
         private final boolean ignoreMalformedByDefault;
-        private final Parameter<Boolean> ignoreMalformed;
+        private final Parameter<Explicit<Boolean>> ignoreMalformed;
 
         public Builder(String name, RangeType type, Settings settings) {
             this(
@@ -163,7 +163,12 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
             this.coerce = Parameter.explicitBoolParam("coerce", true, m -> toType(m).coerce, coerceByDefault);
             this.indexCreatedVersion = indexCreatedVersion;
             this.ignoreMalformedByDefault = ignoreMalformedByDefault;
-            this.ignoreMalformed = Parameter.boolParam("ignore_malformed", true, m -> toType(m).ignoreMalformed, ignoreMalformedByDefault);
+            this.ignoreMalformed = Parameter.explicitBoolParam(
+                "ignore_malformed",
+                true,
+                m -> toType(m).ignoreMalformed,
+                ignoreMalformedByDefault
+            );
             if (this.type != RangeType.DATE) {
                 format.neverSerialize();
                 locale.neverSerialize();
@@ -414,7 +419,7 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
 
     private final boolean coerceByDefault;
     private final Version indexCreatedVersion;
-    private final boolean ignoreMalformed;
+    private final Explicit<Boolean> ignoreMalformed;
     private final boolean ignoreMalformedByDefault;
 
     private RangeFieldMapper(
@@ -515,7 +520,7 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
                             }
                         } catch (final IllegalArgumentException e) {
                             // We have to consume the JSON object in full
-                            if (ignoreMalformed) {
+                            if (ignoreMalformed().value()) {
                                 rangeIsMalformed = true;
                             } else {
                                 throw e;
@@ -534,7 +539,7 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
                 try {
                     range = parseIpRangeFromCidr(parser);
                 } catch (IllegalArgumentException e) {
-                    if (ignoreMalformed) {
+                    if (ignoreMalformed().value()) {
                         context.addIgnoredField(fieldType().name());
                         return;
                     } else {
@@ -569,6 +574,11 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
         } catch (UnknownHostException bogus) {
             throw new AssertionError(bogus);
         }
+    }
+
+    @Override
+    protected Explicit<Boolean> ignoreMalformed() {
+        return ignoreMalformed;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
@@ -91,7 +91,10 @@ public class DateFieldMapperTests extends MapperTestCase {
         checker.registerConflictCheck("print_format", b -> b.field("print_format", "yyyy-MM-dd"));
         checker.registerConflictCheck("locale", b -> b.field("locale", "es"));
         checker.registerConflictCheck("null_value", b -> b.field("null_value", "34500000"));
-        checker.registerUpdateCheck(b -> b.field("ignore_malformed", true), m -> assertTrue(((DateFieldMapper) m).getIgnoreMalformed()));
+        checker.registerUpdateCheck(
+            b -> b.field("ignore_malformed", true),
+            m -> assertTrue(((DateFieldMapper) m).ignoreMalformed().value())
+        );
         checker.registerUpdateCheck(b -> b.field("boost", 2.0), m -> assertEquals(m.fieldType().boost(), 2.0, 0));
     }
 

--- a/server/src/test/java/org/opensearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/IpFieldMapperTests.java
@@ -76,7 +76,10 @@ public class IpFieldMapperTests extends MapperTestCase {
         checker.registerConflictCheck("index", b -> b.field("index", false));
         checker.registerConflictCheck("store", b -> b.field("store", true));
         checker.registerConflictCheck("null_value", b -> b.field("null_value", "::1"));
-        checker.registerUpdateCheck(b -> b.field("ignore_malformed", false), m -> assertFalse(((IpFieldMapper) m).ignoreMalformed()));
+        checker.registerUpdateCheck(
+            b -> b.field("ignore_malformed", false),
+            m -> assertFalse(((IpFieldMapper) m).ignoreMalformed().value())
+        );
     }
 
     public void testExistsQueryDocValuesDisabled() throws IOException {


### PR DESCRIPTION
### Description
There are 9 types of fields that support setting of `ignore_malformed` property, see the table below.

The current logic checks for the index level `FieldMapper.IGNORE_MALFORMED_SETTING` in `catch` section in `parse(ParseContext context)` in the `FieldMapper` class. The current implementation has no visibility into field level settings.

The proposed changes adding an ability for `FieldMapper` to get access field-level setting via `ignoreMalformed()` method. 


| Type | Controlling class |
| --- | --- |
| `ip` | `IpFieldMapper` |
| `ip_range` | `RangeFieldMapper` |
| `geo_point` | `AbstractGeometryFieldMapper` |
| `geo_shape` | `AbstractGeometryFieldMapper` |
| `xy_point` | `AbstractGeometryFieldMapper` |
| `xy_shape` | `AbstractGeometryFieldMapper` |
| numerics | `NumberFieldMapper`, `ScaledFloatFieldMapper` |
| `derived` | `DerivedFieldMapper` |
| `date` | `DateFieldMapper` |

### Related Issues
Resolves #16599

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
