### PR TITLE
Improve serialization of big integer in Lucene.java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Optimized date histogram aggregations by preventing unnecessary object allocations in date rounding utils ([19088](https://github.com/opensearch-project/OpenSearch/pull/19088))
 - Optimize source conversion in gRPC search hits using zero-copy BytesRef ([#19280](https://github.com/opensearch-project/OpenSearch/pull/19280))
 - Add failureaccess as runtime dependency to transport-grpc module  ([#19339](https://github.com/opensearch-project/OpenSearch/pull/19339))
+- Improve serialization of BigInteger in Lucene.java ([19348](https://github.com/opensearch-project/OpenSearch/pull/19348)))
 
 ### Fixed
 - Fix unnecessary refreshes on update preparation failures ([#15261](https://github.com/opensearch-project/OpenSearch/issues/15261))

--- a/server/src/main/java/org/opensearch/common/lucene/Lucene.java
+++ b/server/src/main/java/org/opensearch/common/lucene/Lucene.java
@@ -198,7 +198,7 @@ public class Lucene {
      */
     public static SegmentInfos pruneUnreferencedFiles(String segmentsFileName, Directory directory) throws IOException {
         final SegmentInfos si = readSegmentInfos(segmentsFileName, directory);
-        try (Lock writeLock = directory.obtainLock(IndexWriter.WRITE_LOCK_NAME)) {
+        try (Lock ignored = directory.obtainLock(IndexWriter.WRITE_LOCK_NAME)) {
             int foundSegmentFiles = 0;
             for (final String file : directory.listAll()) {
                 /*
@@ -222,7 +222,7 @@ public class Lucene {
         }
         final IndexCommit cp = getIndexCommit(si, directory);
         try (
-            IndexWriter writer = new IndexWriter(
+            IndexWriter ignored = new IndexWriter(
                 directory,
                 new IndexWriterConfig(Lucene.STANDARD_ANALYZER).setSoftDeletesField(Lucene.SOFT_DELETES_FIELD)
                     .setIndexCommit(cp)
@@ -249,7 +249,7 @@ public class Lucene {
      * this operation fails.
      */
     public static void cleanLuceneIndex(Directory directory) throws IOException {
-        try (Lock writeLock = directory.obtainLock(IndexWriter.WRITE_LOCK_NAME)) {
+        try (Lock ignored = directory.obtainLock(IndexWriter.WRITE_LOCK_NAME)) {
             for (final String file : directory.listAll()) {
                 if (file.startsWith(IndexFileNames.SEGMENTS)) {
                     directory.deleteFile(file); // remove all segment_N files
@@ -257,7 +257,7 @@ public class Lucene {
             }
         }
         try (
-            IndexWriter writer = new IndexWriter(
+            IndexWriter ignored = new IndexWriter(
                 directory,
                 new IndexWriterConfig(Lucene.STANDARD_ANALYZER).setSoftDeletesField(Lucene.SOFT_DELETES_FIELD)
                     .setMergePolicy(NoMergePolicy.INSTANCE) // no merges
@@ -388,7 +388,7 @@ public class Lucene {
             case 7 -> in.readShort();
             case 8 -> in.readBoolean();
             case 9 -> in.readBytesRef();
-            case 10 -> new BigInteger(in.readString());
+            case 10 -> new BigInteger(in.readByteArray());
             default -> throw new IOException("Can't match type [" + type + "]");
         };
     }
@@ -405,9 +405,8 @@ public class Lucene {
     }
 
     public static void writeTopDocs(StreamOutput out, TopDocsAndMaxScore topDocs) throws IOException {
-        if (topDocs.topDocs instanceof CollapseTopFieldDocs) {
+        if (topDocs.topDocs instanceof CollapseTopFieldDocs collapseDocs) {
             out.writeByte((byte) 2);
-            CollapseTopFieldDocs collapseDocs = (CollapseTopFieldDocs) topDocs.topDocs;
 
             writeTotalHits(out, topDocs.topDocs.totalHits);
             out.writeFloat(topDocs.maxScore);
@@ -421,9 +420,8 @@ public class Lucene {
                 writeFieldDoc(out, (FieldDoc) doc);
                 writeSortValue(out, collapseDocs.collapseValues[i]);
             }
-        } else if (topDocs.topDocs instanceof TopFieldDocs) {
+        } else if (topDocs.topDocs instanceof TopFieldDocs topFieldDocs) {
             out.writeByte((byte) 1);
-            TopFieldDocs topFieldDocs = (TopFieldDocs) topDocs.topDocs;
 
             writeTotalHits(out, topDocs.topDocs.totalHits);
             out.writeFloat(topDocs.maxScore);
@@ -459,57 +457,58 @@ public class Lucene {
 
     private static Object readMissingValue(StreamInput in) throws IOException {
         final byte id = in.readByte();
-        switch (id) {
-            case 0:
-                return in.readGenericValue();
-            case 1:
-                return SortField.STRING_FIRST;
-            case 2:
-                return SortField.STRING_LAST;
-            default:
-                throw new IOException("Unknown missing value id: " + id);
-        }
+        return switch (id) {
+            case 0 -> in.readGenericValue();
+            case 1 -> SortField.STRING_FIRST;
+            case 2 -> SortField.STRING_LAST;
+            default -> throw new IOException("Unknown missing value id: " + id);
+        };
     }
 
     public static void writeSortValue(StreamOutput out, Object field) throws IOException {
-        if (field == null) {
-            out.writeByte((byte) 0);
-        } else {
-            Class type = field.getClass();
-            if (type == String.class) {
+        switch (field) {
+            case null -> out.writeByte((byte) 0);
+            case String s -> {
                 out.writeByte((byte) 1);
-                out.writeString((String) field);
-            } else if (type == Integer.class) {
-                out.writeByte((byte) 2);
-                out.writeInt((Integer) field);
-            } else if (type == Long.class) {
-                out.writeByte((byte) 3);
-                out.writeLong((Long) field);
-            } else if (type == Float.class) {
-                out.writeByte((byte) 4);
-                out.writeFloat((Float) field);
-            } else if (type == Double.class) {
-                out.writeByte((byte) 5);
-                out.writeDouble((Double) field);
-            } else if (type == Byte.class) {
-                out.writeByte((byte) 6);
-                out.writeByte((Byte) field);
-            } else if (type == Short.class) {
-                out.writeByte((byte) 7);
-                out.writeShort((Short) field);
-            } else if (type == Boolean.class) {
-                out.writeByte((byte) 8);
-                out.writeBoolean((Boolean) field);
-            } else if (type == BytesRef.class) {
-                out.writeByte((byte) 9);
-                out.writeBytesRef((BytesRef) field);
-            } else if (type == BigInteger.class) {
-                // TODO: improve serialization of BigInteger
-                out.writeByte((byte) 10);
-                out.writeString(field.toString());
-            } else {
-                throw new IOException("Can't handle sort field value of type [" + type + "]");
+                out.writeString(s);
             }
+            case Integer i -> {
+                out.writeByte((byte) 2);
+                out.writeInt(i);
+            }
+            case Long l -> {
+                out.writeByte((byte) 3);
+                out.writeLong(l);
+            }
+            case Float f -> {
+                out.writeByte((byte) 4);
+                out.writeFloat(f);
+            }
+            case Double d -> {
+                out.writeByte((byte) 5);
+                out.writeDouble(d);
+            }
+            case Byte b -> {
+                out.writeByte((byte) 6);
+                out.writeByte(b);
+            }
+            case Short s -> {
+                out.writeByte((byte) 7);
+                out.writeShort(s);
+            }
+            case Boolean b -> {
+                out.writeByte((byte) 8);
+                out.writeBoolean(b);
+            }
+            case BytesRef b -> {
+                out.writeByte((byte) 9);
+                out.writeBytesRef(b);
+            }
+            case BigInteger i -> {
+                out.writeByte((byte) 10);
+                out.writeByteArray(i.toByteArray());
+            }
+            default -> throw new IOException("Can't handle sort field value of type [" + field.getClass() + "]");
         }
     }
 
@@ -577,13 +576,12 @@ public class Lucene {
             );
             newSortField.setMissingValue(sortField.getMissingValue());
             sortField = newSortField;
-        } else if (sortField instanceof NonPruningSortField) {
+        } else if (sortField instanceof NonPruningSortField nonPruningSortField) {
             // There are 2 cases of how NonPruningSortField wraps around its underlying sort field.
             // Which are through the SortField class or SortedSetSortField class
             // We will serialize the sort field based on the type of underlying sort field
             // Here the underlying sort field is SortedSetSortField, therefore, we will follow the
             // logic in serializing SortedSetSortField and also unwrap the SortField case.
-            NonPruningSortField nonPruningSortField = (NonPruningSortField) sortField;
             if (nonPruningSortField.getDelegate().getClass() == SortedSetSortField.class) {
                 SortField newSortField = new SortField(
                     nonPruningSortField.getField(),
@@ -699,11 +697,9 @@ public class Lucene {
     public static SegmentReader segmentReader(LeafReader reader) {
         if (reader instanceof SegmentReader) {
             return (SegmentReader) reader;
-        } else if (reader instanceof FilterLeafReader) {
-            final FilterLeafReader fReader = (FilterLeafReader) reader;
+        } else if (reader instanceof FilterLeafReader fReader) {
             return segmentReader(FilterLeafReader.unwrap(fReader));
-        } else if (reader instanceof FilterCodecReader) {
-            final FilterCodecReader fReader = (FilterCodecReader) reader;
+        } else if (reader instanceof FilterCodecReader fReader) {
             return segmentReader(FilterCodecReader.unwrap(fReader));
         }
         // hard fail - we can't get a SegmentReader


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- In `Lucene.java` Resolves: `// TODO: improve serialization of BigInteger` by changing serialization/de-serialization in this manner:
	- `case BigInteger i -> out.writeString(field.toString());` -> `case BigInteger i -> out.writeByteArray(i.toByteArray());`
	- `case 10 -> new BigInteger(in.readString());` ->  `case 10 -> new BigInteger(in.readByteArray());`
- Minor refactoring with `if-else` to `switch` cases
- Minor refactoring around instance pattern initialization
            
                
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
