### PR TITLE
Exclude `@ExperimentalApi` from compatibility check

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -403,7 +403,7 @@ tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
     ignoreMissingClasses = true
     failOnSourceIncompatibility = true
     annotationIncludes = ['@org.opensearch.common.annotation.PublicApi', '@org.opensearch.common.annotation.DeprecatedApi']
-    annotationExcludes = ['@org.opensearch.common.annotation.InternalApi']
+    annotationExcludes = ['@org.opensearch.common.annotation.InternalApi', '@org.opensearch.common.annotation.ExperimentalApi']
     txtOutputFile = layout.buildDirectory.file("reports/java-compatibility/report.txt")
     htmlOutputFile = layout.buildDirectory.file("reports/java-compatibility/report.html")
     dependsOn downloadJapicmpCompareTarget


### PR DESCRIPTION
@peternied @reta Was this just a miss, or am I confused here? It seems like the whole point of experimental APIs is to exclude them from this compatibility enforcement. See #18754 where a change to an experimental API failed the compatibility check.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
