### PR TITLE
Enable all system generated search processor factories by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Rule based auto-tagging] Add Rule based auto-tagging IT ([#18550](https://github.com/opensearch-project/OpenSearch/pull/18550))
 - Add all-active ingestion as docrep equivalent in pull-based ingestion ([#19316](https://github.com/opensearch-project/OpenSearch/pull/19316))
 - Add skip_list param for date, scaled float and token count fields ([#19142](https://github.com/opensearch-project/OpenSearch/pull/19142))
+- Enable all system generated search processor factories by default. ([#19402](https://github.com/opensearch-project/OpenSearch/pull/19402))
 
 ### Changed
 - Refactor `if-else` chains to use `Java 17 pattern matching switch expressions`(([#18965](https://github.com/opensearch-project/OpenSearch/pull/18965))

--- a/plugins/examples/system-search-processor/src/yamlRestTest/resources/rest-api-spec/test/example-system-search-processor/20_system_search_processor_and_user_defined.yml
+++ b/plugins/examples/system-search-processor/src/yamlRestTest/resources/rest-api-spec/test/example-system-search-processor/20_system_search_processor_and_user_defined.yml
@@ -1,14 +1,6 @@
 ---
 "Use system generated search request processors and user defined search pipeline":
   - do:
-      cluster.put_settings:
-        body:
-          persistent:
-            cluster.search.enabled_system_generated_factories:
-              - "example-search-request-pre-processor-factory"
-              - "example-search-request-post-processor-factory"
-
-  - do:
       search_pipeline.put:
         id: "test-user-defined-pipeline"
         body:
@@ -97,3 +89,9 @@
   - do:
       ingest.delete_pipeline:
         id: "test-user-defined-pipeline"
+
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            cluster.search.enabled_system_generated_factories: ["*"]

--- a/plugins/examples/system-search-processor/src/yamlRestTest/resources/rest-api-spec/test/example-system-search-processor/30_enable_all_system_search_processor.yml
+++ b/plugins/examples/system-search-processor/src/yamlRestTest/resources/rest-api-spec/test/example-system-search-processor/30_enable_all_system_search_processor.yml
@@ -1,13 +1,6 @@
 ---
 "System-generated search processor - enable all":
-  # 1. Enable all system-generated factories
-  - do:
-      cluster.put_settings:
-        body:
-          persistent:
-            cluster.search.enabled_system_generated_factories: "*"
-
-  # 2. Create test index
+  # Create test index
   - do:
       indices.create:
         index: "test-system-generated-search-processor-index"
@@ -22,7 +15,7 @@
               content:
                 type: text
 
-  # 3. Index 10 dummy docs
+  # Index 10 dummy docs
   - do:
       bulk:
         refresh: true
@@ -48,7 +41,7 @@
           {"index": {"_index": "test-system-generated-search-processor-index"}}
           {"trigger_field": "match", "content": "doc10"}
 
-  # 4. Do a match query against the trigger_field with size 2
+  # Do a match query against the trigger_field with size 2
   - do:
       search:
         rest_total_hits_as_int: true
@@ -60,14 +53,14 @@
             match:
               trigger_field: "match"
 
-  # 5. Verify only 2 hits returned and max score is 10
+  # Verify only 2 hits returned and max score is 10
   - match: { hits.total: 10 }
   # The system generated search response processor will truncate the hits to the original query size 2
   - length: { hits.hits: 2 }
   # The system generated search phase results will set this as 10
   - match: { hits.max_score: 10.0 }
 
-  # 6. Cleanup
+  # Cleanup
   - do:
       indices.delete:
         index: "test-system-generated-search-processor-index"
@@ -75,9 +68,3 @@
   - do:
       ingest.delete_pipeline:
         id: "test-user-defined-pipeline"
-
-  - do:
-      cluster.put_settings:
-        body:
-          persistent:
-            cluster.search.enabled_system_generated_factories: []

--- a/plugins/examples/system-search-processor/src/yamlRestTest/resources/rest-api-spec/test/example-system-search-processor/40_system_search_processor_with_conflict.yml
+++ b/plugins/examples/system-search-processor/src/yamlRestTest/resources/rest-api-spec/test/example-system-search-processor/40_system_search_processor_with_conflict.yml
@@ -1,14 +1,6 @@
 ---
 "Use system generated search request processors and user defined search pipeline":
-  # 1. Enable example-search-response-processor-factory
-  - do:
-      cluster.put_settings:
-        body:
-          persistent:
-            cluster.search.enabled_system_generated_factories:
-              - "example-search-response-processor-factory"
-
-  # 2. Create test search pipeline
+  # Create test search pipeline
   - do:
       search_pipeline.put:
         id: "test-user-defined-pipeline"
@@ -17,7 +9,7 @@
             - truncate_hits:
                 target_size: 1
 
-  # 3. Create test index
+  # Create test index
   - do:
       indices.create:
         index: "test-system-generated-search-processor-index"
@@ -32,7 +24,7 @@
               content:
                 type: text
 
-  # 4. Index 10 dummy docs
+  # Index 10 dummy docs
   - do:
       bulk:
         refresh: true
@@ -58,7 +50,7 @@
           {"index": {"_index": "test-system-generated-search-processor-index"}}
           {"trigger_field": "match", "content": "doc10"}
 
-  # 5. Search
+  # Search
   - do:
       catch: bad_request
       search:
@@ -74,14 +66,14 @@
   - match: { status: 400 }
   - match: { error.root_cause.0.reason: "The [truncate_hits] processor cannot be used in a search pipeline because it conflicts with the [example-search-response-processor] processor, which is automatically generated when executing a match query against [trigger_field]." }
 
-  # 6. Disable system-generated factories
+  # Disable system-generated factories
   - do:
       cluster.put_settings:
         body:
           persistent:
             cluster.search.enabled_system_generated_factories: []
 
-  # 7. Search again. This time it will work since the system generated processor is disabled
+  # Search again. This time it will work since the system generated processor is disabled
   - do:
       search:
         rest_total_hits_as_int: true
@@ -104,3 +96,9 @@
   - do:
       ingest.delete_pipeline:
         id: "test-user-defined-pipeline"
+
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            cluster.search.enabled_system_generated_factories: "*"

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -113,7 +113,7 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
      */
     public static final Setting<List<String>> ENABLED_SYSTEM_GENERATED_FACTORIES_SETTING = Setting.listSetting(
         "cluster.search.enabled_system_generated_factories",
-        List.of(),
+        List.of("*"),
         s -> s,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope

--- a/server/src/test/java/org/opensearch/search/pipeline/PipelinedRequestTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/PipelinedRequestTests.java
@@ -89,7 +89,6 @@ public class PipelinedRequestTests extends SearchPipelineTestCase {
     public void testTransformRequestWithSystemGeneratedPipeline() throws Exception {
         SearchPipelineService service = createWithSystemGeneratedProcessors();
         setUpForResolvePipeline(service);
-        enabledAllSystemGeneratedFactories(service);
 
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(5));
         PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, indexNameExpressionResolver);
@@ -155,7 +154,6 @@ public class PipelinedRequestTests extends SearchPipelineTestCase {
     public void testTransformResponseWithSystemGeneratedPipeline() throws Exception {
         SearchPipelineService service = createWithSystemGeneratedProcessors();
         setUpForResolvePipeline(service);
-        enabledAllSystemGeneratedFactories(service);
         int size = 10;
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(size));
         PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, indexNameExpressionResolver);
@@ -271,7 +269,6 @@ public class PipelinedRequestTests extends SearchPipelineTestCase {
     public void testTransformSearchPhaseWithSystemGeneratedPipeline() throws Exception {
         SearchPipelineService service = createWithSystemGeneratedProcessors();
         setUpForResolvePipeline(service);
-        enabledAllSystemGeneratedFactories(service);
 
         SearchPhaseController controller = new SearchPhaseController(
             writableRegistry(),

--- a/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
@@ -185,7 +185,6 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
     public void testResolveSystemGeneratedSearchPipeline_whenHappyCase_thenSuccess() throws Exception {
         SearchPipelineService service = createWithSystemGeneratedProcessors();
         setUpForResolvePipeline(service);
-        enabledAllSystemGeneratedFactories(service);
 
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(5));
         PipelinedRequest pipelinedRequest = service.resolvePipeline(searchRequest, indexNameExpressionResolver);
@@ -243,7 +242,6 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
             Collections.emptyMap()
         );
         setUpForResolvePipeline(service);
-        enabledAllSystemGeneratedFactories(service);
 
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(5));
         IllegalArgumentException exception = assertThrows(
@@ -259,7 +257,6 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
     public void testResolveSystemGeneratedSearchPipeline_whenNotMeetCondition_thenNoGeneration() throws Exception {
         SearchPipelineService service = createWithSystemGeneratedProcessors();
         setUpForResolvePipeline(service);
-        enabledAllSystemGeneratedFactories(service);
 
         // set a large size to not meet the condition to generate the system generated request processor
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(20));
@@ -275,6 +272,7 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
     public void testResolveSystemGeneratedSearchPipeline_whenDisableSystemGeneratedFactories_thenNoGeneration() throws Exception {
         SearchPipelineService service = createWithSystemGeneratedProcessors();
         setUpForResolvePipeline(service);
+        disableAllSystemGeneratedFactories(service);
 
         // set a large size to not meet the condition to generate the system generated request processor
         SearchRequest searchRequest = new SearchRequest("my_index").source(SearchSourceBuilder.searchSource().size(5));

--- a/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineTestCase.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineTestCase.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
+import static org.opensearch.search.pipeline.SearchPipelineService.ENABLED_SYSTEM_GENERATED_FACTORIES_SETTING;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -712,9 +713,9 @@ public abstract class SearchPipelineTestCase extends OpenSearchTestCase {
         return SearchSourceBuilder.searchSource().size(10);
     }
 
-    void enabledAllSystemGeneratedFactories(SearchPipelineService service) throws Exception {
+    void disableAllSystemGeneratedFactories(SearchPipelineService service) {
         service.getClusterService()
             .getClusterSettings()
-            .applySettings(Settings.builder().putList("cluster.search.enabled_system_generated_factories", "*").build());
+            .applySettings(Settings.builder().putList(ENABLED_SYSTEM_GENERATED_FACTORIES_SETTING.getKey(), "").build());
     }
 }


### PR DESCRIPTION
### Description
Enable all system generated search processor factories by default.

When we first introduced system-generated search pipelines, we disabled all processor factories by default and required users to explicitly enable the ones they needed. However, after using this feature to support native MMR and semantic highlighting, we’ve found that enabling all factories by default provides a better user experience.

Here’s why:

- Alignment with the Feature’s Purpose
The primary goal of system-generated pipelines is to improve ease of use. As plugin developers, when we add a new system-generated processor factory ([PR](https://github.com/opensearch-project/OpenSearch/pull/19128)), we typically want it enabled by default. Requiring users to manually enable it works against this goal and introduces unnecessary friction.

- Negligible Performance Impact
While enabling all factories adds a small amount of processing to the search path, the shouldGenerate function is designed to be lightweight. As long as it avoids expensive logic, the latency impact should remain negligible ([benchmark](https://github.com/opensearch-project/OpenSearch/issues/19062#issuecomment-3189422720)).

- Backward Compatibility & Safety Valve
    For features like semantic highlighting, enabling the factory by default ensures backward compatibility without requiring complex logic to auto-enable it when the neural plugin is loaded. Relying on plugins to automatically enable factories could unintentionally override user preferences.

    Since plugins can already programmatically enable factories, disabling them by default doesn’t guarantee that all factories will actually stay disabled. Instead, this setting should be seen as a way for users to disable specific factories in edge cases (for example, if a particular processor causes issues in their workload).

**Summary:**
We propose enabling all system-generated processor factories by default. This simplifies the user experience, maintains compatibility for key features, and still allows users to explicitly disable any factory if needed.

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
