### PR TITLE
Remove unnecessary looping in field data cache clear

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataLoadingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataLoadingIT.java
@@ -33,7 +33,16 @@
 package org.opensearch.index.fielddata;
 
 import org.opensearch.action.admin.cluster.stats.ClusterStatsResponse;
+import org.opensearch.action.admin.indices.cache.clear.ClearIndicesCacheRequest;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Phaser;
 
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
@@ -62,6 +71,126 @@ public class FieldDataLoadingIT extends OpenSearchIntegTestCase {
 
         ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
         assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
+    }
+
+    public void testFieldDataCacheClearConcurrentIndices() throws Exception {
+        // Check concurrently clearing multiple indices from the FD cache correctly removes all expected keys.
+        int numIndices = 10;
+        String indexPrefix = "test";
+        for (int i = 0; i < numIndices; i++) {
+            String index = indexPrefix + i;
+            assertAcked(
+                prepareCreate(index).setMapping(
+                    jsonBuilder().startObject()
+                        .startObject("properties")
+                        .startObject("name")
+                        .field("type", "text")
+                        .field("fielddata", true)
+                        .endObject()
+                        .endObject()
+                        .endObject()
+                )
+            );
+            client().prepareIndex(index).setId("1").setSource("name", "name").get();
+            client().admin().indices().prepareRefresh(index).get();
+            // Search on each index to fill the cache
+            client().prepareSearch(index).setQuery(new MatchAllQueryBuilder()).addSort("name", SortOrder.ASC).get();
+        }
+        ensureGreen();
+        // TODO: Should be 1 entry per field per index in cache, but cannot check this directly until we add the items count stat in a
+        // future PR
+        ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
+        assertTrue(response.getIndicesStats().getFieldData().getMemorySizeInBytes() > 0L);
+
+        // Concurrently clear multiple indices from FD cache
+        Thread[] threads = new Thread[numIndices];
+        Phaser phaser = new Phaser(numIndices + 1);
+        CountDownLatch countDownLatch = new CountDownLatch(numIndices);
+
+        for (int i = 0; i < numIndices; i++) {
+            int finalI = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    ClearIndicesCacheRequest clearCacheRequest = new ClearIndicesCacheRequest().fieldDataCache(true)
+                        .indices(indexPrefix + finalI);
+                    client().admin().indices().clearCache(clearCacheRequest).actionGet();
+                    phaser.arriveAndAwaitAdvance();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                countDownLatch.countDown();
+            });
+            threads[i].start();
+        }
+        phaser.arriveAndAwaitAdvance();
+        countDownLatch.await();
+
+        // Cache size should be 0
+        response = client().admin().cluster().prepareClusterStats().get();
+        assertEquals(0, response.getIndicesStats().getFieldData().getMemorySizeInBytes());
+    }
+
+    public void testFieldDataCacheClearConcurrentFields() throws Exception {
+        // Check concurrently clearing multiple indices + fields from the FD cache correctly removes all expected keys.
+        int numIndices = 10;
+        int numFieldsPerIndex = 5;
+        String indexPrefix = "test";
+        String fieldPrefix = "field";
+        for (int i = 0; i < numIndices; i++) {
+            String index = indexPrefix + i;
+            XContentBuilder req = jsonBuilder().startObject().startObject("properties");
+            for (int j = 0; j < numFieldsPerIndex; j++) {
+                req.startObject(fieldPrefix + j).field("type", "text").field("fielddata", true).endObject();
+            }
+            req.endObject().endObject();
+            assertAcked(prepareCreate(index).setMapping(req));
+            Map<String, String> source = new HashMap<>();
+            for (int j = 0; j < numFieldsPerIndex; j++) {
+                source.put(fieldPrefix + j, "value");
+            }
+            client().prepareIndex(index).setId("1").setSource(source).get();
+            client().admin().indices().prepareRefresh(index).get();
+            // Search on each index to fill the cache
+            for (int j = 0; j < numFieldsPerIndex; j++) {
+                client().prepareSearch(index).setQuery(new MatchAllQueryBuilder()).addSort(fieldPrefix + j, SortOrder.ASC).get();
+            }
+        }
+        ensureGreen();
+
+        ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
+        assertTrue(response.getIndicesStats().getFieldData().getMemorySizeInBytes() > 0L);
+
+        // Concurrently clear multiple indices+fields from FD cache
+        Thread[] threads = new Thread[numIndices * numFieldsPerIndex];
+        Phaser phaser = new Phaser(numIndices * numFieldsPerIndex + 1);
+        CountDownLatch countDownLatch = new CountDownLatch(numIndices * numFieldsPerIndex);
+
+        for (int i = 0; i < numIndices; i++) {
+            int finalI = i;
+            for (int j = 0; j < numFieldsPerIndex; j++) {
+                int finalJ = j;
+                threads[i * numFieldsPerIndex + j] = new Thread(() -> {
+                    try {
+                        ClearIndicesCacheRequest clearCacheRequest = new ClearIndicesCacheRequest().fieldDataCache(true)
+                            .indices(indexPrefix + finalI)
+                            .fields(fieldPrefix + finalJ);
+                        client().admin().indices().clearCache(clearCacheRequest).actionGet();
+                        phaser.arriveAndAwaitAdvance();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                    countDownLatch.countDown();
+                });
+                threads[i * numFieldsPerIndex + j].start();
+            }
+        }
+        phaser.arriveAndAwaitAdvance();
+        countDownLatch.await();
+
+        // Cache size should be 0
+        response = client().admin().cluster().prepareClusterStats().get();
+        assertEquals(0, response.getIndicesStats().getFieldData().getMemorySizeInBytes());
+
     }
 
 }

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -274,13 +274,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 idFieldDataEnabled,
                 scriptService
             );
-            this.indexFieldData = new IndexFieldDataService(
-                indexSettings,
-                indicesFieldDataCache,
-                circuitBreakerService,
-                mapperService,
-                threadPool
-            );
+            this.indexFieldData = new IndexFieldDataService(indexSettings, indicesFieldDataCache, circuitBreakerService, threadPool);
             if (indexSettings.getIndexSortConfig().hasIndexSort()) {
                 // we delay the actual creation of the sort order for this index because the mapping has not been merged yet.
                 // The sort order is validated right after the merge of the mapping later in the process.

--- a/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataService.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/IndexFieldDataService.java
@@ -79,7 +79,6 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
 
     private final IndicesFieldDataCache indicesFieldDataCache;
     // the below map needs to be modified under a lock
-    // TODO: If we change this to ConcurrentHashMap, we can prob remove synchronized blocks, tho I'm not 100% sure.
     private final Map<String, IndexFieldDataCache> fieldDataCaches = new HashMap<>();
     private static final IndexFieldDataCache.Listener DEFAULT_NOOP_LISTENER = new IndexFieldDataCache.Listener() {
         @Override
@@ -107,8 +106,6 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
         // IndicesFieldDataCache.
         indicesFieldDataCache.clear(index());
         fieldDataCaches.clear();
-        // TODO: Exception handling? Dont think we need it now as the purpose is to rethrow several exceptions as one runtime exception, but
-        // we can just have it thrown as normal.
     }
 
     public synchronized void clearField(final String fieldName) {

--- a/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -132,7 +132,7 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
      * @param index The index to clear
      */
     public void clear(Index index) {
-        // TODO: This is for testing only - this should get moved to a markForCleanup type method after i see if tests pass
+        // TODO: In a future PR, this method will instead the index for cleanup and a scheduled thread will actually invalidate
         for (Key key : cache.keys()) {
             if (key.indexCache.index.equals(index)) {
                 cache.invalidate(key);
@@ -148,7 +148,7 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
      * @param field The field to clear
      */
     public void clear(Index index, String field) {
-        // TODO: This is for testing only - this should get moved to a markForCleanup type method after i see if tests pass
+        // TODO: In a future PR, this method will instead the index+field for cleanup and a scheduled thread will actually invalidate
         for (Key key : cache.keys()) {
             if (key.indexCache.index.equals(index)) {
                 if (key.indexCache.fieldName.equals(field)) {
@@ -255,19 +255,19 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
 
         @Override
         public void onClose(CacheKey key) throws IOException {
-            nodeLevelCache.cache.invalidate(new Key(this, key, null)); // TODO: Not sure on this
+            nodeLevelCache.cache.invalidate(new Key(this, key, null));
             // don't call cache.cleanUp here as it would have bad performance implications
         }
 
         @Override
         public void clear() {
-            // TODO: We need this method to work because of the interface, but we won't use it directly in the actual cache clear path.
+            // This method must work to support the interface, but we don't use it directly in the actual cache clear path
             nodeLevelCache.clear(index);
         }
 
         @Override
         public void clear(String fieldName) {
-            // TODO: We need this method to work because of the interface, but we won't use it directly in the actual cache clear path.
+            // This method must work to support the interface, but we don't use it directly in the actual cache clear path
             nodeLevelCache.clear(index, fieldName);
         }
     }

--- a/server/src/test/java/org/opensearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -95,7 +95,6 @@ public class IndexFieldDataServiceTests extends OpenSearchSingleNodeTestCase {
             indexService.getIndexSettings(),
             indicesService.getIndicesFieldDataCache(),
             indicesService.getCircuitBreakerService(),
-            indexService.mapperService(),
             indexService.getThreadPool()
         );
         final BuilderContext ctx = new BuilderContext(indexService.getIndexSettings().getSettings(), new ContentPath(1));
@@ -130,7 +129,7 @@ public class IndexFieldDataServiceTests extends OpenSearchSingleNodeTestCase {
         assertTrue(fd instanceof SortedNumericIndexFieldData);
     }
 
-    public void testIndexFieldDataCacheIsCleredAfterIndexRemoval() throws IOException, InterruptedException {
+    public void testIndexFieldDataCacheIsClearedAfterIndexRemoval() throws IOException, InterruptedException {
         final IndexService indexService = createIndex("test");
         final IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         // copy the ifdService since we can set the listener only once.
@@ -138,7 +137,6 @@ public class IndexFieldDataServiceTests extends OpenSearchSingleNodeTestCase {
             indexService.getIndexSettings(),
             indicesService.getIndicesFieldDataCache(),
             indicesService.getCircuitBreakerService(),
-            indexService.mapperService(),
             indexService.getThreadPool()
         );
 
@@ -194,7 +192,6 @@ public class IndexFieldDataServiceTests extends OpenSearchSingleNodeTestCase {
             indexService.getIndexSettings(),
             indicesService.getIndicesFieldDataCache(),
             indicesService.getCircuitBreakerService(),
-            indexService.mapperService(),
             indexService.getThreadPool()
         );
         final SetOnce<Supplier<SearchLookup>> searchLookupSetOnce = new SetOnce<>();
@@ -220,7 +217,6 @@ public class IndexFieldDataServiceTests extends OpenSearchSingleNodeTestCase {
             indexService.getIndexSettings(),
             indicesService.getIndicesFieldDataCache(),
             indicesService.getCircuitBreakerService(),
-            indexService.mapperService(),
             indexService.getThreadPool()
         );
 
@@ -289,7 +285,6 @@ public class IndexFieldDataServiceTests extends OpenSearchSingleNodeTestCase {
             indexService.getIndexSettings(),
             indicesService.getIndicesFieldDataCache(),
             indicesService.getCircuitBreakerService(),
-            indexService.mapperService(),
             indexService.getThreadPool()
         );
 
@@ -347,7 +342,6 @@ public class IndexFieldDataServiceTests extends OpenSearchSingleNodeTestCase {
             indexService.getIndexSettings(),
             indicesService.getIndicesFieldDataCache(),
             indicesService.getCircuitBreakerService(),
-            indexService.mapperService(),
             indexService.getThreadPool()
         );
         // set it the first time...
@@ -388,7 +382,6 @@ public class IndexFieldDataServiceTests extends OpenSearchSingleNodeTestCase {
             IndexFieldDataService ifds = new IndexFieldDataService(
                 IndexSettingsModule.newIndexSettings("test", Settings.EMPTY),
                 cache,
-                null,
                 null,
                 threadPool
             );

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -3360,7 +3360,6 @@ public class IndexShardTests extends IndexShardTestCase {
             shard.indexSettings,
             indicesFieldDataCache,
             new NoneCircuitBreakerService(),
-            shard.mapperService(),
             shard.getThreadPool()
         );
         IndexFieldData.Global ifd = indexFieldDataService.getForField(foo, "test", () -> {

--- a/test/framework/src/main/java/org/opensearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/AbstractBuilderTestCase.java
@@ -438,7 +438,6 @@ public abstract class AbstractBuilderTestCase extends OpenSearchTestCase {
                 idxSettings,
                 indicesFieldDataCache,
                 new NoneCircuitBreakerService(),
-                mapperService,
                 threadPool
             );
             bitsetFilterCache = new BitsetFilterCache(idxSettings, new BitsetFilterCache.Listener() {


### PR DESCRIPTION
### Description
Previously, clearing a shard from the field data cache (which happens on shard closure like in a B/G, or during manual cache clear) unnecessarily looped through each of the N keys in the whole cache, once per field that uses field data on that index, which can potentially be very large. This takes O(FN) time for F the number of fields on that index. For real user scenarios this could get as long as minutes which caused node drops. 

This PR moves around the cleanup logic a bit, so that the IndicesFieldDataCache itself is the one that iterates through its keys when a cleanup is requested. This takes us from O(FN) to O(N) time to clear a shard.

In the next PR, the iteration itself will be moved to a scheduled cleaner thread, as in the request cache, and the clear() methods on IndicesFieldDataCache will mark those indices/fields for cleanup in that thread, rather than iterating through them then and there. I purposefully split these, because in the case of a whole-cache clean via API call, the existing code in the request cache actually has a similar issue, and I wanted to raise an issue to get feedback on that and then apply the same solution to both the FDC and the RC. 

A future PR will also remove the synchronized blocks in IndexFieldDataService. This depends on the scheduled cleaner thread to work without iteration issues on the cache keys iterator, so it's also separate.

Benchmark results: 
On a single-node OS cluster running on a c5.2xl EC2 instance, I set up indices with 999 field data-enabled fields each. 999 is the max number of fields per index without adjusting settings; it's reasonable to pick such a high value because the users who saw issues were actually using ~20k fields each. Then I searched each field for each index to populate the field data cache with many keys. Finally, I cleared one index (which has 1 shard) using the cache clear API and timed it on the client side (end-to-end). Note this hits the same code path as when the shard closes in a B/G. Scripts to do this are [here](https://github.com/peteralfonsi/misc-scripts/tree/main/cache-clear-timing/fielddata). 

|Number of indices | Baseline clear time (sec) | Contender clear time (sec) | 
|--|--|--|
|100|59.09|0.0993|
|1|0.0153|0.0186|

I purposefully did not time clearing the whole cache at once as this will be changed to the scheduled thread in the next PR. 

We see for 100 indices the speedup is very large. This is because N is very large so checking all N keys 999 times is slow. There isn't a speedup when there's just 1 index; I think the 0.01 sec is mostly overhead of OS processing the request rather than actual cache clear time. 


### Related Issues
Part of https://github.com/opensearch-project/OpenSearch/issues/13862

### Check List
- [x] Functionality includes testing.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
