### PR TITLE
[Backport 2.19] Allow plugins to copy folders into their config dir during installation (#19343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,5 +35,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Change single shard assignment log message from warn to debug ([#18186](https://github.com/opensearch-project/OpenSearch/pull/18186))
 - Replace centos:8 with almalinux:8 since centos docker images are deprecated ([#19154](https://github.com/opensearch-project/OpenSearch/pull/19154))
+- Allow plugins to copy folders into their config dir during installation ([#19343](https://github.com/opensearch-project/OpenSearch/pull/19343))
 
 [Unreleased 2.19.x]: https://github.com/opensearch-project/OpenSearch/compare/fd9a9d90df25bea1af2c6a85039692e815b894f5...2.19

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
@@ -795,7 +795,7 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         assertPlugin("fake", pluginDir, env.v2());
 
         // Verify the directory and file were installed
-        Path installedConfigDir = env.v2().configDir().resolve("fake").resolve("foo");
+        Path installedConfigDir = env.v2().configFile().resolve("fake").resolve("foo");
         assertTrue(Files.exists(installedConfigDir));
         assertTrue(Files.isDirectory(installedConfigDir));
         assertTrue(Files.exists(installedConfigDir.resolve("myconfig.yml")));

--- a/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/opensearch/plugins/InstallPluginCommandTests.java
@@ -423,8 +423,6 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
 
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(configDir)) {
                 for (Path file : stream) {
-                    assertFalse("not a dir", Files.isDirectory(file));
-
                     if (isPosix) {
                         PosixFileAttributes attributes = Files.readAttributes(file, PosixFileAttributes.class);
                         if (user != null) {
@@ -793,9 +791,14 @@ public class InstallPluginCommandTests extends OpenSearchTestCase {
         Files.createDirectories(dirInConfigDir);
         Files.createFile(dirInConfigDir.resolve("myconfig.yml"));
         String pluginZip = createPluginUrl("fake", pluginDir);
-        UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip, env.v1()));
-        assertTrue(e.getMessage(), e.getMessage().contains("Directories not allowed in config dir for plugin"));
-        assertInstallCleaned(env.v2());
+        installPlugin(pluginZip, env.v1());
+        assertPlugin("fake", pluginDir, env.v2());
+
+        // Verify the directory and file were installed
+        Path installedConfigDir = env.v2().configDir().resolve("fake").resolve("foo");
+        assertTrue(Files.exists(installedConfigDir));
+        assertTrue(Files.isDirectory(installedConfigDir));
+        assertTrue(Files.exists(installedConfigDir.resolve("myconfig.yml")));
     }
 
     public void testMissingDescriptor() throws Exception {


### PR DESCRIPTION
(cherry picked from commit bb9a7d4486dde017cab986310f8c70e3573f4b72)

### Description

Manual backport of #19343 to 2.19.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
