### PR TITLE
[2.19] Exclude commons-beanutils from dep on hadoop-miniclusters

### DIFF
--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     exclude group: 'com.nimbusds'
     exclude module: "commons-configuration2"
     exclude module: "commons-beanutils"
+    exclude module: "org.eclipse.jetty"
   }
   api "dnsjava:dnsjava:3.6.2"
   api "org.codehaus.jettison:jettison:${versions.jettison}"


### PR DESCRIPTION
### Description

Excludes more transitive deps from hadoop-miniclusters to mitigate CVEs:

- CVE-2025-48734
- CVE-2024-13009

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
