### PR TITLE
Attach aggregate test report  and coverage report to server check task

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -38,6 +38,7 @@ plugins {
   id('opensearch.internal-cluster-test')
   id('opensearch.optional-dependencies')
   id('me.champeau.gradle.japicmp') version '0.4.6'
+  id 'test-report-aggregation'
 }
 
 apply from: "$rootDir/gradle/fips.gradle"
@@ -365,8 +366,48 @@ tasks.named("dependencyLicenses").configure {
     }.files
 }
 
+if (System.getProperty("moduletests.coverage")) {
+  reporting {
+    reports {
+      testAggregateTestReport(AggregateTestReport) {
+        testSuiteName = "test"
+      }
+    }
+  }
+  tasks.named(JavaBasePlugin.CHECK_TASK_NAME) {
+    dependsOn tasks.named('testAggregateTestReport')
+  }
+}
 tasks.named("filepermissions").configure {
   mustRunAfter("generateProto")
+}
+
+if (System.getProperty("moduletests.coverage")) {
+  plugins.withId('jacoco') {
+    tasks.register('testCodeCoverageReport', JacocoReport) {
+      dependsOn tasks.named('test')
+      executionData fileTree(buildDir.absolutePath + "/jacoco").include("test.exec")
+      sourceDirectories.setFrom files(project(':server').sourceSets.main.allSource.srcDirs)
+      classDirectories.setFrom(files(sourceSets.main.output).filter { it.exists() })
+      reports {
+        xml.required = true
+      }
+    }
+
+    tasks.register('testCodeCoverageReportInternalClusterTest', JacocoReport) {
+      dependsOn tasks.named('internalClusterTest')
+      executionData fileTree(buildDir.absolutePath + "/jacoco").include("internalClusterTest.exec")
+      classDirectories.setFrom(files(sourceSets.main.output).filter { it.exists() })
+
+      reports {
+        xml.required = true
+      }
+    }
+
+    tasks.named(JavaBasePlugin.CHECK_TASK_NAME) {
+      dependsOn (tasks.named('testCodeCoverageReport'), tasks.named('testCodeCoverageReportInternalClusterTest'))
+    }
+  }
 }
 
 tasks.named("licenseHeaders").configure {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change attaches aggregate test report  and coverage report to server check task

- coverage reports are individually generated for unit tests and integration tests and attached to the :server:check task.

- With the usage of the property moduletests.coverage report generation is only confined to check task executed from server module and does not cause any duplicate or irrelevant report generation while running
`./gradlew check` and `./gradlew check -x :server:check` commands 

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/19421

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
