### PR TITLE
Grant access to testclusters dir for tests

### DIFF
--- a/test/framework/src/main/java/org/opensearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/opensearch/bootstrap/BootstrapForTesting.java
@@ -158,6 +158,16 @@ public class BootstrapForTesting {
                         false
                     );
                 }
+                String testclustersDir = System.getProperty("testclusters.dir");
+                if (testclustersDir != null) {
+                    FilePermissionUtils.addDirectoryPath(
+                        perms,
+                        "testclusters.dir",
+                        PathUtils.get(testclustersDir),
+                        "read,readlink,write,delete",
+                        false
+                    );
+                }
                 // custom test config file
                 String testConfigFile = System.getProperty("tests.config");
                 if (Strings.hasLength(testConfigFile)) {


### PR DESCRIPTION
### Description

Similar to https://github.com/opensearch-project/OpenSearch/pull/18988, this PR resolves an issue seen in CCR repo seen on the 3.3 version increment: https://github.com/opensearch-project/cross-cluster-replication/pull/1571

One of the tests reads a classpath resource and then copies to the config directory of one of the testclusters and fails bc the javaagent is forbidding it from writing. See the relevant test lines here: https://github.com/opensearch-project/cross-cluster-replication/blob/main/src/test/kotlin/org/opensearch/replication/integ/rest/StartReplicationIT.kt#L628-L635

Fixes the following error:

```
REPRODUCE WITH: ./gradlew ':integTest' --tests 'org.opensearch.replication.integ.rest.ResumeReplicationIT.test that replication fails to resume when custom analyser is not present in follower' -Dtests.seed=40961F1E09AB0E46 -Dtests.security.manager=true -Dtests.locale=ar-SD -Dtests.timezone=SystemV/AST4 -Druntime.java=24

> Task :integTest

ResumeReplicationIT > test that replication fails to resume when custom analyser is not present in follower FAILED
    java.lang.SecurityException: Denied OPEN (read/write) access to file: /__w/cross-cluster-replication/cross-cluster-replication/build/testclusters/leaderCluster-0/config/synonyms.txt, domain: ProtectionDomain  (file:/__w/cross-cluster-replication/cross-cluster-replication/build/classes/kotlin/test/ <no signer certificates>)
     jdk.internal.loader.ClassLoaders$AppClassLoader@659e0bfd
     <no principals>
     java.security.Permissions@2a07c730 (
    )
        at __randomizedtesting.SeedInfo.seed([40961F1E09AB0E46:B999BD0A425312AD]:0)
        at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:244)
        at java.base/java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:426)
        at org.apache.lucene.tests.mockfile.FilterFileSystemProvider.newOutputStream(FilterFileSystemProvider.java:200)
        at org.apache.lucene.tests.mockfile.FilterFileSystemProvider.newOutputStream(FilterFileSystemProvider.java:200)
        at org.apache.lucene.tests.mockfile.HandleTrackingFS.newOutputStream(HandleTrackingFS.java:132)
        at org.apache.lucene.tests.mockfile.HandleTrackingFS.newOutputStream(HandleTrackingFS.java:132)
        at org.apache.lucene.tests.mockfile.HandleTrackingFS.newOutputStream(HandleTrackingFS.java:132)
        at org.apache.lucene.tests.mockfile.FilterFileSystemProvider.newOutputStream(FilterFileSystemProvider.java:200)
        at java.base/java.nio.file.Files.newOutputStream(Files.java:215)
        at java.base/java.nio.file.Files.copy(Files.java:2852)
        at org.opensearch.replication.integ.rest.ResumeReplicationIT.test that replication fails to resume when custom analyser is not present in follower(ResumeReplicationIT.kt:177)
```

One small change would still be necessary on CCR side to add a systemProp when running integTests:

```
systemProperty 'testclusters.dir', project.layout.buildDirectory.get().file("testclusters").asFile.absolutePath
```

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
