### PR TITLE
[Backport 2.19] Exclude commons-lang and org.jsonschema2pojo from hadoop-miniclusters (#19538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `org.apache.hadoop:hadoop-minicluster` from 3.4.1 to 3.4.2 ([#19605](https://github.com/opensearch-project/OpenSearch/pull/19605))
 - Bump `io.grpc` deps from 1.68.2 to 1.75.0 ([#19495](https://github.com/opensearch-project/OpenSearch/pull/19495))
 - Bump `com.nimbusds:nimbus-jose-jwt` from 10.0.2 to 10.3 ([#19604](https://github.com/opensearch-project/OpenSearch/pull/19604))
+- Exclude commons-lang and org.jsonschema2pojo from hadoop-miniclusters  ([#19538](https://github.com/opensearch-project/OpenSearch/pull/19538))
 
 ### Deprecated
 

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     exclude module: "commons-configuration2"
     exclude module: "commons-beanutils"
     exclude module: "org.eclipse.jetty"
+    exclude group: "commons-lang"
+    exclude group: "org.jsonschema2pojo"
   }
   api "dnsjava:dnsjava:3.6.2"
   api "org.codehaus.jettison:jettison:${versions.jettison}"


### PR DESCRIPTION
(cherry picked from commit 8eb034a904583cdc5915b96bb26f3ed6ef533ed3)

### Description

Backport #19538 to 2.19

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
