### PR TITLE
Add StoreFactory plugin interface for custom Store implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add temporal routing processors for time-based document routing ([#18920](https://github.com/opensearch-project/OpenSearch/issues/18920))
 - The dynamic mapping parameter supports false_allow_templates ([#19065](https://github.com/opensearch-project/OpenSearch/pull/19065))
 - Add a toBuilder method in EngineConfig to support easy modification of configs([#19054](https://github.com/opensearch-project/OpenSearch/pull/19054))
+- Add StoreFactory plugin interface for custom Store implementations([#19091](https://github.com/opensearch-project/OpenSearch/pull/19091))
 
 ### Changed
 - Add CompletionStage variants to methods in the Client Interface and default to ActionListener impl ([#18998](https://github.com/opensearch-project/OpenSearch/pull/18998))

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -199,6 +199,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 BitsetFilterCache.INDEX_LOAD_RANDOM_ACCESS_FILTERS_EAGERLY_SETTING,
                 IndexModule.INDEX_STORE_TYPE_SETTING,
                 IndexModule.INDEX_COMPOSITE_STORE_TYPE_SETTING,
+                IndexModule.INDEX_STORE_FACTORY_SETTING,
                 IndexModule.INDEX_STORE_PRE_LOAD_SETTING,
                 IndexModule.INDEX_STORE_HYBRID_NIO_EXTENSIONS,
                 IndexModule.INDEX_RECOVERY_TYPE_SETTING,

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -79,6 +79,7 @@ import org.opensearch.index.shard.SearchOperationListener;
 import org.opensearch.index.similarity.SimilarityService;
 import org.opensearch.index.store.DefaultCompositeDirectoryFactory;
 import org.opensearch.index.store.FsDirectoryFactory;
+import org.opensearch.index.store.Store;
 import org.opensearch.index.store.remote.directory.RemoteSnapshotDirectoryFactory;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.index.translog.TranslogFactory;
@@ -151,6 +152,17 @@ public final class IndexModule {
     public static final Setting<String> INDEX_COMPOSITE_STORE_TYPE_SETTING = new Setting<>(
         "index.composite_store.type",
         "default",
+        Function.identity(),
+        Property.IndexScope,
+        Property.NodeScope
+    );
+
+    /**
+     * Index setting that selects a custom StoreFactory provided by plugins. If empty, the default store is used
+     */
+    public static final Setting<String> INDEX_STORE_FACTORY_SETTING = new Setting<>(
+        "index.store.factory",
+        "",
         Function.identity(),
         Property.IndexScope,
         Property.NodeScope
@@ -260,6 +272,7 @@ public final class IndexModule {
     private final AtomicBoolean frozen = new AtomicBoolean(false);
     private final BooleanSupplier allowExpensiveQueries;
     private final Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories;
+    private final Map<String, IndexStorePlugin.StoreFactory> storeFactories;
     private final FileCache fileCache;
     private final CompositeIndexSettings compositeIndexSettings;
 
@@ -283,6 +296,7 @@ public final class IndexModule {
         final BooleanSupplier allowExpensiveQueries,
         final IndexNameExpressionResolver expressionResolver,
         final Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories,
+        final Map<String, IndexStorePlugin.StoreFactory> storeFactories,
         final FileCache fileCache,
         final CompositeIndexSettings compositeIndexSettings
     ) {
@@ -297,6 +311,7 @@ public final class IndexModule {
         this.allowExpensiveQueries = allowExpensiveQueries;
         this.expressionResolver = expressionResolver;
         this.recoveryStateFactories = recoveryStateFactories;
+        this.storeFactories = storeFactories == null ? Collections.emptyMap() : Collections.unmodifiableMap(storeFactories);
         this.fileCache = fileCache;
         this.compositeIndexSettings = compositeIndexSettings;
     }
@@ -322,6 +337,7 @@ public final class IndexModule {
             allowExpensiveQueries,
             expressionResolver,
             recoveryStateFactories,
+            Collections.emptyMap(),
             null,
             null
         );
@@ -759,6 +775,7 @@ public final class IndexModule {
                 directoryFactory,
                 compositeDirectoryFactory,
                 remoteDirectoryFactory,
+                resolveStoreFactory(indexSettings, storeFactories),
                 eventListener,
                 readerWrapperFactory,
                 mapperRegistry,
@@ -856,6 +873,21 @@ public final class IndexModule {
         }
 
         return factory;
+    }
+
+    private static IndexStorePlugin.StoreFactory resolveStoreFactory(
+        final IndexSettings indexSettings,
+        final Map<String, IndexStorePlugin.StoreFactory> storeFactories
+    ) {
+        final String key = indexSettings.getValue(INDEX_STORE_FACTORY_SETTING);
+        if (key != null && key.isEmpty() == false) {
+            final IndexStorePlugin.StoreFactory factory = storeFactories.get(key);
+            if (factory == null) {
+                throw new IllegalArgumentException("Unknown store factory [" + key + "]");
+            }
+            return factory;
+        }
+        return Store::new;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -311,7 +311,7 @@ public final class IndexModule {
         this.allowExpensiveQueries = allowExpensiveQueries;
         this.expressionResolver = expressionResolver;
         this.recoveryStateFactories = recoveryStateFactories;
-        this.storeFactories = storeFactories == null ? Collections.emptyMap() : Collections.unmodifiableMap(storeFactories);
+        this.storeFactories = storeFactories;
         this.fileCache = fileCache;
         this.compositeIndexSettings = compositeIndexSettings;
     }
@@ -880,14 +880,14 @@ public final class IndexModule {
         final Map<String, IndexStorePlugin.StoreFactory> storeFactories
     ) {
         final String key = indexSettings.getValue(INDEX_STORE_FACTORY_SETTING);
-        if (key != null && key.isEmpty() == false) {
-            final IndexStorePlugin.StoreFactory factory = storeFactories.get(key);
-            if (factory == null) {
-                throw new IllegalArgumentException("Unknown store factory [" + key + "]");
-            }
-            return factory;
+        if (key == null || key.isEmpty()) {
+            return Store::new;
         }
-        return Store::new;
+        final IndexStorePlugin.StoreFactory factory = storeFactories.get(key);
+        if (factory == null) {
+            throw new IllegalArgumentException("Unknown store factory [" + key + "]");
+        }
+        return factory;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -206,6 +206,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final Object refreshMutex = new Object();
     private volatile TimeValue refreshInterval;
     private volatile boolean shardLevelRefreshEnabled;
+    private final IndexStorePlugin.StoreFactory storeFactory;
 
     @InternalApi
     public IndexService(
@@ -228,6 +229,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         IndexStorePlugin.DirectoryFactory directoryFactory,
         IndexStorePlugin.CompositeDirectoryFactory compositeDirectoryFactory,
         IndexStorePlugin.DirectoryFactory remoteDirectoryFactory,
+        IndexStorePlugin.StoreFactory storeFactory,
         IndexEventListener eventListener,
         Function<IndexService, CheckedFunction<DirectoryReader, DirectoryReader, IOException>> wrapperFactory,
         MapperRegistry mapperRegistry,
@@ -253,6 +255,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         Supplier<Integer> clusterDefaultMaxMergeAtOnceSupplier
     ) {
         super(indexSettings);
+        this.storeFactory = storeFactory;
         this.allowExpensiveQueries = allowExpensiveQueries;
         this.indexSettings = indexSettings;
         this.xContentRegistry = xContentRegistry;
@@ -378,6 +381,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         QueryCache queryCache,
         IndexStorePlugin.DirectoryFactory directoryFactory,
         IndexStorePlugin.DirectoryFactory remoteDirectoryFactory,
+        IndexStorePlugin.StoreFactory storeFactory,
         IndexEventListener eventListener,
         Function<IndexService, CheckedFunction<DirectoryReader, DirectoryReader, IOException>> wrapperFactory,
         MapperRegistry mapperRegistry,
@@ -418,6 +422,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             directoryFactory,
             null,
             remoteDirectoryFactory,
+            storeFactory,
             eventListener,
             wrapperFactory,
             mapperRegistry,
@@ -742,7 +747,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             } else {
                 directory = directoryFactory.newDirectory(this.indexSettings, path);
             }
-            store = new Store(
+            store = storeFactory.newStore(
                 shardId,
                 this.indexSettings,
                 directory,

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -1082,7 +1082,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
          *
          * @opensearch.api
          */
-        @PublicApi(since = "3.1.0")
+        @PublicApi(since = "3.2.0")
         public static class LoadedMetadata {
             public final Map<String, StoreFileMetadata> fileMetadata;
             public final Map<String, String> userData;
@@ -1735,7 +1735,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      *
      * @opensearch.api
      */
-    @PublicApi(since = "3.1.0")
+    @PublicApi(since = "3.2.0")
     public interface OnClose extends Consumer<ShardLock> {
         OnClose EMPTY = new OnClose() {
             /**

--- a/server/src/main/java/org/opensearch/index/store/Store.java
+++ b/server/src/main/java/org/opensearch/index/store/Store.java
@@ -1080,21 +1080,22 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         /**
          * Metadata that is currently loaded
          *
-         * @opensearch.internal
+         * @opensearch.api
          */
-        static class LoadedMetadata {
-            final Map<String, StoreFileMetadata> fileMetadata;
-            final Map<String, String> userData;
-            final long numDocs;
+        @PublicApi(since = "3.1.0")
+        public static class LoadedMetadata {
+            public final Map<String, StoreFileMetadata> fileMetadata;
+            public final Map<String, String> userData;
+            public final long numDocs;
 
-            LoadedMetadata(Map<String, StoreFileMetadata> fileMetadata, Map<String, String> userData, long numDocs) {
+            public LoadedMetadata(Map<String, StoreFileMetadata> fileMetadata, Map<String, String> userData, long numDocs) {
                 this.fileMetadata = fileMetadata;
                 this.userData = userData;
                 this.numDocs = numDocs;
             }
         }
 
-        static LoadedMetadata loadMetadata(IndexCommit commit, Directory directory, Logger logger) throws IOException {
+        public static LoadedMetadata loadMetadata(IndexCommit commit, Directory directory, Logger logger) throws IOException {
             try {
                 final SegmentInfos segmentCommitInfos = Store.readSegmentsInfo(commit, directory);
                 return loadMetadata(segmentCommitInfos, directory, logger);
@@ -1125,11 +1126,11 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             }
         }
 
-        static LoadedMetadata loadMetadata(SegmentInfos segmentInfos, Directory directory, Logger logger) throws IOException {
+        public static LoadedMetadata loadMetadata(SegmentInfos segmentInfos, Directory directory, Logger logger) throws IOException {
             return loadMetadata(segmentInfos, directory, logger, false);
         }
 
-        static LoadedMetadata loadMetadata(SegmentInfos segmentInfos, Directory directory, Logger logger, boolean ignoreSegmentsFile)
+        public static LoadedMetadata loadMetadata(SegmentInfos segmentInfos, Directory directory, Logger logger, boolean ignoreSegmentsFile)
             throws IOException {
             long numDocs = Lucene.getNumDocs(segmentInfos);
             Map<String, String> commitUserDataBuilder = new HashMap<>();
@@ -1732,8 +1733,9 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     /**
      * A listener that is executed once the store is closed and all references to it are released
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "3.1.0")
     public interface OnClose extends Consumer<ShardLock> {
         OnClose EMPTY = new OnClose() {
             /**

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -392,6 +392,7 @@ public class IndicesService extends AbstractLifecycleComponent
     private final Map<String, IndexStorePlugin.CompositeDirectoryFactory> compositeDirectoryFactories;
     private final Map<String, IngestionConsumerFactory> ingestionConsumerFactories;
     private final Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories;
+    private final Map<String, IndexStorePlugin.StoreFactory> storeFactories;
     final AbstractRefCounted indicesRefCount; // pkg-private for testing
     private final CountDownLatch closeLatch = new CountDownLatch(1);
     private volatile boolean idFieldDataEnabled;
@@ -445,6 +446,7 @@ public class IndicesService extends AbstractLifecycleComponent
         Map<String, IndexStorePlugin.CompositeDirectoryFactory> compositeDirectoryFactories,
         ValuesSourceRegistry valuesSourceRegistry,
         Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories,
+        Map<String, IndexStorePlugin.StoreFactory> storeFactories,
         IndexStorePlugin.DirectoryFactory remoteDirectoryFactory,
         Supplier<RepositoriesService> repositoriesServiceSupplier,
         SearchRequestStats searchRequestStats,
@@ -509,6 +511,7 @@ public class IndicesService extends AbstractLifecycleComponent
         this.directoryFactories = directoryFactories;
         this.compositeDirectoryFactories = compositeDirectoryFactories;
         this.recoveryStateFactories = recoveryStateFactories;
+        this.storeFactories = storeFactories;
         this.ingestionConsumerFactories = ingestionConsumerFactories;
         // doClose() is called when shutting down a node, yet there might still be ongoing requests
         // that we need to wait for before closing some resources such as the caches. In order to
@@ -643,6 +646,7 @@ public class IndicesService extends AbstractLifecycleComponent
             Collections.emptyMap(),
             valuesSourceRegistry,
             recoveryStateFactories,
+            Collections.emptyMap(),
             remoteDirectoryFactory,
             repositoriesServiceSupplier,
             searchRequestStats,
@@ -1060,6 +1064,7 @@ public class IndicesService extends AbstractLifecycleComponent
             () -> allowExpensiveQueries,
             indexNameExpressionResolver,
             recoveryStateFactories,
+            storeFactories,
             fileCache,
             compositeIndexSettings
         );
@@ -1179,6 +1184,7 @@ public class IndicesService extends AbstractLifecycleComponent
             () -> allowExpensiveQueries,
             indexNameExpressionResolver,
             recoveryStateFactories,
+            storeFactories,
             fileCache,
             compositeIndexSettings
         );

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -938,6 +938,12 @@ public class Node implements Closeable {
                 .flatMap(m -> m.entrySet().stream())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
+            final Map<String, IndexStorePlugin.StoreFactory> storeFactories = pluginsService.filterPlugins(IndexStorePlugin.class)
+                .stream()
+                .map(IndexStorePlugin::getStoreFactories)
+                .flatMap(m -> m.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
             final RerouteService rerouteService = new BatchedRerouteService(clusterService, clusterModule.getAllocationService()::reroute);
             rerouteServiceReference.set(rerouteService);
             clusterService.setRerouteService(rerouteService);
@@ -991,6 +997,7 @@ public class Node implements Closeable {
                 Map.copyOf(compositeDirectoryFactories),
                 searchModule.getValuesSourceRegistry(),
                 recoveryStateFactories,
+                storeFactories,
                 remoteDirectoryFactory,
                 repositoriesServiceReference::get,
                 searchRequestStats,

--- a/server/src/main/java/org/opensearch/plugins/IndexStorePlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/IndexStorePlugin.java
@@ -38,9 +38,12 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.env.ShardLock;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.store.IndexStoreListener;
+import org.opensearch.index.store.Store;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.threadpool.ThreadPool;
@@ -83,7 +86,9 @@ public interface IndexStorePlugin {
      *
      * @return a map from store type to an directory factory
      */
-    Map<String, DirectoryFactory> getDirectoryFactories();
+    default Map<String, DirectoryFactory> getDirectoryFactories() {
+        return Collections.emptyMap();
+    }
 
     /**
      * An interface that describes how to create a new composite directory instance per shard.
@@ -152,5 +157,44 @@ public interface IndexStorePlugin {
      */
     default Optional<IndexStoreListener> getIndexStoreListener() {
         return Optional.empty();
+    }
+
+    /**
+     * An interface that describes how to create a new Store instance per shard.
+     *
+     * @opensearch.api
+     */
+    @FunctionalInterface
+    @ExperimentalApi
+    interface StoreFactory {
+        /**
+         * Creates a new Store per shard. This method is called once per shard on shard creation.
+         * @param shardId the shard id
+         * @param indexSettings the shard's index settings
+         * @param directory the Lucene directory selected for this shard
+         * @param shardLock the shard lock to associate with the store
+         * @param onClose listener invoked on store close
+         * @param shardPath the shard path
+         * @return a new Store instance
+         */
+        Store newStore(
+            ShardId shardId,
+            IndexSettings indexSettings,
+            Directory directory,
+            ShardLock shardLock,
+            Store.OnClose onClose,
+            ShardPath shardPath
+        ) throws IOException;
+    }
+
+    /**
+     * The {@link StoreFactory} mappings for this plugin. When an index is created a custom store factory can be selected via
+     * {@code index.store.factory}. If not set, the default store is used.
+     *
+     * @return a map from store type key to a store factory
+     */
+    @ExperimentalApi
+    default Map<String, StoreFactory> getStoreFactories() {
+        return Collections.emptyMap();
     }
 }

--- a/server/src/test/java/org/opensearch/plugins/IndexStorePluginTests.java
+++ b/server/src/test/java/org/opensearch/plugins/IndexStorePluginTests.java
@@ -35,12 +35,18 @@ package org.opensearch.plugins;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.env.ShardLock;
 import org.opensearch.index.IndexModule;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.store.FsDirectoryFactory;
+import org.opensearch.index.store.Store;
 import org.opensearch.indices.recovery.RecoveryState;
 import org.opensearch.node.MockNode;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -112,6 +118,27 @@ public class IndexStorePluginTests extends OpenSearchTestCase {
         @Override
         public RecoveryState newRecoveryState(ShardRouting shardRouting, DiscoveryNode targetNode, DiscoveryNode sourceNode) {
             return new RecoveryState(shardRouting, targetNode, sourceNode);
+        }
+    }
+
+    public static class FooStoreFactoryPlugin extends Plugin implements IndexStorePlugin {
+        @Override
+        public Map<String, StoreFactory> getStoreFactories() {
+            return Collections.singletonMap("foo_store", new TestStoreFactory());
+        }
+    }
+
+    public static class TestStoreFactory implements IndexStorePlugin.StoreFactory {
+        @Override
+        public Store newStore(
+            ShardId shardId,
+            IndexSettings indexSettings,
+            org.apache.lucene.store.Directory directory,
+            ShardLock shardLock,
+            Store.OnClose onClose,
+            ShardPath shardPath
+        ) throws IOException {
+            return new Store(shardId, indexSettings, directory, shardLock, onClose, shardPath);
         }
     }
 


### PR DESCRIPTION

### Description
This enables plugins to provide custom Store implementations per index.
- Extend IndexStorePlugin interface with StoreFactory and getStoreFactories() method  
- Add `INDEX_STORE_FACTORY_SETTING` to allow plugins to provide custom Store factories
- Update `IndexService` to use pluggable `StoreFactory` for shard Store creation
- Make `Store.LoadedMetadata` and `Store.OnClose` public API for custom store plugin developers
- Support factory selection via `index.store.factory` setting with fallback to default Store

Will have a PR later to actually implement the Store plugin, which would have a custom store implementation to handle files outside the default store `index` directory.

### Related Issues
Resolves #19090 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
