### PR TITLE
Refactor IndexingStats.Stats with Builder pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Migrate usages of deprecated `Operations#union` from Lucene ([#19397](https://github.com/opensearch-project/OpenSearch/pull/19397))
 - Delegate primitive write methods with ByteSizeCachingDirectory wrapped IndexOutput ([#19432](https://github.com/opensearch-project/OpenSearch/pull/19432))
 - Bump opensearch-protobufs dependency to 0.18.0 and update transport-grpc module compatibility ([#19447](https://github.com/opensearch-project/OpenSearch/issues/19447))
+- Refactor the IndexingStats.Stats class to use the Builder pattern instead of constructors ([#19306](https://github.com/opensearch-project/OpenSearch/pull/19306))
 
 ### Fixed
 - Fix unnecessary refreshes on update preparation failures ([#15261](https://github.com/opensearch-project/OpenSearch/issues/15261))
@@ -134,6 +135,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `lycheeverse/lychee-action` from 2.4.1 to 2.6.1 ([#19463](https://github.com/opensearch-project/OpenSearch/pull/19463))
 
 ### Deprecated
+- Deprecated existing constructors in IndexingStats.Stats in favor of the new Builder ([#19306](https://github.com/opensearch-project/OpenSearch/pull/19306))
 
 ### Removed
 - Enable backward compatibility tests on Mac ([#18983](https://github.com/opensearch-project/OpenSearch/pull/18983))

--- a/server/src/main/java/org/opensearch/index/shard/IndexingStats.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexingStats.java
@@ -165,6 +165,26 @@ public class IndexingStats implements Writeable, ToXContentFragment {
             docStatusStats = new DocStatusStats();
         }
 
+        /**
+         * Private constructor that takes a builder.
+         * This is the sole entry point for creating a new Stats object.
+         * @param builder The builder instance containing all the values.
+         */
+        private Stats(Builder builder) {
+            this.indexCount = builder.indexCount;
+            this.indexTimeInMillis = builder.indexTimeInMillis;
+            this.indexCurrent = builder.indexCurrent;
+            this.indexFailedCount = builder.indexFailedCount;
+            this.deleteCount = builder.deleteCount;
+            this.deleteTimeInMillis = builder.deleteTimeInMillis;
+            this.deleteCurrent = builder.deleteCurrent;
+            this.noopUpdateCount = builder.noopUpdateCount;
+            this.throttleTimeInMillis = builder.throttleTimeInMillis;
+            this.isThrottled = builder.isThrottled;
+            this.docStatusStats = builder.docStatusStats;
+            this.maxLastIndexRequestTimestamp = builder.maxLastIndexRequestTimestamp;
+        }
+
         public Stats(StreamInput in) throws IOException {
             indexCount = in.readVLong();
             indexTimeInMillis = in.readVLong();
@@ -188,6 +208,11 @@ public class IndexingStats implements Writeable, ToXContentFragment {
             }
         }
 
+        /**
+         * This constructor will be deprecated starting in version 3.3.0.
+         * Use {@link Builder} instead.
+         */
+        @Deprecated
         public Stats(
             long indexCount,
             long indexTimeInMillis,
@@ -217,6 +242,11 @@ public class IndexingStats implements Writeable, ToXContentFragment {
             );
         }
 
+        /**
+         * This constructor will be deprecated starting in version 3.3.0.
+         * Use {@link Builder} instead.
+         */
+        @Deprecated
         public Stats(
             long indexCount,
             long indexTimeInMillis,
@@ -386,6 +416,94 @@ public class IndexingStats implements Writeable, ToXContentFragment {
             return builder;
         }
 
+        /**
+         * Builder for the {@link Stats} class.
+         * Provides a fluent API for constructing a Stats object.
+         */
+        public static class Builder {
+            private long indexCount = 0;
+            private long indexTimeInMillis = 0;
+            private long indexCurrent = 0;
+            private long indexFailedCount = 0;
+            private long deleteCount = 0;
+            private long deleteTimeInMillis = 0;
+            private long deleteCurrent = 0;
+            private long noopUpdateCount = 0;
+            private long throttleTimeInMillis = 0;
+            private boolean isThrottled = false;
+            private DocStatusStats docStatusStats = null;
+            private long maxLastIndexRequestTimestamp = 0;
+
+            public Builder() {}
+
+            public Builder indexCount(long count) {
+                this.indexCount = count;
+                return this;
+            }
+
+            public Builder indexTimeInMillis(long time) {
+                this.indexTimeInMillis = time;
+                return this;
+            }
+
+            public Builder indexCurrent(long current) {
+                this.indexCurrent = current;
+                return this;
+            }
+
+            public Builder indexFailedCount(long count) {
+                this.indexFailedCount = count;
+                return this;
+            }
+
+            public Builder deleteCount(long count) {
+                this.deleteCount = count;
+                return this;
+            }
+
+            public Builder deleteTimeInMillis(long time) {
+                this.deleteTimeInMillis = time;
+                return this;
+            }
+
+            public Builder deleteCurrent(long current) {
+                this.deleteCurrent = current;
+                return this;
+            }
+
+            public Builder noopUpdateCount(long count) {
+                this.noopUpdateCount = count;
+                return this;
+            }
+
+            public Builder throttleTimeInMillis(long time) {
+                this.throttleTimeInMillis = time;
+                return this;
+            }
+
+            public Builder isThrottled(boolean throttled) {
+                this.isThrottled = throttled;
+                return this;
+            }
+
+            public Builder docStatusStats(DocStatusStats stats) {
+                this.docStatusStats = stats;
+                return this;
+            }
+
+            public Builder maxLastIndexRequestTimestamp(long timestamp) {
+                this.maxLastIndexRequestTimestamp = timestamp;
+                return this;
+            }
+
+            /**
+             * Creates a {@link Stats} object from the builder's current state.
+             * @return A new Stats instance.
+             */
+            public Stats build() {
+                return new Stats(this);
+            }
+        }
     }
 
     private final Stats totalStats;

--- a/server/src/main/java/org/opensearch/index/shard/InternalIndexingStats.java
+++ b/server/src/main/java/org/opensearch/index/shard/InternalIndexingStats.java
@@ -154,20 +154,19 @@ final class InternalIndexingStats implements IndexingOperationListener {
         private final MaxMetric maxLastIndexRequestTimestamp = new MaxMetric();
 
         IndexingStats.Stats stats(boolean isThrottled, long currentThrottleMillis) {
-            return new IndexingStats.Stats(
-                indexMetric.count(),
-                TimeUnit.NANOSECONDS.toMillis(indexMetric.sum()),
-                indexCurrent.count(),
-                indexFailed.count(),
-                deleteMetric.count(),
-                TimeUnit.NANOSECONDS.toMillis(deleteMetric.sum()),
-                deleteCurrent.count(),
-                noopUpdates.count(),
-                isThrottled,
-                TimeUnit.MILLISECONDS.toMillis(currentThrottleMillis),
-                new IndexingStats.Stats.DocStatusStats(),
-                maxLastIndexRequestTimestamp.get()
-            );
+            return new IndexingStats.Stats.Builder().indexCount(indexMetric.count())
+                .indexTimeInMillis(TimeUnit.NANOSECONDS.toMillis(indexMetric.sum()))
+                .indexCurrent(indexCurrent.count())
+                .indexFailedCount(indexFailed.count())
+                .deleteCount(deleteMetric.count())
+                .deleteTimeInMillis(TimeUnit.NANOSECONDS.toMillis(deleteMetric.sum()))
+                .deleteCurrent(deleteCurrent.count())
+                .noopUpdateCount(noopUpdates.count())
+                .isThrottled(isThrottled)
+                .throttleTimeInMillis(TimeUnit.MILLISECONDS.toMillis(currentThrottleMillis))
+                .docStatusStats(new IndexingStats.Stats.DocStatusStats())
+                .maxLastIndexRequestTimestamp(maxLastIndexRequestTimestamp.get())
+                .build();
         }
     }
 }


### PR DESCRIPTION
### Description
This PR refactors the `IndexingStats.Stats` class to use the Builder pattern instead of relying on multiple constructors.  

By adopting the Builder pattern, it becomes easier to evolve the stats API, add new metrics, and maintain backward compatibility without forcing disruptive constructor changes.

Based on the related issue:
1. Added a Builder and deprecated the existing constructors.
2. Replaced usages of constructors in code and tests with the new Builder.

There are multiple stats-related classes that need similar refactoring, and we are addressing them in priority order. This PR covers IndexingStats.Stats as part of that effort.

### Related Issues
Partially resolves #19225 

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
