### PR TITLE
[Backport 2.19] Replace centos:8 with almalinux:8 since centos docker images are deprecated (#19154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,5 +30,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Change single shard assignment log message from warn to debug ([#18186](https://github.com/opensearch-project/OpenSearch/pull/18186))
+- Replace centos:8 with almalinux:8 since centos docker images are deprecated ([#19154](https://github.com/opensearch-project/OpenSearch/pull/19154))
 
 [Unreleased 2.19.x]: https://github.com/opensearch-project/OpenSearch/compare/fd9a9d90df25bea1af2c6a85039692e815b894f5...2.19

--- a/buildSrc/src/main/java/org/opensearch/gradle/DockerBase.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/DockerBase.java
@@ -36,7 +36,7 @@ package org.opensearch.gradle;
  * This class models the different Docker base images that are used to build Docker distributions of OpenSearch.
  */
 public enum DockerBase {
-    CENTOS("centos:8");
+    ALMALINUX("almalinux:8");
 
     private final String image;
 

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -125,7 +125,7 @@ project.ext {
 }
 
 void addCopyDockerContextTask(Architecture architecture, DockerBase base) {
-  if (base != DockerBase.CENTOS) {
+  if (base != DockerBase.ALMALINUX) {
     throw new GradleException("The only allowed docker base image for builds is CENTOS")
   }
 
@@ -172,8 +172,8 @@ opensearch_distributions {
 tasks.named("preProcessFixture").configure {
   dependsOn opensearch_distributions.docker
   // always run the task, otherwise the folders won't be created
-  outputs.upToDateWhen { 
-    false 
+  outputs.upToDateWhen {
+    false
   }
   doLast {
     // tests expect to have an empty repo
@@ -199,7 +199,7 @@ tasks.named("check").configure {
 }
 
 void addBuildDockerImage(Architecture architecture, DockerBase base) {
-  if (base != DockerBase.CENTOS) {
+  if (base != DockerBase.ALMALINUX) {
     throw new GradleException("The only allowed docker base image for builds is CENTOS")
   }
 
@@ -225,7 +225,7 @@ void addBuildDockerImage(Architecture architecture, DockerBase base) {
 for (final Architecture architecture : Architecture.values()) {
   // We only create Docker images for the distribution on CentOS.
   for (final DockerBase base : DockerBase.values()) {
-    if (base == DockerBase.CENTOS) {
+    if (base == DockerBase.ALMALINUX) {
       addCopyDockerContextTask(architecture, base)
       addBuildDockerImage(architecture, base)
     }
@@ -248,7 +248,7 @@ subprojects { Project subProject ->
     apply plugin: 'distribution'
 
     final Architecture architecture = subProject.name.contains('arm64-') ? Architecture.ARM64 : Architecture.X64
-    final DockerBase base = DockerBase.CENTOS
+    final DockerBase base = DockerBase.ALMALINUX
 
     final String arch = architecture == Architecture.ARM64 ? '-arm64' : ''
     final String extension = 'docker.tar'

--- a/distribution/docker/docker-build-context/build.gradle
+++ b/distribution/docker/docker-build-context/build.gradle
@@ -19,7 +19,7 @@ tasks.register("buildDockerBuildContext", Tar) {
   archiveClassifier = "docker-build-context"
   archiveBaseName = "opensearch"
   // Non-local builds don't need to specify an architecture.
-  with dockerBuildContext(null, DockerBase.CENTOS, false)
+  with dockerBuildContext(null, DockerBase.ALMALINUX, false)
 }
 
 tasks.named("assemble").configure { dependsOn "buildDockerBuildContext" }

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -63,16 +63,12 @@ FROM ${base_image}
 
 ENV OPENSEARCH_CONTAINER true
 
-RUN  sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \\
-     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-Linux-* && \\
-     for iter in {1..10}; do \\
-      ${package_manager} update --setopt=tsflags=nodocs -y && \\
-      ${package_manager} install --setopt=tsflags=nodocs -y \\
-        nc shadow-utils zip unzip && \\
-      ${package_manager} clean all && exit_code=0 && break || exit_code=\$? && echo "${package_manager} error: retry \$iter in 10s" && \\
-      sleep 10; \\
-    done; \\
-    (exit \$exit_code)
+RUN set -e \\
+     && dnf -y update \\
+     && dnf -y install --setopt=tsflags=nodocs \\
+          nmap-ncat shadow-utils zip unzip \\
+     && dnf clean all \\
+     && rm -rf /var/cache/dnf
 
 RUN groupadd -g 1000 opensearch && \\
     adduser -u 1000 -g 1000 -G 0 -d /usr/share/opensearch opensearch && \\


### PR DESCRIPTION
Backport of #19154 to 2.19.