### PR TITLE
Force to use `commons-beanutils:1.11.0`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ tdigest           = "3.3"
 hdrhistogram      = "2.2.2"
 grpc              = "1.68.2"
 json_smart        = "2.5.2"
+commons_beanutils  = "1.11.0"
 
 # when updating the JNA version, also update the version in buildSrc/build.gradle
 jna               = "5.16.0"

--- a/plugins/identity-shiro/build.gradle
+++ b/plugins/identity-shiro/build.gradle
@@ -22,7 +22,7 @@ dependencies {
   // Needed for shiro
   implementation "org.slf4j:slf4j-api:${versions.slf4j}"
 
-  implementation 'commons-beanutils:commons-beanutils:1.11.0'
+  implementation "commons-beanutils:commons-beanutils:${versions.commons_beanutils}"
   implementation 'commons-logging:commons-logging:1.2'
   implementation 'commons-lang:commons-lang:2.6'
 

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -36,6 +36,12 @@ versions << [
   'jetty': '9.4.57.v20241219'
 ]
 
+configurations.all {
+  resolutionStrategy {
+    force "commons-beanutils:commons-beanutils:${versions.commons_beanutils}"
+  }
+}
+
 dependencies {
   api("org.apache.hadoop:hadoop-minicluster:3.4.1") {
     exclude module: 'websocket-client'


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The `org.apache.hadoop:hadoop-minicluster:3.4.1` uses `commons-beanutils:commons-beanutils:1.9.4`. However as of now 3.4.1 is the latest version available https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-minicluster.

With this change now in all runtime and compile class path I can see the `commons-beanutils:commons-beanutils:1.11.0`
<img width="845" height="344" alt="Screenshot 2025-08-07 at 8 51 21 PM" src="https://github.com/user-attachments/assets/270183be-6849-4fd7-8041-94851e290532" />



### Related Issues
Related PR's and issues from past
- https://github.com/opensearch-project/OpenSearch/pull/18775
- https://github.com/opensearch-project/OpenSearch/issues/18401
- Part of: https://github.com/opensearch-project/opensearch-build/issues/5595
- Related Issue: https://github.com/opensearch-project/OpenSearch/issues/18577

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
