### PR TITLE
Clone index input in multipart upload flow

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
@@ -468,7 +468,7 @@ public class RemoteDirectory extends Directory {
 
             WriteContext writeContext = remoteTransferContainer.createWriteContext();
             ((AsyncMultiStreamBlobContainer) blobContainer).asyncBlobUpload(writeContext, completionListener);
-        } catch(Exception e) {
+        } catch (Exception e) {
             logger.warn("Exception while calling asyncBlobUpload, closing IndexInput to avoid leak");
             indexInput.close();
             throw e;

--- a/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteDirectory.java
@@ -458,11 +458,11 @@ public class RemoteDirectory extends Directory {
         });
 
         completionListener = ActionListener.runAfter(completionListener, () -> {
-           try {
-               indexInput.close();
-           } catch(IOException e) {
-               logger.warn("Error occurred while closing index input", e);
-           }
+            try {
+                indexInput.close();
+            } catch (IOException e) {
+                logger.warn("Error occurred while closing index input", e);
+            }
         });
 
         WriteContext writeContext = remoteTransferContainer.createWriteContext();

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -599,13 +599,16 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
     public void copyFrom(Directory from, String src, IOContext context, ActionListener<Void> listener, boolean lowPriorityUpload) {
         try {
             final String remoteFileName = getNewRemoteSegmentFilename(src);
-            boolean uploaded = remoteDataDirectory.copyFrom(from, src, remoteFileName, context, () -> {
-                try {
-                    postUpload(from, src, remoteFileName, getChecksumOfLocalFile(from, src));
-                } catch (IOException e) {
-                    throw new RuntimeException("Exception in segment postUpload for file " + src, e);
-                }
-            }, listener, lowPriorityUpload);
+            boolean uploaded = false;
+            if(src.startsWith("segments_") == false) {
+                uploaded = remoteDataDirectory.copyFrom(from, src, remoteFileName, context, () -> {
+                    try {
+                        postUpload(from, src, remoteFileName, getChecksumOfLocalFile(from, src));
+                    } catch (IOException e) {
+                        throw new RuntimeException("Exception in segment postUpload for file " + src, e);
+                    }
+                }, listener, lowPriorityUpload);
+            }
             if (uploaded == false) {
                 copyFrom(from, src, src, context);
                 listener.onResponse(null);

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -600,7 +600,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         try {
             final String remoteFileName = getNewRemoteSegmentFilename(src);
             boolean uploaded = false;
-            if(src.startsWith("segments_") == false) {
+            if (src.startsWith("segments_") == false) {
                 uploaded = remoteDataDirectory.copyFrom(from, src, remoteFileName, context, () -> {
                     try {
                         postUpload(from, src, remoteFileName, getChecksumOfLocalFile(from, src));

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentInfos;
@@ -600,7 +601,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         try {
             final String remoteFileName = getNewRemoteSegmentFilename(src);
             boolean uploaded = false;
-            if (src.startsWith("segments_") == false) {
+            if (src.startsWith(IndexFileNames.SEGMENTS) == false) {
                 uploaded = remoteDataDirectory.copyFrom(from, src, remoteFileName, context, () -> {
                     try {
                         postUpload(from, src, remoteFileName, getChecksumOfLocalFile(from, src));


### PR DESCRIPTION
### Description
- In multipart upload flow, we open IndexInput for each part and this can cause exhaustion of virtual memory for the OpenSearch process.
- In this PR, instead of creating new IndexInput instance, we clone the original IndexInput instance. Cloned IndexInput instance makes sure not to create a separate map entry in the virtual memory.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
