### PR TITLE
[Tiered Caching] Handle query execution exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fix flaky tests in CloseIndexIT by addressing cluster state synchronization issues ([#18878](https://github.com/opensearch-project/OpenSearch/issues/18878))
+- [Tiered Caching] Handle  query execution exception ([#19000](https://github.com/opensearch-project/OpenSearch/issues/19000))
 
 ### Security
 

--- a/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/TieredSpilloverCacheTests.java
+++ b/modules/cache-common/src/test/java/org/opensearch/cache/common/tier/TieredSpilloverCacheTests.java
@@ -30,6 +30,7 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.tasks.TaskCancelledException;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Before;
@@ -87,6 +88,70 @@ public class TieredSpilloverCacheTests extends OpenSearchTestCase {
         clusterSettings.registerSetting(TOOK_TIME_POLICY_CONCRETE_SETTINGS_MAP.get(CacheType.INDICES_REQUEST_CACHE));
         clusterSettings.registerSetting(TOOK_TIME_DISK_TIER_POLICY_CONCRETE_SETTINGS_MAP.get(CacheType.INDICES_REQUEST_CACHE));
         clusterSettings.registerSetting(DISK_CACHE_ENABLED_SETTING_MAP.get(CacheType.INDICES_REQUEST_CACHE));
+    }
+
+    public void testComputeIfAbsentWhenTheQueryThrowsAnException() throws Exception {
+        int onHeapCacheSize = randomIntBetween(10, 30);
+        int keyValueSize = 50;
+
+        MockCacheRemovalListener<String, String> removalListener = new MockCacheRemovalListener<>();
+        TieredSpilloverCache<String, String> tieredSpilloverCache = initializeTieredSpilloverCache(
+            keyValueSize,
+            randomIntBetween(1, 4),
+            removalListener,
+            Settings.builder()
+                .put(
+                    TieredSpilloverCacheSettings.TIERED_SPILLOVER_ONHEAP_STORE_SIZE.getConcreteSettingForNamespace(
+                        CacheType.INDICES_REQUEST_CACHE.getSettingPrefix()
+                    ).getKey(),
+                    onHeapCacheSize * keyValueSize + "b"
+                )
+                .build(),
+            0,
+            1
+        );
+        ICacheKey<String> key = getICacheKey(UUID.randomUUID().toString());
+        LoadAwareCacheLoader<ICacheKey<String>, String> tieredCacheLoader = new LoadAwareCacheLoader<>() {
+            boolean isLoaded = false;
+
+            @Override
+            public String load(ICacheKey<String> key) {
+                isLoaded = true;
+                throw new TaskCancelledException("Query cancelled!");
+            }
+
+            @Override
+            public boolean isLoaded() {
+                return isLoaded;
+            }
+        };
+        // With this call, we expect an exception from the underlying loader which eventually causes the below call to result into
+        // exception.
+        try {
+            tieredSpilloverCache.computeIfAbsent(key, tieredCacheLoader);
+        } catch (Exception ex) {
+            assertEquals(TaskCancelledException.class, ex.getCause().getClass());
+            assertEquals("Query cancelled!", ex.getCause().getMessage());
+        }
+        // We will call computeIfAbsent again with the same key, but this time the underlying loader should run fine and we should get back
+        // the response.
+        String expectedRespone = "Cool response!";
+        LoadAwareCacheLoader<ICacheKey<String>, String> tieredCacheLoaderWithNoException = new LoadAwareCacheLoader<>() {
+            boolean isLoaded = false;
+
+            @Override
+            public String load(ICacheKey<String> key) {
+                isLoaded = true;
+                return expectedRespone;
+            }
+
+            @Override
+            public boolean isLoaded() {
+                return isLoaded;
+            }
+        };
+        String value = tieredSpilloverCache.computeIfAbsent(key, tieredCacheLoaderWithNoException);
+        assertEquals(expectedRespone, value);
     }
 
     public void testComputeIfAbsentWithoutAnyOnHeapCacheEviction() throws Exception {

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -159,6 +159,7 @@ import org.opensearch.test.DummyShardLock;
 import org.opensearch.test.FieldMaskingReader;
 import org.opensearch.test.VersionUtils;
 import org.opensearch.test.store.MockFSDirectoryFactory;
+import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.Assert;
 

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -159,7 +159,6 @@ import org.opensearch.test.DummyShardLock;
 import org.opensearch.test.FieldMaskingReader;
 import org.opensearch.test.VersionUtils;
 import org.opensearch.test.store.MockFSDirectoryFactory;
-import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.Assert;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Within tiered cache, when a query runs into exceptions [here](https://github.com/opensearch-project/OpenSearch/blob/main/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCache.java#L380) around timeouts, or parent task cancels it etc, it causes the NPE to be thrown [here](https://github.com/opensearch-project/OpenSearch/blob/main/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCache.java#L351) which though is swallowed eventually but this internally causes the query/key to not be removed from the temporary map [here](https://github.com/opensearch-project/OpenSearch/blob/main/modules/cache-common/src/main/java/org/opensearch/cache/common/tier/TieredSpilloverCache.java#L372)  which is responsible to handle concurrent requests for the same key.

This causes that query/key to be stuck around in that map with the exception value, and when the user hits the same query again, it returns the same exception from the map instead of recomputing it where it could have possibly run successfully without exception. This behavior causes the user to see same exception again and again for the same query/key, until unless the next refresh/invalidation happens which causes the key itself to change and recompute the query.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
