### PR TITLE
[Rule-based auto tagging] Bug fix and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add BooleanQuery rewrite moving constant-scoring must clauses to filter clauses ([#18510](https://github.com/opensearch-project/OpenSearch/issues/18510))
 - Add functionality for plugins to inject QueryCollectorContext during QueryPhase ([#18637](https://github.com/opensearch-project/OpenSearch/pull/18637))
 - Add support for non-timing info in profiler ([#18460](https://github.com/opensearch-project/OpenSearch/issues/18460))
+- [Rule-based auto tagging] Bug fix and improvements ([#18726](https://github.com/opensearch-project/OpenSearch/pull/18726))
 - Extend Approximation Framework to other numeric types ([#18530](https://github.com/opensearch-project/OpenSearch/issues/18530))
 - Add Semantic Version field type mapper and extensive unit tests([#18454](https://github.com/opensearch-project/OpenSearch/pull/18454))
 - Pass index settings to system ingest processor factories. ([#18708](https://github.com/opensearch-project/OpenSearch/pull/18708))

--- a/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/action/CreateRuleRequest.java
+++ b/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/action/CreateRuleRequest.java
@@ -49,14 +49,7 @@ public class CreateRuleRequest extends ActionRequest {
 
     @Override
     public ActionRequestValidationException validate() {
-        try {
-            rule.getFeatureType().getFeatureValueValidator().validate(rule.getFeatureValue());
-            return null;
-        } catch (Exception e) {
-            ActionRequestValidationException validationException = new ActionRequestValidationException();
-            validationException.addValidationError("Validation failed: " + e.getMessage());
-            return validationException;
-        }
+        return null;
     }
 
     @Override

--- a/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/autotagging/RuleValidator.java
+++ b/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/autotagging/RuleValidator.java
@@ -114,6 +114,11 @@ public class RuleValidator {
         if (featureType == null) {
             return List.of("Couldn't identify which feature the rule belongs to. Rule feature can't be null.");
         }
+        try {
+            featureType.getFeatureValueValidator().validate(featureValue);
+        } catch (Exception e) {
+            return List.of(e.getMessage());
+        }
         return new ArrayList<>();
     }
 

--- a/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/service/IndexStoredRulePersistenceService.java
+++ b/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/service/IndexStoredRulePersistenceService.java
@@ -16,6 +16,7 @@ import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.cluster.service.ClusterService;
@@ -183,6 +184,7 @@ public class IndexStoredRulePersistenceService implements RulePersistenceService
     private void persistRule(Rule rule, ActionListener<CreateRuleResponse> listener) {
         try {
             IndexRequest indexRequest = new IndexRequest(indexName).id(rule.getId())
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                 .source(rule.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
             client.index(indexRequest).get();
             listener.onResponse(new CreateRuleResponse(rule));
@@ -312,9 +314,8 @@ public class IndexStoredRulePersistenceService implements RulePersistenceService
      */
     private void persistUpdatedRule(String ruleId, Rule updatedRule, ActionListener<UpdateRuleResponse> listener) {
         try {
-            UpdateRequest updateRequest = new UpdateRequest(indexName, ruleId).doc(
-                updatedRule.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)
-            );
+            UpdateRequest updateRequest = new UpdateRequest(indexName, ruleId).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .doc(updatedRule.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
             client.update(updateRequest).get();
             listener.onResponse(new UpdateRuleResponse(updatedRule));
         } catch (Exception e) {

--- a/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/autotagging/RuleValidatorTests.java
+++ b/modules/autotagging-commons/common/src/test/java/org/opensearch/rule/autotagging/RuleValidatorTests.java
@@ -23,6 +23,9 @@ import static org.opensearch.rule.autotagging.RuleTests.FEATURE_VALUE;
 import static org.opensearch.rule.autotagging.RuleTests.TestAttribute.TEST_ATTRIBUTE_1;
 import static org.opensearch.rule.autotagging.RuleTests.UPDATED_AT;
 import static org.opensearch.rule.autotagging.RuleTests._ID;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RuleValidatorTests extends OpenSearchTestCase {
 
@@ -117,5 +120,15 @@ public class RuleValidatorTests extends OpenSearchTestCase {
         RuleValidator validator = new RuleValidator(_ID, DESCRIPTION, ATTRIBUTE_MAP, FEATURE_VALUE, UPDATED_AT, FEATURE_TYPE);
         RuleValidator otherValidator = new RuleValidator(_ID, DESCRIPTION, ATTRIBUTE_MAP, FEATURE_VALUE, UPDATED_AT, FEATURE_TYPE);
         assertEquals(validator, otherValidator);
+    }
+
+    public void testFeatureValueValidationThrows() {
+        FeatureType mockFeatureType = mock(FeatureType.class);
+        FeatureValueValidator mockValidator = mock(FeatureValueValidator.class);
+        when(mockFeatureType.getFeatureValueValidator()).thenReturn(mockValidator);
+        doThrow(new IllegalArgumentException("Invalid feature value")).when(mockValidator).validate("bad-value");
+        RuleValidator validator = new RuleValidator(_ID, DESCRIPTION, ATTRIBUTE_MAP, "bad-value", UPDATED_AT, mockFeatureType);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, validator::validate);
+        assertTrue(ex.getMessage().contains("Invalid feature value"));
     }
 }

--- a/modules/autotagging-commons/src/main/java/org/opensearch/rule/rest/RestGetRuleAction.java
+++ b/modules/autotagging-commons/src/main/java/org/opensearch/rule/rest/RestGetRuleAction.java
@@ -74,10 +74,12 @@ public class RestGetRuleAction extends BaseRestHandler {
         }
 
         final FeatureType featureType = FeatureType.from(request.param(FEATURE_TYPE));
-        final Set<String> excludedKeys = Set.of(FEATURE_TYPE, ID_STRING, SEARCH_AFTER_STRING, "pretty");
-        final List<String> requestParams = request.params().keySet().stream().filter(key -> !excludedKeys.contains(key)).toList();
-
-        for (String attributeName : requestParams) {
+        final List<String> attributeParams = request.params()
+            .keySet()
+            .stream()
+            .filter(key -> featureType.getAllowedAttributesRegistry().containsKey(key))
+            .toList();
+        for (String attributeName : attributeParams) {
             Attribute attribute = featureType.getAttributeFromName(attributeName);
             if (attribute == null) {
                 throw new IllegalArgumentException(attributeName + " is not a valid attribute under feature type " + featureType.getName());

--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/rule/sync/RefreshBasedSyncMechanism.java
@@ -15,6 +15,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.plugin.wlm.WlmClusterSettingValuesProvider;
 import org.opensearch.plugin.wlm.rule.sync.detect.RuleEvent;
 import org.opensearch.plugin.wlm.rule.sync.detect.RuleEventClassifier;
@@ -121,6 +122,10 @@ public class RefreshBasedSyncMechanism extends AbstractLifecycleComponent {
 
                 @Override
                 public void onFailure(Exception e) {
+                    if (e instanceof IndexNotFoundException) {
+                        logger.debug("Rule index not found, skipping rule processing.");
+                        return;
+                    }
                     logger.warn("Failed to get rules from persistence service", e);
                 }
             }


### PR DESCRIPTION
### Description
This PR contains several bug fix/improvements for the rule-based auto tagging feature. 
- Refines the extraction of attribute parameters from `RestRequest` in `RestGetRuleAction`. The previous approach filtered out a few known non-attribute/system params, but it relied on a fixed exclusion list. It could still include other unrelated or unintended params if they weren’t explicitly listed, especially any automatically added query params from the system. 
```
final Set<String> excludedKeys = Set.of(FEATURE_TYPE, ID_STRING, SEARCH_AFTER_STRING, "pretty");
final List<String> requestParams = request.params().keySet().stream().filter(key -> !excludedKeys.contains(key)).toList();
```
This current change whitelists only keys that are explicitly defined as allowed attributes for the given `FeatureType`. It makes the logic stricter and safer by ensuring only valid attribute names are parsed and passed for rule filtering.
```
final List<String> attributeParams = request.params()
    .keySet()
    .stream()
    .filter(key -> featureType.getAllowedAttributesRegistry().containsKey(key))
    .toList();
```
- Moved featureValue validation logic into RuleValidator to centralize and standardize rule validation. This ensures consistent validation across different rule APIs and improves maintainability.
- A force refresh (RefreshPolicy.IMMEDIATE) was added after rule creation and update to ensure the newly written documents are immediately visible for subsequent read operations (e.g., GET or search) in YAML REST tests. Without it, the default refresh interval could delay visibility, causing .yml tests to fail. Note that there seems to be no better way than to add this force refresh, since YAML test doesn't support wait(), and a explicit refresh api performed on system index would result in `got unexpected warning header [
	299 OpenSearch-3.2.0-SNAPSHOT-d622ff5e85377efc43d80e9502001fdac552f0c8 "this request accesses system indices: [.wlm_rules], but in a future major version, direct access to system indices will be prevented by default"`
- Added handling to ignore IndexNotFoundException during rule sync in doRun() since this is the expected behavior if the customer has not created any rules yet.

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
