### PR TITLE
Expand fetch phase profiling to multi-shard queries

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/profile/fetch/FetchProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/profile/fetch/FetchProfilerIT.java
@@ -28,11 +28,6 @@ import java.util.Map;
 
 public class FetchProfilerIT extends OpenSearchIntegTestCase {
 
-    @Override
-    protected int numberOfShards() {
-        return 1; // Use a single shard to ensure all documents are in one shard
-    }
-
     /**
      * This test verifies that the fetch profiler returns reasonable results for a simple match_all query
      */

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -917,6 +917,13 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(searchContext, true, System.nanoTime())
                 ) {
                     fetchPhase.execute(searchContext);
+                    if (searchContext.getProfilers() != null) {
+                        ProfileShardResult shardResults = SearchProfileShardResults.buildFetchOnlyShardResults(
+                            searchContext.getProfilers(),
+                            searchContext.request()
+                        );
+                        searchContext.fetchResult().profileResults(shardResults);
+                    }
                     if (readerContext.singleSession()) {
                         freeReaderContext(request.contextId());
                     }

--- a/server/src/main/java/org/opensearch/search/fetch/FetchSearchResult.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchSearchResult.java
@@ -40,6 +40,7 @@ import org.opensearch.search.SearchHits;
 import org.opensearch.search.SearchPhaseResult;
 import org.opensearch.search.SearchShardTarget;
 import org.opensearch.search.internal.ShardSearchContextId;
+import org.opensearch.search.profile.ProfileShardResult;
 import org.opensearch.search.query.QuerySearchResult;
 
 import java.io.IOException;
@@ -55,6 +56,7 @@ public final class FetchSearchResult extends SearchPhaseResult {
     private SearchHits hits;
     // client side counter
     private transient int counter;
+    private ProfileShardResult profileShardResults;
 
     public FetchSearchResult() {}
 
@@ -62,6 +64,7 @@ public final class FetchSearchResult extends SearchPhaseResult {
         super(in);
         contextId = new ShardSearchContextId(in);
         hits = new SearchHits(in);
+        profileShardResults = in.readOptionalWriteable(ProfileShardResult::new);
     }
 
     public FetchSearchResult(ShardSearchContextId id, SearchShardTarget shardTarget) {
@@ -104,9 +107,18 @@ public final class FetchSearchResult extends SearchPhaseResult {
         return counter++;
     }
 
+    public void profileResults(ProfileShardResult shardResults) {
+        this.profileShardResults = shardResults;
+    }
+
+    public ProfileShardResult getProfileResults() {
+        return profileShardResults;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         contextId.writeTo(out);
         hits.writeTo(out);
+        out.writeOptionalWriteable(profileShardResults);
     }
 }


### PR DESCRIPTION
### Description
Fetch phase profiling has been implemented for the single-shard case. When there is only one shard, the search executes the fetch phase immediately after the query phase and the profile is rebuilt right away.

Focusing on the single-shard case first allowed for isolated development and validation of the core fetch profiling logic before tackling the more complex distributed coordination required for multi-shard searches.

When the search involves multiple shards, executeQueryPhase previously only returned the query-phase results. The coordinating node later sends a ShardFetchRequest for each shard, which runs executeFetchPhase(ShardFetchRequest ...). This method performed the fetch but does not rebuild or attach new profiling information.

The solution I've implemented allows the fetch phase to send profile results back to the coordinator node in the multi shard case. These fetch profile results are then merged with query profile results in the coordinator node. 

### Related Issues
Resolves #18863
<!-- List any other related issues here -->
#18864


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
