### PR TITLE
Add detailed message to changelog workflow (#12979)

### DIFF
--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -19,5 +19,5 @@ jobs:
           changeIsMissingMessage: |
             ❌ ERROR: No update to CHANGELOG.md found!
             This project requires a changelog entry for every user-facing change.
-            Please add a note about your change to the 'Unreleased' section of the CHANGELOG.md file.
-            You can find the file here: https://github.com/opensearch-project/OpenSearch/blob/main/CHANGELOG.md
+            Please add an entry to the changelog or ask a maintainer to add the skip-changelog label.
+            See https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#changelog for more details.


### PR DESCRIPTION
This PR creates a new troubleshooting guide to help new contributors understand and fix common CI/CD failures, as requested in issue #12979.

**What's included:**
- A new guide at `.github/WORKFLOW_TROUBLESHOOTING.md` that covers DCO, Changelog, Gradle, and Backport checks.
- An entry in `CHANGELOG.md` for this change.

Closes #12979