### PR TITLE
Enable include_named_queries_score to be used in msearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.x]
 ### Added
+- Add support for include_named_queries_score in msearch ([#19102](https://github.com/opensearch-project/OpenSearch/issues/19102))
 - Add support for forward translog reading ([#20163](https://github.com/opensearch-project/OpenSearch/pull/20163))
 - Added public getter method in `SourceFieldMapper` to return excluded field ([#20205](https://github.com/opensearch-project/OpenSearch/pull/20205))
 

--- a/server/src/main/java/org/opensearch/search/SearchHit.java
+++ b/server/src/main/java/org/opensearch/search/SearchHit.java
@@ -64,7 +64,6 @@ import org.opensearch.index.mapper.IgnoredFieldMapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.SourceFieldMapper;
 import org.opensearch.index.seqno.SequenceNumbers;
-import org.opensearch.rest.action.search.RestSearchAction;
 import org.opensearch.search.fetch.subphase.highlight.HighlightField;
 import org.opensearch.search.lookup.SourceLookup;
 import org.opensearch.transport.RemoteClusterAware;
@@ -731,8 +730,8 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
         }
         sortValues.toXContent(builder, params);
         if (!matchedQueries.isEmpty()) {
-            boolean includeMatchedQueriesScore = params.paramAsBoolean(RestSearchAction.INCLUDE_NAMED_QUERIES_SCORE_PARAM, false);
-            if (includeMatchedQueriesScore) {
+            boolean includeNamedQueriesScore = matchedQueries.values().stream().anyMatch(value -> value != null && !Float.isNaN(value));
+            if (includeNamedQueriesScore) {
                 builder.startObject(Fields.MATCHED_QUERIES);
                 for (Map.Entry<String, Float> entry : matchedQueries.entrySet()) {
                     builder.field(entry.getKey(), entry.getValue());

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -1571,7 +1571,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             }
         }
         context.trackScores(source.trackScores());
-        context.includeNamedQueriesScore(source.includeNamedQueriesScore());
+        if (source.includeNamedQueriesScore() != null) {
+            context.includeNamedQueriesScore(source.includeNamedQueriesScore());
+        }
         if (source.trackTotalHitsUpTo() != null
             && source.trackTotalHitsUpTo() != SearchContext.TRACK_TOTAL_HITS_ACCURATE
             && context.scrollContext() != null) {

--- a/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java
@@ -625,7 +625,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
      * Applies when there are named queries, to return the scores along as well
      * Defaults to {@code false}.
      */
-    public SearchSourceBuilder includeNamedQueriesScores(boolean includeNamedQueriesScore) {
+    public SearchSourceBuilder includeNamedQueriesScores(Boolean includeNamedQueriesScore) {
         this.includeNamedQueriesScore = includeNamedQueriesScore;
         return this;
     }
@@ -633,8 +633,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     /**
      * Indicates whether scores will be returned as part of every search matched query.s
      */
-    public boolean includeNamedQueriesScore() {
-        return includeNamedQueriesScore != null && includeNamedQueriesScore;
+    public Boolean includeNamedQueriesScore() {
+        return includeNamedQueriesScore;
     }
 
     /**


### PR DESCRIPTION
Enables support for the `include_named_queries_score` query parameter in the `msearch` endpoint.

It also fixes an bug with the `search` endpoint where setting `include_named_queries_score` to `true` 
in the request body (rather than as a URL query parameter) would trigger the computation of named query scores
but not include them in the `SearchHit` output. This was because `SearchHit` previosuly used the URL query parameter
to determine whether to write the scores, instead of checking if the scores were present. Fixing this also enables 
`include_named_queries_score` to be specified in individual search request bodies in `msearch` with no query parameter.

Do I need to 

### Related Issues
Resolves #19102
API changes companion pull request https://github.com/opensearch-project/opensearch-api-specification/pull/955
Public documentation issue/PR https://github.com/opensearch-project/documentation-website/pull/10888

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `include_named_queries_score` parameter in multi-search requests. When specified at the multi-search level, it automatically applies to individual search requests that don't explicitly set their own value.

* **Enhancements**
  * Improved handling of matched query scores in search results based on actual score values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->