### PR TITLE
Update forbidden APIs for JDK 25

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -114,7 +114,7 @@ dependencies {
   api 'com.gradleup.shadow:shadow-gradle-plugin:8.3.9'
   api 'org.jdom:jdom2:2.0.6.1'
   api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${props.getProperty('kotlin')}"
-  api 'de.thetaphi:forbiddenapis:3.9'
+  api 'de.thetaphi:forbiddenapis:3.10'
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.17.12'
   api "org.yaml:snakeyaml:${props.getProperty('snakeyaml')}"
   api 'org.apache.maven:maven-model:3.9.6'

--- a/distribution/tools/plugin-cli/src/main/java/org/opensearch/tools/cli/plugin/PluginSecurity.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/opensearch/tools/cli/plugin/PluginSecurity.java
@@ -36,6 +36,7 @@ import org.opensearch.cli.ExitCodes;
 import org.opensearch.cli.Terminal;
 import org.opensearch.cli.Terminal.Verbosity;
 import org.opensearch.cli.UserException;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.secure_sm.policy.PolicyFile;
 
@@ -96,6 +97,7 @@ class PluginSecurity {
     }
 
     /** Format permission type, name, and actions into a string */
+    @SuppressForbidden(reason = "https://github.com/opensearch-project/OpenSearch/issues/19640")
     static String formatPermission(Permission permission) {
         StringBuilder sb = new StringBuilder();
 

--- a/plugins/repository-hdfs/src/main/java/org/opensearch/repositories/hdfs/HdfsSecurityContext.java
+++ b/plugins/repository-hdfs/src/main/java/org/opensearch/repositories/hdfs/HdfsSecurityContext.java
@@ -33,6 +33,7 @@ package org.opensearch.repositories.hdfs;
 
 import org.apache.hadoop.security.UserGroupInformation;
 import org.opensearch.SpecialPermission;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.env.Environment;
 
 import javax.security.auth.AuthPermission;
@@ -58,6 +59,7 @@ import java.util.Arrays;
  * permissions to grant the blob store restricted execution methods.
  */
 @SuppressWarnings("removal")
+@SuppressForbidden(reason = "https://github.com/opensearch-project/OpenSearch/issues/19640")
 class HdfsSecurityContext {
 
     private static final Permission[] SIMPLE_AUTH_PERMISSIONS;

--- a/qa/evil-tests/src/test/java/org/opensearch/tools/cli/plugin/PluginSecurityTests.java
+++ b/qa/evil-tests/src/test/java/org/opensearch/tools/cli/plugin/PluginSecurityTests.java
@@ -35,6 +35,7 @@ package org.opensearch.tools.cli.plugin;
 import org.opensearch.secure_sm.policy.PolicyInitializationException;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.net.SocketPermission;
 import java.nio.file.Path;
 import java.util.Set;
 
@@ -43,45 +44,35 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
 /** Tests plugin manager security check */
-@SuppressWarnings("removal")
 public class PluginSecurityTests extends OpenSearchTestCase {
 
     /** Test that we can parse the set of permissions correctly for a simple policy */
     public void testParsePermissions() throws Exception {
-        assumeTrue(
-                "test cannot run with security manager enabled",
-                System.getSecurityManager() == null);
         Path scratch = createTempDir();
         Path testFile = this.getDataPath("simple-plugin-security.policy");
         Set<String> actual = PluginSecurity.parsePermissions(testFile, scratch);
-        assertThat(actual, contains(PluginSecurity.formatPermission(new RuntimePermission("queuePrintJob"))));
+        assertThat(actual, contains(PluginSecurity.formatPermission(new SocketPermission("*", "connect"))));
     }
 
     /** Test that we can parse the set of permissions correctly for a complex policy */
     public void testParseTwoPermissions() throws Exception {
-        assumeTrue(
-                "test cannot run with security manager enabled",
-                System.getSecurityManager() == null);
         Path scratch = createTempDir();
         Path testFile = this.getDataPath("complex-plugin-security.policy");
         Set<String> actual = PluginSecurity.parsePermissions(testFile, scratch);
         assertThat(actual, containsInAnyOrder(
-            PluginSecurity.formatPermission(new RuntimePermission("getClassLoader")),
-            PluginSecurity.formatPermission(new RuntimePermission("closeClassLoader"))));
+            PluginSecurity.formatPermission(new SocketPermission("*", "connect,resolve")),
+            PluginSecurity.formatPermission(new SocketPermission("opensearch.org", "connect"))));
     }
 
     /** Test that we can format some simple permissions properly */
     public void testFormatSimplePermission() throws Exception {
         assertEquals(
-                "java.lang.RuntimePermission queuePrintJob",
-                PluginSecurity.formatPermission(new RuntimePermission("queuePrintJob")));
+                "java.net.SocketPermission * connect,resolve",
+                PluginSecurity.formatPermission(new SocketPermission("*", "connect,resolve")));
     }
 
     /** Test that we can format an unresolved permission properly */
     public void testFormatUnresolvedPermission() throws Exception {
-        assumeTrue(
-                "test cannot run with security manager enabled",
-                System.getSecurityManager() == null);
         Path scratch = createTempDir();
         Path testFile = this.getDataPath("unresolved-plugin-security.policy");
         RuntimeException ex = assertThrows(RuntimeException.class, () -> PluginSecurity.parsePermissions(testFile, scratch));

--- a/qa/evil-tests/src/test/resources/org/opensearch/tools/cli/plugin/complex-plugin-security.policy
+++ b/qa/evil-tests/src/test/resources/org/opensearch/tools/cli/plugin/complex-plugin-security.policy
@@ -31,7 +31,6 @@
  */
 
 grant {
-  // needed to cause problems
-  permission java.lang.RuntimePermission "getClassLoader";
-  permission java.lang.RuntimePermission "closeClassLoader";
+  permission java.net.SocketPermission "opensearch.org" "connect";
+  permission java.net.SocketPermission "*" "connect,resolve";
 };

--- a/qa/evil-tests/src/test/resources/org/opensearch/tools/cli/plugin/simple-plugin-security.policy
+++ b/qa/evil-tests/src/test/resources/org/opensearch/tools/cli/plugin/simple-plugin-security.policy
@@ -31,6 +31,5 @@
  */
 
 grant {
-  // needed to waste paper
-  permission java.lang.RuntimePermission "queuePrintJob";
+  permission java.net.SocketPermission "*" "connect";
 };

--- a/server/src/main/java/org/opensearch/bootstrap/OpenSearchPolicy.java
+++ b/server/src/main/java/org/opensearch/bootstrap/OpenSearchPolicy.java
@@ -54,6 +54,7 @@ import java.util.function.Predicate;
  * @opensearch.internal
  **/
 @SuppressWarnings("removal")
+@SuppressForbidden(reason = "https://github.com/opensearch-project/OpenSearch/issues/19640")
 final class OpenSearchPolicy extends Policy {
 
     /** template policy file, the one used in tests */

--- a/server/src/main/java/org/opensearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/opensearch/monitor/jvm/JvmInfo.java
@@ -46,7 +46,6 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
-import java.lang.management.ManagementPermission;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.PlatformManagedObject;
@@ -216,13 +215,7 @@ public class JvmInfo implements ReportingService.Info {
         }
     }
 
-    @SuppressWarnings("removal")
     public static JvmInfo jvmInfo() {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new ManagementPermission("monitor"));
-            sm.checkPropertyAccess("*");
-        }
         return INSTANCE;
     }
 

--- a/test/framework/src/main/java/org/opensearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/opensearch/bootstrap/BootstrapForTesting.java
@@ -86,6 +86,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.systemPropertyAs
  * mode (e.g. assign permissions and install security manager the same way)
  */
 @SuppressWarnings("removal")
+@SuppressForbidden(reason = "https://github.com/opensearch-project/OpenSearch/issues/19640")
 public class BootstrapForTesting {
     private static final String[] TEST_RUNNER_PACKAGES = new String[] {
         // gradle worker


### PR DESCRIPTION
Update the forbidden APIs plugin to the latest release and also fix all the usages of APIs that are newly deprecated in JDK 25.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
