### PR TITLE
[Workload Management] Modify logging message in WorkloadGroupService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add last index request timestamp columns to the `_cat/indices` API. ([10766](https://github.com/opensearch-project/OpenSearch/issues/10766))
 - Introduce a new pull-based ingestion plugin for file-based indexing (for local testing) ([#18591](https://github.com/opensearch-project/OpenSearch/pull/18591))
 - Add support for search pipeline in search and msearch template ([#18564](https://github.com/opensearch-project/OpenSearch/pull/18564))
+- [Workload Management] Modify logging message in WorkloadGroupService ([#18712](https://github.com/opensearch-project/OpenSearch/pull/18712))
 - Add BooleanQuery rewrite moving constant-scoring must clauses to filter clauses ([#18510](https://github.com/opensearch-project/OpenSearch/issues/18510))
 - Add functionality for plugins to inject QueryCollectorContext during QueryPhase ([#18637](https://github.com/opensearch-project/OpenSearch/pull/18637))
 - Add support for non-timing info in profiler ([#18460](https://github.com/opensearch-project/OpenSearch/issues/18460))

--- a/server/src/main/java/org/opensearch/wlm/WorkloadGroupService.java
+++ b/server/src/main/java/org/opensearch/wlm/WorkloadGroupService.java
@@ -288,11 +288,15 @@ public class WorkloadGroupService extends AbstractLifecycleComponent
                     if (threshold < lastRecordedUsage) {
                         reject = true;
                         reason.append(resourceType)
-                            .append(" limit is breaching for ENFORCED type WorkloadGroup: (")
+                            .append(" limit is breaching for workload group ")
+                            .append(workloadGroup.get_id())
+                            .append(", ")
                             .append(threshold)
                             .append(" < ")
                             .append(lastRecordedUsage)
-                            .append("). ");
+                            .append(", wlm mode is ")
+                            .append(workloadGroup.getResiliencyMode())
+                            .append(". ");
                         workloadGroupState.getResourceState().get(resourceType).rejections.inc();
                         // should not double count even if both the resource limits are breaching
                         break;


### PR DESCRIPTION
### Description
This PR updated the rejection reason logging in rejectIfNeeded to dynamically include the actual resiliency mode (SOFT or ENFORCED) from the WorkloadGroup object, instead of hardcoding "ENFORCED". 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
