### PR TITLE
Fix unnecessary refreshes during update retry conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change default value of remote_data_ratio, which is used in Searchable Snapshots and Writeable Warm from 0 to 5 and min allowed value to 1 ([#18767](https://github.com/opensearch-project/OpenSearch/pull/18767))
 - Making multi rate limiters in repository dynamic [#18069](https://github.com/opensearch-project/OpenSearch/pull/18069)
 
+### Fixed
+- Fix unnecessary refreshes on update preparation failures ([#15261](https://github.com/opensearch-project/OpenSearch/issues/15261))
+
 ### Dependencies
 - Bump `stefanzweifel/git-auto-commit-action` from 5 to 6 ([#18524](https://github.com/opensearch-project/OpenSearch/pull/18524))
 - Bump Apache Lucene to 10.2.2 ([#18573](https://github.com/opensearch-project/OpenSearch/pull/18573))


### PR DESCRIPTION
When update operations with retry_on_conflict encounter version conflicts, each retry attempt was triggering the original refresh policy (IMMEDIATE, WAIT_UNTIL), causing unnecessary refresh operations that degrade performance.

This change suppresses the refresh policy to NONE for retry attempts while preserving the original policy for the initial attempt. The refresh will still happen once when the update eventually succeeds or fails permanently.

Fixes #15261

