### PR TITLE
Adds routing field to TermVectorsRequest serialization

### DIFF
--- a/client/rest-high-level/src/main/java/org/opensearch/client/core/TermVectorsRequest.java
+++ b/client/rest-high-level/src/main/java/org/opensearch/client/core/TermVectorsRequest.java
@@ -278,6 +278,7 @@ public class TermVectorsRequest implements ToXContentObject, Validatable {
         if (requestFieldStatistics == false) builder.field("field_statistics", false);
         if (requestTermStatistics) builder.field("term_statistics", true);
         if (perFieldAnalyzer != null) builder.field("per_field_analyzer", perFieldAnalyzer);
+        if (routing != null) builder.field("routing", routing);
 
         if (docBuilder != null) {
             BytesReference doc = BytesReference.bytes(docBuilder);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This adds a missing field to the TermVectorsRequest serialization. Otherwise, TermVectors calls on routed indexes will fail.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
