### PR TITLE
Remove direct execution of application code within gRPC worker thread

### DIFF
--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/Netty4GrpcServerTransport.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/Netty4GrpcServerTransport.java
@@ -356,7 +356,6 @@ public class Netty4GrpcServerTransport extends AuxTransport {
             try {
                 final InetSocketAddress address = new InetSocketAddress(hostAddress, portNumber);
                 final NettyServerBuilder serverBuilder = NettyServerBuilder.forAddress(address)
-                    .directExecutor()
                     .bossEventLoopGroup(eventLoopGroup)
                     .workerEventLoopGroup(eventLoopGroup)
                     .maxInboundMessageSize((int) maxInboundMessageSize)


### PR DESCRIPTION
### Description
Initially `directExecutor` was added to avoid the `io.grpc` package initializing a default static thread pool and to use the `NioEventLoopGroup` configurable by "grpc.netty.worker_count" instead. This is a mistake as the `workerEventLoopGroup` is intended for initial processing (TLS/HTTP2 request building) of requests forwarded by the `bossEventLoopGroup`. These threads are intended to do small amounts of processing and should never handle operations which may block as this risks starving incoming connections even when resource usage is low.

https://groups.google.com/g/grpc-io/c/LrnAbWFozb0/m/VYCVarkWBQAJ
https://grpc.github.io/grpc-java/javadoc/io/grpc/ForwardingServerBuilder.html#directExecutor()

By bulk ingesting with OSB and more concurrent client connections than worker threads available I'm able to starve new client connections on the server after some time:
```
Cannot run task [grpc-index-append]: <AioRpcError of RPC that terminated with:
status = StatusCode.UNAVAILABLE
details = "failed to connect to all addresses; last error: UNKNOWN: ipv4::9400: Failed to connect to remote host: getsockopt(SO_ERROR): Operation timed out (60)"
debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2025-09-08T16:08:15.0263-07:00", grpc_status:14, grpc_message:"failed to connect to all addresses; last error: UNKNOWN: ipv4::9400: Failed to connect to remote host: getsockopt(SO_ERROR): Operation timed out (60)"}"
```

### Related Issues
N/A

### Check List
~~- [ ] Functionality includes testing.~~
~~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~~
~~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
