### PR TITLE
Bugfix - BitmapIndexQuery and BitmapDocValuesQuery to support negative values

### DIFF
--- a/server/src/main/java/org/opensearch/search/query/BitmapDocValuesQuery.java
+++ b/server/src/main/java/org/opensearch/search/query/BitmapDocValuesQuery.java
@@ -51,7 +51,7 @@ public class BitmapDocValuesQuery extends Query implements Accountable {
         this.bitmap = bitmap;
         if (!bitmap.isEmpty()) {
             min = bitmap.first();
-            max = bitmap.last();
+            max = Integer.toUnsignedLong(bitmap.last());
         } else {
             min = 0; // final field
             max = 0;
@@ -71,6 +71,11 @@ public class BitmapDocValuesQuery extends Query implements Accountable {
                         @Override
                         public boolean matches() throws IOException {
                             long value = singleton.longValue();
+                            // Check if negative
+                            if (value < 0) {
+                                // add 2^32 to make it unsigned
+                                value = (1L << 32) + value;
+                            }
                             return value >= min && value <= max && bitmap.contains((int) value);
                         }
 

--- a/server/src/main/java/org/opensearch/search/query/BitmapIndexQuery.java
+++ b/server/src/main/java/org/opensearch/search/query/BitmapIndexQuery.java
@@ -31,6 +31,7 @@ import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.RamUsageEstimator;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Objects;
 
 import org.roaringbitmap.PeekableIntIterator;
@@ -71,7 +72,7 @@ public class BitmapIndexQuery extends Query implements Accountable {
 
     private static BitmapIterator bitmapEncodedIterator(RoaringBitmap bitmap) {
         return new BitmapIterator() {
-            private final PeekableIntIterator iterator = bitmap.getIntIterator();
+            private final PeekableIntIterator iterator = bitmap.getSignedIntIterator();
             private final BytesRef encoded = new BytesRef(new byte[Integer.BYTES]);
 
             public BytesRef next() {
@@ -186,6 +187,7 @@ public class BitmapIndexQuery extends Query implements Accountable {
 
         private boolean matches(byte[] packedValue) {
             while (nextQueryPoint != null) {
+                ArrayUtil.ByteArrayComparator unsignedComparator = ArrayUtil.getUnsignedComparator(nextQueryPoint.offset);
                 int cmp = comparator.compare(nextQueryPoint.bytes, nextQueryPoint.offset, packedValue, 0);
                 if (cmp == 0) {
                     return true;

--- a/server/src/main/java/org/opensearch/search/query/BitmapIndexQuery.java
+++ b/server/src/main/java/org/opensearch/search/query/BitmapIndexQuery.java
@@ -187,7 +187,6 @@ public class BitmapIndexQuery extends Query implements Accountable {
 
         private boolean matches(byte[] packedValue) {
             while (nextQueryPoint != null) {
-                ArrayUtil.ByteArrayComparator unsignedComparator = ArrayUtil.getUnsignedComparator(nextQueryPoint.offset);
                 int cmp = comparator.compare(nextQueryPoint.bytes, nextQueryPoint.offset, packedValue, 0);
                 if (cmp == 0) {
                     return true;


### PR DESCRIPTION
Bugfix - BitmapIndexQuery and BitmapDocValuesQuery to support both +ve and -ve values in same query. also add test cases for negative set of bitmaps.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Changes BitmapIndexQuery to use `bitmap.getSignedIntIterator()` instead of `bitmap.getIntIterator()`
- Changes BitmapDocValuesQuery to set max with unsigned int representation of signed integer. and adds 2^32 if the value is < 0 in `matches` method

### Related Issues
Resolves #18422
- https://github.com/opensearch-project/OpenSearch/issues/18422

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
