### PR TITLE
Issue 19271: Fix DerivedFieldScript to support emitting Float type

### DIFF
--- a/modules/lang-painless/src/test/java/org/opensearch/painless/DerivedFieldScriptTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/DerivedFieldScriptTests.java
@@ -82,6 +82,27 @@ public class DerivedFieldScriptTests extends ScriptTestCase {
         return factory.newFactory(Collections.emptyMap(), lookup);
     }
 
+    public void testEmittingFloatField() throws IOException {
+        SearchLookup lookup = mock(SearchLookup.class);
+
+        // Mock LeafReaderContext
+        MemoryIndex index = new MemoryIndex();
+        LeafReaderContext leafReaderContext = index.createSearcher().getIndexReader().leaves().get(0);
+
+        LeafSearchLookup leafSearchLookup = mock(LeafSearchLookup.class);
+        when(lookup.getLeafSearchLookup(leafReaderContext)).thenReturn(leafSearchLookup);
+
+        // Script that emits a float value
+        DerivedFieldScript script = compile("emit(3.14f)", lookup).newInstance(leafReaderContext);
+        script.setDocument(1);
+        script.execute();
+
+        List<Object> result = script.getEmittedValues();
+        assertEquals(1, result.size());
+        assertEquals(3.14f, result.get(0));
+    }
+
+
     public void testEmittingDoubleField() throws IOException {
         // Mocking field value to be returned
         NumberFieldType fieldType = new NumberFieldType("test_double_field", NumberType.DOUBLE);

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/DerivedFieldScriptTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/DerivedFieldScriptTests.java
@@ -102,7 +102,6 @@ public class DerivedFieldScriptTests extends ScriptTestCase {
         assertEquals(3.14f, result.get(0));
     }
 
-
     public void testEmittingDoubleField() throws IOException {
         // Mocking field value to be returned
         NumberFieldType fieldType = new NumberFieldType("test_double_field", NumberType.DOUBLE);

--- a/server/src/main/java/org/opensearch/script/DerivedFieldScript.java
+++ b/server/src/main/java/org/opensearch/script/DerivedFieldScript.java
@@ -119,6 +119,8 @@ public abstract class DerivedFieldScript {
             return Long.BYTES;
         } else if (obj instanceof Double) {
             return Double.BYTES;
+        }else if (obj instanceof Float) {
+            return Float.BYTES;
         } else if (obj instanceof Boolean) {
             return Byte.BYTES; // Assuming 1 byte for boolean
         } else if (obj instanceof Tuple) {

--- a/server/src/main/java/org/opensearch/script/DerivedFieldScript.java
+++ b/server/src/main/java/org/opensearch/script/DerivedFieldScript.java
@@ -119,7 +119,7 @@ public abstract class DerivedFieldScript {
             return Long.BYTES;
         } else if (obj instanceof Double) {
             return Double.BYTES;
-        }else if (obj instanceof Float) {
+        } else if (obj instanceof Float) {
             return Float.BYTES;
         } else if (obj instanceof Boolean) {
             return Byte.BYTES; // Assuming 1 byte for boolean


### PR DESCRIPTION
### Description
This change addresses a bug in DerivedFieldScript where emitting Float values was not supported, even though the official OpenSearch documentation lists Float as a valid type for derived field scripts.

Issue: The getObjectByteSize method in DerivedFieldScript only accounted for Double, Integer, Long, Boolean, String, and Tuple types. Emitting a Float previously caused an IllegalArgumentException.

Fix: Added support for Float in getObjectByteSize so that scripts emitting Float values are handled correctly without errors.

Tests: A new test testEmittingFloatField has been added in DerivedFieldScriptTests to verify that Float values can be emitted successfully. Existing tests for Double, GeoPoint, multiple values, and byte-size limit continue to pass.

### Related Issues
Resolves #19271


### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
