### PR TITLE
[BUG FIX] Segment Replication cleanup completedReplications when SegmentReplicator.cancel is invoked

### DIFF
--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicator.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicator.java
@@ -395,6 +395,7 @@ public class SegmentReplicator {
         onGoingMergedSegmentReplications.cancelForShard(shardId, reason);
         replicationCheckpointStats.remove(shardId);
         primaryCheckpoint.remove(shardId);
+        completedReplications.remove(shardId);
     }
 
     SegmentReplicationTarget get(ShardId shardId) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
I found that `SegmentReplicator#completedReplications` only has addition logic but no cleanup logic.
We should clean up `SegmentReplicator#completedReplications` when `SegmentReplicator#cancel` is invoked. Otherwise, it may cause a risk of memory leak.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
