### PR TITLE
Don't fail assertion on startup for remote store validation

### DIFF
--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -2976,8 +2976,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     protected void assertSnapshotOrGenericThread() {
         assert Thread.currentThread().getName().contains('[' + ThreadPool.Names.SNAPSHOT_DELETION + ']')
             || Thread.currentThread().getName().contains('[' + ThreadPool.Names.SNAPSHOT + ']')
-            || Thread.currentThread().getName().contains('[' + ThreadPool.Names.GENERIC + ']') : "Expected current thread ["
-                + Thread.currentThread()
+            || Thread.currentThread().getName().contains('[' + ThreadPool.Names.GENERIC + ']')
+            || Thread.currentThread().getName().equals("main") : "Expected current thread ["
+                + Thread.currentThread().getName()
                 + "] to be the snapshot_deletion or snapshot or generic thread.";
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The assertion fixed in this commit is hit on the following stack trace:

```
»  java.lang.AssertionError: Expected current thread [Thread[#1,main,5,main]] to be the snapshot_deletion or snapshot or generic thread.
»       at org.opensearch.repositories.blobstore.BlobStoreRepository.assertSnapshotOrGenericThread(BlobStoreRepository.java:2980)
»       at org.opensearch.repositories.blobstore.BlobStoreRepository.blobContainer(BlobStoreRepository.java:983)
»       at org.opensearch.repositories.url.URLRepository.blobContainer(URLRepository.java:139)
»       at org.opensearch.repositories.blobstore.BlobStoreRepository.listBlobsToGetLatestIndexId(BlobStoreRepository.java:3738)
»       at org.opensearch.repositories.blobstore.BlobStoreRepository.latestIndexBlobId(BlobStoreRepository.java:3720)
»       at org.opensearch.repositories.blobstore.BlobStoreRepository.startVerification(BlobStoreRepository.java:2989)
»       at org.opensearch.node.remotestore.RemoteStoreNodeService.createAndVerifyRepositories(RemoteStoreNodeService.java:156)
»       at org.opensearch.node.Node$LocalNodeFactory.apply(Node.java:2221)
»       at org.opensearch.node.Node$LocalNodeFactory.apply(Node.java:2200)
»       at org.opensearch.transport.TransportService.doStart(TransportService.java:313)
»       at org.opensearch.common.lifecycle.AbstractLifecycleComponent.start(AbstractLifecycleComponent.java:77)
»       at org.opensearch.node.Node.start(Node.java:1741)
»       at org.opensearch.bootstrap.Bootstrap.start(Bootstrap.java:346)
»       at org.opensearch.bootstrap.Bootstrap.init(Bootstrap.java:420)
»       at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:168)
»       at org.opensearch.bootstrap.OpenSearch.execute(OpenSearch.java:159)
»       at org.opensearch.common.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:110)
»       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
»       at org.opensearch.cli.Command.main(Command.java:101)
»       at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:125)
»       at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:91)
```

In other words, this line is guaranteed to be hit from the `main` thread when a node has remote store enabled.

### Related Issues
Resolves #18670

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
