### PR TITLE
Fix unexpected lenient behavior with wildcard fields in query_string

### DIFF
--- a/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java
@@ -889,21 +889,21 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
         boolean isLenient = lenient == null ? context.queryStringLenient() : lenient;
         if (defaultField != null) {
             if (Regex.isMatchAllPattern(defaultField)) {
-                queryParser = new QueryStringQueryParser(context, lenient == null ? true : lenient);
+                queryParser = new QueryStringQueryParser(context, isLenient);
             } else {
                 queryParser = new QueryStringQueryParser(context, defaultField, isLenient);
             }
         } else if (fieldsAndWeights.size() > 0) {
             final Map<String, Float> resolvedFields = QueryParserHelper.resolveMappingFields(context, fieldsAndWeights);
             if (QueryParserHelper.hasAllFieldsWildcard(fieldsAndWeights.keySet())) {
-                queryParser = new QueryStringQueryParser(context, resolvedFields, lenient == null ? true : lenient);
+                queryParser = new QueryStringQueryParser(context, resolvedFields, isLenient);
             } else {
                 queryParser = new QueryStringQueryParser(context, resolvedFields, isLenient);
             }
         } else {
             List<String> defaultFields = context.defaultFields();
             if (QueryParserHelper.hasAllFieldsWildcard(defaultFields)) {
-                queryParser = new QueryStringQueryParser(context, lenient == null ? true : lenient);
+                queryParser = new QueryStringQueryParser(context, isLenient);
             } else {
                 final Map<String, Float> resolvedFields = QueryParserHelper.resolveMappingFields(
                     context,


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
When using wildcard fields (`"*"`) in query_string queries, lenient mode was being forced to true regardless of explicit user settings.
This change ensures consistent lenient behavior by using the properly calculated `isLenient` value instead of forcing lenient=true.

### Related Issues
Resolves #18886

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
