### PR TITLE
Fix flaky file-based indexing tests

### DIFF
--- a/plugins/ingestion-fs/src/test/java/org/opensearch/plugin/ingestion/fs/FileBasedIngestionSingleNodeTests.java
+++ b/plugins/ingestion-fs/src/test/java/org/opensearch/plugin/ingestion/fs/FileBasedIngestionSingleNodeTests.java
@@ -71,6 +71,15 @@ public class FileBasedIngestionSingleNodeTests extends OpenSearchSingleNodeTestC
         try (FileChannel channel = FileChannel.open(shardFile, StandardOpenOption.READ)) {
             channel.force(true);
         }
+
+        // Wait for file to be fully visible by reading it back
+        // This prevents race conditions where tests start before file is ready
+        assertBusy(() -> {
+            java.util.List<String> lines = Files.readAllLines(shardFile, StandardCharsets.UTF_8);
+            assertEquals("File should have exactly 2 lines", 2, lines.size());
+            assertTrue("First line should contain alice", lines.get(0).contains("alice"));
+            assertTrue("Second line should contain bob", lines.get(1).contains("bob"));
+        });
     }
 
     public void testFileIngestion() throws Exception {


### PR DESCRIPTION
### Description
File-based indexing test, especially `FileBasedIngestionSingleNodeTests.testFileIngestionFromLatestPointer` has been marked flaky as it fails expecting 0 results, but returns 2.

This could happen if the file contents are not visible at the time of poller initialization. This PR updates the setup stage to ensure the file contents are visible.

However, this could not be reproduced locally even on running 500 iterations. We'll monitor if the issue is solved after this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
