### PR TITLE
Configurable hash size for segment file metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add sub aggregation support for histogram aggregation using skiplist ([19438](https://github.com/opensearch-project/OpenSearch/pull/19438))
 - Optimization in String Terms Aggregation query for Large Bucket Counts([#18732](https://github.com/opensearch-project/OpenSearch/pull/18732))
 - New cluster setting search.query.max_query_string_length ([#19491](https://github.com/opensearch-project/OpenSearch/pull/19491))
+- Configurable hash size for segment file metadata ([#19499](https://github.com/opensearch-project/OpenSearch/pull/19499))
 
 ### Changed
 - Refactor `if-else` chains to use `Java 17 pattern matching switch expressions`(([#18965](https://github.com/opensearch-project/OpenSearch/pull/18965))

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -190,6 +190,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 FieldMapper.IGNORE_MALFORMED_SETTING,
                 FieldMapper.COERCE_SETTING,
                 Store.INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING,
+                Store.INDEX_STORE_METADATA_HASH_SIZE_SETTING,
                 MapperService.INDEX_MAPPER_DYNAMIC_SETTING,
                 MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING,
                 MapperService.INDEX_MAPPING_NESTED_DOCS_LIMIT_SETTING,


### PR DESCRIPTION
### Description
This change makes the metadata hash size configurable to prevent `CorruptIndexException` on large segment info files.

During recovery, for those small files, OS will do an additional safety check to compute a strong hash and limit the read bytes size to 1MB, which could cause the checksum to be 0 as it's only verifying the first 1MB data and would never reach the last 8 bytes checksum position.

The new` index.store.metadata_hash.size` setting allows users to configure appropriate hashsize limits (default: 1MB) for smaller files. Files exceeding the configured limit skip hash computation with warning logs

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
