### PR TITLE
Bug fix to `scaled_float` in `encodePoint` method

### DIFF
--- a/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/ScaledFloatFieldMapper.java
@@ -219,18 +219,15 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public byte[] encodePoint(Object value, boolean roundUp) {
-            double doubleValue = parse(value);
-            long scaledValue = Math.round(scale(doubleValue));
+            long scaledValue = Math.round(scale(value));
             if (roundUp) {
-                if (scaledValue < Long.MAX_VALUE) {
-                    scaledValue = scaledValue + 1;
-                }
+                scaledValue = scaledValue + 1;
             } else {
-                if (scaledValue > Long.MIN_VALUE) {
-                    scaledValue = scaledValue - 1;
-                }
+                scaledValue = scaledValue - 1;
             }
-            return encodePoint(scaledValue);
+            byte[] point = new byte[Long.BYTES];
+            LongPoint.encodeDimension(scaledValue, point, 0);
+            return point;
         }
 
         public double getScalingFactor() {

--- a/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldMapperTests.java
@@ -33,6 +33,7 @@
 package org.opensearch.index.mapper;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DirectoryReader;
@@ -472,5 +473,18 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
         );
         assertThat(e.getMessage(), containsString("Failed to parse mapping [_doc]: Field [scaling_factor] is required"));
         assertWarnings("Parameter [index_options] has no effect on type [scaled_float] and will be removed in future");
+    }
+
+    public void testScaledFloatEncodePoint() {
+        double scalingFactor = 100.0;
+        ScaledFloatFieldMapper.ScaledFloatFieldType fieldType =
+            new ScaledFloatFieldMapper.ScaledFloatFieldType("test_field", scalingFactor);
+        double originalValue = 10.5;
+        byte[] encodedRoundUp = fieldType.encodePoint(originalValue, true);
+        byte[] encodedRoundDown = fieldType.encodePoint(originalValue, false);
+        long decodedUp = LongPoint.decodeDimension(encodedRoundUp, 0);
+        long decodedDown = LongPoint.decodeDimension(encodedRoundDown, 0);
+        assertEquals(1051, decodedUp); // 10.5 scaled = 1050, then +1 = 1051 (represents 10.51)
+        assertEquals(1049, decodedDown); // 10.5 scaled = 1050, then -1 = 1049 (represents 10.49)
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This bug was introduced part of this PR https://github.com/opensearch-project/OpenSearch/pull/18896, following the same pattern for `encodePoint(Object value, boolean roundUp)` similar to `termQuery` in `ScaledFloatFieldMapper`.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/18546

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
