### PR TITLE
fix flaky WeightedRoutingIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -688,38 +689,44 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
         logger.info("--> network disruption is started");
         networkDisruption.startDisrupting();
 
-        // wait for leader checker to fail
-        Thread.sleep(13000);
+        assertBusy(() -> {
+            // Check cluster health for weighed in node when cluster manager is not discovered, health check should
+            // return a response with 503 status code
+            assertThrows(
+                ClusterManagerNotDiscoveredException.class,
+                () -> client(nodes_in_zone_a.get(0)).admin().cluster().prepareHealth().setLocal(true).setEnsureNodeWeighedIn(true).get()
+            );
 
-        // Check cluster health for weighed in node when cluster manager is not discovered, health check should
-        // return a response with 503 status code
-        assertThrows(
-            ClusterManagerNotDiscoveredException.class,
-            () -> client(nodes_in_zone_a.get(0)).admin().cluster().prepareHealth().setLocal(true).setEnsureNodeWeighedIn(true).get()
-        );
+            // Check cluster health for weighed away node when cluster manager is not discovered, health check should
+            // return a response with 503 status code
+            assertThrows(
+                ClusterManagerNotDiscoveredException.class,
+                () -> client(nodes_in_zone_c.get(0)).admin().cluster().prepareHealth().setLocal(true).setEnsureNodeWeighedIn(true).get()
+            );
+        }, 1, TimeUnit.MINUTES);
 
-        // Check cluster health for weighed away node when cluster manager is not discovered, health check should
-        // return a response with 503 status code
-        assertThrows(
-            ClusterManagerNotDiscoveredException.class,
-            () -> client(nodes_in_zone_c.get(0)).admin().cluster().prepareHealth().setLocal(true).setEnsureNodeWeighedIn(true).get()
-        );
+        logger.info("--> stop network disruption");
         networkDisruption.stopDisrupting();
-        Thread.sleep(1000);
 
-        // delete weights
-        ClusterDeleteWeightedRoutingResponse deleteResponse = client().admin().cluster().prepareDeleteWeightedRouting().setVersion(0).get();
-        assertTrue(deleteResponse.isAcknowledged());
+        assertBusy(() -> {
+            // delete weights
+            ClusterDeleteWeightedRoutingResponse deleteResponse = client().admin()
+                .cluster()
+                .prepareDeleteWeightedRouting()
+                .setVersion(0)
+                .get();
+            assertTrue(deleteResponse.isAcknowledged());
 
-        // Check local cluster health
-        nodeLocalHealth = client(nodes_in_zone_c.get(0)).admin()
-            .cluster()
-            .prepareHealth()
-            .setLocal(true)
-            .setEnsureNodeWeighedIn(true)
-            .get();
-        assertFalse(nodeLocalHealth.isTimedOut());
-        assertTrue(nodeLocalHealth.hasDiscoveredClusterManager());
+            // Check local cluster health
+            ClusterHealthResponse clusterHealthResponse = client(nodes_in_zone_c.get(0)).admin()
+                .cluster()
+                .prepareHealth()
+                .setLocal(true)
+                .setEnsureNodeWeighedIn(true)
+                .get();
+            assertFalse(clusterHealthResponse.isTimedOut());
+            assertTrue(clusterHealthResponse.hasDiscoveredClusterManager());
+        }, 1, TimeUnit.MINUTES);
     }
 
     public void testReadWriteWeightedRoutingMetadataOnNodeRestart() throws Exception {

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
@@ -717,8 +717,16 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
                 .get();
             assertTrue(deleteResponse.isAcknowledged());
 
+            ClusterHealthResponse clusterHealthResponse = client().admin()
+                .cluster()
+                .prepareHealth()
+                .setWaitForNodes("4")
+                .execute()
+                .actionGet();
+            assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
+
             // Check local cluster health
-            ClusterHealthResponse clusterHealthResponse = client(nodes_in_zone_c.get(0)).admin()
+            clusterHealthResponse = client(nodes_in_zone_c.get(0)).admin()
                 .cluster()
                 .prepareHealth()
                 .setLocal(true)


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
I reproduced this test locally. The exception information is as follows:

```
ClusterManagerNotDiscoveredException[cluster-manager not discovered
]
	at __randomizedtesting.SeedInfo.seed([CA32ECE92650D7B6:4E02F48BD9CA9FCF]:0)
	at org.opensearch.action.admin.cluster.health.TransportClusterHealthAction.executeHealth(TransportClusterHealthAction.java:284)
	at org.opensearch.action.admin.cluster.health.TransportClusterHealthAction.clusterManagerOperation(TransportClusterHealthAction.java:158)
	at org.opensearch.action.admin.cluster.health.TransportClusterHealthAction.clusterManagerOperation(TransportClusterHealthAction.java:81)
	at org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction$AsyncSingleAction.lambda$doStart$0(TransportClusterManagerNodeAction.java:262)
	at org.opensearch.action.ActionRunnable$2.doRun(ActionRunnable.java:89)
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
	at org.opensearch.common.util.concurrent.OpenSearchExecutors$DirectExecutorService.execute(OpenSearchExecutors.java:341)
	at org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction$AsyncSingleAction.doStart(TransportClusterManagerNodeAction.java:259)
	at org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction$AsyncSingleAction.tryAction(TransportClusterManagerNodeAction.java:226)
	at org.opensearch.action.support.RetryableAction$1.doRun(RetryableAction.java:139)
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
	at org.opensearch.common.util.concurrent.OpenSearchExecutors$DirectExecutorService.execute(OpenSearchExecutors.java:341)
	at org.opensearch.action.support.RetryableAction.run(RetryableAction.java:117)
	at org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction.doExecute(TransportClusterManagerNodeAction.java:187)
	at org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction.doExecute(TransportClusterManagerNodeAction.java:92)
	at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:220)
	at org.opensearch.action.support.TransportAction.execute(TransportAction.java:190)
	at org.opensearch.action.support.TransportAction.execute(TransportAction.java:109)
	at org.opensearch.transport.client.node.NodeClient.executeLocally(NodeClient.java:113)
	at org.opensearch.transport.client.node.NodeClient.doExecute(NodeClient.java:100)
	at org.opensearch.transport.client.support.AbstractClient.execute(AbstractClient.java:501)
	at org.opensearch.transport.client.support.AbstractClient.execute(AbstractClient.java:488)
	at org.opensearch.transport.client.support.AbstractClient$ClusterAdmin.execute(AbstractClient.java:829)
	at org.opensearch.action.ActionRequestBuilder.execute(ActionRequestBuilder.java:66)
	at org.opensearch.action.ActionRequestBuilder.get(ActionRequestBuilder.java:73)
	at org.opensearch.cluster.routing.WeightedRoutingIT.testClusterHealthResponseWithEnsureNodeWeighedInParam(WeightedRoutingIT.java:722)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1750)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:938)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:974)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:988)
	at org.opensearch.test.OpenSearchTestClusterRule$1.evaluate(OpenSearchTestClusterRule.java:369)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.apache.lucene.tests.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:48)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:45)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:368)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:817)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$3.evaluate(ThreadLeakControl.java:468)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSingleTest(RandomizedRunner.java:947)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$5.evaluate(RandomizedRunner.java:832)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$6.evaluate(RandomizedRunner.java:883)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$7.evaluate(RandomizedRunner.java:894)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleStoreClassName$1.evaluate(TestRuleStoreClassName.java:38)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleAssertionsRequired$1.evaluate(TestRuleAssertionsRequired.java:53)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleIgnoreTestSuites$1.evaluate(TestRuleIgnoreTestSuites.java:47)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:368)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

### Reproduce

Running the following command will result in approximately `6` failures out of every `100` times.

```
./gradlew 'null' --tests 'org.opensearch.cluster.routing.WeightedRoutingIT.testClusterHealthResponseWithEnsureNodeWeighedInParam [seed=[CA32ECE92650D7B6:4E02F48BD9CA9FCF]]' -Dtests.seed=CA32ECE92650D7B6 -Dtests.locale=ses-Latn-ML -Dtests.timezone=Africa/Maputo -Druntime.java=21
```

### Analysis

This is because it is necessary to wait for a period of time after performing `NetworkDisruption#startDisrupting` and `NetworkDisruption#stopDisrupting` before they take effect.
Using `Thread.sleep` does not guarantee the effectiveness of the state.

### Solve

Use `assertBusy` instead of `Thread.sleep`.
After the fix, running locally `100` times did not encounter any issues again, and the average test runtime decreased from `13s` to `3s`.


### Related Issues
Resolves #19028
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
