### PR TITLE
Add `epoch_micros` date format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add a dynamic setting to change skip_cache_factor and min_frequency for querycache ([#18351](https://github.com/opensearch-project/OpenSearch/issues/18351))
 - Add overload constructor for Translog to accept Channel Factory as a parameter ([#18918](https://github.com/opensearch-project/OpenSearch/pull/18918))
 - Add subdirectory-aware store module with recovery support ([#19132](https://github.com/opensearch-project/OpenSearch/pull/19132))
+- Add `epoch_micros` date format ([#14669](https://github.com/opensearch-project/OpenSearch/issues/14669))
 
 ### Changed
 - Add CompletionStage variants to methods in the Client Interface and default to ActionListener impl ([#18998](https://github.com/opensearch-project/OpenSearch/pull/18998))

--- a/server/src/main/java/org/opensearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/opensearch/common/time/DateFormatters.java
@@ -2119,6 +2119,8 @@ public class DateFormatters {
         } else if (FormatNames.EPOCH_MILLIS.matches(input)) {
             return EpochTime.MILLIS_FORMATTER;
             // strict date formats here, must be at least 4 digits for year and two for months and two for day
+        } else if (FormatNames.EPOCH_MICROS.matches(input)) {
+            return EpochTime.MICROS_FORMATTER;
         } else if (FormatNames.STRICT_BASIC_WEEK_DATE.matches(input)) {
             return STRICT_BASIC_WEEK_DATE;
         } else if (FormatNames.STRICT_BASIC_WEEK_DATE_TIME.matches(input)) {

--- a/server/src/main/java/org/opensearch/common/time/FormatNames.java
+++ b/server/src/main/java/org/opensearch/common/time/FormatNames.java
@@ -91,6 +91,7 @@ public enum FormatNames {
     YEAR_MONTH_DAY("yearMonthDay", "year_month_day"),
     EPOCH_SECOND(null, "epoch_second"),
     EPOCH_MILLIS(null, "epoch_millis"),
+    EPOCH_MICROS(null, "epoch_micros"),
     // strict date formats here, must be at least 4 digits for year and two for months and two for day"
     STRICT_BASIC_WEEK_DATE("strictBasicWeekDate", "strict_basic_week_date"),
     STRICT_BASIC_WEEK_DATE_TIME("strictBasicWeekDateTime", "strict_basic_week_date_time"),

--- a/server/src/test/java/org/opensearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/opensearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -782,7 +782,8 @@ public class JavaJodaTimeDuellingTests extends OpenSearchTestCase {
         for (FormatNames format : FormatNames.values()) {
             if (format == FormatNames.ISO8601
                 || format == FormatNames.STRICT_DATE_OPTIONAL_TIME_NANOS
-                || format == FormatNames.RFC3339_LENIENT) {
+                || format == FormatNames.RFC3339_LENIENT
+                || format == FormatNames.EPOCH_MICROS) {
                 // Nanos aren't supported by joda
                 continue;
             }


### PR DESCRIPTION
### Description
Introduce `epoch_micros` date format utilizing the same aproach as for `epoch_millis`

### Related Issues
Resolves #14669 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
