### PR TITLE
Fix Dockerfile in repository s3 to use JDK 21

### DIFF
--- a/test/fixtures/s3-fixture/Dockerfile
+++ b/test/fixtures/s3-fixture/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-11-jre-headless
+RUN apt-get install -qqy openjdk-21-jre-headless
 
 ARG fixtureClass
 ARG port

--- a/test/fixtures/s3-fixture/docker-compose.yml
+++ b/test/fixtures/s3-fixture/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - "80"
 
   s3-fixture-with-session-token:
+    image: img4
     build:
       context: .
       args:
@@ -62,50 +63,50 @@ services:
       - "80"
 
   s3-fixture-with-ec2:
-      build:
-          context: .
-          args:
-              fixtureClass: fixture.s3.S3HttpFixtureWithEC2
-              port: 80
-              bucket: "ec2_bucket"
-              basePath: "ec2_base_path"
-              accessKey: "ec2_access_key"
-              sessionToken: "ec2_session_token"
-          dockerfile: Dockerfile
-      volumes:
-          - ./testfixtures_shared/shared:/fixture/shared
-      ports:
-          - "80"
+    build:
+        context: .
+        args:
+            fixtureClass: fixture.s3.S3HttpFixtureWithEC2
+            port: 80
+            bucket: "ec2_bucket"
+            basePath: "ec2_base_path"
+            accessKey: "ec2_access_key"
+            sessionToken: "ec2_session_token"
+        dockerfile: Dockerfile
+    volumes:
+        - ./testfixtures_shared/shared:/fixture/shared
+    ports:
+        - "80"
 
   s3-fixture-with-ecs:
-      build:
-          context: .
-          args:
-              fixtureClass: fixture.s3.S3HttpFixtureWithECS
-              port: 80
-              bucket: "ecs_bucket"
-              basePath: "ecs_base_path"
-              accessKey: "ecs_access_key"
-              sessionToken: "ecs_session_token"
-          dockerfile: Dockerfile
-      volumes:
-          - ./testfixtures_shared/shared:/fixture/shared
-      ports:
-          - "80"
+    build:
+        context: .
+        args:
+            fixtureClass: fixture.s3.S3HttpFixtureWithECS
+            port: 80
+            bucket: "ecs_bucket"
+            basePath: "ecs_base_path"
+            accessKey: "ecs_access_key"
+            sessionToken: "ecs_session_token"
+        dockerfile: Dockerfile
+    volumes:
+        - ./testfixtures_shared/shared:/fixture/shared
+    ports:
+        - "80"
 
   s3-fixture-with-eks:
-      build:
-          context: .
-          args:
-              fixtureClass: fixture.s3.S3HttpFixtureWithEKS
-              port: 80
-              bucket: "eks_bucket"
-              basePath: "eks_base_path"
-              accessKey: "eks_access_key"
-              roleArn: "eks_role_arn"
-              roleSessionName: "eks_role_session_name"
-          dockerfile: Dockerfile.eks
-      volumes:
-          - ./testfixtures_shared/shared:/fixture/shared
-      ports:
-          - "80"
+    build:
+        context: .
+        args:
+            fixtureClass: fixture.s3.S3HttpFixtureWithEKS
+            port: 80
+            bucket: "eks_bucket"
+            basePath: "eks_base_path"
+            accessKey: "eks_access_key"
+            roleArn: "eks_role_arn"
+            roleSessionName: "eks_role_session_name"
+        dockerfile: Dockerfile.eks
+    volumes:
+        - ./testfixtures_shared/shared:/fixture/shared
+    ports:
+        - "80"


### PR DESCRIPTION
### Description

I ran into issues trying to run tests for the repository-s3 module from my mac due to the test fixture trying to use a version of java (JDK11) that was not compatible with OpenSearch 3.x (min compatibility JDK21).

This PR updates the Dockerfile to Ubuntu 22.04 and OpenJDK 21.

Verified I can run a test:

```
amazon_s3_access_key_temporary=$AWS_ACCESS_KEY_ID amazon_s3_secret_key_temporary=$AWS_SECRET_ACCESS_KEY amazon_s3_session_token_temporary=$AWS_SESSION_TOKEN amazon_s3_base_path_temporary=path amazon_s3_bucket_temporary=cwperx-opensearch amazon_s3_region_temporary=us-west-2 ./gradlew ':plugins:repository-s3:yamlRestTest' --tests 'org.opensearch.repositories.s3.RepositoryS3ClientYamlTestSuiteIT.test {yaml=repository_s3/20_repository_permanent_credentials/Register a read-only repository with a non existing bucket}'
```

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
