### PR TITLE
Fix flaky test RemoteClusterStateServiceTests.testReadClusterStateInParallel_ExceptionDuringRead

### DIFF
--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -1344,8 +1344,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         ClusterState previousClusterState = generateClusterStateWithAllAttributes().build();
         ClusterMetadataManifest manifest = generateClusterMetadataManifestWithAllAttributes().build();
         BlobContainer container = mockBlobStoreObjects();
-        Exception mockException = new IOException("mock exception");
-        when(container.readBlob(anyString())).thenThrow(mockException);
+        String exceptionMsg = "mock exception";
+        when(container.readBlob(anyString())).thenAnswer(inv -> { throw new IOException(exceptionMsg); });
         remoteClusterStateService.start();
         RemoteStateTransferException exception = expectThrows(
             RemoteStateTransferException.class,
@@ -1371,7 +1371,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         );
         assertEquals("Exception during reading cluster state from remote", exception.getMessage());
         assertTrue(exception.getSuppressed().length > 0);
-        assertEquals(mockException, exception.getSuppressed()[0].getCause());
+        assertEquals(exceptionMsg, exception.getSuppressed()[0].getCause().getMessage());
     }
 
     public void testReadClusterStateInParallel_UnexpectedResult() throws IOException {


### PR DESCRIPTION
### Description

This PR makes a simple change to throw a new instance of an IOException every time `container.readBlob` is invoked instead of re-using the same instance. 

This PR is good from a hygiene perspective to not re-use the same object every time a new exception is thrown, but the underlying issue in https://github.com/apache/logging-log4j2/issues/3940 and https://github.com/apache/logging-log4j2/issues/3933 should still be fixed.

This PR is not meant as a replacement for https://github.com/opensearch-project/OpenSearch/pull/19430. I'm opening this up to share the reason for the test failure in this particular test case.

The anomaly-detection repo is also seeing this on `./gradlew test --tests MultiEntityResultTests.testQueryErrorEndRunNotNow -i`

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/19325

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
