### PR TITLE
[Pull-based Ingestion] Fix waitForSearchableDocs in Kinesis tests

### DIFF
--- a/plugins/ingestion-kinesis/src/internalClusterTest/java/org/opensearch/plugin/kinesis/KinesisIngestionBaseIT.java
+++ b/plugins/ingestion-kinesis/src/internalClusterTest/java/org/opensearch/plugin/kinesis/KinesisIngestionBaseIT.java
@@ -117,12 +117,16 @@ public class KinesisIngestionBaseIT extends OpenSearchIntegTestCase {
 
     protected void waitForSearchableDocs(long docCount, List<String> nodes) throws Exception {
         assertBusy(() -> {
-            for (String node : nodes) {
-                final SearchResponse response = client(node).prepareSearch(indexName).setSize(0).setPreference("_only_local").get();
-                final long hits = response.getHits().getTotalHits().value();
-                if (hits < docCount) {
-                    fail("Expected search hits on node: " + node + " to be at least " + docCount + " but was: " + hits);
+            try {
+                for (String node : nodes) {
+                    final SearchResponse response = client(node).prepareSearch(indexName).setSize(0).setPreference("_only_local").get();
+                    final long hits = response.getHits().getTotalHits().value();
+                    if (hits < docCount) {
+                        fail("Expected search hits on node: " + node + " to be at least " + docCount + " but was: " + hits);
+                    }
                 }
+            } catch (Exception e) {
+                fail("Exception while waiting for search results: " + e);
             }
         }, 1, TimeUnit.MINUTES);
     }


### PR DESCRIPTION
### Description
Update the all-active kinesis test to wait till required docs are available, by updating waitForSearchableDocs method.

### Related Issues
Resolves #17678

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
