### PR TITLE
Change field data cache size setting defaults

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataLoadingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/fielddata/FieldDataLoadingIT.java
@@ -32,14 +32,33 @@
 
 package org.opensearch.index.fielddata;
 
+import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.action.admin.cluster.stats.ClusterStatsResponse;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.indices.fielddata.cache.IndicesFieldDataCache.INDICES_FIELDDATA_CACHE_SIZE_KEY;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.greaterThan;
 
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class FieldDataLoadingIT extends OpenSearchIntegTestCase {
+    // To shorten runtimes, set cluster setting INDICES_CACHE_CLEAN_INTERVAL_SETTING to a lower value.
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(IndicesService.INDICES_CACHE_CLEAN_INTERVAL_SETTING.getKey(), "1s")
+            .build();
+    }
 
     public void testEagerGlobalOrdinalsFieldDataLoading() throws Exception {
         assertAcked(
@@ -64,4 +83,58 @@ public class FieldDataLoadingIT extends OpenSearchIntegTestCase {
         assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
     }
 
+    public void testIndicesFieldDataCacheSizeSetting() throws Exception {
+        // Put one value into the cache
+        int maxEntries = 10;
+        int numFields = 2 * maxEntries;
+        String fieldPrefix = "field";
+        createIndex("index", numFields, fieldPrefix);
+        client().prepareSearch("index").setQuery(new MatchAllQueryBuilder()).addSort(fieldPrefix + "0", SortOrder.ASC).get();
+        long sizePerEntry = client().admin().cluster().prepareClusterStats().get().getIndicesStats().getFieldData().getMemorySizeInBytes();
+        assertTrue(sizePerEntry > 0);
+
+        // Set the max size setting so that it can fit maxEntries such entries
+        long maxSize = maxEntries * sizePerEntry + 1;
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder().put(INDICES_FIELDDATA_CACHE_SIZE_KEY.getKey(), maxSize + "b"));
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+
+        // Add >N values to the cache and assert the size is less than the limit
+        for (int i = 1; i < numFields; i++) {
+            client().prepareSearch("index").setQuery(new MatchAllQueryBuilder()).addSort(fieldPrefix + i, SortOrder.ASC).get();
+        }
+        long cacheSize = client().admin().cluster().prepareClusterStats().get().getIndicesStats().getFieldData().getMemorySizeInBytes();
+        assertTrue(cacheSize <= maxSize && cacheSize > sizePerEntry);
+
+        // Set the max size setting to a smaller value and assert the new size is less than that (waiting for refresh)
+        long newMaxSize = 2 * sizePerEntry + 1;
+        updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest.persistentSettings(Settings.builder().put(INDICES_FIELDDATA_CACHE_SIZE_KEY.getKey(), newMaxSize + "b"));
+        assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
+        assertBusy(() -> {
+            long newCacheSize = client().admin()
+                .cluster()
+                .prepareClusterStats()
+                .get()
+                .getIndicesStats()
+                .getFieldData()
+                .getMemorySizeInBytes();
+            assertTrue(newCacheSize <= newMaxSize);
+        });
+    }
+
+    private void createIndex(String index, int numFieldsPerIndex, String fieldPrefix) throws Exception {
+        XContentBuilder req = jsonBuilder().startObject().startObject("properties");
+        for (int j = 0; j < numFieldsPerIndex; j++) {
+            req.startObject(fieldPrefix + j).field("type", "text").field("fielddata", true).endObject();
+        }
+        req.endObject().endObject();
+        assertAcked(prepareCreate(index).setMapping(req));
+        Map<String, String> source = new HashMap<>();
+        for (int j = 0; j < numFieldsPerIndex; j++) {
+            source.put(fieldPrefix + j, "value");
+        }
+        client().prepareIndex(index).setId("1").setSource(source).get();
+        client().admin().indices().prepareRefresh(index).get();
+    }
 }

--- a/server/src/main/java/org/opensearch/common/cache/Cache.java
+++ b/server/src/main/java/org/opensearch/common/cache/Cache.java
@@ -156,7 +156,7 @@ public class Cache<K, V> {
         return this.expireAfterWriteNanos;
     }
 
-    void setMaximumWeight(long maximumWeight) {
+    public void setMaximumWeight(long maximumWeight) {
         if (maximumWeight < 0) {
             throw new IllegalArgumentException("maximumWeight < 0");
         }

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -217,6 +217,7 @@ import static org.opensearch.index.TieredMergePolicyProvider.DEFAULT_MAX_MERGE_A
 import static org.opensearch.index.TieredMergePolicyProvider.MIN_DEFAULT_MAX_MERGE_AT_ONCE;
 import static org.opensearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
 import static org.opensearch.indices.IndicesRequestCache.INDICES_REQUEST_CACHE_MAX_SIZE_ALLOWED_IN_CACHE_SETTING;
+import static org.opensearch.indices.fielddata.cache.IndicesFieldDataCache.INDICES_FIELDDATA_CACHE_SIZE_KEY;
 import static org.opensearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 /**
@@ -503,6 +504,8 @@ public class IndicesService extends AbstractLifecycleComponent
                 circuitBreakerService.getBreaker(CircuitBreaker.FIELDDATA).addWithoutBreaking(-sizeInBytes);
             }
         });
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(INDICES_FIELDDATA_CACHE_SIZE_KEY, indicesFieldDataCache::updateMaximumWeight);
         this.cleanInterval = INDICES_CACHE_CLEAN_INTERVAL_SETTING.get(settings);
         this.cacheCleaner = new CacheCleaner(indicesFieldDataCache, logger, threadPool, this.cleanInterval);
         this.metaStateService = metaStateService;

--- a/server/src/main/java/org/opensearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/opensearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -105,6 +105,9 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         Property.NodeScope
     );
 
+    /**
+     * If an incoming request would cause the field data cache to exceed this size, the request is cancelled.
+     */
     public static final Setting<ByteSizeValue> FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING = Setting.memorySizeSetting(
         "indices.breaker.fielddata.limit",
         "40%",

--- a/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/opensearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -75,10 +75,14 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
 
     private static final Logger logger = LogManager.getLogger(IndicesFieldDataCache.class);
 
+    /**
+     * The size after which the cache will begin to evict entries.
+     */
     public static final Setting<ByteSizeValue> INDICES_FIELDDATA_CACHE_SIZE_KEY = Setting.memorySizeSetting(
         "indices.fielddata.cache.size",
-        new ByteSizeValue(-1),
-        Property.NodeScope
+        "35%",
+        Property.NodeScope,
+        Property.Dynamic
     );
     private final IndexFieldDataCache.Listener indicesFieldDataCacheListener;
     private final Cache<Key, Accountable> cache;
@@ -249,6 +253,10 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
             // soon as possible
             cache.refresh();
         }
+    }
+
+    public void updateMaximumWeight(ByteSizeValue newMaximumWeight) {
+        cache.setMaximumWeight(newMaximumWeight.getBytes());
     }
 
     /**


### PR DESCRIPTION
### Description
Changes field data cache size setting to default to 35% rather than no limit (-1). Previously, by default the FD cache was only limited by the (separate) field breaker setting at 40% of heap size, which would confusingly stop further requests rather than just evicting. Also makes the size setting dynamic.  

As mentioned in the original issue, I'm open to changing the actual values from 35% and 40% to whatever people think is reasonable. See original issue for reasoning behind the two settings having different values.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/19104

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
