### PR TITLE
[Bugfix] Implement SslHandler retrieval logic for transport-reactor-netty4 plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix lag metric for pull-based ingestion when streaming source is empty ([#19393](https://github.com/opensearch-project/OpenSearch/pull/19393))
 - Fix ingestion state xcontent serialization in IndexMetadata and fail fast on mapping errors([#19320](https://github.com/opensearch-project/OpenSearch/pull/19320))
 - Fix updated keyword field params leading to stale responses from request cache ([#19385](https://github.com/opensearch-project/OpenSearch/pull/19385))
+- Implement SslHandler retrieval logic for transport-reactor-netty4 plugin ([#19458](https://github.com/opensearch-project/OpenSearch/pull/19458))
 
 ### Dependencies
 - Bump `com.gradleup.shadow:shadow-gradle-plugin` from 8.3.5 to 8.3.9 ([#19400](https://github.com/opensearch-project/OpenSearch/pull/19400))

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4BaseHttpChannel.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4BaseHttpChannel.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.http.reactor.netty4;
+
+import javax.net.ssl.SSLEngine;
+
+import java.util.Optional;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.handler.ssl.SslHandler;
+import reactor.netty.NettyPipeline;
+import reactor.netty.http.server.HttpServerRequest;
+
+final class ReactorNetty4BaseHttpChannel {
+    private static final String CHANNEL_PROPERTY = "channel";
+    private static final String SSL_HANDLER_PROPERTY = "ssl_http";
+    private static final String SSL_ENGINE_PROPERTY = "ssl_engine";
+
+    private ReactorNetty4BaseHttpChannel() {}
+
+    @SuppressWarnings("unchecked")
+    static <T> Optional<T> get(HttpServerRequest request, String name, Class<T> clazz) {
+        if (CHANNEL_PROPERTY.equalsIgnoreCase(name) == true && clazz.isAssignableFrom(Channel.class) == true) {
+            final Channel[] channels = new Channel[1];
+            request.withConnection(connection -> { channels[0] = connection.channel(); });
+            return Optional.of((T) channels[0]);
+        } else if (SSL_HANDLER_PROPERTY.equalsIgnoreCase(name) == true || SSL_ENGINE_PROPERTY.equalsIgnoreCase(name) == true) {
+            final ChannelHandler[] channels = new ChannelHandler[1];
+            request.withConnection(connection -> {
+                final Channel channel = connection.channel();
+                if (channel.parent() != null) {
+                    channels[0] = channel.parent().pipeline().get(NettyPipeline.SslHandler);
+                } else {
+                    channels[0] = channel.pipeline().get(NettyPipeline.SslHandler);
+                }
+            });
+            if (channels[0] != null) {
+                if (SSL_HANDLER_PROPERTY.equalsIgnoreCase(name) == true && clazz.isInstance(channels[0]) == true) {
+                    return Optional.of((T) channels[0]);
+                } else if (SSL_ENGINE_PROPERTY.equalsIgnoreCase(name) == true
+                    && clazz.isAssignableFrom(SSLEngine.class)
+                    && channels[0] instanceof SslHandler h) {
+                        return Optional.of((T) h.engine());
+                    }
+            }
+        } else {
+            final ChannelHandler[] channels = new ChannelHandler[1];
+            request.withConnection(connection -> { channels[0] = connection.channel().pipeline().get(name); });
+            if (channels[0] != null && clazz.isInstance(channels[0]) == true) {
+                return Optional.of((T) channels[0]);
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4HttpServerTransport.java
@@ -53,6 +53,7 @@ import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
@@ -317,6 +318,8 @@ public class ReactorNetty4HttpServerTransport extends AbstractHttpServerTranspor
             parameters.flatMap(SecureHttpTransportParameters::trustManagerFactory).ifPresent(sslContextBuilder::trustManager);
             parameters.map(SecureHttpTransportParameters::cipherSuites)
                 .ifPresent(ciphers -> sslContextBuilder.ciphers(ciphers, SupportedCipherSuiteFilter.INSTANCE));
+            parameters.flatMap(SecureHttpTransportParameters::clientAuth)
+                .ifPresent(clientAuth -> sslContextBuilder.clientAuth(ClientAuth.valueOf(clientAuth)));
 
             final SslContext sslContext = sslContextBuilder.protocols(
                 parameters.map(SecureHttpTransportParameters::protocols).orElseGet(() -> Arrays.asList(SslUtils.DEFAULT_SSL_PROTOCOLS))

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4NonStreamingHttpChannel.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4NonStreamingHttpChannel.java
@@ -15,6 +15,7 @@ import org.opensearch.http.HttpResponse;
 import org.opensearch.transport.reactor.netty4.Netty4Utils;
 
 import java.net.InetSocketAddress;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.netty.handler.codec.http.FullHttpResponse;
@@ -73,6 +74,11 @@ class ReactorNetty4NonStreamingHttpChannel implements HttpChannel {
     @Override
     public InetSocketAddress getLocalAddress() {
         return (InetSocketAddress) response.hostAddress();
+    }
+
+    @Override
+    public <T> Optional<T> get(String name, Class<T> clazz) {
+        return ReactorNetty4BaseHttpChannel.get(request, name, clazz);
     }
 
     FullHttpResponse createResponse(HttpResponse response) {

--- a/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4StreamingHttpChannel.java
+++ b/plugins/transport-reactor-netty4/src/main/java/org/opensearch/http/reactor/netty4/ReactorNetty4StreamingHttpChannel.java
@@ -19,6 +19,7 @@ import org.opensearch.transport.reactor.netty4.Netty4Utils;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultHttpContent;
@@ -121,6 +122,11 @@ class ReactorNetty4StreamingHttpChannel implements StreamingHttpChannel {
     @Override
     public void subscribe(Subscriber<? super HttpChunk> subscriber) {
         receiver.subscribe(subscriber);
+    }
+
+    @Override
+    public <T> Optional<T> get(String name, Class<T> clazz) {
+        return ReactorNetty4BaseHttpChannel.get(request, name, clazz);
     }
 
     private static HttpContent createContent(HttpResponse response) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Originally was posted on the OpenSearch forum [1], when `transport-reactor-netty4` plugin is activated, some functionality related to `opensearch-security` plugin is not working properly. 

```
$ ./plugins/opensearch-security/tools/securityadmin.sh -dg -cacert config/root-ca.pem  -cert config/node1.pem -w
WARNING: nor OPENSEARCH_JAVA_HOME nor JAVA_HOME is set, will use /usr/bin/java
Listening for transport dt_socket at address: 5005
Security Admin v7
Will connect to localhost:9200 ... done
Listening for transport dt_socket at address: 5005
ERR: An unexpected ResponseException occured: method [GET], host [https://localhost:9200], URI [/_plugins/_security/whoami], status line [HTTP/2.0 403 Forbidden]
No security data
Trace:
org.opensearch.client.ResponseException: method [GET], host [https://localhost:9200], URI [/_plugins/_security/whoami], status line [HTTP/2.0 403 Forbidden]
No security data
        at org.opensearch.client.RestClient.convertResponse(RestClient.java:501)
        at org.opensearch.client.RestClient.performRequest(RestClient.java:384)
        at org.opensearch.client.RestClient.performRequest(RestClient.java:359)
        at org.opensearch.security.tools.SecurityAdmin.execute(SecurityAdmin.java:541)
        at org.opensearch.security.tools.SecurityAdmin.main(SecurityAdmin.java:154)
```
It turned out the that issue was related to the `SslHandler` that `opensearch-security` tries to locate by name. The `transport-reactor-netty4` plugin does use different naming convention and as such, the `SslHandler` has not being detected.

[1] https://forum.opensearch.org/t/pods-not-coming-up-after-using-transport-reactor-netty4-plugin-for-mcp-server/26990

### Related Issues
See please https://forum.opensearch.org/t/pods-not-coming-up-after-using-transport-reactor-netty4-plugin-for-mcp-server/26990

<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
