### PR TITLE
[Pull-based Ingestion] Fix ingestion pause state initialization on replica promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Grant access to testclusters dir for tests ([#19085](https://github.com/opensearch-project/OpenSearch/issues/19085))
 - Fix assertion error when collapsing search results with concurrent segment search enabled ([#19053](https://github.com/opensearch-project/OpenSearch/pull/19053))
 - Fix skip_unavailable setting changing to default during node drop issue ([#18766](https://github.com/opensearch-project/OpenSearch/pull/18766))
+- Fix pull-based ingestion pause state initialization during replica promotion ([#19212](https://github.com/opensearch-project/OpenSearch/pull/19212))
 
 ### Dependencies
 - Bump `com.netflix.nebula.ospackage-base` from 12.0.0 to 12.1.0 ([#19019](https://github.com/opensearch-project/OpenSearch/pull/19019))

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -157,6 +157,8 @@ public class DefaultStreamPoller implements StreamPoller {
         this.errorStrategy = errorStrategy;
         this.indexName = indexSettings.getIndex().getName();
 
+        // handle initial poller states
+        this.paused = initialState == State.PAUSED;
     }
 
     @Override


### PR DESCRIPTION
### Description
Ingestion state was persisted in the cluster state on calling Pause API but the poller was not considering this on replica promotion. Initialize the poller state correctly by considering the initial state passed by the engine. This should avoid the pollers resuming ingestion on replica promotion, and also fix flaky tests.

### Related Issues
Resolves #17693

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
