### PR TITLE
Add a function to SearchPipelineService to check if system generated factory enabled or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Delegate primitive write methods with ByteSizeCachingDirectory wrapped IndexOutput ([#19432](https://github.com/opensearch-project/OpenSearch/pull/19432))
 - Bump opensearch-protobufs dependency to 0.18.0 and update transport-grpc module compatibility ([#19447](https://github.com/opensearch-project/OpenSearch/issues/19447))
 - Bump opensearch-protobufs dependency to 0.19.0 ([#19453](https://github.com/opensearch-project/OpenSearch/issues/19453))
-
+- Add a function to SearchPipelineService to check if system generated factory enabled or not ([#19545](https://github.com/opensearch-project/OpenSearch/pull/19545))
 ### Fixed
 - Fix unnecessary refreshes on update preparation failures ([#15261](https://github.com/opensearch-project/OpenSearch/issues/15261))
 - Fix NullPointerException in segment replicator ([#18997](https://github.com/opensearch-project/OpenSearch/pull/18997))

--- a/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
+++ b/server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java
@@ -79,6 +79,7 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
     public static final String SEARCH_PIPELINE_ORIGIN = "search_pipeline";
     public static final String AD_HOC_PIPELINE_ID = "_ad_hoc_pipeline";
     public static final String NOOP_PIPELINE_ID = "_none";
+    public static final String ALL = "*";
     private static final int MAX_PIPELINE_ID_BYTES = 512;
     private static final Logger logger = LogManager.getLogger(SearchPipelineService.class);
     private final ClusterService clusterService;
@@ -642,5 +643,10 @@ public class SearchPipelineService implements ClusterStateApplier, ReportingServ
             this.configuration = Objects.requireNonNull(configuration);
             this.pipeline = Objects.requireNonNull(pipeline);
         }
+    }
+
+    public boolean isSystemGeneratedFactoryEnabled(String factoryName) {
+        return enabledSystemGeneratedFactories != null
+            && (enabledSystemGeneratedFactories.contains(ALL) || enabledSystemGeneratedFactories.contains(factoryName));
     }
 }

--- a/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineServiceTests.java
@@ -56,6 +56,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import static org.opensearch.search.pipeline.SearchPipelineService.ENABLED_SYSTEM_GENERATED_FACTORIES_SETTING;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -1640,4 +1641,25 @@ public class SearchPipelineServiceTests extends SearchPipelineTestCase {
         return new SearchResponse(sections, null, 0, 0, 0, 0, null, null);
     }
 
+    public void testIsSystemGeneratedFactoryEnabled_whenAllEnabled_thenTrue() throws Exception {
+        SearchPipelineService service = createWithSystemGeneratedProcessors();
+        enabledAllSystemGeneratedFactories(service);
+
+        assertTrue(service.isSystemGeneratedFactoryEnabled("dummy_factory"));
+    }
+
+    public void testIsSystemGeneratedFactoryEnabled_whenEnabled_thenTrue() {
+        SearchPipelineService service = createWithSystemGeneratedProcessors();
+        service.getClusterService()
+            .getClusterSettings()
+            .applySettings(Settings.builder().putList(ENABLED_SYSTEM_GENERATED_FACTORIES_SETTING.getKey(), "dummy_factory").build());
+
+        assertTrue(service.isSystemGeneratedFactoryEnabled("dummy_factory"));
+    }
+
+    public void testIsSystemGeneratedFactoryEnabled_whenNotEnabled_thenFalse() {
+        SearchPipelineService service = createWithSystemGeneratedProcessors();
+
+        assertFalse(service.isSystemGeneratedFactoryEnabled("dummy_factory"));
+    }
 }

--- a/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineTestCase.java
+++ b/server/src/test/java/org/opensearch/search/pipeline/SearchPipelineTestCase.java
@@ -44,6 +44,8 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
+import static org.opensearch.search.pipeline.SearchPipelineService.ALL;
+import static org.opensearch.search.pipeline.SearchPipelineService.ENABLED_SYSTEM_GENERATED_FACTORIES_SETTING;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -712,9 +714,9 @@ public abstract class SearchPipelineTestCase extends OpenSearchTestCase {
         return SearchSourceBuilder.searchSource().size(10);
     }
 
-    void enabledAllSystemGeneratedFactories(SearchPipelineService service) throws Exception {
+    void enabledAllSystemGeneratedFactories(SearchPipelineService service) {
         service.getClusterService()
             .getClusterSettings()
-            .applySettings(Settings.builder().putList("cluster.search.enabled_system_generated_factories", "*").build());
+            .applySettings(Settings.builder().putList(ENABLED_SYSTEM_GENERATED_FACTORIES_SETTING.getKey(), ALL).build());
     }
 }


### PR DESCRIPTION
### Description
Add a function to SearchPipelineService to check if system generated factory enabled or not so that plugins can consume this function rather than build their own.

### Related Issues
Closes #19427

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
