### PR TITLE
Enabling Intra Segment Concurrent Search for only queries without aggregations

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -778,6 +778,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING, // deprecated
                 SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING,
                 SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_MODE,
+                SearchService.CLUSTER_CONCURRENT_INTRA_SEGMENT_SEARCH_MODE,
+                SearchService.CONCURRENT_INTRA_SEGMENT_SEARCH_PARTITION_SIZE_SETTING,
 
                 RemoteStoreSettings.CLUSTER_REMOTE_INDEX_SEGMENT_METADATA_RETENTION_MAX_COUNT_SETTING,
                 RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING,

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -250,6 +250,8 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.INDEX_CONCURRENT_SEGMENT_SEARCH_SETTING, // deprecated
                 IndexSettings.INDEX_CONCURRENT_SEGMENT_SEARCH_MODE,
                 IndexSettings.INDEX_CONCURRENT_SEGMENT_SEARCH_MAX_SLICE_COUNT,
+                IndexSettings.INDEX_CONCURRENT_INTRA_SEGMENT_SEARCH_MODE,
+                IndexSettings.INDEX_CONCURRENT_INTRA_SEGMENT_PARTITION_SIZE,
                 IndexSettings.ALLOW_DERIVED_FIELDS,
 
                 // Settings for star tree index

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -75,6 +75,8 @@ import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_FIELD_NAME
 import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_NESTED_DOCS_LIMIT_SETTING;
 import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING;
 import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING;
+import static org.opensearch.search.SearchService.CONCURRENT_INTRA_SEGMENT_DEFAULT_PARTITION_SIZE_VALUE;
+import static org.opensearch.search.SearchService.CONCURRENT_INTRA_SEGMENT_MINIMUM_PARTITION_SIZE_VALUE;
 import static org.opensearch.search.SearchService.CONCURRENT_SEGMENT_SEARCH_DEFAULT_SLICE_COUNT_VALUE;
 import static org.opensearch.search.SearchService.CONCURRENT_SEGMENT_SEARCH_MIN_SLICE_COUNT_VALUE;
 import static org.opensearch.search.SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_ALL;
@@ -713,6 +715,7 @@ public final class IndexSettings {
         Property.Deprecated
     );
 
+    // TODO : Should use enum
     public static final Setting<String> INDEX_CONCURRENT_SEGMENT_SEARCH_MODE = Setting.simpleString(
         "index.search.concurrent_segment_search.mode",
         CONCURRENT_SEGMENT_SEARCH_MODE_NONE,
@@ -735,6 +738,32 @@ public final class IndexSettings {
         "index.search.concurrent.max_slice_count",
         CONCURRENT_SEGMENT_SEARCH_DEFAULT_SLICE_COUNT_VALUE,
         CONCURRENT_SEGMENT_SEARCH_MIN_SLICE_COUNT_VALUE,
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    public static final Setting<String> INDEX_CONCURRENT_INTRA_SEGMENT_SEARCH_MODE = Setting.simpleString(
+        "index.search.concurrent_intra_segment_search.mode",
+        CONCURRENT_SEGMENT_SEARCH_MODE_NONE,
+        value -> {
+            // TODO : Add support for Auto mode with Intra Segment Search
+            switch (value) {
+                case CONCURRENT_SEGMENT_SEARCH_MODE_ALL:
+                case CONCURRENT_SEGMENT_SEARCH_MODE_NONE:
+                    // valid setting
+                    break;
+                default:
+                    throw new IllegalArgumentException("Setting value must be one of [all, none]");
+            }
+        },
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    public static final Setting<Integer> INDEX_CONCURRENT_INTRA_SEGMENT_PARTITION_SIZE = Setting.intSetting(
+        "index.search.concurrent_intra_segment_search.partition_size",
+        CONCURRENT_INTRA_SEGMENT_DEFAULT_PARTITION_SIZE_VALUE,
+        CONCURRENT_INTRA_SEGMENT_MINIMUM_PARTITION_SIZE_VALUE,
         Property.Dynamic,
         Property.IndexScope
     );

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -1038,6 +1038,8 @@ final class DefaultSearchContext extends SearchContext {
             requestShouldUseConcurrentIntraSegmentSearch.set(false);
         } else if (terminateAfter != DEFAULT_TERMINATE_AFTER) {
             requestShouldUseConcurrentIntraSegmentSearch.set(false);
+        } else if (trackTotalHitsUpTo != TRACK_TOTAL_HITS_DISABLED) {
+            requestShouldUseConcurrentIntraSegmentSearch.set(false);
         } else if (concurrentIntraSegmentSearchMode.equals(CONCURRENT_SEGMENT_SEARCH_MODE_ALL)){ // TODO : Handle auto mode here
             requestShouldUseConcurrentIntraSegmentSearch.set(true);
         } else {

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -1038,9 +1038,9 @@ final class DefaultSearchContext extends SearchContext {
             requestShouldUseConcurrentIntraSegmentSearch.set(false);
         } else if (terminateAfter != DEFAULT_TERMINATE_AFTER) {
             requestShouldUseConcurrentIntraSegmentSearch.set(false);
-        } else if (trackTotalHitsUpTo != TRACK_TOTAL_HITS_DISABLED) {
+        } else if (trackTotalHitsUpTo != TRACK_TOTAL_HITS_DISABLED) { // TODO : Need to handle TotalHitCountCollectorManager
             requestShouldUseConcurrentIntraSegmentSearch.set(false);
-        } else if (concurrentIntraSegmentSearchMode.equals(CONCURRENT_SEGMENT_SEARCH_MODE_ALL)){ // TODO : Handle auto mode here
+        } else if (concurrentIntraSegmentSearchMode.equals(CONCURRENT_SEGMENT_SEARCH_MODE_ALL)) { // TODO : Handle auto mode here
             requestShouldUseConcurrentIntraSegmentSearch.set(true);
         } else {
             requestShouldUseConcurrentIntraSegmentSearch.set(false);

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -348,7 +348,6 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         Property.NodeScope
     );
 
-
     // value 0 means rewrite filters optimization in aggregations will be disabled
     @ExperimentalApi
     public static final Setting<Integer> MAX_AGGREGATION_REWRITE_FILTERS = Setting.intSetting(

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -623,6 +623,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         return leafSlices;
     }
 
+    // FIXME: Remove before merging
     private static void printDistributionLogs(List<LeafReaderContext> leaves, LeafSlice[] leafSlices) {
         StringBuilder res = new StringBuilder();
         long total = 0;

--- a/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
@@ -579,6 +579,11 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
+    public int getSegmentPartitionSize() {
+        return in.getSegmentPartitionSize();
+    }
+
+    @Override
     public boolean shouldUseTimeSeriesDescSortOptimization() {
         return in.shouldUseTimeSeriesDescSortOptimization();
     }

--- a/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
+++ b/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
@@ -53,7 +53,9 @@ final class MaxTargetSliceSupplier {
             if (isIntraSegmentEnabled == true && leafReaderContext.reader().maxDoc() >= minSegmentSizeToSplit) {
                 partitions.addAll(partitionSegment(leafReaderContext, segmentSizeToSplit, targetSliceCount));
             } else {
-                partitions.add(IndexSearcher.LeafReaderContextPartition.createFromAndTo(leafReaderContext, 0, leafReaderContext.reader().maxDoc()));
+                partitions.add(
+                    IndexSearcher.LeafReaderContextPartition.createFromAndTo(leafReaderContext, 0, leafReaderContext.reader().maxDoc())
+                );
             }
             leafToLastUnassignedDocId.put(leafReaderContext.ord, 0);
         }
@@ -113,9 +115,15 @@ final class MaxTargetSliceSupplier {
             // Merging 2 LeafReaderContextPartition that fall within same slice.
             // IndexSearcher in Lucene will throw an exception if not merged as it doesn't help parallelism.
             if (segmentOrdToMergedPartition.containsKey(leafReaderContextPartition.ctx.ord)) {
-                IndexSearcher.LeafReaderContextPartition storedPartition = segmentOrdToMergedPartition.get(leafReaderContextPartition.ctx.ord);
+                IndexSearcher.LeafReaderContextPartition storedPartition = segmentOrdToMergedPartition.get(
+                    leafReaderContextPartition.ctx.ord
+                );
                 effectivePartitionDocCount += storedPartition.maxDocId - storedPartition.minDocId;
-                effectivePartition = IndexSearcher.LeafReaderContextPartition.createFromAndTo(leafReaderContextPartition.ctx, 0, effectivePartitionDocCount);
+                effectivePartition = IndexSearcher.LeafReaderContextPartition.createFromAndTo(
+                    leafReaderContextPartition.ctx,
+                    0,
+                    effectivePartitionDocCount
+                );
             }
             segmentOrdToMergedPartition.put(effectivePartition.ctx.ord, effectivePartition);
             totalSize += effectivePartitionDocCount;
@@ -131,7 +139,9 @@ final class MaxTargetSliceSupplier {
             for (IndexSearcher.LeafReaderContextPartition leafReaderContextPartition : segmentOrdToMergedPartition.values()) {
                 int fromDocId = leafToLastUnassignedDocId.get(leafReaderContextPartition.ctx.ord);
                 int toDocId = fromDocId + leafReaderContextPartition.maxDocId - leafReaderContextPartition.minDocId;
-                partitions.add(IndexSearcher.LeafReaderContextPartition.createFromAndTo(leafReaderContextPartition.ctx, fromDocId, toDocId));
+                partitions.add(
+                    IndexSearcher.LeafReaderContextPartition.createFromAndTo(leafReaderContextPartition.ctx, fromDocId, toDocId)
+                );
                 leafToLastUnassignedDocId.put(leafReaderContextPartition.ctx.ord, toDocId);
             }
             return new IndexSearcher.LeafSlice(partitions);

--- a/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
+++ b/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
@@ -14,8 +14,10 @@ import org.apache.lucene.search.IndexSearcher;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.PriorityQueue;
+import java.util.Map;
 
 /**
  * Supplier to compute leaf slices based on passed in leaves and max target slice count to limit the number of computed slices. It sorts
@@ -27,7 +29,10 @@ import java.util.PriorityQueue;
  */
 final class MaxTargetSliceSupplier {
 
-    static IndexSearcher.LeafSlice[] getSlices(List<LeafReaderContext> leaves, int targetMaxSlice) {
+    static IndexSearcher.LeafSlice[] getSlices(List<LeafReaderContext> leaves, SliceInputConfig sliceInputConfig) {
+
+        int targetMaxSlice = sliceInputConfig.targetMaxSliceCount;
+
         if (targetMaxSlice <= 0) {
             throw new IllegalArgumentException("MaxTargetSliceSupplier called with unexpected slice count of " + targetMaxSlice);
         }
@@ -35,44 +40,148 @@ final class MaxTargetSliceSupplier {
         // slice count should not exceed the segment count
         int targetSliceCount = Math.min(targetMaxSlice, leaves.size());
 
-        // Make a copy so we can sort:
-        List<LeafReaderContext> sortedLeaves = new ArrayList<>(leaves);
+        boolean isIntraSegmentEnabled = sliceInputConfig.intraSegmentEnabled;
+        int segmentSizeToSplit = sliceInputConfig.segmentSizeToSplit; // Smallest partition of a segment
+        int minSegmentSizeToSplit = segmentSizeToSplit * 2; // At least 2 partitions would make sense
 
-        // Sort by maxDoc, descending:
-        sortedLeaves.sort(Collections.reverseOrder(Comparator.comparingInt(l -> l.reader().maxDoc())));
+        List<IndexSearcher.LeafReaderContextPartition> partitions = new ArrayList<>(leaves.size());
 
-        final List<List<IndexSearcher.LeafReaderContextPartition>> groupedLeaves = new ArrayList<>(targetSliceCount);
-        for (int i = 0; i < targetSliceCount; ++i) {
-            groupedLeaves.add(new ArrayList<>());
+        Map<Integer, Integer> leafToLastUnassignedDocId = new HashMap<>(leaves.size());
+
+        for (LeafReaderContext leafReaderContext : leaves) {
+            // Don't split a segment if it's not enabled OR it doesn't meet the size criteria.
+            if (isIntraSegmentEnabled == true && leafReaderContext.reader().maxDoc() >= minSegmentSizeToSplit) {
+                partitions.addAll(partitionSegment(leafReaderContext, segmentSizeToSplit, targetSliceCount));
+            } else {
+                partitions.add(IndexSearcher.LeafReaderContextPartition.createFromAndTo(leafReaderContext, 0, leafReaderContext.reader().maxDoc()));
+            }
+            leafToLastUnassignedDocId.put(leafReaderContext.ord, 0);
         }
 
-        PriorityQueue<Group> groupQueue = new PriorityQueue<>();
+        // Sort all the partitions based on their doc counts in descending order.
+        partitions.sort(Collections.reverseOrder(Comparator.comparingInt(l -> l.maxDocId - l.minDocId)));
+
+        PriorityQueue<LeafSliceBuilder> queue = new PriorityQueue<>(targetSliceCount);
         for (int i = 0; i < targetSliceCount; i++) {
-            groupQueue.offer(new Group(i));
-        }
-        Group minGroup;
-        for (int i = 0; i < sortedLeaves.size(); ++i) {
-            minGroup = groupQueue.poll();
-            groupedLeaves.get(minGroup.index).add(IndexSearcher.LeafReaderContextPartition.createForEntireSegment(sortedLeaves.get(i)));
-            minGroup.sum += sortedLeaves.get(i).reader().maxDoc();
-            groupQueue.offer(minGroup);
+            queue.add(new LeafSliceBuilder());
         }
 
-        return groupedLeaves.stream().map(IndexSearcher.LeafSlice::new).toArray(IndexSearcher.LeafSlice[]::new);
+        for (IndexSearcher.LeafReaderContextPartition partition : partitions) {
+            LeafSliceBuilder leafSliceBuilder = queue.poll();
+            leafSliceBuilder.addLeafPartition(partition);
+            queue.offer(leafSliceBuilder);
+        }
+
+        // Perform de-duplication
+        IndexSearcher.LeafSlice[] leafSlices = new IndexSearcher.LeafSlice[targetSliceCount];
+        int index = 0;
+
+        for (LeafSliceBuilder leafSliceBuilder : queue) {
+            leafSlices[index++] = leafSliceBuilder.build(leafToLastUnassignedDocId);
+        }
+
+        return leafSlices;
     }
 
-    static class Group implements Comparable<Group> {
-        final int index;
-        int sum;
+    static class SliceInputConfig {
+        final int targetMaxSliceCount;
+        final boolean intraSegmentEnabled;
+        final int segmentSizeToSplit;
 
-        public Group(int index) {
-            this.index = index;
-            this.sum = 0;
+        SliceInputConfig(SearchContext searchContext) {
+            targetMaxSliceCount = searchContext.getTargetMaxSliceCount();
+            intraSegmentEnabled = searchContext.shouldUseIntraSegmentConcurrentSearch();
+            segmentSizeToSplit = searchContext.getSegmentPartitionSize();
+        }
+
+        SliceInputConfig(int targetMaxSliceCount, boolean intraSegmentEnabled, int segmentSizeToSplit) {
+            this.targetMaxSliceCount = targetMaxSliceCount;
+            this.intraSegmentEnabled = intraSegmentEnabled;
+            this.segmentSizeToSplit = segmentSizeToSplit;
+        }
+
+    }
+
+    private static class LeafSliceBuilder implements Comparable<LeafSliceBuilder> {
+
+        private int totalSize = 0;
+        private final Map<Integer, IndexSearcher.LeafReaderContextPartition> segmentOrdToMergedPartition = new HashMap<>();
+
+        void addLeafPartition(IndexSearcher.LeafReaderContextPartition leafReaderContextPartition) {
+            IndexSearcher.LeafReaderContextPartition effectivePartition = leafReaderContextPartition;
+            int effectivePartitionDocCount = effectivePartition.maxDocId - effectivePartition.minDocId;
+            // Merging 2 LeafReaderContextPartition that fall within same slice.
+            // IndexSearcher in Lucene will throw an exception if not merged as it doesn't help parallelism.
+            if (segmentOrdToMergedPartition.containsKey(leafReaderContextPartition.ctx.ord)) {
+                IndexSearcher.LeafReaderContextPartition storedPartition = segmentOrdToMergedPartition.get(leafReaderContextPartition.ctx.ord);
+                effectivePartitionDocCount += storedPartition.maxDocId - storedPartition.minDocId;
+                effectivePartition = IndexSearcher.LeafReaderContextPartition.createFromAndTo(leafReaderContextPartition.ctx, 0, effectivePartitionDocCount);
+            }
+            segmentOrdToMergedPartition.put(effectivePartition.ctx.ord, effectivePartition);
+            totalSize += effectivePartitionDocCount;
+        }
+
+        /**
+         * Called when all the leaf partitions are added.
+         * @param leafToLastUnassignedDocId : Map used to track and generate the real From and To docIds for each segment as
+         * @return : Leaf slice containing all partitions with
+         */
+        IndexSearcher.LeafSlice build(Map<Integer, Integer> leafToLastUnassignedDocId) {
+            List<IndexSearcher.LeafReaderContextPartition> partitions = new ArrayList<>(segmentOrdToMergedPartition.size());
+            for (IndexSearcher.LeafReaderContextPartition leafReaderContextPartition : segmentOrdToMergedPartition.values()) {
+                int fromDocId = leafToLastUnassignedDocId.get(leafReaderContextPartition.ctx.ord);
+                int toDocId = fromDocId + leafReaderContextPartition.maxDocId - leafReaderContextPartition.minDocId;
+                partitions.add(IndexSearcher.LeafReaderContextPartition.createFromAndTo(leafReaderContextPartition.ctx, fromDocId, toDocId));
+                leafToLastUnassignedDocId.put(leafReaderContextPartition.ctx.ord, toDocId);
+            }
+            return new IndexSearcher.LeafSlice(partitions);
         }
 
         @Override
-        public int compareTo(Group other) {
-            return Integer.compare(this.sum, other.sum);
+        public int compareTo(LeafSliceBuilder o) {
+            return Integer.compare(totalSize, o.totalSize);
         }
     }
+
+    /**
+     * Consider a segment with 31_000 documents and user has configured 10_000 ( denoted by partitonSize parameter )
+     * as minimum size for the partition of a segment. We first determine number of partitions, 31_000 / 10_000 = 3. <br>
+     * Then, we determine the remainingDocs = 31_000 % 10_000 = 1000 that need to be divided. <br>
+     * Then, it's divided equally amongst all partitions as 10_000 + ( 1000 / 3 ) = 10_333  <br>
+     * Still one partition would get one extra doc which is also considered. So, net result is: <br>
+     * [ 31_000 ] = [ 10_334. 10_333, 10_333 ]
+     */
+    private static List<IndexSearcher.LeafReaderContextPartition> partitionSegment(
+        LeafReaderContext leaf,
+        int partitionSize,
+        int targetSliceCount
+    ) {
+
+        int segmentMaxDoc = leaf.reader().maxDoc();
+        int numPartitions = segmentMaxDoc / partitionSize;
+
+        // Max number of splits/partitions for a segment should not exceed the available slices.
+        if (numPartitions > targetSliceCount) {
+            numPartitions = targetSliceCount;
+            partitionSize = segmentMaxDoc / numPartitions;
+        }
+
+        int remainingDocs = segmentMaxDoc % partitionSize;
+        int minPartitionSize = partitionSize + (remainingDocs / numPartitions);
+        int partitionsWithOneExtraDoc = remainingDocs % numPartitions;
+
+        List<IndexSearcher.LeafReaderContextPartition> partitions = new ArrayList<>(numPartitions);
+
+        int currentStartDocId = 0, currentEndDocId;
+
+        for (int i = 0; i < numPartitions; ++i) {
+            currentEndDocId = currentStartDocId + minPartitionSize;
+            currentEndDocId += (i < partitionsWithOneExtraDoc) ? 1 : 0;
+            partitions.add(IndexSearcher.LeafReaderContextPartition.createFromAndTo(leaf, currentStartDocId, currentEndDocId));
+            currentStartDocId = currentEndDocId;
+        }
+
+        return partitions;
+    }
+
 }

--- a/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
+++ b/server/src/main/java/org/opensearch/search/internal/MaxTargetSliceSupplier.java
@@ -17,8 +17,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
-import java.util.PriorityQueue;
 import java.util.Map;
+import java.util.PriorityQueue;
 
 /**
  * Supplier to compute leaf slices based on passed in leaves and max target slice count to limit the number of computed slices. It sorts

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -433,6 +433,10 @@ public abstract class SearchContext implements Releasable {
         return false;
     }
 
+    public boolean shouldUseIntraSegmentConcurrentSearch() {
+        return false;
+    }
+
     /**
      * Returns local bucket count thresholds based on concurrent segment search status
      */
@@ -516,6 +520,8 @@ public abstract class SearchContext implements Releasable {
     public abstract BucketCollectorProcessor bucketCollectorProcessor();
 
     public abstract int getTargetMaxSliceCount();
+
+    public abstract int getSegmentPartitionSize();
 
     public abstract boolean shouldUseTimeSeriesDescSortOptimization();
 

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -521,8 +521,6 @@ public abstract class SearchContext implements Releasable {
 
     public abstract int getTargetMaxSliceCount();
 
-    public abstract int getSegmentPartitionSize();
-
     public abstract boolean shouldUseTimeSeriesDescSortOptimization();
 
     public boolean getStarTreeIndexEnabled() {
@@ -544,5 +542,9 @@ public abstract class SearchContext implements Releasable {
 
     public boolean keywordIndexOrDocValuesEnabled() {
         return false;
+    }
+
+    public int getSegmentPartitionSize() {
+        return 2;
     }
 }

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -91,6 +91,7 @@ import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
@@ -99,6 +100,7 @@ import static org.opensearch.search.internal.ExitableDirectoryReader.ExitableLea
 import static org.opensearch.search.internal.ExitableDirectoryReader.ExitablePointValues;
 import static org.opensearch.search.internal.ExitableDirectoryReader.ExitableTerms;
 import static org.opensearch.search.internal.IndexReaderUtils.getLeaves;
+import static org.opensearch.search.internal.IndexReaderUtils.verifyPartitionCountInSlices;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
@@ -354,12 +356,9 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 expectedSliceCount = 4;
                 slices = searcher.slicesInternal(leaves, new MaxTargetSliceSupplier.SliceInputConfig(expectedSliceCount, false, 2));
 
-                // 4 slices will be created with 3 leaves in first&last slices and 2 leaves in other slices
+                // 4 slices will be created with 3 leaves in first and last slices and 2 leaves in other slices
                 assertEquals(expectedSliceCount, slices.length);
-                assertEquals(3, slices[0].partitions.length);
-                assertEquals(2, slices[1].partitions.length);
-                assertEquals(2, slices[2].partitions.length);
-                assertEquals(3, slices[3].partitions.length);
+                verifyPartitionCountInSlices(slices, Map.of(3, 2, 2, 2));
             }
         }
     }
@@ -411,12 +410,9 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 int expectedSliceCount = 4;
                 IndexSearcher.LeafSlice[] slices = searcher.slices(leaves);
 
-                // 4 slices will be created with 3 leaves in first&last slices and 2 leaves in other slices
+                // 4 slices will be created with 3 leaves in first & last slices and 2 leaves in other slices
                 assertEquals(expectedSliceCount, slices.length);
-                assertEquals(3, slices[0].partitions.length);
-                assertEquals(2, slices[1].partitions.length);
-                assertEquals(2, slices[2].partitions.length);
-                assertEquals(3, slices[3].partitions.length);
+                verifyPartitionCountInSlices(slices, Map.of(3, 2, 2, 2));
             }
         }
     }

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -341,7 +341,7 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 // Case 1: Verify the slice count when lucene default slice computation is used
                 IndexSearcher.LeafSlice[] slices = searcher.slicesInternal(
                     leaves,
-                    SearchService.CONCURRENT_SEGMENT_SEARCH_MIN_SLICE_COUNT_VALUE
+                    new MaxTargetSliceSupplier.SliceInputConfig(SearchService.CONCURRENT_SEGMENT_SEARCH_MIN_SLICE_COUNT_VALUE, false, 2)
                 );
                 int expectedSliceCount = 2;
                 // 2 slices will be created since max segment per slice of 5 will be reached
@@ -352,7 +352,7 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
 
                 // Case 2: Verify the slice count when custom max slice computation is used
                 expectedSliceCount = 4;
-                slices = searcher.slicesInternal(leaves, expectedSliceCount);
+                slices = searcher.slicesInternal(leaves, new MaxTargetSliceSupplier.SliceInputConfig(expectedSliceCount, false, 2));
 
                 // 4 slices will be created with 3 leaves in first&last slices and 2 leaves in other slices
                 assertEquals(expectedSliceCount, slices.length);

--- a/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
+++ b/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
@@ -17,20 +17,32 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.store.Directory;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.apache.lucene.tests.util.LuceneTestCase.newDirectory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class IndexReaderUtils {
+
+    public static List<LeafReaderContext> getLeaves(int leafCount) throws Exception {
+        return getLeaves(leafCount, 1);
+    }
 
     /**
      * Utility to create leafCount number of {@link LeafReaderContext}
      * @param leafCount count of leaves to create
+     * @param docsPerLeaf : Number of documents per Leaf
      * @return created leaves
      */
-    public static List<LeafReaderContext> getLeaves(int leafCount) throws Exception {
+    public static List<LeafReaderContext> getLeaves(int leafCount, int docsPerLeaf) throws Exception {
         try (
             final Directory directory = newDirectory();
             final IndexWriter iw = new IndexWriter(
@@ -39,11 +51,12 @@ public class IndexReaderUtils {
             )
         ) {
             for (int i = 0; i < leafCount; ++i) {
-                Document document = new Document();
-                final String fieldValue = "value" + i;
-                document.add(new StringField("field1", fieldValue, Field.Store.NO));
-                document.add(new StringField("field2", fieldValue, Field.Store.NO));
-                iw.addDocument(document);
+                for (int j = 0; j < docsPerLeaf; ++j) {
+                    Document document = new Document();
+                    final String fieldValue = "value" + i;
+                    document.add(new StringField("field1", fieldValue, Field.Store.NO));
+                    iw.addDocument(document);
+                }
                 iw.commit();
             }
             try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
@@ -52,4 +65,47 @@ public class IndexReaderUtils {
             }
         }
     }
+
+    /**
+     * For the Input [ 2 -> 1, 1 -> 2 ]
+     * This verifies that 1 slice has 2 partitions and 2 slices has 1 partition each.
+     */
+    public static void verifyPartitionCountInSlices(IndexSearcher.LeafSlice[] slices, Map<Integer, Integer> leafSizesToSliceCount) {
+        Map<Integer, Integer> leafCountToNumSlices = new HashMap<>();
+        for (IndexSearcher.LeafSlice slice : slices) {
+            int existingCount = leafCountToNumSlices.getOrDefault(slice.partitions.length, 0);
+            leafCountToNumSlices.put(slice.partitions.length, existingCount + 1);
+        }
+        assertEquals(leafSizesToSliceCount, leafCountToNumSlices);
+    }
+
+    /**
+     * For the input [ 10 -> 1, 9 -> 2 ]
+     * This verifies that there is one partition with 10 docs and 2 partitions with 9 docs.
+     */
+    public static void verifyPartitionDocCountAcrossSlices(
+        IndexSearcher.LeafSlice[] slices,
+        Map<Integer, Integer> expectedDocCountToPartitionCount
+    ) {
+        Map<Integer, Integer> actualDocCountToPartitionCount = new HashMap<>();
+        for (IndexSearcher.LeafSlice slice : slices) {
+            for (IndexSearcher.LeafReaderContextPartition partition : slice.partitions) {
+                int partitionDocCount = MaxTargetSliceSupplier.getPartitionDocCount(partition);
+                int existingPartitionCount = actualDocCountToPartitionCount.getOrDefault(partitionDocCount, 0);
+                actualDocCountToPartitionCount.put(partitionDocCount, existingPartitionCount + 1);
+            }
+        }
+        assertEquals(expectedDocCountToPartitionCount, actualDocCountToPartitionCount);
+    }
+
+    public static void verifyUniqueSegmentPartitionsPerSlices(IndexSearcher.LeafSlice[] slices) {
+        for (IndexSearcher.LeafSlice slice : slices) {
+            Set<Integer> partitionSeen = new HashSet<>();
+            for (IndexSearcher.LeafReaderContextPartition partition : slice.partitions) {
+                assertFalse(partitionSeen.contains(partition.ctx.ord));
+                partitionSeen.add(partition.ctx.ord);
+            }
+        }
+    }
+
 }

--- a/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
+++ b/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
@@ -81,7 +81,7 @@ public class IndexReaderUtils {
 
     /**
      * For the input [ 10 -> 1, 9 -> 2 ]
-     * This verifies that there is one partition with 10 docs and 2 partitions with 9 docs.
+     * This verifies that there is one partition with 10 docs and 2 partitions with 9 docs each.
      */
     public static void verifyPartitionDocCountAcrossSlices(
         IndexSearcher.LeafSlice[] slices,
@@ -91,11 +91,28 @@ public class IndexReaderUtils {
         for (IndexSearcher.LeafSlice slice : slices) {
             for (IndexSearcher.LeafReaderContextPartition partition : slice.partitions) {
                 int partitionDocCount = MaxTargetSliceSupplier.getPartitionDocCount(partition);
-                int existingPartitionCount = actualDocCountToPartitionCount.getOrDefault(partitionDocCount, 0);
-                actualDocCountToPartitionCount.put(partitionDocCount, existingPartitionCount + 1);
+                int existingSliceCount = actualDocCountToPartitionCount.getOrDefault(partitionDocCount, 0);
+                actualDocCountToPartitionCount.put(partitionDocCount, existingSliceCount + 1);
             }
         }
         assertEquals(expectedDocCountToPartitionCount, actualDocCountToPartitionCount);
+    }
+
+    /**
+     * For the input [ 2 -> 1, 3 -> 1 ]
+     * This verifies that there is one slice with total 2 docs across all it's partitions and 1 slice with total 3 docs.
+     */
+    public static void verifyDocCountAcrossSlices(IndexSearcher.LeafSlice[] slices, Map<Integer, Integer> expectedDocCountToSliceCount) {
+        Map<Integer, Integer> actualDocCountToSliceCount = new HashMap<>();
+        for (IndexSearcher.LeafSlice slice : slices) {
+            int totalDocCount = 0;
+            for (IndexSearcher.LeafReaderContextPartition partition : slice.partitions) {
+                totalDocCount += MaxTargetSliceSupplier.getPartitionDocCount(partition);
+            }
+            int existingSliceCount = actualDocCountToSliceCount.getOrDefault(totalDocCount, 0);
+            actualDocCountToSliceCount.put(totalDocCount, existingSliceCount + 1);
+        }
+        assertEquals(expectedDocCountToSliceCount, actualDocCountToSliceCount);
     }
 
     public static void verifyUniqueSegmentPartitionsPerSlices(IndexSearcher.LeafSlice[] slices) {

--- a/server/src/test/java/org/opensearch/search/internal/MaxTargetSliceSupplierTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/MaxTargetSliceSupplierTests.java
@@ -30,7 +30,10 @@ public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
 
     public void testSliceCountGreaterThanLeafCount() throws Exception {
         int expectedSliceCount = 2;
-        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(getLeaves(expectedSliceCount), new MaxTargetSliceSupplier.SliceInputConfig(5, false, 0));
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(
+            getLeaves(expectedSliceCount),
+            new MaxTargetSliceSupplier.SliceInputConfig(5, false, 0)
+        );
         // verify slice count is same as leaf count
         assertEquals(expectedSliceCount, slices.length);
         for (int i = 0; i < expectedSliceCount; ++i) {
@@ -39,12 +42,21 @@ public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
     }
 
     public void testNegativeSliceCount() {
-        assertThrows(IllegalArgumentException.class, () -> MaxTargetSliceSupplier.getSlices(new ArrayList<>(), new MaxTargetSliceSupplier.SliceInputConfig(randomIntBetween(-3, 0), false, 0)));
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> MaxTargetSliceSupplier.getSlices(
+                new ArrayList<>(),
+                new MaxTargetSliceSupplier.SliceInputConfig(randomIntBetween(-3, 0), false, 0)
+            )
+        );
     }
 
     public void testSingleSliceWithMultipleLeaves() throws Exception {
         int leafCount = randomIntBetween(1, 10);
-        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(getLeaves(leafCount), new MaxTargetSliceSupplier.SliceInputConfig(1, false, 0));
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(
+            getLeaves(leafCount),
+            new MaxTargetSliceSupplier.SliceInputConfig(1, false, 0)
+        );
         assertEquals(1, slices.length);
         assertEquals(leafCount, slices[0].partitions.length);
     }
@@ -55,7 +67,10 @@ public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
 
         // Case 1: test with equal number of leaves per slice
         int expectedSliceCount = 3;
-        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(leaves, new MaxTargetSliceSupplier.SliceInputConfig(expectedSliceCount, false, 0));
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(
+            leaves,
+            new MaxTargetSliceSupplier.SliceInputConfig(expectedSliceCount, false, 0)
+        );
         int expectedLeavesPerSlice = leafCount / expectedSliceCount;
 
         assertEquals(expectedSliceCount, slices.length);
@@ -80,7 +95,10 @@ public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
     }
 
     public void testEmptyLeaves() {
-        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(new ArrayList<>(), new MaxTargetSliceSupplier.SliceInputConfig(2, false, 0));
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(
+            new ArrayList<>(),
+            new MaxTargetSliceSupplier.SliceInputConfig(2, false, 0)
+        );
         assertEquals(0, slices.length);
     }
 

--- a/server/src/test/java/org/opensearch/search/internal/MaxTargetSliceSupplierTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/MaxTargetSliceSupplierTests.java
@@ -8,17 +8,8 @@
 
 package org.opensearch.search.internal;
 
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field;
-import org.apache.lucene.document.StringField;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.store.Directory;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;
@@ -26,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.opensearch.search.internal.IndexReaderUtils.getLeaves;
+import static org.opensearch.search.internal.IndexReaderUtils.verifyDocCountAcrossSlices;
 import static org.opensearch.search.internal.IndexReaderUtils.verifyPartitionCountInSlices;
 import static org.opensearch.search.internal.IndexReaderUtils.verifyPartitionDocCountAcrossSlices;
 import static org.opensearch.search.internal.IndexReaderUtils.verifyUniqueSegmentPartitionsPerSlices;
@@ -101,47 +93,16 @@ public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
     }
 
     public void testOptimizedGroup() throws Exception {
-        try (
-            final Directory directory = newDirectory();
-            final IndexWriter iw = new IndexWriter(
-                directory,
-                new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE)
-            )
-        ) {
-            final String fieldValue = "value";
-            for (int i = 0; i < 3; ++i) {
-                Document document = new Document();
-                document.add(new StringField("field1", fieldValue, Field.Store.NO));
-                iw.addDocument(document);
-            }
-            iw.commit();
-            for (int i = 0; i < 1; ++i) {
-                Document document = new Document();
-                document.add(new StringField("field1", fieldValue, Field.Store.NO));
-                iw.addDocument(document);
-            }
-            iw.commit();
-            for (int i = 0; i < 1; ++i) {
-                Document document = new Document();
-                document.add(new StringField("field1", fieldValue, Field.Store.NO));
-                iw.addDocument(document);
-            }
-            iw.commit();
+        List<LeafReaderContext> leaves = new ArrayList<>(getLeaves(1, 3));
+        leaves.addAll(getLeaves(2, 1));
 
-            try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
-                List<LeafReaderContext> leaves = directoryReader.leaves();
-                assertEquals(3, leaves.size());
-                IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(
-                    leaves,
-                    new MaxTargetSliceSupplier.SliceInputConfig(2, false, 0)
-                );
-                assertEquals(1, slices[0].partitions.length);
-                assertEquals(3, slices[0].getMaxDocs());
-
-                assertEquals(2, slices[1].partitions.length);
-                assertEquals(2, slices[1].getMaxDocs());
-            }
-        }
+        assertEquals(3, leaves.size());
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(
+            leaves,
+            new MaxTargetSliceSupplier.SliceInputConfig(2, false, 0)
+        );
+        verifyPartitionCountInSlices(slices, Map.of(2, 1, 1, 1));
+        verifyDocCountAcrossSlices(slices, Map.of(2, 1, 3, 1));
     }
 
     public void testPartitioningForOneLeaf() throws Exception {

--- a/server/src/test/java/org/opensearch/search/internal/MaxTargetSliceSupplierTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/MaxTargetSliceSupplierTests.java
@@ -131,7 +131,10 @@ public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
             try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
                 List<LeafReaderContext> leaves = directoryReader.leaves();
                 assertEquals(3, leaves.size());
-                IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(leaves, new MaxTargetSliceSupplier.SliceInputConfig(2, false, 0));
+                IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(
+                    leaves,
+                    new MaxTargetSliceSupplier.SliceInputConfig(2, false, 0)
+                );
                 assertEquals(1, slices[0].partitions.length);
                 assertEquals(3, slices[0].getMaxDocs());
 

--- a/server/src/test/java/org/opensearch/search/internal/MaxTargetSliceSupplierTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/MaxTargetSliceSupplierTests.java
@@ -30,7 +30,7 @@ public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
 
     public void testSliceCountGreaterThanLeafCount() throws Exception {
         int expectedSliceCount = 2;
-        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(getLeaves(expectedSliceCount), 5);
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(getLeaves(expectedSliceCount), new MaxTargetSliceSupplier.SliceInputConfig(5, false, 0));
         // verify slice count is same as leaf count
         assertEquals(expectedSliceCount, slices.length);
         for (int i = 0; i < expectedSliceCount; ++i) {
@@ -39,12 +39,12 @@ public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
     }
 
     public void testNegativeSliceCount() {
-        assertThrows(IllegalArgumentException.class, () -> MaxTargetSliceSupplier.getSlices(new ArrayList<>(), randomIntBetween(-3, 0)));
+        assertThrows(IllegalArgumentException.class, () -> MaxTargetSliceSupplier.getSlices(new ArrayList<>(), new MaxTargetSliceSupplier.SliceInputConfig(randomIntBetween(-3, 0), false, 0)));
     }
 
     public void testSingleSliceWithMultipleLeaves() throws Exception {
         int leafCount = randomIntBetween(1, 10);
-        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(getLeaves(leafCount), 1);
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(getLeaves(leafCount), new MaxTargetSliceSupplier.SliceInputConfig(1, false, 0));
         assertEquals(1, slices.length);
         assertEquals(leafCount, slices[0].partitions.length);
     }
@@ -55,7 +55,7 @@ public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
 
         // Case 1: test with equal number of leaves per slice
         int expectedSliceCount = 3;
-        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(leaves, expectedSliceCount);
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(leaves, new MaxTargetSliceSupplier.SliceInputConfig(expectedSliceCount, false, 0));
         int expectedLeavesPerSlice = leafCount / expectedSliceCount;
 
         assertEquals(expectedSliceCount, slices.length);
@@ -65,7 +65,7 @@ public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
 
         // Case 2: test with first 2 slice more leaves than others
         expectedSliceCount = 5;
-        slices = MaxTargetSliceSupplier.getSlices(leaves, expectedSliceCount);
+        slices = MaxTargetSliceSupplier.getSlices(leaves, new MaxTargetSliceSupplier.SliceInputConfig(expectedSliceCount, false, 0));
         int expectedLeavesInFirst2Slice = 3;
         int expectedLeavesInOtherSlice = 2;
 
@@ -80,7 +80,7 @@ public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
     }
 
     public void testEmptyLeaves() {
-        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(new ArrayList<>(), 2);
+        IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(new ArrayList<>(), new MaxTargetSliceSupplier.SliceInputConfig(2, false, 0));
         assertEquals(0, slices.length);
     }
 
@@ -115,7 +115,7 @@ public class MaxTargetSliceSupplierTests extends OpenSearchTestCase {
             try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
                 List<LeafReaderContext> leaves = directoryReader.leaves();
                 assertEquals(3, leaves.size());
-                IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(leaves, 2);
+                IndexSearcher.LeafSlice[] slices = MaxTargetSliceSupplier.getSlices(leaves, new MaxTargetSliceSupplier.SliceInputConfig(2, false, 0));
                 assertEquals(1, slices[0].partitions.length);
                 assertEquals(3, slices[0].getMaxDocs());
 

--- a/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
@@ -705,6 +705,11 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
+    public int getSegmentPartitionSize() {
+        return 2;
+    }
+
+    @Override
     public boolean shouldUseTimeSeriesDescSortOptimization() {
         return indexShard != null
             && indexShard.isTimeSeriesDescSortOptimizationEnabled()


### PR DESCRIPTION
### Description
Enabling Intra Segment Concurrent Search for queries without aggregations. 

Introduced Cluster and Index level settings similar to Concurrent Segment Search. 

Additionally, there is an extra cluster/index setting named `partition_size` which will control how large segments should be sliced/partitioned. 

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/18851
Partially resolves https://github.com/opensearch-project/OpenSearch/issues/18849 as we are not introducing Auto Mode and an execution hint with this PR.

Another limitation with the current PR is Intra Segment Search will only work if `track_total_hits` is disabled. Will follow up in a separate PR. It needs handling of TotalHitCountCollector [similar to how Lucene did](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/TotalHitCountCollectorManager.java#L78-L83) Wrote more about this in https://github.com/opensearch-project/OpenSearch/issues/18854