### PR TITLE
[Backport 3.2] Exclude commons-beanutils from dep on hadoop-miniclusters

### DIFF
--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     exclude group: 'org.apache.kerby'
     exclude group: 'com.nimbusds'
     exclude module: "commons-configuration2"
+    exclude module: "commons-beanutils"
+    exclude module: "org.eclipse.jetty"
   }
   api "dnsjava:dnsjava:3.6.3"
   api "org.codehaus.jettison:jettison:${versions.jettison}"


### PR DESCRIPTION
Cherry picked a90f864b8524bc75570a8461ccb569d2a4bfed42 from #18795

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
