### PR TITLE
[Backport 3.2] Fix max_score yaml test is skipped

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/400_max_score.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/400_max_score.yml
@@ -33,33 +33,35 @@ teardown:
 ---
 "Test max score with sorting on score firstly":
   - skip:
-      version: " - 3.2.0"
+      version: " - 3.1.99"
       reason: Fixed in 3.2.0
 
   - do:
       search:
+        rest_total_hits_as_int: true
         index: test_1
         body:
           query: { term: { foo: bar} }
           sort: [{ _score: desc }, { _doc: desc }]
   - match: { hits.total: 2 }
   - length: { hits.hits: 2 }
-  - match: { max_score: 1.0 }
+  - match: { hits.max_score: 1.0 }
 
   - do:
       search:
+        rest_total_hits_as_int: true
         index: test_1
         body:
           query: { term: { foo: bar} }
           sort: [{ _score: asc }, { _doc: desc }]
   - match: { hits.total: 2 }
   - length: { hits.hits: 2 }
-  - match: { max_score: null }
+  - match: { hits.max_score: null }
 
 ---
 "Test max score with sorting on score firstly with concurrent segment search enabled":
   - skip:
-      version: " - 3.2.0"
+      version: " - 3.1.99"
       reason: Fixed in 3.2.0
 
   - do:
@@ -70,20 +72,22 @@ teardown:
 
   - do:
       search:
+        rest_total_hits_as_int: true
         index: test_1
         body:
           query: { term: { foo: bar} }
           sort: [{ _score: desc }, { _doc: desc }]
   - match: { hits.total: 2 }
   - length: { hits.hits: 2 }
-  - match: { max_score: 1.0 }
+  - match: { hits.max_score: 1.0 }
 
   - do:
       search:
+        rest_total_hits_as_int: true
         index: test_1
         body:
           query: { term: { foo: bar} }
           sort: [{ _score: asc }, { _doc: desc }]
   - match: { hits.total: 2 }
   - length: { hits.hits: 2 }
-  - match: { max_score: null }
+  - match: { hits.max_score: null }


### PR DESCRIPTION
### Description

The skip version in 400_max_score.yml is not correct, that causes the tests are skipped, this PR fixes the version and also fixes the test failure.

### Related Issues
No issue.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
