### PR TITLE
[merged segment warmer] Introduce merged segment checkpoint retention to avoid listAll in computeReferencedSegmentsCheckpoint

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -160,6 +160,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.MAX_NESTED_QUERY_DEPTH_SETTING,
                 IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING,
                 IndexSettings.INDEX_PUBLISH_REFERENCED_SEGMENTS_INTERVAL_SETTING,
+                IndexSettings.INDEX_MERGED_SEGMENT_CHECKPOINT_RETENTION_TIME,
                 IndexSettings.DEFAULT_FIELD_SETTING,
                 IndexSettings.QUERY_STRING_LENIENT_SETTING,
                 IndexSettings.ALLOW_UNMAPPED,

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -179,6 +179,17 @@ public final class IndexSettings {
         Property.IndexScope
     );
 
+    /**
+     * Index setting describing the maximum retention time of merged segment checkpoint in the primary shard, used to prevent memory leak.
+     */
+    public static final Setting<TimeValue> INDEX_MERGED_SEGMENT_CHECKPOINT_RETENTION_TIME = Setting.timeSetting(
+        "index.merged_segment_checkpoint.retention_time",
+        TimeValue.timeValueMinutes(15),
+        TimeValue.timeValueSeconds(0),
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
     public static final Setting<TimeValue> INDEX_SEARCH_IDLE_AFTER = Setting.timeSetting(
         "index.search.idle.after",
         TimeValue.timeValueSeconds(30),
@@ -823,6 +834,7 @@ public final class IndexSettings {
     private volatile Translog.Durability durability;
     private volatile TimeValue syncInterval;
     private volatile TimeValue publishReferencedSegmentsInterval;
+    private volatile TimeValue mergedSegmentCheckpointRetentionTime;
     private volatile TimeValue refreshInterval;
     private volatile ByteSizeValue flushThresholdSize;
     private volatile TimeValue translogRetentionAge;
@@ -1036,6 +1048,7 @@ public final class IndexSettings {
         defaultFields = scopedSettings.get(DEFAULT_FIELD_SETTING);
         syncInterval = INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.get(settings);
         publishReferencedSegmentsInterval = INDEX_PUBLISH_REFERENCED_SEGMENTS_INTERVAL_SETTING.get(settings);
+        mergedSegmentCheckpointRetentionTime = INDEX_MERGED_SEGMENT_CHECKPOINT_RETENTION_TIME.get(settings);
         refreshInterval = scopedSettings.get(INDEX_REFRESH_INTERVAL_SETTING);
         flushThresholdSize = scopedSettings.get(INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING);
         generationThresholdSize = scopedSettings.get(INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING);
@@ -1160,6 +1173,10 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(
             INDEX_PUBLISH_REFERENCED_SEGMENTS_INTERVAL_SETTING,
             this::setPublishReferencedSegmentsInterval
+        );
+        scopedSettings.addSettingsUpdateConsumer(
+            INDEX_MERGED_SEGMENT_CHECKPOINT_RETENTION_TIME,
+            this::setMergedSegmentCheckpointRetentionTime
         );
         scopedSettings.addSettingsUpdateConsumer(MAX_RESULT_WINDOW_SETTING, this::setMaxResultWindow);
         scopedSettings.addSettingsUpdateConsumer(MAX_INNER_RESULT_WINDOW_SETTING, this::setMaxInnerResultWindow);
@@ -1545,6 +1562,14 @@ public final class IndexSettings {
 
     public void setPublishReferencedSegmentsInterval(TimeValue publishReferencedSegmentsInterval) {
         this.publishReferencedSegmentsInterval = publishReferencedSegmentsInterval;
+    }
+
+    public TimeValue getMergedSegmentCheckpointRetentionTime() {
+        return mergedSegmentCheckpointRetentionTime;
+    }
+
+    public void setMergedSegmentCheckpointRetentionTime(TimeValue mergedSegmentCheckpointRetentionTime) {
+        this.mergedSegmentCheckpointRetentionTime = mergedSegmentCheckpointRetentionTime;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/replication/MergedSegmentReplicationTarget.java
+++ b/server/src/main/java/org/opensearch/indices/replication/MergedSegmentReplicationTarget.java
@@ -62,7 +62,7 @@ public class MergedSegmentReplicationTarget extends AbstractSegmentReplicationTa
     protected void finalizeReplication(CheckpointInfoResponse checkpointInfoResponse) throws Exception {
         assert checkpoint instanceof MergedSegmentCheckpoint;
         multiFileWriter.renameAllTempFiles();
-        indexShard.addPendingMergeSegmentCheckpoint((MergedSegmentCheckpoint) checkpoint);
+        indexShard.addReplicaMergedSegmentCheckpoint((MergedSegmentCheckpoint) checkpoint);
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RemoteIndexShardTests.java
@@ -648,8 +648,8 @@ public class RemoteIndexShardTests extends SegmentReplicationIndexShardTests {
     @LockFeatureFlag(MERGED_SEGMENT_WARMER_EXPERIMENTAL_FLAG)
     @Override
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/pull/18720")
-    public void testCleanupRedundantPendingMergeSegment() throws Exception {
-        super.testCleanupRedundantPendingMergeSegment();
+    public void testCleanupReplicaRedundantMergedSegment() throws Exception {
+        super.testCleanupReplicaRedundantMergedSegment();
     }
 
     private RemoteStoreReplicationSource getRemoteStoreReplicationSource(IndexShard shard, Runnable postGetFilesRunnable) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR is based on [[18720](https://github.com/opensearch-project/OpenSearch/pull/18720)]'s follow-up work. Based on the discussion with @ashking94, I made some optimizations. The main purpose is to avoid the `listAll` operation in `IndexShard#computeReferencedSegmentsCheckpoint`.

The main changes in this PR are as follows:

- I Introduced `IndexShard#primaryMergedSegmentCheckpoints` for primary shard to track merged segment checkpoints that have been published for pre-warm but not yet refreshed. We will add merged segment checkpoint to `IndexShard#primaryMergedSegmentCheckpoints` before `publish_merged_segment`.
- Rename `IndexShard#pendingMergedSegmentCheckpoints` to `IndexShard#replicaMergedSegmentCheckpoints`, which is used for replica shard record the pre-copied merged segment checkpoints, which are not yet refreshed.
- When `ReplicationCheckpointUpdater#afterRefresh` is invoked, remove refreshed segment from `IndexShard#primaryMergedSegmentCheckpoints`. The reason why it cannot be executed in `PublishCheckpointAction` can refer to the discussion in issue #[18845](https://github.com/opensearch-project/OpenSearch/issues/18845).
- To avoid memory leaks in `IndexShard#primaryMergedSegmentCheckpoints`, I introduced a configuration `IndexSettings#INDEX_MERGED_SEGMENT_CHECKPOINT_RETENTION_TIME` (default `15` minutes) to clean up expired checkpoints after `publish_referenced_segments`.
- I introduced `MergedSegmentWarmerIT#testPrimaryMergedSegmentCheckpointRetentionTimeout`. Construct a case with redundant merged segment checkpoint in the primary shard and delete it based on the expiration time.


### Related Issues
Resolves #[[18845](https://github.com/opensearch-project/OpenSearch/issues/18845)]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
