### PR TITLE
Remove unnecessary iteration in request cache clear

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/cache/clear/TransportClearIndicesCacheAction.java
@@ -33,6 +33,7 @@
 package org.opensearch.action.admin.indices.cache.clear;
 
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.broadcast.BroadcastShardOperationFailedException;
 import org.opensearch.action.support.broadcast.node.TransportBroadcastByNodeAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.block.ClusterBlockException;
@@ -133,6 +134,11 @@ public class TransportClearIndicesCacheAction extends TransportBroadcastByNodeAc
             request.fields()
         );
         return EmptyResult.INSTANCE;
+    }
+
+    @Override
+    protected void nodeOperation(List<EmptyResult> results, List<BroadcastShardOperationFailedException> accumulatedExceptions) {
+        indicesService.forceClearNodewideCaches();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -239,6 +239,13 @@ public abstract class TransportBroadcastByNodeAction<
     protected abstract ShardsIterator shards(ClusterState clusterState, Request request, String[] concreteIndices);
 
     /**
+     * Executes a node-level operation. This method is called one time per node, after all shard-level operations have completed.
+     * @param results List of results from the completed shard-level operations.
+     * @param accumulatedExceptions List of any exceptions thrown by the shard-level operations.
+     */
+    protected void nodeOperation(List<ShardOperationResult> results, List<BroadcastShardOperationFailedException> accumulatedExceptions) {}
+
+    /**
      * Executes a global block check before polling the cluster state.
      *
      * @param state   the cluster state
@@ -478,6 +485,8 @@ public abstract class TransportBroadcastByNodeAction<
                     results.add((ShardOperationResult) shardResultOrExceptions[i]);
                 }
             }
+
+            nodeOperation(results, accumulatedExceptions);
 
             channel.sendResponse(new NodeResponse(request.getNodeId(), totalShards, results, accumulatedExceptions));
         }

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -266,6 +266,9 @@ public final class IndicesRequestCache implements RemovalListener<ICacheKey<Indi
 
     void clear(CacheEntity entity) {
         cacheCleanupManager.enqueueCleanupKey(new CleanupKey(entity, null));
+    }
+
+    void forceCleanCache() {
         cacheCleanupManager.forceCleanCache();
     }
 

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -2117,6 +2117,7 @@ public class IndicesService extends AbstractLifecycleComponent
 
     /**
      * Clears the caches for the given shard id if the shard is still allocated on this node
+     * Query cache keys are cleared immediately by this method; field data and request cache keys are only marked for cleanup
      */
     public void clearIndexShardCache(ShardId shardId, boolean queryCache, boolean fieldDataCache, boolean requestCache, String... fields) {
         final IndexService service = indexService(shardId.getIndex());
@@ -2127,6 +2128,14 @@ public class IndicesService extends AbstractLifecycleComponent
                 indicesRequestCache.clear(new IndexShardCacheEntity(shard));
             }
         }
+    }
+
+    /**
+     * Force clear node-wide field data and request caches, which will remove any keys which have been previously marked for cleanup.
+     */
+    public void forceClearNodewideCaches() {
+        indicesRequestCache.forceCleanCache();
+        // TODO: FDC can come after, as it relies on other PRs.
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -2117,7 +2117,8 @@ public class IndicesService extends AbstractLifecycleComponent
 
     /**
      * Clears the caches for the given shard id if the shard is still allocated on this node
-     * Query cache keys are cleared immediately by this method; field data and request cache keys are only marked for cleanup
+     * Query cache and field data cache keys are cleared immediately by this method; request cache keys are only marked for cleanup
+     * TODO: In a future PR field data cache keys will also only be marked for cleanup.
      */
     public void clearIndexShardCache(ShardId shardId, boolean queryCache, boolean fieldDataCache, boolean requestCache, String... fields) {
         final IndexService service = indexService(shardId.getIndex());
@@ -2131,11 +2132,11 @@ public class IndicesService extends AbstractLifecycleComponent
     }
 
     /**
-     * Force clear node-wide field data and request caches, which will remove any keys which have been previously marked for cleanup.
+     * Force clear node-wide request cache, which will remove any keys which have been previously marked for cleanup.
      */
     public void forceClearNodewideCaches() {
         indicesRequestCache.forceCleanCache();
-        // TODO: FDC can come after, as it relies on other PRs.
+        // TODO: Field data cache will also be cleared here in a future PR. 
     }
 
     /**

--- a/server/src/test/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
+++ b/server/src/test/java/org/opensearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
@@ -59,8 +59,10 @@ import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.ShardsIterator;
 import org.opensearch.cluster.routing.TestShardRouting;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.support.DefaultShardOperationFailedException;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -68,6 +70,7 @@ import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.tasks.Task;
 import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.transport.CapturingTransport;
@@ -99,6 +102,7 @@ import static org.opensearch.test.ClusterServiceUtils.setState;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.object.HasToString.hasToString;
+import static org.mockito.Mockito.mock;
 
 public class TransportBroadcastByNodeActionTests extends OpenSearchTestCase {
 
@@ -137,6 +141,7 @@ public class TransportBroadcastByNodeActionTests extends OpenSearchTestCase {
         Response,
         TransportBroadcastByNodeAction.EmptyResult> {
         private final Map<ShardRouting, Object> shards = new HashMap<>();
+        private final CounterMetric nodeOperationCount = new CounterMetric();
 
         TestTransportBroadcastByNodeAction(
             TransportService transportService,
@@ -204,6 +209,18 @@ public class TransportBroadcastByNodeActionTests extends OpenSearchTestCase {
         @Override
         protected ClusterBlockException checkRequestBlock(ClusterState state, Request request, String[] concreteIndices) {
             return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, concreteIndices);
+        }
+
+        @Override
+        protected void nodeOperation(
+            List<TransportBroadcastByNodeAction.EmptyResult> results,
+            List<BroadcastShardOperationFailedException> accumulatedExceptions
+        ) {
+            nodeOperationCount.inc();
+        }
+
+        public long getNodeOperationCount() {
+            return nodeOperationCount.count();
         }
 
         public Map<ShardRouting, Object> getResults() {
@@ -452,6 +469,33 @@ public class TransportBroadcastByNodeActionTests extends OpenSearchTestCase {
             assertThat(exception.getMessage(), is("operation indices:admin/test failed"));
             assertThat(exception, hasToString(containsString("operation failed")));
         }
+        assertEquals(1, action.getNodeOperationCount());
+    }
+
+    public void testNodeLevelHookForMultiNode() throws Exception {
+        // Manually send the request from coordinator --> target nodes, action.doExecute() does not do that in this test case setup
+
+        Request request = new Request(new String[] { TEST_INDEX });
+        final PlainActionFuture<Response> listener = PlainActionFuture.newFuture();
+        action.doExecute(mock(Task.class), request, ActionListener.wrap(listener::onResponse, listener::onFailure));
+
+        // Get captured NodeRequest from coordinator for each target node
+        Map<String, List<CapturingTransport.CapturedRequest>> captured = transport.getCapturedRequestsByTargetNodeAndClear();
+        assertFalse("expected at least one target node", captured.isEmpty());
+
+        final TransportBroadcastByNodeAction<?, ?, ?>.BroadcastByNodeTransportRequestHandler handler =
+            action.new BroadcastByNodeTransportRequestHandler();
+
+        for (Map.Entry<String, List<CapturingTransport.CapturedRequest>> e : captured.entrySet()) {
+            CapturingTransport.CapturedRequest cr = e.getValue().get(0);
+            assertEquals(action.transportNodeBroadcastAction, cr.action);
+            TransportBroadcastByNodeAction.NodeRequest nodeReq = (TransportBroadcastByNodeAction.NodeRequest) cr.request;
+
+            final PlainActionFuture<TransportResponse> future = PlainActionFuture.newFuture();
+            TestTransportChannel channel = new TestTransportChannel(future);
+            handler.messageReceived(nodeReq, channel, null);
+        }
+        assertEquals("nodeOperation should run once per target node", captured.size(), action.getNodeOperationCount());
     }
 
     public void testResultAggregation() throws ExecutionException, InterruptedException {


### PR DESCRIPTION
### Description
Adds a node-level hook to TransportBroadcastByNodeAction which runs after all shard-level operations on that node have finished. 

Also reworks TransportClearIndicesCacheAction to use this new hook, to prevent needlessly iterating through all cache keys once per shard, which caused high cache clear latency especially if the disk cache is used. I bundled the two together into one PR since both changes are pretty small. 

I got cache clear numbers from cleaning up 2M request cache keys in a disk tier, spread across 10 indices (1 shard each), on a single node hosted on a c5.2xl instance. 

| Run | Clear time (sec) | 
|--|--|
| Baseline | 131.56 | 
| Contender | 60.62 | 

### Related Issues
Resolves: 
https://github.com/opensearch-project/OpenSearch/issues/19183
https://github.com/opensearch-project/OpenSearch/issues/19118

### Check List
- [x] Functionality includes testing.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
