### PR TITLE
Fix flaky SearchPhaseControllerTests cancellation tests

### DIFF
--- a/server/src/test/java/org/opensearch/action/search/SearchPhaseControllerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchPhaseControllerTests.java
@@ -1747,7 +1747,8 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
         int batchedReduceSize = randomIntBetween(2, expectedNumResults - 1);
         SearchRequest request = getAggregationSearchRequestWithBatchedReduceSize(batchedReduceSize);
         AssertingCircuitBreaker circuitBreaker = new AssertingCircuitBreaker(CircuitBreaker.REQUEST);
-        AtomicInteger cancelAfterRequest = new AtomicInteger(expectedNumResults / 2);
+        AtomicInteger checkCount = new AtomicInteger(0);
+        int cancelAfter = expectedNumResults / 2;
 
         QueryPhaseResultConsumer consumer = searchPhaseController.newSearchPhaseResults(
             fixedExecutor,
@@ -1757,7 +1758,7 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
             expectedNumResults,
             exc -> {},
             () -> {
-                return cancelAfterRequest.decrementAndGet() <= 0;
+                return checkCount.incrementAndGet() > cancelAfter;
             }
         );
 
@@ -1774,7 +1775,8 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
 
         // making sure circuit breaker trips first
         circuitBreaker.shouldBreak.set(true);
-        AtomicInteger cancelAfterRequest = new AtomicInteger(expectedNumResults + 1);
+        AtomicInteger checkCount = new AtomicInteger(0);
+        int cancelAfter = expectedNumResults + 1;
 
         QueryPhaseResultConsumer consumer = searchPhaseController.newSearchPhaseResults(
             fixedExecutor,
@@ -1784,7 +1786,7 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
             expectedNumResults,
             exc -> {},
             () -> {
-                return cancelAfterRequest.decrementAndGet() <= 0;
+                return checkCount.incrementAndGet() > cancelAfter;
             }
         );
 


### PR DESCRIPTION
  The cancellation tests were using AtomicInteger.decrementAndGet()
  in the cancellation predicate, which was called multiple times per
  result due to checkCancellation() being invoked from consumeResult(),
  partialReduce(), and reduce(). This caused non-deterministic behavior
  as the counter could reach zero at unpredictable times.

  Changed to use incrementAndGet() with a threshold check, making the
  cancellation trigger predictable and monotonic.

  Fixes #19094

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
