### PR TITLE
Fix the enforce_hostname_verification check for flight transport

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightService.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/FlightService.java
@@ -125,7 +125,7 @@ public class FlightService extends AuxTransport {
             allocator = AccessController.doPrivileged((PrivilegedAction<BufferAllocator>) () -> new RootAllocator(Integer.MAX_VALUE));
             serverComponents.setAllocator(allocator);
             SslContextProvider sslContextProvider = ServerConfig.isSslEnabled()
-                ? new DefaultSslContextProvider(secureTransportSettingsProvider)
+                ? new DefaultSslContextProvider(secureTransportSettingsProvider, serverComponents.clusterService.getSettings())
                 : null;
             serverComponents.setSslContextProvider(sslContextProvider);
             serverComponents.initComponents();

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightStreamPlugin.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightStreamPlugin.java
@@ -174,7 +174,7 @@ public class FlightStreamPlugin extends Plugin
             flightService.setSecureTransportSettingsProvider(secureTransportSettingsProvider);
         }
         if (isStreamTransportEnabled && ServerConfig.isSslEnabled()) {
-            SslContextProvider sslContextProvider = new DefaultSslContextProvider(secureTransportSettingsProvider);
+            SslContextProvider sslContextProvider = new DefaultSslContextProvider(secureTransportSettingsProvider, settings);
             return Collections.singletonMap(
                 "FLIGHT-SECURE",
                 () -> new FlightTransport(


### PR DESCRIPTION
(cherry picked from commit cbf05b926a5c6c17d70d59edefa34e935ef4f079)

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
On disabling transport.ssl.enforce_hostname_verification, flight transport still uses goes through hostname verification. Ideally, it should honour this setting and skip verification.


### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/19578
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
