### PR TITLE
Fix lucene snapshot workflow to take java version as input and fall back to 25

### DIFF
--- a/.github/workflows/lucene-snapshots.yml
+++ b/.github/workflows/lucene-snapshots.yml
@@ -11,6 +11,11 @@ on:
         type: string
         required: false
         default: 'main'
+      java_version:
+        description: 'Java version to use'
+        type: string
+        required: false
+        default: '25'
 
 jobs:
   publish-snapshots:
@@ -28,23 +33,18 @@ jobs:
           repository: 'apache/lucene'
           ref: ${{ github.event.inputs.ref }}
 
-      - name: Get Java Min Version and Lucene Revision from Lucene Repository
+      - name: Get Lucene Revision
         run: |
-          java_version=`cat build.gradle | grep minJavaVersion | head -1 | grep -Eo '_[0-9]+$' | tr -d '_'`
-          echo "JAVA_VERSION=$java_version" >> $GITHUB_ENV
           echo "REVISION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-      - name: Setup JDK ${{ env.JAVA_VERSION }}
+      - name: Setup JDK ${{ github.event.inputs.java_version }}
         uses: actions/setup-java@v5
         with:
-          java-version: ${{ env.JAVA_VERSION }}
+          java-version: ${{ github.event.inputs.java_version }}
           distribution: 'temurin'
 
-      - name: Initialize gradle settings
-        run: ./gradlew localSettings
-
       - name: Publish Lucene to local maven repo.
-        run: ./gradlew publishJarsPublicationToMavenLocal -Pversion.suffix=snapshot-${{ env.REVISION }}
+        run: ./gradlew publishJarsPublicationToMavenLocal -Pversion.suffix=snapshot-${{ env.REVISION }} -x javadoc
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Our lucene snapshot workflow fails when building lucene main because we were trying to fetch the required java version from build.gradle.  Lucene has refactored a lot of the gradle build post 10x and this has moved under /gradle/libs.versions.toml.

This workflow is manually triggered anyway, rather than depending on that I've updated this to optionally take java version as input, and fall back to 25.  For 10x or older it will clearly state the required version and we can re-run.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/19624

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
