### PR TITLE
Add sandeshkr419 as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -34,6 +34,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Rishabh Maurya    | [rishabhmaurya](https://github.com/rishabhmaurya)       | Amazon      |
 | Rishikesh Pasham  | [Rishikesh1159](https://github.com/Rishikesh1159)       | Amazon      |
 | Sachin Kale       | [sachinpkale](https://github.com/sachinpkale)           | Amazon      |
+| Sandesh Kumar     | [sandeshkr419](https://github.com/sandeshkr419)         | Amazon      |
 | Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
 | Shweta Thareja    | [shwetathareja](https://github.com/shwetathareja)       | Amazon      |
 | Sorabh Hamirwasia | [sohami](https://github.com/sohami)                     | Amazon      |


### PR DESCRIPTION
Note - this should not be merged until https://github.com/opensearch-project/.github/issues/408 is complete.

Following the [nomination process](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer), I have nominated and other maintainers have agreed to add Sandesh Kumar (@sandeshkr419) as a co-maintainer of the OpenSearch repository. He has graciously accepted the invitation.

Sandesh has been an active contributor to OpenSearch since 2021. He has worked across many areas of the project with recent contributions to search and aggregation performance [[1](https://github.com/opensearch-project/OpenSearch/pull/11643), [2](https://github.com/opensearch-project/OpenSearch/pull/18531)] and in leading the addition of [star tree search and query planning support](https://github.com/opensearch-project/OpenSearch/issues/15257).

To date Sandesh has:
Authored [44](https://github.com/opensearch-project/OpenSearch/pulls?q=+is%3Apr+author%3Asandeshkr419+) PRs
Reviewed [174](https://github.com/opensearch-project/OpenSearch/issues?q=is%3Apr%20commenter%3Asandeshkr419) PRs with 102 in the last year
Created [42](https://github.com/opensearch-project/OpenSearch/issues?q=is%3Aissue%20author%3Asandeshkr419) issues

Sandesh is also very active in the community hosting our weekly search triage meeting where he has displayed sound judgement in triaging issues and assisting new contributors.