### PR TITLE
Add `item_count` metric to field data cache stats API

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -842,7 +842,7 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
         assertEquals(new ByteSizeValue(0), statsResponseWithAllIndicesMetrics.getIndicesStats().getStore().getReservedSize());
         assertEquals(new ByteSizeValue(0), statsResponseWithAllIndicesMetrics.getIndicesStats().getFieldData().getMemorySize());
         assertEquals(0, statsResponseWithAllIndicesMetrics.getIndicesStats().getFieldData().getEvictions());
-        assertNull(statsResponseWithAllIndicesMetrics.getIndicesStats().getFieldData().getFields());
+        assertNull(statsResponseWithAllIndicesMetrics.getIndicesStats().getFieldData().getFieldMemorySizes());
         assertEquals(0, statsResponseWithAllIndicesMetrics.getIndicesStats().getSegments().getCount());
         assertEquals(0, statsResponseWithAllIndicesMetrics.getIndicesStats().getSegments().getIndexWriterMemoryInBytes());
         assertEquals(0, statsResponseWithAllIndicesMetrics.getIndicesStats().getSegments().getVersionMapMemoryInBytes());

--- a/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
@@ -234,20 +234,20 @@ public class IndexStatsIT extends ParameterizedStaticSettingsOpenSearchIntegTest
             greaterThan(0L)
         );
         assertThat(
-            nodesStats.getNodes().get(0).getIndices().getFieldData().getFields().get("field") + nodesStats.getNodes()
+            nodesStats.getNodes().get(0).getIndices().getFieldData().getFieldMemorySizes().get("field") + nodesStats.getNodes()
                 .get(1)
                 .getIndices()
                 .getFieldData()
-                .getFields()
+                .getFieldMemorySizes()
                 .get("field"),
             greaterThan(0L)
         );
         assertThat(
-            nodesStats.getNodes().get(0).getIndices().getFieldData().getFields().get("field") + nodesStats.getNodes()
+            nodesStats.getNodes().get(0).getIndices().getFieldData().getFieldMemorySizes().get("field") + nodesStats.getNodes()
                 .get(1)
                 .getIndices()
                 .getFieldData()
-                .getFields()
+                .getFieldMemorySizes()
                 .get("field"),
             lessThan(
                 nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
@@ -267,9 +267,9 @@ public class IndexStatsIT extends ParameterizedStaticSettingsOpenSearchIntegTest
             .execute()
             .actionGet();
         assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
-        assertThat(indicesStats.getTotal().getFieldData().getFields().get("field"), greaterThan(0L));
+        assertThat(indicesStats.getTotal().getFieldData().getFieldMemorySizes().get("field"), greaterThan(0L));
         assertThat(
-            indicesStats.getTotal().getFieldData().getFields().get("field"),
+            indicesStats.getTotal().getFieldData().getFieldMemorySizes().get("field"),
             lessThan(indicesStats.getTotal().getFieldData().getMemorySizeInBytes())
         );
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
@@ -36,6 +36,8 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
 import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.admin.cluster.node.stats.NodeStats;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequestBuilder;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.forcemerge.ForceMergeResponse;
@@ -70,6 +72,7 @@ import org.opensearch.index.TieredMergePolicyProvider;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.cache.query.QueryCacheStats;
 import org.opensearch.index.engine.VersionConflictEngineException;
+import org.opensearch.index.fielddata.FieldDataStats;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.remote.RemoteSegmentStats;
 import org.opensearch.index.shard.IndexShard;
@@ -116,7 +119,6 @@ import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -165,7 +167,7 @@ public class IndexStatsIT extends ParameterizedStaticSettingsOpenSearchIntegTest
         return Settings.builder().put(indexSettings());
     }
 
-    public void testFieldDataStats() throws InterruptedException {
+    public void testFieldDataStats() throws Exception {
         assertAcked(
             client().admin()
                 .indices()
@@ -175,117 +177,86 @@ public class IndexStatsIT extends ParameterizedStaticSettingsOpenSearchIntegTest
                 .get()
         );
         ensureGreen();
-        client().prepareIndex("test").setId("1").setSource("field", "value1", "field2", "value1").execute().actionGet();
-        client().prepareIndex("test").setId("2").setSource("field", "value2", "field2", "value2").execute().actionGet();
+        // Index enough docs to be sure neither primary shard is empty
+        for (int i = 0; i < 100; i++) {
+            client().prepareIndex("test")
+                .setId(Integer.toString(i))
+                .setSource("field", "value" + i, "field2", "value" + i)
+                .execute()
+                .actionGet();
+        }
         refreshAndWaitForReplication();
         indexRandomForConcurrentSearch("test");
+        // Force merge to 1 segment so we can predict counts
+        client().admin().indices().prepareForceMerge().setMaxNumSegments(1).execute().actionGet();
+        refreshAndWaitForReplication();
 
-        NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
-        assertThat(
-            nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
-                .get(1)
-                .getIndices()
-                .getFieldData()
-                .getMemorySizeInBytes(),
-            equalTo(0L)
-        );
-        IndicesStatsResponse indicesStats = client().admin()
-            .indices()
-            .prepareStats("test")
-            .clear()
-            .setFieldData(true)
-            .execute()
-            .actionGet();
-        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0L));
+        for (FieldDataStats totalStats : List.of(getTotalFieldDataStats(false), getIndicesFieldDataStats(false))) {
+            assertEquals(0, totalStats.getMemorySizeInBytes());
+            assertEquals(0, totalStats.getItemCount());
+        }
 
         // sort to load it to field data...
         client().prepareSearch().addSort("field", SortOrder.ASC).execute().actionGet();
-        client().prepareSearch().addSort("field", SortOrder.ASC).execute().actionGet();
 
-        nodesStats = client().admin().cluster().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
-        assertThat(
-            nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
-                .get(1)
-                .getIndices()
-                .getFieldData()
-                .getMemorySizeInBytes(),
-            greaterThan(0L)
-        );
-        indicesStats = client().admin().indices().prepareStats("test").clear().setFieldData(true).execute().actionGet();
-        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
+        for (FieldDataStats totalStats : List.of(getTotalFieldDataStats(false), getIndicesFieldDataStats(false))) {
+            assertTrue(totalStats.getMemorySizeInBytes() > 0);
+            // The search should have hit 2 shards of the total 4 shards, each of which has 1 segment. So we expect 2 entries.
+            assertEquals(2, totalStats.getItemCount());
+        }
 
         // sort to load it to field data...
         client().prepareSearch().addSort("field2", SortOrder.ASC).execute().actionGet();
-        client().prepareSearch().addSort("field2", SortOrder.ASC).execute().actionGet();
+
+        // Now we expect 4 total entries, one per searched segment per field
+        assertEquals(4, getTotalFieldDataStats(false).getItemCount());
 
         // now check the per field stats
-        nodesStats = client().admin()
-            .cluster()
-            .prepareNodesStats("data:true")
-            .setIndices(new CommonStatsFlags().set(CommonStatsFlags.Flag.FieldData, true).fieldDataFields("*"))
-            .execute()
-            .actionGet();
-        assertThat(
-            nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
-                .get(1)
-                .getIndices()
-                .getFieldData()
-                .getMemorySizeInBytes(),
-            greaterThan(0L)
-        );
-        assertThat(
-            nodesStats.getNodes().get(0).getIndices().getFieldData().getFieldMemorySizes().get("field") + nodesStats.getNodes()
-                .get(1)
-                .getIndices()
-                .getFieldData()
-                .getFieldMemorySizes()
-                .get("field"),
-            greaterThan(0L)
-        );
-        assertThat(
-            nodesStats.getNodes().get(0).getIndices().getFieldData().getFieldMemorySizes().get("field") + nodesStats.getNodes()
-                .get(1)
-                .getIndices()
-                .getFieldData()
-                .getFieldMemorySizes()
-                .get("field"),
-            lessThan(
-                nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
-                    .get(1)
-                    .getIndices()
-                    .getFieldData()
-                    .getMemorySizeInBytes()
-            )
-        );
-
-        indicesStats = client().admin()
-            .indices()
-            .prepareStats("test")
-            .clear()
-            .setFieldData(true)
-            .setFieldDataFields("*")
-            .execute()
-            .actionGet();
-        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
-        assertThat(indicesStats.getTotal().getFieldData().getFieldMemorySizes().get("field"), greaterThan(0L));
-        assertThat(
-            indicesStats.getTotal().getFieldData().getFieldMemorySizes().get("field"),
-            lessThan(indicesStats.getTotal().getFieldData().getMemorySizeInBytes())
-        );
+        for (FieldDataStats totalStats : List.of(getTotalFieldDataStats(true), getIndicesFieldDataStats(true))) {
+            assertTrue(totalStats.getMemorySizeInBytes() > 0);
+            for (String fieldName : List.of("field", "field2")) {
+                assertTrue(totalStats.getFieldMemorySizes().get(fieldName) > 0);
+                assertEquals(2, totalStats.getFieldItemCounts().get(fieldName));
+                assertTrue(totalStats.getFieldMemorySizes().get(fieldName) < totalStats.getMemorySizeInBytes());
+            }
+        }
 
         client().admin().indices().prepareClearCache().setFieldDataCache(true).execute().actionGet();
-        nodesStats = client().admin().cluster().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
-        assertThat(
-            nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
-                .get(1)
-                .getIndices()
-                .getFieldData()
-                .getMemorySizeInBytes(),
-            equalTo(0L)
-        );
-        indicesStats = client().admin().indices().prepareStats("test").clear().setFieldData(true).execute().actionGet();
-        assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0L));
+        assertBusy(() -> {
+            for (FieldDataStats postClearStats : List.of(getTotalFieldDataStats(true), getIndicesFieldDataStats(true))) {
+                assertEquals(0, postClearStats.getMemorySizeInBytes());
+                assertEquals(0, postClearStats.getItemCount());
+                for (long fieldMemorySize : postClearStats.getFieldMemorySizes().getStats().values()) {
+                    assertEquals(0, fieldMemorySize);
+                }
+                for (long fieldItemCount : postClearStats.getFieldItemCounts().getStats().values()) {
+                    assertEquals(0, fieldItemCount);
+                }
+            }
+        });
+    }
 
+    private FieldDataStats getTotalFieldDataStats(boolean setFieldDataFields) {
+        NodesStatsRequestBuilder builder = client().admin().cluster().prepareNodesStats("data:true");
+        if (setFieldDataFields) {
+            builder.setIndices(new CommonStatsFlags().set(CommonStatsFlags.Flag.FieldData, true).fieldDataFields("*"));
+        } else {
+            builder.setIndices(true);
+        }
+        NodesStatsResponse nodesStats = builder.execute().actionGet();
+        FieldDataStats total = new FieldDataStats();
+        for (NodeStats node : nodesStats.getNodes()) {
+            total.add(node.getIndices().getFieldData());
+        }
+        return total;
+    }
+
+    private FieldDataStats getIndicesFieldDataStats(boolean setFieldDataFields) {
+        IndicesStatsRequestBuilder builder = client().admin().indices().prepareStats("test").clear().setFieldData(true);
+        if (setFieldDataFields) {
+            builder.setFieldDataFields("*");
+        }
+        return builder.execute().actionGet().getTotal().getFieldData();
     }
 
     public void testClearAllCaches() throws Exception {

--- a/server/src/main/java/org/opensearch/common/FieldMemoryStats.java
+++ b/server/src/main/java/org/opensearch/common/FieldMemoryStats.java
@@ -52,7 +52,6 @@ import java.util.Objects;
  */
 @PublicApi(since = "1.0.0")
 public final class FieldMemoryStats implements Writeable, Iterable<Map.Entry<String, Long>> {
-
     private final Map<String, Long> stats;
 
     /**
@@ -99,6 +98,10 @@ public final class FieldMemoryStats implements Writeable, Iterable<Map.Entry<Str
             builder.endObject();
         }
         builder.endObject();
+    }
+
+    public Map<String, Long> getStats() {
+        return stats;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/fielddata/ShardFieldData.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/ShardFieldData.java
@@ -35,6 +35,7 @@ package org.opensearch.index.fielddata;
 import org.apache.lucene.util.Accountable;
 import org.opensearch.common.FieldMemoryStats;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.common.regex.Regex;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
@@ -55,37 +56,48 @@ public class ShardFieldData implements IndexFieldDataCache.Listener {
 
     private final CounterMetric evictionsMetric = new CounterMetric();
     private final CounterMetric totalMetric = new CounterMetric();
-    private final ConcurrentMap<String, CounterMetric> perFieldTotals = ConcurrentCollections.newConcurrentMap();
+    // Tuple contains field memory size and field count, in that order
+    private final ConcurrentMap<String, Tuple<CounterMetric, CounterMetric>> perFieldInfo = ConcurrentCollections.newConcurrentMap();
+    private final CounterMetric countMetric = new CounterMetric();
 
     public FieldDataStats stats(String... fields) {
         Map<String, Long> fieldTotals = null;
+        Map<String, Long> fieldCounts = null;
         if (CollectionUtils.isEmpty(fields) == false) {
             fieldTotals = new HashMap<>();
-            for (Map.Entry<String, CounterMetric> entry : perFieldTotals.entrySet()) {
+            fieldCounts = new HashMap<>();
+            for (Map.Entry<String, Tuple<CounterMetric, CounterMetric>> entry : perFieldInfo.entrySet()) {
                 if (Regex.simpleMatch(fields, entry.getKey())) {
-                    fieldTotals.put(entry.getKey(), entry.getValue().count());
+                    fieldTotals.put(entry.getKey(), entry.getValue().v1().count());
+                    fieldCounts.put(entry.getKey(), entry.getValue().v2().count());
                 }
             }
         }
         return new FieldDataStats(
             totalMetric.count(),
             evictionsMetric.count(),
-            fieldTotals == null ? null : new FieldMemoryStats(fieldTotals)
+            fieldTotals == null ? null : new FieldMemoryStats(fieldTotals),
+            countMetric.count(),
+            fieldCounts == null ? null : new FieldMemoryStats(fieldCounts)
         );
     }
 
     @Override
     public void onCache(ShardId shardId, String fieldName, Accountable ramUsage) {
         totalMetric.inc(ramUsage.ramBytesUsed());
-        CounterMetric total = perFieldTotals.get(fieldName);
-        if (total != null) {
-            total.inc(ramUsage.ramBytesUsed());
+        countMetric.inc();
+        Tuple<CounterMetric, CounterMetric> fieldInfo = perFieldInfo.get(fieldName);
+        if (fieldInfo != null) {
+            fieldInfo.v1().inc(ramUsage.ramBytesUsed());
+            fieldInfo.v2().inc();
         } else {
-            total = new CounterMetric();
-            total.inc(ramUsage.ramBytesUsed());
-            CounterMetric prev = perFieldTotals.putIfAbsent(fieldName, total);
+            fieldInfo = new Tuple<>(new CounterMetric(), new CounterMetric());
+            fieldInfo.v1().inc(ramUsage.ramBytesUsed());
+            fieldInfo.v2().inc();
+            Tuple<CounterMetric, CounterMetric> prev = perFieldInfo.putIfAbsent(fieldName, fieldInfo);
             if (prev != null) {
-                prev.inc(ramUsage.ramBytesUsed());
+                prev.v1().inc(ramUsage.ramBytesUsed());
+                prev.v2().inc();
             }
         }
     }
@@ -95,13 +107,16 @@ public class ShardFieldData implements IndexFieldDataCache.Listener {
         if (wasEvicted) {
             evictionsMetric.inc();
         }
+        Tuple<CounterMetric, CounterMetric> fieldInfo = perFieldInfo.get(fieldName);
         if (sizeInBytes != -1) {
             totalMetric.dec(sizeInBytes);
-
-            CounterMetric total = perFieldTotals.get(fieldName);
-            if (total != null) {
-                total.dec(sizeInBytes);
+            if (fieldInfo != null) {
+                fieldInfo.v1().dec(sizeInBytes);
             }
+        }
+        countMetric.dec();
+        if (fieldInfo != null) {
+            fieldInfo.v2().dec();
         }
     }
 }

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestFielddataAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestFielddataAction.java
@@ -105,8 +105,8 @@ public class RestFielddataAction extends AbstractCatAction {
         Table table = getTableWithHeader(request);
 
         for (NodeStats nodeStats : nodeStatses.getNodes()) {
-            if (nodeStats.getIndices().getFieldData().getFields() != null) {
-                for (var cursor : nodeStats.getIndices().getFieldData().getFields()) {
+            if (nodeStats.getIndices().getFieldData().getFieldMemorySizes() != null) {
+                for (var cursor : nodeStats.getIndices().getFieldData().getFieldMemorySizes()) {
                     table.startRow();
                     table.addCell(nodeStats.getNode().getId());
                     table.addCell(nodeStats.getNode().getHostName());

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -1372,7 +1372,13 @@ public class NodeStatsTests extends OpenSearchTestCase {
         commonStats.indexing = new IndexingStats();
         commonStats.completion = new CompletionStats();
         commonStats.flush = new FlushStats(randomLongBetween(0, 100), randomLongBetween(0, 100), randomLongBetween(0, 100));
-        commonStats.fieldData = new FieldDataStats(randomLongBetween(0, 100), randomLongBetween(0, 100), null);
+        commonStats.fieldData = new FieldDataStats(
+            randomLongBetween(0, 100),
+            randomLongBetween(0, 100),
+            null,
+            randomLongBetween(0, 100),
+            null
+        );
         commonStats.queryCache = new QueryCacheStats(
             randomLongBetween(0, 100),
             randomLongBetween(0, 100),

--- a/server/src/test/java/org/opensearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
@@ -367,7 +367,13 @@ public class ClusterStatsNodesTests extends OpenSearchTestCase {
         commonStats.indexing = new IndexingStats();
         commonStats.completion = new CompletionStats();
         commonStats.flush = new FlushStats(randomLongBetween(0, 100), randomLongBetween(0, 100), randomLongBetween(0, 100));
-        commonStats.fieldData = new FieldDataStats(randomLongBetween(0, 100), randomLongBetween(0, 100), null);
+        commonStats.fieldData = new FieldDataStats(
+            randomLongBetween(0, 100),
+            randomLongBetween(0, 100),
+            null,
+            randomLongBetween(0, 100),
+            null
+        );
         commonStats.queryCache = new QueryCacheStats(
             randomLongBetween(0, 100),
             randomLongBetween(0, 100),

--- a/server/src/test/java/org/opensearch/action/admin/cluster/stats/ClusterStatsResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/stats/ClusterStatsResponseTests.java
@@ -235,7 +235,13 @@ public class ClusterStatsResponseTests extends OpenSearchTestCase {
         commonStats.indexing = new IndexingStats();
         commonStats.completion = new CompletionStats();
         commonStats.flush = new FlushStats(randomLongBetween(0, 100), randomLongBetween(0, 100), randomLongBetween(0, 100));
-        commonStats.fieldData = new FieldDataStats(randomLongBetween(0, 100), randomLongBetween(0, 100), null);
+        commonStats.fieldData = new FieldDataStats(
+            randomLongBetween(0, 100),
+            randomLongBetween(0, 100),
+            null,
+            randomLongBetween(0, 100),
+            null
+        );
         commonStats.queryCache = new QueryCacheStats(
             randomLongBetween(0, 100),
             randomLongBetween(0, 100),

--- a/server/src/test/java/org/opensearch/index/fielddata/FieldDataStatsTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/FieldDataStatsTests.java
@@ -42,9 +42,11 @@ import java.io.IOException;
 public class FieldDataStatsTests extends OpenSearchTestCase {
 
     public void testSerialize() throws IOException {
-        // TODO: Test both ctors here
         FieldMemoryStats map = randomBoolean() ? null : FieldMemoryStatsTests.randomFieldMemoryStats();
-        FieldDataStats stats = new FieldDataStats(randomNonNegativeLong(), randomNonNegativeLong(), map);
+        // test both ctors
+        FieldDataStats stats = randomBoolean()
+            ? new FieldDataStats(randomNonNegativeLong(), randomNonNegativeLong(), map)
+            : new FieldDataStats(randomNonNegativeLong(), randomNonNegativeLong(), map, randomNonNegativeLong(), map);
         BytesStreamOutput out = new BytesStreamOutput();
         stats.writeTo(out);
         StreamInput input = out.bytes().streamInput();
@@ -53,5 +55,7 @@ public class FieldDataStatsTests extends OpenSearchTestCase {
         assertEquals(stats.getEvictions(), read.getEvictions());
         assertEquals(stats.getMemorySize(), read.getMemorySize());
         assertEquals(stats.getFieldMemorySizes(), read.getFieldMemorySizes());
+        assertEquals(stats.getItemCount(), read.getItemCount());
+        assertEquals(stats.getFieldItemCounts(), read.getFieldItemCounts());
     }
 }

--- a/server/src/test/java/org/opensearch/index/fielddata/FieldDataStatsTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/FieldDataStatsTests.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 public class FieldDataStatsTests extends OpenSearchTestCase {
 
     public void testSerialize() throws IOException {
+        // TODO: Test both ctors here
         FieldMemoryStats map = randomBoolean() ? null : FieldMemoryStatsTests.randomFieldMemoryStats();
         FieldDataStats stats = new FieldDataStats(randomNonNegativeLong(), randomNonNegativeLong(), map);
         BytesStreamOutput out = new BytesStreamOutput();
@@ -51,6 +52,6 @@ public class FieldDataStatsTests extends OpenSearchTestCase {
         assertEquals(-1, input.read());
         assertEquals(stats.getEvictions(), read.getEvictions());
         assertEquals(stats.getMemorySize(), read.getMemorySize());
-        assertEquals(stats.getFields(), read.getFields());
+        assertEquals(stats.getFieldMemorySizes(), read.getFieldMemorySizes());
     }
 }


### PR DESCRIPTION
### Description
Adds an `item_count` metric to the existing `_nodes/stats/indices/fielddata` API. Like memory size, it can be aggregated by field by passing a `fielddata_fields` param listing the desired fields.


Example API response for `curl -XGET "localhost:9200/_nodes/stats/indices/fielddata?pretty&fielddata_fields=text0,text2"`: 

```
"indices" : {
        "fielddata" : {
          "memory_size_in_bytes" : 31184,
          "evictions" : 0,
          "item_count" : 10,
          "fields" : {
            "text0" : {
              "memory_size_in_bytes" : 15580,
              "item_count" : 5
            },
            "text2" : {
              "memory_size_in_bytes" : 15604,
              "item_count" : 5
            }
          }
        }
      }
```

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/19173

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
