### PR TITLE
Fix broken yml test for combined_fields

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/400_combined_fields.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/400_combined_fields.yml
@@ -3,6 +3,8 @@ setup:
       indices.create:
         index: cf_test
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             properties:
               headline:


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This test breaks with a repeatable seed because we randomly set shard count above 1 which changes doc count per segment and therefore scoring.  Fixing it by setting shard count to 1.  We could also resolve this by using dfs searchType, but seems the precedent in our yml tests is to fix the shard count.


### Related Issues
Resolves #18881
### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
