### PR TITLE
Reverts min version req from gradle breaking change workflow to unblock downstream plugin CI

### DIFF
--- a/.github/workflows/detect-breaking-change.yml
+++ b/.github/workflows/detect-breaking-change.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         cache-disabled: true
         arguments: japicmp
-        gradle-version: 8.14.3
+        gradle-version: 8.14
         build-root-directory: server
     - if: failure()
       run: cat server/build/reports/java-compatibility/report.txt


### PR DESCRIPTION
https://github.com/opensearch-project/OpenSearch/pull/18919 lead to failures in downstream security plugin:
```
* Where:
Build file '/home/runner/work/security/security/build.gradle' line: 81
* What went wrong:
A problem occurred evaluating root project 'opensearch-security'.
> Failed to apply plugin class 'org.opensearch.gradle.info.GlobalBuildInfoPlugin'.
   > Gradle 8.14.3+ is required
```

This PR reverts the min version requirement from gradle in breaking change detection action.

Other option is to upgrade downstream plugins, but that requires each plugin to update. This PR immediately unblocks change going in 3.2.0 without any action required from plugin.

https://github.com/opensearch-project/OpenSearch/pull/18919#issuecomment-3156520804

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
