### PR TITLE
Exclude commons-lang and org.jsonschema2pojo from hadoop-miniclusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `com.azure:azure-identity` from 1.14.2 to 1.18.0 ([#19361](https://github.com/opensearch-project/OpenSearch/pull/19361))
 - Bump `net.bytebuddy:byte-buddy` from 1.17.5 to 1.17.7 ([#19371](https://github.com/opensearch-project/OpenSearch/pull/19371))
 - Bump `lycheeverse/lychee-action` from 2.4.1 to 2.6.1 ([#19463](https://github.com/opensearch-project/OpenSearch/pull/19463))
+- Exclude commons-lang and org.jsonschema2pojo from hadoop-miniclusters  ([#19538](https://github.com/opensearch-project/OpenSearch/pull/19538))
 - Bump `io.grpc` deps from 1.68.2 to 1.75.0 ([#19495](https://github.com/opensearch-project/OpenSearch/pull/19495))
 
 ### Deprecated

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -56,6 +56,8 @@ dependencies {
     exclude module: "commons-configuration2"
     exclude module: "commons-beanutils"
     exclude module: "org.eclipse.jetty"
+    exclude group: "commons-lang"
+    exclude group: "org.jsonschema2pojo"
   }
   api "dnsjava:dnsjava:3.6.3"
   api "org.codehaus.jettison:jettison:${versions.jettison}"


### PR DESCRIPTION
### Description

Exclude commons-lang and org.jsonschema2pojo from hadoop-miniclusters to address brining in transitive deps with known CVEs. This miniclusters dependency keeps on giving :/

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
