### PR TITLE
Fix flaky ExistsQueryBuilderTests.testToQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fix flaky tests in CloseIndexIT by addressing cluster state synchronization issues ([#18878](https://github.com/opensearch-project/OpenSearch/issues/18878))
-- Fix flaky ExistsQueryBuilderTests.testToQuery ([#18274](https://github.com/opensearch-project/OpenSearch/issues/18274))
 - Add task cancellation checks in aggregators ([#18426](https://github.com/opensearch-project/OpenSearch/pull/18426))
 - Fix concurrent timings in profiler ([#18540](https://github.com/opensearch-project/OpenSearch/pull/18540))
 - Fix regex query from query string query to work with field alias ([#18215](https://github.com/opensearch-project/OpenSearch/issues/18215))


### PR DESCRIPTION
Test was generating field patterns that matched raw.derived_keyword, which doesnt support exists queries. Fixed by replacing problematic patterns with TEXT_FIELD_NAME.

Fixes #18274