### PR TITLE
[Rule-based Auto-tagging] bug fix on Update Rule API with multiple attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add a toBuilder method in EngineConfig to support easy modification of configs([#19054](https://github.com/opensearch-project/OpenSearch/pull/19054))
 - Add StoreFactory plugin interface for custom Store implementations([#19091](https://github.com/opensearch-project/OpenSearch/pull/19091))
 - Use S3CrtClient for higher throughput while uploading files to S3 ([#18800](https://github.com/opensearch-project/OpenSearch/pull/18800))
+- [Rule-based Auto-tagging] bug fix on Update Rule API with multiple attributes ([#19497](https://github.com/opensearch-project/OpenSearch/pull/19497))
 - Add a dynamic setting to change skip_cache_factor and min_frequency for querycache ([#18351](https://github.com/opensearch-project/OpenSearch/issues/18351))
 - Add overload constructor for Translog to accept Channel Factory as a parameter ([#18918](https://github.com/opensearch-project/OpenSearch/pull/18918))
 - Add subdirectory-aware store module with recovery support ([#19132](https://github.com/opensearch-project/OpenSearch/pull/19132))

--- a/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/RuleUtils.java
+++ b/modules/autotagging-commons/common/src/main/java/org/opensearch/rule/RuleUtils.java
@@ -105,12 +105,16 @@ public class RuleUtils {
      */
     public static Rule composeUpdatedRule(Rule originalRule, UpdateRuleRequest request, FeatureType featureType) {
         String requestDescription = request.getDescription();
-        Map<Attribute, Set<String>> requestMap = request.getAttributeMap();
         String requestLabel = request.getFeatureValue();
+        Map<Attribute, Set<String>> requestMap = request.getAttributeMap();
+        Map<Attribute, Set<String>> updatedAttributeMap = new HashMap<>(originalRule.getAttributeMap());
+        if (requestMap != null && !requestMap.isEmpty()) {
+            updatedAttributeMap.putAll(requestMap);
+        }
         return new Rule(
             originalRule.getId(),
             requestDescription == null ? originalRule.getDescription() : requestDescription,
-            requestMap == null || requestMap.isEmpty() ? originalRule.getAttributeMap() : requestMap,
+            updatedAttributeMap,
             featureType,
             requestLabel == null ? originalRule.getFeatureValue() : requestLabel,
             Instant.now().toString()


### PR DESCRIPTION
### Description
This PR implements a bug fix for the Update Rule API used in rule-based auto-tagging.

Previously, if a rule had two attributes and an update request was sent with only one attribute, both existing attributes would be replaced. With this fix, only the specified attribute will be updated, while the others remain unchanged.

For example, 
the previous rule is 
```
{
  "description": "test1",
  "principal": {"username": ["alice"]},"index_pattern": ["my-index"],
  "workload_group": "x5_wjV3lRjWRO5tG1fydgw"
}'
```
and we only update the field `index_pattern`, the result will still have the original principal entry
```
{
  "description": "test1",
  "index_pattern": ["my-indexxx"],
  "workload_group": "x5_wjV3lRjWRO5tG1fydgw"
}'

{"id":"83e89252-7d30-30ab-8e07-082817115c08","description":"test1","index_pattern":["my-indexxx"],"principal":{"username":["alice"]},"workload_group":"x5_wjV3lRjWRO5tG1fydgw","updated_at":"2025-10-01T21:38:45.397891Z"}%     
```
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
