### PR TITLE
Fix gRPC initialized even without aux type registered

### DIFF
--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/GrpcPlugin.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/GrpcPlugin.java
@@ -145,7 +145,10 @@ public final class GrpcPlugin extends Plugin implements NetworkPlugin, Extensibl
             new DocumentServiceImpl(client),
             new SearchServiceImpl(client, queryUtils)
         );
-        return Collections.singletonMap(GRPC_TRANSPORT_SETTING_KEY, () -> new Netty4GrpcServerTransport(settings, grpcServices, networkService));
+        return Collections.singletonMap(
+            GRPC_TRANSPORT_SETTING_KEY,
+            () -> new Netty4GrpcServerTransport(settings, grpcServices, networkService)
+        );
     }
 
     /**
@@ -185,12 +188,10 @@ public final class GrpcPlugin extends Plugin implements NetworkPlugin, Extensibl
             new DocumentServiceImpl(client),
             new SearchServiceImpl(client, queryUtils)
         );
-        return Collections.singletonMap(GRPC_SECURE_TRANSPORT_SETTING_KEY, () -> new SecureNetty4GrpcServerTransport(
-            settings,
-            grpcServices,
-            networkService,
-            secureAuxTransportSettingsProvider
-        ));
+        return Collections.singletonMap(
+            GRPC_SECURE_TRANSPORT_SETTING_KEY,
+            () -> new SecureNetty4GrpcServerTransport(settings, grpcServices, networkService, secureAuxTransportSettingsProvider)
+        );
     }
 
     /**

--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/GrpcPlugin.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/GrpcPlugin.java
@@ -45,6 +45,7 @@ import java.util.function.Supplier;
 
 import io.grpc.BindableService;
 
+import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.GRPC_TRANSPORT_SETTING_KEY;
 import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_BIND_HOST;
 import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_HOST;
 import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_KEEPALIVE_TIMEOUT;
@@ -55,6 +56,7 @@ import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GR
 import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_PUBLISH_HOST;
 import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_PUBLISH_PORT;
 import static org.opensearch.transport.grpc.Netty4GrpcServerTransport.SETTING_GRPC_WORKER_COUNT;
+import static org.opensearch.transport.grpc.ssl.SecureNetty4GrpcServerTransport.GRPC_SECURE_TRANSPORT_SETTING_KEY;
 import static org.opensearch.transport.grpc.ssl.SecureNetty4GrpcServerTransport.SETTING_GRPC_SECURE_PORT;
 
 /**
@@ -143,8 +145,7 @@ public final class GrpcPlugin extends Plugin implements NetworkPlugin, Extensibl
             new DocumentServiceImpl(client),
             new SearchServiceImpl(client, queryUtils)
         );
-        AuxTransport transport = new Netty4GrpcServerTransport(settings, grpcServices, networkService);
-        return Collections.singletonMap(transport.settingKey(), () -> transport);
+        return Collections.singletonMap(GRPC_TRANSPORT_SETTING_KEY, () -> new Netty4GrpcServerTransport(settings, grpcServices, networkService));
     }
 
     /**
@@ -184,13 +185,12 @@ public final class GrpcPlugin extends Plugin implements NetworkPlugin, Extensibl
             new DocumentServiceImpl(client),
             new SearchServiceImpl(client, queryUtils)
         );
-        AuxTransport transport = new SecureNetty4GrpcServerTransport(
+        return Collections.singletonMap(GRPC_SECURE_TRANSPORT_SETTING_KEY, () -> new SecureNetty4GrpcServerTransport(
             settings,
             grpcServices,
             networkService,
             secureAuxTransportSettingsProvider
-        );
-        return Collections.singletonMap(transport.settingKey(), () -> transport);
+        ));
     }
 
     /**


### PR DESCRIPTION
### Description
Fix a compilation bug after gRPC plugin moved to module. The secure gRPC transport always invokes its constructor as all extension points are called for modules. This is problematic as this extension point has side effects and constructs the transport. It should instead provide a lambda to construct the transport which is only invoked when the transport is configured in settings with `aux.transport.types`.

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
