### PR TITLE
[Pull-based Ingestion] Support all-active mode in pull-based ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Upgrade opensearch-protobufs dependency to 0.13.0 and update transport-grpc module compatibility ([#19007](https://github.com/opensearch-project/OpenSearch/issues/19007))
 - Add new extensible method to DocRequest to specify type ([#19313](https://github.com/opensearch-project/OpenSearch/pull/19313))
 - [Rule based auto-tagging] Add Rule based auto-tagging IT ([#18550](https://github.com/opensearch-project/OpenSearch/pull/18550))
+- Add all-active ingestion as docrep equivalent in pull-based ingestion ([#19316](https://github.com/opensearch-project/OpenSearch/pull/19316)
 
 ### Changed
 - Refactor `if-else` chains to use `Java 17 pattern matching switch expressions`(([#18965](https://github.com/opensearch-project/OpenSearch/pull/18965))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Upgrade opensearch-protobufs dependency to 0.13.0 and update transport-grpc module compatibility ([#19007](https://github.com/opensearch-project/OpenSearch/issues/19007))
 - Add new extensible method to DocRequest to specify type ([#19313](https://github.com/opensearch-project/OpenSearch/pull/19313))
 - [Rule based auto-tagging] Add Rule based auto-tagging IT ([#18550](https://github.com/opensearch-project/OpenSearch/pull/18550))
-- Add all-active ingestion as docrep equivalent in pull-based ingestion ([#19316](https://github.com/opensearch-project/OpenSearch/pull/19316)
 - Add all-active ingestion as docrep equivalent in pull-based ingestion ([#19316](https://github.com/opensearch-project/OpenSearch/pull/19316))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add new extensible method to DocRequest to specify type ([#19313](https://github.com/opensearch-project/OpenSearch/pull/19313))
 - [Rule based auto-tagging] Add Rule based auto-tagging IT ([#18550](https://github.com/opensearch-project/OpenSearch/pull/18550))
 - Add all-active ingestion as docrep equivalent in pull-based ingestion ([#19316](https://github.com/opensearch-project/OpenSearch/pull/19316)
+- Add all-active ingestion as docrep equivalent in pull-based ingestion ([#19316](https://github.com/opensearch-project/OpenSearch/pull/19316))
 
 ### Changed
 - Refactor `if-else` chains to use `Java 17 pattern matching switch expressions`(([#18965](https://github.com/opensearch-project/OpenSearch/pull/18965))

--- a/plugins/ingestion-fs/src/test/java/org/opensearch/plugin/ingestion/fs/FileBasedIngestionSingleNodeTests.java
+++ b/plugins/ingestion-fs/src/test/java/org/opensearch/plugin/ingestion/fs/FileBasedIngestionSingleNodeTests.java
@@ -110,7 +110,7 @@ public class FileBasedIngestionSingleNodeTests extends OpenSearchSingleNodeTestC
             assertEquals(0, ingestionState.getFailedShards());
             assertTrue(
                 Arrays.stream(ingestionState.getShardStates())
-                    .allMatch(state -> state.isPollerPaused() && state.pollerState().equalsIgnoreCase("paused"))
+                    .allMatch(state -> state.isPollerPaused() && state.getPollerState().equalsIgnoreCase("paused"))
             );
         });
 
@@ -129,7 +129,7 @@ public class FileBasedIngestionSingleNodeTests extends OpenSearchSingleNodeTestC
                 Arrays.stream(ingestionState.getShardStates())
                     .allMatch(
                         state -> state.isPollerPaused() == false
-                            && (state.pollerState().equalsIgnoreCase("polling") || state.pollerState().equalsIgnoreCase("processing"))
+                            && (state.getPollerState().equalsIgnoreCase("polling") || state.getPollerState().equalsIgnoreCase("processing"))
                     )
             );
         });

--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
@@ -269,6 +269,7 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.pointer.init.reset", "earliest")
+                .put("ingestion_source.all_active", true)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
         );
@@ -387,6 +388,7 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.pointer.init.reset", "earliest")
+                .put("ingestion_source.all_active", true)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
         );
@@ -438,6 +440,7 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.pointer.init.reset", "earliest")
+                .put("ingestion_source.all_active", true)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
         );

--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
@@ -12,24 +12,38 @@ import org.opensearch.action.admin.cluster.node.info.NodeInfo;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.opensearch.action.admin.cluster.node.info.PluginsAndModules;
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.opensearch.action.admin.indices.stats.IndexStats;
+import org.opensearch.action.admin.indices.stats.ShardStats;
+import org.opensearch.action.admin.indices.streamingingestion.pause.PauseIngestionResponse;
+import org.opensearch.action.admin.indices.streamingingestion.resume.ResumeIngestionResponse;
+import org.opensearch.action.admin.indices.streamingingestion.state.GetIngestionStateResponse;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.routing.allocation.command.AllocateReplicaAllocationCommand;
+import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.indices.pollingingest.PollingIngestStats;
 import org.opensearch.plugins.PluginInfo;
+import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.transport.client.Requests;
 import org.junit.Assert;
 
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.is;
 import static org.awaitility.Awaitility.await;
 
@@ -235,5 +249,321 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
             SearchResponse response = client().prepareSearch(indexName).setQuery(query).get();
             return response.getHits().getTotalHits().value() == 1000;
         });
+    }
+
+    public void testAllActiveIngestion() throws Exception {
+        // Create pull-based index in default replication mode (docrep) and publish some messages
+
+        internalCluster().startClusterManagerOnlyNode();
+        final String nodeA = internalCluster().startDataOnlyNode();
+        for (int i = 0; i < 10; i++) {
+            produceData(Integer.toString(i), "name" + i, "30");
+        }
+
+        createIndex(
+            indexName,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                .put("ingestion_source.type", "kafka")
+                .put("ingestion_source.param.topic", topicName)
+                .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
+                .put("ingestion_source.pointer.init.reset", "earliest")
+                .build(),
+            "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
+        );
+
+        ensureYellowAndNoInitializingShards(indexName);
+        waitForState(() -> {
+            RangeQueryBuilder query = new RangeQueryBuilder("age").gte(28);
+            SearchResponse response = client(nodeA).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            return response.getHits().getTotalHits().value() == 10;
+        });
+        flush(indexName);
+
+        // add a second node and verify the replica ingests the data
+        final String nodeB = internalCluster().startDataOnlyNode();
+        ensureGreen(indexName);
+        assertTrue(nodeA.equals(primaryNodeName(indexName)));
+        assertTrue(nodeB.equals(replicaNodeName(indexName)));
+        waitForState(() -> {
+            RangeQueryBuilder query = new RangeQueryBuilder("age").gte(28);
+            SearchResponse response = client(nodeB).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            return response.getHits().getTotalHits().value() == 10;
+        });
+
+        // verify pause and resume functionality on replica
+
+        // pause ingestion
+        PauseIngestionResponse pauseResponse = pauseIngestion(indexName);
+        assertTrue(pauseResponse.isAcknowledged());
+        assertTrue(pauseResponse.isShardsAcknowledged());
+        waitForState(() -> {
+            GetIngestionStateResponse ingestionState = getIngestionState(indexName);
+            return ingestionState.getShardStates().length == 2
+                && ingestionState.getFailedShards() == 0
+                && Arrays.stream(ingestionState.getShardStates())
+                    .allMatch(state -> state.isPollerPaused() && state.pollerState().equalsIgnoreCase("paused"));
+        });
+
+        for (int i = 10; i < 20; i++) {
+            produceData(Integer.toString(i), "name" + i, "30");
+        }
+
+        // replica must not ingest when paused
+        Thread.sleep(1000);
+        RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder("age").gte(28);
+        SearchResponse replicaResponse = client(nodeB).prepareSearch(indexName)
+            .setPreference("_only_local")
+            .setQuery(rangeQueryBuilder)
+            .get();
+        assertEquals(10, replicaResponse.getHits().getTotalHits().value());
+
+        // resume ingestion
+        ResumeIngestionResponse resumeResponse = resumeIngestion(indexName);
+        assertTrue(resumeResponse.isAcknowledged());
+        assertTrue(resumeResponse.isShardsAcknowledged());
+        waitForState(() -> {
+            GetIngestionStateResponse ingestionState = getIngestionState(indexName);
+            return ingestionState.getShardStates().length == 2
+                && Arrays.stream(ingestionState.getShardStates())
+                    .allMatch(
+                        state -> state.isPollerPaused() == false
+                            && (state.pollerState().equalsIgnoreCase("polling") || state.pollerState().equalsIgnoreCase("processing"))
+                    );
+        });
+
+        // verify replica ingests data after resuming ingestion
+        waitForState(() -> {
+            RangeQueryBuilder query = new RangeQueryBuilder("age").gte(28);
+            SearchResponse responseA = client(nodeA).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            SearchResponse responseB = client(nodeB).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            return responseA.getHits().getTotalHits().value() == 20 && responseB.getHits().getTotalHits().value() == 20;
+        });
+
+        // produce 10 more messages
+        for (int i = 20; i < 30; i++) {
+            produceData(Integer.toString(i), "name" + i, "30");
+        }
+
+        // Add new node and wait for new node to join cluster
+        final String nodeC = internalCluster().startDataOnlyNode();
+        assertBusy(() -> {
+            assertEquals("Should have 4 nodes total (1 master + 3 data)", 4, internalCluster().clusterService().state().nodes().getSize());
+        }, 30, TimeUnit.SECONDS);
+
+        // move replica from nodeB to nodeC
+        ensureGreen(indexName);
+        client().admin().cluster().prepareReroute().add(new MoveAllocationCommand(indexName, 0, nodeB, nodeC)).get();
+        ensureGreen(indexName);
+
+        // confirm replica ingests messages after moving to new node
+        waitForState(() -> {
+            RangeQueryBuilder query = new RangeQueryBuilder("age").gte(28);
+            SearchResponse responseA = client(nodeA).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            SearchResponse responseC = client(nodeC).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            return responseA.getHits().getTotalHits().value() == 30 && responseC.getHits().getTotalHits().value() == 30;
+        });
+
+        for (int i = 30; i < 40; i++) {
+            produceData(Integer.toString(i), "name" + i, "30");
+        }
+
+        // restart replica node and verify ingestion
+        internalCluster().restartNode(nodeC);
+        ensureGreen(indexName);
+        waitForState(() -> {
+            RangeQueryBuilder query = new RangeQueryBuilder("age").gte(28);
+            SearchResponse responseA = client(nodeA).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            SearchResponse responseC = client(nodeC).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            return responseA.getHits().getTotalHits().value() == 40 && responseC.getHits().getTotalHits().value() == 40;
+        });
+
+        // Verify both primary and replica do not have failed messages
+        Map<String, PollingIngestStats> shardTypeToStats = getPollingIngestStatsForPrimaryAndReplica(indexName);
+        assertNotNull(shardTypeToStats.get("primary"));
+        assertNotNull(shardTypeToStats.get("replica"));
+        assertThat(shardTypeToStats.get("primary").getConsumerStats().totalPollerMessageDroppedCount(), is(0L));
+        assertThat(shardTypeToStats.get("primary").getConsumerStats().totalPollerMessageFailureCount(), is(0L));
+        // replica consumes only 10 messages after it has been restarted
+        assertThat(shardTypeToStats.get("replica").getConsumerStats().totalPollerMessageDroppedCount(), is(0L));
+        assertThat(shardTypeToStats.get("replica").getConsumerStats().totalPollerMessageFailureCount(), is(0L));
+
+        GetIngestionStateResponse ingestionState = getIngestionState(indexName);
+        assertEquals(2, ingestionState.getShardStates().length);
+        assertEquals(0, ingestionState.getFailedShards());
+    }
+
+    public void testReplicaPromotionOnAllActiveIngestion() throws Exception {
+        // Create pull-based index in default replication mode (docrep) and publish some messages
+        internalCluster().startClusterManagerOnlyNode();
+        final String nodeA = internalCluster().startDataOnlyNode();
+        for (int i = 0; i < 10; i++) {
+            produceData(Integer.toString(i), "name" + i, "30");
+        }
+
+        createIndex(
+            indexName,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                .put("ingestion_source.type", "kafka")
+                .put("ingestion_source.param.topic", topicName)
+                .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
+                .put("ingestion_source.pointer.init.reset", "earliest")
+                .build(),
+            "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
+        );
+
+        ensureYellowAndNoInitializingShards(indexName);
+        waitForState(() -> {
+            RangeQueryBuilder query = new RangeQueryBuilder("age").gte(28);
+            SearchResponse response = client(nodeA).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            return response.getHits().getTotalHits().value() == 10;
+        });
+
+        // add second node
+        final String nodeB = internalCluster().startDataOnlyNode();
+        ensureGreen(indexName);
+        assertTrue(nodeA.equals(primaryNodeName(indexName)));
+        assertTrue(nodeB.equals(replicaNodeName(indexName)));
+        waitForState(() -> {
+            RangeQueryBuilder query = new RangeQueryBuilder("age").gte(28);
+            SearchResponse response = client(nodeB).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            return response.getHits().getTotalHits().value() == 10;
+        });
+
+        // Validate replica promotion
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(nodeA));
+        ensureYellowAndNoInitializingShards(indexName);
+        assertTrue(nodeB.equals(primaryNodeName(indexName)));
+        for (int i = 10; i < 20; i++) {
+            produceData(Integer.toString(i), "name" + i, "30");
+        }
+
+        waitForState(() -> {
+            RangeQueryBuilder query = new RangeQueryBuilder("age").gte(28);
+            SearchResponse responseC = client(nodeB).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            return responseC.getHits().getTotalHits().value() == 20;
+        });
+
+        // add third node and allocate the replica once the node joins the cluster
+        final String nodeC = internalCluster().startDataOnlyNode();
+        assertBusy(() -> { assertEquals(3, internalCluster().clusterService().state().nodes().getSize()); }, 30, TimeUnit.SECONDS);
+        client().admin().cluster().prepareReroute().add(new AllocateReplicaAllocationCommand(indexName, 0, nodeC)).get();
+        ensureGreen(indexName);
+        waitForState(() -> {
+            RangeQueryBuilder query = new RangeQueryBuilder("age").gte(28);
+            SearchResponse responseC = client(nodeC).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            return responseC.getHits().getTotalHits().value() == 20;
+        });
+
+    }
+
+    public void testSnapshotRestoreOnAllActiveIngestion() throws Exception {
+        // Create pull-based index in default replication mode (docrep) and publish some messages
+        internalCluster().startClusterManagerOnlyNode();
+        final String nodeA = internalCluster().startDataOnlyNode();
+        final String nodeB = internalCluster().startDataOnlyNode();
+        for (int i = 0; i < 20; i++) {
+            produceData(Integer.toString(i), "name" + i, "30");
+        }
+
+        createIndex(
+            indexName,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                .put("ingestion_source.type", "kafka")
+                .put("ingestion_source.param.topic", topicName)
+                .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
+                .put("ingestion_source.pointer.init.reset", "earliest")
+                .build(),
+            "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
+        );
+        ensureGreen(indexName);
+        waitForState(() -> {
+            RangeQueryBuilder query = new RangeQueryBuilder("age").gte(28);
+            SearchResponse responseA = client(nodeA).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            SearchResponse responseB = client(nodeB).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            return responseA.getHits().getTotalHits().value() == 20 && responseB.getHits().getTotalHits().value() == 20;
+        });
+
+        // Register snapshot repository
+        String snapshotRepositoryName = "test-snapshot-repo";
+        String snapshotName = "snapshot-1";
+        assertAcked(
+            client().admin()
+                .cluster()
+                .preparePutRepository(snapshotRepositoryName)
+                .setType("fs")
+                .setSettings(Settings.builder().put("location", randomRepoPath()).put("compress", false))
+        );
+
+        // Take snapshot
+        flush(indexName);
+        CreateSnapshotResponse snapshotResponse = client().admin()
+            .cluster()
+            .prepareCreateSnapshot(snapshotRepositoryName, snapshotName)
+            .setWaitForCompletion(true)
+            .setIndices(indexName)
+            .get();
+        assertTrue(snapshotResponse.getSnapshotInfo().successfulShards() > 0);
+
+        // Delete Index
+        assertAcked(client().admin().indices().prepareDelete(indexName));
+        waitForState(() -> {
+            ClusterState state = client().admin().cluster().prepareState().setIndices(indexName).get().getState();
+            return state.getRoutingTable().hasIndex(indexName) == false && state.getMetadata().hasIndex(indexName) == false;
+        });
+
+        for (int i = 20; i < 40; i++) {
+            produceData(Integer.toString(i), "name" + i, "30");
+        }
+
+        // Restore Index from Snapshot
+        client().admin()
+            .cluster()
+            .prepareRestoreSnapshot(snapshotRepositoryName, snapshotName)
+            .setWaitForCompletion(true)
+            .setIndices(indexName)
+            .get();
+        ensureGreen(indexName);
+
+        refresh(indexName);
+        waitForState(() -> {
+            RangeQueryBuilder query = new RangeQueryBuilder("age").gte(28);
+            SearchResponse responseA = client(nodeA).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            SearchResponse responseB = client(nodeB).prepareSearch(indexName).setPreference("_only_local").setQuery(query).get();
+            return responseA.getHits().getTotalHits().value() == 40 && responseB.getHits().getTotalHits().value() == 40;
+        });
+
+        // Verify both primary and replica have polled only remaining 20 messages
+        Map<String, PollingIngestStats> shardTypeToStats = getPollingIngestStatsForPrimaryAndReplica(indexName);
+        assertNotNull(shardTypeToStats.get("primary"));
+        assertNotNull(shardTypeToStats.get("replica"));
+        assertThat(shardTypeToStats.get("primary").getConsumerStats().totalPolledCount(), is(20L));
+        assertThat(shardTypeToStats.get("primary").getConsumerStats().totalPollerMessageDroppedCount(), is(0L));
+        assertThat(shardTypeToStats.get("primary").getConsumerStats().totalPollerMessageFailureCount(), is(0L));
+        assertThat(shardTypeToStats.get("replica").getConsumerStats().totalPolledCount(), is(20L));
+        assertThat(shardTypeToStats.get("replica").getConsumerStats().totalPollerMessageDroppedCount(), is(0L));
+        assertThat(shardTypeToStats.get("replica").getConsumerStats().totalPollerMessageFailureCount(), is(0L));
+    }
+
+    // returns PollingIngestStats for single primary and single replica
+    private Map<String, PollingIngestStats> getPollingIngestStatsForPrimaryAndReplica(String indexName) {
+        IndexStats indexStats = client().admin().indices().prepareStats(indexName).get().getIndex(indexName);
+        ShardStats[] shards = indexStats.getShards();
+        assertEquals(2, shards.length);
+        Map<String, PollingIngestStats> shardTypeToStats = new HashMap<>();
+        for (ShardStats shardStats : shards) {
+            if (shardStats.getShardRouting().primary()) {
+                shardTypeToStats.put("primary", shardStats.getPollingIngestStats());
+            } else {
+                shardTypeToStats.put("replica", shardStats.getPollingIngestStats());
+            }
+        }
+
+        return shardTypeToStats;
     }
 }

--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/RemoteStoreKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/RemoteStoreKafkaIT.java
@@ -207,7 +207,7 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
             GetIngestionStateResponse ingestionState = getIngestionState(indexName);
             return ingestionState.getFailedShards() == 0
                 && Arrays.stream(ingestionState.getShardStates())
-                    .allMatch(state -> state.isPollerPaused() && state.pollerState().equalsIgnoreCase("paused"));
+                    .allMatch(state -> state.isPollerPaused() && state.getPollerState().equalsIgnoreCase("paused"));
         });
 
         // verify ingestion state is persisted
@@ -225,7 +225,7 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
             GetIngestionStateResponse ingestionState = getIngestionState(indexName);
             return ingestionState.getFailedShards() == 0
                 && Arrays.stream(ingestionState.getShardStates())
-                    .allMatch(state -> state.isPollerPaused() && state.pollerState().equalsIgnoreCase("paused"));
+                    .allMatch(state -> state.isPollerPaused() && state.getPollerState().equalsIgnoreCase("paused"));
         });
         assertEquals(2, getSearchableDocCount(nodeB));
 
@@ -238,7 +238,7 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
             return Arrays.stream(ingestionState.getShardStates())
                 .allMatch(
                     state -> state.isPollerPaused() == false
-                        && (state.pollerState().equalsIgnoreCase("polling") || state.pollerState().equalsIgnoreCase("processing"))
+                        && (state.getPollerState().equalsIgnoreCase("polling") || state.getPollerState().equalsIgnoreCase("processing"))
                 );
         });
         waitForSearchableDocs(4, Arrays.asList(nodeB, nodeC));
@@ -256,9 +256,9 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
         assertEquals(1, ingestionState.getSuccessfulShards());
         assertEquals(1, ingestionState.getTotalShards());
         assertEquals(1, ingestionState.getShardStates().length);
-        assertEquals(0, ingestionState.getShardStates()[0].shardId());
-        assertEquals("POLLING", ingestionState.getShardStates()[0].pollerState());
-        assertEquals("DROP", ingestionState.getShardStates()[0].errorPolicy());
+        assertEquals(0, ingestionState.getShardStates()[0].getShardId());
+        assertEquals("POLLING", ingestionState.getShardStates()[0].getPollerState());
+        assertEquals("DROP", ingestionState.getShardStates()[0].getErrorPolicy());
         assertFalse(ingestionState.getShardStates()[0].isPollerPaused());
 
         GetIngestionStateResponse ingestionStateForInvalidShard = getIngestionState(new String[] { indexName }, new int[] { 1 });
@@ -294,8 +294,8 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
         assertEquals(3, responsePage1.getSuccessfulShards());
         assertEquals(3, responsePage1.getShardStates().length);
         assertTrue(Arrays.stream(responsePage1.getShardStates()).allMatch(shardIngestionState -> {
-            boolean shardsMatch = Set.of(0, 1, 2).contains(shardIngestionState.shardId());
-            boolean indexMatch = "index1".equalsIgnoreCase(shardIngestionState.index());
+            boolean shardsMatch = Set.of(0, 1, 2).contains(shardIngestionState.getShardId());
+            boolean indexMatch = "index1".equalsIgnoreCase(shardIngestionState.getIndex());
             return indexMatch && shardsMatch;
         }));
 
@@ -305,9 +305,9 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
         assertEquals(3, responsePage2.getSuccessfulShards());
         assertEquals(3, responsePage2.getShardStates().length);
         assertTrue(Arrays.stream(responsePage2.getShardStates()).allMatch(shardIngestionState -> {
-            boolean matchIndex1 = Set.of(3, 4).contains(shardIngestionState.shardId())
-                && "index1".equalsIgnoreCase(shardIngestionState.index());
-            boolean matchIndex2 = shardIngestionState.shardId() == 0 && "index2".equalsIgnoreCase(shardIngestionState.index());
+            boolean matchIndex1 = Set.of(3, 4).contains(shardIngestionState.getShardId())
+                && "index1".equalsIgnoreCase(shardIngestionState.getIndex());
+            boolean matchIndex2 = shardIngestionState.getShardId() == 0 && "index2".equalsIgnoreCase(shardIngestionState.getIndex());
             return matchIndex1 || matchIndex2;
         }));
 
@@ -317,8 +317,8 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
         assertEquals(3, responsePage3.getSuccessfulShards());
         assertEquals(3, responsePage3.getShardStates().length);
         assertTrue(Arrays.stream(responsePage3.getShardStates()).allMatch(shardIngestionState -> {
-            boolean shardsMatch = Set.of(1, 2, 3).contains(shardIngestionState.shardId());
-            boolean indexMatch = "index2".equalsIgnoreCase(shardIngestionState.index());
+            boolean shardsMatch = Set.of(1, 2, 3).contains(shardIngestionState.getShardId());
+            boolean indexMatch = "index2".equalsIgnoreCase(shardIngestionState.getIndex());
             return indexMatch && shardsMatch;
         }));
 
@@ -328,8 +328,8 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
         assertEquals(1, responsePage4.getSuccessfulShards());
         assertEquals(1, responsePage4.getShardStates().length);
         assertTrue(Arrays.stream(responsePage4.getShardStates()).allMatch(shardIngestionState -> {
-            boolean shardsMatch = shardIngestionState.shardId() == 4;
-            boolean indexMatch = "index2".equalsIgnoreCase(shardIngestionState.index());
+            boolean shardsMatch = shardIngestionState.getShardId() == 4;
+            boolean indexMatch = "index2".equalsIgnoreCase(shardIngestionState.getIndex());
             return indexMatch && shardsMatch;
         }));
     }
@@ -475,7 +475,7 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
             GetIngestionStateResponse ingestionState = getIngestionState(indexName);
             return ingestionState.getFailedShards() == 0
                 && Arrays.stream(ingestionState.getShardStates())
-                    .allMatch(state -> state.isWriteBlockEnabled() && state.pollerState().equalsIgnoreCase("paused"));
+                    .allMatch(state -> state.isWriteBlockEnabled() && state.getPollerState().equalsIgnoreCase("paused"));
         });
 
         // verify write block state in poller is persisted
@@ -492,7 +492,7 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
         waitForState(() -> {
             GetIngestionStateResponse ingestionState = getIngestionState(indexName);
             return Arrays.stream(ingestionState.getShardStates())
-                .allMatch(state -> state.isWriteBlockEnabled() && state.pollerState().equalsIgnoreCase("paused"));
+                .allMatch(state -> state.isWriteBlockEnabled() && state.getPollerState().equalsIgnoreCase("paused"));
         });
         assertEquals(2, getSearchableDocCount(nodeB));
 
@@ -546,7 +546,7 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
             GetIngestionStateResponse ingestionState = getIngestionState(indexName);
             return ingestionState.getFailedShards() == 0
                 && Arrays.stream(ingestionState.getShardStates())
-                    .allMatch(state -> state.isPollerPaused() && state.pollerState().equalsIgnoreCase("paused"));
+                    .allMatch(state -> state.isPollerPaused() && state.getPollerState().equalsIgnoreCase("paused"));
         });
         // revalidate that only 1 document is visible
         waitForSearchableDocs(1, Arrays.asList(nodeA, nodeB));
@@ -560,7 +560,7 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
             return Arrays.stream(ingestionState.getShardStates())
                 .allMatch(
                     state -> state.isPollerPaused() == false
-                        && (state.pollerState().equalsIgnoreCase("polling") || state.pollerState().equalsIgnoreCase("processing"))
+                        && (state.getPollerState().equalsIgnoreCase("polling") || state.getPollerState().equalsIgnoreCase("processing"))
                 );
         });
 
@@ -618,7 +618,7 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
             GetIngestionStateResponse ingestionState = getIngestionState(indexName);
             return ingestionState.getFailedShards() == 0
                 && Arrays.stream(ingestionState.getShardStates())
-                    .allMatch(state -> state.isPollerPaused() && state.pollerState().equalsIgnoreCase("paused"));
+                    .allMatch(state -> state.isPollerPaused() && state.getPollerState().equalsIgnoreCase("paused"));
         });
 
         // reset consumer by a timestamp after first message was produced

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSingleNodeTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSingleNodeTests.java
@@ -105,7 +105,7 @@ public class KafkaSingleNodeTests extends OpenSearchSingleNodeTestCase {
             GetIngestionStateResponse ingestionState = getIngestionState(indexName);
             return ingestionState.getFailedShards() == 0
                 && Arrays.stream(ingestionState.getShardStates())
-                    .allMatch(state -> state.isPollerPaused() && state.pollerState().equalsIgnoreCase("paused"));
+                    .allMatch(state -> state.isPollerPaused() && state.getPollerState().equalsIgnoreCase("paused"));
         });
 
         produceData("{\"_id\":\"1\",\"_version\":\"2\",\"_op_type\":\"index\",\"_source\":{\"name\":\"name\", \"age\": 30}}");
@@ -121,7 +121,7 @@ public class KafkaSingleNodeTests extends OpenSearchSingleNodeTestCase {
             return Arrays.stream(ingestionState.getShardStates())
                 .allMatch(
                     state -> state.isPollerPaused() == false
-                        && (state.pollerState().equalsIgnoreCase("polling") || state.pollerState().equalsIgnoreCase("processing"))
+                        && (state.getPollerState().equalsIgnoreCase("polling") || state.getPollerState().equalsIgnoreCase("processing"))
                 );
         });
 

--- a/plugins/ingestion-kinesis/src/internalClusterTest/java/org/opensearch/plugin/kinesis/IngestFromKinesisIT.java
+++ b/plugins/ingestion-kinesis/src/internalClusterTest/java/org/opensearch/plugin/kinesis/IngestFromKinesisIT.java
@@ -159,6 +159,7 @@ public class IngestFromKinesisIT extends KinesisIngestionBaseIT {
                 .put("ingestion_source.param.region", localstack.getRegion())
                 .put("ingestion_source.param.access_key", localstack.getAccessKey())
                 .put("ingestion_source.param.secret_key", localstack.getSecretKey())
+                .put("ingestion_source.all_active", true)
                 .put(
                     "ingestion_source.param.endpoint_override",
                     localstack.getEndpointOverride(LocalStackContainer.Service.KINESIS).toString()
@@ -167,7 +168,6 @@ public class IngestFromKinesisIT extends KinesisIngestionBaseIT {
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
         );
 
-        flush(indexName);
         waitForSearchableDocs(10, List.of(nodeA, nodeB));
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/state/GetIngestionStateResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/state/GetIngestionStateResponse.java
@@ -75,7 +75,7 @@ public class GetIngestionStateResponse extends BroadcastResponse {
 
         for (Map.Entry<String, List<ShardIngestionState>> indexShardIngestionStateEntry : shardStateByIndex.entrySet()) {
             builder.startArray(indexShardIngestionStateEntry.getKey());
-            indexShardIngestionStateEntry.getValue().sort(Comparator.comparingInt(ShardIngestionState::shardId));
+            indexShardIngestionStateEntry.getValue().sort(Comparator.comparingInt(ShardIngestionState::getShardId));
             for (ShardIngestionState shardIngestionState : indexShardIngestionStateEntry.getValue()) {
                 shardIngestionState.toXContent(builder, params);
             }

--- a/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/state/ShardIngestionState.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/state/ShardIngestionState.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.action.admin.indices.streamingingestion.state;
 
+import org.opensearch.Version;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -28,34 +29,59 @@ import java.util.Map;
  * @opensearch.experimental
  */
 @ExperimentalApi
-public record ShardIngestionState(String index, int shardId, String pollerState, String errorPolicy, boolean isPollerPaused,
-    boolean isWriteBlockEnabled, String batchStartPointer, boolean isPrimary, String nodeName) implements Writeable, ToXContentFragment {
-
+public class ShardIngestionState implements Writeable, ToXContentFragment {
     private static final String SHARD = "shard";
     private static final String POLLER_STATE = "poller_state";
     private static final String ERROR_POLICY = "error_policy";
     private static final String POLLER_PAUSED = "poller_paused";
     private static final String WRITE_BLOCK_ENABLED = "write_block_enabled";
     private static final String BATCH_START_POINTER = "batch_start_pointer";
-    private static final String PRIMARY_OR_REPLICA = "prirep";
+    private static final String IS_PRIMARY = "is_primary";
     private static final String NODE_NAME = "node";
+
+    private String index;
+    private int shardId;
+    private String pollerState;
+    private String errorPolicy;
+    private boolean isPollerPaused;
+    boolean isWriteBlockEnabled;
+    private String batchStartPointer;
+    private boolean isPrimary;
+    private String nodeName;
 
     public ShardIngestionState() {
         this("", -1, "", "", false, false, "", true, "");
     }
 
     public ShardIngestionState(StreamInput in) throws IOException {
-        this(
-            in.readString(),
-            in.readVInt(),
-            in.readOptionalString(),
-            in.readOptionalString(),
-            in.readBoolean(),
-            in.readBoolean(),
-            in.readString(),
-            in.readBoolean(),
-            in.readString()
-        );
+        this.index = in.readString();
+        this.shardId = in.readVInt();
+        this.pollerState = in.readOptionalString();
+        this.errorPolicy = in.readOptionalString();
+        this.isPollerPaused = in.readBoolean();
+        this.isWriteBlockEnabled = in.readBoolean();
+        this.batchStartPointer = in.readString();
+
+        if (in.getVersion().onOrAfter(Version.V_3_3_0)) {
+            this.isPrimary = in.readBoolean();
+            this.nodeName = in.readString();
+        } else {
+            // added from version 3.3 onwards
+            this.isPrimary = true;
+            this.nodeName = "";
+        }
+    }
+
+    public ShardIngestionState(
+        String index,
+        int shardId,
+        @Nullable String pollerState,
+        @Nullable String errorPolicy,
+        boolean isPollerPaused,
+        boolean isWriteBlockEnabled,
+        String batchStartPointer
+    ) {
+        this(index, shardId, pollerState, errorPolicy, isPollerPaused, isWriteBlockEnabled, batchStartPointer, true, "");
     }
 
     public ShardIngestionState(
@@ -89,8 +115,12 @@ public record ShardIngestionState(String index, int shardId, String pollerState,
         out.writeBoolean(isPollerPaused);
         out.writeBoolean(isWriteBlockEnabled);
         out.writeString(batchStartPointer);
-        out.writeBoolean(isPrimary);
-        out.writeString(nodeName);
+
+        if (out.getVersion().onOrAfter(Version.V_3_3_0)) {
+            // added from version 3.3 onwards
+            out.writeBoolean(isPrimary);
+            out.writeString(nodeName);
+        }
     }
 
     @Override
@@ -102,7 +132,7 @@ public record ShardIngestionState(String index, int shardId, String pollerState,
         builder.field(POLLER_PAUSED, isPollerPaused);
         builder.field(WRITE_BLOCK_ENABLED, isWriteBlockEnabled);
         builder.field(BATCH_START_POINTER, batchStartPointer);
-        builder.field(PRIMARY_OR_REPLICA, isPrimary ? "p" : "r");
+        builder.field(IS_PRIMARY, isPrimary);
         builder.field(NODE_NAME, nodeName);
         builder.endObject();
         return builder;
@@ -115,10 +145,54 @@ public record ShardIngestionState(String index, int shardId, String pollerState,
         Map<String, List<ShardIngestionState>> shardIngestionStatesByIndex = new HashMap<>();
 
         for (ShardIngestionState state : shardIngestionStates) {
-            shardIngestionStatesByIndex.computeIfAbsent(state.index(), (index) -> new ArrayList<>());
-            shardIngestionStatesByIndex.get(state.index()).add(state);
+            shardIngestionStatesByIndex.computeIfAbsent(state.getIndex(), (index) -> new ArrayList<>());
+            shardIngestionStatesByIndex.get(state.getIndex()).add(state);
         }
 
         return shardIngestionStatesByIndex;
+    }
+
+    public String getIndex() {
+        return index;
+    }
+
+    public int getShardId() {
+        return shardId;
+    }
+
+    public String getPollerState() {
+        return pollerState;
+    }
+
+    public String getErrorPolicy() {
+        return errorPolicy;
+    }
+
+    public boolean isPollerPaused() {
+        return isPollerPaused;
+    }
+
+    public boolean isWriteBlockEnabled() {
+        return isWriteBlockEnabled;
+    }
+
+    public String getBatchStartPointer() {
+        return batchStartPointer;
+    }
+
+    public boolean isPrimary() {
+        return isPrimary;
+    }
+
+    public String getNodeName() {
+        return nodeName;
+    }
+
+    public void setPrimary(boolean primary) {
+        this.isPrimary = primary;
+    }
+
+    public void setNodeName(String nodeName) {
+        this.nodeName = nodeName;
     }
 }

--- a/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/state/ShardIngestionState.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/state/ShardIngestionState.java
@@ -29,7 +29,7 @@ import java.util.Map;
  */
 @ExperimentalApi
 public record ShardIngestionState(String index, int shardId, String pollerState, String errorPolicy, boolean isPollerPaused,
-    boolean isWriteBlockEnabled, String batchStartPointer) implements Writeable, ToXContentFragment {
+    boolean isWriteBlockEnabled, String batchStartPointer, boolean isPrimary, String nodeName) implements Writeable, ToXContentFragment {
 
     private static final String SHARD = "shard";
     private static final String POLLER_STATE = "poller_state";
@@ -37,9 +37,11 @@ public record ShardIngestionState(String index, int shardId, String pollerState,
     private static final String POLLER_PAUSED = "poller_paused";
     private static final String WRITE_BLOCK_ENABLED = "write_block_enabled";
     private static final String BATCH_START_POINTER = "batch_start_pointer";
+    private static final String PRIMARY_OR_REPLICA = "prirep";
+    private static final String NODE_NAME = "node";
 
     public ShardIngestionState() {
-        this("", -1, "", "", false, false, "");
+        this("", -1, "", "", false, false, "", true, "");
     }
 
     public ShardIngestionState(StreamInput in) throws IOException {
@@ -49,6 +51,8 @@ public record ShardIngestionState(String index, int shardId, String pollerState,
             in.readOptionalString(),
             in.readOptionalString(),
             in.readBoolean(),
+            in.readBoolean(),
+            in.readString(),
             in.readBoolean(),
             in.readString()
         );
@@ -61,7 +65,9 @@ public record ShardIngestionState(String index, int shardId, String pollerState,
         @Nullable String errorPolicy,
         boolean isPollerPaused,
         boolean isWriteBlockEnabled,
-        String batchStartPointer
+        String batchStartPointer,
+        boolean isPrimary,
+        String nodeName
     ) {
         this.index = index;
         this.shardId = shardId;
@@ -70,6 +76,8 @@ public record ShardIngestionState(String index, int shardId, String pollerState,
         this.isPollerPaused = isPollerPaused;
         this.isWriteBlockEnabled = isWriteBlockEnabled;
         this.batchStartPointer = batchStartPointer;
+        this.isPrimary = isPrimary;
+        this.nodeName = nodeName;
     }
 
     @Override
@@ -81,6 +89,8 @@ public record ShardIngestionState(String index, int shardId, String pollerState,
         out.writeBoolean(isPollerPaused);
         out.writeBoolean(isWriteBlockEnabled);
         out.writeString(batchStartPointer);
+        out.writeBoolean(isPrimary);
+        out.writeString(nodeName);
     }
 
     @Override
@@ -92,6 +102,8 @@ public record ShardIngestionState(String index, int shardId, String pollerState,
         builder.field(POLLER_PAUSED, isPollerPaused);
         builder.field(WRITE_BLOCK_ENABLED, isWriteBlockEnabled);
         builder.field(BATCH_START_POINTER, batchStartPointer);
+        builder.field(PRIMARY_OR_REPLICA, isPrimary ? "p" : "r");
+        builder.field(NODE_NAME, nodeName);
         builder.endObject();
         return builder;
     }

--- a/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/state/TransportGetIngestionStateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/state/TransportGetIngestionStateAction.java
@@ -230,21 +230,10 @@ public class TransportGetIngestionStateAction extends TransportBroadcastByNodeAc
         }
 
         try {
-            ShardIngestionState baseState = indexShard.getIngestionState();
-            String nodeName = clusterService.localNode().getName();
-
-            // rebuild ingestion state with primary/replica and node details
-            return new ShardIngestionState(
-                baseState.index(),
-                baseState.shardId(),
-                baseState.pollerState(),
-                baseState.errorPolicy(),
-                baseState.isPollerPaused(),
-                baseState.isWriteBlockEnabled(),
-                baseState.batchStartPointer(),
-                shardRouting.primary(),
-                nodeName != null ? nodeName : ""
-            );
+            ShardIngestionState shardIngestionState = indexShard.getIngestionState();
+            shardIngestionState.setNodeName(clusterService.localNode().getName());
+            shardIngestionState.setPrimary(shardRouting.primary());
+            return shardIngestionState;
         } catch (final AlreadyClosedException e) {
             throw new ShardNotFoundException(indexShard.shardId());
         }

--- a/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/state/TransportGetIngestionStateAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/state/TransportGetIngestionStateAction.java
@@ -31,7 +31,6 @@ import org.opensearch.index.IndexService;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ShardNotFoundException;
 import org.opensearch.indices.IndicesService;
-import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -151,20 +150,17 @@ public class TransportGetIngestionStateAction extends TransportBroadcastByNodeAc
      */
     @Override
     protected ShardsIterator shards(ClusterState clusterState, GetIngestionStateRequest request, String[] concreteIndices) {
-        Set<String> docRepIndexSet = new HashSet<>();
+        Set<String> allActiveIndexSet = new HashSet<>();
         for (String index : concreteIndices) {
             IndexMetadata indexMetadata = clusterState.metadata().index(index);
-            if (indexMetadata != null) {
-                ReplicationType replicationType = getReplicationType(indexMetadata);
-                if (replicationType == ReplicationType.DOCUMENT) {
-                    docRepIndexSet.add(index);
-                }
+            if (indexMetadata != null && isAllActiveIngestionEnabled(indexMetadata)) {
+                allActiveIndexSet.add(index);
             }
         }
 
         Set<Integer> shardSet = Arrays.stream(request.getShards()).boxed().collect(Collectors.toSet());
         Predicate<ShardRouting> shardFilter = shardRouting -> shardRouting.primary()
-            || docRepIndexSet.contains(shardRouting.getIndexName());
+            || allActiveIndexSet.contains(shardRouting.getIndexName());
         if (shardSet.isEmpty() == false) {
             shardFilter = shardFilter.and(shardRouting -> shardSet.contains(shardRouting.shardId().getId()));
         }
@@ -239,7 +235,9 @@ public class TransportGetIngestionStateAction extends TransportBroadcastByNodeAc
         }
     }
 
-    private ReplicationType getReplicationType(IndexMetadata indexMetadata) {
-        return IndexMetadata.INDEX_REPLICATION_TYPE_SETTING.get(indexMetadata.getSettings());
+    private boolean isAllActiveIngestionEnabled(IndexMetadata indexMetadata) {
+        return indexMetadata.useIngestionSource()
+            && indexMetadata.getIngestionSource() != null
+            && indexMetadata.getIngestionSource().isAllActiveIngestionEnabled();
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.opensearch.cluster.metadata.IndexMetadata.INGESTION_SOURCE_ALL_ACTIVE_INGESTION_SETTING;
 import static org.opensearch.cluster.metadata.IndexMetadata.INGESTION_SOURCE_INTERNAL_QUEUE_SIZE_SETTING;
 import static org.opensearch.cluster.metadata.IndexMetadata.INGESTION_SOURCE_MAX_POLL_SIZE;
 import static org.opensearch.cluster.metadata.IndexMetadata.INGESTION_SOURCE_NUM_PROCESSOR_THREADS_SETTING;
@@ -35,6 +36,7 @@ public class IngestionSource {
     private final int pollTimeout;
     private int numProcessorThreads;
     private int blockingQueueSize;
+    private final boolean allActiveIngestion;
 
     private IngestionSource(
         String type,
@@ -44,7 +46,8 @@ public class IngestionSource {
         long maxPollSize,
         int pollTimeout,
         int numProcessorThreads,
-        int blockingQueueSize
+        int blockingQueueSize,
+        boolean allActiveIngestion
     ) {
         this.type = type;
         this.pointerInitReset = pointerInitReset;
@@ -54,6 +57,7 @@ public class IngestionSource {
         this.pollTimeout = pollTimeout;
         this.numProcessorThreads = numProcessorThreads;
         this.blockingQueueSize = blockingQueueSize;
+        this.allActiveIngestion = allActiveIngestion;
     }
 
     public String getType() {
@@ -88,6 +92,10 @@ public class IngestionSource {
         return blockingQueueSize;
     }
 
+    public boolean isAllActiveIngestionEnabled() {
+        return allActiveIngestion;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -100,7 +108,8 @@ public class IngestionSource {
             && Objects.equals(maxPollSize, ingestionSource.maxPollSize)
             && Objects.equals(pollTimeout, ingestionSource.pollTimeout)
             && Objects.equals(numProcessorThreads, ingestionSource.numProcessorThreads)
-            && Objects.equals(blockingQueueSize, ingestionSource.blockingQueueSize);
+            && Objects.equals(blockingQueueSize, ingestionSource.blockingQueueSize)
+            && Objects.equals(allActiveIngestion, ingestionSource.allActiveIngestion);
     }
 
     @Override
@@ -113,7 +122,8 @@ public class IngestionSource {
             maxPollSize,
             pollTimeout,
             numProcessorThreads,
-            blockingQueueSize
+            blockingQueueSize,
+            allActiveIngestion
         );
     }
 
@@ -139,6 +149,8 @@ public class IngestionSource {
             + numProcessorThreads
             + ", blockingQueueSize="
             + blockingQueueSize
+            + ", allActiveIngestion="
+            + allActiveIngestion
             + '}';
     }
 
@@ -196,6 +208,7 @@ public class IngestionSource {
         private int pollTimeout = INGESTION_SOURCE_POLL_TIMEOUT.getDefault(Settings.EMPTY);
         private int numProcessorThreads = INGESTION_SOURCE_NUM_PROCESSOR_THREADS_SETTING.getDefault(Settings.EMPTY);
         private int blockingQueueSize = INGESTION_SOURCE_INTERNAL_QUEUE_SIZE_SETTING.getDefault(Settings.EMPTY);
+        private boolean allActiveIngestion = INGESTION_SOURCE_ALL_ACTIVE_INGESTION_SETTING.getDefault(Settings.EMPTY);
 
         public Builder(String type) {
             this.type = type;
@@ -208,6 +221,7 @@ public class IngestionSource {
             this.errorStrategy = ingestionSource.errorStrategy;
             this.params = ingestionSource.params;
             this.blockingQueueSize = ingestionSource.blockingQueueSize;
+            this.allActiveIngestion = ingestionSource.allActiveIngestion;
         }
 
         public Builder setPointerInitReset(PointerInitReset pointerInitReset) {
@@ -250,6 +264,11 @@ public class IngestionSource {
             return this;
         }
 
+        public Builder setAllActiveIngestion(boolean allActiveIngestion) {
+            this.allActiveIngestion = allActiveIngestion;
+            return this;
+        }
+
         public IngestionSource build() {
             return new IngestionSource(
                 type,
@@ -259,7 +278,8 @@ public class IngestionSource {
                 maxPollSize,
                 pollTimeout,
                 numProcessorThreads,
-                blockingQueueSize
+                blockingQueueSize,
+                allActiveIngestion
             );
         }
 

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -277,6 +277,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexMetadata.INGESTION_SOURCE_POLL_TIMEOUT,
                 IndexMetadata.INGESTION_SOURCE_NUM_PROCESSOR_THREADS_SETTING,
                 IndexMetadata.INGESTION_SOURCE_INTERNAL_QUEUE_SIZE_SETTING,
+                IndexMetadata.INGESTION_SOURCE_ALL_ACTIVE_INGESTION_SETTING,
 
                 // Settings for search replica
                 IndexMetadata.INDEX_NUMBER_OF_SEARCH_REPLICAS_SETTING,

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -610,6 +610,8 @@ public class IngestionEngine extends InternalEngine {
      */
     public ShardIngestionState getIngestionState() {
         IngestionShardPointer shardPointer = streamPoller.getBatchStartPointer();
+
+        // Node and routing details are set at the routing layer
         return new ShardIngestionState(
             engineConfig.getIndexSettings().getIndex().getName(),
             engineConfig.getShardId().getId(),
@@ -617,7 +619,9 @@ public class IngestionEngine extends InternalEngine {
             streamPoller.getErrorStrategy().getName(),
             streamPoller.isPaused(),
             streamPoller.isWriteBlockEnabled(),
-            shardPointer != null ? shardPointer.toString() : ""
+            shardPointer != null ? shardPointer.toString() : "",
+            true,
+            ""
         );
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -611,7 +611,6 @@ public class IngestionEngine extends InternalEngine {
     public ShardIngestionState getIngestionState() {
         IngestionShardPointer shardPointer = streamPoller.getBatchStartPointer();
 
-        // Node and routing details are set at the routing layer
         return new ShardIngestionState(
             engineConfig.getIndexSettings().getIndex().getName(),
             engineConfig.getShardId().getId(),
@@ -619,9 +618,7 @@ public class IngestionEngine extends InternalEngine {
             streamPoller.getErrorStrategy().getName(),
             streamPoller.isPaused(),
             streamPoller.isWriteBlockEnabled(),
-            shardPointer != null ? shardPointer.toString() : "",
-            true,
-            ""
+            shardPointer != null ? shardPointer.toString() : ""
         );
     }
 }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/IngestionEngineFactory.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/IngestionEngineFactory.java
@@ -8,12 +8,15 @@
 
 package org.opensearch.indices.pollingingest;
 
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.index.IngestionConsumerFactory;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.engine.EngineConfig;
 import org.opensearch.index.engine.EngineFactory;
 import org.opensearch.index.engine.IngestionEngine;
 import org.opensearch.index.engine.NRTReplicationEngine;
+import org.opensearch.indices.replication.common.ReplicationType;
 
 import java.util.Objects;
 
@@ -28,14 +31,26 @@ public class IngestionEngineFactory implements EngineFactory {
         this.ingestionConsumerFactory = Objects.requireNonNull(ingestionConsumerFactory);
     }
 
+    /**
+     * Document replication equivalent in pull-based ingestion is to ingest on both primary and replica nodes using the
+     * IngestionEngine. Segment replication will use the NRTReplicationEngine on replicas.
+     */
     @Override
     public Engine newReadWriteEngine(EngineConfig config) {
-        if (config.isReadOnlyReplica()) {
+        boolean isDocRep = getReplicationType(config) == ReplicationType.DOCUMENT;
+
+        // NRTReplicationEngine is used for segment replication on replicas
+        if (isDocRep == false && config.isReadOnlyReplica()) {
             return new NRTReplicationEngine(config);
         }
 
         IngestionEngine ingestionEngine = new IngestionEngine(config, ingestionConsumerFactory);
         ingestionEngine.start();
         return ingestionEngine;
+    }
+
+    private ReplicationType getReplicationType(EngineConfig config) {
+        IndexSettings indexSettings = config.getIndexSettings();
+        return indexSettings.getValue(IndexMetadata.INDEX_REPLICATION_TYPE_SETTING);
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/GetIngestionStateResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/GetIngestionStateResponseTests.java
@@ -28,8 +28,8 @@ public class GetIngestionStateResponseTests extends OpenSearchTestCase {
 
             try (StreamInput in = out.bytes().streamInput()) {
                 GetIngestionStateResponse deserializedResponse = new GetIngestionStateResponse(in);
-                assertEquals(response.getShardStates()[0].shardId(), deserializedResponse.getShardStates()[0].shardId());
-                assertEquals(response.getShardStates()[1].shardId(), deserializedResponse.getShardStates()[1].shardId());
+                assertEquals(response.getShardStates()[0].getShardId(), deserializedResponse.getShardStates()[0].getShardId());
+                assertEquals(response.getShardStates()[1].getShardId(), deserializedResponse.getShardStates()[1].getShardId());
                 assertEquals(response.getTotalShards(), deserializedResponse.getTotalShards());
                 assertEquals(response.getSuccessfulShards(), deserializedResponse.getSuccessfulShards());
                 assertEquals(response.getFailedShards(), deserializedResponse.getFailedShards());

--- a/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/GetIngestionStateResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/GetIngestionStateResponseTests.java
@@ -19,8 +19,8 @@ public class GetIngestionStateResponseTests extends OpenSearchTestCase {
 
     public void testSerialization() throws IOException {
         ShardIngestionState[] shardStates = new ShardIngestionState[] {
-            new ShardIngestionState("index1", 0, "POLLING", "DROP", false, false, ""),
-            new ShardIngestionState("index1", 1, "PAUSED", "BLOCK", true, false, "") };
+            new ShardIngestionState("index1", 0, "POLLING", "DROP", false, false, "", true, "node"),
+            new ShardIngestionState("index1", 1, "PAUSED", "BLOCK", true, false, "", true, "node") };
         GetIngestionStateResponse response = new GetIngestionStateResponse(shardStates, 2, 2, 0, null, Collections.emptyList());
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {

--- a/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/ShardIngestionStateTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/ShardIngestionStateTests.java
@@ -19,7 +19,7 @@ import java.util.Map;
 public class ShardIngestionStateTests extends OpenSearchTestCase {
 
     public void testSerialization() throws IOException {
-        ShardIngestionState state = new ShardIngestionState("index1", 0, "POLLING", "DROP", false, false, "");
+        ShardIngestionState state = new ShardIngestionState("index1", 0, "POLLING", "DROP", false, false, "", true, "node");
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             state.writeTo(out);
@@ -31,12 +31,15 @@ public class ShardIngestionStateTests extends OpenSearchTestCase {
                 assertEquals(state.pollerState(), deserializedState.pollerState());
                 assertEquals(state.isPollerPaused(), deserializedState.isPollerPaused());
                 assertEquals(state.isWriteBlockEnabled(), deserializedState.isWriteBlockEnabled());
+                assertEquals(state.batchStartPointer(), deserializedState.batchStartPointer());
+                assertEquals(state.isPrimary(), deserializedState.isPrimary());
+                assertEquals(state.nodeName(), deserializedState.nodeName());
             }
         }
     }
 
     public void testSerializationWithNullValues() throws IOException {
-        ShardIngestionState state = new ShardIngestionState("index1", 0, null, null, false, false, "");
+        ShardIngestionState state = new ShardIngestionState("index1", 0, null, null, false, false, "", true, "");
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             state.writeTo(out);
@@ -53,9 +56,9 @@ public class ShardIngestionStateTests extends OpenSearchTestCase {
 
     public void testGroupShardStateByIndex() {
         ShardIngestionState[] states = new ShardIngestionState[] {
-            new ShardIngestionState("index1", 0, "POLLING", "DROP", true, false, ""),
-            new ShardIngestionState("index1", 1, "PAUSED", "DROP", false, false, ""),
-            new ShardIngestionState("index2", 0, "POLLING", "DROP", true, false, "") };
+            new ShardIngestionState("index1", 0, "POLLING", "DROP", true, false, "", true, "node"),
+            new ShardIngestionState("index1", 1, "PAUSED", "DROP", false, false, "", true, "node"),
+            new ShardIngestionState("index2", 0, "POLLING", "DROP", true, false, "", true, "node") };
 
         Map<String, List<ShardIngestionState>> groupedStates = ShardIngestionState.groupShardStateByIndex(states);
 

--- a/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/ShardIngestionStateTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/ShardIngestionStateTests.java
@@ -26,14 +26,14 @@ public class ShardIngestionStateTests extends OpenSearchTestCase {
 
             try (StreamInput in = out.bytes().streamInput()) {
                 ShardIngestionState deserializedState = new ShardIngestionState(in);
-                assertEquals(state.index(), deserializedState.index());
-                assertEquals(state.shardId(), deserializedState.shardId());
-                assertEquals(state.pollerState(), deserializedState.pollerState());
+                assertEquals(state.getIndex(), deserializedState.getIndex());
+                assertEquals(state.getShardId(), deserializedState.getShardId());
+                assertEquals(state.getPollerState(), deserializedState.getPollerState());
                 assertEquals(state.isPollerPaused(), deserializedState.isPollerPaused());
                 assertEquals(state.isWriteBlockEnabled(), deserializedState.isWriteBlockEnabled());
-                assertEquals(state.batchStartPointer(), deserializedState.batchStartPointer());
+                assertEquals(state.getBatchStartPointer(), deserializedState.getBatchStartPointer());
                 assertEquals(state.isPrimary(), deserializedState.isPrimary());
-                assertEquals(state.nodeName(), deserializedState.nodeName());
+                assertEquals(state.getNodeName(), deserializedState.getNodeName());
             }
         }
     }
@@ -46,9 +46,9 @@ public class ShardIngestionStateTests extends OpenSearchTestCase {
 
             try (StreamInput in = out.bytes().streamInput()) {
                 ShardIngestionState deserializedState = new ShardIngestionState(in);
-                assertEquals(state.index(), deserializedState.index());
-                assertEquals(state.shardId(), deserializedState.shardId());
-                assertNull(deserializedState.pollerState());
+                assertEquals(state.getIndex(), deserializedState.getIndex());
+                assertEquals(state.getShardId(), deserializedState.getShardId());
+                assertNull(deserializedState.getPollerState());
                 assertEquals(state.isPollerPaused(), deserializedState.isPollerPaused());
             }
         }
@@ -68,11 +68,11 @@ public class ShardIngestionStateTests extends OpenSearchTestCase {
 
         // Verify index1 shards
         List<ShardIngestionState> indexStates1 = groupedStates.get("index1");
-        assertEquals(0, indexStates1.get(0).shardId());
-        assertEquals(1, indexStates1.get(1).shardId());
+        assertEquals(0, indexStates1.get(0).getShardId());
+        assertEquals(1, indexStates1.get(1).getShardId());
 
         // Verify index2 shards
         List<ShardIngestionState> indexStates2 = groupedStates.get("index2");
-        assertEquals(0, indexStates2.get(0).shardId());
+        assertEquals(0, indexStates2.get(0).getShardId());
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/TransportGetIngestionStateActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/TransportGetIngestionStateActionTests.java
@@ -145,11 +145,11 @@ public class TransportGetIngestionStateActionTests extends OpenSearchTestCase {
         when(clusterService.localNode()).thenReturn(localNode);
 
         ShardIngestionState result = action.shardOperation(request, shardRouting);
-        assertThat(result.index(), equalTo(expectedState.index()));
-        assertThat(result.shardId(), equalTo(expectedState.shardId()));
-        assertThat(result.pollerState(), equalTo(expectedState.pollerState()));
-        assertThat(result.errorPolicy(), equalTo(expectedState.errorPolicy()));
-        assertThat(result.nodeName(), equalTo(expectedState.nodeName()));
+        assertThat(result.getIndex(), equalTo(expectedState.getIndex()));
+        assertThat(result.getShardId(), equalTo(expectedState.getShardId()));
+        assertThat(result.getPollerState(), equalTo(expectedState.getPollerState()));
+        assertThat(result.getErrorPolicy(), equalTo(expectedState.getErrorPolicy()));
+        assertThat(result.getNodeName(), equalTo(expectedState.getNodeName()));
 
     }
 
@@ -200,7 +200,7 @@ public class TransportGetIngestionStateActionTests extends OpenSearchTestCase {
         assertThat(response.getSuccessfulShards(), equalTo(1));
         assertThat(response.getFailedShards(), equalTo(0));
         assertThat(response.getShardStates().length, equalTo(1));
-        assertThat(response.getShardStates()[0].index(), equalTo("test-index"));
-        assertThat(response.getShardStates()[0].shardId(), equalTo(0));
+        assertThat(response.getShardStates()[0].getIndex(), equalTo("test-index"));
+        assertThat(response.getShardStates()[0].getShardId(), equalTo(0));
     }
 }

--- a/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/TransportUpdateIngestionStateActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/streamingingestion/state/TransportUpdateIngestionStateActionTests.java
@@ -14,7 +14,9 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.cluster.block.ClusterBlockLevel;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardsIterator;
 import org.opensearch.cluster.service.ClusterService;
@@ -26,6 +28,7 @@ import org.opensearch.index.IndexService;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.ShardNotFoundException;
 import org.opensearch.indices.IndicesService;
+import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.transport.MockTransportService;
@@ -82,6 +85,16 @@ public class TransportUpdateIngestionStateActionTests extends OpenSearchTestCase
         when(clusterState.routingTable()).thenReturn(mock(org.opensearch.cluster.routing.RoutingTable.class));
         when(clusterState.routingTable().allShardsSatisfyingPredicate(any(), any())).thenReturn(shardsIterator);
 
+        // Mock the metadata
+        Metadata metadata = mock(Metadata.class);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.DOCUMENT.toString()).build();
+
+        // Set up the mocks
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(metadata.index("test-index")).thenReturn(indexMetadata);
+        when(indexMetadata.getSettings()).thenReturn(settings);
+
         ShardsIterator result = action.shards(clusterState, request, new String[] { "test-index" });
         assertThat(result, equalTo(shardsIterator));
     }
@@ -112,7 +125,7 @@ public class TransportUpdateIngestionStateActionTests extends OpenSearchTestCase
         ShardRouting shardRouting = mock(ShardRouting.class);
         IndexService indexService = mock(IndexService.class);
         IndexShard indexShard = mock(IndexShard.class);
-        ShardIngestionState expectedState = new ShardIngestionState("test-index", 0, "PAUSED", "DROP", true, false, "");
+        ShardIngestionState expectedState = new ShardIngestionState("test-index", 0, "PAUSED", "DROP", true, false, "", true, "node");
 
         when(shardRouting.shardId()).thenReturn(mock(ShardId.class));
         when(shardRouting.shardId().getIndex()).thenReturn(mock(Index.class));
@@ -162,7 +175,7 @@ public class TransportUpdateIngestionStateActionTests extends OpenSearchTestCase
     public void testNewResponse() {
         UpdateIngestionStateRequest request = new UpdateIngestionStateRequest(new String[] { "test-index" }, new int[] { 0 });
         List<ShardIngestionState> responses = Collections.singletonList(
-            new ShardIngestionState("test-index", 0, "PAUSED", "DROP", true, false, "")
+            new ShardIngestionState("test-index", 0, "PAUSED", "DROP", true, false, "", true, "node")
         );
         List<DefaultShardOperationFailedException> shardFailures = Collections.emptyList();
         ClusterState clusterState = mock(ClusterState.class);

--- a/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
@@ -105,7 +105,33 @@ public class IngestionSourceTests extends OpenSearchTestCase {
             .setErrorStrategy(DROP)
             .build();
         String expected =
-            "IngestionSource{type='type',pointer_init_reset='PointerInitReset{type='RESET_BY_OFFSET', value=1000}',error_strategy='DROP', params={key=value}, maxPollSize=1000, pollTimeout=1000, numProcessorThreads=1, blockingQueueSize=100}";
+            "IngestionSource{type='type',pointer_init_reset='PointerInitReset{type='RESET_BY_OFFSET', value=1000}',error_strategy='DROP', params={key=value}, maxPollSize=1000, pollTimeout=1000, numProcessorThreads=1, blockingQueueSize=100, allActiveIngestion=false}";
         assertEquals(expected, source.toString());
+    }
+
+    public void testAllActiveIngestionConstructorAndGetter() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("key", "value");
+
+        // Test with all-active ingestion enabled
+        IngestionSource sourceEnabled = new IngestionSource.Builder("type").setParams(params)
+            .setPointerInitReset(pointerInitReset)
+            .setErrorStrategy(DROP)
+            .setAllActiveIngestion(true)
+            .build();
+
+        assertTrue("All-active ingestion should be enabled", sourceEnabled.isAllActiveIngestionEnabled());
+
+        // Test with all-active ingestion disabled
+        IngestionSource sourceDisabled = new IngestionSource.Builder("type").setParams(params)
+            .setPointerInitReset(pointerInitReset)
+            .setErrorStrategy(DROP)
+            .setAllActiveIngestion(false)
+            .build();
+
+        assertFalse("All-active ingestion should be disabled", sourceDisabled.isAllActiveIngestionEnabled());
+
+        IngestionSource ingestionSourceClone = new IngestionSource.Builder(sourceEnabled).build();
+        assertTrue(ingestionSourceClone.isAllActiveIngestionEnabled());
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/IngestionEngineTests.java
@@ -127,8 +127,8 @@ public class IngestionEngineTests extends EngineTestCase {
 
         // validate ingestion state on successful engine creation
         ShardIngestionState ingestionState = ingestionEngine.getIngestionState();
-        assertEquals("test", ingestionState.index());
-        assertEquals("DROP", ingestionState.errorPolicy());
+        assertEquals("test", ingestionState.getIndex());
+        assertEquals("DROP", ingestionState.getErrorPolicy());
         assertFalse(ingestionState.isPollerPaused());
         assertFalse(ingestionState.isWriteBlockEnabled());
     }


### PR DESCRIPTION
### Description
Pull-based ingestion today only supports segment replication. This PR adds an all-active mode where the replica also indexes the documents. This is done by having the replica shards ingest from the streaming source independently and process the messages when the all-active ingestion mode is enabled. The replicas will continue to use the peer recovery mode during shard reinitialization. Note that there is no replication or coordination between the primary and replicas in this mode, as each of them will ingest and index independently.

This mode can be expected to support better throughput in comparison to traditional doc-rep, and also provide better freshness as there is no replication delays.

The GetIngestionState API is enhanced to include primary and node name in the response to differentiate in the response.

### Related Issues
Resolves #19287


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
