### PR TITLE
Fix deadlock in SearchPhaseControllerTests cancellation tests

### DIFF
--- a/server/src/test/java/org/opensearch/action/search/SearchPhaseControllerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchPhaseControllerTests.java
@@ -1826,7 +1826,13 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
                 result.setShardIndex(index);
                 result.size(1);
 
-                consumer.consumeResult(result, latch::countDown);
+                try {
+                    consumer.consumeResult(result, latch::countDown);
+                } catch (Exception e) {
+                    // Ensure latch counts down even on cancellation
+                    latch.countDown();
+                    // Don't rethrow - let the thread complete normally
+                }
             });
             threads[index].start();
         }


### PR DESCRIPTION
  The cancellation tests could deadlock when threads are delayed by OS
  scheduling. If cancellation triggers before all threads start, late
  threads may hit a code path where batchReduceSize causes the latch
  callback to be deferred to a MergeTask. Under certain timing conditions,
  these callbacks never execute, causing latch.await() to hang indefinitely.

  Ensure latch.countDown() is always called by wrapping consumeResult in
  try-catch. This guarantees test completion regardless of cancellation
  timing or exceptions.

  Fixes #19094

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
