### PR TITLE
[merged segment warmer] support cleanup redundant pending merged segments

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
@@ -89,6 +89,7 @@ import org.opensearch.indices.DefaultRemoteStoreSettings;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.indices.replication.checkpoint.MergedSegmentPublisher;
+import org.opensearch.indices.replication.checkpoint.ReferencedSegmentsPublisher;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -731,7 +732,8 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
             () -> indexService.getIndexSettings().getRefreshInterval(),
             indexService.getRefreshMutex(),
             clusterService.getClusterApplierService(),
-            MergedSegmentPublisher.EMPTY
+            MergedSegmentPublisher.EMPTY,
+            ReferencedSegmentsPublisher.EMPTY
         );
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/MergedSegmentWarmerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/MergedSegmentWarmerIT.java
@@ -9,27 +9,34 @@
 package org.opensearch.indices.replication;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.store.Directory;
 import org.opensearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.opensearch.action.admin.indices.segments.IndexShardSegments;
 import org.opensearch.action.admin.indices.segments.IndicesSegmentResponse;
 import org.opensearch.action.admin.indices.segments.ShardSegments;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.set.Sets;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.TieredMergePolicyProvider;
 import org.opensearch.index.engine.Segment;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.ConnectTransportException;
 import org.opensearch.transport.TransportService;
 
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 
 /**
  * This class runs Segment Replication Integ test suite with merged segment warmer enabled.
@@ -173,6 +180,87 @@ public class MergedSegmentWarmerIT extends SegmentReplicationIT {
         client().admin().indices().forceMerge(new ForceMergeRequest(INDEX_NAME).maxNumSegments(1)).get();
         final IndicesSegmentResponse response = client().admin().indices().prepareSegments(INDEX_NAME).get();
         assertEquals(1, response.getIndices().get(INDEX_NAME).getShards().values().size());
+    }
+
+    // Construct a case with redundant pending merge segments in replica shard, and finally delete these files
+    public void testCleanupRedundantPendingMergeFile() throws Exception {
+        final String primaryNode = internalCluster().startDataOnlyNode();
+        createIndex(
+            INDEX_NAME,
+            Settings.builder()
+                .put(indexSettings())
+                .put(TieredMergePolicyProvider.INDEX_MERGE_POLICY_SEGMENTS_PER_TIER_SETTING.getKey(), 5)
+                .put(TieredMergePolicyProvider.INDEX_MERGE_POLICY_MAX_MERGE_AT_ONCE_SETTING.getKey(), 5)
+                .put(IndexSettings.INDEX_MERGE_ON_FLUSH_ENABLED.getKey(), false)
+                .build()
+        );
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        final String replicaNode = internalCluster().startDataOnlyNode();
+        ensureGreen(INDEX_NAME);
+
+        AtomicBoolean forceMergeComplete = new AtomicBoolean(false);
+        MockTransportService primaryTransportService = ((MockTransportService) internalCluster().getInstance(
+            TransportService.class,
+            primaryNode
+        ));
+
+        primaryTransportService.addSendBehavior(
+            internalCluster().getInstance(TransportService.class, replicaNode),
+            (connection, requestId, action, request, options) -> {
+                if (action.equals(SegmentReplicationTargetService.Actions.FILE_CHUNK)) {
+                    if (forceMergeComplete.get() == false) {
+                        logger.trace("mock connection exception");
+                        throw new ConnectTransportException(connection.getNode(), "mock connection exception");
+                    }
+
+                }
+                connection.sendRequest(requestId, action, request, options);
+            }
+        );
+
+        for (int i = 0; i < 30; i++) {
+            client().prepareIndex(INDEX_NAME)
+                .setId(String.valueOf(i))
+                .setSource("foo" + i, "bar" + i)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .get();
+        }
+
+        IndexShard replicaShard = getIndexShard(replicaNode, INDEX_NAME);
+        assertBusy(() -> assertFalse(replicaShard.getPendingMergeSegmentCheckpoints().isEmpty()));
+
+        client().admin().indices().forceMerge(new ForceMergeRequest(INDEX_NAME).maxNumSegments(1)).get();
+        forceMergeComplete.set(true);
+
+        // Verify replica shard has pending merged segments
+        assertBusy(() -> { assertFalse(replicaShard.getPendingMergeSegmentCheckpoints().isEmpty()); }, 1, TimeUnit.MINUTES);
+
+        waitForSegmentCount(INDEX_NAME, 1, logger);
+        primaryTransportService.clearAllRules();
+
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(INDEX_NAME)
+                .setSettings(
+                    Settings.builder()
+                        .put(IndexSettings.INDEX_PUBLISH_REFERENCED_SEGMENTS_INTERVAL_SETTING.getKey(), TimeValue.timeValueSeconds(1))
+                )
+        );
+
+        assertBusy(() -> {
+            IndexShard primaryShard = getIndexShard(primaryNode, INDEX_NAME);
+            Directory primaryDirectory = primaryShard.store().directory();
+            Set<String> primaryFiles = Sets.newHashSet(primaryDirectory.listAll());
+            primaryFiles.removeIf(f -> f.startsWith("segment"));
+            Directory replicaDirectory = replicaShard.store().directory();
+            Set<String> replicaFiles = Sets.newHashSet(replicaDirectory.listAll());
+            replicaFiles.removeIf(f -> f.startsWith("segment"));
+            // Verify replica shard does not have pending merged segments
+            assertEquals(0, replicaShard.getPendingMergeSegmentCheckpoints().size());
+            // Verify that primary shard and replica shard have the same file list
+            assertEquals(primaryFiles, replicaFiles);
+        }, 1, TimeUnit.MINUTES);
     }
 
     public static void waitForSegmentCount(String indexName, int segmentCount, Logger logger) throws Exception {

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -159,6 +159,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.MAX_TERMS_COUNT_SETTING,
                 IndexSettings.MAX_NESTED_QUERY_DEPTH_SETTING,
                 IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING,
+                IndexSettings.INDEX_PUBLISH_REFERENCED_SEGMENTS_INTERVAL_SETTING,
                 IndexSettings.DEFAULT_FIELD_SETTING,
                 IndexSettings.QUERY_STRING_LENIENT_SETTING,
                 IndexSettings.ALLOW_UNMAPPED,

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -106,6 +106,7 @@ import org.opensearch.indices.mapper.MapperRegistry;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.indices.replication.checkpoint.MergedSegmentPublisher;
+import org.opensearch.indices.replication.checkpoint.ReferencedSegmentsPublisher;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
 import org.opensearch.plugins.IndexStorePlugin;
@@ -178,6 +179,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private volatile AsyncGlobalCheckpointTask globalCheckpointTask;
     private volatile AsyncRetentionLeaseSyncTask retentionLeaseSyncTask;
     private volatile AsyncReplicationTask asyncReplicationTask;
+    private volatile AsyncPublishReferencedSegmentsTask asyncPublishReferencedSegmentsTask;
 
     // don't convert to Setting<> and register... we only set this in tests and register via a plugin
     private final String INDEX_TRANSLOG_RETENTION_CHECK_INTERVAL_SETTING = "index.translog.retention.check_interval";
@@ -330,6 +332,9 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             this.retentionLeaseSyncTask = new AsyncRetentionLeaseSyncTask(this);
         }
         this.asyncReplicationTask = new AsyncReplicationTask(this);
+        if (FeatureFlags.isEnabled(FeatureFlags.MERGED_SEGMENT_WARMER_EXPERIMENTAL_SETTING)) {
+            this.asyncPublishReferencedSegmentsTask = new AsyncPublishReferencedSegmentsTask(this);
+        }
         this.translogFactorySupplier = translogFactorySupplier;
         this.recoverySettings = recoverySettings;
         this.remoteStoreSettings = remoteStoreSettings;
@@ -441,6 +446,11 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     // visible for tests
     AsyncReplicationTask getReplicationTask() {
         return asyncReplicationTask;
+    }
+
+    // visible for tests
+    AsyncPublishReferencedSegmentsTask getAsyncPublishReferencedSegmentsTask() {
+        return asyncPublishReferencedSegmentsTask;
     }
 
     /**
@@ -614,6 +624,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             sourceNode,
             discoveryNodes,
             mergedSegmentWarmerFactory,
+            null,
             null
         );
     }
@@ -629,7 +640,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         @Nullable DiscoveryNode sourceNode,
         DiscoveryNodes discoveryNodes,
         MergedSegmentWarmerFactory mergedSegmentWarmerFactory,
-        MergedSegmentPublisher mergedSegmentPublisher
+        MergedSegmentPublisher mergedSegmentPublisher,
+        ReferencedSegmentsPublisher referencedSegmentsPublisher
     ) throws IOException {
         Objects.requireNonNull(retentionLeaseSyncer);
         /*
@@ -762,7 +774,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 this::getRefreshInterval,
                 refreshMutex,
                 clusterService.getClusterApplierService(),
-                this.indexSettings.isSegRepEnabledOrRemoteNode() ? mergedSegmentPublisher : null
+                this.indexSettings.isSegRepEnabledOrRemoteNode() ? mergedSegmentPublisher : null,
+                this.indexSettings.isSegRepEnabledOrRemoteNode() ? referencedSegmentsPublisher : null
             );
             eventListener.indexShardStateChanged(indexShard, null, indexShard.state(), "shard created");
             eventListener.afterIndexShardCreated(indexShard);
@@ -1169,6 +1182,9 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             onRefreshIntervalChange();
             updateFsyncTaskIfNecessary();
             updateReplicationTask();
+            if (FeatureFlags.isEnabled(FeatureFlags.MERGED_SEGMENT_WARMER_EXPERIMENTAL_SETTING)) {
+                updatePublishReferencedSegmentsTask();
+            }
         }
 
         metadataListeners.forEach(c -> c.accept(newIndexMetadata));
@@ -1179,6 +1195,14 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             asyncReplicationTask.close();
         } finally {
             asyncReplicationTask = new AsyncReplicationTask(this);
+        }
+    }
+
+    private void updatePublishReferencedSegmentsTask() {
+        try {
+            asyncPublishReferencedSegmentsTask.close();
+        } finally {
+            asyncPublishReferencedSegmentsTask = new AsyncPublishReferencedSegmentsTask(this);
         }
     }
 
@@ -1505,6 +1529,52 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 } catch (IndexShardClosedException | AlreadyClosedException ex) {
                     // do nothing
                 }
+            }
+        }
+    }
+
+    /**
+     * Publish primary shard referenced segments in a defined interval.
+     *
+     * @opensearch.internal
+     */
+    final class AsyncPublishReferencedSegmentsTask extends BaseAsyncTask {
+
+        AsyncPublishReferencedSegmentsTask(IndexService indexService) {
+            super(indexService, indexService.getIndexSettings().getPublishReferencedSegmentsInterval());
+        }
+
+        @Override
+        protected void runInternal() {
+            indexService.maybePublishReferencedSegments();
+        }
+
+        @Override
+        protected String getThreadPool() {
+            return ThreadPool.Names.GENERIC;
+        }
+
+        @Override
+        public String toString() {
+            return "clean_pending_merge_segment";
+        }
+
+        @Override
+        protected boolean mustReschedule() {
+            return indexSettings.isSegRepEnabledOrRemoteNode() && super.mustReschedule();
+        }
+    }
+
+    private void maybePublishReferencedSegments() {
+        for (IndexShard shard : this.shards.values()) {
+            try {
+                // Only the primary shard publish referenced segments.
+                // The replicas cleans up the redundant pending merge segments according to the primary shard request.
+                if (shard.isPrimaryMode() && shard.routingEntry().active()) {
+                    shard.publishReferencedSegments();
+                }
+            } catch (IOException ex) {
+                // do nothing
             }
         }
     }

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -173,6 +173,15 @@ public final class IndexSettings {
         Property.Dynamic,
         Property.IndexScope
     );
+
+    public static final Setting<TimeValue> INDEX_PUBLISH_REFERENCED_SEGMENTS_INTERVAL_SETTING = Setting.timeSetting(
+        "index.segment_replication.publish_referenced_segments_interval",
+        TimeValue.timeValueMinutes(10),
+        TimeValue.timeValueSeconds(1),
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
     public static final Setting<TimeValue> INDEX_SEARCH_IDLE_AFTER = Setting.timeSetting(
         "index.search.idle.after",
         TimeValue.timeValueSeconds(30),
@@ -817,6 +826,7 @@ public final class IndexSettings {
     private final boolean defaultAllowUnmappedFields;
     private volatile Translog.Durability durability;
     private volatile TimeValue syncInterval;
+    private volatile TimeValue publishReferencedSegmentsInterval;
     private volatile TimeValue refreshInterval;
     private volatile ByteSizeValue flushThresholdSize;
     private volatile TimeValue translogRetentionAge;
@@ -1036,6 +1046,7 @@ public final class IndexSettings {
         this.durability = scopedSettings.get(INDEX_TRANSLOG_DURABILITY_SETTING);
         defaultFields = scopedSettings.get(DEFAULT_FIELD_SETTING);
         syncInterval = INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.get(settings);
+        publishReferencedSegmentsInterval = INDEX_PUBLISH_REFERENCED_SEGMENTS_INTERVAL_SETTING.get(settings);
         refreshInterval = scopedSettings.get(INDEX_REFRESH_INTERVAL_SETTING);
         flushThresholdSize = scopedSettings.get(INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING);
         generationThresholdSize = scopedSettings.get(INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING);
@@ -1157,6 +1168,10 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(MergeSchedulerConfig.AUTO_THROTTLE_SETTING, mergeSchedulerConfig::setAutoThrottle);
         scopedSettings.addSettingsUpdateConsumer(INDEX_TRANSLOG_DURABILITY_SETTING, this::setTranslogDurability);
         scopedSettings.addSettingsUpdateConsumer(INDEX_TRANSLOG_SYNC_INTERVAL_SETTING, this::setTranslogSyncInterval);
+        scopedSettings.addSettingsUpdateConsumer(
+            INDEX_PUBLISH_REFERENCED_SEGMENTS_INTERVAL_SETTING,
+            this::setPublishReferencedSegmentsInterval
+        );
         scopedSettings.addSettingsUpdateConsumer(MAX_RESULT_WINDOW_SETTING, this::setMaxResultWindow);
         scopedSettings.addSettingsUpdateConsumer(MAX_INNER_RESULT_WINDOW_SETTING, this::setMaxInnerResultWindow);
         scopedSettings.addSettingsUpdateConsumer(MAX_ADJACENCY_MATRIX_FILTERS_SETTING, this::setMaxAdjacencyMatrixFilters);
@@ -1535,6 +1550,14 @@ public final class IndexSettings {
 
     public void setTranslogSyncInterval(TimeValue translogSyncInterval) {
         this.syncInterval = translogSyncInterval;
+    }
+
+    public TimeValue getPublishReferencedSegmentsInterval() {
+        return publishReferencedSegmentsInterval;
+    }
+
+    public void setPublishReferencedSegmentsInterval(TimeValue publishReferencedSegmentsInterval) {
+        this.publishReferencedSegmentsInterval = publishReferencedSegmentsInterval;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -157,6 +157,7 @@ import org.opensearch.indices.recovery.RecoveryListener;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.indices.replication.checkpoint.MergedSegmentPublisher;
+import org.opensearch.indices.replication.checkpoint.ReferencedSegmentsPublisher;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.node.Node;
@@ -1249,6 +1250,7 @@ public class IndicesService extends AbstractLifecycleComponent
             remoteStoreStatsTrackerFactory,
             discoveryNodes,
             mergedSegmentWarmerFactory,
+            null,
             null
         );
     }
@@ -1268,7 +1270,8 @@ public class IndicesService extends AbstractLifecycleComponent
         final RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory,
         final DiscoveryNodes discoveryNodes,
         final MergedSegmentWarmerFactory mergedSegmentWarmerFactory,
-        final MergedSegmentPublisher mergedSegmentPublisher
+        final MergedSegmentPublisher mergedSegmentPublisher,
+        final ReferencedSegmentsPublisher referencedSegmentsPublisher
     ) throws IOException {
         Objects.requireNonNull(retentionLeaseSyncer);
         ensureChangesAllowed();
@@ -1286,7 +1289,8 @@ public class IndicesService extends AbstractLifecycleComponent
             sourceNode,
             discoveryNodes,
             mergedSegmentWarmerFactory,
-            mergedSegmentPublisher
+            mergedSegmentPublisher,
+            referencedSegmentsPublisher
         );
         indexShard.addShardFailureCallback(onShardFailure);
         indexShard.startRecovery(recoveryState, recoveryTargetService, recoveryListener, repositoriesService, mapping -> {

--- a/server/src/main/java/org/opensearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/opensearch/indices/cluster/IndicesClusterStateService.java
@@ -86,6 +86,7 @@ import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.indices.replication.SegmentReplicationSourceService;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.checkpoint.MergedSegmentPublisher;
+import org.opensearch.indices.replication.checkpoint.ReferencedSegmentsPublisher;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.indices.replication.common.ReplicationState;
 import org.opensearch.repositories.RepositoriesService;
@@ -156,6 +157,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     private final MergedSegmentWarmerFactory mergedSegmentWarmerFactory;
 
     private final MergedSegmentPublisher mergedSegmentPublisher;
+    private final ReferencedSegmentsPublisher referencedSegmentsPublisher;
 
     @Inject
     public IndicesClusterStateService(
@@ -178,7 +180,8 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         final SegmentReplicationCheckpointPublisher checkpointPublisher,
         final RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory,
         final MergedSegmentWarmerFactory mergedSegmentWarmerFactory,
-        final MergedSegmentPublisher mergedSegmentPublisher
+        final MergedSegmentPublisher mergedSegmentPublisher,
+        final ReferencedSegmentsPublisher referencedSegmentsPublisher
     ) {
         this(
             settings,
@@ -200,7 +203,8 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             retentionLeaseSyncer,
             remoteStoreStatsTrackerFactory,
             mergedSegmentWarmerFactory,
-            mergedSegmentPublisher
+            mergedSegmentPublisher,
+            referencedSegmentsPublisher
         );
     }
 
@@ -225,7 +229,8 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         final RetentionLeaseSyncer retentionLeaseSyncer,
         final RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory,
         final MergedSegmentWarmerFactory mergedSegmentWarmerFactory,
-        final MergedSegmentPublisher mergedSegmentPublisher
+        final MergedSegmentPublisher mergedSegmentPublisher,
+        final ReferencedSegmentsPublisher referencedSegmentsPublisher
     ) {
         this.settings = settings;
         this.checkpointPublisher = checkpointPublisher;
@@ -252,6 +257,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         this.remoteStoreStatsTrackerFactory = remoteStoreStatsTrackerFactory;
         this.mergedSegmentWarmerFactory = mergedSegmentWarmerFactory;
         this.mergedSegmentPublisher = mergedSegmentPublisher;
+        this.referencedSegmentsPublisher = referencedSegmentsPublisher;
     }
 
     @Override
@@ -697,7 +703,8 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 remoteStoreStatsTrackerFactory,
                 nodes,
                 mergedSegmentWarmerFactory,
-                mergedSegmentPublisher
+                mergedSegmentPublisher,
+                referencedSegmentsPublisher
             );
         } catch (Exception e) {
             failAndRemoveShard(shardRouting, true, "failed to create shard", e, state);
@@ -1082,7 +1089,8 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory,
             DiscoveryNodes discoveryNodes,
             MergedSegmentWarmerFactory mergedSegmentWarmerFactory,
-            MergedSegmentPublisher mergedSegmentPublisher
+            MergedSegmentPublisher mergedSegmentPublisher,
+            ReferencedSegmentsPublisher referencedSegmentsPublisher
         ) throws IOException;
 
         /**

--- a/server/src/main/java/org/opensearch/indices/replication/MergedSegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/MergedSegmentReplicationTarget.java
@@ -36,6 +36,7 @@ import org.opensearch.action.StepListener;
 import org.opensearch.common.UUIDs;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.indices.replication.checkpoint.MergeSegmentCheckpoint;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 import org.opensearch.indices.replication.common.ReplicationListener;
 
@@ -84,6 +85,7 @@ public class MergedSegmentReplicationTarget extends AbstractSegmentReplicationTa
     @Override
     protected void finalizeReplication(CheckpointInfoResponse checkpointInfoResponse) throws Exception {
         multiFileWriter.renameAllTempFiles();
+        indexShard.addPendingMergeSegmentCheckpoint((MergeSegmentCheckpoint) checkpoint);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishReferencedSegmentsAction.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishReferencedSegmentsAction.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication.checkpoint;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.replication.ReplicationResponse;
+import org.opensearch.cluster.action.shard.ShardStateAction;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+/**
+ * Replication action responsible for publishing referenced segments to a replica shard.
+ *
+ * @opensearch.api
+ */
+@ExperimentalApi
+public class PublishReferencedSegmentsAction extends AbstractPublishCheckpointAction<
+    PublishReferencedSegmentsRequest,
+    PublishReferencedSegmentsRequest> {
+
+    public static final String ACTION_NAME = "indices:admin/publish_referenced_segments";
+    protected static Logger logger = LogManager.getLogger(PublishReferencedSegmentsAction.class);
+
+    @Inject
+    public PublishReferencedSegmentsAction(
+        Settings settings,
+        TransportService transportService,
+        ClusterService clusterService,
+        IndicesService indicesService,
+        ThreadPool threadPool,
+        ShardStateAction shardStateAction,
+        ActionFilters actionFilters
+    ) {
+        super(
+            settings,
+            ACTION_NAME,
+            transportService,
+            clusterService,
+            indicesService,
+            threadPool,
+            shardStateAction,
+            actionFilters,
+            PublishReferencedSegmentsRequest::new,
+            PublishReferencedSegmentsRequest::new,
+            ThreadPool.Names.GENERIC,
+            logger
+        );
+    }
+
+    @Override
+    protected void doExecute(Task task, PublishReferencedSegmentsRequest request, ActionListener<ReplicationResponse> listener) {
+        assert false : "use PublishReferencedSegmentsAction#publish";
+    }
+
+    /**
+     * Publish referenced segment request to shard
+     */
+    final void publish(IndexShard indexShard, ReferencedSegmentsCheckpoint checkpoint) {
+        doPublish(
+            indexShard,
+            checkpoint,
+            new PublishReferencedSegmentsRequest(checkpoint),
+            "segrep_publish_referenced_segments",
+            false,
+            indexShard.getRecoverySettings().getMergedSegmentReplicationTimeout()
+        );
+    }
+
+    @Override
+    protected void shardOperationOnPrimary(
+        PublishReferencedSegmentsRequest request,
+        IndexShard primary,
+        ActionListener<PrimaryResult<PublishReferencedSegmentsRequest, ReplicationResponse>> listener
+    ) {
+        ActionListener.completeWith(listener, () -> new PrimaryResult<>(request, new ReplicationResponse()));
+    }
+
+    @Override
+    protected void doReplicaOperation(PublishReferencedSegmentsRequest request, IndexShard replica) {
+        if (request.getReferencedSegments().getShardId().equals(replica.shardId())) {
+            replica.cleanupRedundantPendingMergeSegment(request.getReferencedSegments());
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishReferencedSegmentsRequest.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/PublishReferencedSegmentsRequest.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication.checkpoint;
+
+import org.opensearch.action.support.replication.ReplicationRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Replication request responsible for publishing referenced segments request to a replica shard.
+ *
+ * @opensearch.internal
+ */
+public class PublishReferencedSegmentsRequest extends ReplicationRequest<PublishReferencedSegmentsRequest> {
+    private final ReferencedSegmentsCheckpoint referencedSegments;
+
+    public PublishReferencedSegmentsRequest(ReferencedSegmentsCheckpoint referencedSegments) {
+        super(referencedSegments.getShardId());
+        this.referencedSegments = referencedSegments;
+    }
+
+    public PublishReferencedSegmentsRequest(StreamInput in) throws IOException {
+        super(in);
+        this.referencedSegments = new ReferencedSegmentsCheckpoint(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        referencedSegments.writeTo(out);
+    }
+
+    @Override
+    public String toString() {
+        return "PublishReferencedSegmentRequest{" + "referencedSegments=" + referencedSegments + '}';
+    }
+
+    public ReferencedSegmentsCheckpoint getReferencedSegments() {
+        return referencedSegments;
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/replication/checkpoint/ReferencedSegmentsPublisher.java
+++ b/server/src/main/java/org/opensearch/indices/replication/checkpoint/ReferencedSegmentsPublisher.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.indices.replication.checkpoint;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.index.shard.IndexShard;
+
+import java.util.Objects;
+
+/**
+ * Publish primary shard referenced segments.
+ *
+ * @opensearch.api
+ */
+@ExperimentalApi
+public class ReferencedSegmentsPublisher {
+    private final PublishAction publishAction;
+
+    // This Component is behind feature flag so we are manually binding this in IndicesModule.
+    @Inject
+    public ReferencedSegmentsPublisher(PublishReferencedSegmentsAction publishAction) {
+        this(publishAction::publish);
+    }
+
+    public ReferencedSegmentsPublisher(PublishAction publishAction) {
+        this.publishAction = Objects.requireNonNull(publishAction);
+    }
+
+    public void publish(IndexShard indexShard, ReferencedSegmentsCheckpoint checkpoint) {
+        publishAction.publish(indexShard, checkpoint);
+    }
+
+    /**
+     * Represents an action that is invoked to publish referenced segments checkpoint to replica shard
+     *
+     * @opensearch.api
+     */
+    @ExperimentalApi
+    public interface PublishAction {
+        void publish(IndexShard indexShard, ReferencedSegmentsCheckpoint checkpoint);
+    }
+
+    /**
+     * NoOp Checkpoint publisher
+     */
+    public static final ReferencedSegmentsPublisher EMPTY = new ReferencedSegmentsPublisher((indexShard, checkpoint) -> {});
+}

--- a/server/src/test/java/org/opensearch/indices/IndicesLifecycleListenerSingleNodeTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesLifecycleListenerSingleNodeTests.java
@@ -52,6 +52,7 @@ import org.opensearch.index.shard.IndexShardTestCase;
 import org.opensearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.indices.replication.checkpoint.MergedSegmentPublisher;
+import org.opensearch.indices.replication.checkpoint.ReferencedSegmentsPublisher;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
@@ -170,7 +171,8 @@ public class IndicesLifecycleListenerSingleNodeTests extends OpenSearchSingleNod
                 null,
                 DiscoveryNodes.builder().add(localNode).build(),
                 new MergedSegmentWarmerFactory(null, null, null),
-                MergedSegmentPublisher.EMPTY
+                MergedSegmentPublisher.EMPTY,
+                ReferencedSegmentsPublisher.EMPTY
             );
             IndexShardTestCase.updateRoutingEntry(shard, newRouting);
             assertEquals(5, counter.get());

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -89,6 +89,7 @@ import org.opensearch.index.shard.IndexShardState;
 import org.opensearch.index.shard.IndexShardTestCase;
 import org.opensearch.index.shard.ShardNotFoundException;
 import org.opensearch.indices.replication.checkpoint.MergedSegmentPublisher;
+import org.opensearch.indices.replication.checkpoint.ReferencedSegmentsPublisher;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.node.Node;
 import org.opensearch.test.ClusterServiceUtils;
@@ -1424,7 +1425,8 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
             null,
             DiscoveryNodes.builder().add(localNode).build(),
             new MergedSegmentWarmerFactory(null, null, null),
-            MergedSegmentPublisher.EMPTY
+            MergedSegmentPublisher.EMPTY,
+            ReferencedSegmentsPublisher.EMPTY
         );
 
         // Verify that the new shard requestStats entries are empty.

--- a/server/src/test/java/org/opensearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
@@ -62,6 +62,7 @@ import org.opensearch.indices.recovery.PeerRecoveryTargetService;
 import org.opensearch.indices.recovery.RecoveryListener;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.indices.replication.checkpoint.MergedSegmentPublisher;
+import org.opensearch.indices.replication.checkpoint.ReferencedSegmentsPublisher;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.test.OpenSearchTestCase;
@@ -270,7 +271,8 @@ public abstract class AbstractIndicesClusterStateServiceTestCase extends OpenSea
             final RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory,
             final DiscoveryNodes discoveryNodes,
             final MergedSegmentWarmerFactory mergedSegmentWarmerFactory,
-            final MergedSegmentPublisher mergedSegmentPublisher
+            final MergedSegmentPublisher mergedSegmentPublisher,
+            final ReferencedSegmentsPublisher referencedSegmentsPublisher
         ) throws IOException {
             failRandomly();
             RecoveryState recoveryState = new RecoveryState(shardRouting, targetNode, sourceNode);

--- a/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -69,6 +69,7 @@ import org.opensearch.indices.recovery.PeerRecoveryTargetService;
 import org.opensearch.indices.replication.SegmentReplicationSourceService;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.checkpoint.MergedSegmentPublisher;
+import org.opensearch.indices.replication.checkpoint.ReferencedSegmentsPublisher;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.telemetry.tracing.noop.NoopTracer;
@@ -587,7 +588,8 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
             RetentionLeaseSyncer.EMPTY,
             null,
             null,
-            MergedSegmentPublisher.EMPTY
+            MergedSegmentPublisher.EMPTY,
+            ReferencedSegmentsPublisher.EMPTY
         );
     }
 

--- a/server/src/test/java/org/opensearch/indices/replication/MergedSegmentReplicationTargetTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/MergedSegmentReplicationTargetTests.java
@@ -75,6 +75,7 @@ public class MergedSegmentReplicationTargetTests extends IndexShardTestCase {
             spyIndexShard.shardId(),
             spyIndexShard.getPendingPrimaryTerm(),
             1,
+            1,
             indexShard.getLatestReplicationCheckpoint().getCodec(),
             SI_SNAPSHOT,
             IndexFileNames.parseSegmentName(SEGMENT_NAME)

--- a/server/src/test/java/org/opensearch/indices/replication/PrimaryShardReplicationSourceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/PrimaryShardReplicationSourceTests.java
@@ -140,6 +140,7 @@ public class PrimaryShardReplicationSourceTests extends IndexShardTestCase {
             indexShard.shardId(),
             PRIMARY_TERM,
             1,
+            1,
             Codec.getDefault().getName(),
             Map.of("testFile", testMetadata),
             "_0"
@@ -198,6 +199,7 @@ public class PrimaryShardReplicationSourceTests extends IndexShardTestCase {
         final ReplicationCheckpoint checkpoint = new MergeSegmentCheckpoint(
             indexShard.shardId(),
             PRIMARY_TERM,
+            1,
             1,
             Codec.getDefault().getName(),
             Map.of("testFile", testMetadata),

--- a/server/src/test/java/org/opensearch/indices/replication/checkpoint/PublishMergedSegmentActionTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/checkpoint/PublishMergedSegmentActionTests.java
@@ -132,6 +132,7 @@ public class PublishMergedSegmentActionTests extends OpenSearchTestCase {
         final MergeSegmentCheckpoint checkpoint = new MergeSegmentCheckpoint(
             indexShard.shardId(),
             1,
+            1,
             1111,
             Codec.getDefault().getName(),
             Collections.emptyMap(),
@@ -170,6 +171,7 @@ public class PublishMergedSegmentActionTests extends OpenSearchTestCase {
 
         final MergeSegmentCheckpoint checkpoint = new MergeSegmentCheckpoint(
             indexShard.shardId(),
+            1,
             1,
             1111,
             Codec.getDefault().getName(),
@@ -214,6 +216,7 @@ public class PublishMergedSegmentActionTests extends OpenSearchTestCase {
 
         final MergeSegmentCheckpoint checkpoint = new MergeSegmentCheckpoint(
             indexShard.shardId(),
+            1,
             1,
             1111,
             Codec.getDefault().getName(),
@@ -265,6 +268,7 @@ public class PublishMergedSegmentActionTests extends OpenSearchTestCase {
 
         final MergeSegmentCheckpoint checkpoint = new MergeSegmentCheckpoint(
             indexShard.shardId(),
+            1,
             1,
             1111,
             Codec.getDefault().getName(),

--- a/server/src/test/java/org/opensearch/indices/replication/checkpoint/PublishMergedSegmentRequestTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/checkpoint/PublishMergedSegmentRequestTests.java
@@ -25,6 +25,7 @@ public class PublishMergedSegmentRequestTests extends OpenSearchTestCase {
         MergeSegmentCheckpoint checkpoint = new MergeSegmentCheckpoint(
             new ShardId(new Index("1", "1"), 0),
             0,
+            1,
             0,
             "",
             Collections.emptyMap(),
@@ -40,6 +41,7 @@ public class PublishMergedSegmentRequestTests extends OpenSearchTestCase {
         MergeSegmentCheckpoint checkpoint = new MergeSegmentCheckpoint(
             new ShardId(new Index("1", "1"), 0),
             0,
+            1,
             0,
             "",
             Collections.emptyMap(),

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -214,6 +214,7 @@ import org.opensearch.indices.replication.SegmentReplicationSourceFactory;
 import org.opensearch.indices.replication.SegmentReplicationSourceService;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.checkpoint.MergedSegmentPublisher;
+import org.opensearch.indices.replication.checkpoint.ReferencedSegmentsPublisher;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.ingest.IngestService;
 import org.opensearch.ingest.SystemIngestPipelineCache;
@@ -2190,7 +2191,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     SegmentReplicationCheckpointPublisher.EMPTY,
                     mock(RemoteStoreStatsTrackerFactory.class),
                     new MergedSegmentWarmerFactory(null, null, null),
-                    MergedSegmentPublisher.EMPTY
+                    MergedSegmentPublisher.EMPTY,
+                    ReferencedSegmentsPublisher.EMPTY
                 );
 
                 final SystemIndices systemIndices = new SystemIndices(emptyMap());

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -143,6 +143,7 @@ import org.opensearch.indices.replication.SegmentReplicationState;
 import org.opensearch.indices.replication.SegmentReplicationTarget;
 import org.opensearch.indices.replication.SegmentReplicationTargetService;
 import org.opensearch.indices.replication.checkpoint.MergedSegmentPublisher;
+import org.opensearch.indices.replication.checkpoint.ReferencedSegmentsPublisher;
 import org.opensearch.indices.replication.checkpoint.ReplicationCheckpoint;
 import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpointPublisher;
 import org.opensearch.indices.replication.common.CopyState;
@@ -733,7 +734,8 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 indexSettings::getRefreshInterval,
                 new Object(),
                 clusterService.getClusterApplierService(),
-                MergedSegmentPublisher.EMPTY
+                MergedSegmentPublisher.EMPTY,
+                ReferencedSegmentsPublisher.EMPTY
             );
             indexShard.addShardFailureCallback(DEFAULT_SHARD_FAILURE_HANDLER);
             if (remoteStoreStatsTrackerFactory != null) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR is based on [[18255](https://github.com/opensearch-project/OpenSearch/pull/18255)]'s follow-up work. It implements the core process of cleaning up redundant pending merged segments. Meanwhile, this cleanup process can be applied to both **local** and **remote storage** scenarios.

**Example**
Here, an example of generating redundant pending merged segments will be provided.

1. At time1, the primary shard merges `_1.si` and `_2.si` into segment `_3.si`. `_3.si` is pre-copied to the replica shard, which completed at time4.
2. At time2, the primary shard generated `_4.si`, and `_1.si`, `_2.si`, `_4.si` were copied to the replica shard via segment replication, which completed at time5.
3. At time3, the primary shard merges `_3.si` and `_4.si` into segment `_5.si`. `_5.si` is pre-copied to the replica shard, which completed at time6.
4. At time4, the replica completed the pre-copy of `_3.si`, but `_3.si` is not searchable.
5. At time5, the reference counts of `_1.si` and `_2.si` in the primary shard decreased to `0` and were deleted.
6. At time6, `_5.si` on the primary shard becomes searchable. The reference counts of `_3.si` and `_4.si` in the primary shard decreased to `0` and were deleted. `_5.si` were copied to the replica shard via segment replication, which completed at time7 (This process is fast because it has already performed pre-copy).
7. At time7, `_5.si` on the replica shard becomes searchable. The reference counts of `_1.si`, `_2.si` and `_4.si` in the replica shard decreased to `0` and were deleted.
8. After time7, `_3.si` on the replica is the redundant pending merged segment.

|     | primary | replica  |
| :------: | :--: | :----: |
| time1    | _1.si, _2.si, _3.si   |     |
| time2    | _1.si, _2.si, _3.si, _4.si   |     |
| time3    | _1.si, _2.si, _3.si, _4.si, _5.si   |     |
| time4    | _1.si, _2.si, _3.si, _4.si, _5.si   |  _3.si   |
| time5    | _3.si, _4.si, _5.si   |  _1.si, _2.si, _3.si, _4.si   |
| time6    | _5.si   |  _1.si, _2.si, _3.si, _4.si, _5.si   |
| time7    | _5.si   |  _3.si, _5.si   |

**Cleanup strategy**
When the following conditions are met, we will consider the pending merge segment to be redundant and can be deleted.

- The current primary term of the primary shard is greater than the primary term when the pending merge segment was generated, or the primary terms are identical but the segmentInfosVersion of the primary shard is greater than the segmentInfosVersion when the pending merge segment was generated.
- The pending merge segment no longer exists in the primary shard.

**Implement**

- After the merged segment pre-copy is completed, the replica shard needs to record `MergeSegmentCheckpoint` in `IndexShard#pendingMergeSegmentCheckpoints`.
- After the segment replication is completed, the replica shard needs to remove the relevant `MergeSegmentCheckpoint`  from `IndexShard#pendingMergeSegmentCheckpoints`.
- We introduced `IndexService.AsyncPublishReferencedSegmentsTask` to periodically publish the segments referenced by the primary shard to replicas.
- The replica shard cleans up the redundant pending merge segments according to the above **cleanup strategy**.



### Related Issues
Resolves #[[17528](https://github.com/opensearch-project/OpenSearch/issues/17528)], #[[18625](https://github.com/opensearch-project/OpenSearch/issues/18625)]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
