### PR TITLE
[RemoteStore]: Provide support for Composite repository to support SSE encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use S3CrtClient for higher throughput while uploading files to S3 ([#18800](https://github.com/opensearch-project/OpenSearch/pull/18800))
 - [Rule-based Auto-tagging] bug fix on Update Rule API with multiple attributes ([#19497](https://github.com/opensearch-project/OpenSearch/pull/19497))
 - Add a dynamic setting to change skip_cache_factor and min_frequency for querycache ([#18351](https://github.com/opensearch-project/OpenSearch/issues/18351))
+- Adding support for Composite Remote Repository. ([#19240](https://github.com/opensearch-project/OpenSearch/pull/19240))
 - Add overload constructor for Translog to accept Channel Factory as a parameter ([#18918](https://github.com/opensearch-project/OpenSearch/pull/18918))
 - Add subdirectory-aware store module with recovery support ([#19132](https://github.com/opensearch-project/OpenSearch/pull/19132))
 - [Rule-based Auto-tagging] Modify get rule api to suit nested attributes ([#19429](https://github.com/opensearch-project/OpenSearch/pull/19429))

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -371,6 +371,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     );
 
     public static final String SETTING_REMOTE_STORE_ENABLED = "index.remote_store.enabled";
+    public static final String SETTING_REMOTE_STORE_SSE_ENABLED = "index.remote_store.sse.enabled";
     public static final String SETTING_INDEX_APPEND_ONLY_ENABLED = "index.append_only.enabled";
 
     public static final String SETTING_REMOTE_SEGMENT_STORE_REPOSITORY = "index.remote_store.segment.repository";
@@ -406,6 +407,38 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             @Override
             public Iterator<Setting<?>> settings() {
                 final List<Setting<?>> settings = List.of(INDEX_REPLICATION_TYPE_SETTING);
+                return settings.iterator();
+            }
+        },
+        Property.IndexScope,
+        Property.PrivateIndex,
+        Property.Dynamic
+    );
+
+    /**
+     * Used to specify if the index data should be persisted in the remote store.
+     */
+    public static final Setting<Boolean> INDEX_REMOTE_STORE_SSE_ENABLED_SETTING = Setting.boolSetting(
+        SETTING_REMOTE_STORE_SSE_ENABLED,
+        false,
+        new Setting.Validator<>() {
+
+            @Override
+            public void validate(final Boolean value) {}
+
+            @Override
+            public void validate(final Boolean value, final Map<Setting<?>, Object> settings) {
+                final Boolean isRemoteStoreEnabled = (Boolean) settings.get(INDEX_REMOTE_STORE_ENABLED_SETTING);
+                if (!isRemoteStoreEnabled && value) {
+                    throw new IllegalArgumentException(
+                        "Server Side Encryption can be enabled when " + INDEX_REMOTE_STORE_ENABLED_SETTING.getKey() + " is enabled. "
+                    );
+                }
+            }
+
+            @Override
+            public Iterator<Setting<?>> settings() {
+                final List<Setting<?>> settings = List.of(INDEX_REMOTE_STORE_ENABLED_SETTING);
                 return settings.iterator();
             }
         },

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -241,6 +241,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
 
                 // Settings for remote store enablement
                 IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING,
+                IndexMetadata.INDEX_REMOTE_STORE_SSE_ENABLED_SETTING,
                 IndexMetadata.INDEX_REMOTE_SEGMENT_STORE_REPOSITORY_SETTING,
                 IndexMetadata.INDEX_REMOTE_TRANSLOG_REPOSITORY_SETTING,
 

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -697,7 +697,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                     }
 
                     remoteDirectory = ((RemoteSegmentStoreDirectoryFactory) remoteDirectoryFactory).newDirectory(
-                        RemoteStoreNodeAttribute.getRemoteStoreSegmentRepo(this.indexSettings.getNodeSettings()),
+                        RemoteStoreNodeAttribute.getRemoteStoreSegmentRepo(this.indexSettings.getSettings()),
                         this.indexSettings.getUUID(),
                         shardId,
                         this.indexSettings.getRemoteStorePathStrategy(),

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -950,6 +950,8 @@ public final class IndexSettings {
      */
     private final boolean isCompositeIndex;
 
+    private boolean isRemoteStoreSSEnabled;
+
     /**
      * Denotes whether search via star tree index is enabled for this index
      */
@@ -1035,6 +1037,7 @@ public final class IndexSettings {
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
         replicationType = IndexMetadata.INDEX_REPLICATION_TYPE_SETTING.get(settings);
         isRemoteStoreEnabled = settings.getAsBoolean(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, false);
+        isRemoteStoreSSEnabled = settings.getAsBoolean(IndexMetadata.SETTING_REMOTE_STORE_SSE_ENABLED, false);
 
         isWarmIndex = settings.getAsBoolean(IndexModule.IS_WARM_INDEX_SETTING.getKey(), false);
 
@@ -1239,6 +1242,9 @@ public final class IndexSettings {
         );
         scopedSettings.addSettingsUpdateConsumer(ALLOW_DERIVED_FIELDS, this::setAllowDerivedField);
         scopedSettings.addSettingsUpdateConsumer(IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING, this::setRemoteStoreEnabled);
+
+        scopedSettings.addSettingsUpdateConsumer(IndexMetadata.INDEX_REMOTE_STORE_SSE_ENABLED_SETTING, this::setRemoteStoreSseEnabled);
+
         scopedSettings.addSettingsUpdateConsumer(
             IndexMetadata.INDEX_REMOTE_SEGMENT_STORE_REPOSITORY_SETTING,
             this::setRemoteStoreRepository
@@ -1425,6 +1431,13 @@ public final class IndexSettings {
      */
     public boolean isRemoteStoreEnabled() {
         return isRemoteStoreEnabled;
+    }
+
+    /**
+     * Returns if remote store is enabled for this index.
+     */
+    public boolean isRemoteStoreSSEnabled() {
+        return isRemoteStoreSSEnabled;
     }
 
     public boolean isAssignedOnRemoteNode() {
@@ -2135,6 +2148,10 @@ public final class IndexSettings {
 
     public void setRemoteStoreEnabled(boolean isRemoteStoreEnabled) {
         this.isRemoteStoreEnabled = isRemoteStoreEnabled;
+    }
+
+    public void setRemoteStoreSseEnabled(boolean sseEnabled) {
+        this.isRemoteStoreSSEnabled = sseEnabled;
     }
 
     public void setRemoteStoreRepository(String remoteStoreRepository) {

--- a/server/src/main/java/org/opensearch/index/remote/RemoteIndexPathUploader.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteIndexPathUploader.java
@@ -234,15 +234,15 @@ public class RemoteIndexPathUploader extends IndexMetadataUploadListener {
             return;
         }
 
-        translogRepository = (BlobStoreRepository) validateAndGetRepository(RemoteStoreNodeAttribute.getRemoteStoreTranslogRepo(settings));
-        segmentRepository = (BlobStoreRepository) validateAndGetRepository(RemoteStoreNodeAttribute.getRemoteStoreSegmentRepo(settings));
+        translogRepository = (BlobStoreRepository) validateAndGetRepository(RemoteStoreNodeAttribute.getRemoteStoreTranslogRepo(false));
+        segmentRepository = (BlobStoreRepository) validateAndGetRepository(RemoteStoreNodeAttribute.getRemoteStoreSegmentRepo(false));
     }
 
     private boolean isTranslogSegmentRepoSame() {
         // TODO - The current comparison checks the repository name. But it is also possible that the repository are same
         // by attributes, but different by name. We need to handle this.
-        String translogRepoName = RemoteStoreNodeAttribute.getRemoteStoreTranslogRepo(settings);
-        String segmentRepoName = RemoteStoreNodeAttribute.getRemoteStoreSegmentRepo(settings);
+        String translogRepoName = RemoteStoreNodeAttribute.getRemoteStoreTranslogRepo(false);
+        String segmentRepoName = RemoteStoreNodeAttribute.getRemoteStoreSegmentRepo(false);
         return Objects.equals(translogRepoName, segmentRepoName);
     }
 

--- a/server/src/main/java/org/opensearch/index/remote/RemoteMigrationIndexMetadataUpdater.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteMigrationIndexMetadataUpdater.java
@@ -30,7 +30,6 @@ import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_STORE
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_REPLICATION_TYPE;
 import static org.opensearch.index.remote.RemoteStoreUtils.determineRemoteStoreCustomMetadataDuringMigration;
-import static org.opensearch.index.remote.RemoteStoreUtils.getRemoteStoreRepoName;
 
 /**
  * Utils for checking and mutating cluster state during remote migration
@@ -72,13 +71,12 @@ public class RemoteMigrationIndexMetadataUpdater {
                 "Index {} does not have remote store based index settings but all primary shards and STARTED replica shards have moved to remote enabled nodes. Applying remote store settings to the index",
                 index
             );
-            Map<String, String> remoteRepoNames = getRemoteStoreRepoName(discoveryNodes);
-            String segmentRepoName = RemoteStoreNodeAttribute.getSegmentRepoName(remoteRepoNames);
-            String tlogRepoName = RemoteStoreNodeAttribute.getTranslogRepoName(remoteRepoNames);
+            String segmentRepoName = RemoteStoreNodeAttribute.getRemoteStoreSegmentRepo(currentIndexSettings);
+            String translogRepoName = RemoteStoreNodeAttribute.getRemoteStoreTranslogRepo(currentIndexSettings);
 
-            assert Objects.nonNull(segmentRepoName) && Objects.nonNull(tlogRepoName) : "Remote repo names cannot be null";
+            assert Objects.nonNull(segmentRepoName) && Objects.nonNull(translogRepoName) : "Remote repo names cannot be null";
             Settings.Builder indexSettingsBuilder = Settings.builder().put(currentIndexSettings);
-            updateRemoteStoreSettings(indexSettingsBuilder, segmentRepoName, tlogRepoName);
+            updateRemoteStoreSettings(indexSettingsBuilder, segmentRepoName, translogRepoName);
             indexMetadataBuilder.settings(indexSettingsBuilder);
             indexMetadataBuilder.settingsVersion(1 + indexMetadata.getVersion());
         } else {

--- a/server/src/main/java/org/opensearch/index/remote/RemoteStoreCustomMetadataResolver.java
+++ b/server/src/main/java/org/opensearch/index/remote/RemoteStoreCustomMetadataResolver.java
@@ -58,10 +58,10 @@ public class RemoteStoreCustomMetadataResolver {
         return new RemoteStorePathStrategy(pathType, pathHashAlgorithm);
     }
 
-    public boolean isTranslogMetadataEnabled() {
+    public boolean isTranslogMetadataEnabled(Settings idxSettings) {
         Repository repository;
         try {
-            repository = repositoriesServiceSupplier.get().repository(getRemoteStoreTranslogRepo(settings));
+            repository = repositoriesServiceSupplier.get().repository(getRemoteStoreTranslogRepo(idxSettings));
         } catch (RepositoryMissingException ex) {
             throw new IllegalArgumentException("Repository should be created before creating index with remote_store enabled setting", ex);
         }

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -714,7 +714,7 @@ public class IndicesService extends AbstractLifecycleComponent
                 return new RemoteBlobStoreInternalTranslogFactory(
                     repositoriesServiceSupplier,
                     threadPool,
-                    RemoteStoreNodeAttribute.getRemoteStoreTranslogRepo(indexSettings.getNodeSettings()),
+                    RemoteStoreNodeAttribute.getRemoteStoreTranslogRepo(false),
                     remoteStoreStatsTrackerFactory.getRemoteTranslogTransferTracker(shardRouting.shardId()),
                     remoteStoreSettings
                 );

--- a/server/src/main/java/org/opensearch/node/remotestore/CompositeRemoteRepository.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/CompositeRemoteRepository.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.node.remotestore;
+
+import org.opensearch.cluster.metadata.RepositoryMetadata;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Composite Repository for the ServerSideEncryption support.
+ */
+public class CompositeRemoteRepository {
+
+    private final Map<RemoteStoreRepositoryType, Map<CompositeRepositoryEncryptionType, RepositoryMetadata>> repositoryEncryptionTypeMap;
+
+    public CompositeRemoteRepository() {
+        repositoryEncryptionTypeMap = new HashMap<>();
+    }
+
+    public void registerCompositeRepository(
+        final RemoteStoreRepositoryType repositoryType,
+        final CompositeRepositoryEncryptionType type,
+        final RepositoryMetadata metadata
+    ) {
+        Map<CompositeRepositoryEncryptionType, RepositoryMetadata> encryptionTypeMap = repositoryEncryptionTypeMap.get(repositoryType);
+        if (encryptionTypeMap == null) {
+            encryptionTypeMap = new HashMap<>();
+        }
+        encryptionTypeMap.put(type, metadata);
+
+        repositoryEncryptionTypeMap.put(repositoryType, encryptionTypeMap);
+    }
+
+    public RepositoryMetadata getRepository(RemoteStoreRepositoryType repositoryType, CompositeRepositoryEncryptionType encryptionType) {
+        Map<CompositeRepositoryEncryptionType, RepositoryMetadata> encTypeRepoMap = repositoryEncryptionTypeMap.get(repositoryType);
+        return encTypeRepoMap == null ? null : encTypeRepoMap.get(encryptionType);
+    }
+
+    public boolean isServerSideEncryptionEnabled() {
+        return repositoryEncryptionTypeMap.get(RemoteStoreRepositoryType.SEGMENT) != null
+            && repositoryEncryptionTypeMap.get(RemoteStoreRepositoryType.SEGMENT).containsKey(CompositeRepositoryEncryptionType.SERVER);
+    }
+
+    /**
+     * Enum for Remote store repo types
+     */
+    public enum RemoteStoreRepositoryType {
+        SEGMENT,
+        TRANSLOG
+    }
+
+    /**
+     * Enum for composite repo types
+     */
+    public enum CompositeRepositoryEncryptionType {
+        CLIENT,
+        SERVER
+    }
+}

--- a/server/src/main/java/org/opensearch/node/remotestore/RemoteStoreNodeAttribute.java
+++ b/server/src/main/java/org/opensearch/node/remotestore/RemoteStoreNodeAttribute.java
@@ -9,6 +9,7 @@
 package org.opensearch.node.remotestore;
 
 import org.opensearch.cluster.metadata.CryptoMetadata;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.RepositoriesMetadata;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -36,6 +37,12 @@ import java.util.stream.Collectors;
  * @opensearch.internal
  */
 public class RemoteStoreNodeAttribute {
+
+    private static final String REMOTE_STORE_TRANSLOG_REPO_PREFIX = "translog";
+    private static final String REMOTE_STORE_SEGMENT_REPO_PREFIX = "segment";
+
+    private static final String S3_ENCRYPTION_TYPE_KMS = "aws:kms";
+    private static final String S3_SERVER_SIDE_ENCRYPTION_TYPE = "server_side_encryption_type";
 
     public static final List<String> REMOTE_STORE_NODE_ATTRIBUTE_KEY_PREFIX = List.of("remote_store", "remote_publication");
 
@@ -74,6 +81,8 @@ public class RemoteStoreNodeAttribute {
         + CryptoMetadata.SETTINGS_KEY;
     public static final String REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX = "%s.repository.%s.settings.";
 
+    public static final String REPOSITORY_SETTINGS_SSE_ENABLED_ATTRIBUTE_KEY = "sse_enabled";
+
     private final RepositoriesMetadata repositoriesMetadata;
 
     public static List<List<String>> SUPPORTED_DATA_REPO_NAME_ATTRIBUTES = Arrays.asList(
@@ -82,15 +91,21 @@ public class RemoteStoreNodeAttribute {
     );
 
     public static final String REMOTE_STORE_MODE_KEY = "remote_store.mode";
+    public static final String REMOTE_STORE_SSE_REPO_SUFFIX = "-sse";
+
+    private static CompositeRemoteRepository compositeRemoteRepository;
+    private static Map<String, RepositoryMetadata> repositoryMetadataMap;
 
     /**
      * Creates a new {@link RemoteStoreNodeAttribute}
      */
     public RemoteStoreNodeAttribute(DiscoveryNode node) {
+        repositoryMetadataMap = new HashMap<>();
+        compositeRemoteRepository = new CompositeRemoteRepository();
         this.repositoriesMetadata = buildRepositoriesMetadata(node);
     }
 
-    private String validateAttributeNonNull(DiscoveryNode node, String attributeKey) {
+    private String getAndValidateNodeAttribute(DiscoveryNode node, String attributeKey) {
         String attributeValue = node.getAttributes().get(attributeKey);
         if (attributeValue == null || attributeValue.isEmpty()) {
             throw new IllegalStateException("joining node [" + node + "] doesn't have the node attribute [" + attributeKey + "]");
@@ -99,7 +114,7 @@ public class RemoteStoreNodeAttribute {
         return attributeValue;
     }
 
-    private Tuple<String, String> validateAttributeNonNull(DiscoveryNode node, List<String> attributeKeys) {
+    private Tuple<String, String> getAndValidateNodeAttributeEntries(DiscoveryNode node, List<String> attributeKeys) {
         Tuple<String, String> attributeValue = getValue(node.getAttributes(), attributeKeys);
         if (attributeValue == null || attributeValue.v1() == null || attributeValue.v1().isEmpty()) {
             throw new IllegalStateException("joining node [" + node + "] doesn't have the node attribute [" + attributeKeys.get(0) + "]");
@@ -115,8 +130,8 @@ public class RemoteStoreNodeAttribute {
             return null;
         }
 
-        String keyProviderName = validateAttributeNonNull(node, metadataKey + "." + CryptoMetadata.KEY_PROVIDER_NAME_KEY);
-        String keyProviderType = validateAttributeNonNull(node, metadataKey + "." + CryptoMetadata.KEY_PROVIDER_TYPE_KEY);
+        String keyProviderName = getAndValidateNodeAttribute(node, metadataKey + "." + CryptoMetadata.KEY_PROVIDER_NAME_KEY);
+        String keyProviderType = getAndValidateNodeAttribute(node, metadataKey + "." + CryptoMetadata.KEY_PROVIDER_TYPE_KEY);
 
         String settingsAttributeKeyPrefix = String.format(Locale.getDefault(), REPOSITORY_CRYPTO_SETTINGS_PREFIX, prefix, repositoryName);
 
@@ -132,7 +147,7 @@ public class RemoteStoreNodeAttribute {
         return new CryptoMetadata(keyProviderName, keyProviderType, settings.build());
     }
 
-    private Map<String, String> validateSettingsAttributesNonNull(DiscoveryNode node, String repositoryName, String prefix) {
+    private Map<String, String> getSettingAttribute(DiscoveryNode node, String repositoryName, String prefix) {
         String settingsAttributeKeyPrefix = String.format(
             Locale.getDefault(),
             REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
@@ -143,7 +158,7 @@ public class RemoteStoreNodeAttribute {
             .keySet()
             .stream()
             .filter(key -> key.startsWith(settingsAttributeKeyPrefix))
-            .collect(Collectors.toMap(key -> key.replace(settingsAttributeKeyPrefix, ""), key -> validateAttributeNonNull(node, key)));
+            .collect(Collectors.toMap(key -> key.replace(settingsAttributeKeyPrefix, ""), key -> getAndValidateNodeAttribute(node, key)));
 
         if (settingsMap.isEmpty()) {
             throw new IllegalStateException(
@@ -154,12 +169,13 @@ public class RemoteStoreNodeAttribute {
         return settingsMap;
     }
 
-    private RepositoryMetadata buildRepositoryMetadata(DiscoveryNode node, String name, String prefix) {
-        String type = validateAttributeNonNull(
+    private List<RepositoryMetadata> buildRepositoryMetadata(DiscoveryNode node, String name, String prefix) {
+        List<RepositoryMetadata> repoList = new ArrayList<>();
+        String type = getAndValidateNodeAttribute(
             node,
             String.format(Locale.getDefault(), REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT, prefix, name)
         );
-        Map<String, String> settingsMap = validateSettingsAttributesNonNull(node, name, prefix);
+        Map<String, String> settingsMap = getSettingAttribute(node, name, prefix);
 
         Settings.Builder settings = Settings.builder();
         settingsMap.forEach(settings::put);
@@ -168,19 +184,72 @@ public class RemoteStoreNodeAttribute {
 
         // Repository metadata built here will always be for a system repository.
         settings.put(BlobStoreRepository.SYSTEM_REPOSITORY_SETTING.getKey(), true);
+        repoList.add(new RepositoryMetadata(name, type, settings.build(), cryptoMetadata));
 
-        return new RepositoryMetadata(name, type, settings.build(), cryptoMetadata);
+        if (settingsMap.containsKey(REPOSITORY_SETTINGS_SSE_ENABLED_ATTRIBUTE_KEY)) {
+            Settings.Builder sseSetting = Settings.builder();
+            settingsMap.forEach(sseSetting::put);
+
+            // Repository metadata built here will always be for a system repository.
+            sseSetting.put(BlobStoreRepository.SYSTEM_REPOSITORY_SETTING.getKey(), true);
+            sseSetting.put(REPOSITORY_SETTINGS_SSE_ENABLED_ATTRIBUTE_KEY, true);
+            sseSetting.put(S3_SERVER_SIDE_ENCRYPTION_TYPE, S3_ENCRYPTION_TYPE_KMS);
+            repoList.add(new RepositoryMetadata(getServerSideEncryptedRepoName(name), type, sseSetting.build()));
+        }
+        return repoList;
     }
 
     private RepositoriesMetadata buildRepositoriesMetadata(DiscoveryNode node) {
-        Map<String, String> repositoryNamesWithPrefix = getValidatedRepositoryNames(node);
+        Map<String, String> remoteStoryTypeToRepoNameMap = new HashMap<>();
+        Map<String, String> repositoryNamesWithPrefix = getValidatedRepositoryNames(node, remoteStoryTypeToRepoNameMap);
         List<RepositoryMetadata> repositoryMetadataList = new ArrayList<>();
 
         for (Map.Entry<String, String> repository : repositoryNamesWithPrefix.entrySet()) {
-            repositoryMetadataList.add(buildRepositoryMetadata(node, repository.getKey(), repository.getValue()));
+            List<RepositoryMetadata> repoList = buildRepositoryMetadata(node, repository.getKey(), repository.getValue());
+            RepositoryMetadata nonSSERepository = repoList.getFirst();
+
+            repositoryMetadataList.add(nonSSERepository);
+            repositoryMetadataMap.put(nonSSERepository.name(), nonSSERepository);
+
+            if (repoList.size() > 1 && isCompositeRepository(repoList.getLast())) {
+                RepositoryMetadata sseRepository = repoList.getLast();
+                repositoryMetadataMap.put(sseRepository.name(), sseRepository);
+                repositoryMetadataList.add(sseRepository);
+            }
         }
 
+        // Let's Iterate over repo's and build Composite Repository structure
+        for (Map.Entry<String, String> repositoryTypeToNameEntry : remoteStoryTypeToRepoNameMap.entrySet()) {
+            CompositeRemoteRepository.CompositeRepositoryEncryptionType encryptionType =
+                CompositeRemoteRepository.CompositeRepositoryEncryptionType.CLIENT;
+            CompositeRemoteRepository.RemoteStoreRepositoryType remoteStoreRepositoryType =
+                CompositeRemoteRepository.RemoteStoreRepositoryType.SEGMENT;
+            if (repositoryTypeToNameEntry.getKey().contains(REMOTE_STORE_TRANSLOG_REPO_PREFIX)) {
+                remoteStoreRepositoryType = CompositeRemoteRepository.RemoteStoreRepositoryType.TRANSLOG;
+            }
+
+            String repositoryName = repositoryTypeToNameEntry.getValue();
+            compositeRemoteRepository.registerCompositeRepository(
+                remoteStoreRepositoryType,
+                encryptionType,
+                repositoryMetadataMap.get(repositoryName)
+            );
+
+            String sseRepositoryName = getServerSideEncryptedRepoName(repositoryTypeToNameEntry.getValue());
+            if (repositoryMetadataMap.containsKey(sseRepositoryName)) {
+                encryptionType = CompositeRemoteRepository.CompositeRepositoryEncryptionType.SERVER;
+                compositeRemoteRepository.registerCompositeRepository(
+                    remoteStoreRepositoryType,
+                    encryptionType,
+                    repositoryMetadataMap.get(sseRepositoryName)
+                );
+            }
+        }
         return new RepositoriesMetadata(repositoryMetadataList);
+    }
+
+    private boolean isCompositeRepository(RepositoryMetadata repositoryMetadata) {
+        return repositoryMetadata.settings().hasValue(REPOSITORY_SETTINGS_SSE_ENABLED_ATTRIBUTE_KEY);
     }
 
     private static Tuple<String, String> getValue(Map<String, String> attributes, List<String> keys) {
@@ -197,7 +266,7 @@ public class RemoteStoreNodeAttribute {
         DEFAULT
     }
 
-    private Map<String, String> getValidatedRepositoryNames(DiscoveryNode node) {
+    private Map<String, String> getValidatedRepositoryNames(DiscoveryNode node, Map<String, String> remoteStoryTypeToRepoNameMap) {
         Set<Tuple<String, String>> repositoryNames = new HashSet<>();
         RemoteStoreMode remoteStoreMode = RemoteStoreMode.DEFAULT;
         if (containsKey(node.getAttributes(), List.of(REMOTE_STORE_MODE_KEY))) {
@@ -208,15 +277,35 @@ public class RemoteStoreNodeAttribute {
                 throw new IllegalStateException("Unknown remote store mode [" + mode + "] for node [" + node + "]");
             }
         }
+
         if (remoteStoreMode == RemoteStoreMode.SEGMENTS_ONLY) {
-            repositoryNames.add(validateAttributeNonNull(node, REMOTE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEYS));
+            addRepositoryNames(
+                node,
+                remoteStoryTypeToRepoNameMap,
+                repositoryNames,
+                REMOTE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEYS,
+                REMOTE_STORE_SEGMENT_REPO_PREFIX
+            );
         } else if (containsKey(node.getAttributes(), REMOTE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEYS)
             || containsKey(node.getAttributes(), REMOTE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEYS)) {
-                repositoryNames.add(validateAttributeNonNull(node, REMOTE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEYS));
-                repositoryNames.add(validateAttributeNonNull(node, REMOTE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEYS));
-                repositoryNames.add(validateAttributeNonNull(node, REMOTE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEYS));
+                addRepositoryNames(
+                    node,
+                    remoteStoryTypeToRepoNameMap,
+                    repositoryNames,
+                    REMOTE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEYS,
+                    REMOTE_STORE_SEGMENT_REPO_PREFIX
+                );
+                addRepositoryNames(
+                    node,
+                    remoteStoryTypeToRepoNameMap,
+                    repositoryNames,
+                    REMOTE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEYS,
+                    REMOTE_STORE_TRANSLOG_REPO_PREFIX
+                );
+
+                repositoryNames.add(getAndValidateNodeAttributeEntries(node, REMOTE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEYS));
             } else if (containsKey(node.getAttributes(), REMOTE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEYS)) {
-                repositoryNames.add(validateAttributeNonNull(node, REMOTE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEYS));
+                repositoryNames.add(getAndValidateNodeAttributeEntries(node, REMOTE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEYS));
             }
         if (containsKey(node.getAttributes(), REMOTE_ROUTING_TABLE_REPOSITORY_NAME_ATTRIBUTE_KEYS)) {
             if (remoteStoreMode == RemoteStoreMode.SEGMENTS_ONLY) {
@@ -228,7 +317,7 @@ public class RemoteStoreNodeAttribute {
                         + "]"
                 );
             }
-            repositoryNames.add(validateAttributeNonNull(node, REMOTE_ROUTING_TABLE_REPOSITORY_NAME_ATTRIBUTE_KEYS));
+            repositoryNames.add(getAndValidateNodeAttributeEntries(node, REMOTE_ROUTING_TABLE_REPOSITORY_NAME_ATTRIBUTE_KEYS));
         }
 
         Map<String, String> repoNamesWithPrefix = new HashMap<>();
@@ -236,8 +325,19 @@ public class RemoteStoreNodeAttribute {
             String[] attrKeyParts = t.v2().split("\\.");
             repoNamesWithPrefix.put(t.v1(), attrKeyParts[0]);
         });
-
         return repoNamesWithPrefix;
+    }
+
+    private void addRepositoryNames(
+        DiscoveryNode node,
+        Map<String, String> remoteStoryTypeToRepoNameMap,
+        Set<Tuple<String, String>> repositoryNames,
+        List<String> attributeKeys,
+        String remoteStoreRepoPrefix
+    ) {
+        Tuple<String, String> remoteStoreAttributeKeyMap = getAndValidateNodeAttributeEntries(node, attributeKeys);
+        remoteStoryTypeToRepoNameMap.put(remoteStoreRepoPrefix, remoteStoreAttributeKeyMap.v1());
+        repositoryNames.add(remoteStoreAttributeKeyMap);
     }
 
     public static boolean isRemoteStoreAttributePresent(Settings settings) {
@@ -280,22 +380,8 @@ public class RemoteStoreNodeAttribute {
         return false;
     }
 
-    public static String getRemoteStoreSegmentRepo(Settings settings) {
-        for (String prefix : REMOTE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEYS) {
-            if (settings.get(Node.NODE_ATTRIBUTES.getKey() + prefix) != null) {
-                return settings.get(Node.NODE_ATTRIBUTES.getKey() + prefix);
-            }
-        }
-        return null;
-    }
-
-    public static String getRemoteStoreTranslogRepo(Settings settings) {
-        for (String prefix : REMOTE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEYS) {
-            if (settings.get(Node.NODE_ATTRIBUTES.getKey() + prefix) != null) {
-                return settings.get(Node.NODE_ATTRIBUTES.getKey() + prefix);
-            }
-        }
-        return null;
+    public static boolean isRemoteStoreServerSideEncryptionEnabled() {
+        return compositeRemoteRepository != null && compositeRemoteRepository.isServerSideEncryptionEnabled();
     }
 
     public static boolean isRemoteStoreClusterStateEnabled(Settings settings) {
@@ -355,12 +441,69 @@ public class RemoteStoreNodeAttribute {
         return getValueFromAnyKey(repos, REMOTE_ROUTING_TABLE_REPOSITORY_NAME_ATTRIBUTE_KEYS);
     }
 
-    public static String getSegmentRepoName(Map<String, String> repos) {
-        return getValueFromAnyKey(repos, REMOTE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEYS);
+    private static String getRemoteStoreSegmentRepoFromNodeAttribute(Settings settings) {
+        for (String prefix : REMOTE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEYS) {
+            if (settings.get(Node.NODE_ATTRIBUTES.getKey() + prefix) != null) {
+                return settings.get(Node.NODE_ATTRIBUTES.getKey() + prefix);
+            }
+        }
+        return null;
     }
 
-    public static String getTranslogRepoName(Map<String, String> repos) {
-        return getValueFromAnyKey(repos, REMOTE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEYS);
+    private static String getRemoteStoreTranslogRepoFromNodeAttribute(Settings settings) {
+        for (String prefix : REMOTE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEYS) {
+            if (settings.get(Node.NODE_ATTRIBUTES.getKey() + prefix) != null) {
+                return settings.get(Node.NODE_ATTRIBUTES.getKey() + prefix);
+            }
+        }
+        return null;
+    }
+
+    public static String getRemoteStoreSegmentRepo(boolean serverSideEncryptionEnabled) {
+        if (compositeRemoteRepository == null) {
+            return null;
+        }
+
+        CompositeRemoteRepository.RemoteStoreRepositoryType repositoryType = CompositeRemoteRepository.RemoteStoreRepositoryType.SEGMENT;
+        CompositeRemoteRepository.CompositeRepositoryEncryptionType encryptionType =
+            CompositeRemoteRepository.CompositeRepositoryEncryptionType.CLIENT;
+        if (serverSideEncryptionEnabled) {
+            encryptionType = CompositeRemoteRepository.CompositeRepositoryEncryptionType.SERVER;
+        }
+        RepositoryMetadata repositoryMetadata = compositeRemoteRepository.getRepository(repositoryType, encryptionType);
+        return repositoryMetadata == null ? null : repositoryMetadata.name();
+    }
+
+    public static String getRemoteStoreSegmentRepo(Settings indexSettings) {
+        // If already set in index setting no need to check composite repository.
+        String segRepo = indexSettings.get(IndexMetadata.SETTING_REMOTE_SEGMENT_STORE_REPOSITORY);
+        if (segRepo != null) {
+            return segRepo;
+        }
+        return getRemoteStoreSegmentRepo(indexSettings.getAsBoolean(IndexMetadata.SETTING_REMOTE_STORE_SSE_ENABLED, false));
+    }
+
+    public static String getRemoteStoreTranslogRepo(boolean serverSideEncryptionEnabled) {
+        if (compositeRemoteRepository == null) {
+            return null;
+        }
+
+        CompositeRemoteRepository.RemoteStoreRepositoryType repositoryType = CompositeRemoteRepository.RemoteStoreRepositoryType.TRANSLOG;
+        CompositeRemoteRepository.CompositeRepositoryEncryptionType encryptionType =
+            CompositeRemoteRepository.CompositeRepositoryEncryptionType.CLIENT;
+        if (serverSideEncryptionEnabled) {
+            encryptionType = CompositeRemoteRepository.CompositeRepositoryEncryptionType.SERVER;
+        }
+        RepositoryMetadata repositoryMetadata = compositeRemoteRepository.getRepository(repositoryType, encryptionType);
+        return repositoryMetadata == null ? null : repositoryMetadata.name();
+    }
+
+    public static String getRemoteStoreTranslogRepo(Settings indexSettings) {
+        String translogRepository = indexSettings.get(IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY);
+        if (translogRepository != null) {
+            return translogRepository;
+        }
+        return getRemoteStoreTranslogRepo(indexSettings.getAsBoolean(IndexMetadata.SETTING_REMOTE_STORE_SSE_ENABLED, false));
     }
 
     private static String getValueFromAnyKey(Map<String, String> repos, List<String> keys) {
@@ -399,6 +542,10 @@ public class RemoteStoreNodeAttribute {
 
     public static boolean isSegmentRepoConfigured(Map<String, String> attributes) {
         return containsKey(attributes, REMOTE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEYS);
+    }
+
+    public static String getServerSideEncryptedRepoName(String remoteRepoName) {
+        return remoteRepoName + REMOTE_STORE_SSE_REPO_SUFFIX;
     }
 
     private static boolean containsKey(Map<String, String> attributes, List<String> keys) {

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -93,6 +93,7 @@ import org.opensearch.indices.ShardLimitValidator;
 import org.opensearch.indices.SystemIndexDescriptor;
 import org.opensearch.indices.SystemIndices;
 import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
 import org.opensearch.node.remotestore.RemoteStoreNodeService;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
@@ -1396,9 +1397,12 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
     }
 
     public void testRemoteStoreNoUserOverrideExceptReplicationTypeSegmentIndexSettings() {
-        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
-            .nodes(DiscoveryNodes.builder().add(getRemoteNode()).build())
-            .build();
+        DiscoveryNode node = getRemoteNode();
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).nodes(DiscoveryNodes.builder().add(node).build()).build();
+
+        RemoteStoreNodeAttribute remoteStoreNodeAttribute = new RemoteStoreNodeAttribute(node);
+        assert remoteStoreNodeAttribute.getRepositoriesMetadata() != null;
+
         Settings settings = Settings.builder().put(translogRepositoryNameAttributeKey, "my-translog-repo-1").build();
         request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
         final Settings.Builder requestSettings = Settings.builder();
@@ -1426,9 +1430,14 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
     }
 
     public void testRemoteStoreImplicitOverrideReplicationTypeToSegmentForRemoteStore() {
+        DiscoveryNode node = getRemoteNode();
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder().add(getRemoteNode()).build())
             .build();
+
+        RemoteStoreNodeAttribute remoteStoreNodeAttribute = new RemoteStoreNodeAttribute(node);
+        assert remoteStoreNodeAttribute.getRepositoriesMetadata() != null;
+
         Settings settings = Settings.builder().put(translogRepositoryNameAttributeKey, "my-translog-repo-1").build();
         request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
         final Settings.Builder requestSettings = Settings.builder();
@@ -1455,9 +1464,12 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
     }
 
     public void testRemoteStoreNoUserOverrideIndexSettings() {
-        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
-            .nodes(DiscoveryNodes.builder().add(getRemoteNode()).build())
-            .build();
+        DiscoveryNode node = getRemoteNode();
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).nodes(DiscoveryNodes.builder().add(node).build()).build();
+
+        RemoteStoreNodeAttribute remoteStoreNodeAttribute = new RemoteStoreNodeAttribute(node);
+        assert remoteStoreNodeAttribute.getRepositoriesMetadata() != null;
+
         Settings settings = Settings.builder().put(translogRepositoryNameAttributeKey, "my-translog-repo-1").build();
         request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
         Settings indexSettings = aggregateIndexSettings(
@@ -1630,6 +1642,8 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
 
         // remote data node
         DiscoveryNode remoteDataNode = getRemoteNode();
+        RemoteStoreNodeAttribute remoteStoreNodeAttribute = new RemoteStoreNodeAttribute(remoteDataNode);
+        assert remoteStoreNodeAttribute.getRepositoriesMetadata() != null;
 
         discoveryNodes = DiscoveryNodes.builder(discoveryNodes).add(remoteDataNode).localNodeId(remoteDataNode.getId()).build();
 
@@ -1663,6 +1677,10 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             null
         );
 
+    }
+
+    @LockFeatureFlag(REMOTE_STORE_MIGRATION_EXPERIMENTAL)
+    public void testNewIndexIsRemoteStoreBackedForRemoteStoreDirectionAndMixedMode_ExpectException() {
         Map<String, String> missingTranslogAttribute = Map.of(
             REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY,
             "cluster-state-repo-1",
@@ -1670,20 +1688,35 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             "my-segment-repo-1"
         );
 
-        DiscoveryNodes finalDiscoveryNodes = DiscoveryNodes.builder()
+        // non-remote cluster manager node
+        DiscoveryNode nonRemoteClusterManagerNode = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+
+        DiscoveryNodes discoveryNodes = DiscoveryNodes.builder()
             .add(nonRemoteClusterManagerNode)
-            .add(
-                new DiscoveryNode(
-                    UUIDs.base64UUID(),
-                    buildNewFakeTransportAddress(),
-                    missingTranslogAttribute,
-                    Set.of(DiscoveryNodeRole.INGEST_ROLE, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE, DiscoveryNodeRole.DATA_ROLE),
-                    Version.CURRENT
-                )
-            )
+            .localNodeId(nonRemoteClusterManagerNode.getId())
             .build();
 
+        DiscoveryNode missingTranslogNode = new DiscoveryNode(
+            UUIDs.base64UUID(),
+            buildNewFakeTransportAddress(),
+            missingTranslogAttribute,
+            Set.of(DiscoveryNodeRole.INGEST_ROLE, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE, DiscoveryNodeRole.DATA_ROLE),
+            Version.CURRENT
+        );
+        try {
+            RemoteStoreNodeAttribute remoteStoreNodeAttribute = new RemoteStoreNodeAttribute(missingTranslogNode);
+        } catch (Exception e) {
+            // Just eatup the validation exception
+        }
+
+        DiscoveryNodes finalDiscoveryNodes = DiscoveryNodes.builder().add(nonRemoteClusterManagerNode).add(missingTranslogNode).build();
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test-index", "test-index");
         ClusterState finalClusterState = ClusterState.builder(ClusterName.DEFAULT).nodes(finalDiscoveryNodes).build();
+        Settings remoteStoreMigrationSettings = Settings.builder()
+            .put(REMOTE_STORE_COMPATIBILITY_MODE_SETTING.getKey(), RemoteStoreNodeService.CompatibilityMode.MIXED)
+            .put(MIGRATION_DIRECTION_SETTING.getKey(), RemoteStoreNodeService.Direction.REMOTE_STORE)
+            .build();
+        clusterSettings = new ClusterSettings(remoteStoreMigrationSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         ClusterSettings finalClusterSettings = clusterSettings;
 
         final IndexCreationException error = expectThrows(IndexCreationException.class, () -> {
@@ -1702,7 +1735,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         assertEquals(error.getMessage(), "failed to create index [test-index]");
         assertThat(
             error.getCause().getMessage(),
-            containsString("Cluster is migrating to remote store but remote translog is not configured, failing index creation")
+            containsString("Cluster is migrating to remote store but no remote node found, failing index creation")
         );
     }
 
@@ -2701,9 +2734,60 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
 
     private DiscoveryNode getRemoteNode() {
         Map<String, String> attributes = new HashMap<>();
-        attributes.put(REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY, "my-cluster-rep-1");
-        attributes.put(REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY, "my-segment-repo-1");
-        attributes.put(REMOTE_STORE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEY, "my-translog-repo-1");
+        attributes.put(RemoteStoreNodeAttribute.REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY, "my-segment-repo-1");
+        attributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT,
+                "my-segment-repo-1"
+            ),
+            "s3"
+        );
+        attributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                "my-segment-repo-1"
+            ) + "bucket",
+            "test-bucket"
+        );
+
+        attributes.put(RemoteStoreNodeAttribute.REMOTE_STORE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEY, "my-translog-repo-1");
+        attributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT,
+                "my-translog-repo-1"
+            ),
+            "s3"
+        );
+        attributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                "my-translog-repo-1"
+            ) + "bucket",
+            "test-bucket"
+        );
+
+        attributes.put(RemoteStoreNodeAttribute.REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY, "my-cluster-rep-1");
+        attributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT,
+                "my-cluster-rep-1"
+            ),
+            "s3"
+        );
+        attributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                "my-cluster-rep-1"
+            ) + "bucket",
+            "test-bucket"
+        );
+
         return new DiscoveryNode(
             UUIDs.base64UUID(),
             buildNewFakeTransportAddress(),

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreCustomMetadataResolverTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreCustomMetadataResolverTests.java
@@ -196,7 +196,7 @@ public class RemoteStoreCustomMetadataResolverTests extends OpenSearchTestCase {
             () -> repositoriesService,
             settings
         );
-        assertTrue(resolver.isTranslogMetadataEnabled());
+        assertTrue(resolver.isTranslogMetadataEnabled(settings));
     }
 
     public void testTranslogMetadataAllowedFalseWithMinVersionNewer() {
@@ -209,7 +209,7 @@ public class RemoteStoreCustomMetadataResolverTests extends OpenSearchTestCase {
             () -> repositoriesService,
             settings
         );
-        assertFalse(resolver.isTranslogMetadataEnabled());
+        assertFalse(resolver.isTranslogMetadataEnabled(settings));
     }
 
     public void testTranslogMetadataAllowedMinVersionOlder() {
@@ -222,7 +222,7 @@ public class RemoteStoreCustomMetadataResolverTests extends OpenSearchTestCase {
             () -> repositoriesService,
             settings
         );
-        assertFalse(resolver.isTranslogMetadataEnabled());
+        assertFalse(resolver.isTranslogMetadataEnabled(settings));
     }
 
     public void testTranslogPathFixedPathSetting() {

--- a/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
+++ b/server/src/test/java/org/opensearch/index/remote/RemoteStoreUtilsTests.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -458,6 +459,9 @@ public class RemoteStoreUtilsTests extends OpenSearchTestCase {
             .nodes(discoveryNodes)
             .routingTable(createRoutingTableAllShardsStarted(migratedIndex, 1, 1, remoteNode1, remoteNode2))
             .build();
+        RemoteStoreNodeAttribute remoteStoreNodeAttribute = new RemoteStoreNodeAttribute(remoteNode1);
+        assert remoteStoreNodeAttribute.getRepositoriesMetadata() != null;
+
         Metadata mutatedMetadata = finalizeMigration(clusterStateWithDocrepIndexSettings, logger).metadata();
         assertTrue(mutatedMetadata.index(migratedIndex).getVersion() > docrepIdxMetadata.index(migratedIndex).getVersion());
         assertRemoteSettingsApplied(mutatedMetadata.index(migratedIndex));
@@ -544,6 +548,82 @@ public class RemoteStoreUtilsTests extends OpenSearchTestCase {
         remoteStoreNodeAttributes.put(REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY, "my-cluster-repo-1");
         remoteStoreNodeAttributes.put(REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY, "my-segment-repo-1");
         remoteStoreNodeAttributes.put(REMOTE_STORE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEY, "my-translog-repo-1");
+
+        remoteStoreNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT,
+                "my-segment-repo-1"
+            ),
+            "s3"
+        );
+        remoteStoreNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT,
+                "my-translog-repo-1"
+            ),
+            "s3"
+        );
+        remoteStoreNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT,
+                "my-cluster-repo-1"
+            ),
+            "s3"
+        );
+
+        remoteStoreNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                "my-segment-repo-1"
+            ) + "bucket",
+            "test-bucket"
+        );
+        remoteStoreNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                "my-segment-repo-1"
+            ) + "path",
+            "test-path"
+        );
+
+        remoteStoreNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                "my-translog-repo-1"
+            ) + "bucket",
+            "test-bucket"
+        );
+        remoteStoreNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                "my-translog-repo-1"
+            ) + "path",
+            "test-path"
+        );
+
+        remoteStoreNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                "my-cluster-repo-1"
+            ) + "bucket",
+            "test-bucket"
+        );
+        remoteStoreNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                "my-cluster-repo-1"
+            ) + "path",
+            "test-path"
+        );
         return remoteStoreNodeAttributes;
     }
 

--- a/server/src/test/java/org/opensearch/index/store/BaseRemoteSegmentStoreDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/index/store/BaseRemoteSegmentStoreDirectoryTests.java
@@ -68,6 +68,9 @@ public class BaseRemoteSegmentStoreDirectoryTests extends IndexShardTestCase {
         Settings indexSettings = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, org.opensearch.Version.CURRENT)
             .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, true)
+            .put(IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY, "test-tlog-repo")
+            .put(IndexMetadata.SETTING_REMOTE_SEGMENT_STORE_REPOSITORY, "test-seg-repo")
             .build();
         ExecutorService executorService = OpenSearchExecutors.newDirectExecutorService();
 

--- a/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryWithPinnedTimestampTests.java
+++ b/server/src/test/java/org/opensearch/index/store/RemoteSegmentStoreDirectoryWithPinnedTimestampTests.java
@@ -56,12 +56,15 @@ public class RemoteSegmentStoreDirectoryWithPinnedTimestampTests extends RemoteS
 
         Supplier<RepositoriesService> repositoriesServiceSupplier = mock(Supplier.class);
         Settings settings = Settings.builder()
-            .put(Node.NODE_ATTRIBUTES.getKey() + RemoteStoreNodeAttribute.REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY, "remote-repo")
+            .put(
+                Node.NODE_ATTRIBUTES.getKey() + RemoteStoreNodeAttribute.REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY,
+                "segment-test-repo"
+            )
             .build();
         RepositoriesService repositoriesService = mock(RepositoriesService.class);
         when(repositoriesServiceSupplier.get()).thenReturn(repositoriesService);
         BlobStoreRepository blobStoreRepository = mock(BlobStoreRepository.class);
-        when(repositoriesService.repository("remote-repo")).thenReturn(blobStoreRepository);
+        when(repositoriesService.repository("segment-test-repo")).thenReturn(blobStoreRepository);
 
         when(threadPool.schedule(any(), any(), any())).then(invocationOnMock -> {
             updatePinnedTimstampTask = invocationOnMock.getArgument(0);

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTimestampAwareTranslogTests.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.opensearch.action.LatchedActionListener;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobMetadata;
@@ -50,6 +51,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -83,21 +85,94 @@ public class RemoteFsTimestampAwareTranslogTests extends RemoteFsTranslogTests {
 
     @Before
     public void setUp() throws Exception {
+        Supplier<RepositoriesService> repositoriesServiceSupplier = mock(Supplier.class);
+        Settings settings = Settings.builder()
+            .put(
+                Node.NODE_ATTRIBUTES.getKey() + RemoteStoreNodeAttribute.REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY,
+                "segment-test-repo"
+            )
+            .put(
+                Node.NODE_ATTRIBUTES.getKey() + String.format(
+                    Locale.getDefault(),
+                    RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT,
+                    "segment-test-repo"
+                ),
+                "s3"
+            )
+            .put(
+                Node.NODE_ATTRIBUTES.getKey()
+                    + String.format(
+                        Locale.getDefault(),
+                        RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                        "segment-test-repo"
+                    )
+                    + "bucket",
+                "test-bucket"
+            )
+
+            .put(
+                Node.NODE_ATTRIBUTES.getKey() + RemoteStoreNodeAttribute.REMOTE_STORE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEY,
+                "tlog-test-repo"
+            )
+            .put(
+                Node.NODE_ATTRIBUTES.getKey() + String.format(
+                    Locale.getDefault(),
+                    RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT,
+                    "tlog-test-repo"
+                ),
+                "s3"
+            )
+            .put(
+                Node.NODE_ATTRIBUTES.getKey()
+                    + String.format(
+                        Locale.getDefault(),
+                        RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                        "tlog-test-repo"
+                    )
+                    + "bucket",
+                "test-bucket"
+            )
+
+            .put(
+                Node.NODE_ATTRIBUTES.getKey() + RemoteStoreNodeAttribute.REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY,
+                "state-test-repo"
+            )
+            .put(
+                Node.NODE_ATTRIBUTES.getKey() + String.format(
+                    Locale.getDefault(),
+                    RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT,
+                    "state-test-repo"
+                ),
+                "s3"
+            )
+            .put(
+                Node.NODE_ATTRIBUTES.getKey()
+                    + String.format(
+                        Locale.getDefault(),
+                        RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                        "state-test-repo"
+                    )
+                    + "bucket",
+                "test-bucket"
+            )
+
+            .build();
+        RepositoriesService repositoriesService = mock(RepositoriesService.class);
+        when(repositoriesServiceSupplier.get()).thenReturn(repositoriesService);
+        BlobStoreRepository blobStoreRepository = mock(BlobStoreRepository.class);
+        when(repositoriesService.repository("segment-test-repo")).thenReturn(blobStoreRepository);
+        when(repositoriesService.repository("tlog-test-repo")).thenReturn(blobStoreRepository);
+
+        DiscoveryNode node = Mockito.mock(DiscoveryNode.class);
+        when(node.getAttributes()).thenReturn(Node.NODE_ATTRIBUTES.getAsMap(settings));
+        RemoteStoreNodeAttribute remoteStoreNodeAttribute = new RemoteStoreNodeAttribute(node);
+
         super.setUp();
 
         RemoteStoreSettings remoteStoreSettings = new RemoteStoreSettings(
             Settings.builder().put(CLUSTER_REMOTE_STORE_PINNED_TIMESTAMP_ENABLED.getKey(), true).build(),
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
         );
-
-        Supplier<RepositoriesService> repositoriesServiceSupplier = mock(Supplier.class);
-        Settings settings = Settings.builder()
-            .put(Node.NODE_ATTRIBUTES.getKey() + RemoteStoreNodeAttribute.REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY, "remote-repo")
-            .build();
-        RepositoriesService repositoriesService = mock(RepositoriesService.class);
-        when(repositoriesServiceSupplier.get()).thenReturn(repositoriesService);
-        BlobStoreRepository blobStoreRepository = mock(BlobStoreRepository.class);
-        when(repositoriesService.repository("remote-repo")).thenReturn(blobStoreRepository);
 
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.schedule(any(), any(), any())).then(invocationOnMock -> {

--- a/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
+++ b/server/src/test/java/org/opensearch/index/translog/RemoteFsTranslogTests.java
@@ -234,7 +234,7 @@ public class RemoteFsTranslogTests extends OpenSearchTestCase {
             new ByteSizeValue(10 + randomInt(128 * 1024), ByteSizeUnit.BYTES)
         );
         // To simulate that the node is remote backed
-        Settings nodeSettings = Settings.builder().put("node.attr.remote_store.translog.repository", "my-repo-1").build();
+        Settings nodeSettings = Settings.builder().put("node.attr.remote_store.translog.repository", "tlog-test-repo").build();
         final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings, nodeSettings);
         return new TranslogConfig(shardId, path, indexSettings, NON_RECYCLING_INSTANCE, bufferSize, "", false);
     }

--- a/server/src/test/java/org/opensearch/node/remotestore/CompositeRemoteRepositoryTests.java
+++ b/server/src/test/java/org/opensearch/node/remotestore/CompositeRemoteRepositoryTests.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.node.remotestore;
+
+import org.opensearch.cluster.metadata.RepositoryMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class CompositeRemoteRepositoryTests extends OpenSearchTestCase {
+
+    private CompositeRemoteRepository compositeRepo;
+    private RepositoryMetadata mockMetadata;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        compositeRepo = new CompositeRemoteRepository();
+        mockMetadata = new RepositoryMetadata("test-repo", "fs", Settings.EMPTY);
+    }
+
+    public void testRegisterCompositeRepository() {
+        compositeRepo.registerCompositeRepository(
+            CompositeRemoteRepository.RemoteStoreRepositoryType.SEGMENT,
+            CompositeRemoteRepository.CompositeRepositoryEncryptionType.SERVER,
+            mockMetadata
+        );
+
+        RepositoryMetadata result = compositeRepo.getRepository(
+            CompositeRemoteRepository.RemoteStoreRepositoryType.SEGMENT,
+            CompositeRemoteRepository.CompositeRepositoryEncryptionType.SERVER
+        );
+
+        assertNotNull(result);
+        assertEquals(mockMetadata, result);
+    }
+
+    public void testIsServerSideEncryptionEnabled() {
+        compositeRepo.registerCompositeRepository(
+            CompositeRemoteRepository.RemoteStoreRepositoryType.SEGMENT,
+            CompositeRemoteRepository.CompositeRepositoryEncryptionType.CLIENT,
+            mockMetadata
+        );
+
+        // When no SERVER encryption type is registered
+        assertFalse(compositeRepo.isServerSideEncryptionEnabled());
+
+        // When SERVER encryption type is registered
+        compositeRepo.registerCompositeRepository(
+            CompositeRemoteRepository.RemoteStoreRepositoryType.SEGMENT,
+            CompositeRemoteRepository.CompositeRepositoryEncryptionType.SERVER,
+            mockMetadata
+        );
+
+        assertTrue(compositeRepo.isServerSideEncryptionEnabled());
+    }
+
+    public void testMultipleRepositoryTypes() {
+        compositeRepo.registerCompositeRepository(
+            CompositeRemoteRepository.RemoteStoreRepositoryType.SEGMENT,
+            CompositeRemoteRepository.CompositeRepositoryEncryptionType.CLIENT,
+            mockMetadata
+        );
+
+        compositeRepo.registerCompositeRepository(
+            CompositeRemoteRepository.RemoteStoreRepositoryType.TRANSLOG,
+            CompositeRemoteRepository.CompositeRepositoryEncryptionType.SERVER,
+            mockMetadata
+        );
+
+        assertNotNull(
+            compositeRepo.getRepository(
+                CompositeRemoteRepository.RemoteStoreRepositoryType.SEGMENT,
+                CompositeRemoteRepository.CompositeRepositoryEncryptionType.CLIENT
+            )
+        );
+
+        assertNotNull(
+            compositeRepo.getRepository(
+                CompositeRemoteRepository.RemoteStoreRepositoryType.TRANSLOG,
+                CompositeRemoteRepository.CompositeRepositoryEncryptionType.SERVER
+            )
+        );
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestUtils.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestUtils.java
@@ -18,6 +18,7 @@ import org.opensearch.node.remotestore.RemoteStoreNodeAttribute;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class IndexShardTestUtils {
@@ -41,7 +42,83 @@ public class IndexShardTestUtils {
         remoteNodeAttributes.put(RemoteStoreNodeAttribute.REMOTE_STORE_CLUSTER_STATE_REPOSITORY_NAME_ATTRIBUTE_KEY, MOCK_STATE_REPO_NAME);
         remoteNodeAttributes.put(RemoteStoreNodeAttribute.REMOTE_STORE_SEGMENT_REPOSITORY_NAME_ATTRIBUTE_KEY, MOCK_SEGMENT_REPO_NAME);
         remoteNodeAttributes.put(RemoteStoreNodeAttribute.REMOTE_STORE_TRANSLOG_REPOSITORY_NAME_ATTRIBUTE_KEY, MOCK_TLOG_REPO_NAME);
-        return new DiscoveryNode(
+        remoteNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT,
+                MOCK_SEGMENT_REPO_NAME
+            ),
+            "s3"
+        );
+        remoteNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT,
+                MOCK_TLOG_REPO_NAME
+            ),
+            "s3"
+        );
+        remoteNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_TYPE_ATTRIBUTE_KEY_FORMAT,
+                MOCK_STATE_REPO_NAME
+            ),
+            "s3"
+        );
+
+        remoteNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                MOCK_SEGMENT_REPO_NAME
+            ) + "bucket",
+            "test-bucket"
+        );
+        remoteNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                MOCK_SEGMENT_REPO_NAME
+            ) + "path",
+            "test-path"
+        );
+
+        remoteNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                MOCK_TLOG_REPO_NAME
+            ) + "bucket",
+            "test-bucket"
+        );
+        remoteNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                MOCK_TLOG_REPO_NAME
+            ) + "path",
+            "test-path"
+        );
+
+        remoteNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                MOCK_STATE_REPO_NAME
+            ) + "bucket",
+            "test-bucket"
+        );
+        remoteNodeAttributes.put(
+            String.format(
+                Locale.getDefault(),
+                RemoteStoreNodeAttribute.REMOTE_STORE_REPOSITORY_SETTINGS_ATTRIBUTE_KEY_PREFIX,
+                MOCK_STATE_REPO_NAME
+            ) + "path",
+            "test-path"
+        );
+
+        DiscoveryNode node = new DiscoveryNode(
             id,
             id,
             IndexShardTestCase.buildNewFakeTransportAddress(),
@@ -49,6 +126,9 @@ public class IndexShardTestUtils {
             DiscoveryNodeRole.BUILT_IN_ROLES,
             Version.CURRENT
         );
+        RemoteStoreNodeAttribute remoteStoreNodeAttribute = new RemoteStoreNodeAttribute(node);
+        assert (remoteStoreNodeAttribute.getRepositoriesMetadata() != null);
+        return node;
     }
 
     public static DiscoveryNodes getFakeDiscoveryNodes(List<ShardRouting> shardRoutings) {


### PR DESCRIPTION
### Description
As part of this PR we are adding support for Composite repository for the remote store SSE enabled Index data for Segment/Translog.

Currently Remote-store creates a single repository to store Segment/Translog data. To support sse enabled repository we will need to provide support for composite repository which will be created based on presence of `sse_enabled` flag. The repository created will have specific encryption type to support "SSE" feature. These will be Internal repository matching the existing repository "Translog/Segment" suffixed with "-sse" to the existing repo name.

### Related Issues
Resolves #[https://github.com/https://github.com/opensearch-project/OpenSearch/issues/19235]

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
