### PR TITLE
Remove the setShardIndex parameter in CollapseTopFieldDocs.merge()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fix flaky tests in CloseIndexIT by addressing cluster state synchronization issues ([#18878](https://github.com/opensearch-project/OpenSearch/issues/18878))
 - [Tiered Caching] Handle  query execution exception ([#19000](https://github.com/opensearch-project/OpenSearch/issues/19000))
-- Fix assertion error when collapsing search results with concurrent segment search enabled
+- Fix assertion error when collapsing search results with concurrent segment search enabled ([#19053](https://github.com/opensearch-project/OpenSearch/pull/19053))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix flaky tests in CloseIndexIT by addressing cluster state synchronization issues ([#18878](https://github.com/opensearch-project/OpenSearch/issues/18878))
 - [Tiered Caching] Handle  query execution exception ([#19000](https://github.com/opensearch-project/OpenSearch/issues/19000))
 - Grant access to testclusters dir for tests ([#19085](https://github.com/opensearch-project/OpenSearch/issues/19085))
+- Fix assertion error when collapsing search results with concurrent segment search enabled ([#19053](https://github.com/opensearch-project/OpenSearch/pull/19053))
 
 ### Dependencies
 - Bump `com.netflix.nebula.ospackage-base` from 12.0.0 to 12.1.0 ([#19019](https://github.com/opensearch-project/OpenSearch/pull/19019))
@@ -41,11 +42,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Removed
 - Enable backward compatibility tests on Mac ([#18983](https://github.com/opensearch-project/OpenSearch/pull/18983))
-
-### Fixed
-- Fix flaky tests in CloseIndexIT by addressing cluster state synchronization issues ([#18878](https://github.com/opensearch-project/OpenSearch/issues/18878))
-- [Tiered Caching] Handle  query execution exception ([#19000](https://github.com/opensearch-project/OpenSearch/issues/19000))
-- Fix assertion error when collapsing search results with concurrent segment search enabled ([#19053](https://github.com/opensearch-project/OpenSearch/pull/19053))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 - Enable backward compatibility tests on Mac ([#18983](https://github.com/opensearch-project/OpenSearch/pull/18983))
 
+### Fixed
+- Fix flaky tests in CloseIndexIT by addressing cluster state synchronization issues ([#18878](https://github.com/opensearch-project/OpenSearch/issues/18878))
+- [Tiered Caching] Handle  query execution exception ([#19000](https://github.com/opensearch-project/OpenSearch/issues/19000))
+- Fix assertion error when collapsing search results with concurrent segment search enabled
+
 ### Security
 
 [Unreleased 3.x]: https://github.com/opensearch-project/OpenSearch/compare/3.1...main

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/110_field_collapsing.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/110_field_collapsing.yml
@@ -511,7 +511,7 @@ setup:
   - gte: { hits.hits.2.inner_hits.sub_hits.hits.hits.1._primary_term: 1 }
 
 ---
-"Test field collapsing with sorting":
+"Test field collapsing with sort":
   - skip:
       version: " - 3.2.99"
       reason: Fixed in 3.3.0
@@ -559,7 +559,7 @@ setup:
   - match: { hits.hits.1._source.marker: 'doc2' }
 
 ---
-"Test field collapsing with sorting when concurrent segment search enabled":
+"Test field collapsing with sort when concurrent segment search enabled":
   - skip:
       version: " - 3.2.99"
       reason: Fixed in 3.3.0

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/110_field_collapsing.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/110_field_collapsing.yml
@@ -509,3 +509,104 @@ setup:
   - match: { hits.hits.2.inner_hits.sub_hits.hits.hits.1._id: "4" }
   - gte: { hits.hits.2.inner_hits.sub_hits.hits.hits.1._seq_no: 0 }
   - gte: { hits.hits.2.inner_hits.sub_hits.hits.hits.1._primary_term: 1 }
+
+---
+"Test field collapsing with sorting":
+  - skip:
+      version: " - 3.2.99"
+      reason: Fixed in 3.3.0
+  - do:
+      indices.create:
+        index:  test_1
+        body:
+          mappings:
+            properties:
+              sort_field: { type: integer }
+              collapse_field: { type: integer }
+              marker: {type: keyword}
+
+  - do:
+      index:
+        index:  test_1
+        refresh: true
+        id:     1
+        body:   { sort_field: 1, collapse_field: 1, marker: "doc1" }
+  - do:
+      index:
+        index:  test_1
+        refresh: true
+        id:     2
+        body:   { sort_field: 1, collapse_field: 2, marker: "doc2" }
+  - do:
+      index:
+        index:  test_1
+        refresh: true
+        id:     3
+        body:   { sort_field: 1, collapse_field: 2, marker: "doc3" }
+
+  - do:
+      search:
+        index: test_1
+        size: 2
+        body:
+          collapse: { field: collapse_field }
+          sort: [{ sort_field: desc }]
+  - match: { hits.total.value: 3 }
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._id: '1' }
+  - match: { hits.hits.0._source.marker: 'doc1' }
+  - match: { hits.hits.1._id: '2' }
+  - match: { hits.hits.1._source.marker: 'doc2' }
+
+---
+"Test field collapsing with sorting when concurrent segment search enabled":
+  - skip:
+      version: " - 3.2.99"
+      reason: Fixed in 3.3.0
+  - do:
+      indices.create:
+        index:  test_1
+        body:
+          mappings:
+            properties:
+              sort_field: { type: integer }
+              collapse_field: { type: integer }
+              marker: {type: keyword}
+
+  - do:
+      index:
+        index:  test_1
+        refresh: true
+        id:     1
+        body:   { sort_field: 1, collapse_field: 1, marker: "doc1" }
+  - do:
+      index:
+        index:  test_1
+        refresh: true
+        id:     2
+        body:   { sort_field: 1, collapse_field: 2, marker: "doc2" }
+  - do:
+      index:
+        index:  test_1
+        refresh: true
+        id:     3
+        body:   { sort_field: 1, collapse_field: 2, marker: "doc3" }
+  - do:
+      indices.put_settings:
+        index: test_1
+        body:
+          index.search.concurrent_segment_search.mode: 'all'
+
+  - do:
+      search:
+        index: test_1
+        size: 2
+        body:
+          collapse: { field: collapse_field }
+          sort: [{ sort_field: desc }]
+  - match: { hits.total.value: 3 }
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._id: '1' }
+  - match: { hits.hits.0._source.marker: 'doc1' }
+  - match: { hits.hits.1._id: '2' }
+  - match: { hits.hits.1._source.marker: 'doc2' }

--- a/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
@@ -233,7 +233,7 @@ public final class SearchPhaseController {
         } else if (topDocs instanceof CollapseTopFieldDocs) {
             final CollapseTopFieldDocs[] shardTopDocs = results.toArray(new CollapseTopFieldDocs[numShards]);
             final Sort sort = createSort(shardTopDocs);
-            mergedTopDocs = CollapseTopFieldDocs.merge(sort, from, topN, shardTopDocs, false);
+            mergedTopDocs = CollapseTopFieldDocs.merge(sort, from, topN, shardTopDocs);
         } else if (topDocs instanceof TopFieldDocs) {
             final TopFieldDocs[] shardTopDocs = results.toArray(new TopFieldDocs[numShards]);
             final Sort sort = createSort(shardTopDocs);

--- a/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
@@ -331,8 +331,7 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
                     sort,
                     0,
                     numHits,
-                    topFieldDocs.toArray(new CollapseTopFieldDocs[0]),
-                    false
+                    topFieldDocs.toArray(new CollapseTopFieldDocs[0])
                 );
                 result.topDocs(new TopDocsAndMaxScore(topDocs, maxScore), sortFmt);
             };

--- a/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
@@ -332,7 +332,7 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
                     0,
                     numHits,
                     topFieldDocs.toArray(new CollapseTopFieldDocs[0]),
-                    true
+                    false
                 );
                 result.topDocs(new TopDocsAndMaxScore(topDocs, maxScore), sortFmt);
             };

--- a/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
@@ -1123,6 +1123,9 @@ public class QueryPhaseTests extends IndexShardTestCase {
         assertEquals(2, context.queryResult().topDocs().topDocs.scoreDocs.length);
         assertThat(context.queryResult().topDocs().topDocs.totalHits.value(), equalTo((long) numDocs));
         assertThat(context.queryResult().topDocs().topDocs, instanceOf(CollapseTopFieldDocs.class));
+        for (ScoreDoc scoreDoc: context.queryResult().topDocs().topDocs.scoreDocs) {
+            assertEquals(-1, scoreDoc.shardIndex);
+        }
 
         CollapseTopFieldDocs topDocs = (CollapseTopFieldDocs) context.queryResult().topDocs().topDocs;
         assertThat(topDocs.collapseValues.length, equalTo(2));
@@ -1135,6 +1138,9 @@ public class QueryPhaseTests extends IndexShardTestCase {
         assertEquals(2, context.queryResult().topDocs().topDocs.scoreDocs.length);
         assertThat(context.queryResult().topDocs().topDocs.totalHits.value(), equalTo((long) numDocs));
         assertThat(context.queryResult().topDocs().topDocs, instanceOf(CollapseTopFieldDocs.class));
+        for (ScoreDoc scoreDoc: context.queryResult().topDocs().topDocs.scoreDocs) {
+            assertEquals(-1, scoreDoc.shardIndex);
+        }
 
         topDocs = (CollapseTopFieldDocs) context.queryResult().topDocs().topDocs;
         assertThat(topDocs.collapseValues.length, equalTo(2));
@@ -1147,6 +1153,9 @@ public class QueryPhaseTests extends IndexShardTestCase {
         assertEquals(2, context.queryResult().topDocs().topDocs.scoreDocs.length);
         assertThat(context.queryResult().topDocs().topDocs.totalHits.value(), equalTo((long) numDocs));
         assertThat(context.queryResult().topDocs().topDocs, instanceOf(CollapseTopFieldDocs.class));
+        for (ScoreDoc scoreDoc: context.queryResult().topDocs().topDocs.scoreDocs) {
+            assertEquals(-1, scoreDoc.shardIndex);
+        }
 
         topDocs = (CollapseTopFieldDocs) context.queryResult().topDocs().topDocs;
         assertThat(topDocs.collapseValues.length, equalTo(2));

--- a/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryPhaseTests.java
@@ -1123,7 +1123,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         assertEquals(2, context.queryResult().topDocs().topDocs.scoreDocs.length);
         assertThat(context.queryResult().topDocs().topDocs.totalHits.value(), equalTo((long) numDocs));
         assertThat(context.queryResult().topDocs().topDocs, instanceOf(CollapseTopFieldDocs.class));
-        for (ScoreDoc scoreDoc: context.queryResult().topDocs().topDocs.scoreDocs) {
+        for (ScoreDoc scoreDoc : context.queryResult().topDocs().topDocs.scoreDocs) {
             assertEquals(-1, scoreDoc.shardIndex);
         }
 
@@ -1138,7 +1138,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         assertEquals(2, context.queryResult().topDocs().topDocs.scoreDocs.length);
         assertThat(context.queryResult().topDocs().topDocs.totalHits.value(), equalTo((long) numDocs));
         assertThat(context.queryResult().topDocs().topDocs, instanceOf(CollapseTopFieldDocs.class));
-        for (ScoreDoc scoreDoc: context.queryResult().topDocs().topDocs.scoreDocs) {
+        for (ScoreDoc scoreDoc : context.queryResult().topDocs().topDocs.scoreDocs) {
             assertEquals(-1, scoreDoc.shardIndex);
         }
 
@@ -1153,7 +1153,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         assertEquals(2, context.queryResult().topDocs().topDocs.scoreDocs.length);
         assertThat(context.queryResult().topDocs().topDocs.totalHits.value(), equalTo((long) numDocs));
         assertThat(context.queryResult().topDocs().topDocs, instanceOf(CollapseTopFieldDocs.class));
-        for (ScoreDoc scoreDoc: context.queryResult().topDocs().topDocs.scoreDocs) {
+        for (ScoreDoc scoreDoc : context.queryResult().topDocs().topDocs.scoreDocs) {
             assertEquals(-1, scoreDoc.shardIndex);
         }
 


### PR DESCRIPTION
### Description

In Lucene 9.0.0, this [change](https://github.com/apache/lucene-solr/pull/757) was introduced that removes the ability of TopDocs.merge to set shard indices, and we adopted the change in 2.0.0, but [CollapseTopFieldDocs.merge()](https://github.com/opensearch-project/OpenSearch/blob/0cc83a97fa6f5e71036c88e08bf05682495af5ea/server/src/main/java/org/apache/lucene/search/grouping/CollapseTopFieldDocs.java#L177) still supports setting shard indices, that should also be removed.

As a result, when collapsing search results with concurrent segment search enabled, the shardIndex of the top docs are set twice in both [queryPhase](https://github.com/opensearch-project/OpenSearch/blob/8f310f5e37c65f9c3116c05685a6713eb5e68886/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java#L335) and [FetchSearchPhase](https://github.com/opensearch-project/OpenSearch/blob/8f310f5e37c65f9c3116c05685a6713eb5e68886/server/src/main/java/org/opensearch/action/search/FetchSearchPhase.java#L136), that causes incorrect result are collected in queryPhase and later triggers an assertion error.

Actually, setting shard indices in queryPhase when calling CollapseTopFieldDocs.merge() is not needed because we are merging segment level results, they are all from one shard, we can only compare the lucene doc id when tie breaking for same sort value, small doc id wins.

This PR removes the setShardIndex parameter in CollapseTopFieldDocs.merge() method, following the change of the Lucene PR: https://github.com/apache/lucene-solr/pull/757.


### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/19051 and https://github.com/opensearch-project/OpenSearch/issues/19111.

### Check List
- [x] Functionality includes testing.
<del> - [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
<del>- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
