### PR TITLE
Fix regression: preserve not(not X) in BooleanFlatteningRewriter

### DIFF
--- a/server/src/main/java/org/opensearch/search/query/rewriters/BooleanFlatteningRewriter.java
+++ b/server/src/main/java/org/opensearch/search/query/rewriters/BooleanFlatteningRewriter.java
@@ -131,7 +131,7 @@ public class BooleanFlatteningRewriter implements QueryRewriter {
 
                 // Special handling for double negation: NOT over a bool that is ONLY NOTs
                 if (clauseType == ClauseType.MUST_NOT && canFlatten(nestedBool, ClauseType.MUST_NOT)) {
-                    // not( bool( must_not: [X1..Xn] ) )  ==>  must( bool( should: [X1..Xn], minimum_should_match: 1 ) )
+                    // not( bool( must_not: [X1..Xn] ) ) ==> must( bool( should: [X1..Xn], minimum_should_match: 1 ) )
                     // This preserves the logical equivalence not(not(X)) == X and generalizes to multiple X via OR.
                     BoolQueryBuilder orQuery = new BoolQueryBuilder();
                     orQuery.minimumShouldMatch(1);

--- a/server/src/test/java/org/opensearch/search/query/rewriters/BooleanFlatteningRewriterTests.java
+++ b/server/src/test/java/org/opensearch/search/query/rewriters/BooleanFlatteningRewriterTests.java
@@ -103,7 +103,7 @@ public class BooleanFlatteningRewriterTests extends OpenSearchTestCase {
     }
 
     public void testDoubleNegationConvertedToPositiveMustShould() {
-        // not( bool( must_not: [ term ] ) )  => must( bool( should: [ term ], msm=1 ) )
+        // not( bool( must_not: [ term ] ) ) => must( bool( should: [ term ], msm=1 ) )
         QueryBuilder inner = QueryBuilders.boolQuery().mustNot(QueryBuilders.termQuery("product", "Oranges"));
         QueryBuilder query = QueryBuilders.boolQuery().mustNot(inner);
 

--- a/server/src/test/java/org/opensearch/search/query/rewriters/BooleanFlatteningRewriterTests.java
+++ b/server/src/test/java/org/opensearch/search/query/rewriters/BooleanFlatteningRewriterTests.java
@@ -116,6 +116,50 @@ public class BooleanFlatteningRewriterTests extends OpenSearchTestCase {
         assertThat(rewrittenBool.mustNot().get(0), instanceOf(BoolQueryBuilder.class));
     }
 
+    public void testDeMorganPatternNotFlattenedUnderMustNot() {
+        // not( bool( must: [A, B] ) ) should not be flattened by BooleanFlatteningRewriter
+        QueryBuilder inner = QueryBuilders.boolQuery().must(QueryBuilders.termQuery("f", "A")).must(QueryBuilders.termQuery("f", "B"));
+        QueryBuilder query = QueryBuilders.boolQuery().mustNot(inner);
+
+        QueryBuilder rewritten = rewriter.rewrite(query, context);
+        assertThat(rewritten, instanceOf(BoolQueryBuilder.class));
+        BoolQueryBuilder rewrittenBool = (BoolQueryBuilder) rewritten;
+        assertThat(rewrittenBool.mustNot().size(), equalTo(1));
+        assertThat(rewrittenBool.mustNot().get(0), instanceOf(BoolQueryBuilder.class));
+    }
+
+    public void testRandomizedMustNotInnerNotFlattened() {
+        // Build inner bool with random number of must_not terms
+        int n = between(1, 5);
+        BoolQueryBuilder inner = QueryBuilders.boolQuery();
+        for (int i = 0; i < n; i++) {
+            inner.mustNot(QueryBuilders.termQuery("p", "v" + i));
+        }
+        QueryBuilder query = QueryBuilders.boolQuery().mustNot(inner);
+
+        QueryBuilder rewritten = rewriter.rewrite(query, context);
+        assertThat(rewritten, instanceOf(BoolQueryBuilder.class));
+        BoolQueryBuilder rewrittenBool = (BoolQueryBuilder) rewritten;
+        assertThat(rewrittenBool.mustNot().size(), equalTo(1));
+        assertThat(rewrittenBool.mustNot().get(0), instanceOf(BoolQueryBuilder.class));
+    }
+
+    public void testTopLevelPropertiesPreserved() {
+        BoolQueryBuilder query = QueryBuilders.boolQuery()
+            .queryName("qn")
+            .boost(2.0f)
+            .minimumShouldMatch(2)
+            .must(QueryBuilders.boolQuery().must(QueryBuilders.termQuery("field", "v")))
+            .should(QueryBuilders.boolQuery().should(QueryBuilders.termQuery("f2", "v2")));
+
+        QueryBuilder rewritten = rewriter.rewrite(query, context);
+        assertThat(rewritten, instanceOf(BoolQueryBuilder.class));
+        BoolQueryBuilder rewrittenBool = (BoolQueryBuilder) rewritten;
+        assertThat(rewrittenBool.queryName(), equalTo("qn"));
+        assertThat(rewrittenBool.boost(), equalTo(2.0f));
+        assertThat(rewrittenBool.minimumShouldMatch(), equalTo("2"));
+    }
+
     @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/18906")
     public void testDeepNesting() {
         // TODO: This test expects complete flattening of deeply nested bool queries
@@ -152,6 +196,53 @@ public class BooleanFlatteningRewriterTests extends OpenSearchTestCase {
 
         QueryBuilder rewritten = rewriter.rewrite(query, context);
         assertSame(query, rewritten); // Should not flatten due to different minimumShouldMatch
+    }
+
+    public void testDoNotFlattenWhenNestedHasNonDefaultBoost() {
+        // Nested bool with non-default boost should not be flattened
+        BoolQueryBuilder nested = QueryBuilders.boolQuery().boost(2.0f).must(QueryBuilders.termQuery("field", "value"));
+        BoolQueryBuilder query = QueryBuilders.boolQuery().must(nested);
+
+        QueryBuilder rewritten = rewriter.rewrite(query, context);
+        assertThat(rewritten, instanceOf(BoolQueryBuilder.class));
+        BoolQueryBuilder outer = (BoolQueryBuilder) rewritten;
+        assertThat(outer.must().size(), equalTo(1));
+        assertThat(outer.must().get(0), instanceOf(BoolQueryBuilder.class));
+        BoolQueryBuilder preserved = (BoolQueryBuilder) outer.must().get(0);
+        assertThat(preserved.boost(), equalTo(2.0f));
+        assertThat(preserved.must().size(), equalTo(1));
+    }
+
+    public void testDoNotFlattenWhenNestedHasQueryName() {
+        // Nested bool with queryName should not be flattened
+        BoolQueryBuilder nested = QueryBuilders.boolQuery().queryName("inner").must(QueryBuilders.termQuery("f", "v"));
+        BoolQueryBuilder query = QueryBuilders.boolQuery().must(nested);
+
+        QueryBuilder rewritten = rewriter.rewrite(query, context);
+        assertThat(rewritten, instanceOf(BoolQueryBuilder.class));
+        BoolQueryBuilder outer = (BoolQueryBuilder) rewritten;
+        assertThat(outer.must().size(), equalTo(1));
+        assertThat(outer.must().get(0), instanceOf(BoolQueryBuilder.class));
+        BoolQueryBuilder preserved = (BoolQueryBuilder) outer.must().get(0);
+        assertThat(preserved.queryName(), equalTo("inner"));
+    }
+
+    public void testShouldClauseNotFlattenedWhenNestedHasMinimumShouldMatch() {
+        // Nested should with MSM should not be flattened
+        BoolQueryBuilder nested = QueryBuilders.boolQuery()
+            .should(QueryBuilders.termQuery("f1", "v1"))
+            .should(QueryBuilders.termQuery("f2", "v2"))
+            .minimumShouldMatch(1);
+        BoolQueryBuilder query = QueryBuilders.boolQuery().should(nested).must(QueryBuilders.termQuery("g", "w"));
+
+        QueryBuilder rewritten = rewriter.rewrite(query, context);
+        assertThat(rewritten, instanceOf(BoolQueryBuilder.class));
+        BoolQueryBuilder outer = (BoolQueryBuilder) rewritten;
+        assertThat(outer.should().size(), equalTo(1));
+        assertThat(outer.should().get(0), instanceOf(BoolQueryBuilder.class));
+        BoolQueryBuilder preserved = (BoolQueryBuilder) outer.should().get(0);
+        assertThat(preserved.minimumShouldMatch(), equalTo("1"));
+        assertThat(outer.must().size(), equalTo(1));
     }
 
     public void testEmptyBooleanQuery() {
@@ -192,5 +283,16 @@ public class BooleanFlatteningRewriterTests extends OpenSearchTestCase {
         QueryBuilder rewritten = rewriter.rewrite(query, context);
         BoolQueryBuilder result = (BoolQueryBuilder) rewritten;
         assertThat(result.queryName(), equalTo("outer"));
+    }
+
+    public void testIdempotence() {
+        // After one rewrite, a second rewrite should be a no-op (structurally identical)
+        QueryBuilder query = QueryBuilders.boolQuery()
+            .must(QueryBuilders.boolQuery().must(QueryBuilders.termQuery("f", "v")))
+            .filter(QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("g", "w")));
+
+        QueryBuilder once = rewriter.rewrite(query, context);
+        QueryBuilder twice = rewriter.rewrite(once, context);
+        assertEquals(once.toString(), twice.toString());
     }
 }


### PR DESCRIPTION
Resolve #19266 by fixing double-negation under MUST_NOT introduced by #19060 When parent is must_not and nested bool has only must_not clauses, rewrite to a positive OR:

   not(bool(must_not:[X1..Xn])) => filter(bool(should:[X1..Xn], minimum_should_match=1))
   Use FILTER (not MUST) to preserve non-scoring semantics of must_not
   Leave other flattenings unchanged; only trigger on pure must_not nested bool
   Add unit test: testDoubleNegationConvertedToPositiveMustShould

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
