### PR TITLE
Explicitly configure log4j for server tests

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -388,6 +388,7 @@ tasks.named("licenseHeaders").configure {
 tasks.test {
     environment "node.roles.test", "[]"
     jvmArgs += ["--add-opens", "java.base/java.nio.file=ALL-UNNAMED", "-Djdk.attach.allowAttachSelf=true", "-XX:+EnableDynamicAgentLoading" ]
+    systemProperty 'log4j2.configurationFile', file('src/test/resources/log4j2-test.xml').toURI().toString()
 }
 
 tasks.named("sourcesJar").configure {

--- a/server/src/test/resources/log4j-test.xml
+++ b/server/src/test/resources/log4j-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~
+  ~ The OpenSearch Contributors require contributions made to
+  ~ this file be licensed under the Apache-2.0 license or a
+  ~ compatible open source license.
+  -->
+
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ISO8601} [%t] %-5p %c - %m%n" disableAnsi="true"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="ERROR">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
### Description

CI for the core repo has been flaky since the recent log4j update in https://github.com/opensearch-project/OpenSearch/pull/19184.

The same error has now been observed in both the core and AD repos:

```
REPRODUCE WITH: ./gradlew ':server:test' --tests 'org.opensearch.gateway.remote.RemoteClusterStateServiceTests.testReadClusterStateInParallel_ExceptionDuringRead' -Dtests.seed=7D187563E049ADC9 -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=saq-Latn-KE -Dtests.timezone=Pacific/Tahiti -Druntime.java=24

RemoteClusterStateServiceTests > testReadClusterStateInParallel_ExceptionDuringRead FAILED
    java.lang.AssertionError: 
    Expected: (an empty collection or iterable containing [a string starting with "No Root logger was configured, creating default ERROR-level Root logger with Console appender"] or iterable containing [a string starting with "No Root logger was configured, creating default ERROR-level Root logger with Console appender", a string starting with "No Root logger was configured, creating default ERROR-level Root logger with Console appender"])
         but: was <[An exception occurred processing Appender console, An exception occurred processing Appender console, An exception occurred processing Appender console]>
        at __randomizedtesting.SeedInfo.seed([7D187563E049ADC9:837EBCCE32AFF7B9]:0)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at org.apache.lucene.tests.util.LuceneTestCase.assertThat(LuceneTestCase.java:2104)
        at org.opensearch.test.OpenSearchTestCase.checkStaticState(OpenSearchTestCase.java:740)
        at org.opensearch.test.OpenSearchTestCase.after(OpenSearchTestCase.java:506)
```

The changes in this PR will explicitly configure log4j to prevent it from falling back to the default. 

### Related Issues

Attempt to fix https://github.com/opensearch-project/OpenSearch/issues/19325

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
