### PR TITLE
Remove cap on Java version used by forbidden APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Adding ScriptedAvg class to painless spi to allowlist usage from plugins ([#19006](https://github.com/opensearch-project/OpenSearch/pull/19006))
 - Replace centos:8 with almalinux:8 since centos docker images are deprecated ([#19154](https://github.com/opensearch-project/OpenSearch/pull/19154))
 - Add CompletionStage variants to IndicesAdminClient as an alternative to ActionListener ([#19161](https://github.com/opensearch-project/OpenSearch/pull/19161))
+- Remove cap on Java version used by forbidden APIs ([#19163](https://github.com/opensearch-project/OpenSearch/pull/19163))
 
 ### Fixed
 - Fix unnecessary refreshes on update preparation failures ([#15261](https://github.com/opensearch-project/OpenSearch/issues/15261))

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -114,7 +114,7 @@ dependencies {
   api 'com.gradleup.shadow:shadow-gradle-plugin:8.3.5'
   api 'org.jdom:jdom2:2.0.6.1'
   api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${props.getProperty('kotlin')}"
-  api 'de.thetaphi:forbiddenapis:3.8'
+  api 'de.thetaphi:forbiddenapis:3.9'
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.17.12'
   api "org.yaml:snakeyaml:${props.getProperty('snakeyaml')}"
   api 'org.apache.maven:maven-model:3.9.6'

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/tools/cli/plugin/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/tools/cli/plugin/InstallPluginCommand.java
@@ -399,7 +399,7 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
     @SuppressForbidden(reason = "Make HEAD request using URLConnection.connect()")
     boolean urlExists(Terminal terminal, String urlString) throws IOException {
         terminal.println(VERBOSE, "Checking if url exists: " + urlString);
-        URL url = new URL(urlString);
+        URL url = URI.create(urlString).toURL();
         assert "https".equals(url.getProtocol()) : "Use of https protocol is required";
         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
         urlConnection.addRequestProperty("User-Agent", "opensearch-plugin-installer");
@@ -427,7 +427,7 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
     @SuppressForbidden(reason = "We use getInputStream to download plugins")
     Path downloadZip(Terminal terminal, String urlString, Path tmpDir, boolean isBatch) throws IOException {
         terminal.println(VERBOSE, "Retrieving zip from " + urlString);
-        URL url = new URL(urlString);
+        URL url = URI.create(urlString).toURL();
         Path zip = Files.createTempFile(tmpDir, null, ".zip");
         URLConnection urlConnection = url.openConnection();
         urlConnection.addRequestProperty("User-Agent", "opensearch-plugin-installer");
@@ -684,7 +684,7 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
      */
     // pkg private for tests
     URL openUrl(String urlString) throws IOException {
-        URL checksumUrl = new URL(urlString);
+        URL checksumUrl = URI.create(urlString).toURL();
         HttpURLConnection connection = (HttpURLConnection) checksumUrl.openConnection();
         if (connection.getResponseCode() == 404) {
             return null;

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/tools/cli/plugin/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/tools/cli/plugin/InstallPluginCommandTests.java
@@ -526,7 +526,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Path pluginDir = createPluginDir(temp);
         String pluginZip = createPluginUrl("fake", pluginDir);
         Path pluginZipWithSpaces = createTempFile("foo bar", ".zip");
-        try (InputStream in = FileSystemUtils.openFileURLStream(new URL(pluginZip))) {
+        try (InputStream in = FileSystemUtils.openFileURLStream(URI.create(pluginZip).toURL())) {
             Files.copy(in, pluginZipWithSpaces, StandardCopyOption.REPLACE_EXISTING);
         }
         installPlugin(pluginZipWithSpaces.toUri().toURL().toString(), env.v1());
@@ -536,8 +536,8 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
     public void testMalformedUrlNotMaven() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         // has two colons, so it appears similar to maven coordinates
-        MalformedURLException e = expectThrows(MalformedURLException.class, () -> installPlugin("://host:1234", env.v1()));
-        assertTrue(e.getMessage(), e.getMessage().contains("no protocol"));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> installPlugin("://host:1234", env.v1()));
+        assertThat(e.getMessage(), startsWith("Expected scheme name"));
     }
 
     public void testFileNotMaven() throws Exception {

--- a/libs/core/src/test/java/org/opensearch/core/util/FileSystemUtilsTests.java
+++ b/libs/core/src/test/java/org/opensearch/core/util/FileSystemUtilsTests.java
@@ -40,6 +40,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.ByteBuffer;
@@ -132,21 +133,21 @@ public class FileSystemUtilsTests extends OpenSearchTestCase {
     }
 
     public void testOpenFileURLStream() throws IOException {
-        URL urlWithWrongProtocol = new URL("http://www.google.com");
+        URL urlWithWrongProtocol = URI.create("http://www.google.com").toURL();
         try (InputStream is = FileSystemUtils.openFileURLStream(urlWithWrongProtocol)) {
             fail("Should throw IllegalArgumentException due to invalid protocol");
         } catch (IllegalArgumentException e) {
             assertEquals("Invalid protocol [http], must be [file] or [jar]", e.getMessage());
         }
 
-        URL urlWithHost = new URL("file", "localhost", txtFile.toString());
+        URL urlWithHost = URI.create("file://localhost/" + txtFile.toString()).toURL();
         try (InputStream is = FileSystemUtils.openFileURLStream(urlWithHost)) {
             fail("Should throw IllegalArgumentException due to host");
         } catch (IllegalArgumentException e) {
             assertEquals("URL cannot have host. Found: [localhost]", e.getMessage());
         }
 
-        URL urlWithPort = new URL("file", "", 80, txtFile.toString());
+        URL urlWithPort = URI.create("file://:80/" + txtFile.toString()).toURL();
         try (InputStream is = FileSystemUtils.openFileURLStream(urlWithPort)) {
             fail("Should throw IllegalArgumentException due to port");
         } catch (IllegalArgumentException e) {

--- a/libs/ssl-config/src/test/java/org/opensearch/common/ssl/DefaultJdkTrustConfigTests.java
+++ b/libs/ssl-config/src/test/java/org/opensearch/common/ssl/DefaultJdkTrustConfigTests.java
@@ -77,12 +77,12 @@ public class DefaultJdkTrustConfigTests extends OpenSearchTestCase {
     private void assertHasTrustedIssuer(X509ExtendedTrustManager trustManager, String name) {
         final String lowerName = name.toLowerCase(Locale.ROOT);
         final Optional<X509Certificate> ca = Stream.of(trustManager.getAcceptedIssuers())
-            .filter(cert -> cert.getSubjectDN().getName().toLowerCase(Locale.ROOT).contains(lowerName))
+            .filter(cert -> cert.getSubjectX500Principal().getName().toLowerCase(Locale.ROOT).contains(lowerName))
             .findAny();
         if (ca.isPresent() == false) {
             logger.info("Failed to find issuer [{}] in trust manager, but did find ...", lowerName);
             for (X509Certificate cert : trustManager.getAcceptedIssuers()) {
-                logger.info(" - {}", cert.getSubjectDN().getName().replaceFirst("^\\w+=([^,]+),.*", "$1"));
+                logger.info(" - {}", cert.getSubjectX500Principal().getName().replaceFirst("^\\w+=([^,]+),.*", "$1"));
             }
             Assert.fail("Cannot find trusted issuer with name [" + name + "].");
         }

--- a/libs/ssl-config/src/test/java/org/opensearch/common/ssl/PemKeyConfigTests.java
+++ b/libs/ssl-config/src/test/java/org/opensearch/common/ssl/PemKeyConfigTests.java
@@ -154,8 +154,8 @@ public class PemKeyConfigTests extends OpenSearchTestCase {
         assertThat(chain, notNullValue());
         assertThat(chain, arrayWithSize(1));
         final X509Certificate certificate = chain[0];
-        assertThat(certificate.getIssuerDN().getName(), is("CN=Test CA 1"));
-        assertThat(certificate.getSubjectDN().getName(), is(expectedDN));
+        assertThat(certificate.getIssuerX500Principal().getName(), is("CN=Test CA 1"));
+        assertThat(certificate.getSubjectX500Principal().getName(), is(expectedDN));
         assertThat(certificate.getSubjectAlternativeNames(), iterableWithSize(2));
         assertThat(
             certificate.getSubjectAlternativeNames(),

--- a/libs/ssl-config/src/test/java/org/opensearch/common/ssl/PemTrustConfigTests.java
+++ b/libs/ssl-config/src/test/java/org/opensearch/common/ssl/PemTrustConfigTests.java
@@ -146,7 +146,7 @@ public class PemTrustConfigTests extends OpenSearchTestCase {
         final X509ExtendedTrustManager trustManager = trustConfig.createTrustManager();
         final X509Certificate[] issuers = trustManager.getAcceptedIssuers();
         final Set<String> issuerNames = Stream.of(issuers)
-            .map(X509Certificate::getSubjectDN)
+            .map(X509Certificate::getSubjectX500Principal)
             .map(Principal::getName)
             .collect(Collectors.toSet());
 

--- a/libs/ssl-config/src/test/java/org/opensearch/common/ssl/StoreKeyConfigTests.java
+++ b/libs/ssl-config/src/test/java/org/opensearch/common/ssl/StoreKeyConfigTests.java
@@ -183,8 +183,8 @@ public class StoreKeyConfigTests extends OpenSearchTestCase {
             assertThat(chain, notNullValue());
             assertThat(chain, arrayWithSize(1));
             final X509Certificate certificate = chain[0];
-            assertThat(certificate.getIssuerDN().getName(), is("CN=Test CA 1"));
-            assertThat(certificate.getSubjectDN().getName(), is("CN=" + name));
+            assertThat(certificate.getIssuerX500Principal().getName(), is("CN=Test CA 1"));
+            assertThat(certificate.getSubjectX500Principal().getName(), is("CN=" + name));
             assertThat(certificate.getSubjectAlternativeNames(), iterableWithSize(2));
             assertThat(
                 certificate.getSubjectAlternativeNames(),

--- a/libs/ssl-config/src/test/java/org/opensearch/common/ssl/StoreTrustConfigTests.java
+++ b/libs/ssl-config/src/test/java/org/opensearch/common/ssl/StoreTrustConfigTests.java
@@ -140,7 +140,7 @@ public class StoreTrustConfigTests extends OpenSearchTestCase {
         final X509ExtendedTrustManager trustManager = trustConfig.createTrustManager();
         final X509Certificate[] issuers = trustManager.getAcceptedIssuers();
         final Set<String> issuerNames = Stream.of(issuers)
-            .map(X509Certificate::getSubjectDN)
+            .map(X509Certificate::getSubjectX500Principal)
             .map(Principal::getName)
             .collect(Collectors.toSet());
 

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/DateProcessorTests.java
@@ -46,12 +46,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.IllformedLocaleException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class DateProcessorTests extends OpenSearchTestCase {
 
@@ -315,7 +317,7 @@ public class DateProcessorTests extends OpenSearchTestCase {
             () -> processor.execute(RandomDocumentPicks.randomIngestDocument(random(), document))
         );
         assertThat(e.getMessage(), equalTo("unable to parse date [2010]"));
-        assertThat(e.getCause().getMessage(), equalTo("Unknown language: invalid"));
+        assertThat(e.getCause(), instanceOf(IllformedLocaleException.class));
     }
 
     public void testOutputFormat() {

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/Compiler.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/Compiler.java
@@ -50,7 +50,7 @@ import org.objectweb.asm.util.Printer;
 
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.security.CodeSource;
 import java.security.SecureClassLoader;
 import java.security.cert.Certificate;
@@ -77,7 +77,7 @@ final class Compiler {
     static {
         try {
             // Setup the code privileges.
-            CODESOURCE = new CodeSource(new URL("file:" + BootstrapInfo.UNTRUSTED_CODEBASE), (Certificate[]) null);
+            CODESOURCE = new CodeSource(URI.create("file:" + BootstrapInfo.UNTRUSTED_CODEBASE).toURL(), (Certificate[]) null);
         } catch (MalformedURLException impossible) {
             throw new RuntimeException(impossible);
         }

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/lookup/PainlessLookupBuilder.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/lookup/PainlessLookupBuilder.java
@@ -57,7 +57,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.security.AccessController;
 import java.security.CodeSource;
 import java.security.PrivilegedAction;
@@ -120,7 +120,7 @@ public final class PainlessLookupBuilder {
 
     static {
         try {
-            CODESOURCE = new CodeSource(new URL("file:" + BootstrapInfo.UNTRUSTED_CODEBASE), (Certificate[]) null);
+            CODESOURCE = new CodeSource(URI.create("file:" + BootstrapInfo.UNTRUSTED_CODEBASE).toURL(), (Certificate[]) null);
         } catch (MalformedURLException mue) {
             throw new RuntimeException(mue);
         }

--- a/modules/repository-url/src/main/java/org/opensearch/common/blobstore/url/URLBlobContainer.java
+++ b/modules/repository-url/src/main/java/org/opensearch/common/blobstore/url/URLBlobContainer.java
@@ -43,6 +43,7 @@ import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.NoSuchFileException;
 import java.security.AccessController;
@@ -136,9 +137,11 @@ public class URLBlobContainer extends AbstractBlobContainer {
     @Override
     public InputStream readBlob(String name) throws IOException {
         try {
-            return new BufferedInputStream(getInputStream(new URL(path, name)), blobStore.bufferSizeInBytes());
+            return new BufferedInputStream(getInputStream(this.path.toURI().resolve(name).toURL()), blobStore.bufferSizeInBytes());
         } catch (FileNotFoundException fnfe) {
             throw new NoSuchFileException("[" + name + "] blob not found");
+        } catch (URISyntaxException e) {
+            throw new IOException(e);
         }
     }
 

--- a/modules/repository-url/src/main/java/org/opensearch/repositories/url/URLRepository.java
+++ b/modules/repository-url/src/main/java/org/opensearch/repositories/url/URLRepository.java
@@ -50,6 +50,7 @@ import org.opensearch.repositories.RepositoryException;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
@@ -85,10 +86,10 @@ public class URLRepository extends BlobStoreRepository {
         Property.NodeScope
     );
 
-    public static final Setting<URL> URL_SETTING = new Setting<>("url", "http:", URLRepository::parseURL, Property.NodeScope);
+    public static final Setting<URL> URL_SETTING = new Setting<>("url", "http://?", URLRepository::parseURL, Property.NodeScope);
     public static final Setting<URL> REPOSITORIES_URL_SETTING = new Setting<>(
         "repositories.url.url",
-        (s) -> s.get("repositories.uri.url", "http:"),
+        (s) -> s.get("repositories.uri.url", "http://?"),
         URLRepository::parseURL,
         Property.NodeScope
     );
@@ -194,7 +195,7 @@ public class URLRepository extends BlobStoreRepository {
 
     private static URL parseURL(String s) {
         try {
-            return new URL(s);
+            return URI.create(s).toURL();
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Unable to parse URL repository setting", e);
         }

--- a/modules/repository-url/src/yamlRestTest/java/org/opensearch/repositories/url/RepositoryURLClientYamlTestSuiteIT.java
+++ b/modules/repository-url/src/yamlRestTest/java/org/opensearch/repositories/url/RepositoryURLClientYamlTestSuiteIT.java
@@ -55,7 +55,6 @@ import org.junit.Before;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
-import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
@@ -120,7 +119,7 @@ public class RepositoryURLClientYamlTestSuiteIT extends OpenSearchClientYamlSuit
         List<String> allowedUrls = (List<String>) XContentMapValues.extractValue("defaults.repositories.url.allowed_urls", clusterSettings);
         for (String allowedUrl : allowedUrls) {
             try {
-                InetAddress inetAddress = InetAddress.getByName(new URL(allowedUrl).getHost());
+                InetAddress inetAddress = InetAddress.getByName(URI.create(allowedUrl).getHost());
                 if (inetAddress.isAnyLocalAddress() || inetAddress.isLoopbackAddress()) {
                     Request createUrlRepositoryRequest = new Request("PUT", "/_snapshot/repository-url");
                     createUrlRepositoryRequest.setEntity(buildRepositorySettings("url", Settings.builder().put("url", allowedUrl).build()));

--- a/plugins/examples/rest-handler/src/javaRestTest/java/org/opensearch/example/resthandler/ExampleFixtureIT.java
+++ b/plugins/examples/rest-handler/src/javaRestTest/java/org/opensearch/example/resthandler/ExampleFixtureIT.java
@@ -40,6 +40,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -53,7 +54,7 @@ public class ExampleFixtureIT extends OpenSearchTestCase {
         final String externalAddress = System.getProperty("external.address");
         assertNotNull("External address must not be null", externalAddress);
 
-        final URL url = new URL("http://" + externalAddress);
+        final URL url = URI.create("http://" + externalAddress).toURL();
         final InetAddress address = InetAddress.getByName(url.getHost());
         try (
             Socket socket = new Socket(address, url.getPort());

--- a/qa/evil-tests/src/test/java/org/opensearch/bootstrap/SystemCallFilterTests.java
+++ b/qa/evil-tests/src/test/java/org/opensearch/bootstrap/SystemCallFilterTests.java
@@ -39,7 +39,7 @@ import org.opensearch.test.OpenSearchTestCase;
 public class SystemCallFilterTests extends OpenSearchTestCase {
 
     /** command to try to run in tests */
-    static final String EXECUTABLE = Constants.WINDOWS ? "calc" : "ls";
+    static final String[] EXECUTABLE = new String[] { Constants.WINDOWS ? "calc" : "ls" };
 
     @SuppressWarnings("removal")
     @Override

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/ReloadSecureSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/ReloadSecureSettingsIT.java
@@ -50,7 +50,6 @@ import org.opensearch.transport.RemoteTransportException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.security.AccessControlException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -449,20 +448,9 @@ public class ReloadSecureSettingsIT extends OpenSearchIntegTestCase {
         }
     }
 
-    @SuppressWarnings("removal")
     private SecureSettings writeEmptyKeystore(Environment environment, char[] password) throws Exception {
         final KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.create();
-        try {
-            keyStoreWrapper.save(environment.configDir(), password);
-        } catch (final AccessControlException e) {
-            if (e.getPermission() instanceof RuntimePermission && e.getPermission().getName().equals("accessUserInformation")) {
-                // this is expected: the save method is extra diligent and wants to make sure
-                // the keystore is readable, not relying on umask and whatnot. It's ok, we don't
-                // care about this in tests.
-            } else {
-                throw e;
-            }
-        }
+        keyStoreWrapper.save(environment.configDir(), password);
         return keyStoreWrapper;
     }
 

--- a/server/src/main/java/org/opensearch/common/util/LocaleUtils.java
+++ b/server/src/main/java/org/opensearch/common/util/LocaleUtils.java
@@ -37,7 +37,7 @@ import java.util.Locale;
 import java.util.MissingResourceException;
 
 /**
- * Utilities for for dealing with {@link Locale} objects
+ * Utilities for dealing with {@link Locale} objects
  *
  * @opensearch.internal
  */
@@ -90,23 +90,18 @@ public class LocaleUtils {
     }
 
     private static Locale parseParts(String[] parts) {
-        switch (parts.length) {
-            case 3:
-                // lang, country, variant
-                return new Locale(parts[0], parts[1], parts[2]);
-            case 2:
-                // lang, country
-                return new Locale(parts[0], parts[1]);
-            case 1:
+        return switch (parts.length) {
+            case 3 -> new Locale.Builder().setLanguage(parts[0]).setRegion(parts[1]).setVariant(parts[2]).build();
+            case 2 -> new Locale.Builder().setLanguage(parts[0]).setRegion(parts[1]).build();
+            case 1 -> {
                 if ("ROOT".equalsIgnoreCase(parts[0])) {
-                    return Locale.ROOT;
+                    yield Locale.ROOT;
                 }
-                // lang
-                return new Locale(parts[0]);
-            default:
-                throw new IllegalArgumentException(
-                    "Locales can have at most 3 parts but got " + parts.length + ": " + Arrays.asList(parts)
-                );
-        }
+                yield new Locale.Builder().setLanguage(parts[0]).build();
+            }
+            default -> throw new IllegalArgumentException(
+                "Locales can have at most 3 parts but got " + parts.length + ": " + Arrays.asList(parts)
+            );
+        };
     }
 }

--- a/server/src/main/java/org/opensearch/search/profile/fetch/FlatFetchProfileTree.java
+++ b/server/src/main/java/org/opensearch/search/profile/fetch/FlatFetchProfileTree.java
@@ -65,7 +65,7 @@ class FlatFetchProfileTree {
     /** Start profiling a new fetch phase and return its breakdown. */
     FetchProfileBreakdown startFetchPhase(String element) {
         // Make phase name unique for concurrent slices by including thread info
-        String uniqueElement = element + "_" + Thread.currentThread().getId();
+        String uniqueElement = element + "_" + Thread.currentThread().threadId();
 
         Node node = rootsMap.get(uniqueElement);
         if (node == null) {
@@ -81,8 +81,8 @@ class FlatFetchProfileTree {
     /** Start profiling a fetch sub-phase under the specified parent phase. */
     FetchProfileBreakdown startSubPhase(String element, String parentElement) {
         // Make phase names unique for concurrent slices
-        String uniqueParentElement = parentElement + "_" + Thread.currentThread().getId();
-        String uniqueElement = element + "_" + Thread.currentThread().getId();
+        String uniqueParentElement = parentElement + "_" + Thread.currentThread().threadId();
+        String uniqueElement = element + "_" + Thread.currentThread().threadId();
 
         Node parent = phaseMap.get(uniqueParentElement);
         if (parent == null) {
@@ -107,7 +107,7 @@ class FlatFetchProfileTree {
      */
     void endFetchPhase(String element) {
         // Make phase name unique for concurrent slices
-        String uniqueElement = element + "_" + Thread.currentThread().getId();
+        String uniqueElement = element + "_" + Thread.currentThread().threadId();
 
         Node node = phaseMap.get(uniqueElement);
         if (node == null) {

--- a/server/src/test/java/org/opensearch/action/termvectors/AbstractTermVectorsTestCase.java
+++ b/server/src/test/java/org/opensearch/action/termvectors/AbstractTermVectorsTestCase.java
@@ -223,9 +223,8 @@ public abstract class AbstractTermVectorsTestCase extends ParameterizedStaticSet
             if (requestPayloads) {
                 requested += "payload,";
             }
-            Locale aLocale = new Locale("en", "US");
             return String.format(
-                aLocale,
+                Locale.US,
                 "(doc: %s\n requested: %s, fields: %s)",
                 doc,
                 requested,

--- a/server/src/test/java/org/opensearch/bootstrap/SecurityTests.java
+++ b/server/src/test/java/org/opensearch/bootstrap/SecurityTests.java
@@ -35,6 +35,7 @@ package org.opensearch.bootstrap;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -80,7 +81,7 @@ public class SecurityTests extends OpenSearchTestCase {
     public void testProcessExecution() throws Exception {
         assumeTrue("test requires security manager", System.getSecurityManager() != null);
         try {
-            Runtime.getRuntime().exec("ls");
+            Runtime.getRuntime().exec(new String[] { "ls" });
             fail("didn't get expected exception");
         } catch (SecurityException expected) {}
     }
@@ -89,15 +90,15 @@ public class SecurityTests extends OpenSearchTestCase {
     public void testReadPolicyWithCodebases() throws IOException {
         final Map<String, URL> codebases = Map.of(
             "test-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar",
-            new URL("file://test-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar"),
+            URI.create("file://test-netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar").toURL(),
             "test-kafka-server-common-3.6.1.jar",
-            new URL("file://test-kafka-server-common-3.6.1.jar"),
+            URI.create("file://test-kafka-server-common-3.6.1.jar").toURL(),
             "test-kafka-server-common-3.6.1-test.jar",
-            new URL("file://test-kafka-server-common-3.6.1-test.jar"),
+            URI.create("file://test-kafka-server-common-3.6.1-test.jar").toURL(),
             "test-lucene-core-9.11.0-snapshot-8a555eb.jar",
-            new URL("file://test-lucene-core-9.11.0-snapshot-8a555eb.jar"),
+            URI.create("file://test-lucene-core-9.11.0-snapshot-8a555eb.jar").toURL(),
             "test-zstd-jni-1.5.6-1.jar",
-            new URL("file://test-zstd-jni-1.5.6-1.jar")
+            URI.create("file://test-zstd-jni-1.5.6-1.jar").toURL()
         );
 
         AccessController.doPrivileged(

--- a/server/src/test/java/org/opensearch/common/cache/CacheTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/CacheTests.java
@@ -774,7 +774,7 @@ public class CacheTests extends OpenSearchTestCase {
         // start a watchdog service
         ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
         scheduler.scheduleAtFixedRate(() -> {
-            Set<Long> ids = threads.stream().map(t -> t.getId()).collect(Collectors.toSet());
+            Set<Long> ids = threads.stream().map(Thread::threadId).collect(Collectors.toSet());
             ThreadMXBean mxBean = ManagementFactory.getThreadMXBean();
             long[] deadlockedThreads = mxBean.findDeadlockedThreads();
             if (!deadlock.get() && deadlockedThreads != null) {

--- a/server/src/test/java/org/opensearch/env/EnvironmentTests.java
+++ b/server/src/test/java/org/opensearch/env/EnvironmentTests.java
@@ -38,7 +38,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -86,17 +86,20 @@ public class EnvironmentTests extends OpenSearchTestCase {
         assertThat(environment.resolveRepoFile("/somethingeles/repos/repo1"), nullValue());
         assertThat(environment.resolveRepoFile("/test/other/repo"), notNullValue());
 
-        assertThat(environment.resolveRepoURL(new URL("file:///test/repos/repo1")), notNullValue());
-        assertThat(environment.resolveRepoURL(new URL("file:/test/repos/repo1")), notNullValue());
-        assertThat(environment.resolveRepoURL(new URL("file://test/repos/repo1")), nullValue());
-        assertThat(environment.resolveRepoURL(new URL("file:///test/repos/../repo1")), nullValue());
-        assertThat(environment.resolveRepoURL(new URL("http://localhost/test/")), nullValue());
+        assertThat(environment.resolveRepoURL(URI.create("file:///test/repos/repo1").toURL()), notNullValue());
+        assertThat(environment.resolveRepoURL(URI.create("file:/test/repos/repo1").toURL()), notNullValue());
+        assertThat(environment.resolveRepoURL(URI.create("file://test/repos/repo1").toURL()), nullValue());
+        assertThat(environment.resolveRepoURL(URI.create("file:///test/repos/../repo1").toURL()), nullValue());
+        assertThat(environment.resolveRepoURL(URI.create("http://localhost/test/").toURL()), nullValue());
 
-        assertThat(environment.resolveRepoURL(new URL("jar:file:///test/repos/repo1!/repo/")), notNullValue());
-        assertThat(environment.resolveRepoURL(new URL("jar:file:/test/repos/repo1!/repo/")), notNullValue());
-        assertThat(environment.resolveRepoURL(new URL("jar:file:///test/repos/repo1!/repo/")).toString(), endsWith("repo1!/repo/"));
-        assertThat(environment.resolveRepoURL(new URL("jar:file:///test/repos/../repo1!/repo/")), nullValue());
-        assertThat(environment.resolveRepoURL(new URL("jar:http://localhost/test/../repo1?blah!/repo/")), nullValue());
+        assertThat(environment.resolveRepoURL(URI.create("jar:file:///test/repos/repo1!/repo/").toURL()), notNullValue());
+        assertThat(environment.resolveRepoURL(URI.create("jar:file:/test/repos/repo1!/repo/").toURL()), notNullValue());
+        assertThat(
+            environment.resolveRepoURL(URI.create("jar:file:///test/repos/repo1!/repo/").toURL()).toString(),
+            endsWith("repo1!/repo/")
+        );
+        assertThat(environment.resolveRepoURL(URI.create("jar:file:///test/repos/../repo1!/repo/").toURL()), nullValue());
+        assertThat(environment.resolveRepoURL(URI.create("jar:http://localhost/test/../repo1?blah!/repo/").toURL()), nullValue());
     }
 
     public void testPathDataWhenNotSet() {

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -193,7 +193,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.URL;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -2017,9 +2017,9 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         TransportAddress[] transportAddresses = new TransportAddress[stringAddresses.length];
         int i = 0;
         for (String stringAddress : stringAddresses) {
-            URL url = new URL("http://" + stringAddress);
-            InetAddress inetAddress = InetAddress.getByName(url.getHost());
-            transportAddresses[i++] = new TransportAddress(new InetSocketAddress(inetAddress, url.getPort()));
+            URI uri = URI.create("http://" + stringAddress);
+            InetAddress inetAddress = InetAddress.getByName(uri.getHost());
+            transportAddresses[i++] = new TransportAddress(new InetSocketAddress(inetAddress, uri.getPort()));
         }
         return new ExternalTestCluster(
             createTempDir(),


### PR DESCRIPTION
There was a check in the forbidden APIs plugin to cap the Java version at 14, presumably from ages ago when the plugin did not support Java 15 or newer. That means we have not been enforcing any Java deprecations in the past 5 years. This removes that check, updates the plugin to 3.9, and fixes all the resulting deprecation failures.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
