### PR TITLE
[Backport 2.19] Wrap checked exceptions in painless.DefBootstrap (#19706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 
 ### Changed
-
 - Change single shard assignment log message from warn to debug ([#18186](https://github.com/opensearch-project/OpenSearch/pull/18186))
 - Replace centos:8 with almalinux:8 since centos docker images are deprecated ([#19154](https://github.com/opensearch-project/OpenSearch/pull/19154))
 - Allow plugins to copy folders into their config dir during installation ([#19343](https://github.com/opensearch-project/OpenSearch/pull/19343))
 - Onboarding new maven snapshots publishing to s3 ([#19632](https://github.com/opensearch-project/OpenSearch/pull/19632))
+- Wrap checked exceptions in painless.DefBootstrap to support JDK-25 ([#19706](https://github.com/opensearch-project/OpenSearch/pull/19706))
 
 [Unreleased 2.19.x]: https://github.com/opensearch-project/OpenSearch/compare/fd9a9d90df25bea1af2c6a85039692e815b894f5...2.19

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/DefBootstrapTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/DefBootstrapTests.java
@@ -46,6 +46,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 
+import static org.hamcrest.Matchers.instanceOf;
+
 public class DefBootstrapTests extends OpenSearchTestCase {
     private final PainlessLookup painlessLookup = PainlessLookupBuilder.buildFromWhitelists(Whitelist.BASE_WHITELISTS);
 
@@ -157,9 +159,11 @@ public class DefBootstrapTests extends OpenSearchTestCase {
         map.put("a", "b");
         assertEquals(2, (int) handle.invokeExact((Object) map));
 
-        final IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> {
+        final DefBootstrap.WrappedCheckedException wrapped = expectThrows(DefBootstrap.WrappedCheckedException.class, () -> {
             Integer.toString((int) handle.invokeExact(new Object()));
         });
+        assertThat(wrapped.getCause(), instanceOf(IllegalArgumentException.class));
+        final IllegalArgumentException iae = (IllegalArgumentException) wrapped.getCause();
         assertEquals("dynamic method [java.lang.Object, size/0] not found", iae.getMessage());
         assertTrue("Does not fail inside ClassValue.computeValue()", Arrays.stream(iae.getStackTrace()).anyMatch(e -> {
             return e.getMethodName().equals("computeValue") && e.getClassName().startsWith("org.opensearch.painless.DefBootstrap$PIC$");


### PR DESCRIPTION
A behavior change in [JDK-25][1] means that ClassValue.getFromHashMap will now wrap any checked exceptions with `java.lang.Error`. The fix is to wrap checked exceptions in `ClassValue.computeValue` with a specific RuntimeException wrapper, and then unwrap it later when handling.

[1]: https://bugs.openjdk.org/browse/JDK-8351996

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
