### PR TITLE
Add Atri Sharma as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,6 +11,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Andriy Redko      | [reta](https://github.com/reta)                         | Independent |
 | Ankit Jain        | [jainankitk](https://github.com/jainankitk)             | Amazon      |
 | Ashish Singh      | [ashking94](https://github.com/ashking94)               | Amazon      |
+| Atri Sharma       | [atris](https://github.com/atris)                       | Apple       |
 | Bharathwaj G      | [bharath-techie](https://github.com/bharath-techie)     | Amazon      |
 | Bukhtawar Khan    | [Bukhtawar](https://github.com/Bukhtawar)               | Amazon      |
 | Charlotte Henkle  | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |


### PR DESCRIPTION
Following the [nomination process](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer), I have nominated and other maintainers have agreed to add Atri Sharma (@atris ) as a co-maintainer of the OpenSearch repository. He has gratiously accepted the invitation.

---

Atri has become a very active contributor to OpenSearch. He implemented [temporal-based routing processors](https://github.com/opensearch-project/OpenSearch/issues/18920) that allows for temporal locality at a shard level for time-based workloads. He leveraged existing primitives (search and ingest processors) to implement the feature which allows users to enable it with no client-side changes. He also implemented two other enhancements to document routing for [ACL-based routing](https://github.com/opensearch-project/OpenSearch/issues/18829) and [hierarchy-based routing](https://github.com/opensearch-project/OpenSearch/issues/18816).
 
Beyond his own work, he has contributed fixes for 5 flaky tests not directly related to code he introduced (with at least one more currently in progress). He has also been an active reviewer, commenting on a total of [20 pull requests](https://github.com/opensearch-project/OpenSearch/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen+commenter%3Aatris).

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
