### PR TITLE
Enable --enable-preview for JDK21 to enable MemorySegment for faster vector search.

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -80,6 +80,10 @@ ${error.file}
 # disabling may reduce performance on vector optimized lucene
 20-:--add-modules=jdk.incubator.vector
 
+# Enable FFM for vector search.
+# Since 22+, FFM API becomes standard, no more preview.
+21:--enable-preview
+
 # See please https://bugs.openjdk.org/browse/JDK-8341127 (openjdk/jdk#21283)
 23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.setAsTypeCache
 23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.asTypeUncached


### PR DESCRIPTION
### Description
Issue : https://github.com/opensearch-project/OpenSearch/issues/19338

To support FP16 in vector search, we can achieve up to 2x faster performance by leveraging [MemorySegment](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/foreign/MemorySegment.html), which is a preview feature in JDK 21.

Since Java does not natively support the FP16 data type, the current implementation reconstructs two bytes into a float, resulting in significantly slower performance compared to using C++ for FP16 distance calculations. By using [MemorySegment](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/foreign/MemorySegment.html) to access the mapped pointer directly and passing it to C++ code, we can eliminate this overhead and improve efficiency.

However, [MemorySegment](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/foreign/MemorySegment.html) is only available as a preview API in JDK 21 and became a standard feature starting with JDK 22. This PR adds the --enable-preview flag for JDK 21 to enable its use.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/OpenSearch/issues/19338

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
