### PR TITLE
Add Channel Factory parameter to Translog

### DIFF
--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogFactory.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogFactory.java
@@ -37,7 +37,8 @@ public class InternalTranslogFactory implements TranslogFactory {
             translogDeletionPolicy,
             globalCheckpointSupplier,
             primaryTermSupplier,
-            persistedSequenceNumberConsumer
+            persistedSequenceNumberConsumer,
+            null
         );
     }
 }

--- a/server/src/main/java/org/opensearch/index/translog/LocalTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/LocalTranslog.java
@@ -49,9 +49,10 @@ public class LocalTranslog extends Translog {
         TranslogDeletionPolicy deletionPolicy,
         final LongSupplier globalCheckpointSupplier,
         final LongSupplier primaryTermSupplier,
-        final LongConsumer persistedSequenceNumberConsumer
+        final LongConsumer persistedSequenceNumberConsumer,
+        final ChannelFactory channelFactory
     ) throws IOException {
-        super(config, translogUUID, deletionPolicy, globalCheckpointSupplier, primaryTermSupplier, persistedSequenceNumberConsumer);
+        super(config, translogUUID, deletionPolicy, globalCheckpointSupplier, primaryTermSupplier, persistedSequenceNumberConsumer, channelFactory);
         try {
             final Checkpoint checkpoint = readCheckpoint(location);
             final Path nextTranslogFile = location.resolve(getFilename(checkpoint.generation + 1));

--- a/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
+++ b/server/src/main/java/org/opensearch/index/translog/RemoteFsTranslog.java
@@ -109,7 +109,7 @@ public class RemoteFsTranslog extends Translog {
         RemoteTranslogTransferTracker remoteTranslogTransferTracker,
         RemoteStoreSettings remoteStoreSettings
     ) throws IOException {
-        super(config, translogUUID, deletionPolicy, globalCheckpointSupplier, primaryTermSupplier, persistedSequenceNumberConsumer);
+        super(config, translogUUID, deletionPolicy, globalCheckpointSupplier, primaryTermSupplier, persistedSequenceNumberConsumer, null);
         logger = Loggers.getLogger(getClass(), shardId);
         this.startedPrimarySupplier = startedPrimarySupplier;
         this.remoteTranslogTransferTracker = remoteTranslogTransferTracker;

--- a/server/src/main/java/org/opensearch/index/translog/Translog.java
+++ b/server/src/main/java/org/opensearch/index/translog/Translog.java
@@ -153,6 +153,7 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
     protected final String translogUUID;
     protected final TranslogDeletionPolicy deletionPolicy;
     protected final LongConsumer persistedSequenceNumberConsumer;
+    protected final ChannelFactory channelFactory;
 
     /**
      * Creates a new Translog instance. This method will create a new transaction log unless the given {@link TranslogGeneration} is
@@ -179,7 +180,8 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
         TranslogDeletionPolicy deletionPolicy,
         final LongSupplier globalCheckpointSupplier,
         final LongSupplier primaryTermSupplier,
-        final LongConsumer persistedSequenceNumberConsumer
+        final LongConsumer persistedSequenceNumberConsumer,
+        final ChannelFactory channelFactory
     ) throws IOException {
         super(config.getShardId(), config.getIndexSettings());
         this.config = config;
@@ -194,6 +196,7 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
         writeLock = new ReleasableLock(rwl.writeLock());
         this.location = config.getTranslogPath();
         Files.createDirectories(this.location);
+        this.channelFactory = channelFactory != null ? channelFactory : FileChannel :: open;
     }
 
     /** recover all translog files found on disk */
@@ -296,7 +299,7 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
     }
 
     TranslogReader openReader(Path path, Checkpoint checkpoint) throws IOException {
-        FileChannel channel = FileChannel.open(path, StandardOpenOption.READ);
+        FileChannel channel = getChannelFactory().open(path, StandardOpenOption.READ);
         try {
             assert Translog.parseIdFromFileName(path) == checkpoint.generation : "expected generation: "
                 + Translog.parseIdFromFileName(path)
@@ -1901,7 +1904,7 @@ public abstract class Translog extends AbstractIndexShardComponent implements In
     }
 
     ChannelFactory getChannelFactory() {
-        return FileChannel::open;
+        return this.channelFactory;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/translog/TruncateTranslogAction.java
+++ b/server/src/main/java/org/opensearch/index/translog/TruncateTranslogAction.java
@@ -221,7 +221,8 @@ public class TruncateTranslogAction {
                     retainAllTranslogPolicy,
                     () -> translogGlobalCheckpoint,
                     () -> primaryTerm,
-                    seqNo -> {}
+                    seqNo -> {},
+                    null
                 );
                 Translog.Snapshot snapshot = translog.newSnapshot(0, Long.MAX_VALUE)
             ) {

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -4175,7 +4175,8 @@ public class InternalEngineTests extends EngineTestCase {
             createTranslogDeletionPolicy(INDEX_SETTINGS),
             () -> SequenceNumbers.NO_OPS_PERFORMED,
             primaryTerm::get,
-            seqNo -> {}
+            seqNo -> {},
+            null
         );
         translog.add(new Translog.Index("SomeBogusId", 0, primaryTerm.get(), "{}".getBytes(Charset.forName("UTF-8"))));
         assertEquals(generation.translogFileGeneration, translog.currentFileGeneration());

--- a/server/src/test/java/org/opensearch/index/translog/LocalTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/LocalTranslogTests.java
@@ -222,7 +222,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
             createTranslogDeletionPolicy(config.getIndexSettings()),
             () -> SequenceNumbers.NO_OPS_PERFORMED,
             primaryTerm::get,
-            getPersistedSeqNoConsumer()
+            getPersistedSeqNoConsumer(),
+            null
         );
     }
 
@@ -233,7 +234,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
             createTranslogDeletionPolicy(config.getIndexSettings()),
             () -> SequenceNumbers.NO_OPS_PERFORMED,
             primaryTerm::get,
-            getPersistedSeqNoConsumer()
+            getPersistedSeqNoConsumer(),
+            null
         );
     }
 
@@ -269,7 +271,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
             deletionPolicy,
             () -> globalCheckpoint.get(),
             primaryTerm::get,
-            getPersistedSeqNoConsumer()
+            getPersistedSeqNoConsumer(),
+            null
         );
     }
 
@@ -1504,7 +1507,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 new DefaultTranslogDeletionPolicy(-1, -1, 0),
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                persistedSeqNos::add
+                persistedSeqNos::add,
+                channelFactory
             ) {
                 @Override
                 ChannelFactory getChannelFactory() {
@@ -1609,7 +1613,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 new DefaultTranslogDeletionPolicy(-1, -1, 0),
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                persistedSeqNos::add
+                persistedSeqNos::add,
+                channelFactory
             ) {
                 @Override
                 ChannelFactory getChannelFactory() {
@@ -1706,7 +1711,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 new DefaultTranslogDeletionPolicy(-1, -1, 0),
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                persistedSeqNos::add
+                persistedSeqNos::add,
+                channelFactory
             ) {
                 @Override
                 ChannelFactory getChannelFactory() {
@@ -1812,7 +1818,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 translog.getDeletionPolicy(),
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                seqNo -> {}
+                seqNo -> {},
+                null
             );
             assertEquals(
                 "lastCommitted must be 1 less than current",
@@ -1871,7 +1878,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 deletionPolicy,
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                seqNo -> {}
+                seqNo -> {},
+                null
             )
         ) {
             assertNotNull(translogGeneration);
@@ -1898,7 +1906,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                     deletionPolicy,
                     () -> SequenceNumbers.NO_OPS_PERFORMED,
                     primaryTerm::get,
-                    seqNo -> {}
+                    seqNo -> {},
+                    null
                 )
             ) {
                 assertNotNull(translogGeneration);
@@ -1960,7 +1969,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 deletionPolicy,
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                seqNo -> {}
+                seqNo -> {},
+                null
             )
         ) {
             assertNotNull(translogGeneration);
@@ -1988,7 +1998,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                     deletionPolicy,
                     () -> SequenceNumbers.NO_OPS_PERFORMED,
                     primaryTerm::get,
-                    seqNo -> {}
+                    seqNo -> {},
+                    null
                 )
             ) {
                 assertNotNull(translogGeneration);
@@ -2052,7 +2063,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 deletionPolicy,
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                seqNo -> {}
+                seqNo -> {},
+                null
             )
         );
         assertThat(
@@ -2078,7 +2090,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 deletionPolicy,
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                seqNo -> {}
+                seqNo -> {},
+                null
             )
         ) {
             assertNotNull(translogGeneration);
@@ -2376,7 +2389,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 createTranslogDeletionPolicy(),
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                seqNo -> {}
+                seqNo -> {},
+                null
             );
             fail("translog doesn't belong to this UUID");
         } catch (TranslogCorruptedException ex) {
@@ -2388,7 +2402,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
             deletionPolicy,
             () -> SequenceNumbers.NO_OPS_PERFORMED,
             primaryTerm::get,
-            seqNo -> {}
+            seqNo -> {},
+            null
         );
         try (Translog.Snapshot snapshot = this.translog.newSnapshot(randomLongBetween(0, firstUncommitted), Long.MAX_VALUE)) {
             for (int i = firstUncommitted; i < translogOperations; i++) {
@@ -2618,7 +2633,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 deletionPolicy,
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                seqNo -> {}
+                seqNo -> {},
+                null
             )
         ) {
             assertEquals(
@@ -2775,7 +2791,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                     createTranslogDeletionPolicy(),
                     () -> SequenceNumbers.NO_OPS_PERFORMED,
                     primaryTerm::get,
-                    seqNo -> {}
+                    seqNo -> {},
+                    null
                 );
                 Translog.Snapshot snapshot = tlog.newSnapshot()
             ) {
@@ -2838,7 +2855,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
             deletionPolicy,
             () -> SequenceNumbers.NO_OPS_PERFORMED,
             primaryTerm::get,
-            seqNo -> {}
+            seqNo -> {},
+            null
         );
         assertThat(translog.getMinFileGeneration(), equalTo(1L));
         // no trimming done yet, just recovered
@@ -2907,7 +2925,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 deletionPolicy,
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                seqNo -> {}
+                seqNo -> {},
+                null
             )
         ) {
             // we don't know when things broke exactly
@@ -2983,7 +3002,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
             deletionPolicy,
             () -> SequenceNumbers.NO_OPS_PERFORMED,
             primaryTerm::get,
-            seqNo -> {}
+            seqNo -> {},
+            channelFactory
         ) {
             @Override
             ChannelFactory getChannelFactory() {
@@ -3130,7 +3150,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 createTranslogDeletionPolicy(),
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                seqNo -> {}
+                seqNo -> {},
+                null
             ) {
                 @Override
                 protected TranslogWriter createWriter(
@@ -3198,7 +3219,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 translog.getDeletionPolicy(),
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                seqNo -> {}
+                seqNo -> {},
+                null
             )
         );
         assertEquals(ex.getMessage(), "failed to create new translog file");
@@ -3225,7 +3247,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 deletionPolicy,
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                seqNo -> {}
+                seqNo -> {},
+                null
             )
         ) {
             assertFalse(tlog.syncNeeded());
@@ -3247,7 +3270,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 deletionPolicy,
                 () -> SequenceNumbers.NO_OPS_PERFORMED,
                 primaryTerm::get,
-                seqNo -> {}
+                seqNo -> {},
+                null
             )
         );
         assertEquals(ex.getMessage(), "failed to create new translog file");
@@ -3377,7 +3401,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                     deletionPolicy,
                     () -> SequenceNumbers.NO_OPS_PERFORMED,
                     primaryTerm::get,
-                    seqNo -> {}
+                    seqNo -> {},
+                    null
                 );
                 Translog.Snapshot snapshot = translog.newSnapshot(localCheckpointOfSafeCommit + 1, Long.MAX_VALUE)
             ) {
@@ -3472,7 +3497,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
             deletionPolicy,
             () -> SequenceNumbers.NO_OPS_PERFORMED,
             primaryTerm::get,
-            seqNo -> {}
+            seqNo -> {},
+            null
         );
         translog.add(new Translog.Index("2", 1, primaryTerm.get(), new byte[] { 2 }));
         translog.rollGeneration();
@@ -3486,7 +3512,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
             deletionPolicy,
             () -> SequenceNumbers.NO_OPS_PERFORMED,
             primaryTerm::get,
-            seqNo -> {}
+            seqNo -> {},
+            null
         );
     }
 
@@ -3847,7 +3874,7 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 LongSupplier globalCheckpointSupplier,
                 LongSupplier primaryTermSupplier
             ) throws IOException {
-                super(config, translogUUID, deletionPolicy, globalCheckpointSupplier, primaryTermSupplier, seqNo -> {});
+                super(config, translogUUID, deletionPolicy, globalCheckpointSupplier, primaryTermSupplier, seqNo -> {}, null);
             }
 
             void callCloseDirectly() throws IOException {
@@ -3953,7 +3980,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                     brokenTranslog.getDeletionPolicy(),
                     () -> SequenceNumbers.NO_OPS_PERFORMED,
                     primaryTerm::get,
-                    seqNo -> {}
+                    seqNo -> {},
+                    null
                 )
             ) {
                 recoveredTranslog.rollGeneration();
@@ -3987,7 +4015,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                 createTranslogDeletionPolicy(config.getIndexSettings()),
                 globalCheckpointSupplier,
                 primaryTerm::get,
-                persistedSeqNos::add
+                persistedSeqNos::add,
+                null
             )
         ) {
             Thread[] threads = new Thread[between(2, 8)];
@@ -4068,7 +4097,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
             createTranslogDeletionPolicy(),
             () -> SequenceNumbers.NO_OPS_PERFORMED,
             primaryTerm::get,
-            seqNo -> {}
+            seqNo -> {},
+            channelFactory
         ) {
             @Override
             ChannelFactory getChannelFactory() {

--- a/server/src/test/java/org/opensearch/index/translog/TranslogManagerTestCase.java
+++ b/server/src/test/java/org/opensearch/index/translog/TranslogManagerTestCase.java
@@ -94,7 +94,8 @@ public abstract class TranslogManagerTestCase extends OpenSearchTestCase {
             createTranslogDeletionPolicy(INDEX_SETTINGS),
             () -> SequenceNumbers.NO_OPS_PERFORMED,
             primaryTermSupplier,
-            seqNo -> {}
+            seqNo -> {},
+            null
         );
     }
 

--- a/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
@@ -549,7 +549,8 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
             createTranslogDeletionPolicy(INDEX_SETTINGS),
             () -> SequenceNumbers.NO_OPS_PERFORMED,
             primaryTermSupplier,
-            seqNo -> {}
+            seqNo -> {},
+            null
         );
     }
 


### PR DESCRIPTION
### Description
Adds a channel factory parameter to translog constructor which was earlier always defaulted to `FileChannel::open`. This enables us to pass our own channel factory which was not possible by overriding otherwise.

### Related Issues
Related:
 - https://github.com/opensearch-project/opensearch-storage-encryption/pull/39

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
