### PR TITLE
Grok processor supports capturing multiple values for same field name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Star-Tree] Add star-tree search related stats ([#18707](https://github.com/opensearch-project/OpenSearch/pull/18707))
 - Add support for plugins to profile information ([#18656](https://github.com/opensearch-project/OpenSearch/pull/18656))
 - Add support for Combined Fields query ([#18724](https://github.com/opensearch-project/OpenSearch/pull/18724))
+- Grok processor supports capturing multiple values for same field name
 
 ### Changed
 - Update Subject interface to use CheckedRunnable ([#18570](https://github.com/opensearch-project/OpenSearch/issues/18570))

--- a/libs/grok/src/main/java/org/opensearch/grok/Grok.java
+++ b/libs/grok/src/main/java/org/opensearch/grok/Grok.java
@@ -99,17 +99,28 @@ public final class Grok {
     private final Regex compiledExpression;
     private final MatcherWatchdog matcherWatchdog;
     private final List<GrokCaptureConfig> captureConfig;
+    private final boolean captureAllMatches;
 
     public Grok(Map<String, String> patternBank, String grokPattern, Consumer<String> logCallBack) {
-        this(patternBank, grokPattern, true, MatcherWatchdog.noop(), logCallBack);
+        this(patternBank, grokPattern, true, MatcherWatchdog.noop(), logCallBack, false);
     }
 
     public Grok(Map<String, String> patternBank, String grokPattern, MatcherWatchdog matcherWatchdog, Consumer<String> logCallBack) {
-        this(patternBank, grokPattern, true, matcherWatchdog, logCallBack);
+        this(patternBank, grokPattern, true, matcherWatchdog, logCallBack, false);
+    }
+
+    public Grok(
+        Map<String, String> patternBank,
+        String grokPattern,
+        MatcherWatchdog matcherWatchdog,
+        Consumer<String> logCallBack,
+        boolean captureAllMatches
+    ) {
+        this(patternBank, grokPattern, true, matcherWatchdog, logCallBack, captureAllMatches);
     }
 
     Grok(Map<String, String> patternBank, String grokPattern, boolean namedCaptures, Consumer<String> logCallBack) {
-        this(patternBank, grokPattern, namedCaptures, MatcherWatchdog.noop(), logCallBack);
+        this(patternBank, grokPattern, namedCaptures, MatcherWatchdog.noop(), logCallBack, false);
     }
 
     private Grok(
@@ -117,11 +128,13 @@ public final class Grok {
         String grokPattern,
         boolean namedCaptures,
         MatcherWatchdog matcherWatchdog,
-        Consumer<String> logCallBack
+        Consumer<String> logCallBack,
+        boolean captureAllMatches
     ) {
         this.patternBank = patternBank;
         this.namedCaptures = namedCaptures;
         this.matcherWatchdog = matcherWatchdog;
+        this.captureAllMatches = captureAllMatches;
 
         validatePatternBank();
 
@@ -395,7 +408,7 @@ public final class Grok {
         if (result == Matcher.FAILED) {
             return false;
         }
-        extracter.extract(utf8Bytes, offset, matcher.getEagerRegion());
+        extracter.extract(utf8Bytes, offset, matcher.getEagerRegion(), captureAllMatches);
         return true;
     }
 

--- a/libs/grok/src/main/java/org/opensearch/grok/GrokCaptureType.java
+++ b/libs/grok/src/main/java/org/opensearch/grok/GrokCaptureType.java
@@ -104,13 +104,16 @@ enum GrokCaptureType {
     protected final GrokCaptureExtracter rawExtracter(int[] backRefs, Consumer<? super String> emit) {
         return new GrokCaptureExtracter() {
             @Override
-            void extract(byte[] utf8Bytes, int offset, Region region) {
+            void extract(byte[] utf8Bytes, int offset, Region region, boolean captureAllMatches) {
                 for (int number : backRefs) {
                     if (region.getBeg(number) >= 0) {
                         int matchOffset = offset + region.getBeg(number);
                         int matchLength = region.getEnd(number) - region.getBeg(number);
                         emit.accept(new String(utf8Bytes, matchOffset, matchLength, StandardCharsets.UTF_8));
-                        return; // Capture only the first value.
+                        // return the first match value if captureAllMatches is false, else continue to capture all values
+                        if (!captureAllMatches) {
+                            return;
+                        }
                     }
                 }
             }

--- a/modules/ingest-common/src/main/java/org/opensearch/ingest/common/GrokProcessor.java
+++ b/modules/ingest-common/src/main/java/org/opensearch/ingest/common/GrokProcessor.java
@@ -58,6 +58,7 @@ public final class GrokProcessor extends AbstractProcessor {
     private final Grok grok;
     private final boolean traceMatch;
     private final boolean ignoreMissing;
+    private final boolean captureAllMatches;
 
     GrokProcessor(
         String tag,
@@ -67,14 +68,16 @@ public final class GrokProcessor extends AbstractProcessor {
         String matchField,
         boolean traceMatch,
         boolean ignoreMissing,
+        boolean captureAllMatches,
         MatcherWatchdog matcherWatchdog
     ) {
         super(tag, description);
         this.matchField = matchField;
         this.matchPatterns = matchPatterns;
-        this.grok = new Grok(patternBank, combinePatterns(matchPatterns, traceMatch), matcherWatchdog, logger::debug);
+        this.grok = new Grok(patternBank, combinePatterns(matchPatterns, traceMatch), matcherWatchdog, logger::debug, captureAllMatches);
         this.traceMatch = traceMatch;
         this.ignoreMissing = ignoreMissing;
+        this.captureAllMatches = captureAllMatches;
         // Joni warnings are only emitted on an attempt to match, and the warning emitted for every call to match which is too verbose
         // so here we emit a warning (if there is one) to the logfile at warn level on construction / processor creation.
         new Grok(patternBank, combinePatterns(matchPatterns, traceMatch), matcherWatchdog, logger::warn).match("___nomatch___");
@@ -130,6 +133,10 @@ public final class GrokProcessor extends AbstractProcessor {
         return matchPatterns;
     }
 
+    boolean isCaptureAllMatches() {
+        return captureAllMatches;
+    }
+
     static String combinePatterns(List<String> patterns, boolean traceMatch) {
         String combinedPattern;
         if (patterns.size() > 1) {
@@ -176,6 +183,7 @@ public final class GrokProcessor extends AbstractProcessor {
             List<String> matchPatterns = ConfigurationUtils.readList(TYPE, processorTag, config, "patterns");
             boolean traceMatch = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "trace_match", false);
             boolean ignoreMissing = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "ignore_missing", false);
+            boolean captureAllMatches = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "capture_all_matches", false);
 
             if (matchPatterns.isEmpty()) {
                 throw newConfigurationException(TYPE, processorTag, "patterns", "List of patterns must not be empty");
@@ -195,6 +203,7 @@ public final class GrokProcessor extends AbstractProcessor {
                     matchField,
                     traceMatch,
                     ignoreMissing,
+                    captureAllMatches,
                     matcherWatchdog
                 );
             } catch (Exception e) {

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/GrokProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/GrokProcessorFactoryTests.java
@@ -134,4 +134,19 @@ public class GrokProcessorFactoryTests extends OpenSearchTestCase {
             equalTo("[patterns] Invalid regex pattern found in: [%{MY_PATTERN:name}!]. premature end of char-class")
         );
     }
+
+    public void testBuildWithCaptureAllMatches() throws Exception {
+        GrokProcessor.Factory factory = new GrokProcessor.Factory(Collections.emptyMap(), MatcherWatchdog.noop());
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "_field");
+        config.put("patterns", Collections.singletonList("(?<foo>\\w+)"));
+        config.put("capture_all_matches", true);
+        String processorTag = randomAlphaOfLength(10);
+        GrokProcessor processor = factory.create(null, processorTag, null, config);
+        assertThat(processor.getTag(), equalTo(processorTag));
+        assertThat(processor.getMatchField(), equalTo("_field"));
+        assertThat(processor.getGrok(), notNullValue());
+        assertThat(processor.isCaptureAllMatches(), is(true));
+    }
 }

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/121_grok_capture_all_matches.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/121_grok_capture_all_matches.yml
@@ -1,0 +1,164 @@
+---
+teardown:
+  - do:
+      ingest.delete_pipeline:
+        id: "my_pipeline"
+        ignore: 404
+
+---
+"Test Grok Pipeline with capture_all_matches disabled (default)":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "grok" : {
+                  "field" : "field1",
+                  "patterns" : ["%{IP:ipAddress} %{IP:ipAddress} %{IP:ipAddress}"]
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        pipeline: "my_pipeline"
+        body: {field1: "192.168.1.1 10.0.0.1 172.16.0.1"}
+
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: { _source.ipAddress: "192.168.1.1" }
+
+---
+"Test Grok Pipeline with capture_all_matches enabled":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "grok" : {
+                  "field" : "field1",
+                  "patterns" : ["%{IP:ipAddress} %{IP:ipAddress} %{IP:ipAddress}"],
+                  "capture_all_matches": true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        pipeline: "my_pipeline"
+        body: {field1: "192.168.1.1 10.0.0.1 172.16.0.1"}
+
+  - do:
+      get:
+        index: test
+        id: 1
+  - length: { _source.ipAddress: 3 }
+  - match: { _source.ipAddress.0: "192.168.1.1" }
+  - match: { _source.ipAddress.1: "10.0.0.1" }
+  - match: { _source.ipAddress.2: "172.16.0.1" }
+
+
+---
+"Test Grok Pipeline with capture_all_matches and multiple patterns":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "grok" : {
+                  "field" : "field1",
+                  "patterns" : [
+                    "User %{WORD:username} logged in from %{IP:ipAddress}",
+                    "IP: %{IP:ipAddress}"
+                  ],
+                  "capture_all_matches": true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        pipeline: "my_pipeline"
+        body: {field1: "User john logged in from 192.168.1.1"}
+
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: { _source.username: "john" }
+  - match: { _source.ipAddress: "192.168.1.1" }
+
+  - do:
+      index:
+        index: test
+        id: 2
+        pipeline: "my_pipeline"
+        body: {field1: "IP: 10.0.0.1"}
+
+  - do:
+      get:
+        index: test
+        id: 2
+  - match: { _source.ipAddress: "10.0.0.1" }
+
+---
+"Test Grok Pipeline with capture_all_matches and custom pattern":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "grok" : {
+                  "field" : "field1",
+                  "patterns" : ["Tags: %{TAGS:tag}, %{TAGS:tag}, %{TAGS:tag}"],
+                  "pattern_definitions" : {
+                    "TAGS" : "[a-z0-9]+"
+                  },
+                  "capture_all_matches": true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: 1
+        pipeline: "my_pipeline"
+        body: {field1: "Tags: foo, bar, baz"}
+
+  - do:
+      get:
+        index: test
+        id: 1
+  - match: { _source.tag.0: "foo" }
+  - match: { _source.tag.1: "bar" }
+  - match: { _source.tag.2: "baz" }
+  - length: { _source.tag: 3 }


### PR DESCRIPTION
### Description

Add an option `capture_all_matches` for the grok ingest processor, when set to `true`, all matched values for same field name will be collected into an array, by default, only the first the matched value will be captured.

By checking the code: https://github.com/opensearch-project/OpenSearch/blob/89edd4c6372412ae257c56c256e82599eac7769f/libs/grok/src/main/java/org/opensearch/grok/GrokCaptureType.java#L113, found that maybe the current behavior is by design, but I also checked other ingestion tool like Logstash, it captures all matched values by default, so I think we can let the users decide the behavior by adding an extra option.

### Related Issues

https://github.com/opensearch-project/OpenSearch/issues/18790

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
