### PR TITLE
ci: Add workflow to detect backport conflicts before merging

### DIFF
--- a/.github/workflows/backport-check.yml
+++ b/.github/workflows/backport-check.yml
@@ -1,0 +1,75 @@
+name: Backport Conflict Check
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+jobs:
+  check-backport:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract backport label
+        id: extract
+        run: |
+          echo 'Extracting backport label...'
+          version=$(jq -r '
+            .pull_request.labels // []
+            | map(.name // empty)
+            | map(select(startswith("backport ")))
+            | first // ""
+            | sub("^backport "; "")
+            ' "$GITHUB_EVENT_PATH")
+
+          if [[ -z "$version" || "$version" == "null" ]]; then
+            echo "No backport label found. Skipping."
+            echo "version=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Backport version: '$version'"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout backport target branch (from upstream)
+        if: ${{ steps.extract.outputs.version != '' }}
+        run: |
+          git init .
+          git remote add upstream https://github.com/opensearch-project/OpenSearch.git
+          git fetch upstream ${{ steps.extract.outputs.version }}
+          git checkout -b backport-target FETCH_HEAD
+
+          git remote add prrepo https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git
+          git fetch prrepo ${{ github.event.pull_request.head.ref }}
+
+      - name: Set git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Attempt cherry-pick of PR commits
+        if: ${{ steps.extract.outputs.version != '' }}
+        run: |
+          set -o pipefail
+          {
+            git cherry-pick ${{ github.event.pull_request.head.sha }}
+          } &> err.log || {
+            cat err.log > conflict.txt
+            exit 1
+          }
+
+      - name: Report conflicts as PR comment
+        if: ${{ steps.extract.outputs.version != '' && failure() }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let conflictMsg = "⚠️ Backport conflict detected for branch `${{ steps.extract.outputs.version }}`\n";
+            if (fs.existsSync('conflict.txt')) {
+              const conflicts = fs.readFileSync('conflict.txt', 'utf8');
+              conflictMsg += "```\n" + conflicts + "\n```";
+            }
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: conflictMsg
+            });


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR introduces a new GitHub Actions workflow, Backport Conflict Check.
The workflow automatically verifies whether a pull request can be cleanly cherry-picked into a branch labeled with a `backport <version>` tag.

Key features:
- Detects `backport <version>` label on PR.
- Fetches the corresponding upstream target branch.
- Attempts git cherry-pick of the PR’s head commit.
- Reports conflicts back to the PR as a comment when detected.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/12097


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
