### PR TITLE
Add version check in 121_grok_capture_all_matches.yml

### DIFF
--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/121_grok_capture_all_matches.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/121_grok_capture_all_matches.yml
@@ -39,6 +39,9 @@ teardown:
 
 ---
 "Test Grok Pipeline with capture_all_matches enabled":
+  - skip:
+      version: " - 3.2.99"
+      reason: Introduced in 3.3.0
   - do:
       ingest.put_pipeline:
         id: "my_pipeline"
@@ -76,6 +79,9 @@ teardown:
 
 ---
 "Test Grok Pipeline with capture_all_matches and multiple patterns":
+  - skip:
+      version: " - 3.2.99"
+      reason: Introduced in 3.3.0
   - do:
       ingest.put_pipeline:
         id: "my_pipeline"
@@ -126,6 +132,9 @@ teardown:
 
 ---
 "Test Grok Pipeline with capture_all_matches and custom pattern":
+  - skip:
+      version: " - 3.2.99"
+      reason: Introduced in 3.3.0
   - do:
       ingest.put_pipeline:
         id: "my_pipeline"


### PR DESCRIPTION
### Description

The version check section in the new added 121_grok_capture_all_matches.yml file is missing, may cause compatibility test to fail.

### Related Issues
No issue.

### Check List
<del>- [ ] Functionality includes testing.
<del>- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
<del>- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
