### PR TITLE
Add query argument in QueryCollectorContextSpecFactory

### DIFF
--- a/server/src/main/java/org/opensearch/search/query/QueryCollectorContextSpecFactory.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryCollectorContextSpecFactory.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.search.query;
 
+import org.apache.lucene.search.Query;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.search.internal.SearchContext;
 
@@ -21,12 +22,14 @@ import java.util.Optional;
 public interface QueryCollectorContextSpecFactory {
     /**
      * @param searchContext context needed to create collector context spec
+     * @param query query required to create collector context spec
      * @param queryCollectorArguments arguments to create collector context spec
      * @return QueryCollectorContextSpec
      * @throws IOException
      */
     Optional<QueryCollectorContextSpec> createQueryCollectorContextSpec(
         SearchContext searchContext,
+        Query query,
         QueryCollectorArguments queryCollectorArguments
     ) throws IOException;
 }

--- a/server/src/main/java/org/opensearch/search/query/QueryCollectorContextSpecRegistry.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryCollectorContextSpecRegistry.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.search.query;
 
+import org.apache.lucene.search.Query;
 import org.opensearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -49,12 +50,17 @@ public final class QueryCollectorContextSpecRegistry {
      */
     public static Optional<QueryCollectorContextSpec> getQueryCollectorContextSpec(
         final SearchContext searchContext,
+        final Query query,
         final QueryCollectorArguments queryCollectorArguments
     ) throws IOException {
         Iterator<QueryCollectorContextSpecFactory> iterator = registry.iterator();
         while (iterator.hasNext()) {
             QueryCollectorContextSpecFactory factory = iterator.next();
-            Optional<QueryCollectorContextSpec> spec = factory.createQueryCollectorContextSpec(searchContext, queryCollectorArguments);
+            Optional<QueryCollectorContextSpec> spec = factory.createQueryCollectorContextSpec(
+                searchContext,
+                query,
+                queryCollectorArguments
+            );
             if (spec.isEmpty() == false) {
                 return spec;
             }

--- a/server/src/main/java/org/opensearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/opensearch/search/query/QueryPhase.java
@@ -446,14 +446,16 @@ public class QueryPhase {
             boolean hasFilterCollector,
             boolean hasTimeout
         ) throws IOException {
-            QueryCollectorContext queryCollectorContext = getQueryCollectorContext(searchContext, hasFilterCollector);
+            QueryCollectorContext queryCollectorContext = getQueryCollectorContext(searchContext, query, hasFilterCollector);
             return searchWithCollector(searchContext, searcher, query, collectors, queryCollectorContext, hasFilterCollector, hasTimeout);
         }
 
-        private QueryCollectorContext getQueryCollectorContext(SearchContext searchContext, boolean hasFilterCollector) throws IOException {
+        private QueryCollectorContext getQueryCollectorContext(SearchContext searchContext, Query query, boolean hasFilterCollector)
+            throws IOException {
             // create the top docs collector last when the other collectors are known
             final Optional<QueryCollectorContext> queryCollectorContextOpt = QueryCollectorContextSpecRegistry.getQueryCollectorContextSpec(
                 searchContext,
+                query,
                 new QueryCollectorArguments.Builder().hasFilterCollector(hasFilterCollector).build()
             ).map(queryCollectorContextSpec -> new QueryCollectorContext(queryCollectorContextSpec.getContextName()) {
                 @Override

--- a/server/src/test/java/org/opensearch/search/query/QueryCollectorContextSpecRegistryTests.java
+++ b/server/src/test/java/org/opensearch/search/query/QueryCollectorContextSpecRegistryTests.java
@@ -49,11 +49,14 @@ public class QueryCollectorContextSpecRegistryTests extends OpenSearchTestCase {
         QueryCollectorArguments mockArguments = new QueryCollectorArguments.Builder().build();
         // Given
         QueryCollectorContextSpecRegistry.registerFactory(mockFactory1);
-        when(mockFactory1.createQueryCollectorContextSpec(mockSearchContext, mockArguments)).thenReturn(Optional.of(mockSpec));
+        when(mockFactory1.createQueryCollectorContextSpec(mockSearchContext, mockSearchContext.query(), mockArguments)).thenReturn(
+            Optional.of(mockSpec)
+        );
 
         // When
         Optional<QueryCollectorContextSpec> result = QueryCollectorContextSpecRegistry.getQueryCollectorContextSpec(
             mockSearchContext,
+            mockSearchContext.query(),
             mockArguments
         );
 
@@ -69,6 +72,7 @@ public class QueryCollectorContextSpecRegistryTests extends OpenSearchTestCase {
         // When
         Optional<QueryCollectorContextSpec> result = QueryCollectorContextSpecRegistry.getQueryCollectorContextSpec(
             mockSearchContext,
+            mockSearchContext.query(),
             mockArguments
         );
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
SearchContext always preserves the original query. Therefore, the query object in searchWith method of QueryPhaseSearcher can have different query object in following cases:
1. When a custom query gets directly injected in QueryPhaseSearcher
2. When a query is rewritten. 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
