### PR TITLE
Migrate deprecated usages of Operations#union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Optimize source conversion in gRPC search hits using zero-copy BytesRef ([#19280](https://github.com/opensearch-project/OpenSearch/pull/19280))
 - Allow plugins to copy folders into their config dir during installation ([#19343](https://github.com/opensearch-project/OpenSearch/pull/19343))
 - Add failureaccess as runtime dependency to transport-grpc module  ([#19339](https://github.com/opensearch-project/OpenSearch/pull/19339))
+- Migrate usages of deprecated `Operations#union` from Lucene ([#19397](https://github.com/opensearch-project/OpenSearch/pull/19397))
 
 ### Fixed
 - Fix unnecessary refreshes on update preparation failures ([#15261](https://github.com/opensearch-project/OpenSearch/issues/15261))

--- a/server/src/main/java/org/opensearch/common/lucene/search/AutomatonQueries.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/AutomatonQueries.java
@@ -41,6 +41,7 @@ import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -177,7 +178,7 @@ public class AutomatonQueries {
         int altCase = Character.isLowerCase(codepoint) ? Character.toUpperCase(codepoint) : Character.toLowerCase(codepoint);
         Automaton result;
         if (altCase != codepoint) {
-            result = Operations.union(case1, Automata.makeChar(altCase));
+            result = Operations.union(Arrays.asList(case1, Automata.makeChar(altCase)));
         } else {
             result = case1;
         }

--- a/server/src/main/java/org/opensearch/common/xcontent/support/XContentMapValues.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/support/XContentMapValues.java
@@ -301,8 +301,9 @@ public class XContentMapValues {
      *  For instance, if the original simple regex is `foo`, this will translate
      *  it into `foo` OR `foo.*`. */
     private static Automaton makeMatchDotsInFieldNames(Automaton automaton) {
+        Automaton automationMatchingFields = Operations.concatenate(Arrays.asList(automaton, Automata.makeChar('.'), Automata.makeAnyString()));
         return Operations.determinize(
-            Operations.union(automaton, Operations.concatenate(Arrays.asList(automaton, Automata.makeChar('.'), Automata.makeAnyString()))),
+            Operations.union(Arrays.asList(automaton, automationMatchingFields)),
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
         );
     }

--- a/server/src/main/java/org/opensearch/common/xcontent/support/XContentMapValues.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/support/XContentMapValues.java
@@ -301,7 +301,9 @@ public class XContentMapValues {
      *  For instance, if the original simple regex is `foo`, this will translate
      *  it into `foo` OR `foo.*`. */
     private static Automaton makeMatchDotsInFieldNames(Automaton automaton) {
-        Automaton automationMatchingFields = Operations.concatenate(Arrays.asList(automaton, Automata.makeChar('.'), Automata.makeAnyString()));
+        Automaton automationMatchingFields = Operations.concatenate(
+            Arrays.asList(automaton, Automata.makeChar('.'), Automata.makeAnyString())
+        );
         return Operations.determinize(
             Operations.union(Arrays.asList(automaton, automationMatchingFields)),
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT

--- a/server/src/main/java/org/opensearch/common/xcontent/support/XContentMapValues.java
+++ b/server/src/main/java/org/opensearch/common/xcontent/support/XContentMapValues.java
@@ -301,11 +301,11 @@ public class XContentMapValues {
      *  For instance, if the original simple regex is `foo`, this will translate
      *  it into `foo` OR `foo.*`. */
     private static Automaton makeMatchDotsInFieldNames(Automaton automaton) {
-        Automaton automationMatchingFields = Operations.concatenate(
+        Automaton automatonMatchingFields = Operations.concatenate(
             Arrays.asList(automaton, Automata.makeChar('.'), Automata.makeAnyString())
         );
         return Operations.determinize(
-            Operations.union(Arrays.asList(automaton, automationMatchingFields)),
+            Operations.union(Arrays.asList(automaton, automatonMatchingFields)),
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
         );
     }

--- a/server/src/main/java/org/opensearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/opensearch/indices/SystemIndices.java
@@ -141,9 +141,9 @@ public class SystemIndices {
     }
 
     private static CharacterRunAutomaton buildCharacterRunAutomaton(Collection<SystemIndexDescriptor> descriptors) {
-        List<Automaton> automations = descriptors.stream()
+        List<Automaton> automatons = descriptors.stream()
             .map(descriptor -> Regex.simpleMatchToAutomaton(descriptor.getIndexPattern()))
             .collect(Collectors.toList());
-        return new CharacterRunAutomaton(Operations.determinize(Operations.union(automations), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT));
+        return new CharacterRunAutomaton(Operations.determinize(Operations.union(automatons), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT));
     }
 }

--- a/server/src/main/java/org/opensearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/opensearch/indices/SystemIndices.java
@@ -34,7 +34,6 @@ package org.opensearch.indices;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
@@ -45,7 +44,6 @@ import org.opensearch.core.index.Index;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -146,8 +144,6 @@ public class SystemIndices {
         List<Automaton> automations = descriptors.stream()
             .map(descriptor -> Regex.simpleMatchToAutomaton(descriptor.getIndexPattern()))
             .collect(Collectors.toList());
-        return new CharacterRunAutomaton(
-            Operations.determinize(Operations.union(automations), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT)
-        );
+        return new CharacterRunAutomaton(Operations.determinize(Operations.union(automations), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT));
     }
 }

--- a/server/src/main/java/org/opensearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/opensearch/indices/SystemIndices.java
@@ -143,11 +143,11 @@ public class SystemIndices {
     }
 
     private static CharacterRunAutomaton buildCharacterRunAutomaton(Collection<SystemIndexDescriptor> descriptors) {
-        Optional<Automaton> automaton = descriptors.stream()
+        List<Automaton> automations = descriptors.stream()
             .map(descriptor -> Regex.simpleMatchToAutomaton(descriptor.getIndexPattern()))
-            .reduce(Operations::union);
+            .collect(Collectors.toList());
         return new CharacterRunAutomaton(
-            Operations.determinize(automaton.orElse(Automata.makeEmpty()), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT)
+            Operations.determinize(Operations.union(automations), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT)
         );
     }
 }


### PR DESCRIPTION
This PR does a minor change to migrate usages of deprecated Lucene Operations#union to a non-deprecated version, preserving the original behaviour.

### Description
Migrate usages of `org.apache.lucene.util.automaton.Operations#union(Automaton, Automaton)` to `org.apache.lucene.util.automaton.Operations#union(Collection<Automation>)`

### Related Issues
None

### Check List
- [x] Functionality includes testing.
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~~
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
