### PR TITLE
Add karenyrx as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,6 +20,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Binlong Gao       | [gaobinlong](https://github.com/gaobinlong)             | Amazon      |
 | Gaurav Bafna      | [gbbafna](https://github.com/gbbafna)                   | Amazon      |
 | Jay Deng          | [jed326](https://github.com/jed326)                     | Amazon      |
+| Karen Xu          | [karenyrx](https://github.com/karenyrx)                 | Uber        |
 | Ke Wei            | [kkewwei](https://github.com/kkewwei)                   | ByteDance   |
 | Kunal Kotwani     | [kotwanikunal](https://github.com/kotwanikunal)         | Amazon      |
 | Varun Bansal      | [linuxpi](https://github.com/linuxpi)                   | Amazon      |


### PR DESCRIPTION
Following the [nomination process](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer), I have nominated and other maintainers have agreed to add Karen Xu (@karenyrx) as a co-maintainer of the OpenSearch repository. She has graciously accepted the invitation.

---

Karen has spearheaded the project to add gRPC APIs to OpenSearch over the past 6 months. This includes working on the core changes to add the gRPC and Protobuf dependencies, and integrating with the existing transport layer. 

To date, Karen has:
* authored [23 PRs](https://github.com/opensearch-project/OpenSearch/pulls?q=+is%3Apr+author%3Akarenyrx+). (all relatively large PRs w/ hundreds/thousands line of changes)
* reviewed [27 PR](https://github.com/opensearch-project/OpenSearch/issues?q=is%3Apr%20commenter%3Akarenyrx)s.
* created [18 issues](https://github.com/opensearch-project/OpenSearch/issues?q=is%3Aissue%20author%3Akarenyrx). (including feature request and proposals)

Outside of core, Karen has worked on automating the construction of gRPC service definitions from the opensearch-api-specification. She made the gRPC version of query DSL pluggable (via plugin extensions) and added support for kNN queries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
