### PR TITLE
fix for node stats for filecache stats becoming -ve

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/utils/cache/stats/DefaultStatsCounter.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/cache/stats/DefaultStatsCounter.java
@@ -62,7 +62,9 @@ public class DefaultStatsCounter<K, V> implements StatsCounter<K, V> {
     public void recordRemoval(V value, boolean pinned, long weight) {
         removeCount++;
         removeWeight += weight;
-        usage -= weight;
+        if(usage>0){
+            usage -= weight;
+        }
     }
 
     @Override
@@ -85,17 +87,23 @@ public class DefaultStatsCounter<K, V> implements StatsCounter<K, V> {
     public void recordEviction(V value, long weight) {
         evictionCount++;
         evictionWeight += weight;
-        usage -= weight;
+        if(usage>0) {
+            usage -= weight;
+        }
     }
 
     @Override
     public void recordUsage(V value, long weight, boolean pinned, boolean shouldDecrease) {
+        if(shouldDecrease && usage==0)
+            return;
         weight = shouldDecrease ? -1 * weight : weight;
         usage += weight;
     }
 
     @Override
     public void recordActiveUsage(V value, long weight, boolean pinned, boolean shouldDecrease) {
+        if(shouldDecrease && activeUsage==0)
+            return;
         weight = shouldDecrease ? -1 * weight : weight;
         activeUsage += weight;
     }
@@ -109,6 +117,8 @@ public class DefaultStatsCounter<K, V> implements StatsCounter<K, V> {
      */
     @Override
     public void recordPinnedUsage(V value, long weight, boolean shouldDecrease) {
+        if(shouldDecrease && pinnedUsage==0)
+            return;
         weight = shouldDecrease ? -1 * weight : weight;
         pinnedUsage += weight;
     }


### PR DESCRIPTION

### Description
After creating the warm index and or indexing docs, if we check the node stats, we get the failure response of type illegal_argument_exception.
These changes are fix for that.
The approach being we prevent setting any -ve value in the stats.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/19464


### Check List
- [Y ] Functionality includes testing.
- [ N] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ N] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
