### PR TITLE
Reset isPipelineResolved to false to resolve the system ingest pipeline again.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Close IndexFieldDataService asynchronously ([#18888](https://github.com/opensearch-project/OpenSearch/pull/18888))
 - Fix query string regex queries incorrectly swallowing TooComplexToDeterminizeException ([#18883](https://github.com/opensearch-project/OpenSearch/pull/18883))
 - Fix socks5 user password settings for Azure repo ([#18904](https://github.com/opensearch-project/OpenSearch/pull/18904))
-
+- Reset isPipelineResolved to false to resolve the system ingest pipeline again. ([#18911](https://github.com/opensearch-project/OpenSearch/pull/18911))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/ingest/IngestService.java
+++ b/server/src/main/java/org/opensearch/ingest/IngestService.java
@@ -1266,9 +1266,12 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         final PipelineHolder holder = pipelines.get(pipelineId);
         if (IngestPipelineType.SYSTEM_FINAL.equals(pipelineType)) {
             Pipeline indexPipeline = systemIngestPipelineCache.getSystemIngestPipeline(pipelineId);
-            // In very edge case it is possible the cache is invalidated after we resolve the
-            // pipeline. So try to resolve the system ingest pipeline again here.
+            // In some edge cases it is possible the cache is invalidated after we resolve the
+            // pipeline or the request is forwarded from a non-ingest node. In that case we should try to resolve the
+            // system ingest pipeline on this node one more time.
             if (indexPipeline == null) {
+                // reset isPipelineResolved as false so that we can resolve it again
+                indexRequest.isPipelineResolved(false);
                 resolveSystemIngestPipeline(actionRequest, indexRequest, state.metadata());
                 final String newPipelineId = indexRequest.getSystemIngestPipeline();
                 // set it as NOOP to avoid duplicated execution after we switch back to the write thread


### PR DESCRIPTION
### Description
Reset isPipelineResolved to false to resolve the system ingest pipeline again. If we don't reset it as false we simply skip resolving the pipeline.

### Related Issues
Resolves #18909

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
