### PR TITLE
Fix flaky PruneFileCacheIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/filecache/PruneFileCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/filecache/PruneFileCacheIT.java
@@ -83,11 +83,11 @@ public class PruneFileCacheIT extends AbstractSnapshotIntegTestCase {
         }
 
         assertBusy(() -> {
-            long usage = getFileCacheUsage();
+            long usage = getFileCacheUsage(client);
             assertTrue("Cache should be populated after index access", usage > 0);
         }, 30, TimeUnit.SECONDS);
 
-        long usageBefore = getFileCacheUsage();
+        long usageBefore = getFileCacheUsage(client);
         logger.info("--> File cache usage before prune: {} bytes", usageBefore);
         assertTrue("File cache should have data before prune", usageBefore > 0);
 
@@ -109,7 +109,7 @@ public class PruneFileCacheIT extends AbstractSnapshotIntegTestCase {
         assertTrue("Should have pruned bytes", response.getTotalPrunedBytes() > 0);
 
         // Verify cache usage after prune
-        long usageAfter = getFileCacheUsage();
+        long usageAfter = getFileCacheUsage(client);
         logger.info("--> File cache usage after prune: {} bytes", usageAfter);
 
         // Cache should be reduced (might not be zero if files are still referenced)
@@ -148,11 +148,11 @@ public class PruneFileCacheIT extends AbstractSnapshotIntegTestCase {
         assertDocCount(restoredIndexName, 100L);
 
         assertBusy(() -> {
-            long usage = getFileCacheUsage();
+            long usage = getFileCacheUsage(client);
             assertTrue("Cache should be populated", usage > 0);
         }, 30, TimeUnit.SECONDS);
 
-        long usageBefore = getFileCacheUsage();
+        long usageBefore = getFileCacheUsage(client);
 
         PruneFileCacheRequest request = new PruneFileCacheRequest();
         PlainActionFuture<PruneFileCacheResponse> future = new PlainActionFuture<>();
@@ -170,7 +170,7 @@ public class PruneFileCacheIT extends AbstractSnapshotIntegTestCase {
         assertTrue("Node should have cache capacity", nodeResponse.getCacheCapacity() > 0);
         assertTrue("Node should report pruned bytes", nodeResponse.getPrunedBytes() >= 0);
 
-        long usageAfter = getFileCacheUsage();
+        long usageAfter = getFileCacheUsage(client);
         long expectedPruned = usageBefore - usageAfter;
         assertEquals("Response should match actual cache reduction", expectedPruned, response.getTotalPrunedBytes());
     }
@@ -261,8 +261,8 @@ public class PruneFileCacheIT extends AbstractSnapshotIntegTestCase {
     /**
      * Returns total file cache usage across all warm nodes in bytes.
      */
-    private long getFileCacheUsage() {
-        NodesStatsResponse response = client().admin().cluster().nodesStats(new NodesStatsRequest().all()).actionGet();
+    private long getFileCacheUsage(Client client) {
+        NodesStatsResponse response = client.admin().cluster().nodesStats(new NodesStatsRequest().all()).actionGet();
 
         long totalUsage = 0L;
         for (NodeStats stats : response.getNodes()) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The test seems to rely on a set of stats returned from some random node, which may differ from the node that processes the prune request.

Ideally, by using the same client for each call, we'll have a more consistent view of the file cache usage.

I ran the test with 500 iterations after this fix and it passed every time.

### Related Issues
N/A

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
