### PR TITLE
Return 404 for missing indices in cluster health API instead of RED w…

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -419,13 +419,9 @@ public class TransportClusterHealthAction extends TransportClusterManagerNodeRea
             }
         }
         if (CollectionUtils.isEmpty(request.indices()) == false) {
-            try {
-                indexNameExpressionResolver.concreteIndexNames(clusterState, IndicesOptions.strictExpand(), request);
-                waitForCounter++;
-            } catch (IndexNotFoundException e) {
-                response.setStatus(ClusterHealthStatus.RED); // no indices, make sure its RED
-                // missing indices, wait a bit more...
-            }
+            indexNameExpressionResolver.concreteIndexNames(clusterState, IndicesOptions.strictExpand(), request);
+            waitForCounter++;
+
         }
         if (!request.waitForNodes().isEmpty()) {
             if (request.waitForNodes().startsWith(">=")) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR Changes the behaviour of the cluster health API when a non-existing-index is requested.
Previously, the API would wait until timeout and returns  RED status of cluster
With this change, the API now immediately throws `IndexNotFoundException`, which maps to HTTP 404.  

### Related Issues
Resolves #19022 


### Check List
- [ ] Functionality includes testing.
  - Updated `ClusterHealthIT` to expect `IndexNotFoundException` instead of `RED` for missing indices.
  - Updated/added unit tests in `ClusterStateHealthTests` to validate immediate 404 behavior.
- [ ] API changes companion pull request created, if applicable. (N/A, no REST spec change)
- [ ] Public documentation issue/PR created, if applicable. (Can be added if maintainers request doc update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
