### PR TITLE
[Workload Management] Rename QueryGroup to WorkloadGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add support for custom index name resolver from cluster plugin ([#18593](https://github.com/opensearch-project/OpenSearch/pull/18593))
 - Disallow resize for Warm Index, add Parameterized ITs for close in remote store ([#18686](https://github.com/opensearch-project/OpenSearch/pull/18686))
 - Ability to run Code Coverage with Gradle and produce the jacoco reports locally ([#18509](https://github.com/opensearch-project/OpenSearch/issues/18509))
+- [Workload Management] Update logging and Javadoc, rename QueryGroup to WorkloadGroup ([#18711](https://github.com/opensearch-project/OpenSearch/issues/18711))
 - Add NodeResourceUsageStats to ClusterInfo ([#18480](https://github.com/opensearch-project/OpenSearch/issues/18472))
 - Introduce SecureHttpTransportParameters experimental API (to complement SecureTransportParameters counterpart) ([#18572](https://github.com/opensearch-project/OpenSearch/issues/18572))
 - Create equivalents of JSM's AccessController in the java agent ([#18346](https://github.com/opensearch-project/OpenSearch/issues/18346))

--- a/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/autotagging/Rule.java
+++ b/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/autotagging/Rule.java
@@ -31,7 +31,7 @@ import java.util.Set;
  * of a rule. The indexed view may differ in representation.
  * {
  *     "id": "fwehf8302582mglfio349==",
- *     "description": "Assign Query Group for Index Logs123"
+ *     "description": "Assign Workload Group for Index Logs123"
  *     "index_pattern": ["logs123"],
  *     "workload_group": "dev_workload_group_id",
  *     "updated_at": "01-10-2025T21:23:21.456Z"

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/action/package-info.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/action/package-info.java
@@ -7,6 +7,6 @@
  */
 
 /**
- * Package for the action classes related to query groups in WorkloadManagementPlugin
+ * Package for the action classes related to workload groups in WorkloadManagementPlugin
  */
 package org.opensearch.plugin.wlm.action;

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rest/package-info.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rest/package-info.java
@@ -7,6 +7,6 @@
  */
 
 /**
- * Package for the rest classes related to query groups in WorkloadManagementPlugin
+ * Package for the rest classes related to workload groups in WorkloadManagementPlugin
  */
 package org.opensearch.plugin.wlm.rest;

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/service/WorkloadGroupPersistenceService.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/service/WorkloadGroupPersistenceService.java
@@ -54,7 +54,7 @@ public class WorkloadGroupPersistenceService {
     /**
      *  max WorkloadGroup count setting name
      */
-    public static final String QUERY_GROUP_COUNT_SETTING_NAME = "node.workload_group.max_count";
+    public static final String WORKLOAD_GROUP_COUNT_SETTING_NAME = "node.workload_group.max_count";
     /**
      * default max workloadGroup count on any node at any given point in time
      */
@@ -67,7 +67,7 @@ public class WorkloadGroupPersistenceService {
      *  max WorkloadGroup count setting
      */
     public static final Setting<Integer> MAX_QUERY_GROUP_COUNT = Setting.intSetting(
-        QUERY_GROUP_COUNT_SETTING_NAME,
+        WORKLOAD_GROUP_COUNT_SETTING_NAME,
         DEFAULT_MAX_QUERY_GROUP_COUNT_VALUE,
         0,
         WorkloadGroupPersistenceService::validateMaxWorkloadGroupCount,
@@ -116,7 +116,7 @@ public class WorkloadGroupPersistenceService {
      */
     private static void validateMaxWorkloadGroupCount(int maxWorkloadGroupCount) {
         if (maxWorkloadGroupCount > DEFAULT_MAX_QUERY_GROUP_COUNT_VALUE || maxWorkloadGroupCount < MIN_QUERY_GROUP_COUNT_VALUE) {
-            throw new IllegalArgumentException(QUERY_GROUP_COUNT_SETTING_NAME + " should be in range [1-100].");
+            throw new IllegalArgumentException(WORKLOAD_GROUP_COUNT_SETTING_NAME + " should be in range [1-100].");
         }
     }
 
@@ -162,7 +162,7 @@ public class WorkloadGroupPersistenceService {
 
         // check if maxWorkloadGroupCount will breach
         if (existingWorkloadGroups.size() == maxWorkloadGroupCount) {
-            logger.warn("{} value exceeded its assigned limit of {}.", QUERY_GROUP_COUNT_SETTING_NAME, maxWorkloadGroupCount);
+            logger.warn("{} value exceeded its assigned limit of {}.", WORKLOAD_GROUP_COUNT_SETTING_NAME, maxWorkloadGroupCount);
             throw new IllegalStateException("Can't create more than " + maxWorkloadGroupCount + " WorkloadGroups in the system.");
         }
 

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/service/package-info.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/service/package-info.java
@@ -7,6 +7,6 @@
  */
 
 /**
- * Package for the service classes related to query groups in WorkloadManagementPlugin
+ * Package for the service classes related to workload groups in WorkloadManagementPlugin
  */
 package org.opensearch.plugin.wlm.service;

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/WorkloadManagementPluginTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/WorkloadManagementPluginTests.java
@@ -138,7 +138,7 @@ public class WorkloadManagementPluginTests extends OpenSearchTestCase {
         assertEquals("workload_group", featureType.getName());
     }
 
-    public void testGetSettingsIncludesMaxQueryGroupCount() {
+    public void testGetSettingsIncludesMaxWorkloadGroupCount() {
         List<?> settings = plugin.getSettings();
         assertTrue(settings.contains(WorkloadGroupPersistenceService.MAX_QUERY_GROUP_COUNT));
     }

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/service/WorkloadGroupPersistenceServiceTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/service/WorkloadGroupPersistenceServiceTests.java
@@ -59,8 +59,8 @@ import static org.opensearch.plugin.wlm.WorkloadGroupTestUtils.workloadGroupOne;
 import static org.opensearch.plugin.wlm.WorkloadGroupTestUtils.workloadGroupPersistenceService;
 import static org.opensearch.plugin.wlm.WorkloadGroupTestUtils.workloadGroupTwo;
 import static org.opensearch.plugin.wlm.action.WorkloadGroupActionTestUtils.updateWorkloadGroupRequest;
-import static org.opensearch.plugin.wlm.service.WorkloadGroupPersistenceService.QUERY_GROUP_COUNT_SETTING_NAME;
 import static org.opensearch.plugin.wlm.service.WorkloadGroupPersistenceService.SOURCE;
+import static org.opensearch.plugin.wlm.service.WorkloadGroupPersistenceService.WORKLOAD_GROUP_COUNT_SETTING_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyString;
@@ -155,7 +155,7 @@ public class WorkloadGroupPersistenceServiceTests extends OpenSearchTestCase {
             .updatedAt(1690934400000L)
             .build();
         Metadata metadata = Metadata.builder().workloadGroups(Map.of(_ID_ONE, workloadGroupOne, _ID_TWO, workloadGroupTwo)).build();
-        Settings settings = Settings.builder().put(QUERY_GROUP_COUNT_SETTING_NAME, 2).build();
+        Settings settings = Settings.builder().put(WORKLOAD_GROUP_COUNT_SETTING_NAME, 2).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings, clusterSettingsSet());
         ClusterService clusterService = new ClusterService(settings, clusterSettings, mock(ThreadPool.class));
         ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).metadata(metadata).build();
@@ -174,7 +174,7 @@ public class WorkloadGroupPersistenceServiceTests extends OpenSearchTestCase {
      * Tests the invalid value of {@code node.workload_group.max_count}
      */
     public void testInvalidMaxWorkloadGroupCount() {
-        Settings settings = Settings.builder().put(QUERY_GROUP_COUNT_SETTING_NAME, 2).build();
+        Settings settings = Settings.builder().put(WORKLOAD_GROUP_COUNT_SETTING_NAME, 2).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings, clusterSettingsSet());
         ClusterService clusterService = new ClusterService(settings, clusterSettings, mock(ThreadPool.class));
         WorkloadGroupPersistenceService workloadGroupPersistenceService = new WorkloadGroupPersistenceService(
@@ -189,7 +189,7 @@ public class WorkloadGroupPersistenceServiceTests extends OpenSearchTestCase {
      * Tests the valid value of {@code node.workload_group.max_count}
      */
     public void testValidMaxSandboxCountSetting() {
-        Settings settings = Settings.builder().put(QUERY_GROUP_COUNT_SETTING_NAME, 100).build();
+        Settings settings = Settings.builder().put(WORKLOAD_GROUP_COUNT_SETTING_NAME, 100).build();
         ClusterService clusterService = new ClusterService(settings, clusterSettings(), mock(ThreadPool.class));
         WorkloadGroupPersistenceService workloadGroupPersistenceService = new WorkloadGroupPersistenceService(
             clusterService,

--- a/server/src/main/java/org/opensearch/wlm/MutableWorkloadGroupFragment.java
+++ b/server/src/main/java/org/opensearch/wlm/MutableWorkloadGroupFragment.java
@@ -185,7 +185,7 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
 
     /**
      * This enum models the different WorkloadGroup resiliency modes
-     * SOFT - means that this query group can consume more than query group resource limits if node is not in duress
+     * SOFT - means that this workload group can consume more than workload group resource limits if node is not in duress
      * ENFORCED - means that it will never breach the assigned limits and will cancel as soon as the limits are breached
      * MONITOR - it will not cause any cancellation but just log the eligible task cancellations
      */

--- a/server/src/main/java/org/opensearch/wlm/WorkloadGroupService.java
+++ b/server/src/main/java/org/opensearch/wlm/WorkloadGroupService.java
@@ -139,7 +139,7 @@ public class WorkloadGroupService extends AbstractLifecycleComponent
             try {
                 doRun();
             } catch (Exception e) {
-                logger.debug("Exception occurred in Query Sandbox service", e);
+                logger.debug("Exception occurred in Workload Group service", e);
             }
         }, this.workloadManagementSettings.getWorkloadGroupServiceRunInterval(), ThreadPool.Names.GENERIC);
     }
@@ -160,26 +160,26 @@ public class WorkloadGroupService extends AbstractLifecycleComponent
         Metadata previousMetadata = event.previousState().metadata();
         Metadata currentMetadata = event.state().metadata();
 
-        // Extract the query groups from both the current and previous cluster states
+        // Extract the workload groups from both the current and previous cluster states
         Map<String, WorkloadGroup> previousWorkloadGroups = previousMetadata.workloadGroups();
         Map<String, WorkloadGroup> currentWorkloadGroups = currentMetadata.workloadGroups();
 
-        // Detect new query groups added in the current cluster state
+        // Detect new workload groups added in the current cluster state
         for (String workloadGroupName : currentWorkloadGroups.keySet()) {
             if (!previousWorkloadGroups.containsKey(workloadGroupName)) {
-                // New query group detected
+                // New workload group detected
                 WorkloadGroup newWorkloadGroup = currentWorkloadGroups.get(workloadGroupName);
-                // Perform any necessary actions with the new query group
+                // Perform any necessary actions with the new workload group
                 workloadGroupsStateAccessor.addNewWorkloadGroup(newWorkloadGroup.get_id());
             }
         }
 
-        // Detect query groups deleted in the current cluster state
+        // Detect workload groups deleted in the current cluster state
         for (String workloadGroupName : previousWorkloadGroups.keySet()) {
             if (!currentWorkloadGroups.containsKey(workloadGroupName)) {
-                // Query group deleted
+                // Workload group deleted
                 WorkloadGroup deletedWorkloadGroup = previousWorkloadGroups.get(workloadGroupName);
-                // Perform any necessary actions with the deleted query group
+                // Perform any necessary actions with the deleted workload group
                 this.deletedWorkloadGroups.add(deletedWorkloadGroup);
                 workloadGroupsStateAccessor.removeWorkloadGroup(deletedWorkloadGroup.get_id());
             }
@@ -188,13 +188,13 @@ public class WorkloadGroupService extends AbstractLifecycleComponent
     }
 
     /**
-     * updates the failure stats for the query group
+     * updates the failure stats for the workload group
      *
-     * @param workloadGroupId query group identifier
+     * @param workloadGroupId workload group identifier
      */
     public void incrementFailuresFor(final String workloadGroupId) {
         WorkloadGroupState workloadGroupState = workloadGroupsStateAccessor.getWorkloadGroupState(workloadGroupId);
-        // This can happen if the request failed for a deleted query group
+        // This can happen if the request failed for a deleted workload group
         // or new workloadGroup is being created and has not been acknowledged yet
         if (workloadGroupState == null) {
             return;
@@ -203,7 +203,7 @@ public class WorkloadGroupService extends AbstractLifecycleComponent
     }
 
     /**
-     * @return node level query group stats
+     * @return node level workload group stats
      */
     public WorkloadGroupStats nodeStats(Set<String> workloadGroupIds, Boolean requestedBreached) {
         final Map<String, WorkloadGroupStatsHolder> statsHolderMap = new HashMap<>();
@@ -250,7 +250,7 @@ public class WorkloadGroupService extends AbstractLifecycleComponent
     }
 
     /**
-     * @param workloadGroupId query group identifier
+     * @param workloadGroupId workload group identifier
      */
     public void rejectIfNeeded(String workloadGroupId) {
         if (workloadManagementSettings.getWlmMode() != WlmMode.ENABLED) {
@@ -260,8 +260,8 @@ public class WorkloadGroupService extends AbstractLifecycleComponent
         if (workloadGroupId == null || workloadGroupId.equals(WorkloadGroupTask.DEFAULT_WORKLOAD_GROUP_ID_SUPPLIER.get())) return;
         WorkloadGroupState workloadGroupState = workloadGroupsStateAccessor.getWorkloadGroupState(workloadGroupId);
 
-        // This can happen if the request failed for a deleted query group
-        // or new workloadGroup is being created and has not been acknowledged yet or invalid query group id
+        // This can happen if the request failed for a deleted workload group
+        // or new workloadGroup is being created and has not been acknowledged yet or invalid workload group id
         if (workloadGroupState == null) {
             return;
         }
@@ -348,7 +348,7 @@ public class WorkloadGroupService extends AbstractLifecycleComponent
         final WorkloadGroupTask workloadGroupTask = (WorkloadGroupTask) task;
         String workloadGroupId = workloadGroupTask.getWorkloadGroupId();
 
-        // set the default workloadGroupId if not existing in the active query groups
+        // set the default workloadGroupId if not existing in the active workload groups
         String finalWorkloadGroupId = workloadGroupId;
         boolean exists = activeWorkloadGroups.stream().anyMatch(workloadGroup -> workloadGroup.get_id().equals(finalWorkloadGroupId));
 

--- a/server/src/main/java/org/opensearch/wlm/WorkloadGroupsStateAccessor.java
+++ b/server/src/main/java/org/opensearch/wlm/WorkloadGroupsStateAccessor.java
@@ -31,7 +31,7 @@ public class WorkloadGroupsStateAccessor {
     }
 
     /**
-     * returns the query groups state
+     * returns the workload groups state
      */
     public Map<String, WorkloadGroupState> getWorkloadGroupStateMap() {
         return workloadGroupStateMap;
@@ -40,7 +40,7 @@ public class WorkloadGroupsStateAccessor {
     /**
      * return WorkloadGroupState for the given workloadGroupId
      * @param workloadGroupId
-     * @return WorkloadGroupState for the given workloadGroupId, if id is invalid return default query group state
+     * @return WorkloadGroupState for the given workloadGroupId, if id is invalid return default workload group state
      */
     public WorkloadGroupState getWorkloadGroupState(String workloadGroupId) {
         return workloadGroupStateMap.getOrDefault(

--- a/server/src/main/java/org/opensearch/wlm/WorkloadManagementSettings.java
+++ b/server/src/main/java/org/opensearch/wlm/WorkloadManagementSettings.java
@@ -49,13 +49,13 @@ public class WorkloadManagementSettings {
     );
 
     /**
-     * Setting name for Query Group Service run interval
+     * Setting name for Workload Group Service run interval
      */
     public static final String QUERYGROUP_ENFORCEMENT_INTERVAL_SETTING_NAME = "wlm.workload_group.enforcement_interval";
 
     private TimeValue workloadGroupServiceRunInterval;
     /**
-     * Setting to control the run interval of Query Group Service
+     * Setting to control the run interval of Workload Group Service
      */
     public static final Setting<Long> QUERYGROUP_SERVICE_RUN_INTERVAL_SETTING = Setting.longSetting(
         QUERYGROUP_ENFORCEMENT_INTERVAL_SETTING_NAME,

--- a/server/src/main/java/org/opensearch/wlm/stats/WorkloadGroupState.java
+++ b/server/src/main/java/org/opensearch/wlm/stats/WorkloadGroupState.java
@@ -15,26 +15,26 @@ import java.util.EnumMap;
 import java.util.Map;
 
 /**
- * This class will keep the point in time view of the query group stats
+ * This class will keep the point in time view of the workload group stats
  */
 public class WorkloadGroupState {
     /**
-     * co-ordinator level completions at the query group level, this is a cumulative counter since the Opensearch start time
+     * co-ordinator level completions at the workload group level, this is a cumulative counter since the Opensearch start time
      */
     public final CounterMetric totalCompletions = new CounterMetric();
 
     /**
-     * rejections at the query group level, this is a cumulative counter since the OpenSearch start time
+     * rejections at the workload group level, this is a cumulative counter since the OpenSearch start time
      */
     public final CounterMetric totalRejections = new CounterMetric();
 
     /**
-     * this will track the cumulative failures in a query group
+     * this will track the cumulative failures in a workload group
      */
     public final CounterMetric failures = new CounterMetric();
 
     /**
-     * This will track total number of cancellations in the query group due to all resource type breaches
+     * This will track total number of cancellations in the workload group due to all resource type breaches
      */
     public final CounterMetric totalCancellations = new CounterMetric();
 
@@ -54,7 +54,7 @@ public class WorkloadGroupState {
 
     /**
      *
-     * @return co-ordinator completions in the query group
+     * @return co-ordinator completions in the workload group
      */
     public long getTotalCompletions() {
         return totalCompletions.count();
@@ -62,7 +62,7 @@ public class WorkloadGroupState {
 
     /**
      *
-     * @return rejections in the query group
+     * @return rejections in the workload group
      */
     public long getTotalRejections() {
         return totalRejections.count();
@@ -70,7 +70,7 @@ public class WorkloadGroupState {
 
     /**
      *
-     * @return failures in the query group
+     * @return failures in the workload group
      */
     public long getFailures() {
         return failures.count();
@@ -81,15 +81,15 @@ public class WorkloadGroupState {
     }
 
     /**
-     * getter for query group resource state
-     * @return the query group resource state
+     * getter for workload group resource state
+     * @return the workload group resource state
      */
     public Map<ResourceType, ResourceTypeState> getResourceState() {
         return resourceState;
     }
 
     /**
-     * This class holds the resource level stats for the query group
+     * This class holds the resource level stats for the workload group
      */
     public static class ResourceTypeState {
         public final ResourceType resourceType;

--- a/server/src/main/java/org/opensearch/wlm/stats/WorkloadGroupStats.java
+++ b/server/src/main/java/org/opensearch/wlm/stats/WorkloadGroupStats.java
@@ -87,7 +87,7 @@ public class WorkloadGroupStats implements ToXContentObject, Writeable {
     }
 
     /**
-     * This is a stats holder object which will hold the data for a query group at a point in time
+     * This is a stats holder object which will hold the data for a workload group at a point in time
      * the instance will only be created on demand through stats api
      */
     public static class WorkloadGroupStatsHolder implements ToXContentObject, Writeable {

--- a/server/src/main/java/org/opensearch/wlm/stats/package-info.java
+++ b/server/src/main/java/org/opensearch/wlm/stats/package-info.java
@@ -7,6 +7,6 @@
  */
 
 /**
- * Query group stats related artifacts
+ * Workload group stats related artifacts
  */
 package org.opensearch.wlm.stats;

--- a/server/src/main/java/org/opensearch/wlm/tracker/CpuUsageCalculator.java
+++ b/server/src/main/java/org/opensearch/wlm/tracker/CpuUsageCalculator.java
@@ -14,7 +14,7 @@ import org.opensearch.wlm.WorkloadGroupTask;
 import java.util.List;
 
 /**
- * class to help make cpu usage calculations for the query group
+ * class to help make cpu usage calculations for the workload group
  */
 public class CpuUsageCalculator extends ResourceUsageCalculator {
     // This value should be initialised at the start time of the process and be used throughout the codebase

--- a/server/src/main/java/org/opensearch/wlm/tracker/MemoryUsageCalculator.java
+++ b/server/src/main/java/org/opensearch/wlm/tracker/MemoryUsageCalculator.java
@@ -15,7 +15,7 @@ import org.opensearch.wlm.WorkloadGroupTask;
 import java.util.List;
 
 /**
- * class to help make memory usage calculations for the query group
+ * class to help make memory usage calculations for the workload group
  */
 public class MemoryUsageCalculator extends ResourceUsageCalculator {
     public static final long HEAP_SIZE_BYTES = JvmStats.jvmStats().getMem().getHeapMax().getBytes();

--- a/server/src/main/java/org/opensearch/wlm/tracker/ResourceUsageCalculator.java
+++ b/server/src/main/java/org/opensearch/wlm/tracker/ResourceUsageCalculator.java
@@ -14,14 +14,14 @@ import org.opensearch.wlm.WorkloadGroupTask;
 import java.util.List;
 
 /**
- * This class is used to track query group level resource usage
+ * This class is used to track workload group level resource usage
  */
 @PublicApi(since = "2.18.0")
 public abstract class ResourceUsageCalculator {
     /**
-     * calculates the current resource usage for the query group
+     * calculates the current resource usage for the workload group
      *
-     * @param tasks        list of tasks in the query group
+     * @param tasks        list of tasks in the workload group
      */
     public abstract double calculateResourceUsage(List<WorkloadGroupTask> tasks);
 

--- a/server/src/test/java/org/opensearch/wlm/WorkloadGroupServiceTests.java
+++ b/server/src/test/java/org/opensearch/wlm/WorkloadGroupServiceTests.java
@@ -477,7 +477,7 @@ public class WorkloadGroupServiceTests extends OpenSearchTestCase {
         task.setWorkloadGroupId(mockThreadPool.getThreadContext());
         assertTrue(workloadGroupService.shouldSBPHandle(task));
 
-        // Valid query group task but wlm not enabled
+        // Valid workload group task but wlm not enabled
         when(mockWorkloadManagementSettings.getWlmMode()).thenReturn(WlmMode.DISABLED);
         activeWorkloadGroups.add(
             new WorkloadGroup(

--- a/server/src/test/java/org/opensearch/wlm/tracker/WorkloadGroupTaskResourceTrackingTests.java
+++ b/server/src/test/java/org/opensearch/wlm/tracker/WorkloadGroupTaskResourceTrackingTests.java
@@ -50,7 +50,7 @@ public class WorkloadGroupTaskResourceTrackingTests extends OpenSearchTestCase {
         WorkloadGroupTask task = new SearchTask(1, "test", "test", () -> "Test", TaskId.EMPTY_TASK_ID, new HashMap<>());
         taskResourceTrackingService.startTracking(task);
 
-        // since the query group id is not set we should not track this task
+        // since the workload group id is not set we should not track this task
         Map<String, WorkloadGroupLevelResourceUsageView> resourceUsageViewMap = workloadGroupResourceUsageTrackerService
             .constructWorkloadGroupLevelUsageViews();
         assertTrue(resourceUsageViewMap.isEmpty());


### PR DESCRIPTION
### Description
Renamed all remaining instances of QueryGroup to WorkloadGroup in code comments, Javadocs, and identifiers where applicable, to align with the current naming convention used in the workload management feature.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
