### PR TITLE
Fix NPE in segment replicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fix unnecessary refreshes on update preparation failures ([#15261](https://github.com/opensearch-project/OpenSearch/issues/15261))
+- Fix NullPointerException in segment replicator ([#18997](https://github.com/opensearch-project/OpenSearch/pull/18997))
 
 ### Dependencies
 

--- a/server/src/main/java/org/opensearch/indices/replication/SegmentReplicator.java
+++ b/server/src/main/java/org/opensearch/indices/replication/SegmentReplicator.java
@@ -160,12 +160,16 @@ public class SegmentReplicator {
      */
     public ReplicationStats getSegmentReplicationStats(final ShardId shardId) {
         final ConcurrentNavigableMap<Long, ReplicationCheckpointStats> existingCheckpointStats = replicationCheckpointStats.get(shardId);
-        if (existingCheckpointStats == null || existingCheckpointStats.isEmpty()) {
+        if (existingCheckpointStats == null) {
             return ReplicationStats.empty();
         }
 
         Map.Entry<Long, ReplicationCheckpointStats> lowestEntry = existingCheckpointStats.firstEntry();
         Map.Entry<Long, ReplicationCheckpointStats> highestEntry = existingCheckpointStats.lastEntry();
+
+        if (lowestEntry == null || highestEntry == null) {
+            return ReplicationStats.empty();
+        }
 
         long bytesBehind = highestEntry.getValue().getBytesBehind();
         long replicationLag = bytesBehind > 0L


### PR DESCRIPTION
IndexStatsIT.testConcurrentIndexingAndStatsRequests sometimes fails with the following NPE:

```
IndexStatsIT > testConcurrentIndexingAndStatsRequests {p0={"cluster.indices.replication.strategy":"SEGMENT"}} FAILED
    java.lang.AssertionError:
    Expected: an empty collection
         but: <[[test][3] failed, reason [BroadcastShardOperationFailedException[operation indices:monitor/stats failed]; nested: NullPointerException[Cannot invoke "java.util.Map$Entry.getValue()" because "highestEntry" is null]; ]]>
        at __randomizedtesting.SeedInfo.seed([B56C9D0503BD16AE:2FDF6CC817B0190]:0)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
        at org.junit.Assert.assertThat(Assert.java:964)
        at org.junit.Assert.assertThat(Assert.java:930)
        at org.opensearch.indices.stats.IndexStatsIT.testConcurrentIndexingAndStatsRequests(IndexStatsIT.java:1451)
```

The `isEmpty()` check on the concurrent map is not sufficient because entries can be removed after the check but before retrieving them.

This is one of the failures seen in #15836

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
