### PR TITLE
Add assemble dependency for distribution packages

### DIFF
--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -450,6 +450,7 @@ subprojects {
   artifacts {
     'default' buildDist
   }
+  tasks.named("assemble").configure { dependsOn(parent.tasks.named(buildTask)) }
 
   if (dpkgExists() || rpmExists()) {
 


### PR DESCRIPTION
We previously hit this behavior change with the archive builds. The same fix needs to be applied to the distribution packages to explicitly add the assemble dependency.

### Related Issues
Resolves #19625

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
