### PR TITLE
`Lucene.java` Code Improvement

### DIFF
--- a/server/src/main/java/org/opensearch/common/lucene/Lucene.java
+++ b/server/src/main/java/org/opensearch/common/lucene/Lucene.java
@@ -358,62 +358,40 @@ public class Lucene {
         Comparable[] cFields = new Comparable[in.readVInt()];
         for (int j = 0; j < cFields.length; j++) {
             byte type = in.readByte();
-            if (type == 0) {
-                cFields[j] = null;
-            } else if (type == 1) {
-                cFields[j] = in.readString();
-            } else if (type == 2) {
-                cFields[j] = in.readInt();
-            } else if (type == 3) {
-                cFields[j] = in.readLong();
-            } else if (type == 4) {
-                cFields[j] = in.readFloat();
-            } else if (type == 5) {
-                cFields[j] = in.readDouble();
-            } else if (type == 6) {
-                cFields[j] = in.readByte();
-            } else if (type == 7) {
-                cFields[j] = in.readShort();
-            } else if (type == 8) {
-                cFields[j] = in.readBoolean();
-            } else if (type == 9) {
-                cFields[j] = in.readBytesRef();
-            } else if (type == 10) {
-                cFields[j] = new BigInteger(in.readString());
-            } else {
-                throw new IOException("Can't match type [" + type + "]");
-            }
+            cFields[j] = switch (type) {
+                case 0 -> null;
+                case 1 -> in.readString();
+                case 2 -> in.readInt();
+                case 3 -> in.readLong();
+                case 4 -> in.readFloat();
+                case 5 -> in.readDouble();
+                case 6 -> in.readByte();
+                case 7 -> in.readShort();
+                case 8 -> in.readBoolean();
+                case 9 -> in.readBytesRef();
+                case 10 -> new BigInteger(in.readString());
+                default -> throw new IOException("Can't match type [" + type + "]");
+            };
         }
         return new FieldDoc(in.readVInt(), in.readFloat(), cFields);
     }
 
     public static Comparable readSortValue(StreamInput in) throws IOException {
         byte type = in.readByte();
-        if (type == 0) {
-            return null;
-        } else if (type == 1) {
-            return in.readString();
-        } else if (type == 2) {
-            return in.readInt();
-        } else if (type == 3) {
-            return in.readLong();
-        } else if (type == 4) {
-            return in.readFloat();
-        } else if (type == 5) {
-            return in.readDouble();
-        } else if (type == 6) {
-            return in.readByte();
-        } else if (type == 7) {
-            return in.readShort();
-        } else if (type == 8) {
-            return in.readBoolean();
-        } else if (type == 9) {
-            return in.readBytesRef();
-        } else if (type == 10) {
-            return new BigInteger(in.readString());
-        } else {
-            throw new IOException("Can't match type [" + type + "]");
-        }
+        return switch (type) {
+            case 0 -> null;
+            case 1 -> in.readString();
+            case 2 -> in.readInt();
+            case 3 -> in.readLong();
+            case 4 -> in.readFloat();
+            case 5 -> in.readDouble();
+            case 6 -> in.readByte();
+            case 7 -> in.readShort();
+            case 8 -> in.readBoolean();
+            case 9 -> in.readBytesRef();
+            case 10 -> new BigInteger(in.readString());
+            default -> throw new IOException("Can't match type [" + type + "]");
+        };
     }
 
     public static ScoreDoc readScoreDoc(StreamInput in) throws IOException {

--- a/server/src/main/java/org/opensearch/common/lucene/Lucene.java
+++ b/server/src/main/java/org/opensearch/common/lucene/Lucene.java
@@ -357,26 +357,23 @@ public class Lucene {
     public static FieldDoc readFieldDoc(StreamInput in) throws IOException {
         Comparable[] cFields = new Comparable[in.readVInt()];
         for (int j = 0; j < cFields.length; j++) {
-            byte type = in.readByte();
-            cFields[j] = switch (type) {
-                case 0 -> null;
-                case 1 -> in.readString();
-                case 2 -> in.readInt();
-                case 3 -> in.readLong();
-                case 4 -> in.readFloat();
-                case 5 -> in.readDouble();
-                case 6 -> in.readByte();
-                case 7 -> in.readShort();
-                case 8 -> in.readBoolean();
-                case 9 -> in.readBytesRef();
-                case 10 -> new BigInteger(in.readString());
-                default -> throw new IOException("Can't match type [" + type + "]");
-            };
+            cFields[j] = readTypedValue(in);
         }
         return new FieldDoc(in.readVInt(), in.readFloat(), cFields);
     }
 
     public static Comparable readSortValue(StreamInput in) throws IOException {
+        return readTypedValue(in);
+    }
+
+    /**
+     * Reads a typed value from the stream based on a type byte prefix.
+     *
+     * @param in the input stream
+     * @return the deserialized Comparable value
+     * @throws IOException if reading fails or type is unknown
+     */
+    private static Comparable readTypedValue(StreamInput in) throws IOException {
         byte type = in.readByte();
         return switch (type) {
             case 0 -> null;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Initially this default if-else code was identified by @expani. The existing `readFieldDoc` and `readSortValue` are used at the transport layer. This code change when compiled creates a `tableswitch` which Jumps directly to the corresponding code location.

Not modifying the `writeSortValue` to pattern matching switch as from my understanding `tableswitch` only works with integer primitives.

### Related Issues
N/A.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
