### PR TITLE
[WLM] change the max invariant for workload group count

### DIFF
--- a/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/service/WorkloadGroupPersistenceService.java
+++ b/plugins/workload-management/src/main/java/org/opensearch/plugin/wlm/service/WorkloadGroupPersistenceService.java
@@ -161,7 +161,7 @@ public class WorkloadGroupPersistenceService {
         String groupName = workloadGroup.getName();
 
         // check if maxWorkloadGroupCount will breach
-        if (existingWorkloadGroups.size() == maxWorkloadGroupCount) {
+        if (existingWorkloadGroups.size() >= maxWorkloadGroupCount) {
             logger.warn("{} value exceeded its assigned limit of {}.", WORKLOAD_GROUP_COUNT_SETTING_NAME, maxWorkloadGroupCount);
             throw new IllegalStateException("Can't create more than " + maxWorkloadGroupCount + " WorkloadGroups in the system.");
         }

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/service/WorkloadGroupPersistenceServiceTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/service/WorkloadGroupPersistenceServiceTests.java
@@ -185,6 +185,26 @@ public class WorkloadGroupPersistenceServiceTests extends OpenSearchTestCase {
         assertThrows(IllegalArgumentException.class, () -> workloadGroupPersistenceService.setMaxWorkloadGroupCount(-1));
     }
 
+    public void testMaxWorkloadGroupCountCase() {
+        Settings settings = Settings.builder().put(WORKLOAD_GROUP_COUNT_SETTING_NAME, 1).build();
+        Metadata metadata = Metadata.builder().workloadGroups(Map.of(_ID_ONE, workloadGroupOne)).build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, clusterSettingsSet());
+        ClusterService clusterService = new ClusterService(settings, clusterSettings, mock(ThreadPool.class));
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).metadata(metadata).build();
+        WorkloadGroupPersistenceService workloadGroupPersistenceService1 = new WorkloadGroupPersistenceService(
+            clusterService,
+            settings,
+            clusterSettings
+        );
+        WorkloadGroup newWorkloadGroup = builder().name(NAME_NONE_EXISTED)
+            ._id("W5iIqHyhgi4K1qIAAAAIHw==")
+            .mutableWorkloadGroupFragment(new MutableWorkloadGroupFragment(ResiliencyMode.MONITOR, Map.of(ResourceType.MEMORY, 0.1)))
+            .updatedAt(1690934400000L)
+            .build();
+
+        assertThrows(IllegalStateException.class, () -> workloadGroupPersistenceService1.saveWorkloadGroupInClusterState(newWorkloadGroup, clusterState));
+    }
+
     /**
      * Tests the valid value of {@code node.workload_group.max_count}
      */


### PR DESCRIPTION
### Description
Although cluster state is processed sequentially but this change address the concern of allowing workload group creation once workload group count is beyond limit.

### Check List
- [X] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
