### PR TITLE
fix StreamStringTermsAggregatorTests by replacing RandomIndexWriter with plain IndexWriter #18956 WIP

### DIFF
--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/StreamStringTermsAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/StreamStringTermsAggregatorTests.java
@@ -57,7 +57,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
     public void testBuildAggregationsBatchDirectBucketCreation() throws Exception {
         try (Directory directory = newDirectory()) {
-            try (IndexWriter indexWriter = new IndexWriter(directory, newIndexWriterConfig())) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
                 Document document = new Document();
                 document.add(new SortedSetDocValuesField("field", new BytesRef("apple")));
                 document.add(new SortedSetDocValuesField("field", new BytesRef("banana")));
@@ -154,7 +154,7 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
 
     public void testBuildAggregationsBatchWithSingleValuedOrds() throws Exception {
         try (Directory directory = newDirectory()) {
-            try (IndexWriter indexWriter = new IndexWriter(directory, newIndexWriterConfig())) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
                 for (int i = 0; i < 10; i++) {
                     Document document = new Document();
                     document.add(new SortedSetDocValuesField("field", new BytesRef("term_" + (i % 3))));
@@ -225,7 +225,7 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
 
     public void testBuildAggregationsBatchWithSize() throws Exception {
         try (Directory directory = newDirectory()) {
-            try (IndexWriter indexWriter = new IndexWriter(directory, newIndexWriterConfig())) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
                 // Create fewer unique terms to test size parameter more meaningfully
                 for (int i = 0; i < 20; i++) {
                     Document document = new Document();
@@ -274,7 +274,7 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
 
     public void testBuildAggregationsBatchWithCountOrder() throws Exception {
         try (Directory directory = newDirectory()) {
-            try (IndexWriter indexWriter = new IndexWriter(directory, newIndexWriterConfig())) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
                 for (int i = 0; i < 3; i++) {
                     Document document = new Document();
                     document.add(new SortedSetDocValuesField("field", new BytesRef("common")));
@@ -488,7 +488,7 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
 
     public void testSubAggregationWithSum() throws Exception {
         try (Directory directory = newDirectory()) {
-            try (IndexWriter indexWriter = new IndexWriter(directory, newIndexWriterConfig())) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
                 Document document = new Document();
                 document.add(new SortedSetDocValuesField("category", new BytesRef("electronics")));
                 document.add(new NumericDocValuesField("sales", 1000));
@@ -818,7 +818,7 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
             // Create first aggregation with some data
             List<InternalAggregation> aggs = new ArrayList<>();
 
-            try (IndexWriter indexWriter1 = new IndexWriter(directory1, newIndexWriterConfig())) {
+            try (IndexWriter indexWriter1 = new IndexWriter(directory1, new IndexWriterConfig())) {
                 Document doc = new Document();
                 doc.add(new SortedSetDocValuesField("category", new BytesRef("electronics")));
                 indexWriter1.addDocument(doc);
@@ -837,7 +837,7 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
             }
 
             // Create second aggregation with overlapping data
-            try (IndexWriter indexWriter2 = new IndexWriter(directory2, newIndexWriterConfig())) {
+            try (IndexWriter indexWriter2 = new IndexWriter(directory2, new IndexWriterConfig())) {
                 Document doc = new Document();
                 doc.add(new SortedSetDocValuesField("category", new BytesRef("electronics")));
                 indexWriter2.addDocument(doc);
@@ -991,7 +991,7 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
             }
 
             // Second aggregation with different terms
-            try (IndexWriter indexWriter2 = new IndexWriter(directory2, newIndexWriterConfig())) {
+            try (IndexWriter indexWriter2 = new IndexWriter(directory2, new IndexWriterConfig())) {
                 for (int i = 3; i < 8; i++) {
                     Document doc = new Document();
                     doc.add(new SortedSetDocValuesField("category", new BytesRef("cat_" + i)));
@@ -1037,7 +1037,7 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
 
     public void testReduceSingleAggregation() throws Exception {
         try (Directory directory = newDirectory()) {
-            try (IndexWriter indexWriter = new IndexWriter(directory, newIndexWriterConfig())) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
                 // Add multiple documents with different categories to test reduce logic properly
                 Document doc1 = new Document();
                 doc1.add(new SortedSetDocValuesField("category", new BytesRef("electronics")));

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/StreamStringTermsAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/StreamStringTermsAggregatorTests.java
@@ -558,12 +558,12 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
 
     public void testSubAggregationWithAvg() throws Exception {
         try (Directory directory = newDirectory()) {
-            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
                 Document document = new Document();
                 document.add(new SortedSetDocValuesField("product", new BytesRef("laptop")));
                 document.add(new NumericDocValuesField("rating", 4));
                 indexWriter.addDocument(document);
-                indexWriter.commit();
+
                 document = new Document();
                 document.add(new SortedSetDocValuesField("product", new BytesRef("laptop")));
                 document.add(new NumericDocValuesField("rating", 5));
@@ -574,7 +574,7 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
                 document.add(new NumericDocValuesField("rating", 3));
                 indexWriter.addDocument(document);
 
-                try (IndexReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
+                try (IndexReader indexReader = maybeWrapReaderEs(DirectoryReader.open(indexWriter))) {
                     IndexSearcher indexSearcher = newIndexSearcher(indexReader);
                     MappedFieldType productFieldType = new KeywordFieldMapper.KeywordFieldType("product");
                     MappedFieldType ratingFieldType = new NumberFieldMapper.NumberFieldType("rating", NumberFieldMapper.NumberType.LONG);
@@ -628,12 +628,12 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
 
     public void testSubAggregationWithMinAndCount() throws Exception {
         try (Directory directory = newDirectory()) {
-            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
                 Document document = new Document();
                 document.add(new SortedSetDocValuesField("store", new BytesRef("store_a")));
                 document.add(new NumericDocValuesField("inventory", 100));
                 indexWriter.addDocument(document);
-                indexWriter.commit();
+
                 document = new Document();
                 document.add(new SortedSetDocValuesField("store", new BytesRef("store_a")));
                 document.add(new NumericDocValuesField("inventory", 50));
@@ -644,7 +644,7 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
                 document.add(new NumericDocValuesField("inventory", 200));
                 indexWriter.addDocument(document);
 
-                try (IndexReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
+                try (IndexReader indexReader = maybeWrapReaderEs(DirectoryReader.open(indexWriter))) {
                     IndexSearcher indexSearcher = newIndexSearcher(indexReader);
                     MappedFieldType storeFieldType = new KeywordFieldMapper.KeywordFieldType("store");
                     MappedFieldType inventoryFieldType = new NumberFieldMapper.NumberFieldType(
@@ -712,13 +712,13 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
 
     public void testMultipleSubAggregations() throws Exception {
         try (Directory directory = newDirectory()) {
-            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
                 Document document = new Document();
                 document.add(new SortedSetDocValuesField("region", new BytesRef("north")));
                 document.add(new NumericDocValuesField("temperature", 25));
                 document.add(new NumericDocValuesField("humidity", 60));
                 indexWriter.addDocument(document);
-                indexWriter.commit();
+
                 document = new Document();
                 document.add(new SortedSetDocValuesField("region", new BytesRef("north")));
                 document.add(new NumericDocValuesField("temperature", 30));
@@ -731,7 +731,7 @@ public class StreamStringTermsAggregatorTests extends AggregatorTestCase {
                 document.add(new NumericDocValuesField("humidity", 80));
                 indexWriter.addDocument(document);
 
-                try (IndexReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
+                try (IndexReader indexReader = maybeWrapReaderEs(DirectoryReader.open(indexWriter))) {
                     IndexSearcher indexSearcher = newIndexSearcher(indexReader);
                     MappedFieldType regionFieldType = new KeywordFieldMapper.KeywordFieldType("region");
                     MappedFieldType tempFieldType = new NumberFieldMapper.NumberFieldType("temperature", NumberFieldMapper.NumberType.LONG);


### PR DESCRIPTION
- I replaced RandomIndexWriter to plain IndexWriter to avoid unexpected segments in test which are unable to handle more than single segment
- for other test I've added explicit segmenting. TODO It needs to be reviewed.
- Perhaps StreamingTermsAggregator should reject second segment via assert or there should be a proper publish/reset flow. TODO, WIP

so far this commit fixes the known reason for flackines (I belive)

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
