### PR TITLE
[GRPC] Remove `experimental` designation from transport-grpc settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Making multi rate limiters in repository dynamic [#18069](https://github.com/opensearch-project/OpenSearch/pull/18069)
 - Optimize grouping for segment concurrent search by ensuring that documents within each group are as equal as possible ([#18451](https://github.com/opensearch-project/OpenSearch/pull/18451))
 - Move transport-grpc from a core plugin to a module ([#18897](https://github.com/opensearch-project/OpenSearch/pull/18897))
+- Remove `experimental` designation from transport-grpc settings ([#18915](https://github.com/opensearch-project/OpenSearch/pull/18915))
 
 ### Dependencies
 - Bump `stefanzweifel/git-auto-commit-action` from 5 to 6 ([#18524](https://github.com/opensearch-project/OpenSearch/pull/18524))

--- a/modules/transport-grpc/README.md
+++ b/modules/transport-grpc/README.md
@@ -9,15 +9,15 @@ The `transport-grpc` module initializes a new client/server transport implementi
 Enable this transport with:
 
 ```
-setting 'aux.transport.types',                              '[experimental-transport-grpc]'
-setting 'aux.transport.experimental-transport-grpc.port',   '9400-9500' //optional
+setting 'aux.transport.types',                              '[transport-grpc]'
+setting 'aux.transport.transport-grpc.port',   '9400-9500' //optional
 ```
 
 For the secure transport:
 
 ```
-setting 'aux.transport.types',                                      '[experimental-secure-transport-grpc]'
-setting 'aux.transport.experimental-secure-transport-grpc.port',    '9400-9500' //optional
+setting 'aux.transport.types',                                      '[secure-transport-grpc]'
+setting 'aux.transport.secure-transport-grpc.port',    '9400-9500' //optional
 ```
 
 
@@ -76,5 +76,5 @@ setting 'grpc.netty.keepalive_timeout',                 '1s'
 To run OpenSearch with the gRPC transport enabled:
 
 ```bash
-./gradlew run -Dtests.opensearch.aux.transport.types="[experimental-transport-grpc]"
+./gradlew run -Dtests.opensearch.aux.transport.types="[transport-grpc]"
 ```

--- a/modules/transport-grpc/build.gradle
+++ b/modules/transport-grpc/build.gradle
@@ -16,7 +16,7 @@ opensearchplugin {
 
 testClusters {
   integTest {
-    setting 'aux.transport.types', '[experimental-transport-grpc]'
+    setting 'aux.transport.types', '[transport-grpc]'
   }
 }
 

--- a/modules/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/Netty4GrpcServerTransport.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/Netty4GrpcServerTransport.java
@@ -62,7 +62,7 @@ public class Netty4GrpcServerTransport extends AuxTransport {
     /**
      * Type key for configuring settings of this auxiliary transport.
      */
-    public static final String GRPC_TRANSPORT_SETTING_KEY = "experimental-transport-grpc";
+    public static final String GRPC_TRANSPORT_SETTING_KEY = "transport-grpc";
 
     /**
      * Port range on which to bind.

--- a/modules/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransport.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/plugin/transport/grpc/ssl/SecureNetty4GrpcServerTransport.java
@@ -42,7 +42,7 @@ public class SecureNetty4GrpcServerTransport extends Netty4GrpcServerTransport {
     /**
      * Type key to select secure transport.
      */
-    public static final String GRPC_SECURE_TRANSPORT_SETTING_KEY = "experimental-secure-transport-grpc";
+    public static final String GRPC_SECURE_TRANSPORT_SETTING_KEY = "secure-transport-grpc";
 
     /**
      * Distinct port setting required as it depends on transport type key.


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Remove the "experimental" designation from all transport-grpc settings, in preparation for the upcoming 3.2 GRPC GA 
Corresponding public doc fixes will be made in https://github.com/opensearch-project/documentation-website/pull/10651/files 

### Related Issues
Part of https://github.com/opensearch-project/OpenSearch/issues/16787

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
