### PR TITLE
Refactor ThreadPoolStats.Stats with Builder pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Disable pruning for `doc_values` for the wildcard field mapper ([#18568](https://github.com/opensearch-project/OpenSearch/pull/18568))
 - Make all methods in Engine.Result public ([#19276](https://github.com/opensearch-project/OpenSearch/pull/19275))
 - Create and attach interclusterTest and yamlRestTest code coverage reports to gradle check task([#19165](https://github.com/opensearch-project/OpenSearch/pull/19165))
+- Refactor the ThreadPoolStats.Stats class to use the Builder pattern instead of constructors ([#19306](https://github.com/opensearch-project/OpenSearch/pull/19306))
 
 ### Fixed
 - Fix unnecessary refreshes on update preparation failures ([#15261](https://github.com/opensearch-project/OpenSearch/issues/15261))
@@ -87,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `com.nimbusds:oauth2-oidc-sdk` from 11.25 to 11.28 ([#19291](https://github.com/opensearch-project/OpenSearch/pull/19291))
 
 ### Deprecated
+- Deprecated existing constructors in ThreadPoolStats.Stats in favor of the new Builder ([#19306](https://github.com/opensearch-project/OpenSearch/pull/19306))
 
 ### Removed
 - Enable backward compatibility tests on Mac ([#18983](https://github.com/opensearch-project/OpenSearch/pull/18983))

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -548,7 +548,18 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
                     rejected = ((XRejectedExecutionHandler) rejectedExecutionHandler).rejected();
                 }
             }
-            stats.add(new ThreadPoolStats.Stats(name, threads, queue, active, rejected, largest, completed, waitTimeNanos));
+
+            stats.add(
+                new ThreadPoolStats.Stats.Builder().name(name)
+                    .threads(threads)
+                    .queue(queue)
+                    .active(active)
+                    .rejected(rejected)
+                    .largest(largest)
+                    .completed(completed)
+                    .waitTimeNanos(waitTimeNanos)
+                    .build()
+            );
         }
         return new ThreadPoolStats(stats);
     }
@@ -587,14 +598,14 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
     /**
      * Schedules a one-shot command to run after a given delay. The command is run in the context of the calling thread.
      *
-     * @param command the command to run
-     * @param delay delay before the task executes
+     * @param command  the command to run
+     * @param delay    delay before the task executes
      * @param executor the name of the thread pool on which to execute this task. SAME means "execute on the scheduler thread" which changes
-     *        the meaning of the ScheduledFuture returned by this method. In that case the ScheduledFuture will complete only when the
-     *        command completes.
+     *                 the meaning of the ScheduledFuture returned by this method. In that case the ScheduledFuture will complete only when the
+     *                 command completes.
      * @return a ScheduledFuture who's get will return when the task is has been added to its target thread pool and throw an exception if
-     *         the task is canceled before it was added to its target thread pool. Once the task has been added to its target thread pool
-     *         the ScheduledFuture will cannot interact with it.
+     * the task is canceled before it was added to its target thread pool. Once the task has been added to its target thread pool
+     * the ScheduledFuture will cannot interact with it.
      * @throws OpenSearchRejectedExecutionException if the task cannot be scheduled for execution
      */
     @Override

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPoolStats.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPoolStats.java
@@ -72,6 +72,27 @@ public class ThreadPoolStats implements Writeable, ToXContentFragment, Iterable<
         private final long completed;
         private final long waitTimeNanos;
 
+        /**
+         * Private constructor that takes a builder.
+         * This is the sole entry point for creating a new Stats object.
+         * @param builder The builder instance containing all the values.
+         */
+        private Stats(Builder builder) {
+            this.name = builder.name;
+            this.threads = builder.threads;
+            this.queue = builder.queue;
+            this.active = builder.active;
+            this.rejected = builder.rejected;
+            this.largest = builder.largest;
+            this.completed = builder.completed;
+            this.waitTimeNanos = builder.waitTimeNanos;
+        }
+
+        /**
+         * This constructor will be deprecated in 4.0
+         * Use Builder to create Stats object
+         */
+        @Deprecated
         public Stats(String name, int threads, int queue, int active, long rejected, int largest, long completed, long waitTimeNanos) {
             this.name = name;
             this.threads = threads;
@@ -189,6 +210,71 @@ public class ThreadPoolStats implements Writeable, ToXContentFragment, Iterable<
                     compare = Integer.compare(getThreads(), other.getThreads());
                 }
                 return compare;
+            }
+        }
+
+        /**
+         * Builder for the {@link Stats} class.
+         * Provides a fluent API for constructing a Stats object.
+         */
+        public static class Builder {
+            private String name = "";
+            private int threads = 0;
+            private int queue = 0;
+            private int active = 0;
+            private long rejected = 0;
+            private int largest = 0;
+            private long completed = 0;
+            private long waitTimeNanos = 0;
+
+            public Builder() {}
+
+            public Builder name(String name) {
+                this.name = name;
+                return this;
+            }
+
+            public Builder threads(int threads) {
+                this.threads = threads;
+                return this;
+            }
+
+            public Builder queue(int queue) {
+                this.queue = queue;
+                return this;
+            }
+
+            public Builder active(int active) {
+                this.active = active;
+                return this;
+            }
+
+            public Builder rejected(long rejected) {
+                this.rejected = rejected;
+                return this;
+            }
+
+            public Builder largest(int largest) {
+                this.largest = largest;
+                return this;
+            }
+
+            public Builder completed(long completed) {
+                this.completed = completed;
+                return this;
+            }
+
+            public Builder waitTimeNanos(long waitTimeNanos) {
+                this.waitTimeNanos = waitTimeNanos;
+                return this;
+            }
+
+            /**
+             * Creates a {@link Stats} object from the builder's current state.
+             * @return A new Stats instance.
+             */
+            public Stats build() {
+                return new Stats(this);
             }
         }
     }

--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -734,16 +734,15 @@ public class NodeStatsTests extends OpenSearchTestCase {
             List<ThreadPoolStats.Stats> threadPoolStatsList = new ArrayList<>();
             for (int i = 0; i < numThreadPoolStats; i++) {
                 threadPoolStatsList.add(
-                    new ThreadPoolStats.Stats(
-                        randomAlphaOfLengthBetween(3, 10),
-                        randomIntBetween(1, 1000),
-                        randomIntBetween(1, 1000),
-                        randomIntBetween(1, 1000),
-                        randomNonNegativeLong(),
-                        randomIntBetween(1, 1000),
-                        randomIntBetween(1, 1000),
-                        randomIntBetween(-1, 10)
-                    )
+                    new ThreadPoolStats.Stats.Builder().name(randomAlphaOfLengthBetween(3, 10))
+                        .threads(randomIntBetween(1, 1000))
+                        .queue(randomIntBetween(1, 1000))
+                        .active(randomIntBetween(1, 1000))
+                        .rejected(randomNonNegativeLong())
+                        .largest(randomIntBetween(1, 1000))
+                        .completed(randomIntBetween(1, 1000))
+                        .waitTimeNanos(randomIntBetween(-1, 10))
+                        .build()
                 );
             }
             threadPoolStats = new ThreadPoolStats(threadPoolStatsList);

--- a/server/src/test/java/org/opensearch/index/autoforcemerge/AutoForceMergeManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/autoforcemerge/AutoForceMergeManagerTests.java
@@ -180,9 +180,17 @@ public class AutoForceMergeManagerTests extends OpenSearchTestCase {
         when(cpu.getPercent()).thenReturn((short) 50);
         when(jvm.getHeapUsedPercent()).thenReturn((short) 60);
         ThreadPoolStats stats = new ThreadPoolStats(
-            Arrays.asList(new ThreadPoolStats.Stats(
-                ThreadPool.Names.FORCE_MERGE, 1, 0, 0, 0, 1, 0, 0
-            ))
+            Arrays.asList(
+                new ThreadPoolStats.Stats.Builder().name(ThreadPool.Names.FORCE_MERGE)
+                    .threads(1)
+                    .queue(0)
+                    .active(0)
+                    .rejected(0)
+                    .largest(1)
+                    .completed(0)
+                    .waitTimeNanos(0)
+                    .build()
+            )
         );
         when(threadPool.stats()).thenReturn(stats);
 
@@ -196,9 +204,16 @@ public class AutoForceMergeManagerTests extends OpenSearchTestCase {
         when(cpu.getPercent()).thenReturn((short) 50);
         when(jvm.getHeapUsedPercent()).thenReturn((short) 60);
         ThreadPoolStats stats = new ThreadPoolStats(
-            Arrays.asList(new ThreadPoolStats.Stats(
-                ThreadPool.Names.FORCE_MERGE, 1, 0, 0, 0, 1, 0, 0
-            ))
+            Arrays.asList(new ThreadPoolStats.Stats.Builder().name(ThreadPool.Names.FORCE_MERGE)
+                .threads(1)
+                .queue(0)
+                .active(0)
+                .rejected(0)
+                .largest(1)
+                .completed(0)
+                .waitTimeNanos(0)
+                .build()
+            )
         );
         when(threadPool.stats()).thenReturn(stats);
         Settings settings = getConfiguredClusterSettings(false, false, Collections.emptyMap());
@@ -275,9 +290,17 @@ public class AutoForceMergeManagerTests extends OpenSearchTestCase {
         when(cpu.getPercent()).thenReturn((short) 50);
         when(jvm.getHeapUsedPercent()).thenReturn((short) 50);
         ThreadPoolStats stats = new ThreadPoolStats(
-            Arrays.asList(new ThreadPoolStats.Stats(
-                ThreadPool.Names.FORCE_MERGE, 1, 1, 1, 0, 1, 0, -1
-            ))
+            Arrays.asList(
+                new ThreadPoolStats.Stats.Builder().name(ThreadPool.Names.FORCE_MERGE)
+                    .threads(1)
+                    .queue(1)
+                    .active(1)
+                    .rejected(0)
+                    .largest(1)
+                    .completed(0)
+                    .waitTimeNanos(-1)
+                    .build()
+            )
         );
         when(threadPool.stats()).thenReturn(stats);
         AutoForceMergeManager autoForceMergeManager = clusterSetupWithNode(getConfiguredClusterSettings(true, true, Collections.emptyMap()), getNodeWithRoles(DATA_NODE_1, Set.of(DiscoveryNodeRole.DATA_ROLE)));
@@ -414,7 +437,17 @@ public class AutoForceMergeManagerTests extends OpenSearchTestCase {
         ExecutorService executorService = Executors.newFixedThreadPool(forceMergeThreads);
         when(threadPool.executor(ThreadPool.Names.FORCE_MERGE)).thenReturn(executorService);
         ThreadPoolStats stats = new ThreadPoolStats(
-            Arrays.asList(new ThreadPoolStats.Stats(ThreadPool.Names.FORCE_MERGE, forceMergeThreads, 0, 0, 0, forceMergeThreads, 0, -1))
+            Arrays.asList(
+                new ThreadPoolStats.Stats.Builder().name(ThreadPool.Names.FORCE_MERGE)
+                    .threads(forceMergeThreads)
+                    .queue(0)
+                    .active(0)
+                    .rejected(0)
+                    .largest(forceMergeThreads)
+                    .completed(0)
+                    .waitTimeNanos(-1)
+                    .build()
+            )
         );
         when(threadPool.stats()).thenReturn(stats);
 
@@ -464,7 +497,17 @@ public class AutoForceMergeManagerTests extends OpenSearchTestCase {
         ExecutorService executorService = Executors.newFixedThreadPool(forceMergeThreads);
         when(threadPool.executor(ThreadPool.Names.FORCE_MERGE)).thenReturn(executorService);
         ThreadPoolStats stats = new ThreadPoolStats(
-            Arrays.asList(new ThreadPoolStats.Stats(ThreadPool.Names.FORCE_MERGE, forceMergeThreads, 0, 0, 0, forceMergeThreads, 0, -1))
+            Arrays.asList(
+                new ThreadPoolStats.Stats.Builder().name(ThreadPool.Names.FORCE_MERGE)
+                    .threads(forceMergeThreads)
+                    .queue(0)
+                    .active(0)
+                    .rejected(0)
+                    .largest(forceMergeThreads)
+                    .completed(0)
+                    .waitTimeNanos(-1)
+                    .build()
+            )
         );
         when(threadPool.stats()).thenReturn(stats);
         IndexService indexService1 = mock(IndexService.class);
@@ -520,7 +563,17 @@ public class AutoForceMergeManagerTests extends OpenSearchTestCase {
         ExecutorService executorService = Executors.newFixedThreadPool(forceMergeThreads);
         when(threadPool.executor(ThreadPool.Names.FORCE_MERGE)).thenReturn(executorService);
         ThreadPoolStats stats = new ThreadPoolStats(
-            Arrays.asList(new ThreadPoolStats.Stats(ThreadPool.Names.FORCE_MERGE, forceMergeThreads, 0, 0, 0, forceMergeThreads, 0, -1))
+            Arrays.asList(
+                new ThreadPoolStats.Stats.Builder().name(ThreadPool.Names.FORCE_MERGE)
+                    .threads(forceMergeThreads)
+                    .queue(0)
+                    .active(0)
+                    .rejected(0)
+                    .largest(forceMergeThreads)
+                    .completed(0)
+                    .waitTimeNanos(-1)
+                    .build()
+            )
         );
         when(threadPool.stats()).thenReturn(stats);
 

--- a/server/src/test/java/org/opensearch/threadpool/ThreadPoolStatsTests.java
+++ b/server/src/test/java/org/opensearch/threadpool/ThreadPoolStatsTests.java
@@ -51,13 +51,19 @@ import static org.hamcrest.Matchers.equalTo;
 public class ThreadPoolStatsTests extends OpenSearchTestCase {
     public void testThreadPoolStatsSort() throws IOException {
         List<ThreadPoolStats.Stats> stats = new ArrayList<>();
-        stats.add(new ThreadPoolStats.Stats("z", -1, 0, 0, 0, 0, 0L, 0L));
-        stats.add(new ThreadPoolStats.Stats("m", 3, 0, 0, 0, 0, 0L, 0L));
-        stats.add(new ThreadPoolStats.Stats("m", 1, 0, 0, 0, 0, 0L, 0L));
-        stats.add(new ThreadPoolStats.Stats("d", -1, 0, 0, 0, 0, 0L, 0L));
-        stats.add(new ThreadPoolStats.Stats("m", 2, 0, 0, 0, 0, 0L, 0L));
-        stats.add(new ThreadPoolStats.Stats("t", -1, 0, 0, 0, 0, 0L, 0L));
-        stats.add(new ThreadPoolStats.Stats("a", -1, 0, 0, 0, 0, 0L, 0L));
+        ThreadPoolStats.Stats.Builder defaultStats = new ThreadPoolStats.Stats.Builder().queue(0)
+            .active(0)
+            .rejected(0)
+            .largest(0)
+            .completed(0L)
+            .waitTimeNanos(0L);
+        stats.add(defaultStats.name("z").threads(-1).build());
+        stats.add(defaultStats.name("m").threads(3).build());
+        stats.add(defaultStats.name("m").threads(1).build());
+        stats.add(defaultStats.name("d").threads(-1).build());
+        stats.add(defaultStats.name("m").threads(2).build());
+        stats.add(defaultStats.name("t").threads(-1).build());
+        stats.add(defaultStats.name("a").threads(-1).build());
 
         List<ThreadPoolStats.Stats> copy = new ArrayList<>(stats);
         Collections.sort(copy);
@@ -79,11 +85,17 @@ public class ThreadPoolStatsTests extends OpenSearchTestCase {
         try (BytesStreamOutput os = new BytesStreamOutput()) {
 
             List<ThreadPoolStats.Stats> stats = new ArrayList<>();
-            stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.SEARCH, -1, 0, 0, 0, 0, 0L, 0L));
-            stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.WARMER, -1, 0, 0, 0, 0, 0L, -1L));
-            stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.GENERIC, -1, 0, 0, 0, 0, 0L, -1L));
-            stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.FORCE_MERGE, -1, 0, 0, 0, 0, 0L, -1L));
-            stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.SAME, -1, 0, 0, 0, 0, 0L, -1L));
+            ThreadPoolStats.Stats.Builder defaultStats = new ThreadPoolStats.Stats.Builder().threads(-1)
+                .queue(0)
+                .active(0)
+                .rejected(0)
+                .largest(0)
+                .completed(0L);
+            stats.add(defaultStats.name(ThreadPool.Names.SEARCH).waitTimeNanos(0L).build());
+            stats.add(defaultStats.name(ThreadPool.Names.WARMER).waitTimeNanos(-1L).build());
+            stats.add(defaultStats.name(ThreadPool.Names.GENERIC).waitTimeNanos(-1L).build());
+            stats.add(defaultStats.name(ThreadPool.Names.FORCE_MERGE).waitTimeNanos(-1L).build());
+            stats.add(defaultStats.name(ThreadPool.Names.SAME).waitTimeNanos(-1L).build());
 
             ThreadPoolStats threadPoolStats = new ThreadPoolStats(stats);
             try (XContentBuilder builder = new XContentBuilder(MediaTypeRegistry.JSON.xContent(), os)) {


### PR DESCRIPTION
### Description
This PR refactors the `ThreadPoolStats.Stats` class to use the Builder pattern instead of relying on multiple constructors.  

By adopting the Builder pattern, it becomes easier to evolve the stats API, add new metrics, and maintain backward compatibility without forcing disruptive constructor changes.

Based on the related issue:
1. Added a Builder and deprecated the existing constructors.
2. Replaced usages of constructors in code and tests with the new Builder.

There are multiple stats-related classes that need similar refactoring, and we are addressing them in priority order. This PR covers IndexingStats.Stats as part of that effort.

### Related Issues
Partially resolves #19225 

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
