### PR TITLE
Update ide.gradle to write --add-modules to .idea/compiler.xml.

### DIFF
--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -52,13 +52,12 @@ if (System.getProperty('idea.active') == 'true') {
   tasks.register('configureIncubatorVectorModule') {
     group = 'ide'
     description = 'Configures the incubator module compiler settings'
-
+    /*
+    libs/common includes jdk.incubator.vector package which is hardware/runtime dependant.
+    Add compiler option --add-modules for intellij test runner when compiling this module.
+    */
     doLast {
       modifyXml('.idea/compiler.xml') { xml ->
-        /*
-        libs/common includes jdk.incubator.vector package which is hardware/runtime dependant.
-        Add compiler option --add-modules for intellij test runner when compiling this module.
-        */
         def javacSettings = xml.component.find { it.'@name' == 'JavacSettings' }
         if (!javacSettings) {
           javacSettings = xml.appendNode('component', [name: 'JavacSettings'])

--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -49,6 +49,33 @@ if (System.getProperty('idea.active') == 'true') {
     }
   }
 
+  tasks.register('configureIncubatorVectorModule') {
+    group = 'ide'
+    description = 'Configures the incubator module compiler settings'
+
+    doLast {
+      modifyXml('.idea/compiler.xml') { xml ->
+        /*
+        libs/common includes jdk.incubator.vector package which is hardware/runtime dependant.
+        Add compiler option --add-modules for intellij test runner when compiling this module.
+        */
+        def javacSettings = xml.component.find { it.'@name' == 'JavacSettings' }
+        if (!javacSettings) {
+          javacSettings = xml.appendNode('component', [name: 'JavacSettings'])
+        }
+        def additionalOptions = javacSettings.option.find { it.'@name' == 'ADDITIONAL_OPTIONS_STRING' }
+        if (!additionalOptions) {
+          javacSettings.appendNode('option', [
+            name: 'ADDITIONAL_OPTIONS_STRING',
+            value: '--add-modules jdk.incubator.vector'
+          ])
+        } else {
+          additionalOptions.'@value' = '--add-modules jdk.incubator.vector'
+        }
+      }
+    }
+  }
+
   idea {
     project {
       vcs = 'Git'
@@ -60,7 +87,7 @@ if (System.getProperty('idea.active') == 'true') {
           testRunner = 'choose_per_test'
         }
         taskTriggers {
-          afterSync tasks.named('configureIdeaGradleJvm')
+          afterSync tasks.named('configureIdeaGradleJvm'), tasks.named('configureIncubatorVectorModule')
         }
         codeStyle {
           java {


### PR DESCRIPTION
### Description
I notice that IntelliJ will sometimes produce the error:
```
.../OpenSearch/libs/common/src/main/java/org/opensearch/common/round/BtreeSearcher.java:13:21
java: package jdk.incubator.vector is not visible
(package jdk.incubator.vector is declared in module jdk.incubator.vector, which is not in the module graph)
```

This appears to be the result of IntelliJ defaulting to its own test runner after a restart/update/cleared cache.
Settings -> Build, Execution, Deployment -> Build Tools -> Gradle will be set to:
"Build and run using: IntelliJ IDEA"
"Run tests using: Choose per test"

When setting these both to "Gradle" the error goes away as gradle is able to find the extra config option as set here:
https://github.com/opensearch-project/OpenSearch/blob/main/libs/common/build.gradle#L54-L57

However using the IntelliJ test runner does not honor the compiler option as configured in the above build.gradle. This change updates ide.gradle to inject this compiler option into `.idea/compiler.xml`.

### Related Issues
N/A

Adding skip-changelog here as it's a dev QOL only change.

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
