### PR TITLE
Fix bwc @timestamp upgrade issue by adding a version check on skip_list param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix pull-based ingestion out-of-bounds offset scenarios and remove persisted offsets ([#19607](https://github.com/opensearch-project/OpenSearch/pull/19607))
 - [Star Tree] Fix sub-aggregator casting for search with profile=true ([19652](https://github.com/opensearch-project/OpenSearch/pull/19652))
 - Fix issue with updating core with a patch number other than 0 ([#19377](https://github.com/opensearch-project/OpenSearch/pull/19377))
+- Fix bwc @timestamp upgrade issue by adding a version check on skip_list param ([19670](https://github.com/opensearch-project/OpenSearch/pull/19670))
 
 ### Dependencies
 - Update to Gradle 9.1 ([#19575](https://github.com/opensearch-project/OpenSearch/pull/19575))

--- a/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
@@ -852,14 +852,15 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
     }
 
     boolean isSkiplistDefaultEnabled(IndexSortConfig indexSortConfig, String fieldName) {
-        if (!isSkiplistConfigured) {
-            if (indexSortConfig.hasPrimarySortOnField(fieldName)) {
-                return true;
+        if (this.indexCreatedVersion.onOrAfter(Version.V_3_3_0)) {
+            if (!isSkiplistConfigured) {
+                if (indexSortConfig.hasPrimarySortOnField(fieldName)) {
+                    return true;
+                }
+                if (DataStreamFieldMapper.Defaults.TIMESTAMP_FIELD.getName().equals(fieldName)) {
+                    return true;
+                }
             }
-            if (DataStreamFieldMapper.Defaults.TIMESTAMP_FIELD.getName().equals(fieldName)) {
-                return true;
-            }
-
         }
         return false;
     }

--- a/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/DateFieldMapperTests.java
@@ -869,16 +869,25 @@ public class DateFieldMapperTests extends MapperTestCase {
 
     public void testIsSkiplistDefaultEnabled() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "date")));
+        testIsSkiplistEnabled(mapper, true);
+
+    }
+
+    public void testIsSkiplistDefaultDisabledInOlderVersions() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(Version.V_3_2_0, fieldMapping(b -> b.field("type", "date")));
+        testIsSkiplistEnabled(mapper, false);
+    }
+
+    private void testIsSkiplistEnabled(DocumentMapper mapper, boolean expectedValue) throws IOException {
         DateFieldMapper dateFieldMapper = (DateFieldMapper) mapper.mappers().getMapper("field");
 
         // Test with no index sort and non-timestamp field
         IndexMetadata noSortindexMetadata = new IndexMetadata.Builder("index").settings(getIndexSettings()).build();
-        IndexSettings noSolrIndexSettings = new IndexSettings(noSortindexMetadata, getIndexSettings());
         IndexSortConfig noSortConfig = new IndexSortConfig(new IndexSettings(noSortindexMetadata, getIndexSettings()));
         assertFalse(dateFieldMapper.isSkiplistDefaultEnabled(noSortConfig, "field"));
 
         // timestamp field
-        assertTrue(dateFieldMapper.isSkiplistDefaultEnabled(noSortConfig, "@timestamp"));
+        assertEquals(expectedValue, dateFieldMapper.isSkiplistDefaultEnabled(noSortConfig, "@timestamp"));
 
         // Create index settings with an index sort.
         Settings settings = Settings.builder()
@@ -892,9 +901,11 @@ public class DateFieldMapperTests extends MapperTestCase {
         IndexMetadata indexMetadata = new IndexMetadata.Builder("index").settings(settings).build();
         IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
         IndexSortConfig sortConfig = new IndexSortConfig(indexSettings);
-        assertTrue(dateFieldMapper.isSkiplistDefaultEnabled(sortConfig, "field"));
-        assertTrue(dateFieldMapper.isSkiplistDefaultEnabled(sortConfig, "@timestamp"));
+        assertEquals(expectedValue, dateFieldMapper.isSkiplistDefaultEnabled(sortConfig, "field"));
+        assertEquals(expectedValue, dateFieldMapper.isSkiplistDefaultEnabled(sortConfig, "@timestamp"));
     }
+
+
 
     public void testSkipListIntegrationFieldBehaviorConsistency() throws IOException {
         // Test that field behavior is consistent between skip_list enabled and disabled


### PR DESCRIPTION


### Description
This skip_list param was introduced in 3.3.0, so any index created since then will have skip_list set to true. This way older indexes with @timestamp or index sort date field will continue to remain zero.

This way new indexes can take advantage of the performance enhancement in date histogram aggregation. 

This is proper fix compared to https://github.com/opensearch-project/OpenSearch/pull/19661

### Testing

Manually tested appending to big5 index created using 3.2.0. 

Looking at how to add a bwc integ test. Existing ones do not have date field. 




### Related Issues
Fixes https://github.com/opensearch-project/OpenSearch/issues/19660
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
