### PR TITLE
[Pull-based Ingestion] Prevent shard initialization failures due to transient consumer errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Make GRPC transport extensible to allow plugins to register and expose their own GRPC services ([#18516](https://github.com/opensearch-project/OpenSearch/pull/18516))
 - Added approximation support for range queries with now in date field ([#18511](https://github.com/opensearch-project/OpenSearch/pull/18511))
 - Upgrade to protobufs 0.6.0 and clean up deprecated TermQueryProtoUtils code ([#18880](https://github.com/opensearch-project/OpenSearch/pull/18880))
+- Prevent shard initialization failure due to streaming consumer errors ([#18877](https://github.com/opensearch-project/OpenSearch/pull/18877))
 
 ### Changed
 - Update Subject interface to use CheckedRunnable ([#18570](https://github.com/opensearch-project/OpenSearch/issues/18570))

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSingleNodeTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSingleNodeTests.java
@@ -133,6 +133,24 @@ public class KafkaSingleNodeTests extends OpenSearchSingleNodeTestCase {
         });
     }
 
+    // This test validates shard initialization does not fail due to kafka connection errors.
+    public void testShardInitializationUsingUnknownTopic() throws Exception {
+        createIndexWithMappingSource(
+            indexName,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put("ingestion_source.type", "kafka")
+                .put("ingestion_source.pointer.init.reset", "earliest")
+                .put("ingestion_source.param.topic", "unknownTopic")
+                .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
+                .put("index.replication.type", "SEGMENT")
+                .build(),
+            mappings
+        );
+        ensureGreen(indexName);
+    }
+
     private void setupKafka() {
         kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"))
             // disable topic auto creation

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -576,7 +576,7 @@ public class IngestionEngine extends InternalEngine {
         }
 
         if (streamPoller.getConsumer() == null) {
-            throw new OpenSearchException("Consumer is not yet initialized");
+            throw new IllegalStateException("Consumer is not yet initialized");
         }
 
         try {

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -459,20 +459,20 @@ public class DefaultStreamPoller implements StreamPoller {
             switch (resetState) {
                 case EARLIEST:
                     initialBatchStartPointer = consumer.earliestPointer();
-                    logger.info("Resetting offset by seeking to earliest offset {}", initialBatchStartPointer.asString());
+                    logger.info("Resetting pointer by seeking to earliest pointer {}", initialBatchStartPointer.asString());
                     break;
                 case LATEST:
                     initialBatchStartPointer = consumer.latestPointer();
-                    logger.info("Resetting offset by seeking to latest offset {}", initialBatchStartPointer.asString());
+                    logger.info("Resetting pointer by seeking to latest pointer {}", initialBatchStartPointer.asString());
                     break;
                 case RESET_BY_OFFSET:
                     initialBatchStartPointer = consumer.pointerFromOffset(resetValue);
-                    logger.info("Resetting offset by seeking to offset {}", initialBatchStartPointer.asString());
+                    logger.info("Resetting pointer by seeking to pointer {}", initialBatchStartPointer.asString());
                     break;
                 case RESET_BY_TIMESTAMP:
                     initialBatchStartPointer = consumer.pointerFromTimestampMillis(Long.parseLong(resetValue));
                     logger.info(
-                        "Resetting offset by seeking to timestamp {}, corresponding offset {}",
+                        "Resetting pointer by seeking to timestamp {}, corresponding pointer {}",
                         resetValue,
                         initialBatchStartPointer.asString()
                     );

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -16,6 +16,7 @@ import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.IngestionConsumerFactory;
 import org.opensearch.index.IngestionShardConsumer;
 import org.opensearch.index.IngestionShardPointer;
 import org.opensearch.index.Message;
@@ -35,6 +36,7 @@ import java.util.concurrent.Executors;
 public class DefaultStreamPoller implements StreamPoller {
     private static final Logger logger = LogManager.getLogger(DefaultStreamPoller.class);
     private static final int DEFAULT_POLLER_SLEEP_PERIOD_MS = 100;
+    private static final int CONSUMER_INIT_RETRY_INTERVAL_MS = 10000;
 
     private volatile State state = State.NONE;
 
@@ -49,7 +51,11 @@ public class DefaultStreamPoller implements StreamPoller {
 
     private volatile long lastPolledMessageTimestamp = 0;
 
+    @Nullable
     private IngestionShardConsumer consumer;
+    private IngestionConsumerFactory consumerFactory;
+    private String consumerClientId;
+    private int shardId;
 
     private ExecutorService consumerThread;
 
@@ -83,7 +89,9 @@ public class DefaultStreamPoller implements StreamPoller {
     public DefaultStreamPoller(
         IngestionShardPointer startPointer,
         Set<IngestionShardPointer> persistedPointers,
-        IngestionShardConsumer consumer,
+        IngestionConsumerFactory consumerFactory,
+        String consumerClientId,
+        int shardId,
         IngestionEngine ingestionEngine,
         ResetState resetState,
         String resetValue,
@@ -97,14 +105,10 @@ public class DefaultStreamPoller implements StreamPoller {
         this(
             startPointer,
             persistedPointers,
-            consumer,
-            new PartitionedBlockingQueueContainer(
-                numProcessorThreads,
-                consumer.getShardId(),
-                ingestionEngine,
-                errorStrategy,
-                blockingQueueSize
-            ),
+            consumerFactory,
+            consumerClientId,
+            shardId,
+            new PartitionedBlockingQueueContainer(numProcessorThreads, shardId, ingestionEngine, errorStrategy, blockingQueueSize),
             resetState,
             resetValue,
             errorStrategy,
@@ -115,10 +119,15 @@ public class DefaultStreamPoller implements StreamPoller {
         );
     }
 
+    /**
+     * Visible for testing.
+     */
     DefaultStreamPoller(
         IngestionShardPointer startPointer,
         Set<IngestionShardPointer> persistedPointers,
-        IngestionShardConsumer consumer,
+        IngestionConsumerFactory consumerFactory,
+        String consumerClientId,
+        int shardId,
         PartitionedBlockingQueueContainer blockingQueueContainer,
         ResetState resetState,
         String resetValue,
@@ -128,7 +137,9 @@ public class DefaultStreamPoller implements StreamPoller {
         int pollTimeout,
         IndexSettings indexSettings
     ) {
-        this.consumer = Objects.requireNonNull(consumer);
+        this.consumerFactory = Objects.requireNonNull(consumerFactory);
+        this.consumerClientId = Objects.requireNonNull(consumerClientId);
+        this.shardId = shardId;
         this.resetState = resetState;
         this.resetValue = resetValue;
         this.initialBatchStartPointer = startPointer;
@@ -141,10 +152,7 @@ public class DefaultStreamPoller implements StreamPoller {
         }
         this.blockingQueueContainer = blockingQueueContainer;
         this.consumerThread = Executors.newSingleThreadExecutor(
-            r -> new Thread(
-                r,
-                String.format(Locale.ROOT, "stream-poller-consumer-%d-%d", consumer.getShardId(), System.currentTimeMillis())
-            )
+            r -> new Thread(r, String.format(Locale.ROOT, "stream-poller-consumer-%d-%d", shardId, System.currentTimeMillis()))
         );
         this.errorStrategy = errorStrategy;
         this.indexName = indexSettings.getIndex().getName();
@@ -178,7 +186,7 @@ public class DefaultStreamPoller implements StreamPoller {
         if (closed) {
             throw new IllegalStateException("poller is closed!");
         }
-        logger.info("Starting poller for shard {}", consumer.getShardId());
+        logger.info("Starting poller for shard {}", shardId);
 
         IngestionShardPointer failedShardPointer = null;
         while (true) {
@@ -188,45 +196,26 @@ public class DefaultStreamPoller implements StreamPoller {
                     break;
                 }
 
-                // reset the offset
-                if (resetState != ResetState.NONE) {
-                    switch (resetState) {
-                        case EARLIEST:
-                            initialBatchStartPointer = consumer.earliestPointer();
-                            logger.info("Resetting offset by seeking to earliest offset {}", initialBatchStartPointer.asString());
-                            break;
-                        case LATEST:
-                            initialBatchStartPointer = consumer.latestPointer();
-                            logger.info("Resetting offset by seeking to latest offset {}", initialBatchStartPointer.asString());
-                            break;
-                        case RESET_BY_OFFSET:
-                            initialBatchStartPointer = consumer.pointerFromOffset(resetValue);
-                            logger.info("Resetting offset by seeking to offset {}", initialBatchStartPointer.asString());
-                            break;
-                        case RESET_BY_TIMESTAMP:
-                            initialBatchStartPointer = consumer.pointerFromTimestampMillis(Long.parseLong(resetValue));
-                            logger.info(
-                                "Resetting offset by seeking to timestamp {}, corresponding offset {}",
-                                resetValue,
-                                initialBatchStartPointer.asString()
-                            );
-                            break;
-                    }
-                    resetState = ResetState.NONE;
+                // Initialize consumer if not already initialized
+                if (this.consumer == null) {
+                    initializeConsumer(CONSUMER_INIT_RETRY_INTERVAL_MS);
+                    continue;
                 }
+
+                // reset the consumer offset
+                handleResetState();
 
                 if (paused || isWriteBlockEnabled) {
                     state = State.PAUSED;
                     try {
                         Thread.sleep(DEFAULT_POLLER_SLEEP_PERIOD_MS);
                     } catch (Throwable e) {
-                        logger.error("Error in pausing the poller of shard {}: {}", consumer.getShardId(), e);
+                        logger.error("Error in pausing the poller of shard {}: {}", shardId, e);
                     }
                     continue;
                 }
 
                 state = State.POLLING;
-
                 List<IngestionShardConsumer.ReadResult<? extends IngestionShardPointer, ? extends Message>> results;
 
                 if (includeBatchStartPointer) {
@@ -251,7 +240,7 @@ public class DefaultStreamPoller implements StreamPoller {
                 // Currently we do not have a good way to skip past the failing messages.
                 // The user will have the option to manually update the offset and resume ingestion.
                 // todo: support retry?
-                logger.error("Pausing ingestion. Fatal error occurred in polling the shard {}: {}", consumer.getShardId(), e);
+                logger.error("Pausing ingestion. Fatal error occurred in polling the shard {}: {}", shardId, e);
                 totalConsumerErrorCount.inc();
                 pause();
             }
@@ -283,12 +272,7 @@ public class DefaultStreamPoller implements StreamPoller {
                     result.getPointer().asString()
                 );
             } catch (Exception e) {
-                logger.error(
-                    "Error in processing a record. Shard {}, pointer {}: {}",
-                    consumer.getShardId(),
-                    result.getPointer().asString(),
-                    e
-                );
+                logger.error("Error in processing a record. Shard {}, pointer {}: {}", shardId, result.getPointer().asString(), e);
                 errorStrategy.handleError(e, IngestionErrorStrategy.ErrorStage.POLLING);
                 totalPollerMessageFailureCount.inc();
 
@@ -352,18 +336,18 @@ public class DefaultStreamPoller implements StreamPoller {
         while (state != State.CLOSED) {
             // Check if the timeout has been reached
             if (System.currentTimeMillis() - startTime > timeout) {
-                logger.error("Timeout reached while waiting for shard {} to close", consumer.getShardId());
+                logger.error("Timeout reached while waiting for shard {} to close", shardId);
                 break; // Exit the loop if the timeout is reached
             }
             try {
                 Thread.sleep(100);
             } catch (Throwable e) {
-                logger.error("Error in closing the poller of shard {}: {}", consumer.getShardId(), e);
+                logger.error("Error in closing the poller of shard {}: {}", shardId, e);
             }
         }
         consumerThread.shutdown();
         blockingQueueContainer.close();
-        logger.info("closed the poller of shard {}", consumer.getShardId());
+        logger.info("closed the poller of shard {}", shardId);
     }
 
     @Override
@@ -445,6 +429,7 @@ public class DefaultStreamPoller implements StreamPoller {
         this.isWriteBlockEnabled = isWriteBlockEnabled;
     }
 
+    @Nullable
     @Override
     public IngestionShardConsumer getConsumer() {
         return consumer;
@@ -463,6 +448,182 @@ public class DefaultStreamPoller implements StreamPoller {
         } catch (Exception e) {
             logger.error("Error applying cluster state in stream poller", e);
             throw e;
+        }
+    }
+
+    /**
+     * Handles the reset state logic, updating the initialBatchStartPointer based on the reset state.
+     */
+    private void handleResetState() {
+        if (resetState != ResetState.NONE) {
+            switch (resetState) {
+                case EARLIEST:
+                    initialBatchStartPointer = consumer.earliestPointer();
+                    logger.info("Resetting offset by seeking to earliest offset {}", initialBatchStartPointer.asString());
+                    break;
+                case LATEST:
+                    initialBatchStartPointer = consumer.latestPointer();
+                    logger.info("Resetting offset by seeking to latest offset {}", initialBatchStartPointer.asString());
+                    break;
+                case RESET_BY_OFFSET:
+                    initialBatchStartPointer = consumer.pointerFromOffset(resetValue);
+                    logger.info("Resetting offset by seeking to offset {}", initialBatchStartPointer.asString());
+                    break;
+                case RESET_BY_TIMESTAMP:
+                    initialBatchStartPointer = consumer.pointerFromTimestampMillis(Long.parseLong(resetValue));
+                    logger.info(
+                        "Resetting offset by seeking to timestamp {}, corresponding offset {}",
+                        resetValue,
+                        initialBatchStartPointer.asString()
+                    );
+                    break;
+            }
+            resetState = ResetState.NONE;
+        }
+    }
+
+    /**
+     * Initializes the consumer using the provided consumerFactory. If an error is encountered during initialization,
+     * the poller thread sleeps for the provided duration before retrying/proceeding with the polling loop.
+     */
+    private void initializeConsumer(int sleepDurationOnError) {
+        try {
+            this.consumer = consumerFactory.createShardConsumer(consumerClientId, shardId);
+            logger.info("Successfully initialized consumer for shard {}", shardId);
+        } catch (Exception e) {
+            logger.warn("Failed to create consumer for shard {}: {}", shardId, e.getMessage());
+            totalConsumerErrorCount.inc();
+            try {
+                Thread.sleep(sleepDurationOnError);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /**
+     * Builder for DefaultStreamPoller
+     */
+    public static class Builder {
+        private IngestionShardPointer startPointer;
+        private Set<IngestionShardPointer> persistedPointers;
+        private IngestionConsumerFactory consumerFactory;
+        private String consumerClientId;
+        private int shardId;
+        private IngestionEngine ingestionEngine;
+        private ResetState resetState = ResetState.LATEST;
+        private String resetValue = "";
+        private IngestionErrorStrategy errorStrategy;
+        private State initialState = State.NONE;
+        private long maxPollSize = 1000;
+        private int pollTimeout = 1000;
+        private int numProcessorThreads = 1;
+        private int blockingQueueSize = 100;
+
+        /**
+         * Initialize the builder with mandatory parameters
+         */
+        public Builder(
+            IngestionShardPointer startPointer,
+            Set<IngestionShardPointer> persistedPointers,
+            IngestionConsumerFactory consumerFactory,
+            String consumerClientId,
+            int shardId,
+            IngestionEngine ingestionEngine
+        ) {
+            this.startPointer = startPointer;
+            this.persistedPointers = Objects.requireNonNull(persistedPointers);
+            this.consumerFactory = Objects.requireNonNull(consumerFactory);
+            this.consumerClientId = Objects.requireNonNull(consumerClientId);
+            this.shardId = shardId;
+            this.ingestionEngine = Objects.requireNonNull(ingestionEngine);
+            this.errorStrategy = new DropIngestionErrorStrategy("poller");
+        }
+
+        /**
+         * Set error strategy
+         */
+        public Builder errorStrategy(IngestionErrorStrategy errorStrategy) {
+            this.errorStrategy = Objects.requireNonNull(errorStrategy);
+            return this;
+        }
+
+        /**
+         * Set reset state
+         */
+        public Builder resetState(ResetState resetState) {
+            this.resetState = resetState;
+            return this;
+        }
+
+        /**
+         * Set reset value
+         */
+        public Builder resetValue(String resetValue) {
+            this.resetValue = resetValue;
+            return this;
+        }
+
+        /**
+         * Set initial state
+         */
+        public Builder initialState(State initialState) {
+            this.initialState = initialState;
+            return this;
+        }
+
+        /**
+         * Set max poll size
+         */
+        public Builder maxPollSize(long maxPollSize) {
+            this.maxPollSize = maxPollSize;
+            return this;
+        }
+
+        /**
+         * Set poll timeout
+         */
+        public Builder pollTimeout(int pollTimeout) {
+            this.pollTimeout = pollTimeout;
+            return this;
+        }
+
+        /**
+         * Set number of processor threads
+         */
+        public Builder numProcessorThreads(int numProcessorThreads) {
+            this.numProcessorThreads = numProcessorThreads;
+            return this;
+        }
+
+        /**
+         * Set blocking queue size
+         */
+        public Builder blockingQueueSize(int blockingQueueSize) {
+            this.blockingQueueSize = blockingQueueSize;
+            return this;
+        }
+
+        /**
+         * Build the DefaultStreamPoller instance
+         */
+        public DefaultStreamPoller build() {
+            return new DefaultStreamPoller(
+                startPointer,
+                persistedPointers,
+                consumerFactory,
+                consumerClientId,
+                shardId,
+                ingestionEngine,
+                resetState,
+                resetValue,
+                errorStrategy,
+                initialState,
+                maxPollSize,
+                pollTimeout,
+                numProcessorThreads,
+                blockingQueueSize
+            );
         }
     }
 }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -86,7 +86,7 @@ public class DefaultStreamPoller implements StreamPoller {
 
     private PartitionedBlockingQueueContainer blockingQueueContainer;
 
-    public DefaultStreamPoller(
+    private DefaultStreamPoller(
         IngestionShardPointer startPointer,
         Set<IngestionShardPointer> persistedPointers,
         IngestionConsumerFactory consumerFactory,

--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -17,6 +17,7 @@ import org.opensearch.cluster.block.ClusterBlocks;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.IngestionConsumerFactory;
 import org.opensearch.index.IngestionShardConsumer;
 import org.opensearch.index.IngestionShardPointer;
 import org.opensearch.index.engine.FakeIngestionSource;
@@ -43,6 +44,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -55,7 +57,7 @@ import static org.mockito.Mockito.when;
 
 public class DefaultStreamPollerTests extends OpenSearchTestCase {
     private DefaultStreamPoller poller;
-    private FakeIngestionSource.FakeIngestionConsumer fakeConsumer;
+    private FakeIngestionSource.FakeIngestionConsumerFactory fakeConsumerFactory;
     private MessageProcessorRunnable processorRunnable;
     private MessageProcessorRunnable.MessageProcessor processor;
     private List<byte[]> messages;
@@ -73,7 +75,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         messages = new ArrayList<>();
         messages.add("{\"_id\":\"1\",\"_source\":{\"name\":\"bob\", \"age\": 24}}".getBytes(StandardCharsets.UTF_8));
         messages.add("{\"_id\":\"2\",\"_source\":{\"name\":\"alice\", \"age\": 21}}".getBytes(StandardCharsets.UTF_8));
-        fakeConsumer = new FakeIngestionSource.FakeIngestionConsumer(messages, 0);
+        fakeConsumerFactory = new FakeIngestionSource.FakeIngestionConsumerFactory(messages);
         processor = mock(MessageProcessorRunnable.MessageProcessor.class);
         errorStrategy = new DropIngestionErrorStrategy("ingestion_source");
         processorRunnable = new MessageProcessorRunnable(new ArrayBlockingQueue<>(5), processor, errorStrategy);
@@ -84,7 +86,9 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
             persistedPointers,
-            fakeConsumer,
+            fakeConsumerFactory,
+            "",
+            0,
             partitionedBlockingQueueContainer,
             StreamPoller.ResetState.NONE,
             "",
@@ -146,7 +150,9 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
             persistedPointers,
-            fakeConsumer,
+            fakeConsumerFactory,
+            "",
+            0,
             partitionedBlockingQueueContainer,
             StreamPoller.ResetState.NONE,
             "",
@@ -187,7 +193,9 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(1),
             persistedPointers,
-            fakeConsumer,
+            fakeConsumerFactory,
+            "",
+            0,
             partitionedBlockingQueueContainer,
             StreamPoller.ResetState.EARLIEST,
             "",
@@ -214,7 +222,9 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
             persistedPointers,
-            fakeConsumer,
+            fakeConsumerFactory,
+            "",
+            0,
             partitionedBlockingQueueContainer,
             StreamPoller.ResetState.LATEST,
             "",
@@ -237,7 +247,9 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(2),
             persistedPointers,
-            fakeConsumer,
+            fakeConsumerFactory,
+            "",
+            0,
             partitionedBlockingQueueContainer,
             StreamPoller.ResetState.RESET_BY_OFFSET,
             "1",
@@ -283,6 +295,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     public void testDropErrorIngestionStrategy() throws TimeoutException, InterruptedException {
         messages.add("{\"_id\":\"3\",\"_source\":{\"name\":\"bob\", \"age\": 24}}".getBytes(StandardCharsets.UTF_8));
         messages.add("{\"_id\":\"4\",\"_source\":{\"name\":\"alice\", \"age\": 21}}".getBytes(StandardCharsets.UTF_8));
+        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer("", 0);
         List<
             IngestionShardConsumer.ReadResult<
                 FakeIngestionSource.FakeIngestionShardPointer,
@@ -313,10 +326,15 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         PartitionedBlockingQueueContainer blockingQueueContainer = new PartitionedBlockingQueueContainer(processorRunnable, 0);
         blockingQueueContainer.startProcessorThreads();
 
+        IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt())).thenReturn(mockConsumer);
+
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
             persistedPointers,
-            mockConsumer,
+            mockConsumerFactory,
+            "",
+            0,
             blockingQueueContainer,
             StreamPoller.ResetState.NONE,
             "",
@@ -340,6 +358,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     public void testBlockErrorIngestionStrategy() throws TimeoutException, InterruptedException {
         messages.add("{\"_id\":\"3\",\"_source\":{\"name\":\"bob\", \"age\": 24}}".getBytes(StandardCharsets.UTF_8));
         messages.add("{\"_id\":\"4\",\"_source\":{\"name\":\"alice\", \"age\": 21}}".getBytes(StandardCharsets.UTF_8));
+        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer("", 0);
         List<
             IngestionShardConsumer.ReadResult<
                 FakeIngestionSource.FakeIngestionShardPointer,
@@ -369,11 +388,15 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         processorRunnable = new MessageProcessorRunnable(mockQueue, processor, errorStrategy);
         PartitionedBlockingQueueContainer blockingQueueContainer = new PartitionedBlockingQueueContainer(processorRunnable, 0);
         blockingQueueContainer.startProcessorThreads();
+        IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt())).thenReturn(mockConsumer);
 
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
             persistedPointers,
-            mockConsumer,
+            mockConsumerFactory,
+            "",
+            0,
             blockingQueueContainer,
             StreamPoller.ResetState.NONE,
             "",
@@ -407,7 +430,9 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
             persistedPointers,
-            fakeConsumer,
+            fakeConsumerFactory,
+            "",
+            0,
             blockingQueueContainer,
             StreamPoller.ResetState.NONE,
             "",
@@ -439,6 +464,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
     public void testPersistedBatchStartPointer() throws TimeoutException, InterruptedException {
         messages.add("{\"_id\":\"3\",\"_source\":{\"name\":\"bob\", \"age\": 24}}".getBytes(StandardCharsets.UTF_8));
         messages.add("{\"_id\":\"4\",\"_source\":{\"name\":\"alice\", \"age\": 21}}".getBytes(StandardCharsets.UTF_8));
+        FakeIngestionSource.FakeIngestionConsumer fakeConsumer = fakeConsumerFactory.createShardConsumer("", 0);
         List<
             IngestionShardConsumer.ReadResult<
                 FakeIngestionSource.FakeIngestionShardPointer,
@@ -470,11 +496,15 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         when(mockConsumer.readNext(any(), anyBoolean(), anyLong(), anyInt())).thenReturn(readResultsBatch1);
 
         when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(readResultsBatch2).thenReturn(Collections.emptyList());
+        IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt())).thenReturn(mockConsumer);
 
         poller = new DefaultStreamPoller(
             new FakeIngestionSource.FakeIngestionShardPointer(0),
             persistedPointers,
-            mockConsumer,
+            mockConsumerFactory,
+            "",
+            0,
             blockingQueueContainer,
             StreamPoller.ResetState.NONE,
             "",
@@ -523,5 +553,46 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         ClusterChangedEvent event = mock(ClusterChangedEvent.class);
         doThrow(new RuntimeException()).when(event).blocksChanged();
         assertThrows(RuntimeException.class, () -> poller.clusterChanged(event));
+    }
+
+    public void testConsumerInitializationRetry() throws Exception {
+        // Create a mock consumer that will be returned on successful initialization
+        IngestionShardConsumer mockConsumer = mock(IngestionShardConsumer.class);
+        when(mockConsumer.getShardId()).thenReturn(0);
+        when(mockConsumer.readNext(anyLong(), anyInt())).thenReturn(Collections.emptyList());
+
+        // Create a mock consumer factory that fails on first call but succeeds on second call
+        IngestionConsumerFactory mockConsumerFactory = mock(IngestionConsumerFactory.class);
+        when(mockConsumerFactory.createShardConsumer(anyString(), anyInt())).thenThrow(
+            new RuntimeException("Simulated consumer initialization failure")
+        ).thenReturn(mockConsumer);
+
+        // Create a poller with the mock factory
+        poller = new DefaultStreamPoller(
+            new FakeIngestionSource.FakeIngestionShardPointer(0),
+            persistedPointers,
+            mockConsumerFactory,
+            "",
+            0,
+            partitionedBlockingQueueContainer,
+            StreamPoller.ResetState.NONE,
+            "",
+            errorStrategy,
+            StreamPoller.State.NONE,
+            1000,
+            1000,
+            indexSettings
+        );
+
+        poller.start();
+        assertBusy(() -> {
+            PollingIngestStats stats = poller.getStats();
+            assertEquals(1, stats.getConsumerStats().totalConsumerErrorCount());
+            assertEquals(StreamPoller.State.POLLING, poller.getState());
+        }, 30, TimeUnit.SECONDS);
+
+        // Verify the consumer factory was called twice (once for failure, once for success)
+        verify(mockConsumerFactory, times(2)).createShardConsumer(anyString(), anyInt());
+        assertNotNull(poller.getConsumer());
     }
 }


### PR DESCRIPTION
### Description
Transient consumer errors (such as kafka connection issues) fail shard/engine initialization today, resulting in possibility of cascading failures, where all the primary and replica shards can go down. This PR moves the consumer initialization logic into the poller with retries in case of transient errors.

### Related Issues
Follow up for #16929 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
