### PR TITLE
Use gradle version catalog for plugins/telemetry-otel

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -157,6 +157,24 @@ roaringbitmap = { group = "org.roaringbitmap", name = "RoaringBitmap", version.r
 spatial4j = { group = "org.locationtech.spatial4j", name = "spatial4j", version.ref = "spatial4j" }
 tdigest = { group = "com.tdunning", name = "t-digest", version.ref = "tdigest" }
 
+# OpenTelemetry libraries
+opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api", version.ref = "opentelemetry" }
+opentelemetry-common = { group = "io.opentelemetry", name = "opentelemetry-common", version.ref = "opentelemetry" }
+opentelemetry-context = { group = "io.opentelemetry", name = "opentelemetry-context", version.ref = "opentelemetry" }
+opentelemetry-sdk = { group = "io.opentelemetry", name = "opentelemetry-sdk", version.ref = "opentelemetry" }
+opentelemetry-sdk-common = { group = "io.opentelemetry", name = "opentelemetry-sdk-common", version.ref = "opentelemetry" }
+opentelemetry-sdk-trace = { group = "io.opentelemetry", name = "opentelemetry-sdk-trace", version.ref = "opentelemetry" }
+opentelemetry-sdk-metrics = { group = "io.opentelemetry", name = "opentelemetry-sdk-metrics", version.ref = "opentelemetry" }
+opentelemetry-sdk-logs = { group = "io.opentelemetry", name = "opentelemetry-sdk-logs", version.ref = "opentelemetry" }
+opentelemetry-exporter-logging = { group = "io.opentelemetry", name = "opentelemetry-exporter-logging", version.ref = "opentelemetry" }
+opentelemetry-exporter-otlp = { group = "io.opentelemetry", name = "opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
+opentelemetry-exporter-common = { group = "io.opentelemetry", name = "opentelemetry-exporter-common", version.ref = "opentelemetry" }
+opentelemetry-exporter-otlp-common = { group = "io.opentelemetry", name = "opentelemetry-exporter-otlp-common", version.ref = "opentelemetry" }
+opentelemetry-exporter-sender-okhttp = { group = "io.opentelemetry", name = "opentelemetry-exporter-sender-okhttp", version.ref = "opentelemetry" }
+opentelemetry-semconv = { group = "io.opentelemetry.semconv", name = "opentelemetry-semconv", version.ref = "opentelemetrysemconv" }
+opentelemetry-sdk-testing = { group = "io.opentelemetry", name = "opentelemetry-sdk-testing", version.ref = "opentelemetry" }
+kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+
 [bundles]
 asm = [
     "asm-analysis",
@@ -207,4 +225,20 @@ bouncycastle = [
     "bouncycastle-pkix",
     "bouncycastle-pg",
     "bouncycastle-util"
+]
+
+opentelemetry = [
+    "opentelemetry-api",
+    "opentelemetry-common",
+    "opentelemetry-context",
+    "opentelemetry-sdk",
+    "opentelemetry-sdk-common",
+    "opentelemetry-sdk-trace",
+    "opentelemetry-sdk-metrics",
+    "opentelemetry-sdk-logs",
+    "opentelemetry-exporter-logging",
+    "opentelemetry-exporter-otlp",
+    "opentelemetry-exporter-common",
+    "opentelemetry-exporter-otlp-common",
+    "opentelemetry-semconv"
 ]

--- a/plugins/telemetry-otel/build.gradle
+++ b/plugins/telemetry-otel/build.gradle
@@ -21,25 +21,13 @@ opensearchplugin {
 
 dependencies {
   api project(":libs:opensearch-telemetry")
-  api "io.opentelemetry:opentelemetry-api:${versions.opentelemetry}"
-  api "io.opentelemetry:opentelemetry-common:${versions.opentelemetry}"
-  api "io.opentelemetry:opentelemetry-context:${versions.opentelemetry}"
-  api "io.opentelemetry:opentelemetry-sdk:${versions.opentelemetry}"
-  api "io.opentelemetry:opentelemetry-sdk-common:${versions.opentelemetry}"
-  api "io.opentelemetry:opentelemetry-sdk-trace:${versions.opentelemetry}"
-  api "io.opentelemetry:opentelemetry-sdk-metrics:${versions.opentelemetry}"
-  api "io.opentelemetry:opentelemetry-exporter-logging:${versions.opentelemetry}"
-  api "io.opentelemetry.semconv:opentelemetry-semconv:${versions.opentelemetrysemconv}"
-  api "io.opentelemetry:opentelemetry-sdk-logs:${versions.opentelemetry}"
-  api "io.opentelemetry:opentelemetry-exporter-otlp:${versions.opentelemetry}"
-  api "io.opentelemetry:opentelemetry-exporter-common:${versions.opentelemetry}"
-  api "io.opentelemetry:opentelemetry-exporter-otlp-common:${versions.opentelemetry}"
-  runtimeOnly "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
+  api libs.bundles.opentelemetry
+  api "io.opentelemetry:opentelemetry-api-incubator:${libs.versions.opentelemetry.get()}-alpha"
+  runtimeOnly libs.kotlin.stdlib
   runtimeOnly "com.squareup.okhttp3:okhttp:4.11.0"
   runtimeOnly "com.squareup.okio:okio-jvm:3.5.0"
-  runtimeOnly "io.opentelemetry:opentelemetry-exporter-sender-okhttp:${versions.opentelemetry}"
-  api "io.opentelemetry:opentelemetry-api-incubator:${versions.opentelemetry}-alpha"
-  testImplementation "io.opentelemetry:opentelemetry-sdk-testing:${versions.opentelemetry}"
+  runtimeOnly libs.opentelemetry.exporter.sender.okhttp
+  testImplementation libs.opentelemetry.sdk.testing
 }
 
 


### PR DESCRIPTION
### Description

Use gradle version catalog for plugins/telemetry-otel

This will allow dependabot to monitor otel deps properly.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
