### PR TITLE
Fix flakey test testOverflowDisabledAsynchronous

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
@@ -113,7 +113,7 @@ public class TransferManager {
     }
 
     @ExperimentalApi
-    public void fetchBlobAsync(BlobFetchRequest blobFetchRequest) throws IOException {
+    public CompletableFuture<IndexInput> fetchBlobAsync(BlobFetchRequest blobFetchRequest) throws IOException {
         final Path key = blobFetchRequest.getFilePath();
         logger.trace("Asynchronous fetchBlob called for {}", key.toString());
         try {
@@ -133,7 +133,7 @@ public class TransferManager {
             // decrement this reference _after_ creating the clone to be returned.
             // Making sure remote recovery thread-pool take care of background download
             try {
-                cacheEntry.asyncLoadIndexInput(threadPool.executor(ThreadPool.Names.REMOTE_RECOVERY));
+                return cacheEntry.asyncLoadIndexInput(threadPool.executor(ThreadPool.Names.REMOTE_RECOVERY));
             } catch (Exception exception) {
                 fileCache.decRef(key);
                 throw exception;

--- a/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTestCase.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTestCase.java
@@ -347,6 +347,7 @@ public abstract class TransferManagerTestCase extends OpenSearchTestCase {
         BlobFetchRequest blobFetchRequest = BlobFetchRequest.builder().fileName(blobname).directory(directory).blobParts(blobParts).build();
         // It will trigger async load
         transferManager.fetchBlobAsync(blobFetchRequest);
+        fileCache.get(blobFetchRequest.getFilePath());
         fileCache.decRef(blobFetchRequest.getFilePath());
         // Making the read call to fetch from file cache
         return transferManager.fetchBlob(blobFetchRequest);

--- a/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTestCase.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTestCase.java
@@ -348,8 +348,6 @@ public abstract class TransferManagerTestCase extends OpenSearchTestCase {
         BlobFetchRequest blobFetchRequest = BlobFetchRequest.builder().fileName(blobname).directory(directory).blobParts(blobParts).build();
         // It will trigger async load
         transferManager.fetchBlobAsync(blobFetchRequest);
-        fileCache.get(blobFetchRequest.getFilePath());
-        fileCache.decRef(blobFetchRequest.getFilePath());
         // Making the read call to fetch from file cache
         return transferManager.fetchBlob(blobFetchRequest);
     }

--- a/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTestCase.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTestCase.java
@@ -320,9 +320,7 @@ public abstract class TransferManagerTestCase extends OpenSearchTestCase {
         BlobFetchRequest blobFetchRequest = BlobFetchRequest.builder().fileName(blobname).directory(directory).blobParts(blobParts).build();
         // It will trigger async load
         transferManager.fetchBlobAsync(blobFetchRequest);
-        Thread.sleep(2000);
-        assertEquals(Optional.of(0), Optional.of(fileCache.getRef(blobFetchRequest.getFilePath())));
-        assertNotNull(fileCache.get(blobFetchRequest.getFilePath()));
+        fileCache.get(blobFetchRequest.getFilePath());
         fileCache.decRef(blobFetchRequest.getFilePath());
         // Making the read call to fetch from file cache
         IndexInput indexInput = transferManager.fetchBlob(blobFetchRequest);

--- a/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTestCase.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/utils/TransferManagerTestCase.java
@@ -347,7 +347,6 @@ public abstract class TransferManagerTestCase extends OpenSearchTestCase {
         BlobFetchRequest blobFetchRequest = BlobFetchRequest.builder().fileName(blobname).directory(directory).blobParts(blobParts).build();
         // It will trigger async load
         transferManager.fetchBlobAsync(blobFetchRequest);
-        assertNotNull(fileCache.get(blobFetchRequest.getFilePath()));
         fileCache.decRef(blobFetchRequest.getFilePath());
         // Making the read call to fetch from file cache
         return transferManager.fetchBlob(blobFetchRequest);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
I found this flakey test in #[18890](https://github.com/opensearch-project/OpenSearch/pull/18890)'s [gradle test](https://build.ci.opensearch.org/job/gradle-check/61454/).
I investigated the cause and fixed it.
```
java.lang.AssertionError: unexpected exception type thrown; expected:<java.io.IOException> but was:<java.lang.AssertionError>
	at __randomizedtesting.SeedInfo.seed([6A2AFF70E0EFA082:D601FF6FAC77A86]:0)
	at org.junit.Assert.assertThrows(Assert.java:1020)
	at org.junit.Assert.assertThrows(Assert.java:981)
	at org.opensearch.index.store.remote.utils.TransferManagerTestCase.testOverflowDisabledAsynchronous(TransferManagerTestCase.java:205)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1750)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:938)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:974)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:988)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.apache.lucene.tests.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:48)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:45)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:368)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:817)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$3.evaluate(ThreadLeakControl.java:468)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSingleTest(RandomizedRunner.java:947)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$5.evaluate(RandomizedRunner.java:832)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$6.evaluate(RandomizedRunner.java:883)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$7.evaluate(RandomizedRunner.java:894)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleStoreClassName$1.evaluate(TestRuleStoreClassName.java:38)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleAssertionsRequired$1.evaluate(TestRuleAssertionsRequired.java:53)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleIgnoreTestSuites$1.evaluate(TestRuleIgnoreTestSuites.java:47)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:368)
	at java.base/java.lang.Thread.run(Thread.java:1447)
Caused by: java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertNotNull(Assert.java:713)
	at org.junit.Assert.assertNotNull(Assert.java:723)
	at org.opensearch.index.store.remote.utils.TransferManagerTestCase.asyncFetchBlobWithName(TransferManagerTestCase.java:350)
	at org.opensearch.index.store.remote.utils.TransferManagerTestCase.lambda$testOverflowDisabledAsynchronous$0(TransferManagerTestCase.java:205)
	at org.junit.Assert.assertThrows(Assert.java:1001)
	... 40 more
```

### Reproduce
The issue can be reproduced by running the following command, and it occurs approximately once every `3000` runs.

```
./gradlew ':server:test' --tests 'org.opensearch.index.store.remote.utils.TransferManagerRemoteDirectoryReaderTests.testOverflowDisabledAsynchronous' -Dtests.seed=6A2AFF70E0EFA082 -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=sk-Latn-SK -Dtests.timezone=America/Indiana/Petersburg -Druntime.java=24
```

### Analysis
The reason is that `TransferManager#fetchBlobAsync` is an asynchronous operation, and if `TransferManager#fetchBlobAsync` completes before the `assertNotNull`, problem will be reproduced. 

If a `Thread.sleep(1000)` is added before the `assertNotNull`, this issue can be reproduced stably.
```
private IndexInput asyncFetchBlobWithName(String blobname) throws IOException {
    List<BlobFetchRequest.BlobPart> blobParts = new ArrayList<>();
    blobParts.add(new BlobFetchRequest.BlobPart("blob", 0, EIGHT_MB));
    BlobFetchRequest blobFetchRequest = BlobFetchRequest.builder().fileName(blobname).directory(directory).blobParts(blobParts).build();
    // It will trigger async load
    transferManager.fetchBlobAsync(blobFetchRequest);
    // To reproduce the problem stably, we can add Thread.sleep(1000) before the assertNotNull.
    try {
        Thread.sleep(1000);
    } catch (Exception e) {}
    assertNotNull(fileCache.get(blobFetchRequest.getFilePath()));
    fileCache.decRef(blobFetchRequest.getFilePath());
    // Making the read call to fetch from file cache
    return transferManager.fetchBlob(blobFetchRequest);
}
```

In summary we should remove `assertNotNull`.

### Solution

After discussing with @andrross , we made the following modifications: 

1. To avoid using `Thread.sleep` in the test, we modified the return value type of `TransferManager#fetchBlobAsync` to `CompletableFuture<IndexInput>`.
2. Removed redundant logic from test code `TransferManagerTestCase#asyncFetchBlobWithName`.

Meanwhile, we would like to invite the author (@ajaymovva) to take a look and see if the above understanding is correct.

### Related Issues
Resolves #[[18850](https://github.com/opensearch-project/OpenSearch/issues/18850)]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
