### PR TITLE
[Backport 2.19] Use ScoreDoc instead of FieldDoc when creating TopScoreDocCollectorManager to avoid unnecessary conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Null check field names in QueryStringQueryBuilder ([#18194](https://github.com/opensearch-project/OpenSearch/pull/18194))
 - Fix illegal argument exception when creating a PIT ([#16781](https://github.com/opensearch-project/OpenSearch/pull/16781))
 - Fix the bug of Access denied error when rolling log files ([#18597](https://github.com/opensearch-project/OpenSearch/pull/18597))
+- Use ScoreDoc instead of FieldDoc when creating TopScoreDocCollectorManager to avoid unnecessary conversion ([#18802](https://github.com/opensearch-project/OpenSearch/pull/18802))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
@@ -361,11 +361,7 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
         ) {
             if (sortAndFormats == null) {
                 if (searchAfter != null) {
-                    return TopScoreDocCollector.createSharedManager(
-                        numHits,
-                        searchAfter,
-                        hitCountThreshold
-                    );
+                    return TopScoreDocCollector.createSharedManager(numHits, searchAfter, hitCountThreshold);
                 } else {
                     return TopScoreDocCollector.createSharedManager(numHits, null, hitCountThreshold);
                 }

--- a/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
@@ -360,11 +360,10 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
             int hitCountThreshold
         ) {
             if (sortAndFormats == null) {
-                // See please https://github.com/apache/lucene/pull/450, should be fixed in 9.x
                 if (searchAfter != null) {
                     return TopScoreDocCollector.createSharedManager(
                         numHits,
-                        new FieldDoc(searchAfter.doc, searchAfter.score),
+                        searchAfter,
                         hitCountThreshold
                     );
                 } else {


### PR DESCRIPTION
### Description

Backport https://github.com/opensearch-project/OpenSearch/pull/18802 to 2.19


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
