### PR TITLE
Wipe request cache on mapper updates that can change query results

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -890,7 +890,10 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
         // Force merge the index to ensure there can be no background merges during the subsequent searches that would invalidate the cache
         forceMerge(client, index);
 
-        SearchResponse resp = client.prepareSearch(index).setRequestCache(true).setQuery(QueryBuilders.disMaxQuery().add(QueryBuilders.termQuery(field, "foo")).add(QueryBuilders.termQuery(field, "bar"))).get();
+        SearchResponse resp = client.prepareSearch(index)
+            .setRequestCache(true)
+            .setQuery(QueryBuilders.disMaxQuery().add(QueryBuilders.termQuery(field, "foo")).add(QueryBuilders.termQuery(field, "bar")))
+            .get();
         assertSearchResponse(resp);
         // When use_similarity=false all 6 docs should have equal scores
         double delta = 0.0001;
@@ -907,12 +910,13 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
         client.admin().indices().putMapping(mappingRequest).actionGet();
 
         // The request cache should be wiped
-        assertBusy(() -> {
-            assertEquals(getNodeCacheStats(client).getMemorySizeInBytes(), 0);
-        });
+        assertBusy(() -> { assertEquals(getNodeCacheStats(client).getMemorySizeInBytes(), 0); });
 
         // Run same search again and ensure docs do NOT all have same scores anymore, and that RC is not used (no hits)
-        resp = client.prepareSearch(index).setRequestCache(true).setQuery(QueryBuilders.disMaxQuery().add(QueryBuilders.termQuery(field, "foo")).add(QueryBuilders.termQuery(field, "bar"))).get();
+        resp = client.prepareSearch(index)
+            .setRequestCache(true)
+            .setQuery(QueryBuilders.disMaxQuery().add(QueryBuilders.termQuery(field, "foo")).add(QueryBuilders.termQuery(field, "bar")))
+            .get();
         assertSearchResponse(resp);
         // the doc with the rarer term should now have a higher score than the others, which should all have equal scores
         assertEquals(resp.getHits().getHits().length, 6);
@@ -928,6 +932,10 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
         stats = getNodeCacheStats(client);
         assertEquals(0, stats.getHitCount());
         assertTrue(stats.getMemorySizeInBytes() > 0);
+
+        // TODO: Test that updating some other value like eager_global_ordinals does NOT wipe cache
+        // and that adding a totally new field does not wipe cache even if it's got use_similarity
+        // also test more structures like nested fields, missing field type name, ...
     }
 
     private Path[] shardDirectory(String server, Index index, int shard) {

--- a/server/src/main/java/org/opensearch/cluster/ClusterChangedEvent.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterChangedEvent.java
@@ -201,6 +201,12 @@ public class ClusterChangedEvent {
         return metadata1 != metadata2;
     }
 
+    public static boolean indexMappingMetadataChanged(IndexMetadata metadata1, IndexMetadata metadata2) {
+        assert metadata1 != null && metadata2 != null;
+        return metadata1.mapping() != metadata2.mapping(); // TODO: Not sure this is fine - gets the "_doc" key from map, which appears to
+                                                           // hold what I want, but not sure of purpose of map
+    }
+
     /**
      * Returns <code>true</code> iff the cluster level blocks have changed between cluster states.
      * Note that this is an object reference equality test, not an equals test.

--- a/server/src/main/java/org/opensearch/cluster/ClusterChangedEvent.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterChangedEvent.java
@@ -203,8 +203,7 @@ public class ClusterChangedEvent {
 
     public static boolean indexMappingMetadataChanged(IndexMetadata metadata1, IndexMetadata metadata2) {
         assert metadata1 != null && metadata2 != null;
-        return metadata1.mapping() != metadata2.mapping(); // TODO: Not sure this is fine - gets the "_doc" key from map, which appears to
-                                                           // hold what I want, but not sure of purpose of map
+        return metadata1.mapping() != metadata2.mapping();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -772,7 +772,6 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
         }
 
         /**
-         * TODO: Name is TBD, maybe can think of smth better
          * @return A set of the names of the parameters for this field which, when updated, can affect query results.
          */
         public Set<String> getParametersAffectingQueryResults() {

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -751,9 +751,10 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
      *
      * @opensearch.internal
      */
-    public static final class TypeParser implements Mapper.TypeParser {
+    public static class TypeParser implements Mapper.TypeParser {
 
         private final BiFunction<String, ParserContext, Builder> builderFunction;
+        private final static Set<String> EMPTY_PARAMS_AFFECTING_QUERY_RESULTS = new HashSet<>();
 
         /**
          * Creates a new TypeParser
@@ -764,10 +765,18 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public final Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             Builder builder = builderFunction.apply(name, parserContext);
             builder.parse(name, parserContext, node);
             return builder;
+        }
+
+        /**
+         * TODO: Name is TBD, maybe can think of smth better
+         * @return A set of the names of the parameters for this field which, when updated, can affect query results.
+         */
+        public Set<String> getParametersAffectingQueryResults() {
+            return EMPTY_PARAMS_AFFECTING_QUERY_RESULTS;
         }
     }
 }

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -2129,6 +2129,19 @@ public class IndicesService extends AbstractLifecycleComponent
         }
     }
 
+    @Override
+    public void clearIndexShardCacheForAllShards(
+        Index index,
+        boolean queryCache,
+        boolean fieldDataCache,
+        boolean requestCache,
+        String... fields
+    ) {
+        for (IndexShard indexShard : indexService(index)) {
+            clearIndexShardCache(indexShard.shardId(), queryCache, fieldDataCache, requestCache, fields);
+        }
+    }
+
     /**
      * Returns a function which given an index name, returns a predicate which fields must match in order to be returned by get mappings,
      * get index, get field mappings and field capabilities API. Useful to filter the fields that such API return.
@@ -2145,6 +2158,10 @@ public class IndicesService extends AbstractLifecycleComponent
      */
     public boolean isMetadataField(String field) {
         return mapperRegistry.isMetadataField(field);
+    }
+
+    public Map<String, Set<String>> getParametersAffectingQueryResults() {
+        return mapperRegistry.getParametersAffectingQueryResults();
     }
 
     /**

--- a/server/src/test/java/org/opensearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
@@ -48,6 +48,7 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.MergedSegmentWarmerFactory;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.remote.RemoteStoreStatsTrackerFactory;
 import org.opensearch.index.seqno.RetentionLeaseSyncer;
 import org.opensearch.index.shard.IndexEventListener;
@@ -296,6 +297,17 @@ public abstract class AbstractIndicesClusterStateServiceTestCase extends OpenSea
         public Iterator<MockIndexService> iterator() {
             return indices.values().iterator();
         }
+
+        @Override
+        public void clearIndexShardCacheForAllShards(
+            Index index,
+            boolean queryCache,
+            boolean fieldDataCache,
+            boolean requestCache,
+            String... fields
+        ) {
+            return; // TODO
+        }
     }
 
     /**
@@ -360,6 +372,11 @@ public abstract class AbstractIndicesClusterStateServiceTestCase extends OpenSea
         @Override
         public Index index() {
             return indexSettings.getIndex();
+        }
+
+        @Override
+        public MapperService mapperService() {
+            return null; // TODO
         }
     }
 

--- a/server/src/test/java/org/opensearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
@@ -306,7 +306,7 @@ public abstract class AbstractIndicesClusterStateServiceTestCase extends OpenSea
             boolean requestCache,
             String... fields
         ) {
-            return; // TODO
+            return;
         }
     }
 
@@ -376,7 +376,7 @@ public abstract class AbstractIndicesClusterStateServiceTestCase extends OpenSea
 
         @Override
         public MapperService mapperService() {
-            return null; // TODO
+            return null;
         }
     }
 

--- a/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/server/src/test/java/org/opensearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -589,7 +589,8 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
             null,
             null,
             MergedSegmentPublisher.EMPTY,
-            ReferencedSegmentsPublisher.EMPTY
+            ReferencedSegmentsPublisher.EMPTY,
+            Map.of()
         );
     }
 


### PR DESCRIPTION
### Description
Wipes the request cache for an index when mapper updates that can change query results for that index happen. This is done by comparing mapping before and after in IndicesClusterStateService. It was done this way because there wasn't a good way of having the Mapper objects themselves communicate the results of their merge back out - see [this](https://github.com/opensearch-project/OpenSearch/issues/19279#issuecomment-3299560538) comment for more. 

Any other ParametrizedFieldMapper inheritors which want to register parameters that can affect query results, and therefore should cause cache clear, can override their TypeParser with one that provides those parameters in its `getParametersAffectingQueryResults()` method. See how it's done in the KeywordFieldMapper for an example. This should work for non-core mappers too. 

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/19279

### Check List
- [x] Functionality includes testing.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
