### PR TITLE
Himkak/node stats api with warm index solu2

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/WritableWarmIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/WritableWarmIT.java
@@ -206,7 +206,6 @@ public class WritableWarmIT extends RemoteStoreBaseIntegTestCase {
 
         // ensuring cluster is green
         ensureGreen();
-
         NodesStatsResponse nodesStatsResponse = client().admin().cluster().nodesStats(new NodesStatsRequest().all()).actionGet();
         assertFalse(nodesStatsResponse.toString().contains("Exception"));
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/WritableWarmIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/WritableWarmIT.java
@@ -195,6 +195,7 @@ public class WritableWarmIT extends RemoteStoreBaseIntegTestCase {
         Settings settings = Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), true)
             .build();
 
         assertAcked(client().admin().indices().prepareCreate(INDEX_NAME_2).setSettings(settings).get());
@@ -205,6 +206,9 @@ public class WritableWarmIT extends RemoteStoreBaseIntegTestCase {
 
         // ensuring cluster is green
         ensureGreen();
+
+        NodesStatsResponse nodesStatsResponse = client().admin().cluster().nodesStats(new NodesStatsRequest().all()).actionGet();
+        assertFalse(nodesStatsResponse.toString().contains("Exception"));
 
         SearchResponse searchResponse = client().prepareSearch(INDEX_NAME_2).setQuery(QueryBuilders.matchAllQuery()).get();
         // Asserting that search returns same number of docs as ingested
@@ -218,7 +222,7 @@ public class WritableWarmIT extends RemoteStoreBaseIntegTestCase {
 
         // TODO: Make these validation more robust, when SwitchableIndexInput is implemented.
 
-        NodesStatsResponse nodesStatsResponse = client().admin().cluster().nodesStats(new NodesStatsRequest().all()).actionGet();
+        nodesStatsResponse = client().admin().cluster().nodesStats(new NodesStatsRequest().all()).actionGet();
 
         AggregateFileCacheStats fileCacheStats = nodesStatsResponse.getNodes()
             .stream()

--- a/server/src/main/java/org/opensearch/index/store/CompositeDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/CompositeDirectory.java
@@ -439,9 +439,8 @@ public class CompositeDirectory extends FilterDirectory {
 
     protected void cacheFile(String name) throws IOException {
         Path filePath = getFilePath(name);
-
-        fileCache.put(filePath, new CachedFullFileIndexInput(fileCache, filePath, localDirectory.openInput(name, IOContext.DEFAULT)));
         fileCache.pin(filePath);
+        fileCache.put(filePath, new CachedFullFileIndexInput(fileCache, filePath, localDirectory.openInput(name, IOContext.DEFAULT)));
         fileCache.decRef(filePath);
     }
 


### PR DESCRIPTION
Description
After creating the warm index and or indexing docs, if we check the node stats, we get the failure response of type illegal_argument_exception.
These changes are fix for that.
With these changes 
- while caching file we pin the file after put and decRef 
- While removing the file from cache, we unpin it and then remove

Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/19464

Check List
[ x] Functionality includes testing.
[ x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
[ x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
