### PR TITLE
[bug] Resize request should throw 4xx as part of validation failure for write block

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1652,7 +1652,7 @@ public class MetadataCreateIndexService {
 
         // ensure write operations on the source index is blocked
         if (state.blocks().indexBlocked(ClusterBlockLevel.WRITE, sourceIndex) == false) {
-            throw new IllegalStateException(
+            throw new IllegalArgumentException(
                 "index " + sourceIndex + " must block write operations to resize index. use \"index.blocks.write=true\""
             );
         }

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -341,7 +341,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         assertEquals(
             "index source must block write operations to resize index. use \"index.blocks.write=true\"",
             expectThrows(
-                IllegalStateException.class,
+                IllegalArgumentException.class,
                 () -> MetadataCreateIndexService.validateShrinkIndex(
                     createClusterState("source", randomIntBetween(2, 100), randomIntBetween(0, 10), Settings.EMPTY),
                     "source",
@@ -443,7 +443,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         assertEquals(
             "index source must block write operations to resize index. use \"index.blocks.write=true\"",
             expectThrows(
-                IllegalStateException.class,
+                IllegalArgumentException.class,
                 () -> MetadataCreateIndexService.validateSplitIndex(
                     createClusterState("source", randomIntBetween(2, 100), randomIntBetween(0, 10), Settings.EMPTY),
                     "source",
@@ -529,7 +529,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         assertEquals(
             "index source must block write operations to resize index. use \"index.blocks.write=true\"",
             expectThrows(
-                IllegalStateException.class,
+                IllegalArgumentException.class,
                 () -> MetadataCreateIndexService.validateCloneIndex(
                     createClusterState("source", randomIntBetween(2, 100), randomIntBetween(0, 10), Settings.EMPTY),
                     "source",


### PR DESCRIPTION
### Description
Resize request should throw 4xx as part of validation failure for write block.

- Exception type updated (server behavior)
File: server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
Change: Throw `IllegalArgumentException` (was `IllegalStateException`) when resize is attempted without a write block.

- Also updated the corresponding tests.

### Related Issues

Closes #19026

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
