### PR TITLE
 Add query planner Phase 2: logical planning and cost estimation

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
@@ -39,6 +39,7 @@ public class FeatureFlagSettings extends AbstractScopedSettings {
         FeatureFlags.TERM_VERSION_PRECOMMIT_ENABLE_SETTING,
         FeatureFlags.ARROW_STREAMS_SETTING,
         FeatureFlags.STREAM_TRANSPORT_SETTING,
-        FeatureFlags.MERGED_SEGMENT_WARMER_EXPERIMENTAL_SETTING
+        FeatureFlags.MERGED_SEGMENT_WARMER_EXPERIMENTAL_SETTING,
+        FeatureFlags.QUERY_PLANNER_SETTING
     );
 }

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -121,6 +121,12 @@ public class FeatureFlags {
     public static final Setting<Boolean> ARROW_STREAMS_SETTING = Setting.boolSetting(ARROW_STREAMS, false, Property.NodeScope);
 
     /**
+     * Gates the query planner functionality.
+     */
+    public static final String QUERY_PLANNER = FEATURE_FLAG_PREFIX + "query_planner.enabled";
+    public static final Setting<Boolean> QUERY_PLANNER_SETTING = Setting.boolSetting(QUERY_PLANNER, false, Property.NodeScope);
+
+    /**
      * Underlying implementation for feature flags.
      * All settable feature flags are tracked here in FeatureFlagsImpl.featureFlags.
      * Contains all functionality across test and server use cases.
@@ -146,6 +152,7 @@ public class FeatureFlags {
                 put(ARROW_STREAMS_SETTING, ARROW_STREAMS_SETTING.getDefault(Settings.EMPTY));
                 put(STREAM_TRANSPORT_SETTING, STREAM_TRANSPORT_SETTING.getDefault(Settings.EMPTY));
                 put(MERGED_SEGMENT_WARMER_EXPERIMENTAL_SETTING, MERGED_SEGMENT_WARMER_EXPERIMENTAL_SETTING.getDefault(Settings.EMPTY));
+                put(QUERY_PLANNER_SETTING, QUERY_PLANNER_SETTING.getDefault(Settings.EMPTY));
             }
         };
 

--- a/server/src/main/java/org/opensearch/search/planner/AbstractQueryPlanNode.java
+++ b/server/src/main/java/org/opensearch/search/planner/AbstractQueryPlanNode.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.apache.lucene.search.Query;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Base implementation of QueryPlanNode providing common functionality.
+ *
+ * @opensearch.internal
+ */
+public abstract class AbstractQueryPlanNode implements QueryPlanNode {
+
+    protected final Query luceneQuery;
+    protected final QueryNodeType nodeType;
+    protected final List<QueryPlanNode> children;
+    protected volatile QueryCost estimatedCost;
+
+    protected AbstractQueryPlanNode(Query luceneQuery, QueryNodeType nodeType) {
+        this(luceneQuery, nodeType, Collections.emptyList());
+    }
+
+    protected AbstractQueryPlanNode(Query luceneQuery, QueryNodeType nodeType, List<QueryPlanNode> children) {
+        this.luceneQuery = luceneQuery;
+        this.nodeType = nodeType;
+        this.children = Collections.unmodifiableList(children);
+    }
+
+    @Override
+    public Query getLuceneQuery() {
+        return luceneQuery;
+    }
+
+    @Override
+    public QueryNodeType getType() {
+        return nodeType;
+    }
+
+    @Override
+    public List<QueryPlanNode> getChildren() {
+        return children;
+    }
+
+    @Override
+    public QueryCost getEstimatedCost() {
+        QueryCost cost = estimatedCost;
+        if (cost == null) {
+            cost = calculateCost();
+            estimatedCost = cost;
+        }
+        return cost;
+    }
+
+    /**
+     * Calculate the cost for this node. Subclasses should implement
+     * their specific cost calculation logic.
+     */
+    protected abstract QueryCost calculateCost();
+
+    @Override
+    public QueryPlanProfile getProfile() {
+        QueryPlanProfile profile = new QueryPlanProfile(nodeType.name(), getEstimatedCost());
+        addProfileAttributes(profile);
+        return profile;
+    }
+
+    /**
+     * Add node-specific attributes to the profile.
+     * Subclasses can override to add custom attributes.
+     */
+    protected void addProfileAttributes(QueryPlanProfile profile) {
+        profile.addAttribute("lucene_query", luceneQuery.toString());
+        profile.addAttribute("children_count", children.size());
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(nodeType.name()).append("[");
+        sb.append("query=").append(luceneQuery.getClass().getSimpleName());
+        sb.append(", cost=").append(getEstimatedCost().getTotalCost());
+        if (!children.isEmpty()) {
+            sb.append(", children=").append(children.size());
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/CostEstimator.java
+++ b/server/src/main/java/org/opensearch/search/planner/CostEstimator.java
@@ -1,0 +1,177 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Weight;
+import org.opensearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Estimates query costs by combining Lucene's cost model with OpenSearch-specific heuristics.
+ *
+ * @opensearch.internal
+ */
+public class CostEstimator {
+
+    private final QueryShardContext queryShardContext;
+    private final IndexSearcher searcher;
+    private final IndexReader reader;
+
+    // Cost multipliers for different query types
+    private static final Map<String, CostMultipliers> QUERY_COST_MULTIPLIERS = new HashMap<>();
+
+    static {
+        // Initialize cost multipliers
+        QUERY_COST_MULTIPLIERS.put("Script", new CostMultipliers(10.0, 2.0, 1.0));
+        QUERY_COST_MULTIPLIERS.put("Fuzzy", new CostMultipliers(5.0, 3.0, 1.0));
+        QUERY_COST_MULTIPLIERS.put("Regexp", new CostMultipliers(5.0, 3.0, 1.0));
+        QUERY_COST_MULTIPLIERS.put("Wildcard", new CostMultipliers(2.0, 1.0, 2.0));
+        QUERY_COST_MULTIPLIERS.put("Prefix", new CostMultipliers(2.0, 1.0, 2.0));
+        QUERY_COST_MULTIPLIERS.put("Range", new CostMultipliers(1.0, 1.0, 1.5));
+        QUERY_COST_MULTIPLIERS.put("Nested", new CostMultipliers(2.0, 2.0, 1.0));
+        QUERY_COST_MULTIPLIERS.put("FunctionScore", new CostMultipliers(3.0, 1.0, 1.0));
+    }
+
+    private static class CostMultipliers {
+        final double cpu;
+        final double memory;
+        final double io;
+
+        CostMultipliers(double cpu, double memory, double io) {
+            this.cpu = cpu;
+            this.memory = memory;
+            this.io = io;
+        }
+    }
+
+    public CostEstimator(QueryShardContext queryShardContext) {
+        this.queryShardContext = queryShardContext;
+        this.searcher = queryShardContext.searcher();
+        this.reader = searcher != null ? searcher.getIndexReader() : null;
+    }
+
+    /**
+     * Estimates the document frequency for a term.
+     */
+    public long estimateTermDocFrequency(String field, String value) {
+        if (reader == null) {
+            // Default estimate if no reader available
+            return 100;
+        }
+
+        try {
+            Term term = new Term(field, value);
+            return reader.docFreq(term);
+        } catch (IOException e) {
+            // Fall back to estimate
+            return 100;
+        }
+    }
+
+    /**
+     * Gets the total number of documents in the index.
+     */
+    public long getTotalDocs() {
+        if (reader == null) {
+            return 10000; // Default estimate
+        }
+        return reader.maxDoc();
+    }
+
+    /**
+     * Estimates cost for a generic query using Lucene's Weight API.
+     */
+    public long estimateGenericCost(Query query) {
+        if (searcher == null) {
+            // Fallback estimate based on query type
+            return estimateFallbackCost(query);
+        }
+
+        try {
+            // Create weight to get scorer and cost
+            Weight weight = searcher.createWeight(searcher.rewrite(query), org.apache.lucene.search.ScoreMode.COMPLETE, 1);
+
+            // Aggregate costs across all leaves
+            if (reader != null && !reader.leaves().isEmpty()) {
+                long totalCost = 0;
+                for (var leafContext : reader.leaves()) {
+                    var scorer = weight.scorer(leafContext);
+                    if (scorer != null) {
+                        totalCost += scorer.iterator().cost();
+                    }
+                }
+                if (totalCost > 0) {
+                    return totalCost;
+                }
+            }
+        } catch (IOException e) {
+            // Fall back to estimate
+        }
+
+        return estimateFallbackCost(query);
+    }
+
+    private long estimateFallbackCost(Query query) {
+        // Heuristic estimates when we can't get actual costs
+        String queryType = query.getClass().getSimpleName();
+
+        // Base estimates as percentage of total docs
+        long totalDocs = getTotalDocs();
+
+        if (queryType.contains("MatchAllDocs")) {
+            return totalDocs;
+        } else if (queryType.contains("Term")) {
+            return totalDocs / 100; // ~1% of docs
+        } else if (queryType.contains("Range")) {
+            return totalDocs / 10; // ~10% of docs
+        } else if (queryType.contains("Wildcard") || queryType.contains("Prefix")) {
+            return totalDocs / 5; // ~20% of docs
+        } else if (queryType.contains("Fuzzy") || queryType.contains("Regexp")) {
+            return totalDocs / 2; // ~50% of docs (expensive)
+        }
+
+        // Default: 5% of docs
+        return totalDocs / 20;
+    }
+
+    /**
+     * Estimates additional costs beyond Lucene's document-based cost.
+     */
+    public QueryCost estimateFullCost(Query query, long luceneCost) {
+        String queryType = query.getClass().getSimpleName();
+
+        // Find matching cost multipliers
+        CostMultipliers multipliers = null;
+        for (Map.Entry<String, CostMultipliers> entry : QUERY_COST_MULTIPLIERS.entrySet()) {
+            if (queryType.contains(entry.getKey())) {
+                multipliers = entry.getValue();
+                break;
+            }
+        }
+
+        // Use defaults if no specific multipliers found
+        double cpuMultiplier = multipliers != null ? multipliers.cpu : 1.0;
+        double memoryMultiplier = multipliers != null ? multipliers.memory : 1.0;
+        double ioMultiplier = multipliers != null ? multipliers.io : 1.0;
+
+        // Base costs
+        double cpuCost = 0.001 * cpuMultiplier;
+        long memoryCost = (long) (luceneCost * 8 * memoryMultiplier);
+        double ioCost = 0.01 * ioMultiplier;
+
+        return new QueryCost(luceneCost, cpuCost, memoryCost, ioCost, true);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/CostEstimator.java
+++ b/server/src/main/java/org/opensearch/search/planner/CostEstimator.java
@@ -38,23 +38,23 @@ public class CostEstimator {
     // Cost multipliers for different query types
     private static final Map<String, CostMultipliers> QUERY_COST_MULTIPLIERS = new HashMap<>();
 
-    // Fallback cost fractions
-    private static final double FALLBACK_TERM_FRACTION = 0.01;
-    private static final double FALLBACK_RANGE_FRACTION = 0.1;
-    private static final double FALLBACK_WILDCARD_FRACTION = 0.2;
-    private static final double FALLBACK_FUZZY_FRACTION = 0.5;
-    private static final double FALLBACK_DEFAULT_FRACTION = 0.05;
+    // Fallback cost fractions when actual costs can't be computed
+    private static final double FALLBACK_TERM_FRACTION = 0.008;  // ~0.8% of docs for medium selectivity term
+    private static final double FALLBACK_RANGE_FRACTION = 0.12;   // Ranges typically match more docs
+    private static final double FALLBACK_WILDCARD_FRACTION = 0.18; // Wildcards are expensive
+    private static final double FALLBACK_FUZZY_FRACTION = 0.35;    // Fuzzy matches are very expensive
+    private static final double FALLBACK_DEFAULT_FRACTION = 0.05;  // Conservative default
 
     static {
-        // Initialize cost multipliers
-        QUERY_COST_MULTIPLIERS.put("Script", new CostMultipliers(10.0, 2.0, 1.0));
-        QUERY_COST_MULTIPLIERS.put("Fuzzy", new CostMultipliers(5.0, 3.0, 1.0));
-        QUERY_COST_MULTIPLIERS.put("Regexp", new CostMultipliers(5.0, 3.0, 1.0));
-        QUERY_COST_MULTIPLIERS.put("Wildcard", new CostMultipliers(2.0, 1.0, 2.0));
-        QUERY_COST_MULTIPLIERS.put("Prefix", new CostMultipliers(2.0, 1.0, 2.0));
-        QUERY_COST_MULTIPLIERS.put("Range", new CostMultipliers(1.0, 1.0, 1.5));
-        QUERY_COST_MULTIPLIERS.put("Nested", new CostMultipliers(2.0, 2.0, 1.0));
-        QUERY_COST_MULTIPLIERS.put("FunctionScore", new CostMultipliers(3.0, 1.0, 1.0));
+        // Initialize cost multipliers based on query complexity
+        QUERY_COST_MULTIPLIERS.put("Script", new CostMultipliers(12.5, 2.3, 1.0));
+        QUERY_COST_MULTIPLIERS.put("Fuzzy", new CostMultipliers(4.8, 3.2, 1.1));
+        QUERY_COST_MULTIPLIERS.put("Regexp", new CostMultipliers(5.2, 2.8, 1.0));
+        QUERY_COST_MULTIPLIERS.put("Wildcard", new CostMultipliers(2.3, 1.0, 1.8));
+        QUERY_COST_MULTIPLIERS.put("Prefix", new CostMultipliers(1.7, 1.0, 1.6));
+        QUERY_COST_MULTIPLIERS.put("Range", new CostMultipliers(1.0, 1.0, 1.4));
+        QUERY_COST_MULTIPLIERS.put("Nested", new CostMultipliers(2.1, 2.2, 1.0));
+        QUERY_COST_MULTIPLIERS.put("FunctionScore", new CostMultipliers(3.5, 1.2, 1.0));
     }
 
     private static class CostMultipliers {

--- a/server/src/main/java/org/opensearch/search/planner/LogicalPlanBuilder.java
+++ b/server/src/main/java/org/opensearch/search/planner/LogicalPlanBuilder.java
@@ -1,0 +1,324 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.PointRangeQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TermRangeQuery;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.search.planner.nodes.BooleanPlanNode;
+import org.opensearch.search.planner.nodes.GenericPlanNode;
+import org.opensearch.search.planner.nodes.MatchAllPlanNode;
+import org.opensearch.search.planner.nodes.MatchPlanNode;
+import org.opensearch.search.planner.nodes.RangePlanNode;
+import org.opensearch.search.planner.nodes.TermPlanNode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Builds a logical query plan from OpenSearch QueryBuilder.
+ * This converts the query structure into a tree of QueryPlanNodes
+ * that can be analyzed and optimized.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class LogicalPlanBuilder {
+
+    private final QueryShardContext queryShardContext;
+    private final CostEstimator costEstimator;
+
+    public LogicalPlanBuilder(QueryShardContext queryShardContext) {
+        this.queryShardContext = queryShardContext;
+        this.costEstimator = new CostEstimator(queryShardContext);
+    }
+
+    /**
+     * Builds a logical plan from a QueryBuilder.
+     *
+     * @param queryBuilder The query to build a plan for
+     * @return The root node of the query plan
+     * @throws Exception If the query cannot be converted to Lucene query
+     */
+    public QueryPlanNode build(QueryBuilder queryBuilder) throws Exception {
+        if (queryBuilder == null) {
+            return null;
+        }
+
+        // Try to build directly from QueryBuilder for known types
+        if (queryBuilder instanceof BoolQueryBuilder
+            || queryBuilder instanceof TermQueryBuilder
+            || queryBuilder instanceof RangeQueryBuilder
+            || queryBuilder instanceof MatchQueryBuilder) {
+            return buildFromQueryBuilder(queryBuilder);
+        }
+
+        // Fallback: Rewrite and convert to Lucene query
+        QueryBuilder rewritten = queryBuilder.rewrite(queryShardContext);
+        Query luceneQuery = rewritten.toQuery(queryShardContext);
+        return buildNode(luceneQuery, rewritten);
+    }
+
+    private QueryPlanNode buildNode(Query query, QueryBuilder queryBuilder) throws Exception {
+        if (query instanceof BooleanQuery) {
+            return buildBooleanNode((BooleanQuery) query, queryBuilder);
+        } else if (query instanceof TermQuery) {
+            return buildTermNode((TermQuery) query, queryBuilder);
+        } else if (query instanceof PointRangeQuery || query instanceof TermRangeQuery) {
+            return buildRangeNode(query, queryBuilder);
+        } else if (query instanceof MatchAllDocsQuery) {
+            return buildMatchAllNode(query);
+        } else {
+            // For other query types, create a generic node
+            return buildGenericNode(query, queryBuilder);
+        }
+    }
+
+    private QueryPlanNode buildBooleanNode(BooleanQuery boolQuery, QueryBuilder queryBuilder) throws Exception {
+        // If we have the original BoolQueryBuilder, use it to preserve context
+        if (queryBuilder instanceof BoolQueryBuilder) {
+            return buildFromBoolQueryBuilder((BoolQueryBuilder) queryBuilder);
+        }
+
+        // Otherwise fall back to processing Lucene query
+        List<QueryPlanNode> mustClauses = new ArrayList<>();
+        List<QueryPlanNode> filterClauses = new ArrayList<>();
+        List<QueryPlanNode> shouldClauses = new ArrayList<>();
+        List<QueryPlanNode> mustNotClauses = new ArrayList<>();
+
+        // Process each clause
+        for (BooleanClause clause : boolQuery.clauses()) {
+            Query clauseQuery = clause.query();
+            QueryPlanNode clauseNode = buildNode(clauseQuery, null);
+
+            switch (clause.occur()) {
+                case MUST:
+                    mustClauses.add(clauseNode);
+                    break;
+                case FILTER:
+                    filterClauses.add(clauseNode);
+                    break;
+                case SHOULD:
+                    shouldClauses.add(clauseNode);
+                    break;
+                case MUST_NOT:
+                    mustNotClauses.add(clauseNode);
+                    break;
+            }
+        }
+
+        int minimumShouldMatch = boolQuery.getMinimumNumberShouldMatch();
+
+        return new BooleanPlanNode(boolQuery, mustClauses, filterClauses, shouldClauses, mustNotClauses, minimumShouldMatch);
+    }
+
+    private QueryPlanNode buildTermNode(TermQuery termQuery, QueryBuilder queryBuilder) {
+        // If we have the original TermQueryBuilder, use it
+        if (queryBuilder instanceof TermQueryBuilder) {
+            try {
+                return buildFromTermQueryBuilder((TermQueryBuilder) queryBuilder);
+            } catch (Exception e) {
+                // Fall back to Lucene query processing
+            }
+        }
+
+        String field = termQuery.getTerm().field();
+        String value = termQuery.getTerm().text();
+
+        // Estimate document frequency
+        long estimatedDocFreq = costEstimator.estimateTermDocFrequency(field, value);
+
+        return new TermPlanNode(termQuery, field, value, estimatedDocFreq);
+    }
+
+    private QueryPlanNode buildMatchAllNode(Query query) {
+        return new MatchAllPlanNode(query, costEstimator.getTotalDocs());
+    }
+
+    private QueryPlanNode buildRangeNode(Query query, QueryBuilder queryBuilder) {
+        // If we have the original RangeQueryBuilder, use it
+        if (queryBuilder instanceof RangeQueryBuilder) {
+            try {
+                return buildFromRangeQueryBuilder((RangeQueryBuilder) queryBuilder);
+            } catch (Exception e) {
+                // Fall back to Lucene query processing
+            }
+        }
+
+        // Try to extract field information from the query
+        String field = null;
+        Object from = null;
+        Object to = null;
+        boolean includeFrom = true;
+        boolean includeTo = true;
+        
+        if (query instanceof PointRangeQuery) {
+            PointRangeQuery prq = (PointRangeQuery) query;
+            field = prq.getField();
+            // Point range queries use byte arrays - would need field type info for proper conversion
+        } else if (query instanceof TermRangeQuery) {
+            TermRangeQuery trq = (TermRangeQuery) query;
+            field = trq.getField();
+            from = trq.getLowerTerm() != null ? trq.getLowerTerm().utf8ToString() : null;
+            to = trq.getUpperTerm() != null ? trq.getUpperTerm().utf8ToString() : null;
+            includeFrom = trq.includesLower();
+            includeTo = trq.includesUpper();
+        }
+        
+        long estimatedDocs = costEstimator.estimateGenericCost(query);
+        return new RangePlanNode(query, field, from, to, includeFrom, includeTo, estimatedDocs);
+    }
+
+    private QueryPlanNode buildGenericNode(Query query, QueryBuilder queryBuilder) {
+        // For queries we don't have specific nodes for yet
+        return new GenericPlanNode(query, determineNodeType(query), costEstimator.estimateGenericCost(query));
+    }
+
+    private QueryNodeType determineNodeType(Query query) {
+        String className = query.getClass().getSimpleName();
+
+        // Map query class names to node types
+        for (QueryNodeType type : QueryNodeType.values()) {
+            if (type == QueryNodeType.OTHER) continue;
+
+            String typeName = type.name();
+            if (type == QueryNodeType.VECTOR && className.contains("KNN")) {
+                return type;
+            }
+
+            // Convert enum name to class name pattern (e.g., FUNCTION_SCORE -> FunctionScore)
+            String pattern = typeName.replace("_", "");
+            if (className.toUpperCase(Locale.ROOT).contains(pattern)) {
+                return type;
+            }
+        }
+
+        return QueryNodeType.OTHER;
+    }
+
+    /**
+     * Builds a query plan node directly from a QueryBuilder without converting to Lucene query.
+     * This preserves field names, values, and other metadata.
+     */
+    private QueryPlanNode buildFromQueryBuilder(QueryBuilder queryBuilder) throws Exception {
+        if (queryBuilder instanceof BoolQueryBuilder) {
+            return buildFromBoolQueryBuilder((BoolQueryBuilder) queryBuilder);
+        } else if (queryBuilder instanceof TermQueryBuilder) {
+            return buildFromTermQueryBuilder((TermQueryBuilder) queryBuilder);
+        } else if (queryBuilder instanceof RangeQueryBuilder) {
+            return buildFromRangeQueryBuilder((RangeQueryBuilder) queryBuilder);
+        } else if (queryBuilder instanceof MatchQueryBuilder) {
+            return buildFromMatchQueryBuilder((MatchQueryBuilder) queryBuilder);
+        }
+
+        // Fallback to Lucene conversion
+        QueryBuilder rewritten = queryBuilder.rewrite(queryShardContext);
+        Query luceneQuery = rewritten.toQuery(queryShardContext);
+        return buildNode(luceneQuery, rewritten);
+    }
+
+    private QueryPlanNode buildFromBoolQueryBuilder(BoolQueryBuilder boolQuery) throws Exception {
+        List<QueryPlanNode> mustClauses = new ArrayList<>();
+        List<QueryPlanNode> filterClauses = new ArrayList<>();
+        List<QueryPlanNode> shouldClauses = new ArrayList<>();
+        List<QueryPlanNode> mustNotClauses = new ArrayList<>();
+
+        // Build child nodes for each clause type
+        for (QueryBuilder must : boolQuery.must()) {
+            mustClauses.add(buildFromQueryBuilder(must));
+        }
+        for (QueryBuilder filter : boolQuery.filter()) {
+            filterClauses.add(buildFromQueryBuilder(filter));
+        }
+        for (QueryBuilder should : boolQuery.should()) {
+            shouldClauses.add(buildFromQueryBuilder(should));
+        }
+        for (QueryBuilder mustNot : boolQuery.mustNot()) {
+            mustNotClauses.add(buildFromQueryBuilder(mustNot));
+        }
+
+        // Get minimum should match
+        String minimumShouldMatch = boolQuery.minimumShouldMatch();
+        int minShouldMatch = 0;
+        if (minimumShouldMatch != null) {
+            try {
+                minShouldMatch = Integer.parseInt(minimumShouldMatch);
+            } catch (NumberFormatException e) {
+                // Handle percentage or other formats - for now default to 0
+            }
+        }
+
+        Query luceneQuery = boolQuery.rewrite(queryShardContext).toQuery(queryShardContext);
+
+        return new BooleanPlanNode((BooleanQuery) luceneQuery, mustClauses, filterClauses, shouldClauses, mustNotClauses, minShouldMatch);
+    }
+
+    private QueryPlanNode buildFromTermQueryBuilder(TermQueryBuilder termQuery) throws Exception {
+        String field = termQuery.fieldName();
+        Object value = termQuery.value();
+
+        // Estimate document frequency
+        long estimatedDocFreq = costEstimator.estimateTermDocFrequency(field, value.toString());
+
+        // Create Lucene query
+        Query luceneQuery = termQuery.rewrite(queryShardContext).toQuery(queryShardContext);
+
+        return new TermPlanNode(luceneQuery, field, value, estimatedDocFreq);
+    }
+
+    private QueryPlanNode buildFromRangeQueryBuilder(RangeQueryBuilder rangeQuery) throws Exception {
+        String field = rangeQuery.fieldName();
+        Object from = rangeQuery.from();
+        Object to = rangeQuery.to();
+        boolean includeFrom = rangeQuery.includeLower();
+        boolean includeTo = rangeQuery.includeUpper();
+
+        Query luceneQuery = rangeQuery.rewrite(queryShardContext).toQuery(queryShardContext);
+        
+        long estimatedDocs;
+        try {
+            estimatedDocs = costEstimator.estimateGenericCost(luceneQuery);
+        } catch (Exception e) {
+            estimatedDocs = costEstimator.getTotalDocs() / 10;
+        }
+
+        return new RangePlanNode(luceneQuery, field, from, to, includeFrom, includeTo, estimatedDocs);
+    }
+
+    private QueryPlanNode buildFromMatchQueryBuilder(MatchQueryBuilder matchQuery) throws Exception {
+        String field = matchQuery.fieldName();
+        String text = matchQuery.value().toString();
+        String analyzer = matchQuery.analyzer();
+
+        int termCount = Math.max(1, Math.min(10, text.split("\\s+").length));
+        
+        Query luceneQuery = matchQuery.rewrite(queryShardContext).toQuery(queryShardContext);
+        
+        long estimatedDocs;
+        try {
+            estimatedDocs = costEstimator.estimateGenericCost(luceneQuery);
+        } catch (Exception e) {
+            estimatedDocs = costEstimator.getTotalDocs() / 20;
+        }
+
+        return new MatchPlanNode(luceneQuery, field, text, analyzer, termCount, estimatedDocs);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/LogicalPlanBuilder.java
+++ b/server/src/main/java/org/opensearch/search/planner/LogicalPlanBuilder.java
@@ -36,7 +36,6 @@ import org.opensearch.search.planner.nodes.TermPlanNode;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * Builds logical query plans from OpenSearch QueryBuilder.
@@ -209,22 +208,16 @@ public class LogicalPlanBuilder {
     }
 
     private QueryNodeType determineNodeType(Query query) {
-        String className = query.getClass().getSimpleName();
-
-        // Map query class names to node types
-        for (QueryNodeType type : QueryNodeType.values()) {
-            if (type == QueryNodeType.OTHER) continue;
-
-            String typeName = type.name();
-            if (type == QueryNodeType.VECTOR && className.contains("KNN")) {
-                return type;
-            }
-
-            // Convert enum name to class name pattern (e.g., FUNCTION_SCORE -> FunctionScore)
-            String pattern = typeName.replace("_", "");
-            if (className.toUpperCase(Locale.ROOT).contains(pattern)) {
-                return type;
-            }
+        // We only handle specific types in our plan nodes currently
+        // Add more specific cases as we implement specialized plan nodes
+        if (query instanceof org.apache.lucene.search.WildcardQuery) {
+            return QueryNodeType.WILDCARD;
+        } else if (query instanceof org.apache.lucene.search.PrefixQuery) {
+            return QueryNodeType.PREFIX;
+        } else if (query instanceof org.apache.lucene.search.FuzzyQuery) {
+            return QueryNodeType.FUZZY;
+        } else if (query instanceof org.apache.lucene.search.RegexpQuery) {
+            return QueryNodeType.REGEXP;
         }
 
         return QueryNodeType.OTHER;

--- a/server/src/main/java/org/opensearch/search/planner/QueryCost.java
+++ b/server/src/main/java/org/opensearch/search/planner/QueryCost.java
@@ -1,0 +1,126 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Represents the estimated cost of executing a query.
+ * Combines Lucene's document-based cost with additional factors.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class QueryCost {
+
+    /**
+     * Lucene's cost estimate (typically number of matching documents)
+     */
+    private final long luceneCost;
+
+    /**
+     * Additional CPU cost for complex operations (e.g., script evaluation, analysis)
+     */
+    private final double cpuCost;
+
+    /**
+     * Memory cost estimate in bytes
+     */
+    private final long memoryCost;
+
+    /**
+     * I/O cost factor (e.g., for range queries, wildcard queries)
+     */
+    private final double ioCost;
+
+    /**
+     * Whether this cost is an estimate or actual
+     */
+    private final boolean isEstimate;
+
+    public QueryCost(long luceneCost, double cpuCost, long memoryCost, double ioCost, boolean isEstimate) {
+        this.luceneCost = luceneCost;
+        this.cpuCost = cpuCost;
+        this.memoryCost = memoryCost;
+        this.ioCost = ioCost;
+        this.isEstimate = isEstimate;
+    }
+
+    /**
+     * Creates a cost based only on Lucene's estimate
+     */
+    public static QueryCost fromLucene(long luceneCost) {
+        return new QueryCost(luceneCost, 0.0, 0, 0.0, true);
+    }
+
+    /**
+     * Returns a combined cost score for comparison
+     */
+    public double getTotalCost() {
+        // Weighted combination of different cost factors
+        return luceneCost + (cpuCost * 1000) + (memoryCost / 1024.0) + (ioCost * 100);
+    }
+
+    public long getLuceneCost() {
+        return luceneCost;
+    }
+
+    public double getCpuCost() {
+        return cpuCost;
+    }
+
+    public long getMemoryCost() {
+        return memoryCost;
+    }
+
+    public double getIoCost() {
+        return ioCost;
+    }
+
+    public boolean isEstimate() {
+        return isEstimate;
+    }
+
+    /**
+     * Combines costs from multiple sources (e.g., for boolean queries)
+     */
+    public static QueryCost combine(List<QueryCost> costs, double coordinationOverhead) {
+        long totalLucene = 0;
+        double totalCpu = coordinationOverhead;
+        long totalMemory = 0;
+        double totalIo = 0;
+        boolean allEstimates = true;
+
+        for (QueryCost cost : costs) {
+            totalLucene += cost.luceneCost;
+            totalCpu += cost.cpuCost;
+            totalMemory += cost.memoryCost;
+            totalIo += cost.ioCost;
+            allEstimates &= cost.isEstimate;
+        }
+
+        return new QueryCost(totalLucene, totalCpu, totalMemory, totalIo, allEstimates);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            Locale.ROOT,
+            "QueryCost[lucene=%d, cpu=%.2f, memory=%d, io=%.2f, estimate=%s]",
+            luceneCost,
+            cpuCost,
+            memoryCost,
+            ioCost,
+            isEstimate
+        );
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/QueryNodeType.java
+++ b/server/src/main/java/org/opensearch/search/planner/QueryNodeType.java
@@ -1,0 +1,160 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+/**
+ * Types of query plan nodes, used for optimization and execution strategies.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public enum QueryNodeType {
+    /**
+     * Boolean query with must/should/filter/must_not clauses
+     */
+    BOOLEAN,
+
+    /**
+     * Term query - exact match on a field
+     */
+    TERM,
+
+    /**
+     * Terms query - matches any of multiple values
+     */
+    TERMS,
+
+    /**
+     * Range query - numeric or date range
+     */
+    RANGE,
+
+    /**
+     * Match query - analyzed text search
+     */
+    MATCH,
+
+    /**
+     * Match all query
+     */
+    MATCH_ALL,
+
+    /**
+     * Wildcard query
+     */
+    WILDCARD,
+
+    /**
+     * Prefix query
+     */
+    PREFIX,
+
+    /**
+     * Fuzzy query
+     */
+    FUZZY,
+
+    /**
+     * Regexp query
+     */
+    REGEXP,
+
+    /**
+     * Script query
+     */
+    SCRIPT,
+
+    /**
+     * Nested query
+     */
+    NESTED,
+
+    /**
+     * Function score query
+     */
+    FUNCTION_SCORE,
+
+    /**
+     * Constant score query
+     */
+    CONSTANT_SCORE,
+
+    /**
+     * Disjunction max query
+     */
+    DIS_MAX,
+
+    /**
+     * Multi-match query
+     */
+    MULTI_MATCH,
+
+    /**
+     * Query string query
+     */
+    QUERY_STRING,
+
+    /**
+     * Simple query string
+     */
+    SIMPLE_QUERY_STRING,
+
+    /**
+     * Exists query
+     */
+    EXISTS,
+
+    /**
+     * Geo queries
+     */
+    GEO,
+
+    /**
+     * Vector/KNN queries
+     */
+    VECTOR,
+
+    /**
+     * Unknown or custom query type
+     */
+    OTHER;
+
+    /**
+     * Returns true if this query type typically has high computational cost
+     */
+    public boolean isComputationallyExpensive() {
+        switch (this) {
+            case SCRIPT:
+            case WILDCARD:
+            case REGEXP:
+            case FUZZY:
+            case FUNCTION_SCORE:
+            case VECTOR:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Returns true if this query type benefits from being executed early
+     */
+    public boolean preferEarlyExecution() {
+        switch (this) {
+            case TERM:
+            case TERMS:
+            case EXISTS:
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/QueryPlanNode.java
+++ b/server/src/main/java/org/opensearch/search/planner/QueryPlanNode.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.util.List;
+
+/**
+ * Represents a node in a query execution plan tree.
+ * Wraps a Lucene Query with additional metadata and cost information.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public interface QueryPlanNode {
+
+    /**
+     * Returns the Lucene query wrapped by this plan node.
+     *
+     * @return The Lucene query
+     */
+    Query getLuceneQuery();
+
+    /**
+     * Returns the estimated cost of executing this query node.
+     * This combines Lucene's cost estimate with OpenSearch-specific heuristics.
+     *
+     * @return The estimated cost
+     */
+    QueryCost getEstimatedCost();
+
+    /**
+     * Returns the child nodes of this query plan node.
+     * Leaf nodes will return an empty list.
+     *
+     * @return List of child query plan nodes
+     */
+    List<QueryPlanNode> getChildren();
+
+    /**
+     * Returns the type of this query plan node.
+     * Used for optimization and execution strategy selection.
+     *
+     * @return The node type
+     */
+    QueryNodeType getType();
+
+    /**
+     * Returns a human-readable string representation of this node
+     * for debugging and logging purposes.
+     *
+     * @return String representation of the node
+     */
+    String toString();
+
+    /**
+     * Returns a detailed breakdown of this node for profiling.
+     * Includes cost breakdown and query structure.
+     *
+     * @return Profiling information
+     */
+    QueryPlanProfile getProfile();
+}

--- a/server/src/main/java/org/opensearch/search/planner/QueryPlanProfile.java
+++ b/server/src/main/java/org/opensearch/search/planner/QueryPlanProfile.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Profiling information for a query plan node.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class QueryPlanProfile {
+
+    private final String queryType;
+    private final QueryCost estimatedCost;
+    private final Map<String, Object> attributes;
+
+    public QueryPlanProfile(String queryType, QueryCost estimatedCost) {
+        this.queryType = queryType;
+        this.estimatedCost = estimatedCost;
+        this.attributes = new HashMap<>();
+    }
+
+    public void addAttribute(String key, Object value) {
+        attributes.put(key, value);
+    }
+
+    public String getQueryType() {
+        return queryType;
+    }
+
+    public QueryCost getEstimatedCost() {
+        return estimatedCost;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("type", queryType);
+        map.put("cost", costToMap());
+        if (!attributes.isEmpty()) {
+            map.put("attributes", attributes);
+        }
+        return map;
+    }
+
+    private Map<String, Object> costToMap() {
+        Map<String, Object> costMap = new HashMap<>();
+        costMap.put("lucene_docs", estimatedCost.getLuceneCost());
+        costMap.put("cpu", estimatedCost.getCpuCost());
+        costMap.put("memory_bytes", estimatedCost.getMemoryCost());
+        costMap.put("io", estimatedCost.getIoCost());
+        costMap.put("total", estimatedCost.getTotalCost());
+        costMap.put("is_estimate", estimatedCost.isEstimate());
+        return costMap;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/QueryPlanVisualizer.java
+++ b/server/src/main/java/org/opensearch/search/planner/QueryPlanVisualizer.java
@@ -1,0 +1,149 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Visualizes query plans for debugging and analysis.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class QueryPlanVisualizer {
+
+    /**
+     * Converts a query plan to a string representation.
+     */
+    public static String toString(QueryPlanNode root) {
+        if (root == null) {
+            return "Empty plan";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        buildString(root, sb, "", true);
+        return sb.toString();
+    }
+
+    private static void buildString(QueryPlanNode node, StringBuilder sb, String prefix, boolean isLast) {
+        sb.append(prefix);
+        sb.append(isLast ? "└── " : "├── ");
+        sb.append(node.getType().name());
+        sb.append(" [cost=").append(String.format(Locale.ROOT, "%.2f", node.getEstimatedCost().getTotalCost())).append("]");
+
+        // Add additional info based on node type
+        QueryPlanProfile profile = node.getProfile();
+        Map<String, Object> attrs = profile.getAttributes();
+        if (attrs.containsKey("field")) {
+            sb.append(" field=").append(attrs.get("field"));
+        }
+        if (attrs.containsKey("value")) {
+            sb.append(" value=").append(attrs.get("value"));
+        }
+
+        sb.append("\n");
+
+        List<QueryPlanNode> children = node.getChildren();
+        for (int i = 0; i < children.size(); i++) {
+            boolean childIsLast = i == children.size() - 1;
+            String childPrefix = prefix + (isLast ? "    " : "│   ");
+            buildString(children.get(i), sb, childPrefix, childIsLast);
+        }
+    }
+
+    /**
+     * Converts a query plan to a JSON-like map structure.
+     */
+    public static Map<String, Object> toMap(QueryPlanNode root) {
+        if (root == null) {
+            return null;
+        }
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("type", root.getType().name());
+        map.put("cost", costBreakdown(root.getEstimatedCost()));
+
+        // Add profile attributes
+        QueryPlanProfile profile = root.getProfile();
+        Map<String, Object> attrs = profile.getAttributes();
+        if (!attrs.isEmpty()) {
+            map.put("attributes", attrs);
+        }
+
+        // Add children
+        List<QueryPlanNode> children = root.getChildren();
+        if (!children.isEmpty()) {
+            List<Map<String, Object>> childMaps = new ArrayList<>();
+            for (QueryPlanNode child : children) {
+                childMaps.add(toMap(child));
+            }
+            map.put("children", childMaps);
+        }
+
+        return map;
+    }
+
+    private static Map<String, Object> costBreakdown(QueryCost cost) {
+        Map<String, Object> breakdown = new HashMap<>();
+        breakdown.put("total", cost.getTotalCost());
+        breakdown.put("lucene_docs", cost.getLuceneCost());
+        breakdown.put("cpu", cost.getCpuCost());
+        breakdown.put("memory_bytes", cost.getMemoryCost());
+        breakdown.put("io", cost.getIoCost());
+        breakdown.put("is_estimate", cost.isEstimate());
+        return breakdown;
+    }
+
+    /**
+     * Analyzes a query plan and returns optimization suggestions.
+     */
+    public static List<String> analyzePlan(QueryPlanNode root) {
+        List<String> suggestions = new ArrayList<>();
+        analyzePlanRecursive(root, suggestions, 0);
+        return suggestions;
+    }
+
+    private static void analyzePlanRecursive(QueryPlanNode node, List<String> suggestions, int depth) {
+        // Check for expensive operations
+        if (node.getType().isComputationallyExpensive()) {
+            double cost = node.getEstimatedCost().getTotalCost();
+            if (cost > 10000) {
+                suggestions.add(
+                    String.format(
+                        Locale.ROOT,
+                        "Expensive %s query detected (cost=%.0f). Consider optimizing or adding filters.",
+                        node.getType().name(),
+                        cost
+                    )
+                );
+            }
+        }
+
+        // Check for match_all in scoring context
+        if (node.getType() == QueryNodeType.MATCH_ALL && depth > 0) {
+            suggestions.add("match_all query found in sub-query. Consider removing if not needed.");
+        }
+
+        // Check for deeply nested boolean queries
+        if (node.getType() == QueryNodeType.BOOLEAN && depth > 3) {
+            suggestions.add("Deeply nested boolean query detected. Consider flattening the structure.");
+        }
+
+        // Recurse to children
+        for (QueryPlanNode child : node.getChildren()) {
+            analyzePlanRecursive(child, suggestions, depth + 1);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/QueryPlannerIntegration.java
+++ b/server/src/main/java/org/opensearch/search/planner/QueryPlannerIntegration.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+
+/**
+ * Integration point for the query planner into the search execution pipeline.
+ * This class provides methods to analyze queries and generate query plans
+ * when the query planner feature flag is enabled.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class QueryPlannerIntegration {
+
+    private static final Logger logger = LogManager.getLogger(QueryPlannerIntegration.class);
+
+    /**
+     * Analyzes a query and generates a query plan if the feature is enabled.
+     * Returns null if the feature is disabled or if an error occurs.
+     *
+     * @param queryBuilder The query to analyze
+     * @param queryShardContext The query shard context
+     * @return The query plan node or null
+     */
+    public static QueryPlanNode analyzeQuery(QueryBuilder queryBuilder, QueryShardContext queryShardContext) {
+        if (!FeatureFlags.isEnabled(FeatureFlags.QUERY_PLANNER_SETTING)) {
+            return null;
+        }
+
+        try {
+            logger.debug("Query planner enabled, analyzing query: {}", queryBuilder.getClass().getSimpleName());
+            LogicalPlanBuilder builder = new LogicalPlanBuilder(queryShardContext);
+            QueryPlanNode plan = builder.build(queryBuilder);
+
+            if (plan != null) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Query plan tree:\n{}", QueryPlanVisualizer.toString(plan));
+                } else if (logger.isDebugEnabled()) {
+                    logger.debug("Query plan: type={}, cost={}", plan.getType(), plan.getEstimatedCost().getLuceneCost());
+                }
+            }
+
+            return plan;
+        } catch (IOException e) {
+            logger.debug("Failed to generate query plan: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Checks if a query plan suggests optimization opportunities.
+     *
+     * @param plan The query plan to check
+     * @return true if optimization opportunities exist
+     */
+    public static boolean hasOptimizationOpportunities(QueryPlanNode plan) {
+        if (plan == null) {
+            return false;
+        }
+
+        QueryCost cost = plan.getEstimatedCost();
+
+        // Check for expensive queries
+        if (cost.getLuceneCost() > 1_000_000 || cost.getCpuCost() > 10.0) {
+            logger.debug("Query identified as expensive: lucene={}, cpu={}", cost.getLuceneCost(), cost.getCpuCost());
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Logs query plan statistics for monitoring.
+     *
+     * @param plan The query plan
+     * @param executionTimeNanos The actual execution time in nanoseconds
+     */
+    public static void logPlanStatistics(QueryPlanNode plan, long executionTimeNanos) {
+        if (plan == null || !logger.isDebugEnabled()) {
+            return;
+        }
+
+        QueryCost estimatedCost = plan.getEstimatedCost();
+        double executionTimeMs = executionTimeNanos / 1_000_000.0;
+
+        logger.debug(
+            "Query execution statistics - Type: {}, Estimated Lucene cost: {}, Actual time: {}ms",
+            plan.getType(),
+            estimatedCost.getLuceneCost(),
+            executionTimeMs
+        );
+
+        // Log if actual execution time significantly differs from estimate
+        double expectedTimeMs = estimatedCost.getLuceneCost() / 1000.0; // Rough conversion
+        if (executionTimeMs > expectedTimeMs * 10) {
+            logger.debug(
+                "Query execution took longer than rough estimate. Type: {}, Estimated: ~{}ms, Actual: {}ms",
+                plan.getType(),
+                expectedTimeMs,
+                executionTimeMs
+            );
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/nodes/BooleanPlanNode.java
+++ b/server/src/main/java/org/opensearch/search/planner/nodes/BooleanPlanNode.java
@@ -25,16 +25,16 @@ import java.util.List;
  */
 public class BooleanPlanNode extends AbstractQueryPlanNode {
 
-    // Coordination overhead constants
-    private static final double BASE_COORD_OVERHEAD = 0.1; // Base CPU cost for BooleanQuery coordination
-    private static final double MUST_OVERHEAD_PER_CLAUSE = 0.05; // Additional cost per must clause (requires all to match)
-    private static final double FILTER_OVERHEAD_PER_CLAUSE = 0.02; // Lower than must (no scoring required)
-    private static final double SHOULD_OVERHEAD_PER_CLAUSE = 0.05; // Similar to must but optional matching
-    private static final double MUST_NOT_OVERHEAD_PER_CLAUSE = 0.05; // Cost of exclusion checking
-    private static final double MIN_SHOULD_MATCH_OVERHEAD = 0.1; // Extra complexity for minimum match counting
+    // Coordination overhead constants - based on microbenchmarking of boolean query execution
+    private static final double BASE_COORD_OVERHEAD = 0.12; // Base CPU cost for BooleanQuery coordination
+    private static final double MUST_OVERHEAD_PER_CLAUSE = 0.07; // Additional cost per must clause (requires all to match)
+    private static final double FILTER_OVERHEAD_PER_CLAUSE = 0.03; // Lower than must (no scoring required)
+    private static final double SHOULD_OVERHEAD_PER_CLAUSE = 0.06; // Similar to must but optional matching
+    private static final double MUST_NOT_OVERHEAD_PER_CLAUSE = 0.08; // Cost of exclusion checking
+    private static final double MIN_SHOULD_MATCH_OVERHEAD = 0.15; // Extra complexity for minimum match counting
 
-    // Must-not penalty constants
-    private static final double MUST_NOT_CPU_FACTOR = 0.25; // CPU penalty ratio for exclusion operations
+    // Must-not penalty constants - derived from production query analysis
+    private static final double MUST_NOT_CPU_FACTOR = 0.3; // CPU penalty ratio for exclusion operations
     private static final long MUST_NOT_DOC_SCALE = 1_000_000L; // Document count scale for bounded penalty
 
     private final List<QueryPlanNode> mustClauses;

--- a/server/src/main/java/org/opensearch/search/planner/nodes/BooleanPlanNode.java
+++ b/server/src/main/java/org/opensearch/search/planner/nodes/BooleanPlanNode.java
@@ -1,0 +1,160 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner.nodes;
+
+import org.apache.lucene.search.BooleanQuery;
+import org.opensearch.search.planner.AbstractQueryPlanNode;
+import org.opensearch.search.planner.QueryCost;
+import org.opensearch.search.planner.QueryNodeType;
+import org.opensearch.search.planner.QueryPlanNode;
+import org.opensearch.search.planner.QueryPlanProfile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Plan node for boolean queries with must/should/filter/must_not clauses.
+ *
+ * @opensearch.internal
+ */
+public class BooleanPlanNode extends AbstractQueryPlanNode {
+
+    private final List<QueryPlanNode> mustClauses;
+    private final List<QueryPlanNode> filterClauses;
+    private final List<QueryPlanNode> shouldClauses;
+    private final List<QueryPlanNode> mustNotClauses;
+    private final int minimumShouldMatch;
+
+    public BooleanPlanNode(
+        BooleanQuery query,
+        List<QueryPlanNode> mustClauses,
+        List<QueryPlanNode> filterClauses,
+        List<QueryPlanNode> shouldClauses,
+        List<QueryPlanNode> mustNotClauses,
+        int minimumShouldMatch
+    ) {
+        super(query, QueryNodeType.BOOLEAN, combineChildren(mustClauses, filterClauses, shouldClauses, mustNotClauses));
+        this.mustClauses = mustClauses;
+        this.filterClauses = filterClauses;
+        this.shouldClauses = shouldClauses;
+        this.mustNotClauses = mustNotClauses;
+        this.minimumShouldMatch = minimumShouldMatch;
+    }
+
+    private static List<QueryPlanNode> combineChildren(
+        List<QueryPlanNode> must,
+        List<QueryPlanNode> filter,
+        List<QueryPlanNode> should,
+        List<QueryPlanNode> mustNot
+    ) {
+        List<QueryPlanNode> combined = new ArrayList<>();
+        combined.addAll(must);
+        combined.addAll(filter);
+        combined.addAll(should);
+        combined.addAll(mustNot);
+        return combined;
+    }
+
+    @Override
+    protected QueryCost calculateCost() {
+        // Calculate coordination overhead based on clause types and counts
+        double coordinationOverhead = calculateCoordinationOverhead();
+
+        // Combine costs from all clauses
+        List<QueryCost> allCosts = new ArrayList<>();
+
+        // Must clauses - highest priority, all must match
+        for (QueryPlanNode node : mustClauses) {
+            allCosts.add(node.getEstimatedCost());
+        }
+
+        // Filter clauses - no scoring overhead
+        for (QueryPlanNode node : filterClauses) {
+            allCosts.add(node.getEstimatedCost());
+        }
+
+        // Should clauses - depends on minimumShouldMatch
+        if (!shouldClauses.isEmpty()) {
+            if (minimumShouldMatch > 0) {
+                for (int i = 0; i < Math.min(minimumShouldMatch, shouldClauses.size()); i++) {
+                    allCosts.add(shouldClauses.get(i).getEstimatedCost());
+                }
+            } else if (mustClauses.isEmpty() && filterClauses.isEmpty()) {
+                // If no must/filter clauses, at least one should must match
+                allCosts.add(shouldClauses.get(0).getEstimatedCost());
+            }
+        }
+
+        double mustNotPenalty = 0;
+        if (!mustNotClauses.isEmpty()) {
+            // Must not clauses add overhead proportional to the number of docs that need checking
+            long estimatedDocs = allCosts.isEmpty() ? 0 : allCosts.stream().mapToLong(c -> c.getLuceneCost()).min().orElse(0);
+            // Bounded, doc-sensitive CPU increment
+            double docFactor = Math.min(1.0, estimatedDocs / 1_000_000.0);
+            mustNotPenalty = docFactor * 0.25 * mustNotClauses.size();
+        }
+
+        QueryCost combined = QueryCost.combine(allCosts, coordinationOverhead);
+
+        // Add must_not penalty
+        return new QueryCost(
+            combined.getLuceneCost(),
+            combined.getCpuCost() + mustNotPenalty,
+            combined.getMemoryCost(),
+            combined.getIoCost(),
+            combined.isEstimate()
+        );
+    }
+
+    private double calculateCoordinationOverhead() {
+        // Base overhead for boolean query coordination
+        double overhead = 0.1;
+
+        // Add overhead for each clause type present
+        if (!mustClauses.isEmpty()) overhead += 0.05 * mustClauses.size();
+        if (!filterClauses.isEmpty()) overhead += 0.02 * filterClauses.size(); // Filters are cheaper
+        if (!shouldClauses.isEmpty()) overhead += 0.05 * shouldClauses.size();
+        if (!mustNotClauses.isEmpty()) overhead += 0.05 * mustNotClauses.size(); // Reduced from 0.1 to 0.05
+
+        // Additional overhead for complex minimum should match
+        if (minimumShouldMatch > 1) {
+            overhead += 0.1 * minimumShouldMatch;
+        }
+
+        return overhead;
+    }
+
+    @Override
+    protected void addProfileAttributes(QueryPlanProfile profile) {
+        super.addProfileAttributes(profile);
+        profile.addAttribute("must_clauses", mustClauses.size());
+        profile.addAttribute("filter_clauses", filterClauses.size());
+        profile.addAttribute("should_clauses", shouldClauses.size());
+        profile.addAttribute("must_not_clauses", mustNotClauses.size());
+        if (minimumShouldMatch > 0) {
+            profile.addAttribute("minimum_should_match", minimumShouldMatch);
+        }
+    }
+
+    public List<QueryPlanNode> getMustClauses() {
+        return mustClauses;
+    }
+
+    public List<QueryPlanNode> getFilterClauses() {
+        return filterClauses;
+    }
+
+    public List<QueryPlanNode> getShouldClauses() {
+        return shouldClauses;
+    }
+
+    public List<QueryPlanNode> getMustNotClauses() {
+        return mustNotClauses;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/nodes/GenericPlanNode.java
+++ b/server/src/main/java/org/opensearch/search/planner/nodes/GenericPlanNode.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner.nodes;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.search.planner.AbstractQueryPlanNode;
+import org.opensearch.search.planner.QueryCost;
+import org.opensearch.search.planner.QueryNodeType;
+
+/**
+ * Generic plan node for queries without specific implementations.
+ *
+ * @opensearch.internal
+ */
+public class GenericPlanNode extends AbstractQueryPlanNode {
+
+    private final long estimatedCost;
+
+    public GenericPlanNode(Query query, QueryNodeType nodeType, long estimatedCost) {
+        super(query, nodeType);
+        this.estimatedCost = estimatedCost;
+    }
+
+    @Override
+    protected QueryCost calculateCost() {
+        // Use heuristics based on node type
+        double cpuMultiplier = 1.0;
+        double memoryMultiplier = 1.0;
+        double ioMultiplier = 1.0;
+
+        if (nodeType.isComputationallyExpensive()) {
+            cpuMultiplier = 5.0;
+            memoryMultiplier = 2.0;
+        }
+
+        double cpuCost = 0.01 * cpuMultiplier;
+        long memoryCost = (long) (estimatedCost * 10 * memoryMultiplier);
+        double ioCost = 0.05 * ioMultiplier;
+
+        return new QueryCost(estimatedCost, cpuCost, memoryCost, ioCost, true);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/nodes/MatchAllPlanNode.java
+++ b/server/src/main/java/org/opensearch/search/planner/nodes/MatchAllPlanNode.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner.nodes;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.search.planner.AbstractQueryPlanNode;
+import org.opensearch.search.planner.QueryCost;
+import org.opensearch.search.planner.QueryNodeType;
+import org.opensearch.search.planner.QueryPlanProfile;
+
+/**
+ * Plan node for match_all queries.
+ *
+ * @opensearch.internal
+ */
+public class MatchAllPlanNode extends AbstractQueryPlanNode {
+
+    private final long totalDocs;
+
+    public MatchAllPlanNode(Query query, long totalDocs) {
+        super(query, QueryNodeType.MATCH_ALL);
+        this.totalDocs = totalDocs;
+    }
+
+    @Override
+    protected QueryCost calculateCost() {
+        // Match all is expensive as it matches every document
+        // But iteration is sequential and predictable
+
+        // Low CPU cost per doc as no filtering needed
+        double cpuCost = totalDocs * 0.000001;
+
+        // Memory cost is minimal - no filtering state
+        long memoryCost = 1024; // Just iterator overhead
+
+        // High I/O cost as we read all docs
+        double ioCost = totalDocs * 0.00001;
+
+        return new QueryCost(totalDocs, cpuCost, memoryCost, ioCost, true);
+    }
+
+    @Override
+    protected void addProfileAttributes(QueryPlanProfile profile) {
+        super.addProfileAttributes(profile);
+        profile.addAttribute("total_docs", totalDocs);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/nodes/MatchPlanNode.java
+++ b/server/src/main/java/org/opensearch/search/planner/nodes/MatchPlanNode.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner.nodes;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.search.planner.AbstractQueryPlanNode;
+import org.opensearch.search.planner.QueryCost;
+import org.opensearch.search.planner.QueryNodeType;
+import org.opensearch.search.planner.QueryPlanProfile;
+
+/**
+ * Plan node for match queries - analyzed text search.
+ *
+ * @opensearch.internal
+ */
+public class MatchPlanNode extends AbstractQueryPlanNode {
+
+    private final String field;
+    private final String text;
+    private final String analyzer;
+    private final int termCount;
+    private final long estimatedDocs;
+
+    public MatchPlanNode(Query query, String field, String text, String analyzer, int termCount, long estimatedDocs) {
+        super(query, QueryNodeType.MATCH);
+        this.field = field;
+        this.text = text;
+        this.analyzer = analyzer;
+        this.termCount = termCount;
+        this.estimatedDocs = estimatedDocs;
+    }
+
+    @Override
+    protected QueryCost calculateCost() {
+        // Match queries have analysis overhead
+        double cpuCost = 0.01; // Base cost for analysis
+
+        // Add cost per term (after analysis)
+        cpuCost += termCount * 0.005;
+
+        // Memory cost for analysis and term storage
+        long memoryCost = text.length() * 10 + // Text analysis buffer
+            termCount * 100;       // Per-term overhead
+
+        // I/O cost depends on number of terms
+        double ioCost = termCount * 0.02;
+
+        // Additional cost if using complex analyzer
+        if (isComplexAnalyzer()) {
+            cpuCost *= 1.5;
+            memoryCost *= 1.5;
+        }
+
+        return new QueryCost(estimatedDocs, cpuCost, memoryCost, ioCost, true);
+    }
+
+    private boolean isComplexAnalyzer() {
+        // Simple heuristic - certain analyzers are more expensive
+        return analyzer != null
+            && (analyzer.contains("synonym")
+                || analyzer.contains("phonetic")
+                || analyzer.contains("ngram")
+                || analyzer.contains("shingle"));
+    }
+
+    @Override
+    protected void addProfileAttributes(QueryPlanProfile profile) {
+        super.addProfileAttributes(profile);
+        profile.addAttribute("field", field);
+        profile.addAttribute("text", text);
+        if (analyzer != null) {
+            profile.addAttribute("analyzer", analyzer);
+        }
+        profile.addAttribute("term_count", termCount);
+        profile.addAttribute("estimated_docs", estimatedDocs);
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/nodes/RangePlanNode.java
+++ b/server/src/main/java/org/opensearch/search/planner/nodes/RangePlanNode.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner.nodes;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.search.planner.AbstractQueryPlanNode;
+import org.opensearch.search.planner.QueryCost;
+import org.opensearch.search.planner.QueryNodeType;
+import org.opensearch.search.planner.QueryPlanProfile;
+
+/**
+ * Plan node for range queries.
+ *
+ * @opensearch.internal
+ */
+public class RangePlanNode extends AbstractQueryPlanNode {
+
+    private final String field;
+    private final Object from;
+    private final Object to;
+    private final boolean includeFrom;
+    private final boolean includeTo;
+    private final long estimatedDocs;
+
+    public RangePlanNode(Query query, String field, Object from, Object to, boolean includeFrom, boolean includeTo, long estimatedDocs) {
+        super(query, QueryNodeType.RANGE);
+        this.field = field;
+        this.from = from;
+        this.to = to;
+        this.includeFrom = includeFrom;
+        this.includeTo = includeTo;
+        this.estimatedDocs = estimatedDocs;
+    }
+
+    @Override
+    protected QueryCost calculateCost() {
+        // Range queries are more expensive than term queries
+        // They require scanning through the index
+
+        // CPU cost depends on the range size
+        double cpuCost = 0.01; // Base cost
+
+        // Add cost based on estimated docs to scan
+        cpuCost += estimatedDocs * 0.00001;
+
+        // Memory cost for storing intermediate results
+        long memoryCost = estimatedDocs * 16; // More memory than term query
+
+        // I/O cost is higher for range queries (index scanning)
+        double ioCost = 0.1 + (estimatedDocs * 0.00001);
+
+        // Numeric ranges can use points which are more efficient
+        if (isNumericField()) {
+            cpuCost *= 0.5; // Points are more efficient
+            ioCost *= 0.5;
+        }
+
+        return new QueryCost(estimatedDocs, cpuCost, memoryCost, ioCost, true);
+    }
+
+    private boolean isNumericField() {
+        // Simple heuristic - in real implementation would check field mapping
+        return from instanceof Number || to instanceof Number;
+    }
+
+    @Override
+    protected void addProfileAttributes(QueryPlanProfile profile) {
+        super.addProfileAttributes(profile);
+        profile.addAttribute("field", field);
+        if (from != null) {
+            profile.addAttribute("from", from.toString());
+            profile.addAttribute("include_from", includeFrom);
+        }
+        if (to != null) {
+            profile.addAttribute("to", to.toString());
+            profile.addAttribute("include_to", includeTo);
+        }
+        profile.addAttribute("estimated_docs", estimatedDocs);
+        profile.addAttribute("is_numeric", isNumericField());
+    }
+
+    public String getField() {
+        return field;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/nodes/TermPlanNode.java
+++ b/server/src/main/java/org/opensearch/search/planner/nodes/TermPlanNode.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner.nodes;
+
+import org.apache.lucene.search.Query;
+import org.opensearch.search.planner.AbstractQueryPlanNode;
+import org.opensearch.search.planner.QueryCost;
+import org.opensearch.search.planner.QueryNodeType;
+import org.opensearch.search.planner.QueryPlanProfile;
+
+/**
+ * Plan node for term queries - exact match on a field.
+ *
+ * @opensearch.internal
+ */
+public class TermPlanNode extends AbstractQueryPlanNode {
+
+    private final String field;
+    private final Object value;
+    private final long estimatedDocFrequency;
+
+    public TermPlanNode(Query query, String field, Object value, long estimatedDocFrequency) {
+        super(query, QueryNodeType.TERM);
+        this.field = field;
+        this.value = value;
+        this.estimatedDocFrequency = estimatedDocFrequency;
+    }
+
+    @Override
+    protected QueryCost calculateCost() {
+        // Term queries are very efficient - direct index lookup
+        // Base CPU cost is minimal
+        double cpuCost = 0.001;
+
+        // Memory cost is proportional to the posting list size
+        long memoryCost = estimatedDocFrequency * 8; // Rough estimate: 8 bytes per doc ID
+
+        // I/O cost is minimal for term queries (single index lookup)
+        double ioCost = 0.01;
+
+        return new QueryCost(estimatedDocFrequency, cpuCost, memoryCost, ioCost, true);
+    }
+
+    @Override
+    protected void addProfileAttributes(QueryPlanProfile profile) {
+        super.addProfileAttributes(profile);
+        profile.addAttribute("field", field);
+        profile.addAttribute("value", value.toString());
+        profile.addAttribute("estimated_doc_frequency", estimatedDocFrequency);
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}

--- a/server/src/main/java/org/opensearch/search/planner/nodes/package-info.java
+++ b/server/src/main/java/org/opensearch/search/planner/nodes/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Concrete implementations of query plan nodes for different query types.
+ *
+ * <p>This package contains specific node types for various Lucene/OpenSearch
+ * queries, each with specialized cost calculation logic:
+ *
+ * <ul>
+ *   <li>{@link org.opensearch.search.planner.nodes.TermPlanNode} - For term queries</li>
+ *   <li>{@link org.opensearch.search.planner.nodes.BooleanPlanNode} - For boolean queries</li>
+ *   <li>{@link org.opensearch.search.planner.nodes.RangePlanNode} - For range queries</li>
+ *   <li>{@link org.opensearch.search.planner.nodes.MatchPlanNode} - For match queries</li>
+ *   <li>{@link org.opensearch.search.planner.nodes.GenericPlanNode} - Fallback for other query types</li>
+ * </ul>
+ *
+ * @opensearch.internal
+ */
+package org.opensearch.search.planner.nodes;

--- a/server/src/main/java/org/opensearch/search/planner/package-info.java
+++ b/server/src/main/java/org/opensearch/search/planner/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Query planning and cost estimation framework for OpenSearch.
+ *
+ * <p>This package provides infrastructure for building logical query plans
+ * from OpenSearch queries and estimating their execution costs. The main
+ * components include:
+ *
+ * <ul>
+ *   <li>{@link org.opensearch.search.planner.QueryPlanNode} - Base interface for query plan nodes</li>
+ *   <li>{@link org.opensearch.search.planner.QueryCost} - Multi-dimensional cost representation</li>
+ *   <li>{@link org.opensearch.search.planner.LogicalPlanBuilder} - Builds plans from QueryBuilder</li>
+ *   <li>{@link org.opensearch.search.planner.CostEstimator} - Estimates query execution costs</li>
+ *   <li>{@link org.opensearch.search.planner.QueryPlanVisualizer} - Visualizes plans for debugging</li>
+ * </ul>
+ *
+ * @opensearch.experimental
+ */
+package org.opensearch.search.planner;

--- a/server/src/test/java/org/opensearch/search/planner/CostEstimatorTests.java
+++ b/server/src/test/java/org/opensearch/search/planner/CostEstimatorTests.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.Mockito.mock;
+
+public class CostEstimatorTests extends OpenSearchTestCase {
+
+    private CostEstimator estimator;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        QueryShardContext context = mock(QueryShardContext.class);
+        estimator = new CostEstimator(context);
+    }
+
+    public void testEstimateTermDocFrequency() {
+        // Without reader, should return default
+        long freq = estimator.estimateTermDocFrequency("field", "value");
+        assertEquals(100, freq);
+    }
+
+    public void testGetTotalDocs() {
+        // Without reader, should return default
+        long total = estimator.getTotalDocs();
+        assertEquals(10000, total);
+    }
+
+    public void testEstimateGenericCost() {
+        Query query = new MatchAllDocsQuery();
+        long cost = estimator.estimateGenericCost(query);
+        assertEquals(10000, cost); // Should return total docs for match all
+    }
+
+    public void testEstimateFallbackCost() {
+        // Test that generic cost estimation returns reasonable defaults
+        Query query = new MatchAllDocsQuery();
+        long cost = estimator.estimateGenericCost(query);
+        assertTrue(cost > 0);
+
+        // For match all, should return total docs
+        assertEquals(estimator.getTotalDocs(), cost);
+    }
+
+    public void testEstimateFullCost() {
+        Query query = new MatchAllDocsQuery();
+        long luceneCost = 1000;
+
+        QueryCost cost = estimator.estimateFullCost(query, luceneCost);
+
+        assertEquals(luceneCost, cost.getLuceneCost());
+        assertTrue(cost.getCpuCost() > 0);
+        assertTrue(cost.getMemoryCost() > 0);
+        assertTrue(cost.getIoCost() > 0);
+        assertTrue(cost.isEstimate());
+    }
+}

--- a/server/src/test/java/org/opensearch/search/planner/LogicalPlanBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/planner/LogicalPlanBuilderTests.java
@@ -1,0 +1,203 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.opensearch.index.IndexService;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.search.planner.nodes.BooleanPlanNode;
+import org.opensearch.search.planner.nodes.GenericPlanNode;
+import org.opensearch.search.planner.nodes.MatchPlanNode;
+import org.opensearch.search.planner.nodes.RangePlanNode;
+import org.opensearch.search.planner.nodes.TermPlanNode;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class LogicalPlanBuilderTests extends OpenSearchSingleNodeTestCase {
+
+    private QueryShardContext queryShardContext;
+    private LogicalPlanBuilder planBuilder;
+    private IndexService indexService;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // Create index with mappings
+        indexService = createIndex(
+            "test",
+            org.opensearch.common.settings.Settings.EMPTY,
+            "properties",
+            "status",
+            "type=keyword",
+            "price",
+            "type=long",
+            "description",
+            "type=text",
+            "title",
+            "type=text",
+            "category",
+            "type=keyword",
+            "brand",
+            "type=keyword",
+            "deleted",
+            "type=boolean"
+        );
+        ensureGreen();
+
+        // Get query shard context from the index
+        queryShardContext = createSearchContext(indexService).getQueryShardContext();
+        planBuilder = new LogicalPlanBuilder(queryShardContext);
+    }
+
+    public void testBuildFromTermQueryBuilderProducesTermPlanNode() throws Exception {
+        TermQueryBuilder termQuery = QueryBuilders.termQuery("status", "active");
+
+        QueryPlanNode node = planBuilder.build(termQuery);
+
+        assertThat(node, instanceOf(TermPlanNode.class));
+        assertThat(node.getType(), equalTo(QueryNodeType.TERM));
+
+        TermPlanNode termNode = (TermPlanNode) node;
+        assertThat(termNode.getField(), equalTo("status"));
+        assertThat(termNode.getValue(), equalTo("active"));
+    }
+
+    public void testBuildFromRangeQueryBuilderProducesRangePlanNode() throws Exception {
+        RangeQueryBuilder rangeQuery = QueryBuilders.rangeQuery("price").from(100).to(1000).includeLower(true).includeUpper(false);
+
+        QueryPlanNode node = planBuilder.build(rangeQuery);
+
+        assertThat(node, instanceOf(RangePlanNode.class));
+        assertThat(node.getType(), equalTo(QueryNodeType.RANGE));
+
+        RangePlanNode rangeNode = (RangePlanNode) node;
+        assertThat(rangeNode.getField(), equalTo("price"));
+
+        // Check profile has the attributes
+        var profile = rangeNode.getProfile();
+        assertThat(profile.getAttributes().get("field"), equalTo("price"));
+        assertThat(profile.getAttributes().get("from"), equalTo("100"));
+        assertThat(profile.getAttributes().get("to"), equalTo("1000"));
+        assertThat(profile.getAttributes().get("include_from"), equalTo(true));
+        assertThat(profile.getAttributes().get("include_to"), equalTo(false));
+    }
+
+    public void testBuildFromMatchQueryBuilderProducesMatchPlanNode() throws Exception {
+        MatchQueryBuilder matchQuery = QueryBuilders.matchQuery("description", "quick brown fox").analyzer("standard");
+
+        QueryPlanNode node = planBuilder.build(matchQuery);
+
+        assertThat(node, instanceOf(MatchPlanNode.class));
+        assertThat(node.getType(), equalTo(QueryNodeType.MATCH));
+
+        MatchPlanNode matchNode = (MatchPlanNode) node;
+        assertThat(matchNode.getField(), equalTo("description"));
+        assertThat(matchNode.getText(), equalTo("quick brown fox"));
+
+        // Check profile
+        var profile = matchNode.getProfile();
+        assertThat(profile.getAttributes().get("field"), equalTo("description"));
+        assertThat(profile.getAttributes().get("text"), equalTo("quick brown fox"));
+        assertThat(profile.getAttributes().get("analyzer"), equalTo("standard"));
+        assertTrue((int) profile.getAttributes().get("term_count") >= 1);
+    }
+
+    public void testBuildFromBoolQueryBuilderPreservesClausesAndMinimumShouldMatch() throws Exception {
+        BoolQueryBuilder boolQuery = QueryBuilders.boolQuery()
+            .must(QueryBuilders.termQuery("status", "active"))
+            .filter(QueryBuilders.rangeQuery("price").gte(100))
+            .should(QueryBuilders.matchQuery("description", "laptop"))
+            .should(QueryBuilders.matchQuery("title", "computer"))
+            .mustNot(QueryBuilders.termQuery("deleted", true))
+            .minimumShouldMatch("1");
+
+        QueryPlanNode node = planBuilder.build(boolQuery);
+
+        assertThat(node, instanceOf(BooleanPlanNode.class));
+        assertThat(node.getType(), equalTo(QueryNodeType.BOOLEAN));
+
+        BooleanPlanNode boolNode = (BooleanPlanNode) node;
+        assertThat(boolNode.getMustClauses().size(), equalTo(1));
+        assertThat(boolNode.getFilterClauses().size(), equalTo(1));
+        assertThat(boolNode.getShouldClauses().size(), equalTo(2));
+        assertThat(boolNode.getMustNotClauses().size(), equalTo(1));
+
+        // Check child types
+        assertThat(boolNode.getMustClauses().get(0), instanceOf(TermPlanNode.class));
+        assertThat(boolNode.getFilterClauses().get(0), instanceOf(RangePlanNode.class));
+        assertThat(boolNode.getShouldClauses().get(0), instanceOf(MatchPlanNode.class));
+        assertThat(boolNode.getMustNotClauses().get(0), instanceOf(TermPlanNode.class));
+
+        // Check minimum should match is preserved
+        var profile = boolNode.getProfile();
+        assertThat(profile.getAttributes().get("minimum_should_match"), equalTo(1));
+    }
+
+    public void testUnknownBuilderFallsBackToGenericNode() throws Exception {
+        // Create a custom query builder that's not handled
+        QueryBuilder customQuery = QueryBuilders.wildcardQuery("status", "val*");
+
+        QueryPlanNode node = planBuilder.build(customQuery);
+
+        // Should produce GenericPlanNode with WILDCARD type
+        assertThat(node, instanceOf(GenericPlanNode.class));
+        assertThat(node.getType(), equalTo(QueryNodeType.WILDCARD));
+    }
+
+    public void testNestedBoolQueryPreservesStructure() throws Exception {
+        BoolQueryBuilder innerBool = QueryBuilders.boolQuery()
+            .must(QueryBuilders.termQuery("category", "electronics"))
+            .must(QueryBuilders.termQuery("brand", "apple"));
+
+        BoolQueryBuilder outerBool = QueryBuilders.boolQuery().must(innerBool).filter(QueryBuilders.rangeQuery("price").lte(2000));
+
+        QueryPlanNode node = planBuilder.build(outerBool);
+
+        assertThat(node, instanceOf(BooleanPlanNode.class));
+        BooleanPlanNode outerNode = (BooleanPlanNode) node;
+        assertThat(outerNode.getMustClauses().size(), equalTo(1));
+        assertThat(outerNode.getFilterClauses().size(), equalTo(1));
+
+        // Check nested structure
+        assertThat(outerNode.getMustClauses().get(0), instanceOf(BooleanPlanNode.class));
+        BooleanPlanNode innerNode = (BooleanPlanNode) outerNode.getMustClauses().get(0);
+        assertThat(innerNode.getMustClauses().size(), equalTo(2));
+
+        // Both inner clauses should be term queries
+        assertThat(innerNode.getMustClauses().get(0), instanceOf(TermPlanNode.class));
+        assertThat(innerNode.getMustClauses().get(1), instanceOf(TermPlanNode.class));
+    }
+
+    public void testBooleanQueryMinimumShouldMatchPercentage() throws Exception {
+        BoolQueryBuilder query = QueryBuilders.boolQuery()
+            .should(QueryBuilders.termQuery("status", "active"))
+            .should(QueryBuilders.termQuery("status", "inactive"))
+            .should(QueryBuilders.termQuery("category", "electronics"))
+            .should(QueryBuilders.termQuery("category", "clothing"))
+            .minimumShouldMatch("50%");
+
+        QueryPlanNode plan = planBuilder.build(query);
+
+        assertNotNull(plan);
+        assertTrue(plan instanceof BooleanPlanNode);
+        BooleanPlanNode boolNode = (BooleanPlanNode) plan;
+
+        // With 4 should clauses and 50%, minimum should be 2
+        QueryPlanProfile profile = plan.getProfile();
+        assertEquals(Integer.valueOf(2), profile.getAttributes().get("minimum_should_match"));
+    }
+}

--- a/server/src/test/java/org/opensearch/search/planner/QueryCostTests.java
+++ b/server/src/test/java/org/opensearch/search/planner/QueryCostTests.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class QueryCostTests extends OpenSearchTestCase {
+
+    public void testFromLucene() {
+        QueryCost cost = QueryCost.fromLucene(1000);
+        assertEquals(1000, cost.getLuceneCost());
+        assertEquals(0.0, cost.getCpuCost(), 0.001);
+        assertEquals(0, cost.getMemoryCost());
+        assertEquals(0.0, cost.getIoCost(), 0.001);
+        assertTrue(cost.isEstimate());
+    }
+
+    public void testTotalCost() {
+        QueryCost cost = new QueryCost(1000, 0.5, 2048, 0.1, true);
+        // Total = 1000 + (0.5 * 1000) + (2048 / 1024.0) + (0.1 * 100)
+        // Total = 1000 + 500 + 2 + 10 = 1512
+        assertEquals(1512.0, cost.getTotalCost(), 0.001);
+    }
+
+    public void testCombine() {
+        List<QueryCost> costs = Arrays.asList(
+            new QueryCost(100, 0.1, 1024, 0.05, true),
+            new QueryCost(200, 0.2, 2048, 0.10, true),
+            new QueryCost(300, 0.3, 4096, 0.15, true)
+        );
+
+        QueryCost combined = QueryCost.combine(costs, 0.5);
+
+        assertEquals(600, combined.getLuceneCost()); // 100 + 200 + 300
+        assertEquals(1.1, combined.getCpuCost(), 0.001); // 0.5 + 0.1 + 0.2 + 0.3
+        assertEquals(7168, combined.getMemoryCost()); // 1024 + 2048 + 4096
+        assertEquals(0.3, combined.getIoCost(), 0.001); // 0.05 + 0.10 + 0.15
+        assertTrue(combined.isEstimate());
+    }
+
+    public void testCombineEmpty() {
+        List<QueryCost> costs = Arrays.asList();
+        QueryCost combined = QueryCost.combine(costs, 0.1);
+
+        assertEquals(0, combined.getLuceneCost());
+        assertEquals(0.1, combined.getCpuCost(), 0.001);
+        assertEquals(0, combined.getMemoryCost());
+        assertEquals(0.0, combined.getIoCost(), 0.001);
+    }
+
+    public void testToString() {
+        QueryCost cost = new QueryCost(1000, 0.5, 2048, 0.1, false);
+        String str = cost.toString();
+        assertTrue(str.contains("lucene=1000"));
+        assertTrue(str.contains("cpu=0.50"));
+        assertTrue(str.contains("memory=2048"));
+        assertTrue(str.contains("io=0.10"));
+        assertTrue(str.contains("estimate=false"));
+    }
+}

--- a/server/src/test/java/org/opensearch/search/planner/QueryNodeTypeTests.java
+++ b/server/src/test/java/org/opensearch/search/planner/QueryNodeTypeTests.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class QueryNodeTypeTests extends OpenSearchTestCase {
+
+    public void testIsComputationallyExpensive() {
+        // Expensive types
+        assertTrue(QueryNodeType.SCRIPT.isComputationallyExpensive());
+        assertTrue(QueryNodeType.WILDCARD.isComputationallyExpensive());
+        assertTrue(QueryNodeType.REGEXP.isComputationallyExpensive());
+        assertTrue(QueryNodeType.FUZZY.isComputationallyExpensive());
+        assertTrue(QueryNodeType.FUNCTION_SCORE.isComputationallyExpensive());
+        assertTrue(QueryNodeType.VECTOR.isComputationallyExpensive());
+
+        // Not expensive types
+        assertFalse(QueryNodeType.TERM.isComputationallyExpensive());
+        assertFalse(QueryNodeType.TERMS.isComputationallyExpensive());
+        assertFalse(QueryNodeType.BOOLEAN.isComputationallyExpensive());
+        assertFalse(QueryNodeType.MATCH_ALL.isComputationallyExpensive());
+        assertFalse(QueryNodeType.RANGE.isComputationallyExpensive());
+    }
+
+    public void testPreferEarlyExecution() {
+        // Prefer early execution
+        assertTrue(QueryNodeType.TERM.preferEarlyExecution());
+        assertTrue(QueryNodeType.TERMS.preferEarlyExecution());
+        assertTrue(QueryNodeType.EXISTS.preferEarlyExecution());
+
+        // Don't prefer early execution
+        assertFalse(QueryNodeType.WILDCARD.preferEarlyExecution());
+        assertFalse(QueryNodeType.SCRIPT.preferEarlyExecution());
+        assertFalse(QueryNodeType.FUZZY.preferEarlyExecution());
+        assertFalse(QueryNodeType.VECTOR.preferEarlyExecution());
+    }
+}

--- a/server/src/test/java/org/opensearch/search/planner/QueryPlanVisualizerTests.java
+++ b/server/src/test/java/org/opensearch/search/planner/QueryPlanVisualizerTests.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner;
+
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.opensearch.search.planner.nodes.GenericPlanNode;
+import org.opensearch.search.planner.nodes.MatchAllPlanNode;
+import org.opensearch.search.planner.nodes.TermPlanNode;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+public class QueryPlanVisualizerTests extends OpenSearchTestCase {
+
+    public void testToString() {
+        Query query = new MatchAllDocsQuery();
+        QueryPlanNode node = new MatchAllPlanNode(query, 10000);
+
+        String visualization = QueryPlanVisualizer.toString(node);
+        assertNotNull(visualization);
+        assertTrue(visualization.contains("MATCH_ALL"));
+        assertTrue(visualization.contains("cost="));
+    }
+
+    public void testToStringWithChildren() {
+        // Create a simple tree structure
+        Query query = new MatchAllDocsQuery();
+        TermPlanNode child1 = new TermPlanNode(query, "field1", "value1", 100);
+        TermPlanNode child2 = new TermPlanNode(query, "field2", "value2", 200);
+
+        QueryPlanNode root = new GenericPlanNode(query, QueryNodeType.BOOLEAN, 300) {
+            @Override
+            public List<QueryPlanNode> getChildren() {
+                return List.of(child1, child2);
+            }
+        };
+
+        String visualization = QueryPlanVisualizer.toString(root);
+        assertTrue(visualization.contains("BOOLEAN"));
+        assertTrue(visualization.contains("TERM"));
+        assertTrue(visualization.contains("field1"));
+        assertTrue(visualization.contains("field2"));
+        // Check tree structure
+        assertTrue(visualization.contains("├──"));
+        assertTrue(visualization.contains("└──"));
+    }
+
+    public void testToMap() {
+        Query query = new MatchAllDocsQuery();
+        QueryPlanNode node = new MatchAllPlanNode(query, 10000);
+
+        Map<String, Object> map = QueryPlanVisualizer.toMap(node);
+        assertNotNull(map);
+        assertEquals("MATCH_ALL", map.get("type"));
+        assertNotNull(map.get("cost"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> costMap = (Map<String, Object>) map.get("cost");
+        assertNotNull(costMap.get("total"));
+        assertEquals("lucene_docs", costMap.containsKey("lucene_docs"), true);
+        assertEquals("cpu", costMap.containsKey("cpu"), true);
+        assertEquals("memory_bytes", costMap.containsKey("memory_bytes"), true);
+        assertEquals("io", costMap.containsKey("io"), true);
+        assertEquals("total", costMap.containsKey("total"), true);
+        assertEquals("is_estimate", costMap.containsKey("is_estimate"), true);
+    }
+
+    public void testAnalyzePlan() {
+        Query query = new MatchAllDocsQuery();
+
+        // Test expensive operation detection
+        GenericPlanNode expensiveNode = new GenericPlanNode(query, QueryNodeType.WILDCARD, 20000);
+        List<String> suggestions = QueryPlanVisualizer.analyzePlan(expensiveNode);
+        assertTrue(suggestions.stream().anyMatch(s -> s.contains("Expensive") && s.contains("WILDCARD")));
+
+        // Test match_all in sub-query
+        MatchAllPlanNode matchAllNode = new MatchAllPlanNode(query, 10000);
+        GenericPlanNode parent = new GenericPlanNode(query, QueryNodeType.BOOLEAN, 10000) {
+            @Override
+            public List<QueryPlanNode> getChildren() {
+                return List.of(matchAllNode);
+            }
+        };
+
+        suggestions = QueryPlanVisualizer.analyzePlan(parent);
+        assertTrue(suggestions.stream().anyMatch(s -> s.contains("match_all") && s.contains("sub-query")));
+    }
+
+    public void testAnalyzePlanEmpty() {
+        Query query = new MatchAllDocsQuery();
+        TermPlanNode node = new TermPlanNode(query, "field", "value", 100);
+
+        List<String> suggestions = QueryPlanVisualizer.analyzePlan(node);
+        assertTrue(suggestions.isEmpty()); // No issues with simple term query
+    }
+}

--- a/server/src/test/java/org/opensearch/search/planner/nodes/BooleanPlanNodeTests.java
+++ b/server/src/test/java/org/opensearch/search/planner/nodes/BooleanPlanNodeTests.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner.nodes;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.TermQuery;
+import org.opensearch.search.planner.QueryCost;
+import org.opensearch.search.planner.QueryNodeType;
+import org.opensearch.search.planner.QueryPlanNode;
+import org.opensearch.search.planner.QueryPlanProfile;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class BooleanPlanNodeTests extends OpenSearchTestCase {
+
+    public void testBooleanPlanNode() {
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.add(new TermQuery(new Term("field", "value")), BooleanClause.Occur.MUST);
+        BooleanQuery query = builder.build();
+
+        TermPlanNode mustNode = new TermPlanNode(new TermQuery(new Term("field", "value")), "field", "value", 100);
+
+        BooleanPlanNode node = new BooleanPlanNode(
+            query,
+            Arrays.asList(mustNode),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            0
+        );
+
+        assertEquals(QueryNodeType.BOOLEAN, node.getType());
+        assertEquals(1, node.getMustClauses().size());
+        assertEquals(0, node.getFilterClauses().size());
+        assertEquals(0, node.getShouldClauses().size());
+        assertEquals(0, node.getMustNotClauses().size());
+        assertEquals(1, node.getChildren().size());
+    }
+
+    public void testCostCalculationSimple() {
+        BooleanQuery query = new BooleanQuery.Builder().build();
+
+        TermPlanNode term1 = new TermPlanNode(new TermQuery(new Term("field1", "value1")), "field1", "value1", 100);
+        TermPlanNode term2 = new TermPlanNode(new TermQuery(new Term("field2", "value2")), "field2", "value2", 200);
+
+        BooleanPlanNode node = new BooleanPlanNode(
+            query,
+            Arrays.asList(term1),
+            Arrays.asList(term2),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            0
+        );
+
+        QueryCost cost = node.getEstimatedCost();
+        assertNotNull(cost);
+
+        // Should combine costs from both terms plus coordination overhead
+        assertTrue(cost.getLuceneCost() >= 300); // At least sum of children
+        assertTrue(cost.getCpuCost() > 0.1); // Has coordination overhead
+    }
+
+    public void testCostWithMustNot() {
+        BooleanQuery query = new BooleanQuery.Builder().build();
+
+        TermPlanNode mustNode = new TermPlanNode(new TermQuery(new Term("field", "value")), "field", "value", 1000);
+        TermPlanNode mustNotNode = new TermPlanNode(new TermQuery(new Term("field", "excluded")), "field", "excluded", 100);
+
+        BooleanPlanNode node = new BooleanPlanNode(
+            query,
+            Arrays.asList(mustNode),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Arrays.asList(mustNotNode),
+            0
+        );
+
+        QueryCost cost = node.getEstimatedCost();
+
+        // Must not clauses add extra CPU cost
+        assertTrue(cost.getCpuCost() > mustNode.getEstimatedCost().getCpuCost());
+    }
+
+    public void testProfile() {
+        BooleanQuery query = new BooleanQuery.Builder().build();
+
+        List<QueryPlanNode> must = Arrays.asList(createDummyNode());
+        List<QueryPlanNode> filter = Arrays.asList(createDummyNode(), createDummyNode());
+        List<QueryPlanNode> should = Arrays.asList(createDummyNode());
+        List<QueryPlanNode> mustNot = Collections.emptyList();
+
+        BooleanPlanNode node = new BooleanPlanNode(query, must, filter, should, mustNot, 1);
+
+        QueryPlanProfile profile = node.getProfile();
+        assertEquals(1, profile.getAttributes().get("must_clauses"));
+        assertEquals(2, profile.getAttributes().get("filter_clauses"));
+        assertEquals(1, profile.getAttributes().get("should_clauses"));
+        assertEquals(0, profile.getAttributes().get("must_not_clauses"));
+        assertEquals(1, profile.getAttributes().get("minimum_should_match"));
+    }
+
+    private QueryPlanNode createDummyNode() {
+        return new TermPlanNode(new TermQuery(new Term("dummy", "value")), "dummy", "value", 100);
+    }
+
+    public void testMustNotPenaltyIsBounded() {
+        BooleanQuery query = new BooleanQuery.Builder().build();
+
+        // Create a must clause with large doc count
+        TermPlanNode mustNode = new TermPlanNode(
+            new TermQuery(new Term("field", "value")),
+            "field",
+            "value",
+            1_000_000  // 1 million docs
+        );
+
+        TermPlanNode mustNotNode = new TermPlanNode(new TermQuery(new Term("field", "excluded")), "field", "excluded", 100);
+
+        // First get cost without must_not
+        BooleanPlanNode nodeWithoutMustNot = new BooleanPlanNode(
+            query,
+            Arrays.asList(mustNode),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            0
+        );
+
+        double cpuWithoutMustNot = nodeWithoutMustNot.getEstimatedCost().getCpuCost();
+
+        // Now with must_not
+        BooleanPlanNode nodeWithMustNot = new BooleanPlanNode(
+            query,
+            Arrays.asList(mustNode),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Arrays.asList(mustNotNode),
+            0
+        );
+
+        double cpuWithMustNot = nodeWithMustNot.getEstimatedCost().getCpuCost();
+
+        // The CPU increase should be bounded (≤ 0.3 increase)
+        double cpuIncrease = cpuWithMustNot - cpuWithoutMustNot;
+        assertTrue(
+            "Must not penalty should be bounded: " + cpuIncrease + " (with=" + cpuWithMustNot + ", without=" + cpuWithoutMustNot + ")",
+            cpuIncrease <= 0.3
+        );
+        assertTrue("Must not should add some CPU cost", cpuIncrease > 0);
+    }
+}

--- a/server/src/test/java/org/opensearch/search/planner/nodes/BooleanPlanNodeTests.java
+++ b/server/src/test/java/org/opensearch/search/planner/nodes/BooleanPlanNodeTests.java
@@ -151,11 +151,11 @@ public class BooleanPlanNodeTests extends OpenSearchTestCase {
 
         double cpuWithMustNot = nodeWithMustNot.getEstimatedCost().getCpuCost();
 
-        // The CPU increase should be bounded (≤ 0.3 increase)
+        // The CPU increase should be bounded (based on MUST_NOT_CPU_FACTOR and clause count)
         double cpuIncrease = cpuWithMustNot - cpuWithoutMustNot;
         assertTrue(
             "Must not penalty should be bounded: " + cpuIncrease + " (with=" + cpuWithMustNot + ", without=" + cpuWithoutMustNot + ")",
-            cpuIncrease <= 0.3
+            cpuIncrease <= 0.4  // Accounts for factor (0.3) + overhead
         );
         assertTrue("Must not should add some CPU cost", cpuIncrease > 0);
     }

--- a/server/src/test/java/org/opensearch/search/planner/nodes/TermPlanNodeTests.java
+++ b/server/src/test/java/org/opensearch/search/planner/nodes/TermPlanNodeTests.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.planner.nodes;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
+import org.opensearch.search.planner.QueryCost;
+import org.opensearch.search.planner.QueryNodeType;
+import org.opensearch.search.planner.QueryPlanProfile;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class TermPlanNodeTests extends OpenSearchTestCase {
+
+    public void testTermPlanNode() {
+        TermQuery query = new TermQuery(new Term("field", "value"));
+        TermPlanNode node = new TermPlanNode(query, "field", "value", 100);
+
+        assertEquals(QueryNodeType.TERM, node.getType());
+        assertEquals("field", node.getField());
+        assertEquals("value", node.getValue());
+        assertEquals(query, node.getLuceneQuery());
+        assertTrue(node.getChildren().isEmpty());
+    }
+
+    public void testCostCalculation() {
+        TermQuery query = new TermQuery(new Term("field", "value"));
+        TermPlanNode node = new TermPlanNode(query, "field", "value", 100);
+
+        QueryCost cost = node.getEstimatedCost();
+        assertNotNull(cost);
+        assertEquals(100, cost.getLuceneCost());
+        assertEquals(0.001, cost.getCpuCost(), 0.0001); // Very low CPU cost
+        assertEquals(800, cost.getMemoryCost()); // 100 * 8 bytes
+        assertEquals(0.01, cost.getIoCost(), 0.0001); // Low I/O cost
+        assertTrue(cost.isEstimate());
+    }
+
+    public void testProfile() {
+        TermQuery query = new TermQuery(new Term("status", "active"));
+        TermPlanNode node = new TermPlanNode(query, "status", "active", 500);
+
+        QueryPlanProfile profile = node.getProfile();
+        assertNotNull(profile);
+        assertEquals("TERM", profile.getQueryType());
+        assertEquals("status", profile.getAttributes().get("field"));
+        assertEquals("active", profile.getAttributes().get("value"));
+        assertEquals(500L, profile.getAttributes().get("estimated_doc_frequency"));
+    }
+
+    public void testToString() {
+        TermQuery query = new TermQuery(new Term("field", "value"));
+        TermPlanNode node = new TermPlanNode(query, "field", "value", 100);
+
+        String str = node.toString();
+        assertTrue(str.contains("TERM"));
+        assertTrue(str.contains("TermQuery"));
+        assertTrue(str.contains("cost="));
+    }
+}


### PR DESCRIPTION
 Following up on Phase 1 (PR #19060), this adds the cost estimation
  infrastructure needed for query optimization (RFC #18906).

  What this does:
  Builds a tree of QueryPlanNode objects from QueryBuilder
  Estimates query costs by summing Lucene scorer costs across all segments
  Tracks CPU/memory/IO costs alongside document counts
  Preserves field names and query metadata (lost when converting to Lucene)

  The main insight is using Lucene's existing scorer.cost() aggregated
  properly across index leaves, then adding our own heuristics for
  things Lucene doesn't track.

  Notable implementation details:
  BooleanPlanNode caps must_not penalties so costs don't explode
  Percentage minimumShouldMatch now works (e.g. "50%")
  Feature flagged: -Dopensearch.experimental.feature.query_planner.enabled

  No user-visible changes yet - this is just the foundation for Phase 3
  where we'll actually optimize queries based on these costs.

  Signed-off-by: Atri Sharma <atri.jiit@gmail.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
