### PR TITLE
Fix race condition when calling TranslogManager#trimUnreferencedTranslogFiles

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
@@ -170,7 +170,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
                 public void trimUnreferencedTranslogFiles() throws TranslogException {
                     final Store store = engineConfig.getStore();
                     store.incRef();
-                    try (ReleasableLock ignored = readLock.acquire()) {
+                    try (ReleasableLock ignored = writeLock.acquire()) {
                         ensureOpen();
                         final List<IndexCommit> commits = DirectoryReader.listCommits(store.directory());
                         if (commits.size() == 1 && translogStats.getTranslogSizeInBytes() > translogStats.getUncommittedSizeInBytes()) {


### PR DESCRIPTION
Fix flaky `IndexServiceTests.testAsyncTranslogTrimTaskOnClosedIndex`

### Description

**TL;DR:** This PR attempts to fix flaky `IndexServiceTests.testAsyncTranslogTrimTaskOnClosedIndex` which experiences race condition triggered by async tasks:
1. task that turns off translog retention and trims the translog (see `org.opensearch.index.shard.IndexShard#turnOffTranslogRetention` -> `AbstractRunnable#doRun`) AND 
2. the async `trim_translog` task, which is scheduled to run every 200ms for test purposes

**A bit longer version:**
It seems there are 2 threads at play here, that hit the `TranslogWriter.create` at the same time. The `TranslogWriter` could be created only once though. The full stacktrace from one of CI runs follows:
```
[2025-10-01T05:17:20,732][WARN ][o.o.i.e.Engine           ] [node_s_0] [test][0] failed engine [translog trimming failed]
org.opensearch.index.translog.TranslogException: failed to create new translog file
	at org.opensearch.index.translog.Translog.createWriter(Translog.java:594) ~[main/:?]
	at org.opensearch.index.translog.LocalTranslog.<init>(LocalTranslog.java:95) ~[main/:?]
	at org.opensearch.index.translog.InternalTranslogFactory.newTranslog(InternalTranslogFactory.java:61) ~[main/:?]
	at org.opensearch.index.engine.NoOpEngine$2.trimUnreferencedTranslogFiles(NoOpEngine.java:188) [main/:?]
	at org.opensearch.index.shard.IndexShard.trimTranslog(IndexShard.java:1641) [main/:?]
	at org.opensearch.index.shard.IndexShard$4.doRun(IndexShard.java:3278) [main/:?]
	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:975) [main/:?]
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [main/:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619) [?:?]
	at java.base/java.lang.Thread.run(Thread.java:1447) [?:?]
Caused by: java.nio.file.FileAlreadyExistsException: /var/jenkins/workspace/gradle-check/search/server/build/testrun/test/temp/org.opensearch.index.IndexServiceTests_5511701C154C04C0-001/tempDir-002/data/nodes/0/indices/iaUQDlrKT7eEbuZ412jCTg/0/translog/translog-9.tlog
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:94) ~[?:?]
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106) ~[?:?]
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111) ~[?:?]
	at java.base/sun.nio.fs.UnixFileSystemProvider.newFileChannel(UnixFileSystemProvider.java:213) ~[?:?]
	at org.apache.lucene.tests.mockfile.FilterFileSystemProvider.newFileChannel(FilterFileSystemProvider.java:206) ~[lucene-test-framework-10.3.0.jar:10.3.0 e2871287e4a378739f0b74081d124e3668347875 - 2025-09-05 20:56:14]
	at org.apache.lucene.tests.mockfile.DisableFsyncFS.newFileChannel(DisableFsyncFS.java:44) ~[lucene-test-framework-10.3.0.jar:10.3.0 e2871287e4a378739f0b74081d124e3668347875 - 2025-09-05 20:56:14]
	at org.apache.lucene.tests.mockfile.FilterFileSystemProvider.newFileChannel(FilterFileSystemProvider.java:206) ~[lucene-test-framework-10.3.0.jar:10.3.0 e2871287e4a378739f0b74081d124e3668347875 - 2025-09-05 20:56:14]
	at java.base/java.nio.channels.FileChannel.open(FileChannel.java:301) ~[?:?]
	at java.base/java.nio.channels.FileChannel.open(FileChannel.java:353) ~[?:?]
	at org.opensearch.index.translog.ChannelFactory.open(ChannelFactory.java:51) ~[main/:?]
	at org.opensearch.index.translog.TranslogWriter.create(TranslogWriter.java:228) ~[main/:?]
	at org.opensearch.index.translog.Translog.createWriter(Translog.java:575) ~[main/:?]
	... 10 more
```
a bit deeper investigation shows that the 2 async jobs mentioned above can run with an unfortunate timing, both triggering `IndexShard.trimTranslog` which in turn calls `NoOpEngine.trimUnreferencedTranslogFiles`.

The critical section in `trimUnreferencedTranslogFiles` from `NoOpEngine` though seems to be protected by an instance of the ReadLock, which essentially allows both threads to enter the critical section and try to create an instance of `TranslogWriter` using the same Translog generation.

Creating TranslogWriter with the same generation will succeed the first time but fails subsequently as the underlying file `translog-{generationId}.tlog` already exists.

**Solution:** it seems that downgrading the lock being used in the critical section from engine-scoped ReadLock to an instance of WriteLock solves the issue.

What are your thoughts, does it make sense? Is it too much to penalize translog trimming that much? 

### Related Issues
Resolves #14407

### Check List
- [ ] Functionality includes testing.
- ~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- ~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
