### PR TITLE
Update permission for read in /sys/fs/cgroup/system.slice/opensearch.service/- path

### DIFF
--- a/distribution/packages/src/common/systemd/opensearch.service
+++ b/distribution/packages/src/common/systemd/opensearch.service
@@ -96,9 +96,8 @@ ProtectControlGroups=yes
 LockPersonality=yes
 
 
-# System call filtering
 # System call filterings which restricts which system calls a process can make
-# @ means allowed
+# @ means predefined sets
 # ~ means not allowed
 # These syscalls are related to mmap which is needed for OpenSearch Services
 SystemCallFilter=seccomp mincore
@@ -149,6 +148,7 @@ ReadOnlyPaths=/proc/self/mountinfo /proc/diskstats
 ## Allow read access to control group stats
 ReadOnlyPaths=/proc/self/cgroup /sys/fs/cgroup/cpu /sys/fs/cgroup/cpu/-
 ReadOnlyPaths=/sys/fs/cgroup/cpuacct /sys/fs/cgroup/cpuacct/- /sys/fs/cgroup/memory /sys/fs/cgroup/memory/-
+ReadOnlyPaths=/sys/fs/cgroup/system.slice/opensearch.service/-
 
 
 RestrictNamespaces=true

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -247,8 +247,7 @@ grant {
   permission java.io.FilePermission "/sys/fs/cgroup/memory.swap.current", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/memory.max", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/memory.current", "read";
-  permission java.io.FilePermission "/sys/fs/cgroup/system.slice/hosted-compute-agent.service/memory.max", "read";
-  permission java.io.FilePermission "/sys/fs/cgroup/system.slice/hosted-compute-agent.service/memory.current", "read";
+  permission java.io.FilePermission "/sys/fs/cgroup/system.slice/opensearch.service/-", "read";
 
   // needed by RestClientBuilder
   permission java.io.FilePermission "${java.home}/lib/security/cacerts", "read";


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The changes in https://github.com/opensearch-project/OpenSearch/pull/18771 is incomplete as we have seen these errors shown in 3.2.0:

/sys/fs/cgroup/system.slice/opensearch.service/memory.max
/sys/fs/cgroup/system.slice/opensearch.service/memory.swap.max
/sys/fs/cgroup/system.slice/opensearch.service/memory.current

```
Caused by: java.lang.SecurityException: Denied OPEN (read) access to file: /sys/fs/cgroup/system.slice/opensearch.service/memory.max, domain: ProtectionDomain  (file:/usr/share/opensearch/lib/opensearch-3.2.0.jar <no signer certificates>)
 jdk.internal.loader.ClassLoaders$AppClassLoader@18b4aac2
 <no principals>
 java.security.Permissions@7fec168e (
)


	at java.base/java.nio.channels.FileChannel.open(FileChannel.java:347) ~[?:?]
	at java.base/java.nio.file.Files.lines(Files.java:3738) ~[?:?]
	at java.base/java.nio.file.Files.lines(Files.java:3829) ~[?:?]
	at java.base/jdk.internal.platform.CgroupSubsystemController.getStringValue(CgroupSubsystemController.java:66) ~[?:?]
	at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getMemoryLimit(CgroupV2Subsystem.java:247) ~[?:?]
	at java.base/jdk.internal.platform.CgroupMetrics.getMemoryLimit(CgroupMetrics.java:129) ~[?:?]
	at jdk.management@24.0.2/com.sun.management.internal.OperatingSystemImpl.getTotalMemorySize(OperatingSystemImpl.java:246) ~[?:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	... 36 more
```

### Related Issues
https://build.ci.opensearch.org/blue/organizations/jenkins/distribution-validation/detail/distribution-validation/3518/pipeline/

### Check List
- ~~[ ] Functionality includes testing.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~~
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
