### PR TITLE
Fix LocalTranslogTests handling of corrupted translog recovery

### DIFF
--- a/server/src/test/java/org/opensearch/index/translog/LocalTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/LocalTranslogTests.java
@@ -3368,8 +3368,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                     localCheckpointOfSafeCommit = failableTLog.getDeletionPolicy().getLocalCheckpointOfSafeCommit();
                     IOUtils.closeWhileHandlingException(failableTLog);
                 }
-            } catch (TranslogException | MockDirectoryWrapper.FakeIOException ex) {
-                // failed - that's ok, we didn't even create it
+            } catch (TranslogException | MockDirectoryWrapper.FakeIOException | TranslogCorruptedException ex) {
+                // failed - that's ok, we didn't even create it or it was corrupted from partial writes
             } catch (IOException ex) {
                 assertEquals(ex.getMessage(), "__FAKE__ no space left on device");
             }
@@ -3379,8 +3379,8 @@ public class LocalTranslogTests extends OpenSearchTestCase {
                     TranslogDeletionPolicy deletionPolicy = createTranslogDeletionPolicy();
                     deletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpointOfSafeCommit);
                     IOUtils.close(getFailableTranslog(fail, config, randomBoolean(), false, generationUUID, deletionPolicy));
-                } catch (TranslogException | MockDirectoryWrapper.FakeIOException ex) {
-                    // failed - that's ok, we didn't even create it
+                } catch (TranslogException | MockDirectoryWrapper.FakeIOException | TranslogCorruptedException ex) {
+                    // failed - that's ok, we didn't even create it or it was corrupted from partial writes
                 } catch (IOException ex) {
                     assertEquals(ex.getMessage(), "__FAKE__ no space left on device");
                 }


### PR DESCRIPTION
  Partial writes can corrupt translog files during simulated failures.
  When recovering these files, TranslogCorruptedException is thrown but
  wasn't caught since it extends OpenSearchException, not TranslogException.

  Add TranslogCorruptedException to catch blocks alongside other expected
  exceptions during translog recovery attempts.

  Fixes #19168

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
