### PR TITLE
Fix the version check in 400_max_score.yml

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/400_max_score.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/400_max_score.yml
@@ -33,7 +33,7 @@ teardown:
 ---
 "Test max score with sorting on score firstly":
   - skip:
-      version: " - 3.2.0"
+      version: " - 3.1.99"
       reason: Fixed in 3.2.0
 
   - do:
@@ -61,7 +61,7 @@ teardown:
 ---
 "Test max score with sorting on score firstly with concurrent segment search enabled":
   - skip:
-      version: " - 3.2.0"
+      version: " - 3.1.99"
       reason: Fixed in 3.2.0
 
   - do:


### PR DESCRIPTION
### Description

The version check in 400_max_score.yml is not correct, the bug is fixed in 3.2.0, so the skip version should be 3.1.99 rather than 3.2.0 which causes that yaml test is skipped.

### Related Issues
No issue.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
