### PR TITLE
Minor tweaks to agent Gradle logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -420,8 +420,11 @@ gradle.projectsEvaluated {
 
         // Add Java Agent for security sandboxing
         if (!(project.path in [':build-tools', ":libs:agent-sm:bootstrap", ":libs:agent-sm:agent"])) {
-          dependsOn(project(':libs:agent-sm:agent').prepareAgent)
-          jvmArgs += ["-javaagent:" + project(':libs:agent-sm:agent').jar.archiveFile.get()]
+          dependsOn(':libs:agent-sm:agent:jar')
+          // Defer resolution of jar file until task execution by using doFirst
+          doFirst {
+            jvmArgs += ["-javaagent:" + project(':libs:agent-sm:agent').jar.archiveFile.get()]
+          }
         }
         if (BuildParams.isInFipsJvm()) {
           def fipsSecurityFile = project.rootProject.file('distribution/src/config/fips_java.security')

--- a/buildSrc/src/main/java/org/opensearch/gradle/precommit/PomValidationPrecommitPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/precommit/PomValidationPrecommitPlugin.java
@@ -57,7 +57,6 @@ public class PomValidationPrecommitPlugin extends PrecommitPlugin {
                 .withType(GenerateMavenPom.class)
                 .named("generatePomFileFor" + publicationName + "Publication");
             validateTask.configure(task -> {
-                task.dependsOn(generateMavenPom);
                 task.getPomFile().fileProvider(generateMavenPom.map(GenerateMavenPom::getDestination));
                 // Force the validate to run after all generate tasks since they overwrite the same POM file
                 task.mustRunAfter(project.getTasks().withType(GenerateMavenPom.class));

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -312,7 +312,7 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
    *             Properties to expand when copying packaging files             *
    *****************************************************************************/
   configurations {
-    ['libs', 'libsPluginCli', 'libsKeystoreCli', 'libsFipsInstallerCli', 'bcFips'].each {
+    ['libs', 'libsPluginCli', 'libsKeystoreCli', 'libsFipsInstallerCli', 'bcFips', 'agent'].each {
       create(it) {
         canBeConsumed = false
         canBeResolved = true
@@ -334,6 +334,8 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
     libsPluginCli project(':distribution:tools:plugin-cli')
     libsKeystoreCli project(path: ':distribution:tools:keystore-cli')
     libsFipsInstallerCli project(path: ':distribution:tools:fips-demo-installer-cli')
+
+    agent project(':libs:agent-sm:agent')
 
     bcFips libs.bundles.bouncycastle
   }
@@ -365,10 +367,7 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
 
     agentFiles = {
       copySpec {
-        from(project(':libs:agent-sm:agent').prepareAgent) {
-          include '**/*.jar'
-          exclude '**/*-javadoc.jar'
-          exclude '**/*-sources.jar'
+        from(configurations.agent) {
           // strip the version since jvm.options is using agent without version
           rename("opensearch-agent-${project.version}.jar", "opensearch-agent.jar")
         }

--- a/libs/agent-sm/agent/build.gradle
+++ b/libs/agent-sm/agent/build.gradle
@@ -19,11 +19,17 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 }
 
+tasks.register('prepareAgent', Copy) {
+  from(configurations.runtimeClasspath)
+  into layout.buildDirectory.dir("distributions")
+}
+
 var bootClasspath = configurations.bootstrap.incoming.artifactView { }.files
   .getFiles()
   .collect { it.name }
 
 jar {
+  dependsOn prepareAgent
   manifest {
     attributes(
       "Can-Redefine-Classes": "true",
@@ -47,12 +53,6 @@ tasks.named('forbiddenApisMain').configure {
   onlyIf { false }
 }
 
-task prepareAgent(type: Copy) {
-  from(configurations.runtimeClasspath)
-  into "$buildDir/distributions"
-  dependsOn jar
-}
-
 thirdPartyAudit {
   ignoreMissingClasses(
     'com.sun.jna.FunctionMapper',
@@ -73,15 +73,7 @@ tasks.named('validateNebulaPom') {
 }
 
 tasks.test {
-  dependsOn prepareAgent
+  dependsOn jar
   jvmArgs += ["-javaagent:" + project.jar.archiveFile.get()]
   forkEvery = 1
-}
-
-tasks.check {
-  dependsOn test
-}
-
-tasks.named('assemble') {
-  dependsOn prepareAgent
 }

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -130,7 +130,7 @@ project(':test:fixtures:krb5kdc-fixture').tasks.preProcessFixture {
 // Create HDFS File System Testing Fixtures for HA/Secure combinations
 for (String fixtureName : ['hdfsFixture', 'haHdfsFixture', 'secureHdfsFixture', 'secureHaHdfsFixture']) {
   def tsk = tasks.register(fixtureName, org.opensearch.gradle.test.AntFixture) {
-    dependsOn configurations.hdfsFixture, project(':test:fixtures:krb5kdc-fixture').tasks.postProcessFixture, project(':libs:agent-sm:agent').prepareAgent
+    dependsOn configurations.hdfsFixture, project(':test:fixtures:krb5kdc-fixture').tasks.postProcessFixture, ':libs:agent-sm:agent:jar'
     executable = "${BuildParams.runtimeJavaHome}/bin/java"
     env 'CLASSPATH', "${-> configurations.hdfsFixture.asPath}"
     maxWaitInSeconds = 60

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -105,8 +105,11 @@ test {
   systemProperty 'tests.gradle_wire_compat_versions', BuildParams.bwcVersions.wireCompatible.join(',')
   systemProperty 'tests.gradle_unreleased_versions', BuildParams.bwcVersions.unreleased.join(',')
 
-  dependsOn(project(':libs:agent-sm:agent').prepareAgent)
-  jvmArgs += ["-javaagent:" + project(':libs:agent-sm:agent').jar.archiveFile.get()]
+  dependsOn(':libs:agent-sm:agent:jar')
+  // Defer resolution of agent jar file until task execution by using doFirst
+  doFirst {
+    jvmArgs += ["-javaagent:" + project(':libs:agent-sm:agent').jar.archiveFile.get()]
+  }
 }
 
 tasks.register("integTest", Test) {


### PR DESCRIPTION
While doing some other Gradle changes I ran into some really odd failures that ultimately led me down a rabbit hole that resulted in some changes that better match best practices:

- Change distribution/build.gradle to use an agent configuration as opposed to taking a direct task dependency. This is how it gets artifacts from other subprojects and is a Gradle best practice.
- Defer the evalution of the agent jar file until task execution which also makes the logic less brittle to other Gradle changes.
- Make `prepareAgent` depend on `jar` as opposed to the other way around. This removes the need for other projects that need the jar file to depend on anything other than the `jar` task.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
