### PR TITLE
Propagate regex exception in query_string queries

### DIFF
--- a/server/src/main/java/org/opensearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/opensearch/index/search/QueryStringQueryParser.java
@@ -57,6 +57,7 @@ import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.RegExp;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import org.opensearch.common.lucene.search.Queries;
 import org.opensearch.common.regex.Regex;
 import org.opensearch.common.unit.Fuzziness;
@@ -795,7 +796,9 @@ public class QueryStringQueryParser extends XQueryParser {
             termStr = getAnalyzer().normalize(currentFieldType.name(), termStr).utf8ToString();
             return currentFieldType.regexpQuery(termStr, RegExp.ALL, 0, getDeterminizeWorkLimit(), getMultiTermRewriteMethod(), context);
         } catch (RuntimeException e) {
-            if (lenient) {
+            // Lenient queries are intended for data type mismatches, but TooComplexToDeterminizeException
+            // comes up from the same place in the code. Don't create a lenient query in this case.
+            if (lenient && !(e instanceof TooComplexToDeterminizeException)) {
                 return newLenientFieldQuery(field, e);
             }
             throw e;

--- a/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/QueryStringQueryBuilderTests.java
@@ -803,8 +803,14 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             TooComplexToDeterminizeException.class,
             () -> queryBuilder.toQuery(createShardContext())
         );
-        assertThat(e.getMessage(), containsString("Determinizing automaton"));
-        assertThat(e.getMessage(), containsString("would require more than 10000 effort"));
+        assertTrue(e.getMessage().contains("Determinizing automaton"));
+        assertTrue(e.getMessage().contains("would require more than 10000 effort"));
+
+        // TooComplexToDeterminizeException should be thrown even if lenient is true
+        QueryStringQueryBuilder lenientQueryBuilder = queryStringQuery("/[ac]*a[ac]{50,200}/").defaultField(TEXT_FIELD_NAME).lenient(true);
+        e = expectThrows(TooComplexToDeterminizeException.class, () -> lenientQueryBuilder.toQuery(createShardContext()));
+        assertTrue(e.getMessage().contains("Determinizing automaton"));
+        assertTrue(e.getMessage().contains("would require more than 10000 effort"));
     }
 
     /**


### PR DESCRIPTION
### Description
In `query_string` queries that use regex, `TooComplexToDeterminizeException` was incorrectly swallowed if `lenient` query behavior was on. `lenient` is [intended](https://docs.opensearch.org/latest/query-dsl/full-text/query-string/#parameters) to "ignore data type mismatches between the query and the document field," but `TooComplexToDeterminizeException` comes from the same place in the code despite not having to do with data type mismatches. This caused `query_string` queries to return 200 incorrectly even when the same regex on a `regexp` query would return 400. 

A related question is why `lenient` was on in the first place within `QueryStringQueryBuilder`, given that the index setting defaults to `false` and I didn't specify it in the query body. I will raise a separate issue for this as I'm not sure if the current behavior is intended or not and I want to get feedback from others. Either way though, the fix in this PR should apply. 

Testing: added coverage to the existing UT. Also manually tested the query from the issue: 

```
curl -XGET "localhost:9200/_search?pretty" -H 'Content-Type: application/json' -d'
          {
          "query": {
          "query_string": {
                "query":{
                "f1:/.*value.*|.*__two__.*|.*__three__.*|.*__four__.*|.*__five__.*|.*__six__.*|.*__seven__.*|.*__eight__.*|.*__nine__.*/",
                "analyze_wildcard": true
              }
        }
        }'
```
This originally succeeded, but now correctly returns 400: 
```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "query_shard_exception",
        "reason" : "failed to create query: Determinizing automaton with 89 states and 115 transitions would require more than 10000 effort.",
        "index" : "text_regex",
        "index_uuid" : "H5Dk6CxwTWuwYIDh1BEEQg"
      }
    ],
    "type" : "search_phase_execution_exception",
    "reason" : "all shards failed",
    "phase" : "query",
    "grouped" : true,
    "failed_shards" : [
      {
        "shard" : 0,
        "index" : "text_regex",
        "node" : "TQ_xeOJ-QD2z_bbHPLY-vw",
        "reason" : {
          "type" : "query_shard_exception",
          "reason" : "failed to create query: Determinizing automaton with 89 states and 115 transitions would require more than 10000 effort.",
          "index" : "text_regex",
          "index_uuid" : "H5Dk6CxwTWuwYIDh1BEEQg",
          "caused_by" : {
            "type" : "too_complex_to_determinize_exception",
            "reason" : "Determinizing automaton with 89 states and 115 transitions would require more than 10000 effort."
          }
        }
      }
    ]
  },
  "status" : 400
}
```

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/18733

### Check List
- [x] Functionality includes testing.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
