### PR TITLE
Revert back to Gradle 8.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix lag metric for pull-based ingestion when streaming source is empty ([#19393](https://github.com/opensearch-project/OpenSearch/pull/19393))
 
 ### Dependencies
-- Update to Gradle 9.1.0 ([#19329](https://github.com/opensearch-project/OpenSearch/pull/19329))
 - Bump `com.netflix.nebula.ospackage-base` from 12.0.0 to 12.1.0 ([#19019](https://github.com/opensearch-project/OpenSearch/pull/19019))
 - Bump `actions/checkout` from 4 to 5 ([#19023](https://github.com/opensearch-project/OpenSearch/pull/19023))
 - Bump `commons-cli:commons-cli` from 1.9.0 to 1.10.0 ([#19021](https://github.com/opensearch-project/OpenSearch/pull/19021))

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -130,7 +130,7 @@ dependencies {
   testFixturesApi gradleTestKit()
   testImplementation 'org.wiremock:wiremock-standalone:3.6.0'
   testImplementation "org.mockito:mockito-core:${props.getProperty('mockito')}"
-  integTestImplementation('org.spockframework:spock-core:2.4-M6-groovy-4.0') {
+  integTestImplementation('org.spockframework:spock-core:2.3-groovy-3.0') {
     exclude module: "groovy"
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,10 +26,7 @@ options.forkOptions.memoryMaximumSize=3g
 systemProp.org.gradle.dependency.duplicate.project.detection=false
 
 # Enforce the build to fail on deprecated gradle api usage
-# TODO: Waiting for https://github.com/google/protobuf-gradle-plugin/commit/894f2d25e2b511bc11661f4d23e47ee0671e82ad
-# to be released in the Protobuf gradle plugin, at which this point can be changed
-# back to `fail`
-systemProp.org.gradle.warning.mode=all
+systemProp.org.gradle.warning.mode=fail
 
 systemProp.jdk.tls.client.protocols=TLSv1.2,TLSv1.3
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionSha256Sum=b84e04fa845fecba48551f425957641074fcc00a88a84d2aae5808743b35fc85
+distributionSha256Sum=ed1a8d686605fd7c23bdf62c7fc7add1c5b23b2bbc3721e661934ef4a4911d7c


### PR DESCRIPTION
Something in Gradle 9 broke the assemble workflow such that the tarballs are not being generated. This is a minimal revert of #19329 to go back to using Gradle 8.14.3 which fixes the assemble workflow.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
