### PR TITLE
[BUG] Repository s3 plugin test S3RepositoryThirdPartyTests.java does not have an option to override path_style_access and endpoint #18796

### DIFF
--- a/plugins/repository-s3/README.md
+++ b/plugins/repository-s3/README.md
@@ -26,4 +26,4 @@ AWS_REGION=us-west-2 amazon_s3_access_key=$AWS_ACCESS_KEY_ID amazon_s3_secret_ke
 Optional environment variables:
 
 - `amazon_s3_path_style_access`: Possible values true or false. Default is false.
-- `amazon_s3_endpoint`: s3 custom endpoint url if aws s3 default endpoint is not being used. 
+- `amazon_s3_endpoint`: s3 custom endpoint url if aws s3 default endpoint is not being used.

--- a/plugins/repository-s3/README.md
+++ b/plugins/repository-s3/README.md
@@ -23,3 +23,7 @@ Integration tests require several environment variables.
 ```
 AWS_REGION=us-west-2 amazon_s3_access_key=$AWS_ACCESS_KEY_ID amazon_s3_secret_key=$AWS_SECRET_ACCESS_KEY amazon_s3_base_path=path amazon_s3_bucket=dblock-opensearch ./gradlew :plugins:repository-s3:s3ThirdPartyTest
 ```
+Optional environment variables:
+
+- `amazon_s3_path_style_access`: Possible values true or false. Default is false.
+- `amazon_s3_endpoint`: s3 custom endpoint url if aws s3 default endpoint is not being used. 

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -161,6 +161,9 @@ String s3PermanentSecretKey = System.getenv("amazon_s3_secret_key")
 String s3PermanentBucket = System.getenv("amazon_s3_bucket")
 String s3PermanentBasePath = System.getenv("amazon_s3_base_path")
 String s3PermanentRegion = System.getenv("amazon_s3_region")
+String s3Endpoint = System.getenv("amazon_s3_endpoint")
+String s3PathStyleAccess = System.getenv("amazon_s3_path_style_access")
+
 
 String s3TemporaryAccessKey = System.getenv("amazon_s3_access_key_temporary")
 String s3TemporarySecretKey = System.getenv("amazon_s3_secret_key_temporary")
@@ -418,6 +421,14 @@ TaskProvider s3ThirdPartyTest = tasks.register("s3ThirdPartyTest", Test) {
   nonInputProperties.systemProperty 'test.s3.base', s3PermanentBasePath + "_third_party_tests_" + BuildParams.testSeed
   if (useFixture) {
     nonInputProperties.systemProperty 'test.s3.endpoint', "${-> fixtureAddress('minio-fixture', 'minio-fixture', '9000') }"
+  }
+  else {
+	  if (s3Endpoint != null) {
+		  systemProperty 'test.s3.endpoint', s3Endpoint
+	  }
+  }
+  if (s3PathStyleAccess) {
+	  systemProperty 'test.s3.path_style_access', s3PathStyleAccess
   }
 }
 tasks.named("check").configure { dependsOn(s3ThirdPartyTest) }

--- a/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3RepositoryThirdPartyTests.java
+++ b/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3RepositoryThirdPartyTests.java
@@ -94,6 +94,9 @@ public class S3RepositoryThirdPartyTests extends AbstractThirdPartyRepositoryTes
             .put("region", System.getProperty("test.s3.region", "us-west-2"))
             .put("base_path", System.getProperty("test.s3.base", "testpath"));
         final String endpoint = System.getProperty("test.s3.endpoint");
+        final boolean pathStyleAccess = Boolean.parseBoolean(System.getProperty("test.s3.path_style_access"));
+        settings.put("path_style_access",pathStyleAccess);
+        
         if (endpoint != null) {
             settings.put("endpoint", endpoint);
         } else {

--- a/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3RepositoryThirdPartyTests.java
+++ b/plugins/repository-s3/src/internalClusterTest/java/org/opensearch/repositories/s3/S3RepositoryThirdPartyTests.java
@@ -95,8 +95,8 @@ public class S3RepositoryThirdPartyTests extends AbstractThirdPartyRepositoryTes
             .put("base_path", System.getProperty("test.s3.base", "testpath"));
         final String endpoint = System.getProperty("test.s3.endpoint");
         final boolean pathStyleAccess = Boolean.parseBoolean(System.getProperty("test.s3.path_style_access"));
-        settings.put("path_style_access",pathStyleAccess);
-        
+        settings.put("path_style_access", pathStyleAccess);
+
         if (endpoint != null) {
             settings.put("endpoint", endpoint);
         } else {


### PR DESCRIPTION
Issue #18796



### Description
Describe the bug
[Repository s3 plugin test S3RepositoryThirdPartyTests.java does not have an option to override path_style_access and endpoint for integration tests, this helps to test for different possible s3 settings.
With the fix we will be able to test any changes with above 2 settings variations ,
Current integration test is, AWS_REGION=us-west-2 amazon_s3_access_key=$AWS_ACCESS_KEY_ID amazon_s3_secret_key=$AWS_SECRET_ACCESS_KEY amazon_s3_base_path=path amazon_s3_bucket=dblock-opensearch ./gradlew :plugins:repository-s3:s3ThirdPartyTest
With this chaange, we will also pass custom path_style_access and endpoint.
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
