### PR TITLE
Fix  bug "synonym_graph filter fails with word_delimiter_graph when using whitespace or classic tokenizer in synonym_analyzer"

### DIFF
--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/ScriptedConditionTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/ScriptedConditionTokenFilterFactory.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.analysis.common;
 
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.miscellaneous.ConditionalTokenFilter;
 import org.opensearch.common.settings.Settings;
@@ -84,7 +85,8 @@ public class ScriptedConditionTokenFilterFactory extends AbstractTokenFilterFact
         TokenizerFactory tokenizer,
         List<CharFilterFactory> charFilters,
         List<TokenFilterFactory> previousTokenFilters,
-        Function<String, TokenFilterFactory> allFilters
+        Function<String, TokenFilterFactory> allFilters,
+        Function<String, Analyzer> analyzersBuiltSoFar
     ) {
         List<TokenFilterFactory> filters = new ArrayList<>();
         List<TokenFilterFactory> existingChain = new ArrayList<>(previousTokenFilters);
@@ -95,7 +97,7 @@ public class ScriptedConditionTokenFilterFactory extends AbstractTokenFilterFact
                     "ScriptedConditionTokenFilter [" + name() + "] refers to undefined token filter [" + filter + "]"
                 );
             }
-            tff = tff.getChainAwareTokenFilterFactory(tokenizer, charFilters, existingChain, allFilters);
+            tff = tff.getChainAwareTokenFilterFactory(tokenizer, charFilters, existingChain, allFilters, analyzersBuiltSoFar);
             filters.add(tff);
             existingChain.add(tff);
         }

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/SynonymGraphTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/SynonymGraphTokenFilterFactory.java
@@ -70,9 +70,10 @@ public class SynonymGraphTokenFilterFactory extends SynonymTokenFilterFactory {
         TokenizerFactory tokenizer,
         List<CharFilterFactory> charFilters,
         List<TokenFilterFactory> previousTokenFilters,
-        Function<String, TokenFilterFactory> allFilters
+        Function<String, TokenFilterFactory> allFilters,
+        Function<String, Analyzer> analyzersBuiltSoFar
     ) {
-        final Analyzer analyzer = buildSynonymAnalyzer(tokenizer, charFilters, previousTokenFilters, allFilters);
+        final Analyzer analyzer = buildSynonymAnalyzer(tokenizer, charFilters, previousTokenFilters, allFilters, analyzersBuiltSoFar);
         final SynonymMap synonyms = buildSynonyms(analyzer, getRulesFromSettings(environment));
         final String name = name();
         return new TokenFilterFactory() {

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/SynonymTokenFilterFactory.java
@@ -112,9 +112,10 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         TokenizerFactory tokenizer,
         List<CharFilterFactory> charFilters,
         List<TokenFilterFactory> previousTokenFilters,
-        Function<String, TokenFilterFactory> allFilters
+        Function<String, TokenFilterFactory> allFilters,
+        Function<String, Analyzer> analyzersBuiltSoFar
     ) {
-        final Analyzer analyzer = buildSynonymAnalyzer(tokenizer, charFilters, previousTokenFilters, allFilters);
+        final Analyzer analyzer = buildSynonymAnalyzer(tokenizer, charFilters, previousTokenFilters, allFilters, analyzersBuiltSoFar);
         final SynonymMap synonyms = buildSynonyms(analyzer, getRulesFromSettings(environment));
         final String name = name();
         return new TokenFilterFactory() {
@@ -147,10 +148,15 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         TokenizerFactory tokenizer,
         List<CharFilterFactory> charFilters,
         List<TokenFilterFactory> tokenFilters,
-        Function<String, TokenFilterFactory> allFilters
+        Function<String, TokenFilterFactory> allFilters,
+        Function<String, Analyzer> analyzersBuiltSoFar
     ) {
         if (synonymAnalyzerName != null) {
-            Analyzer customSynonymAnalyzer;
+            // first, check settings analyzers
+            Analyzer customSynonymAnalyzer = analyzersBuiltSoFar.apply(synonymAnalyzerName);
+            if (customSynonymAnalyzer != null) {
+                return customSynonymAnalyzer;
+            }
             try {
                 customSynonymAnalyzer = analysisRegistry.getAnalyzer(synonymAnalyzerName);
             } catch (IOException e) {

--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/EdgeNGramTokenizerTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/EdgeNGramTokenizerTests.java
@@ -49,10 +49,8 @@ import org.opensearch.test.VersionUtils;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.Arrays;
 import java.util.Collections;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasToString;
 
 public class EdgeNGramTokenizerTests extends OpenSearchTokenStreamTestCase {
 
@@ -99,7 +97,14 @@ public class EdgeNGramTokenizerTests extends OpenSearchTokenStreamTestCase {
                 IllegalArgumentException.class,
                 () -> buildAnalyzers(VersionUtils.randomVersionBetween(random(), Version.V_3_0_0, Version.CURRENT), "edgeNGram")
             );
-            assertThat(e, hasToString(containsString("The [edgeNGram] tokenizer name was deprecated pre 1.0.")));
+
+            boolean found = Arrays.stream(e.getSuppressed())
+                .map(org.opensearch.ExceptionsHelper::unwrapCause)
+                .map(Throwable::getMessage)
+                .findFirst()
+                .get()
+                .contains("The [edgeNGram] tokenizer name was deprecated pre 1.0.");
+            assertTrue("expected deprecation message in suppressed causes", found);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/analysis/AnalysisRegistry.java
+++ b/server/src/main/java/org/opensearch/index/analysis/AnalysisRegistry.java
@@ -54,6 +54,7 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -305,7 +306,7 @@ public final class AnalysisRegistry implements Closeable {
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
-            });
+            }, null);
             tokenFilterFactories.add(tff);
         }
 
@@ -362,7 +363,30 @@ public final class AnalysisRegistry implements Closeable {
 
     private Map<String, AnalyzerProvider<?>> buildAnalyzerFactories(IndexSettings indexSettings) throws IOException {
         final Map<String, Settings> analyzersSettings = indexSettings.getSettings().getGroups("index.analysis.analyzer");
-        return buildMapping(Component.ANALYZER, indexSettings, analyzersSettings, analyzers, prebuiltAnalysis.analyzerProviderFactories);
+
+        // Some analyzers depend on others that need to be built first
+        // Sort by 'order', default to 1000
+        List<Map.Entry<String, Settings>> sortedEntries = analyzersSettings.entrySet().stream().sorted((a, b) -> {
+            int orderA = a.getValue().getAsInt("order", 100);
+            int orderB = b.getValue().getAsInt("order", 100);
+            if (orderA != orderB) {
+                return Integer.compare(orderA, orderB);
+            }
+            return a.getKey().compareTo(b.getKey());
+        }).collect(Collectors.toList());
+
+        Map<String, Settings> sortedAnalyzersSettings = new LinkedHashMap<>();
+        for (Map.Entry<String, Settings> entry : sortedEntries) {
+            sortedAnalyzersSettings.put(entry.getKey(), entry.getValue());
+        }
+
+        return buildMapping(
+            Component.ANALYZER,
+            indexSettings,
+            sortedAnalyzersSettings,
+            analyzers,
+            prebuiltAnalysis.analyzerProviderFactories
+        );
     }
 
     private Map<String, AnalyzerProvider<?>> buildNormalizerFactories(IndexSettings indexSettings) throws IOException {
@@ -486,7 +510,7 @@ public final class AnalysisRegistry implements Closeable {
         Map<String, ? extends AnalysisModule.AnalysisProvider<T>> defaultInstance
     ) throws IOException {
         Settings defaultSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, settings.getIndexVersionCreated()).build();
-        Map<String, T> factories = new HashMap<>();
+        Map<String, T> factories = new LinkedHashMap<>(); // keep insertion order
         for (Map.Entry<String, Settings> entry : settingsMap.entrySet()) {
             String name = entry.getKey();
             Settings currentSettings = entry.getValue();
@@ -637,21 +661,27 @@ public final class AnalysisRegistry implements Closeable {
         Map<String, NamedAnalyzer> analyzers = new HashMap<>();
         Map<String, NamedAnalyzer> normalizers = new HashMap<>();
         Map<String, NamedAnalyzer> whitespaceNormalizers = new HashMap<>();
+        Map<String, Exception> buildErrors = new LinkedHashMap<>();
+        Map<String, Analyzer> analyzersBuiltSoFar = new HashMap<>();
         for (Map.Entry<String, AnalyzerProvider<?>> entry : analyzerProviders.entrySet()) {
-            analyzers.merge(
-                entry.getKey(),
-                produceAnalyzer(
+            try {
+                NamedAnalyzer namedAnalyzer = produceAnalyzer(
                     entry.getKey(),
                     entry.getValue(),
                     tokenFilterFactoryFactories,
                     charFilterFactoryFactories,
-                    tokenizerFactoryFactories
-                ),
-                (k, v) -> {
+                    tokenizerFactoryFactories,
+                    analyzersBuiltSoFar
+                );
+                analyzers.merge(entry.getKey(), namedAnalyzer, (k, v) -> {
                     throw new IllegalStateException("already registered analyzer with name: " + entry.getKey());
-                }
-            );
+                });
+                analyzersBuiltSoFar.put(entry.getKey(), namedAnalyzer);
+            } catch (Exception e) {
+                buildErrors.put(entry.getKey(), e);
+            }
         }
+
         for (Map.Entry<String, AnalyzerProvider<?>> entry : normalizerProviders.entrySet()) {
             processNormalizerFactory(
                 entry.getKey(),
@@ -707,6 +737,14 @@ public final class AnalysisRegistry implements Closeable {
                 throw new IllegalArgumentException("analyzer name must not start with '_'. got \"" + analyzer.getKey() + "\"");
             }
         }
+
+        if (!buildErrors.isEmpty()) {
+            IllegalArgumentException aggregated = new IllegalArgumentException("Failed to build analyzers: " + buildErrors.keySet());
+            buildErrors.forEach(
+                (name, ex) -> aggregated.addSuppressed(new IllegalArgumentException("[" + name + "] " + ex.getMessage(), ex))
+            );
+            throw aggregated;
+        }
         return new IndexAnalyzers(analyzers, normalizers, whitespaceNormalizers);
     }
 
@@ -717,6 +755,17 @@ public final class AnalysisRegistry implements Closeable {
         Map<String, CharFilterFactory> charFilters,
         Map<String, TokenizerFactory> tokenizers
     ) {
+        return produceAnalyzer(name, analyzerFactory, tokenFilters, charFilters, tokenizers, Collections.emptyMap());
+    }
+
+    private static NamedAnalyzer produceAnalyzer(
+        String name,
+        AnalyzerProvider<?> analyzerFactory,
+        Map<String, TokenFilterFactory> tokenFilters,
+        Map<String, CharFilterFactory> charFilters,
+        Map<String, TokenizerFactory> tokenizers,
+        Map<String, Analyzer> analyzersBuiltSoFar
+    ) {
         /*
          * Lucene defaults positionIncrementGap to 0 in all analyzers but
          * Elasticsearch defaults them to 0 only before version 2.0
@@ -725,7 +774,7 @@ public final class AnalysisRegistry implements Closeable {
          */
         int overridePositionIncrementGap = TextFieldMapper.Defaults.POSITION_INCREMENT_GAP;
         if (analyzerFactory instanceof CustomAnalyzerProvider) {
-            ((CustomAnalyzerProvider) analyzerFactory).build(tokenizers, charFilters, tokenFilters);
+            ((CustomAnalyzerProvider) analyzerFactory).build(tokenizers, charFilters, tokenFilters, analyzersBuiltSoFar);
             /*
              * Custom analyzers already default to the correct, version
              * dependent positionIncrementGap and the user is be able to

--- a/server/src/main/java/org/opensearch/index/analysis/CustomAnalyzerProvider.java
+++ b/server/src/main/java/org/opensearch/index/analysis/CustomAnalyzerProvider.java
@@ -61,9 +61,10 @@ public class CustomAnalyzerProvider extends AbstractIndexAnalyzerProvider<Analyz
     void build(
         final Map<String, TokenizerFactory> tokenizers,
         final Map<String, CharFilterFactory> charFilters,
-        final Map<String, TokenFilterFactory> tokenFilters
+        final Map<String, TokenFilterFactory> tokenFilters,
+        final Map<String, Analyzer> analyzersBuiltSoFar
     ) {
-        customAnalyzer = create(name(), analyzerSettings, tokenizers, charFilters, tokenFilters);
+        customAnalyzer = create(name(), analyzerSettings, tokenizers, charFilters, tokenFilters, analyzersBuiltSoFar);
     }
 
     /**
@@ -75,12 +76,20 @@ public class CustomAnalyzerProvider extends AbstractIndexAnalyzerProvider<Analyz
         Settings analyzerSettings,
         Map<String, TokenizerFactory> tokenizers,
         Map<String, CharFilterFactory> charFilters,
-        Map<String, TokenFilterFactory> tokenFilters
+        Map<String, TokenFilterFactory> tokenFilters,
+        Map<String, Analyzer> analyzersBuiltSoFar
     ) {
         int positionIncrementGap = TextFieldMapper.Defaults.POSITION_INCREMENT_GAP;
         positionIncrementGap = analyzerSettings.getAsInt("position_increment_gap", positionIncrementGap);
         int offsetGap = analyzerSettings.getAsInt("offset_gap", -1);
-        AnalyzerComponents components = createComponents(name, analyzerSettings, tokenizers, charFilters, tokenFilters);
+        AnalyzerComponents components = createComponents(
+            name,
+            analyzerSettings,
+            tokenizers,
+            charFilters,
+            tokenFilters,
+            analyzersBuiltSoFar
+        );
         if (components.analysisMode().equals(AnalysisMode.SEARCH_TIME)) {
             return new ReloadableCustomAnalyzer(components, positionIncrementGap, offsetGap);
         } else {

--- a/server/src/main/java/org/opensearch/index/analysis/TokenFilterFactory.java
+++ b/server/src/main/java/org/opensearch/index/analysis/TokenFilterFactory.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.analysis;
 
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.opensearch.common.annotation.PublicApi;
@@ -76,12 +77,14 @@ public interface TokenFilterFactory {
      * @param charFilters           any CharFilterFactories for the preceding chain
      * @param previousTokenFilters  a list of TokenFilterFactories in the preceding chain
      * @param allFilters            access to previously defined TokenFilterFactories
+     * @param analyzersBuiltSoFar   already built analyzers
      */
     default TokenFilterFactory getChainAwareTokenFilterFactory(
         TokenizerFactory tokenizer,
         List<CharFilterFactory> charFilters,
         List<TokenFilterFactory> previousTokenFilters,
-        Function<String, TokenFilterFactory> allFilters
+        Function<String, TokenFilterFactory> allFilters,
+        Function<String, Analyzer> analyzersBuiltSoFar
     ) {
         return this;
     }


### PR DESCRIPTION
This PR fixes the  "synonym_graph filter fails with word_delimiter_graph when using whitespace or classic tokenizer in synonym_analyzer" bug

The solution is two folds
- Fail safe instead of fail fast when building the analyzers.
- Build the depending analyzers first.


**Fail safe instead of fail fast when building the analyzers**
Right now, if an analyzer fails for some reason the whole building process fails with an exception.

**Build the depending analyzers first**:
Synonym custom analyzers may depend on another analyzer that has to be built first. 
The PR adds a logic to:

- add option "order" attribute that defines precedence order between analyzers
- add 'analyzersBuiltSoFar' to _getChainAwareTokenFilterFactory_ to pass the already built analyzers needed by the one being built

Resolves [#18037](https://github.com/opensearch-project/OpenSearch/issues/18037)

  
### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
