### PR TITLE
Add min/max size methods for MemorySizeSetting

### DIFF
--- a/server/src/test/java/org/opensearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/opensearch/common/settings/SettingTests.java
@@ -1383,16 +1383,21 @@ public class SettingTests extends OpenSearchTestCase {
     // MemorySizeValue
     public void testMemorySizeValueParser() throws Exception {
         String expectedKey = "test key";
-        MemorySizeValueParser memorySizeValueParser = new MemorySizeValueParser(expectedKey);
+        MemorySizeValueParser memorySizeValueParserWithoutBounds = new MemorySizeValueParser(expectedKey);
+        MemorySizeValueParser memorySizeValueParserWithBounds = new MemorySizeValueParser(expectedKey, "0%", "10%");
+        for (MemorySizeValueParser memorySizeValueParser : List.of(memorySizeValueParserWithBounds, memorySizeValueParserWithoutBounds)) {
 
-        assertEquals(expectedKey, memorySizeValueParser.getKey());
+            assertEquals(expectedKey, memorySizeValueParser.getKey());
 
-        try (BytesStreamOutput out = new BytesStreamOutput()) {
-            memorySizeValueParser.writeTo(out);
-            out.flush();
-            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
-                memorySizeValueParser = new MemorySizeValueParser(in);
-                assertEquals(expectedKey, memorySizeValueParser.getKey());
+            try (BytesStreamOutput out = new BytesStreamOutput()) {
+                memorySizeValueParser.writeTo(out);
+                out.flush();
+                try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+                    MemorySizeValueParser deserialized = new MemorySizeValueParser(in);
+                    assertEquals(expectedKey, deserialized.getKey());
+                    assertEquals(memorySizeValueParser.getMax(), deserialized.getMax());
+                    assertEquals(memorySizeValueParser.getMin(), deserialized.getMin());
+                }
             }
         }
     }


### PR DESCRIPTION
### Description
Adds convenience methods allowing min/max values for MemorySizeSetting (settings which are parsed from either byte value strings like "500kb" or percentages of the total heap size like "1%"). The min/max arguments are strings which are parsed by the same parser as the default value, so they can also be either byte value strings or percentage strings.

### Related Issues
Didn't raise an issue for this as it's pretty minor, but came up in review for https://github.com/opensearch-project/OpenSearch/pull/19152. Separated it out as it was not really that related to the original PR and required its own tests, etc. 

### Check List
- [x] Functionality includes testing.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
