### PR TITLE
[Feauture Branch] Add JNI layer and rust methods to execute substrait plan

### DIFF
--- a/plugins/engine-datafusion/build.gradle
+++ b/plugins/engine-datafusion/build.gradle
@@ -29,6 +29,25 @@ opensearchplugin {
 dependencies {
     implementation "org.apache.logging.log4j:log4j-api:${versions.log4j}"
     implementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
+
+    // Bundle Jackson in the plugin JAR using 'api' like other OpenSearch plugins
+    api "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+    api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+    api "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+
+    // Apache Arrow dependencies for memory management
+    implementation "org.apache.arrow:arrow-memory-core:17.0.0"
+    implementation "org.apache.arrow:arrow-memory-unsafe:17.0.0"
+    implementation "org.apache.arrow:arrow-vector:17.0.0"
+    implementation "org.apache.arrow:arrow-c-data:17.0.0"
+    implementation "org.apache.arrow:arrow-format:17.0.0"
+    // SLF4J API for Arrow logging compatibility
+    implementation "org.slf4j:slf4j-api:1.7.36"
+    // CheckerFramework annotations required by Arrow 17.0.0
+    implementation "org.checkerframework:checker-qual:3.42.0"
+    // FlatBuffers dependency required by Arrow 17.0.0
+    implementation "com.google.flatbuffers:flatbuffers-java:23.5.26"
+
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
     testImplementation "org.mockito:mockito-core:${versions.mockito}"

--- a/plugins/engine-datafusion/jni/Cargo.toml
+++ b/plugins/engine-datafusion/jni/Cargo.toml
@@ -11,14 +11,20 @@ crate-type = ["cdylib"]
 
 [dependencies]
 datafusion = "49.0.0"
-arrow = "55.2"
+arrow = { version = "55.2", features = ["ffi", "ipc_compression"] }
 arrow-json = "55.2"
 
 # JNI dependencies
 jni = "0.21"
 
+# Substrait support
+datafusion-substrait = "49.0.0"
+prost = "0.13"
+
+
 # Async runtime
 tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros"] }
+futures = "0.3"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/plugins/engine-datafusion/jni/src/lib.rs
+++ b/plugins/engine-datafusion/jni/src/lib.rs
@@ -5,19 +5,30 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
+mod util;
 
-use jni::objects::JClass;
-use jni::sys::{jlong, jstring};
+use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
+use datafusion::physical_plan::SendableRecordBatchStream;
+use jni::objects::{JByteArray, JClass, JObject, JString};
+use jni::sys::{jbyteArray, jlong, jstring};
 use jni::JNIEnv;
 
 use datafusion::execution::context::SessionContext;
-
+use datafusion::prelude::*;
 use datafusion::DATAFUSION_VERSION;
-use datafusion::prelude::SessionConfig;
 
-/// Create a new DataFusion session context
+use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
+use prost::Message;
+
+use crate::util::{set_object_result_error, set_object_result_ok};
+use arrow::array::{Array, StructArray};
+use futures::stream::StreamExt;
+use futures::TryStreamExt;
+use std::ptr::addr_of_mut;
+use tokio::runtime::Runtime;
+
 #[no_mangle]
-pub extern "system" fn Java_org_opensearch_datafusion_DataFusionJNI_createContext(
+pub extern "system" fn Java_org_opensearch_datafusion_core_SessionContext_createContext(
     _env: JNIEnv,
     _class: JClass,
 ) -> jlong {
@@ -27,14 +38,232 @@ pub extern "system" fn Java_org_opensearch_datafusion_DataFusionJNI_createContex
     ctx
 }
 
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_core_SessionContext_createRuntime(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jlong {
+    if let Ok(runtime) = Runtime::new() {
+        Box::into_raw(Box::new(runtime)) as jlong
+    } else {
+        // TODO error handling
+        -1
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_core_SessionContext_registerParquetTable(
+    mut env: JNIEnv,
+    _class: JClass,
+    context_id: jlong,
+    runtime_id: jlong,
+    parquet_file_path: JString,
+    table_name: JString
+) -> jlong {
+    if context_id == 0 {
+        let _ = env.throw_new("java/lang/RuntimeException", "Invalid context ID");
+        return 0;
+    }
+
+    if runtime_id == 0 {
+        let _ = env.throw_new("java/lang/RuntimeException", "Invalid runtime ID");
+        return 0;
+    }
+
+    let parquet_path: String = match env.get_string(&parquet_file_path) {
+        Ok(path) => path.into(),
+        Err(e) => {
+            let _ = env.throw_new("java/lang/RuntimeException",
+                                  &format!("Failed to get parquet file path: {}", e));
+            return 0;
+        }
+    };
+
+    let table_name_str: String = match env.get_string(&table_name) {
+        Ok(name) => name.into(),
+        Err(e) => {
+            let _ = env.throw_new("java/lang/RuntimeException",
+                                  &format!("Failed to get table name: {}", e));
+            return 0;
+        }
+    };
+
+    let context = unsafe { &*(context_id as *const SessionContext) };
+    let runtime = unsafe { &*(runtime_id as *const Runtime) };
+
+    match runtime.block_on(async {
+        if std::path::Path::new(&parquet_path).exists() {
+            context.register_parquet(&table_name_str, &parquet_path, ParquetReadOptions::default()).await
+        } else {
+            Err(datafusion::error::DataFusionError::Execution(
+                format!("Parquet file not found: {}", parquet_path)
+            ))
+        }
+    }) {
+        Ok(_) => 1, // Success
+        Err(e) => {
+            let _ = env.throw_new("java/lang/RuntimeException",
+                                  &format!("Failed to register parquet table: {}", e));
+            0 // Failure
+        }
+    }
+}
+
 /// Close and cleanup a DataFusion context
 #[no_mangle]
-pub extern "system" fn Java_org_opensearch_datafusion_DataFusionJNI_closeContext(
+pub extern "system" fn Java_org_opensearch_datafusion_core_SessionContext_closeContext(
     _env: JNIEnv,
     _class: JClass,
     context_id: jlong,
 ) {
-    let _ = unsafe { Box::from_raw(context_id as *mut SessionContext) };
+    if context_id != 0 {
+        let _ = unsafe { Box::from_raw(context_id as *mut SessionContext) };
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_core_SessionContext_closeRuntime(
+    _env: JNIEnv,
+    _class: JClass,
+    pointer: jlong,
+) {
+    if pointer != 0 {
+        let _ = unsafe { Box::from_raw(pointer as *mut Runtime) };
+    }
+}
+
+/// Execute a Substrait query plan and return SendableRecordBatchStream as jlong
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_DataFusionService_nativeExecuteSubstraitQueryStream(
+    env: JNIEnv,
+    _class: JClass,
+    runtime_id: jlong,
+    context_id: jlong,
+    query_plan_bytes: jbyteArray,
+) -> jlong {
+    println!("DataFusionService_nativeExecuteSubstraitQueryStream: Starting execution");
+    println!("runtime_id: {}, context_id: {}", runtime_id, context_id);
+
+    let runtime = unsafe { &*(runtime_id as *const Runtime) };
+    let context = unsafe { &*(context_id as *const SessionContext) };
+    println!("Retrieved runtime and context pointers successfully");
+
+    println!("query_plan_bytes raw pointer: {:?}", query_plan_bytes);
+
+    if query_plan_bytes.is_null() {
+        println!("ERROR: query_plan_bytes is null!");
+        return 0;
+    }
+
+    let byte_array = unsafe { JByteArray::from_raw(query_plan_bytes) };
+    println!("Created JByteArray from raw pointer");
+
+    let plan_bytes = match env.convert_byte_array(byte_array) {
+        Ok(bytes) => {
+            println!("Successfully converted byte array, size: {} bytes", bytes.len());
+            bytes
+        },
+        Err(e) => {
+            println!("Failed to convert byte array: {:?}", e);
+            return 0; // Return 0 on error
+        }
+    };
+
+    println!("Starting async block execution");
+    runtime.block_on(async {
+        println!("Decoding Substrait plan...");
+        let substrait_plan = datafusion_substrait::substrait::proto::Plan::decode(&plan_bytes[..]).unwrap();
+        println!("Substrait plan decoded successfully, relations: {}", substrait_plan.relations.len());
+
+        println!("Converting Substrait plan to DataFusion logical plan...");
+        let logical_plan = from_substrait_plan(&context.state(), &substrait_plan).await.unwrap();
+        println!("Logical plan created successfully");
+
+        println!("Executing logical plan...");
+        let dataframe = context.execute_logical_plan(logical_plan).await.unwrap();
+        println!("DataFrame created successfully");
+
+        println!("Getting execution stream...");
+        let stream = dataframe.execute_stream().await.unwrap();
+        println!("Stream created successfully");
+
+        let stream_ptr = Box::into_raw(Box::new(stream)) as jlong;
+        println!("Stream pointer created: {}", stream_ptr);
+        stream_ptr
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_RecordBatchStream_next(
+    mut env: JNIEnv,
+    _class: JClass,
+    runtime: jlong,
+    stream: jlong,
+    callback: JObject,
+) {
+    let runtime = unsafe { &mut *(runtime as *mut Runtime) };
+    let stream = unsafe { &mut *(stream as *mut SendableRecordBatchStream) };
+    runtime.block_on(async {
+        let next = stream.try_next().await;
+        match next {
+            Ok(Some(batch)) => {
+                // Convert to struct array for compatibility with FFI
+                let struct_array: StructArray = batch.into();
+                let array_data = struct_array.into_data();
+                let mut ffi_array = FFI_ArrowArray::new(&array_data);
+                // ffi_array must remain alive until after the callback is called
+                set_object_result_ok(&mut env, callback, addr_of_mut!(ffi_array));
+            }
+            Ok(None) => {
+                set_object_result_ok(&mut env, callback, 0 as *mut FFI_ArrowSchema);
+            }
+            Err(err) => {
+                set_object_result_error(&mut env, callback, &err);
+            }
+        }
+    });
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_RecordBatchStream_getSchema(
+    mut env: JNIEnv,
+    _class: JClass,
+    stream: jlong,
+    callback: JObject,
+) {
+    let stream = unsafe { &mut *(stream as *mut SendableRecordBatchStream) };
+    let schema = stream.schema();
+    // Print field details for debugging
+    for (i, field) in schema.fields().iter().enumerate() {
+        println!("  Field {}: name='{}', type={:?}, nullable={}",
+                 i, field.name(), field.data_type(), field.is_nullable());
+    }
+    let ffi_schema = FFI_ArrowSchema::try_from(&*schema);
+    match ffi_schema {
+        Ok(mut ffi_schema) => {
+            println!("Created FFI schema successfully, about to call Java...");
+            // ffi_schema must remain alive until after the callback is called
+            set_object_result_ok(&mut env, callback, addr_of_mut!(ffi_schema));
+            println!("Returned from Java callback");
+        }
+        Err(err) => {
+            set_object_result_error(&mut env, callback, &err);
+        }
+    }
+    println!("Rust function ending normally");
+}
+
+
+
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_RecordBatchStream_closeStream(
+    _env: JNIEnv,
+    _class: JClass,
+    pointer: jlong,
+) {
+    if pointer != 0 {
+        let _ = unsafe { Box::from_raw(pointer as *mut SendableRecordBatchStream) };
+    }
 }
 
 /// Get version information
@@ -43,5 +272,9 @@ pub extern "system" fn Java_org_opensearch_datafusion_DataFusionJNI_getVersion(
     env: JNIEnv,
     _class: JClass,
 ) -> jstring {
-    env.new_string(DATAFUSION_VERSION).expect("Couldn't create Java string").as_raw()
+    let version_info = format!(
+        "{{\"datafusion_version\": \"{}\", \"substrait_version\": \"0.50.0\"}}",
+        DATAFUSION_VERSION
+    );
+    env.new_string(version_info).expect("Couldn't create Java string").as_raw()
 }

--- a/plugins/engine-datafusion/jni/src/util.rs
+++ b/plugins/engine-datafusion/jni/src/util.rs
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+use std::error::Error;
+
+use jni::objects::JObject;
+use jni::sys::jlong;
+use jni::JNIEnv;
+
+/// Set error message from a result using a Consumer<String> Java callback
+pub fn set_object_result_ok<T>(env: &mut JNIEnv, callback: JObject, address: *mut T) {
+    let err_message = env
+        .new_string("")
+        .expect("Couldn't create empty java string");
+
+    println!("About to call Java callback...");
+
+    let result = env.call_method(
+        callback,
+        "callback",
+        "(Ljava/lang/String;J)V",
+        &[(&err_message).into(), (address as jlong).into()],
+    );
+
+    match result {
+        Ok(_) => {
+            println!("Java callback completed successfully - no Rust cleanup issue");
+        }
+        Err(jni_error) => {
+            println!("Java callback failed with JNI error: {:?}", jni_error);
+
+            // Check what kind of Java exception occurred
+            if let Ok(true) = env.exception_check() {
+                println!("There IS a pending Java exception:");
+                let _ = env.exception_describe(); // This prints the Java stack trace
+                let _ = env.exception_clear();
+            } else {
+                println!("No Java exception - this would be a pure JNI issue");
+            }
+            // Don't panic
+            return;
+        }
+    }
+}
+
+/// Set error result by calling an ObjectResultCallback
+pub fn set_object_result_error<T: Error>(env: &mut JNIEnv, callback: JObject, error: &T) {
+    let err_message = env
+        .new_string(error.to_string())
+        .expect("Couldn't create java string for error message");
+    let address = -1 as jlong;
+    env.call_method(
+        callback,
+        "callback",
+        "(Ljava/lang/String;J)V",
+        &[(&err_message).into(), address.into()],
+    )
+        .expect("Failed to call object result callback with error");
+}

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DatafusionEngine.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DatafusionEngine.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.datafusion;
+
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.datafusion.core.SessionContext;
+import org.opensearch.index.engine.SearchExecutionEngine;
+import org.opensearch.search.aggregations.SearchResultsCollector;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * DataFusion search execution engine implementation that executes Substrait query plans
+ * using the DataFusion query engine for OpenSearch.
+ */
+public class DatafusionEngine implements SearchExecutionEngine {
+
+    private static final Logger logger = LogManager.getLogger(DatafusionEngine.class);
+    private final DataFusionService dataFusionService;
+
+    /**
+     * Constructs a new DatafusionEngine with the specified DataFusion service.
+     *
+     * @param dataFusionService the DataFusion service used for query execution
+     */
+    public DatafusionEngine(DataFusionService dataFusionService) {
+        this.dataFusionService = dataFusionService;
+    }
+
+    @Override
+    public Map<String, Object[]> execute(byte[] queryPlanIR) {
+        Map<String, Object[]> finalRes = new HashMap<>();
+        try {
+            SessionContext defaultSessionContext = dataFusionService.getDefaultContext();
+            long streamPointer = dataFusionService.executeSubstraitQueryStream(queryPlanIR);
+            RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+            RecordBatchStream stream = new RecordBatchStream(defaultSessionContext, streamPointer, allocator);
+
+            // We can have some collectors passed like this which can collect the results and convert to InternalAggregation
+            // Is the possible? need to check
+            SearchResultsCollector<RecordBatchStream> collector = new SearchResultsCollector<RecordBatchStream>() {
+                @Override
+                public void collect(RecordBatchStream value) {
+                    VectorSchemaRoot root = value.getVectorSchemaRoot();
+                    for(Field field : root.getSchema().getFields()) {
+                        String filedName = field.getName();
+                        FieldVector fieldVector = root.getVector(filedName);
+                        Object[] fieldValues = new Object[fieldVector.getValueCount()];
+                        for (int i = 0; i < fieldVector.getValueCount(); i++) {
+                            fieldValues[i] = fieldVector.getObject(i);
+                        }
+                        finalRes.put(filedName, fieldValues);
+                    }
+                }
+            };
+
+            while (stream.loadNextBatch().join()) {
+                collector.collect(stream);
+             }
+
+             System.out.println("Final Results:");
+             for (Map.Entry<String, Object[]> entry : finalRes.entrySet()) {
+                 System.out.println(entry.getKey() + ": " + java.util.Arrays.toString(entry.getValue()));
+             }
+
+
+        } catch (Exception exception) {
+            logger.error("Failed to execute Substrait query plan", exception);
+        }
+        return finalRes;
+    }
+}

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/ErrorUtil.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/ErrorUtil.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.datafusion;
+
+/**
+ * Utility class for error handling in DataFusion operations.
+ */
+public class ErrorUtil {
+    private ErrorUtil() {}
+
+    static boolean containsError(String errString) {
+        return errString != null && !errString.isEmpty();
+    }
+}

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/ObjectResultCallback.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/ObjectResultCallback.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.datafusion;
+
+interface ObjectResultCallback {
+    void callback(String errMessage, long value);
+}

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/RecordBatchStream.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/RecordBatchStream.java
@@ -1,0 +1,146 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.datafusion;
+
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.CDataDictionaryProvider;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.datafusion.core.SessionContext;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.arrow.c.Data.importField;
+
+/**
+ * Represents a stream of Apache Arrow record batches from DataFusion query execution.
+ * Provides a Java interface to iterate through query results in a memory-efficient way.
+ */
+public class RecordBatchStream {
+
+    private final SessionContext context;
+    private final long streamPointer;
+    private final BufferAllocator allocator;
+    private final CDataDictionaryProvider dictionaryProvider;
+    private boolean initialized = false;
+    private VectorSchemaRoot vectorSchemaRoot = null;
+
+    /**
+     * Creates a new RecordBatchStream for the given stream pointer
+     * @param ctx the session context
+     * @param streamId pointer to the native stream
+     * @param allocator memory allocator for Arrow vectors
+     */
+    public RecordBatchStream(SessionContext ctx, long streamId, BufferAllocator allocator) {
+        this.context = ctx;
+        this.streamPointer = streamId;
+        this.allocator = allocator;
+        this.dictionaryProvider = new CDataDictionaryProvider();
+    }
+
+    /**
+     * Gets the Arrow VectorSchemaRoot for accessing the current batch data
+     * @return the VectorSchemaRoot containing the current batch
+     */
+    public VectorSchemaRoot getVectorSchemaRoot() {
+        ensureInitialized();
+        return vectorSchemaRoot;
+    }
+
+    private Schema getSchema() {
+        // Native method is not async, but use a future to store the result for convenience
+        CompletableFuture<Schema> result = new CompletableFuture<>();
+        getSchema(
+            streamPointer,
+            (errString, arrowSchemaAddress) -> {
+                if (ErrorUtil.containsError(errString)) {
+                    result.completeExceptionally(new RuntimeException(errString));
+                } else {
+                    try {
+                        ArrowSchema arrowSchema = ArrowSchema.wrap(arrowSchemaAddress);
+                        Schema schema = importSchema(allocator, arrowSchema, dictionaryProvider);
+                        result.complete(schema);
+                    } catch (Exception e) {
+                        result.completeExceptionally(e);
+                    }
+                }
+            });
+        return result.join();
+    }
+
+    private Schema importSchema(BufferAllocator allocator, ArrowSchema schema, CDataDictionaryProvider provider) {
+        Field structField = importField(allocator, schema, provider);
+        System.out.println(structField);
+        if (structField.getType().getTypeID() != ArrowType.ArrowTypeID.Struct) {
+            throw new IllegalArgumentException("Cannot import schema: ArrowSchema describes non-struct type");
+        }
+        return new Schema(structField.getChildren(), structField.getMetadata());
+    }
+
+    private void ensureInitialized() {
+        if (!initialized) {
+            Schema schema = getSchema();
+            this.vectorSchemaRoot = VectorSchemaRoot.create(schema, allocator);
+        }
+        initialized = true;
+    }
+
+    /**
+     * Loads the next batch of data from the stream
+     * @return a CompletableFuture that completes with true if more data is available, false if end of stream
+     */
+    public CompletableFuture<Boolean> loadNextBatch() {
+        ensureInitialized();
+        long runtimePointer = context.getRuntime();
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        next(
+            runtimePointer,
+            streamPointer,
+            (errString, arrowArrayAddress) -> {
+                if (ErrorUtil.containsError(errString)) {
+                    result.completeExceptionally(new RuntimeException(errString));
+                } else if (arrowArrayAddress == 0) {
+                    // Reached end of stream
+                    result.complete(false);
+                } else {
+                    try {
+                        ArrowArray arrowArray = ArrowArray.wrap(arrowArrayAddress);
+                        Data.importIntoVectorSchemaRoot(
+                            allocator, arrowArray, vectorSchemaRoot, dictionaryProvider);
+                        result.complete(true);
+                    } catch (Exception e) {
+                        result.completeExceptionally(e);
+                    }
+                }
+            });
+        return result;
+    }
+
+    /**
+     * Closes the stream and releases all associated resources
+     * @throws Exception if an error occurs during cleanup
+     */
+    public void close() throws Exception {
+        closeStream(streamPointer);
+        dictionaryProvider.close();
+        if (initialized) {
+            vectorSchemaRoot.close();
+        }
+    }
+
+
+    private static native void next(long runtime, long pointer, ObjectResultCallback callback);
+    private static native void getSchema(long pointer, ObjectResultCallback callback);
+    private static native void closeStream(long pointer);
+}

--- a/server/src/main/java/org/opensearch/index/engine/SearchExecutionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/SearchExecutionEngine.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.util.Map;
+
+/**
+ * SearchExecutionEngine
+ * @opensearch.internal
+ */
+@ExperimentalApi
+public interface SearchExecutionEngine {
+    /**
+     * execute
+     * @param queryPlanIR
+     * @return
+     */
+    Map<String, Object[]> execute(byte[] queryPlanIR);
+}

--- a/server/src/main/java/org/opensearch/plugins/SearchEnginePlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/SearchEnginePlugin.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.index.engine.SearchExecutionEngine;
+
+import java.io.IOException;
+
+/**
+ * Plugin interface for extending OpenSearch engine functionality.
+ * This interface allows plugins to extend the core engine capabilities.
+ *
+ * @opensearch.internal
+ */
+@ExperimentalApi
+public interface SearchEnginePlugin {
+    /**
+     * createEngine
+     * @return
+     * @throws IOException
+     */
+    SearchExecutionEngine createEngine() throws IOException;
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/SearchResultsCollector.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/SearchResultsCollector.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations;
+
+/**
+ * Experimental
+ * @opensearch.internal
+ */
+public interface SearchResultsCollector<T> {
+
+    /**
+     * collect
+     */
+    void collect(T value);
+}
+


### PR DESCRIPTION
### Description
This PR focuses on the methods in JNI layer and implementations in rust to execute the substratit plan in DF in rust.
Also defined interfaces in Core, but this doesn't have the code which actually uses it in the query phase.

### Related Issues


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
