### PR TITLE
Harden the circuit breaker and failure handle logic in query result consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Optimization in String Terms Aggregation query for Large Bucket Counts([#18732](https://github.com/opensearch-project/OpenSearch/pull/18732))
 - New cluster setting search.query.max_query_string_length ([#19491](https://github.com/opensearch-project/OpenSearch/pull/19491))
 - Add `StreamNumericTermsAggregator` to allow numeric term aggregation streaming ([#19335](https://github.com/opensearch-project/OpenSearch/pull/19335))
+- Harden the circuit breaker and failure handle logic in query result consumer ([#19396](https://github.com/opensearch-project/OpenSearch/pull/19396))
 
 ### Changed
 - Refactor `if-else` chains to use `Java 17 pattern matching switch expressions`(([#18965](https://github.com/opensearch-project/OpenSearch/pull/18965))

--- a/server/src/main/java/org/opensearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/opensearch/action/search/QueryPhaseResultConsumer.java
@@ -342,6 +342,9 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
         }
 
         private synchronized long addWithoutBreaking(long size) {
+            if (hasFailure()) {
+                return circuitBreakerBytes;
+            }
             circuitBreaker.addWithoutBreaking(size);
             circuitBreakerBytes += size;
             maxAggsCurrentBufferSize = Math.max(maxAggsCurrentBufferSize, circuitBreakerBytes);
@@ -349,6 +352,9 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
         }
 
         private synchronized long addEstimateAndMaybeBreak(long estimatedSize) {
+            if (hasFailure()) {
+                return circuitBreakerBytes;
+            }
             circuitBreaker.addEstimateBytesAndMaybeBreak(estimatedSize, "<reduce_aggs>");
             circuitBreakerBytes += estimatedSize;
             maxAggsCurrentBufferSize = Math.max(maxAggsCurrentBufferSize, circuitBreakerBytes);

--- a/server/src/main/java/org/opensearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/opensearch/action/search/QueryPhaseResultConsumer.java
@@ -278,7 +278,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
 
     private void checkCancellation() {
         if (isTaskCancelled.getAsBoolean()) {
-            pendingMerges.onMergeFailure(new TaskCancelledException("request has been terminated"));
+            pendingMerges.onFailure(new TaskCancelledException("request has been terminated"));
         }
     }
 
@@ -416,7 +416,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
                     addEstimateAndMaybeBreak(aggsSize);
                     aggsCurrentBufferSize += aggsSize;
                 } catch (CircuitBreakingException e) {
-                    onMergeFailure(e);
+                    onFailure(e);
                     return true;
                 }
             }
@@ -470,7 +470,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
                         ++numReducePhases;
                         newMerge = partialReduce(toConsume, task.emptyResults, topDocsStats, thisMergeResult, numReducePhases);
                     } catch (Exception t) {
-                        onMergeFailure(t);
+                        PendingMerges.this.onFailure(t);
                         return;
                     }
                     onAfterMerge(task, newMerge, estimatedTotalSize);
@@ -478,7 +478,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
 
                 @Override
                 public void onFailure(Exception exc) {
-                    onMergeFailure(exc);
+                    PendingMerges.this.onFailure(exc);
                 }
             });
         }
@@ -510,7 +510,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
         }
 
         // Idempotent and thread-safe failure handling
-        private synchronized void onMergeFailure(Exception exc) {
+        private synchronized void onFailure(Exception exc) {
             if (hasFailure()) {
                 assert circuitBreakerBytes == 0;
                 return;

--- a/server/src/main/java/org/opensearch/action/search/StreamQueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/opensearch/action/search/StreamQueryPhaseResultConsumer.java
@@ -59,6 +59,6 @@ public class StreamQueryPhaseResultConsumer extends QueryPhaseResultConsumer {
         // For streaming, we skip the ArraySearchPhaseResults.consumeResult() call
         // since it doesn't support multiple results from the same shard.
         QuerySearchResult querySearchResult = result.queryResult();
-        pendingMerges.consume(querySearchResult, next);
+        pendingReduces.consume(querySearchResult, next);
     }
 }

--- a/server/src/test/java/org/opensearch/action/search/SearchPhaseControllerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchPhaseControllerTests.java
@@ -1065,7 +1065,7 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
         SearchRequest request = randomSearchRequest();
         request.source(new SearchSourceBuilder().aggregation(AggregationBuilders.avg("foo")));
         request.setBatchedReduceSize(bufferSize);
-        ArraySearchPhaseResults<SearchPhaseResult> consumer = searchPhaseController.newSearchPhaseResults(
+        QueryPhaseResultConsumer consumer = searchPhaseController.newSearchPhaseResults(
             fixedExecutor,
             new NoopCircuitBreaker(CircuitBreaker.REQUEST),
             SearchProgressListener.NOOP,
@@ -1134,18 +1134,17 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
             result.setSearchShardTarget(new SearchShardTarget("node", new ShardId("a", "b", shardId), null, OriginalIndices.NONE));
             consumer.consumeResult(result, latch::countDown);
             numEmptyResponses--;
-
         }
         latch.await();
         final int numTotalReducePhases;
         if (numShards > bufferSize) {
             if (bufferSize == 2) {
-                assertEquals(1, ((QueryPhaseResultConsumer) consumer).getNumReducePhases());
+                assertEquals(1, consumer.getNumReducePhases());
                 assertEquals(1, reductions.size());
                 assertEquals(false, reductions.get(0));
                 numTotalReducePhases = 2;
             } else {
-                assertEquals(0, ((QueryPhaseResultConsumer) consumer).getNumReducePhases());
+                assertEquals(0, consumer.getNumReducePhases());
                 assertEquals(0, reductions.size());
                 numTotalReducePhases = 1;
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

This PR is meant for harden the circuit breaker logic in query result consumer. The main logic change is only at one place, `addEstimateAndMaybeBreak(aggsSize)` in `consumeResult` before actually perform any real "consume logic".

On the other hand, considering this is a important but spaghetti code, and possibly need to be improved in the future, some refactoring works are also done.

#### Circuit Breaker Change

Circuit breaker `addEstimateBytesAndMaybeBreak` are used twice
1. before `consume`: query result received at coordinator transport layer, and will be handled by query result consumer. We estimate the heap size of the query result, and check if it breaks the REQUEST circuit breaker.
2. during `tryExecuteNext`: before doing partial reduce on the buffered query results, we estimate the extra heap size that will be used, and check if it breaks the REQUEST circuit breaker.

Some context about the partial merge logic:
- `PendingMerges` are the core logic to buffer and reduce shard results in a batched manner without waiting for all results arrived.
- `consume` buffer the shard result and check if the buffer size reaches threshold, and create merge task from buffer.
- `tryExecuteNext` poll merge task from queue and perform the partial reduce.

#### Refactoring around Failure Handling

The rule I followed is to use `onMergeFailure` to handle any failure we captured. It could be a circuit breaker exception, a task cancellation exception or any exception caught during the partial reduce.

`onMergeFailure` stores the failure, resets the circuit breaker, and clears the merge task queue. It also sends the cancel search task request to other nodes so they could try stop processing the shard query at their best.

<img width="1227" height="952" alt="image" src="https://github.com/user-attachments/assets/cf4cdb16-704a-4185-a732-56a23a17cfc0" />

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
