### PR TITLE
 Update permission for read in /sys/fs/cgroup/system.slice/- path

### DIFF
--- a/distribution/packages/src/common/systemd/opensearch.service
+++ b/distribution/packages/src/common/systemd/opensearch.service
@@ -148,7 +148,7 @@ ReadOnlyPaths=/proc/self/mountinfo /proc/diskstats
 ## Allow read access to control group stats
 ReadOnlyPaths=/proc/self/cgroup /sys/fs/cgroup/cpu /sys/fs/cgroup/cpu/-
 ReadOnlyPaths=/sys/fs/cgroup/cpuacct /sys/fs/cgroup/cpuacct/- /sys/fs/cgroup/memory /sys/fs/cgroup/memory/-
-ReadOnlyPaths=/sys/fs/cgroup/system.slice/opensearch.service/-
+ReadOnlyPaths=/sys/fs/cgroup/system.slice/-
 
 
 RestrictNamespaces=true

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -231,6 +231,8 @@ grant {
   permission java.io.FilePermission "/proc/diskstats", "read";
 
   // control group stats on Linux
+  // TODO: update later when wildcard is supported in policy
+  // https://github.com/opensearch-project/OpenSearch/pull/18987
   permission java.io.FilePermission "/proc/self/cgroup", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/cpu", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/cpu/-", "read";

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -247,7 +247,7 @@ grant {
   permission java.io.FilePermission "/sys/fs/cgroup/memory.swap.current", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/memory.max", "read";
   permission java.io.FilePermission "/sys/fs/cgroup/memory.current", "read";
-  permission java.io.FilePermission "/sys/fs/cgroup/system.slice/opensearch.service/-", "read";
+  permission java.io.FilePermission "/sys/fs/cgroup/system.slice/-", "read";
 
   // needed by RestClientBuilder
   permission java.io.FilePermission "${java.home}/lib/security/cacerts", "read";


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Update permission for read in /sys/fs/cgroup/system.slice/- path.

If running in docker the folder location changed compares to #18975:
```
/sys/fs/cgroup/system.slice/<>.service/memory.max

becomes

/sys/fs/cgroup/system.slice/docker-89906b83d995faf977d24e8d25bc465a5df6c0eb0a51deedb9aae6b929b85ce1.scope/system.slice/opensearch.service/memory.max

```

### Related Issues
Follow up #18975

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
