### PR TITLE
Fix: Include script params in BulkRequest size calculation

### DIFF
--- a/server/src/main/java/org/opensearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BulkRequest.java
@@ -54,16 +54,12 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.MediaType;
+import org.opensearch.script.Script;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.transport.client.Client;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 import static org.opensearch.action.ValidateActions.addValidationError;
 
@@ -198,8 +194,10 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
         if (request.upsertRequest() != null) {
             sizeInBytes += request.upsertRequest().source().length();
         }
-        if (request.script() != null) {
-            sizeInBytes += request.script().getIdOrCode().length() * 2;
+        Script script = request.script();
+        if (script != null) {
+            sizeInBytes += (long) script.getIdOrCode().length() * 2L;
+            sizeInBytes += script.getParams().toString().length();
         }
         indices.add(request.index());
         return this;


### PR DESCRIPTION
## Description
The BulkRequest's size calculation currently doesn't account for the size of script parameters in update operations. This can lead to underestimating the actual request size when script parameters are used, potentially causing memory-related issues in bulk operations.

## Changes
- Added script parameters size calculation in `BulkRequest.internalAdd(UpdateRequest)`
- Size is calculated using `script.getParams().toString().length()`

## Example Use Case
When using bulk updates with scripted updates that contain parameters:
```java
BulkRequest bulk = new BulkRequest();
UpdateRequest update = new UpdateRequest("index", "id")
    .script(new Script(ScriptType.INLINE, "painless", 
        "ctx._source.field += params.value", 
        Collections.singletonMap("value", "large_parameter_value")));
bulk.add(update);