### PR TITLE
Add varunbharadwaj as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -36,6 +36,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
 | Shweta Thareja    | [shwetathareja](https://github.com/shwetathareja)       | Amazon      |
 | Sorabh Hamirwasia | [sohami](https://github.com/sohami)                     | Amazon      |
+| Varun Bharadwaj   | [varunbharadwaj](https://github.com/varunbharadwaj)     | Uber        |
 | Yupeng Fu         | [yupeng9](https://github.com/yupeng9)                   | Uber        |
 
 ## Emeritus


### PR DESCRIPTION
Following the [nomination process](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer), I have nominated and other maintainers have agreed to add Varun Bharadwaj (@varunbharadwaj) as a co-maintainer of the OpenSearch repository. He has graciously accepted the invitation.

---

Varun took over the work on pull-based ingestion after Yupeng's initial implementation. He added APIs to [support pausing and resuming ingestion](https://github.com/opensearch-project/OpenSearch/pull/17631), [multithreaded indexing](https://github.com/opensearch-project/OpenSearch/pull/17912) for pull-based ingestion, added another ingestion source for testing by [pulling from files](https://github.com/opensearch-project/OpenSearch/pull/18591), added [support for "all-active" ingestion](https://github.com/opensearch-project/OpenSearch/pull/19316) (essentially document replication, but where replicas also pull from the ingestion source), and has addressed [issues](https://github.com/opensearch-project/OpenSearch/pull/18877) [discovered](https://github.com/opensearch-project/OpenSearch/pull/18304) [as](https://github.com/opensearch-project/OpenSearch/pull/18250) [Uber](https://github.com/opensearch-project/OpenSearch/pull/19320) [starts](https://github.com/opensearch-project/OpenSearch/pull/19393) [using](https://github.com/opensearch-project/OpenSearch/pull/19407) pull-based ingestion in production.

As of today, Varun has
* authored [26](https://github.com/opensearch-project/OpenSearch/pulls?q=+is%3Apr+author%3Avarunbharadwaj++) PRs
* reviewed [31](https://github.com/opensearch-project/OpenSearch/issues?q=is%3Apr%20commenter%3Avarunbharadwaj) PRs.
* created [13](https://github.com/opensearch-project/OpenSearch/issues?q=is%3Aissue%20%20author%3Avarunbharadwaj) issues.

Varun has reviewed PRs on [adding a new (pluggable) store](https://github.com/opensearch-project/OpenSearch/pull/19132) implementation, adding [temporal routing processors](https://github.com/opensearch-project/OpenSearch/pull/18966), and [improving gRPC serialization performance](https://github.com/opensearch-project/OpenSearch/pull/18303).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
