### PR TITLE
Expand streaming Aggregations to  Cardinality Aggregator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add `StreamNumericTermsAggregator` to allow numeric term aggregation streaming ([#19335](https://github.com/opensearch-project/OpenSearch/pull/19335))
 - Query planning to determine flush mode for streaming aggregations ([#19488](https://github.com/opensearch-project/OpenSearch/pull/19488))
 - Harden the circuit breaker and failure handle logic in query result consumer ([#19396](https://github.com/opensearch-project/OpenSearch/pull/19396))
+- Add streaming cardinality aggregator ([#19484](https://github.com/opensearch-project/OpenSearch/pull/19484))
 
 ### Changed
 - Refactor `if-else` chains to use `Java 17 pattern matching switch expressions`(([#18965](https://github.com/opensearch-project/OpenSearch/pull/18965))

--- a/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/streaming/aggregation/SubAggregationIT.java
+++ b/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/streaming/aggregation/SubAggregationIT.java
@@ -33,7 +33,9 @@ import org.opensearch.search.aggregations.bucket.terms.StreamNumericTermsAggrega
 import org.opensearch.search.aggregations.bucket.terms.StreamStringTermsAggregator;
 import org.opensearch.search.aggregations.bucket.terms.StringTerms;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.Cardinality;
 import org.opensearch.search.aggregations.metrics.Max;
+import org.opensearch.search.aggregations.metrics.StreamCardinalityAggregator;
 import org.opensearch.search.profile.ProfileResult;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.ParameterizedDynamicSettingsOpenSearchIntegTestCase;
@@ -104,7 +106,8 @@ public class SubAggregationIT extends ParameterizedDynamicSettingsOpenSearchInte
             "{\n"
                 + "  \"properties\": {\n"
                 + "    \"field1\": { \"type\": \"keyword\" },\n"
-                + "    \"field2\": { \"type\": \"integer\" }\n"
+                + "    \"field2\": { \"type\": \"integer\" },\n"
+                + "    \"field3\": { \"type\": \"keyword\" }\n"
                 + "  }\n"
                 + "}",
             XContentType.JSON
@@ -115,35 +118,35 @@ public class SubAggregationIT extends ParameterizedDynamicSettingsOpenSearchInte
         BulkRequest bulkRequest = new BulkRequest();
 
         // We'll create 3 segments per shard by indexing docs into each segment and forcing a flush
-        // Segment 1 - we'll add docs with field2 values in 1-3 range
+        // Segment 1 - we'll add docs with field2 values in 1-3 range, field3 values type1-3
         for (int i = 0; i < 10; i++) {
-            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value1", "field2", 1));
-            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value2", "field2", 2));
-            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value3", "field2", 3));
+            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value1", "field2", 1, "field3", "type1"));
+            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value2", "field2", 2, "field3", "type1"));
+            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value3", "field2", 3, "field3", "type1"));
         }
         BulkResponse bulkResponse = client().bulk(bulkRequest).actionGet();
         assertFalse(bulkResponse.hasFailures()); // Verify ingestion was successful
         client().admin().indices().flush(new FlushRequest("index").force(true)).actionGet();
         client().admin().indices().refresh(new RefreshRequest("index")).actionGet();
 
-        // Segment 2 - we'll add docs with field2 values in 11-13 range
+        // Segment 2 - we'll add docs with field2 values in 11-13 range, field3 values type4-6
         bulkRequest = new BulkRequest();
         for (int i = 0; i < 10; i++) {
-            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value1", "field2", 11));
-            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value2", "field2", 12));
-            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value3", "field2", 13));
+            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value1", "field2", 11, "field3", "type2"));
+            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value2", "field2", 12, "field3", "type2"));
+            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value3", "field2", 13, "field3", "type2"));
         }
         bulkResponse = client().bulk(bulkRequest).actionGet();
         assertFalse(bulkResponse.hasFailures());
         client().admin().indices().flush(new FlushRequest("index").force(true)).actionGet();
         client().admin().indices().refresh(new RefreshRequest("index")).actionGet();
 
-        // Segment 3 - we'll add docs with field2 values in 21-23 range
+        // Segment 3 - we'll add docs with field2 values in 21-23 range, field3 values type7-9
         bulkRequest = new BulkRequest();
         for (int i = 0; i < 10; i++) {
-            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value1", "field2", 21));
-            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value2", "field2", 22));
-            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value3", "field2", 23));
+            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value1", "field2", 21, "field3", "type3"));
+            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value2", "field2", 22, "field3", "type3"));
+            bulkRequest.add(new IndexRequest("index").source(XContentType.JSON, "field1", "value3", "field2", 23, "field3", "type3"));
         }
         bulkResponse = client().bulk(bulkRequest).actionGet();
         assertFalse(bulkResponse.hasFailures());
@@ -432,6 +435,137 @@ public class SubAggregationIT extends ParameterizedDynamicSettingsOpenSearchInte
                         .build()
                 )
                 .get();
+        }
+    }
+
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testStreamingCardinalityAggregationUsed() throws Exception {
+        // This test validates cardinality streaming aggregation with profile to verify streaming is used
+        ActionFuture<SearchResponse> future = client().prepareStreamSearch("index")
+            .addAggregation(AggregationBuilders.cardinality("cardinality_agg").field("field1"))
+            .setSize(0)
+            .setRequestCache(false)
+            .setProfile(true)
+            .execute();
+        SearchResponse resp = future.actionGet();
+        assertNotNull(resp);
+        assertEquals(NUM_SHARDS, resp.getTotalShards());
+        assertEquals(90, resp.getHits().getTotalHits().value());
+
+        // Validate that streaming cardinality aggregation was actually used
+        assertNotNull("Profile response should be present", resp.getProfileResults());
+        boolean foundStreamingCardinality = false;
+        for (var shardProfile : resp.getProfileResults().values()) {
+            List<ProfileResult> aggProfileResults = shardProfile.getAggregationProfileResults().getProfileResults();
+            for (var profileResult : aggProfileResults) {
+                if (StreamCardinalityAggregator.class.getSimpleName().equals(profileResult.getQueryName())) {
+                    var debug = profileResult.getDebugInfo();
+                    if (debug != null && debug.containsKey("streaming_enabled")) {
+                        foundStreamingCardinality = true;
+                        assertTrue("streaming_enabled should be true", (Boolean) debug.get("streaming_enabled"));
+                        assertTrue("streaming_precision should be positive", ((Number) debug.get("streaming_precision")).intValue() > 0);
+                        break;
+                    }
+                }
+            }
+            if (foundStreamingCardinality) break;
+        }
+        assertTrue("Expected to find streaming cardinality in profile", foundStreamingCardinality);
+
+        // Also verify the result is correct
+        Cardinality cardinalityAgg = resp.getAggregations().get("cardinality_agg");
+        assertNotNull(cardinalityAgg);
+        // field1 has 3 unique values: value1, value2, value3
+        assertTrue("Expected cardinality around 3, got " + cardinalityAgg.getValue(), cardinalityAgg.getValue() >= 2);
+        assertTrue("Expected cardinality around 3, got " + cardinalityAgg.getValue(), cardinalityAgg.getValue() <= 4);
+    }
+
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testStreamingCardinalityAggregation() throws Exception {
+        // Test cardinality of field1 which has 3 unique values (value1, value2, value3)
+        ActionFuture<SearchResponse> future = client().prepareStreamSearch("index")
+            .addAggregation(AggregationBuilders.cardinality("cardinality_agg").field("field1").precisionThreshold(1000))
+            .setSize(0)
+            .setRequestCache(false)
+            .execute();
+        SearchResponse resp = future.actionGet();
+
+        assertNotNull(resp);
+        assertEquals(NUM_SHARDS, resp.getTotalShards());
+        assertEquals(90, resp.getHits().getTotalHits().value());
+
+        Cardinality cardinalityAgg = resp.getAggregations().get("cardinality_agg");
+        assertNotNull("Cardinality aggregation should not be null", cardinalityAgg);
+        // field1 has 3 unique values: value1, value2, value3
+        // HyperLogLog is approximate, so we allow some tolerance
+        assertTrue("Expected cardinality around 3, got " + cardinalityAgg.getValue(), cardinalityAgg.getValue() >= 2);
+        assertTrue("Expected cardinality around 3, got " + cardinalityAgg.getValue(), cardinalityAgg.getValue() <= 4);
+    }
+
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testStreamingCardinalityWithPrecisionThreshold() throws Exception {
+        // Test cardinality with different precision thresholds
+        ActionFuture<SearchResponse> future = client().prepareStreamSearch("index")
+            .addAggregation(AggregationBuilders.cardinality("cardinality_low").field("field1").precisionThreshold(10))
+            .addAggregation(AggregationBuilders.cardinality("cardinality_high").field("field1").precisionThreshold(1000))
+            .setSize(0)
+            .setRequestCache(false)
+            .execute();
+        SearchResponse resp = future.actionGet();
+
+        assertNotNull(resp);
+        assertEquals(NUM_SHARDS, resp.getTotalShards());
+        assertEquals(90, resp.getHits().getTotalHits().value());
+
+        Cardinality lowPrecision = resp.getAggregations().get("cardinality_low");
+        assertNotNull(lowPrecision);
+        assertEquals(3, lowPrecision.getValue(), 0.0);
+
+        Cardinality highPrecision = resp.getAggregations().get("cardinality_high");
+        assertNotNull(highPrecision);
+        assertEquals(3, highPrecision.getValue(), 0.0);
+
+        // Both should give the same result for small cardinality
+        assertEquals(lowPrecision.getValue(), highPrecision.getValue(), 0.0);
+    }
+
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testStreamingCardinalityAsSubAggregation() throws Exception {
+        // Test cardinality as a sub-aggregation under terms aggregation
+        // Using field3 (keyword field) for cardinality since StreamCardinalityAggregator only supports ordinal value sources
+        TermsAggregationBuilder agg = terms("terms_agg").field("field1")
+            .subAggregation(AggregationBuilders.cardinality("cardinality_subagg").field("field3").precisionThreshold(1000));
+
+        ActionFuture<SearchResponse> future = client().prepareStreamSearch("index")
+            .addAggregation(agg)
+            .setSize(0)
+            .setRequestCache(false)
+            .execute();
+        SearchResponse resp = future.actionGet();
+
+        assertNotNull(resp);
+        assertEquals(NUM_SHARDS, resp.getTotalShards());
+        assertEquals(90, resp.getHits().getTotalHits().value());
+
+        StringTerms termsAgg = resp.getAggregations().get("terms_agg");
+        assertNotNull(termsAgg);
+        List<StringTerms.Bucket> buckets = termsAgg.getBuckets();
+        assertEquals(3, buckets.size());
+
+        buckets.sort(Comparator.comparing(StringTerms.Bucket::getKeyAsString));
+
+        // Each bucket should have cardinality of 3 (each field1 value appears with 3 different field3 values)
+        // Based on the data: all field1 values→{type1,type2,type3}
+        for (StringTerms.Bucket bucket : buckets) {
+            assertEquals(30, bucket.getDocCount());
+            Cardinality cardinalitySubAgg = bucket.getAggregations().get("cardinality_subagg");
+            assertNotNull(cardinalitySubAgg);
+            // Each field1 value appears with exactly 3 field3 values
+            // HyperLogLog is approximate, allow some tolerance
+            assertTrue(
+                "Expected cardinality around 3 for bucket " + bucket.getKeyAsString() + ", got " + cardinalitySubAgg.getValue(),
+                cardinalitySubAgg.getValue() >= 2 && cardinalitySubAgg.getValue() <= 4
+            );
         }
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/AggregatorBase.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/AggregatorBase.java
@@ -305,7 +305,7 @@ public abstract class AggregatorBase extends Aggregator {
         collectableSubAggregators.reset();
     }
 
-    protected void doReset() {}
+    public void doReset() {}
 
     /** Called upon release of the aggregator. */
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/BucketCollectorProcessor.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/BucketCollectorProcessor.java
@@ -108,6 +108,9 @@ public class BucketCollectorProcessor {
             } else if (currentCollector instanceof BucketCollector) {
                 // Perform build aggregation during post collection
                 if (currentCollector instanceof Aggregator) {
+                    // Call postCollection() before building to ensure collectors finalize their data
+                    // This is critical for aggregators like CardinalityAggregator that defer processing until postCollect()
+                    ((BucketCollector) currentCollector).postCollection();
                     aggregations.add(((Aggregator) currentCollector).buildTopLevelBatch());
                 } else if (currentCollector instanceof MultiBucketCollector) {
                     for (Collector innerCollector : ((MultiBucketCollector) currentCollector).getCollectors()) {

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -88,24 +88,24 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
 
     private static final Logger logger = LogManager.getLogger(CardinalityAggregator.class);
 
-    private final CardinalityAggregatorFactory.ExecutionMode executionMode;
-    private final int precision;
-    private final ValuesSource valuesSource;
+    final CardinalityAggregatorFactory.ExecutionMode executionMode;
+    final int precision;
+    final ValuesSource valuesSource;
 
     private final ValuesSourceConfig valuesSourceConfig;
 
     // Expensive to initialize, so we only initialize it when we have an actual value source
     @Nullable
-    private HyperLogLogPlusPlus counts;
+    HyperLogLogPlusPlus counts;
 
-    private Collector collector;
+    Collector collector;
 
-    private int emptyCollectorsUsed;
-    private int numericCollectorsUsed;
-    private int ordinalsCollectorsUsed;
-    private int ordinalsCollectorsOverheadTooHigh;
-    private int stringHashingCollectorsUsed;
-    private int dynamicPrunedSegments;
+    int emptyCollectorsUsed;
+    int numericCollectorsUsed;
+    int ordinalsCollectorsUsed;
+    int ordinalsCollectorsOverheadTooHigh;
+    int stringHashingCollectorsUsed;
+    int dynamicPrunedSegments;
 
     public CardinalityAggregator(
         String name,
@@ -349,7 +349,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
      *
      * @opensearch.internal
      */
-    private abstract static class Collector extends LeafBucketCollector implements Releasable {
+    abstract static class Collector extends LeafBucketCollector implements Releasable {
 
         public abstract void postCollect() throws IOException;
 
@@ -488,7 +488,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
      *
      * @opensearch.internal
      */
-    private static class EmptyCollector extends Collector {
+    static class EmptyCollector extends Collector {
 
         @Override
         public void collect(int doc, long bucketOrd) {

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
@@ -104,6 +104,9 @@ class CardinalityAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext, Aggregator parent, Map<String, Object> metadata) throws IOException {
+        if (searchContext.isStreamSearch()) {
+            return new StreamCardinalityAggregator(name, config, precision(), searchContext, parent, metadata, executionMode);
+        }
         return new CardinalityAggregator(name, config, precision(), searchContext, parent, metadata, executionMode);
     }
 
@@ -114,6 +117,9 @@ class CardinalityAggregatorFactory extends ValuesSourceAggregatorFactory {
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
+        if (searchContext.isStreamSearch()) {
+            return new StreamCardinalityAggregator(name, config, precision(), searchContext, parent, metadata, executionMode);
+        }
         return queryShardContext.getValuesSourceRegistry()
             .getAggregator(CardinalityAggregationBuilder.REGISTRY_KEY, config)
             .build(name, config, precision(), searchContext, parent, metadata, executionMode);

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregator.java
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.metrics;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.opensearch.search.aggregations.Aggregator;
+import org.opensearch.search.aggregations.LeafBucketCollector;
+import org.opensearch.search.aggregations.support.ValuesSource;
+import org.opensearch.search.aggregations.support.ValuesSourceConfig;
+import org.opensearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class StreamCardinalityAggregator extends CardinalityAggregator {
+
+    private Collector streamCollector;
+
+    public StreamCardinalityAggregator(
+        String name,
+        ValuesSourceConfig valuesSourceConfig,
+        int precision,
+        SearchContext context,
+        Aggregator parent,
+        Map<String, Object> metadata,
+        CardinalityAggregatorFactory.ExecutionMode executionMode
+    ) throws IOException {
+        super(name, valuesSourceConfig, precision, context, parent, metadata, executionMode);
+    }
+
+    @Override
+    public LeafBucketCollector getLeafCollector(LeafReaderContext ctx, final LeafBucketCollector sub) throws IOException {
+        // Clean up previous collector if it exists
+        if (streamCollector != null) {
+            try {
+                streamCollector.postCollect();
+            } finally {
+                streamCollector.close();
+                streamCollector = null;
+            }
+        }
+
+        // Handle null values source
+        if (valuesSource == null) {
+            emptyCollectorsUsed++;
+            streamCollector = new EmptyCollector();
+            return streamCollector;
+        }
+
+        // Only support ordinal value sources for streaming
+        if (!(valuesSource instanceof ValuesSource.Bytes.WithOrdinals)) {
+            throw new IllegalStateException("StreamCardinalityAggregator only supports ordinal value sources");
+        }
+
+        // Handle ordinal value sources - always use OrdinalsCollector
+        final SortedSetDocValues ordinalValues = ((ValuesSource.Bytes.WithOrdinals) valuesSource).ordinalsValues(ctx);
+        final long maxOrd = ordinalValues.getValueCount();
+        if (maxOrd == 0) {
+            emptyCollectorsUsed++;
+            streamCollector = new EmptyCollector();
+        } else {
+            ordinalsCollectorsUsed++;
+            streamCollector = new OrdinalsCollector(counts, ordinalValues, context.bigArrays());
+        }
+        return streamCollector;
+    }
+
+    @Override
+    protected void doPostCollection() throws IOException {
+        if (streamCollector != null) {
+            try {
+                streamCollector.postCollect();
+            } finally {
+                streamCollector.close();
+                streamCollector = null;
+            }
+        }
+    }
+
+    @Override
+    protected void doClose() {
+        super.doClose();
+        if (streamCollector != null) {
+            streamCollector.close();
+            streamCollector = null;
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregator.java
@@ -73,6 +73,22 @@ public class StreamCardinalityAggregator extends CardinalityAggregator {
     }
 
     @Override
+    public void doReset() {
+        super.doReset();
+        // Clean up the stream collector for the next batch
+        if (streamCollector != null) {
+            streamCollector.close();
+            streamCollector = null;
+        }
+        // Close and recreate the HyperLogLog counts for the next batch
+        // HyperLogLog doesn't have a public reset method, so we need to recreate it
+        if (counts != null) {
+            counts.close();
+            counts = valuesSource == null ? null : new HyperLogLogPlusPlus(precision, context.bigArrays(), 1);
+        }
+    }
+
+    @Override
     protected void doPostCollection() throws IOException {
         if (streamCollector != null) {
             try {

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregator.java
@@ -19,6 +19,11 @@ import org.opensearch.search.internal.SearchContext;
 import java.io.IOException;
 import java.util.Map;
 
+/**
+ * A streaming aggregator that computes approximate counts of unique values.
+ *
+ * @opensearch.internal
+ */
 public class StreamCardinalityAggregator extends CardinalityAggregator {
 
     private Collector streamCollector;

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregator.java
@@ -15,16 +15,20 @@ import org.opensearch.search.aggregations.LeafBucketCollector;
 import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.aggregations.support.ValuesSourceConfig;
 import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.streaming.Streamable;
+import org.opensearch.search.streaming.StreamingCostMetrics;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 /**
  * A streaming aggregator that computes approximate counts of unique values.
  *
  * @opensearch.internal
  */
-public class StreamCardinalityAggregator extends CardinalityAggregator {
+public class StreamCardinalityAggregator extends CardinalityAggregator implements Streamable {
 
     private Collector streamCollector;
 
@@ -111,6 +115,49 @@ public class StreamCardinalityAggregator extends CardinalityAggregator {
         if (streamCollector != null) {
             streamCollector.close();
             streamCollector = null;
+        }
+    }
+
+    @Override
+    public void collectDebugInfo(BiConsumer<String, Object> add) {
+        super.collectDebugInfo(add);
+
+        StreamingCostMetrics metrics = getStreamingCostMetrics();
+        add.accept("streaming_enabled", metrics.streamable());
+        add.accept("streaming_precision", precision);
+        add.accept("streaming_estimated_cardinality", metrics.estimatedBucketCount());
+        add.accept("streaming_estimated_docs", metrics.estimatedDocCount());
+        add.accept("streaming_segment_count", metrics.segmentCount());
+    }
+
+    @Override
+    public StreamingCostMetrics getStreamingCostMetrics() {
+        try {
+            // For cardinality, we don't have a fixed topN size like terms aggregations
+            // Instead, we use the precision parameter to estimate memory requirements
+            int topNSize = 1 << precision; // HyperLogLog register count is 2^precision
+
+            // Only support ordinal value sources (strings/keywords)
+            if (!(valuesSource instanceof ValuesSource.Bytes.WithOrdinals)) {
+                return StreamingCostMetrics.nonStreamable();
+            }
+
+            ValuesSource.Bytes.WithOrdinals ordinalValuesSource = (ValuesSource.Bytes.WithOrdinals) valuesSource;
+            List<LeafReaderContext> leaves = context.searcher().getIndexReader().leaves();
+            long maxCardinality = 0;
+            long totalDocsWithField = 0;
+
+            for (LeafReaderContext leaf : leaves) {
+                SortedSetDocValues docValues = ordinalValuesSource.ordinalsValues(leaf);
+                if (docValues != null) {
+                    maxCardinality = Math.max(maxCardinality, docValues.getValueCount());
+                    totalDocsWithField += docValues.cost();
+                }
+            }
+
+            return new StreamingCostMetrics(true, topNSize, maxCardinality, leaves.size(), totalDocsWithField);
+        } catch (IOException e) {
+            return StreamingCostMetrics.nonStreamable();
         }
     }
 }

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregatorTests.java
@@ -1241,6 +1241,84 @@ public class StreamCardinalityAggregatorTests extends AggregatorTestCase {
         }
     }
 
+    public void testGetStreamingCostMetrics() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
+                // Add documents with various unique values
+                for (int i = 0; i < 10; i++) {
+                    Document document = new Document();
+                    document.add(new SortedSetDocValuesField("field", new BytesRef("value_" + i)));
+                    indexWriter.addDocument(document);
+                }
+
+                try (IndexReader indexReader = maybeWrapReaderEs(DirectoryReader.open(indexWriter))) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("test").field("field")
+                        .precisionThreshold(100);
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    // Get streaming cost metrics
+                    org.opensearch.search.streaming.StreamingCostMetrics metrics = aggregator.getStreamingCostMetrics();
+
+                    // Verify metrics
+                    assertTrue("Should be streamable", metrics.streamable());
+                    assertTrue("Should have positive topN size", metrics.topNSize() > 0);
+                    assertTrue("Should have positive segment count", metrics.segmentCount() > 0);
+                    assertEquals("Should have 1 segment", 1, metrics.segmentCount());
+                    assertTrue("Should have estimated cardinality", metrics.estimatedBucketCount() >= 10);
+                    assertTrue("Should have estimated docs", metrics.estimatedDocCount() >= 10);
+                }
+            }
+        }
+    }
+
+    public void testGetStreamingCostMetricsWithEmptyIndex() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+                try (IndexReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("test").field("field");
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    // Get streaming cost metrics
+                    org.opensearch.search.streaming.StreamingCostMetrics metrics = aggregator.getStreamingCostMetrics();
+
+                    // Verify metrics for empty index
+                    assertTrue("Should be streamable", metrics.streamable());
+                    assertTrue("Should have positive topN size", metrics.topNSize() > 0);
+                    assertEquals("Should have 0 estimated cardinality", 0, metrics.estimatedBucketCount());
+                    assertEquals("Should have 0 estimated docs", 0, metrics.estimatedDocCount());
+                }
+            }
+        }
+    }
+
     private InternalAggregation buildInternalStreamingAggregation(
         CardinalityAggregationBuilder builder,
         MappedFieldType fieldType,

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregatorTests.java
@@ -436,6 +436,388 @@ public class StreamCardinalityAggregatorTests extends AggregatorTestCase {
         }
     }
 
+    public void testMultipleBatches() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+                Document document = new Document();
+                document.add(new SortedSetDocValuesField("field", new BytesRef("batch1_value1")));
+                indexWriter.addDocument(document);
+
+                document = new Document();
+                document.add(new SortedSetDocValuesField("field", new BytesRef("batch1_value2")));
+                indexWriter.addDocument(document);
+
+                try (IndexReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("test").field("field");
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    // First batch
+                    aggregator.preCollection();
+                    assertEquals("strictly single segment", 1, indexSearcher.getIndexReader().leaves().size());
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+
+                    InternalCardinality firstBatch = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+                    assertTrue(firstBatch.getValue() > 0);
+
+                    // Reset for second batch
+                    aggregator.doReset();
+
+                    // Second batch
+                    aggregator.preCollection();
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+
+                    InternalCardinality secondBatch = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+                    assertTrue(secondBatch.getValue() > 0);
+                }
+            }
+        }
+    }
+
+    public void testLargeCardinality() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
+                // Create documents with many unique values
+                for (int i = 0; i < 1000; i++) {
+                    Document document = new Document();
+                    document.add(new SortedSetDocValuesField("field", new BytesRef("value_" + i)));
+                    indexWriter.addDocument(document);
+                }
+
+                try (IndexReader indexReader = maybeWrapReaderEs(DirectoryReader.open(indexWriter))) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("test").field("field");
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    aggregator.preCollection();
+                    assertEquals("strictly single segment", 1, indexSearcher.getIndexReader().leaves().size());
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+
+                    InternalCardinality result = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+
+                    assertThat(result, notNullValue());
+                    // With 1000 unique values, cardinality should be close to 1000 (allowing for HLL approximation)
+                    assertTrue(result.getValue() > 900);
+                }
+            }
+        }
+    }
+
+    public void testWithDuplicates() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
+                // Create many documents but only a few unique values
+                for (int i = 0; i < 100; i++) {
+                    Document document = new Document();
+                    document.add(new SortedSetDocValuesField("field", new BytesRef("value_" + (i % 3))));
+                    indexWriter.addDocument(document);
+                }
+
+                try (IndexReader indexReader = maybeWrapReaderEs(DirectoryReader.open(indexWriter))) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("test").field("field");
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    aggregator.preCollection();
+                    assertEquals("strictly single segment", 1, indexSearcher.getIndexReader().leaves().size());
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+
+                    InternalCardinality result = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+
+                    assertThat(result, notNullValue());
+                    // Should have exactly 3 unique values
+                    assertTrue(result.getValue() >= 2 && result.getValue() <= 4); // Allow some HLL approximation error
+                }
+            }
+        }
+    }
+
+    public void testSingleUniqueValue() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
+                // Create many documents with the same value
+                for (int i = 0; i < 50; i++) {
+                    Document document = new Document();
+                    document.add(new SortedSetDocValuesField("field", new BytesRef("same_value")));
+                    indexWriter.addDocument(document);
+                }
+
+                try (IndexReader indexReader = maybeWrapReaderEs(DirectoryReader.open(indexWriter))) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("test").field("field");
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    aggregator.preCollection();
+                    assertEquals("strictly single segment", 1, indexSearcher.getIndexReader().leaves().size());
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+
+                    InternalCardinality result = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+
+                    assertThat(result, notNullValue());
+                    // Should have cardinality of 1
+                    assertEquals(1, result.getValue(), 0);
+                }
+            }
+        }
+    }
+
+    public void testReduceWithMultipleAggregations() throws Exception {
+        try (Directory directory1 = newDirectory(); Directory directory2 = newDirectory(); Directory directory3 = newDirectory()) {
+            List<InternalAggregation> aggs = new ArrayList<>();
+
+            // First aggregation
+            try (IndexWriter indexWriter1 = new IndexWriter(directory1, new IndexWriterConfig())) {
+                for (int i = 0; i < 10; i++) {
+                    Document doc = new Document();
+                    doc.add(new SortedSetDocValuesField("field", new BytesRef("value_" + i)));
+                    indexWriter1.addDocument(doc);
+                }
+
+                try (IndexReader reader1 = maybeWrapReaderEs(DirectoryReader.open(indexWriter1))) {
+                    IndexSearcher searcher1 = newIndexSearcher(reader1);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+                    aggs.add(
+                        buildInternalStreamingAggregation(
+                            new CardinalityAggregationBuilder("cardinality").field("field"),
+                            fieldType,
+                            searcher1
+                        )
+                    );
+                }
+            }
+
+            // Second aggregation - overlapping values
+            try (IndexWriter indexWriter2 = new IndexWriter(directory2, new IndexWriterConfig())) {
+                for (int i = 5; i < 15; i++) {
+                    Document doc = new Document();
+                    doc.add(new SortedSetDocValuesField("field", new BytesRef("value_" + i)));
+                    indexWriter2.addDocument(doc);
+                }
+
+                try (IndexReader reader2 = maybeWrapReaderEs(DirectoryReader.open(indexWriter2))) {
+                    IndexSearcher searcher2 = newIndexSearcher(reader2);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+                    aggs.add(
+                        buildInternalStreamingAggregation(
+                            new CardinalityAggregationBuilder("cardinality").field("field"),
+                            fieldType,
+                            searcher2
+                        )
+                    );
+                }
+            }
+
+            // Third aggregation - new values
+            try (IndexWriter indexWriter3 = new IndexWriter(directory3, new IndexWriterConfig())) {
+                for (int i = 15; i < 20; i++) {
+                    Document doc = new Document();
+                    doc.add(new SortedSetDocValuesField("field", new BytesRef("value_" + i)));
+                    indexWriter3.addDocument(doc);
+                }
+
+                try (IndexReader reader3 = maybeWrapReaderEs(DirectoryReader.open(indexWriter3))) {
+                    IndexSearcher searcher3 = newIndexSearcher(reader3);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+                    aggs.add(
+                        buildInternalStreamingAggregation(
+                            new CardinalityAggregationBuilder("cardinality").field("field"),
+                            fieldType,
+                            searcher3
+                        )
+                    );
+                }
+            }
+
+            // Reduce the aggregations
+            InternalAggregation.ReduceContext ctx = InternalAggregation.ReduceContext.forFinalReduction(
+                new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService()),
+                getMockScriptService(),
+                b -> {},
+                PipelineTree.EMPTY
+            );
+
+            InternalAggregation reduced = aggs.get(0).reduce(aggs, ctx);
+            assertThat(reduced, instanceOf(InternalCardinality.class));
+
+            InternalCardinality cardinality = (InternalCardinality) reduced;
+            // After reducing, should have approximately 20 unique values (0-19)
+            assertTrue(cardinality.getValue() > 15);
+        }
+    }
+
+    public void testDifferentPrecisionThresholds() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
+                // Create documents with 50 unique values
+                for (int i = 0; i < 50; i++) {
+                    Document document = new Document();
+                    document.add(new SortedSetDocValuesField("field", new BytesRef("value_" + i)));
+                    indexWriter.addDocument(document);
+                }
+
+                try (IndexReader indexReader = maybeWrapReaderEs(DirectoryReader.open(indexWriter))) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    // Test with low precision
+                    CardinalityAggregationBuilder lowPrecisionBuilder = new CardinalityAggregationBuilder("test").field("field")
+                        .precisionThreshold(10);
+
+                    StreamCardinalityAggregator lowPrecisionAgg = createStreamAggregator(
+                        null,
+                        lowPrecisionBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    lowPrecisionAgg.preCollection();
+                    indexSearcher.search(new MatchAllDocsQuery(), lowPrecisionAgg);
+                    lowPrecisionAgg.postCollection();
+
+                    InternalCardinality lowPrecisionResult = (InternalCardinality) lowPrecisionAgg.buildAggregations(new long[] { 0 })[0];
+
+                    // Test with high precision
+                    CardinalityAggregationBuilder highPrecisionBuilder = new CardinalityAggregationBuilder("test").field("field")
+                        .precisionThreshold(1000);
+
+                    StreamCardinalityAggregator highPrecisionAgg = createStreamAggregator(
+                        null,
+                        highPrecisionBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    highPrecisionAgg.preCollection();
+                    indexSearcher.search(new MatchAllDocsQuery(), highPrecisionAgg);
+                    highPrecisionAgg.postCollection();
+
+                    InternalCardinality highPrecisionResult = (InternalCardinality) highPrecisionAgg.buildAggregations(new long[] { 0 })[0];
+
+                    // Both should give reasonable results, high precision should be closer to actual
+                    assertTrue(lowPrecisionResult.getValue() > 0);
+                    assertTrue(highPrecisionResult.getValue() > 0);
+                }
+            }
+        }
+    }
+
+    public void testResetClearsState() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+                // First batch data
+                Document document = new Document();
+                document.add(new SortedSetDocValuesField("field", new BytesRef("first_batch")));
+                indexWriter.addDocument(document);
+
+                try (IndexReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("test").field("field");
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    // First collection
+                    aggregator.preCollection();
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+                    InternalCardinality firstResult = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+                    long firstCardinality = firstResult.getValue();
+
+                    // Reset
+                    aggregator.doReset();
+
+                    // Second collection - should start fresh
+                    aggregator.preCollection();
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+                    InternalCardinality secondResult = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+                    long secondCardinality = secondResult.getValue();
+
+                    // After reset, cardinality should be the same since we're processing the same data
+                    assertEquals(firstCardinality, secondCardinality);
+                }
+            }
+        }
+    }
+
     private InternalAggregation buildInternalStreamingAggregation(
         CardinalityAggregationBuilder builder,
         MappedFieldType fieldType,

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/StreamCardinalityAggregatorTests.java
@@ -1,0 +1,462 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.metrics;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.MockBigArrays;
+import org.opensearch.common.util.MockPageCacheRecycler;
+import org.opensearch.core.common.breaker.CircuitBreaker;
+import org.opensearch.core.indices.breaker.NoneCircuitBreakerService;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.search.aggregations.AggregatorTestCase;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.MultiBucketConsumerService;
+import org.opensearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.opensearch.test.InternalAggregationTestCase.DEFAULT_MAX_BUCKETS;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class StreamCardinalityAggregatorTests extends AggregatorTestCase {
+
+    public void testBasicCardinality() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
+                Document document = new Document();
+                document.add(new SortedSetDocValuesField("field", new BytesRef("apple")));
+                indexWriter.addDocument(document);
+
+                document = new Document();
+                document.add(new SortedSetDocValuesField("field", new BytesRef("banana")));
+                indexWriter.addDocument(document);
+
+                document = new Document();
+                document.add(new SortedSetDocValuesField("field", new BytesRef("apple")));
+                indexWriter.addDocument(document);
+
+                try (IndexReader indexReader = maybeWrapReaderEs(DirectoryReader.open(indexWriter))) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("test").field("field");
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    aggregator.preCollection();
+                    assertEquals("strictly single segment", 1, indexSearcher.getIndexReader().leaves().size());
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+
+                    InternalCardinality result = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+
+                    assertThat(result, notNullValue());
+                    // Cardinality is approximate, so we check it's close to expected value
+                    assertTrue(result.getValue() > 0);
+                }
+            }
+        }
+    }
+
+    public void testEmptyResults() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+                try (IndexReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("test").field("field");
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    aggregator.preCollection();
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+
+                    InternalCardinality result = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+
+                    assertThat(result, notNullValue());
+                    assertEquals(0, result.getValue(), 0);
+                }
+            }
+        }
+    }
+
+    public void testWithMultipleValues() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
+                for (int i = 0; i < 10; i++) {
+                    Document document = new Document();
+                    document.add(new SortedSetDocValuesField("field", new BytesRef("term_" + (i % 5))));
+                    indexWriter.addDocument(document);
+                }
+
+                try (IndexReader indexReader = maybeWrapReaderEs(DirectoryReader.open(indexWriter))) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("test").field("field");
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    aggregator.preCollection();
+                    assertEquals("strictly single segment", 1, indexSearcher.getIndexReader().leaves().size());
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+
+                    InternalCardinality result = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+
+                    assertThat(result, notNullValue());
+                    // Should have approximately 5 unique values (term_0 through term_4)
+                    assertTrue(result.getValue() > 0);
+                }
+            }
+        }
+    }
+
+    public void testWithMultiValuedDocuments() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
+                Document document = new Document();
+                document.add(new SortedSetDocValuesField("field", new BytesRef("apple")));
+                document.add(new SortedSetDocValuesField("field", new BytesRef("banana")));
+                indexWriter.addDocument(document);
+
+                document = new Document();
+                document.add(new SortedSetDocValuesField("field", new BytesRef("banana")));
+                document.add(new SortedSetDocValuesField("field", new BytesRef("cherry")));
+                indexWriter.addDocument(document);
+
+                document = new Document();
+                document.add(new SortedSetDocValuesField("field", new BytesRef("apple")));
+                indexWriter.addDocument(document);
+
+                try (IndexReader indexReader = maybeWrapReaderEs(DirectoryReader.open(indexWriter))) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("test").field("field");
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    aggregator.preCollection();
+                    assertEquals("strictly single segment", 1, indexSearcher.getIndexReader().leaves().size());
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+
+                    InternalCardinality result = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+
+                    assertThat(result, notNullValue());
+                    // Should have approximately 3 unique values (apple, banana, cherry)
+                    assertTrue(result.getValue() > 0);
+                }
+            }
+        }
+    }
+
+    public void testReset() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+                Document document = new Document();
+                document.add(new SortedSetDocValuesField("field", new BytesRef("test")));
+                indexWriter.addDocument(document);
+
+                try (IndexReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("test").field("field");
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    aggregator.preCollection();
+                    assertEquals("strictly single segment", 1, indexSearcher.getIndexReader().leaves().size());
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+
+                    InternalCardinality firstResult = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+                    assertTrue(firstResult.getValue() > 0);
+
+                    aggregator.doReset();
+
+                    aggregator.preCollection();
+                    assertEquals("strictly single segment", 1, indexSearcher.getIndexReader().leaves().size());
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+
+                    InternalCardinality secondResult = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+                    assertTrue(secondResult.getValue() > 0);
+                }
+            }
+        }
+    }
+
+    public void testReduceSimple() throws Exception {
+        try (Directory directory1 = newDirectory(); Directory directory2 = newDirectory()) {
+            // Create first aggregation with some data
+            List<InternalAggregation> aggs = new ArrayList<>();
+
+            try (IndexWriter indexWriter1 = new IndexWriter(directory1, new IndexWriterConfig())) {
+                Document doc = new Document();
+                doc.add(new SortedSetDocValuesField("field", new BytesRef("apple")));
+                indexWriter1.addDocument(doc);
+
+                doc = new Document();
+                doc.add(new SortedSetDocValuesField("field", new BytesRef("banana")));
+                indexWriter1.addDocument(doc);
+
+                try (IndexReader reader1 = maybeWrapReaderEs(DirectoryReader.open(indexWriter1))) {
+                    IndexSearcher searcher1 = newIndexSearcher(reader1);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+                    aggs.add(
+                        buildInternalStreamingAggregation(
+                            new CardinalityAggregationBuilder("cardinality").field("field"),
+                            fieldType,
+                            searcher1
+                        )
+                    );
+                }
+            }
+
+            // Create second aggregation with overlapping data
+            try (IndexWriter indexWriter2 = new IndexWriter(directory2, new IndexWriterConfig())) {
+                Document doc = new Document();
+                doc.add(new SortedSetDocValuesField("field", new BytesRef("banana")));
+                indexWriter2.addDocument(doc);
+
+                doc = new Document();
+                doc.add(new SortedSetDocValuesField("field", new BytesRef("cherry")));
+                indexWriter2.addDocument(doc);
+
+                try (IndexReader reader2 = maybeWrapReaderEs(DirectoryReader.open(indexWriter2))) {
+                    IndexSearcher searcher2 = newIndexSearcher(reader2);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+                    aggs.add(
+                        buildInternalStreamingAggregation(
+                            new CardinalityAggregationBuilder("cardinality").field("field"),
+                            fieldType,
+                            searcher2
+                        )
+                    );
+                }
+            }
+
+            // Reduce the aggregations
+            InternalAggregation.ReduceContext ctx = InternalAggregation.ReduceContext.forFinalReduction(
+                new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService()),
+                getMockScriptService(),
+                b -> {},
+                PipelineTree.EMPTY
+            );
+
+            InternalAggregation reduced = aggs.get(0).reduce(aggs, ctx);
+            assertThat(reduced, instanceOf(InternalCardinality.class));
+
+            InternalCardinality cardinality = (InternalCardinality) reduced;
+            // After reducing, should have approximately 3 unique values (apple, banana, cherry)
+            assertTrue(cardinality.getValue() > 0);
+        }
+    }
+
+    public void testReduceSingleAggregation() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
+                // Add multiple documents with different values
+                for (int i = 0; i < 5; i++) {
+                    Document doc = new Document();
+                    doc.add(new SortedSetDocValuesField("field", new BytesRef("value_" + i)));
+                    indexWriter.addDocument(doc);
+                }
+
+                indexWriter.commit();
+
+                try (IndexReader reader = maybeWrapReaderEs(DirectoryReader.open(indexWriter))) {
+                    IndexSearcher searcher = newIndexSearcher(reader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("cardinality").field("field");
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        searcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    // Execute the aggregator
+                    aggregator.preCollection();
+                    assertEquals("strictly single segment", 1, searcher.getIndexReader().leaves().size());
+                    searcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+
+                    // Get the result and reduce it
+                    InternalCardinality topLevel = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+
+                    // Now perform the reduce operation
+                    MultiBucketConsumerService.MultiBucketConsumer reduceBucketConsumer =
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            Integer.MAX_VALUE,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        );
+                    InternalAggregation.ReduceContext context = InternalAggregation.ReduceContext.forFinalReduction(
+                        aggregator.context().bigArrays(),
+                        getMockScriptService(),
+                        reduceBucketConsumer,
+                        PipelineTree.EMPTY
+                    );
+
+                    InternalCardinality reduced = (InternalCardinality) topLevel.reduce(Collections.singletonList(topLevel), context);
+
+                    assertThat(reduced, notNullValue());
+                    // Should have approximately 5 unique values
+                    assertTrue(reduced.getValue() > 0);
+                }
+            }
+        }
+    }
+
+    public void testWithPrecisionThreshold() throws Exception {
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
+                // Create documents with many unique values
+                for (int i = 0; i < 100; i++) {
+                    Document document = new Document();
+                    document.add(new SortedSetDocValuesField("field", new BytesRef("value_" + i)));
+                    indexWriter.addDocument(document);
+                }
+
+                try (IndexReader indexReader = maybeWrapReaderEs(DirectoryReader.open(indexWriter))) {
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
+                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+
+                    CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("test").field("field")
+                        .precisionThreshold(100);
+
+                    StreamCardinalityAggregator aggregator = createStreamAggregator(
+                        null,
+                        aggregationBuilder,
+                        indexSearcher,
+                        createIndexSettings(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(
+                            DEFAULT_MAX_BUCKETS,
+                            new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+                        ),
+                        fieldType
+                    );
+
+                    aggregator.preCollection();
+                    assertEquals("strictly single segment", 1, indexSearcher.getIndexReader().leaves().size());
+                    indexSearcher.search(new MatchAllDocsQuery(), aggregator);
+                    aggregator.postCollection();
+
+                    InternalCardinality result = (InternalCardinality) aggregator.buildAggregations(new long[] { 0 })[0];
+
+                    assertThat(result, notNullValue());
+                    // With 100 unique values, cardinality should be close to 100
+                    assertTrue(result.getValue() > 50);
+                }
+            }
+        }
+    }
+
+    private InternalAggregation buildInternalStreamingAggregation(
+        CardinalityAggregationBuilder builder,
+        MappedFieldType fieldType,
+        IndexSearcher searcher
+    ) throws IOException {
+        StreamCardinalityAggregator aggregator = createStreamAggregator(
+            null,
+            builder,
+            searcher,
+            createIndexSettings(),
+            new MultiBucketConsumerService.MultiBucketConsumer(
+                DEFAULT_MAX_BUCKETS,
+                new NoneCircuitBreakerService().getBreaker(CircuitBreaker.REQUEST)
+            ),
+            fieldType
+        );
+
+        aggregator.preCollection();
+        assertEquals("strictly single segment", 1, searcher.getIndexReader().leaves().size());
+        searcher.search(new MatchAllDocsQuery(), aggregator);
+        aggregator.postCollection();
+        return aggregator.buildTopLevel();
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Expands streaming aggregations to cardinality aggregator. This PR ensures that we only use the Ordinals Collector while streaming and resets the value after each new batch.

### Related Issues
Resolves #19515 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
