### PR TITLE
[Rule-based Auto-tagging] restructure the in-memory trie to store values as a set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add temporal routing processors for time-based document routing ([#18920](https://github.com/opensearch-project/OpenSearch/issues/18920))
 - Implement Query Rewriting Infrastructure ([#19060](https://github.com/opensearch-project/OpenSearch/pull/19060))
 - The dynamic mapping parameter supports false_allow_templates ([#19065](https://github.com/opensearch-project/OpenSearch/pull/19065) ([#19097](https://github.com/opensearch-project/OpenSearch/pull/19097)))
+- [Rule-based Auto-tagging] restructure the in-memory trie to store values as a set ([#19344](https://github.com/opensearch-project/OpenSearch/pull/19344))
 - Add a toBuilder method in EngineConfig to support easy modification of configs([#19054](https://github.com/opensearch-project/OpenSearch/pull/19054))
 - Add StoreFactory plugin interface for custom Store implementations([#19091](https://github.com/opensearch-project/OpenSearch/pull/19091))
 - Use S3CrtClient for higher throughput while uploading files to S3 ([#18800](https://github.com/opensearch-project/OpenSearch/pull/18800))

--- a/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/storage/AttributeValueStore.java
+++ b/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/storage/AttributeValueStore.java
@@ -8,7 +8,10 @@
 
 package org.opensearch.rule.storage;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * This interface provides apis to store Rule attribute values
@@ -23,14 +26,30 @@ public interface AttributeValueStore<K, V> {
 
     /**
      * removes the key and associated value from attribute value store
+     * @param key key of the value to be removed
+     * @param value to be removed
+     */
+    default void remove(K key, V value) {
+        remove(key);
+    }
+
+    /**
+     * removes the key and associated value from attribute value store
      * @param key to be removed
      */
     void remove(K key);
 
     /**
+     * Returns the values associated with the key
+     * @param key in the data structure
+     */
+    default List<Set<V>> getAll(K key) {
+        return new ArrayList<>();
+    }
+
+    /**
      * Returns the value associated with the key
      * @param key in the data structure
-     * @return
      */
     Optional<V> get(K key);
 

--- a/modules/autotagging-commons/src/main/java/org/opensearch/rule/InMemoryRuleProcessingService.java
+++ b/modules/autotagging-commons/src/main/java/org/opensearch/rule/InMemoryRuleProcessingService.java
@@ -66,7 +66,7 @@ public class InMemoryRuleProcessingService {
     private void removeOperation(Map.Entry<Attribute, Set<String>> attributeEntry, Rule rule) {
         AttributeValueStore<String, String> valueStore = attributeValueStoreFactory.getAttributeValueStore(attributeEntry.getKey());
         for (String value : attributeEntry.getValue()) {
-            valueStore.remove(value.replace(WILDCARD, ""));
+            valueStore.remove(value.replace(WILDCARD, ""), rule.getFeatureValue());
         }
     }
 
@@ -92,12 +92,13 @@ public class InMemoryRuleProcessingService {
                 attributeExtractor.getAttribute()
             );
             for (String value : attributeExtractor.extract()) {
-                Optional<String> possibleMatch = valueStore.get(value);
+                List<Set<String>> candidateMatches = valueStore.getAll(value);
 
-                if (possibleMatch.isEmpty()) {
+                if (candidateMatches == null || candidateMatches.isEmpty()) {
                     return Optional.empty();
                 }
 
+                Optional<String> possibleMatch = candidateMatches.get(0).stream().findAny();
                 if (result.isEmpty()) {
                     result = possibleMatch;
                 } else {


### PR DESCRIPTION
In this PR, we restructured the in-memory rule tries so that values are stored as a set instead of a single string.
The reason is that as we add more attributes into the system, a single attribute key may correspond to multiple valid labels.

For example:
```
Rule 1: index_pattern: [a], label: label1
Rule 2: index_pattern: [a], username: [b], label: label2
```

These two rules are not duplicates—both should be stored. In the trie for index_pattern, the key a would map to:
```
a → { label1, label2 }
```

By switching from a string to a set, we can correctly represent multiple labels for the same attribute key without overwriting or losing data.

More documentation on the feature is here: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/rule-based-autotagging/autotagging/

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
