### PR TITLE
Enhance SimpleCommandLineArgumentProvider constructor

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/SimpleCommandLineArgumentProvider.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/SimpleCommandLineArgumentProvider.java
@@ -26,30 +26,47 @@
  */
 
 /*
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
+ * Modifications Copyright OpenSearch Contributors.
+ * See GitHub history for details.
  */
 
 package org.opensearch.gradle;
 
 import org.gradle.process.CommandLineArgumentProvider;
-
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
- * A {@link CommandLineArgumentProvider} implementation that simply returns the given list. This implementation does not track any
- * arguments as inputs, so this is useful for passing arguments that should not be used for the purposes of input snapshotting.
+ * Provides a fixed list of command-line arguments to Gradle tasks.
+ * This implementation does not track these arguments as inputs,
+ * which is useful for arguments that should not affect Gradle input snapshotting.
  */
 public class SimpleCommandLineArgumentProvider implements CommandLineArgumentProvider {
+
     private final List<String> arguments;
 
+    /**
+     * Constructs a new SimpleCommandLineArgumentProvider.
+     *
+     * @param arguments the command-line arguments to provide; may be null or empty.
+     */
     public SimpleCommandLineArgumentProvider(String... arguments) {
-        this.arguments = Arrays.asList(arguments);
+        if (arguments == null) {
+            this.arguments = Collections.emptyList();
+        } else {
+            this.arguments = List.of(arguments); // Immutable list (Java 9+)
+        }
     }
 
     @Override
     public Iterable<String> asArguments() {
         return arguments;
+    }
+
+    @Override
+    public String toString() {
+        return "SimpleCommandLineArgumentProvider{" +
+                "arguments=" + arguments +
+                '}';
     }
 }


### PR DESCRIPTION
Updated constructor to handle null arguments and use an immutable list.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
