### PR TITLE
fix issue 18446 NPE by making sure scoreSupplier.get() returns non-null scorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed assertion unsafe use of ClusterService.state() in ResourceUsageCollectorService ([#19775])(https://github.com/opensearch-project/OpenSearch/pull/19775))
 - Fix Unified highlighter for nested fields when using matchPhrasePrefixQuery ([#19442](https://github.com/opensearch-project/OpenSearch/pull/19442))
 - Add S3Repository.LEGACY_MD5_CHECKSUM_CALCULATION to list of repository-s3 settings ([#19788](https://github.com/opensearch-project/OpenSearch/pull/19788))
+- Fix NPE of ScriptScoreQuery ([#19650](https://github.com/opensearch-project/OpenSearch/pull/19650))
 
 ### Dependencies
 - Update to Gradle 9.2 ([#19575](https://github.com/opensearch-project/OpenSearch/pull/19575)) ([#19856](https://github.com/opensearch-project/OpenSearch/pull/19856))

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/ScriptScoreQueryIT.java
@@ -55,6 +55,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.opensearch.index.query.QueryBuilders.boolQuery;
+import static org.opensearch.index.query.QueryBuilders.idsQuery;
 import static org.opensearch.index.query.QueryBuilders.matchQuery;
 import static org.opensearch.index.query.QueryBuilders.scriptScoreQuery;
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
@@ -216,5 +217,25 @@ public class ScriptScoreQueryIT extends ParameterizedStaticSettingsOpenSearchInt
             updateSettingsRequest.persistentSettings(Settings.builder().put("search.allow_expensive_queries", (String) null));
             assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
         }
+    }
+
+    // test case added for issue https://github.com/opensearch-project/OpenSearch/issues/18446
+    public void testScriptScoreNotExistingQuery() throws Exception {
+        assertAcked(prepareCreate("test-index").setMapping("field2", "type=double"));
+        client().prepareIndex("test-index").setId("1").setSource("field2", 1).get();
+        refresh();
+        indexRandomForConcurrentSearch("test-index");
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("param1", 0.1);
+        Script script = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['field2'].value * param1", params);
+        QueryBuilder idsQuery = idsQuery().addIds("2");
+        QueryBuilder scriptScoreQuery = scriptScoreQuery(idsQuery, script);
+        // Issue 18446 arises because of null Scorer returned from ScorerSupplier.
+        // However, Lucene prefers bulkScorer() instead of scorer() which doesn't trigger NPE as stated in issue 18446.
+        // As a result, we have to set profile to true to force the usage of scorer() instead of bulkScorer(),
+        // to make sure we test the intended code path
+        SearchResponse resp = client().prepareSearch("test-index").setQuery(scriptScoreQuery).setProfile(true).get();
+        assertNoFailures(resp);
     }
 }

--- a/server/src/main/java/org/opensearch/common/lucene/search/function/ScriptScoreQuery.java
+++ b/server/src/main/java/org/opensearch/common/lucene/search/function/ScriptScoreQuery.java
@@ -134,16 +134,6 @@ public class ScriptScoreQuery extends Query {
                 Weight weight = this;
                 return new ScorerSupplier() {
                     @Override
-                    public Scorer get(long leadCost) throws IOException {
-                        Scorer subQueryScorer = subQueryScorerSupplier.get(leadCost);
-                        Scorer scriptScorer = new ScriptScorer(weight, makeScoreScript(context), subQueryScorer, subQueryScoreMode, boost, null);
-                        if (minScore != null) {
-                            scriptScorer = new MinScoreScorer(weight, scriptScorer, minScore);
-                        }
-                        return scriptScorer;
-                    }
-
-                    @Override
                     public BulkScorer bulkScorer() throws IOException {
                         if (minScore == null) {
                             final BulkScorer subQueryBulkScorer = subQueryScorerSupplier.bulkScorer();
@@ -151,6 +141,23 @@ public class ScriptScoreQuery extends Query {
                         } else {
                             return super.bulkScorer();
                         }
+                    }
+
+                    @Override
+                    public Scorer get(long leadCost) throws IOException {
+                        Scorer subQueryScorer = subQueryScorerSupplier.get(leadCost);
+                        Scorer scriptScorer = new ScriptScorer(
+                            weight,
+                            makeScoreScript(context),
+                            subQueryScorer,
+                            subQueryScoreMode,
+                            boost,
+                            null
+                        );
+                        if (minScore != null) {
+                            scriptScorer = new MinScoreScorer(weight, scriptScorer, minScore);
+                        }
+                        return scriptScorer;
                     }
 
                     @Override


### PR DESCRIPTION
### Description
fix issue [18446](https://github.com/opensearch-project/OpenSearch/issues/18446) NPE by making sure scoreSupplier.get() returns non-null scorer

### Related Issues
Resolves [#[18446]](https://github.com/opensearch-project/OpenSearch/issues/18446)

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
