### PR TITLE
Fix access specifier for FieldMapper method to allow usage by plugins 

### DIFF
--- a/modules/mapper-extras/src/javaRestTest/java/org/opensearch/index/mapper/ScaledFloatDerivedSourceIT.java
+++ b/modules/mapper-extras/src/javaRestTest/java/org/opensearch/index/mapper/ScaledFloatDerivedSourceIT.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.admin.indices.refresh.RefreshResponse;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.index.IndexRequestBuilder;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.io.IOException;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING;
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+
+public class ScaledFloatDerivedSourceIT extends OpenSearchIntegTestCase {
+
+    public void testScaledFloatDerivedSource() throws Exception {
+        Settings.Builder settings = Settings.builder();
+        settings.put(indexSettings());
+        settings.put("index.derived_source.enabled", "true");
+
+        prepareCreate("test").setSettings(settings)
+            .setMapping(
+                jsonBuilder().startObject()
+                    .startObject("properties")
+                    .startObject("foo")
+                    .field("type", "scaled_float")
+                    .field("scaling_factor", "100")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+            )
+            .get();
+
+        ensureGreen("test");
+
+        assertEquals(DocWriteResponse.Result.CREATED, prepareIndex("one_doc", 1.2123422f).get().getResult());
+
+        RefreshResponse refreshResponse = refresh("test");
+        assertEquals(RestStatus.OK, refreshResponse.getStatus());
+        assertEquals(0, refreshResponse.getFailedShards());
+        assertEquals(INDEX_NUMBER_OF_SHARDS_SETTING.get(settings.build()).intValue(), refreshResponse.getSuccessfulShards());
+
+        GetResponse getResponse = client().prepareGet().setFetchSource(true).setId("one_doc").setIndex("test").get(TimeValue.timeValueMinutes(1));
+        assertTrue(getResponse.isExists());
+        assertEquals(1.21d, getResponse.getSourceAsMap().get("foo"));
+    }
+
+    private IndexRequestBuilder prepareIndex(String id, float number) throws IOException {
+        return client().prepareIndex("test").setId(id).setSource(jsonBuilder().startObject().field("foo", number).endObject().toString(), XContentType.JSON);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
@@ -642,7 +642,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     /**
      * Validates if doc values is enabled for a field or not
      */
-    void checkDocValuesForDerivedSource() {
+    protected void checkDocValuesForDerivedSource() {
         if (!mappedFieldType.hasDocValues()) {
             throw new UnsupportedOperationException("Unable to derive source for [" + name() + "] with doc values disabled");
         }
@@ -651,7 +651,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     /**
      * Validates if stored field is enabled for a field or not
      */
-    void checkStoredForDerivedSource() {
+    protected void checkStoredForDerivedSource() {
         if (!mappedFieldType.isStored()) {
             throw new UnsupportedOperationException("Unable to derive source for [" + name() + "] with store disabled");
         }
@@ -660,7 +660,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     /**
      * Validates if doc_values or stored field is enabled for a field or not
      */
-    void checkStoredAndDocValuesForDerivedSource() {
+    protected void checkStoredAndDocValuesForDerivedSource() {
         if (!mappedFieldType.isStored() && !mappedFieldType.hasDocValues()) {
             throw new UnsupportedOperationException("Unable to derive source for [" + name() + "] with stored and " + "docValues disabled");
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
When enabling scaled_float field, due to different ClassLoader being used for module, and core, ScaledFloatFieldMapper is unable to access package-protected methods. This is leading to process being killed due to the fatal error. This commit fixes the same.

```
java.lang.IllegalAccessError: class org.opensearch.index.mapper.ScaledFloatFieldMapper tried to access method 'void org.opensearch.index.mapper.FieldMapper.checkStoredAndDocValuesForDerivedSource()' (org.opensearch.index.mapper.ScaledFloatFieldMapper is in unnamed module of loader java.net.FactoryURLClassLoader @16b57f2; org.opensearch.index.mapper.FieldMapper is in unnamed module of loader 'app')
```

### Related Issues
NA

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
