### PR TITLE
Fix potential concurrent modification exception in DiscoveryNodeFilters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix pull-based ingestion out-of-bounds offset scenarios and remove persisted offsets ([#19607](https://github.com/opensearch-project/OpenSearch/pull/19607))
 - Fix issue with updating core with a patch number other than 0 ([#19377](https://github.com/opensearch-project/OpenSearch/pull/19377))
 - [Java Agent] Allow JRT protocol URLs in protection domain extraction ([#19683](https://github.com/opensearch-project/OpenSearch/pull/19683))
+- Fix potential concurrent modification exception when updating allocation filters ([#19701])(https://github.com/opensearch-project/OpenSearch/pull/19701))
 
 ### Dependencies
 - Update to Gradle 9.1 ([#19575](https://github.com/opensearch-project/OpenSearch/pull/19575))

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNodeFilters.java
@@ -97,7 +97,7 @@ public class DiscoveryNodeFilters {
             updated = new DiscoveryNodeFilters(opType, new HashMap<>());
         } else {
             assert opType == original.opType : "operation type should match with node filter parameter";
-            updated = new DiscoveryNodeFilters(original.opType, original.filters);
+            updated = new DiscoveryNodeFilters(original.opType, new HashMap<>(original.filters));
         }
         for (Map.Entry<String, String> entry : filters.entrySet()) {
             String[] values = Strings.tokenizeToStringArray(entry.getValue(), ",");

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
@@ -193,7 +193,7 @@ public class FilterAllocationDecider extends AllocationDecider {
     @Override
     public Decision canAllocateAnyShardToNode(RoutingNode node, RoutingAllocation allocation) {
         Decision decision = shouldClusterFilter(node.node(), allocation);
-        return decision != null && decision == Decision.NO ? decision : Decision.ALWAYS;
+        return decision == Decision.NO ? decision : Decision.ALWAYS;
     }
 
     private Decision shouldFilter(ShardRouting shardRouting, DiscoveryNode node, RoutingAllocation allocation) {
@@ -258,6 +258,13 @@ public class FilterAllocationDecider extends AllocationDecider {
     }
 
     private Decision shouldClusterFilter(DiscoveryNode node, RoutingAllocation allocation) {
+        // Copy values to local variables so we're not null-checking on volatile fields.
+        // The value of a volatile field could change from non-null to null between the
+        // check and its usage.
+        DiscoveryNodeFilters clusterRequireFilters = this.clusterRequireFilters;
+        DiscoveryNodeFilters clusterIncludeFilters = this.clusterIncludeFilters;
+        DiscoveryNodeFilters clusterExcludeFilters = this.clusterExcludeFilters;
+
         if (clusterRequireFilters != null) {
             if (clusterRequireFilters.match(node) == false) {
                 return allocation.decision(


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
While I haven't seen concurrency issues in DiscoveryNodeFilters, the included unit test (which fails without cloning the original filters) shows that there is potential for an exception.

While in here, I also made some reads from volatile variables in FilterAllocationDecider more atomic to avoid potential null-pointer exceptions.

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
