### PR TITLE
Modernize FilePartitionConsumer.java

### DIFF
--- a/plugins/ingestion-fs/README.md
+++ b/plugins/ingestion-fs/README.md
@@ -25,8 +25,11 @@ For example, create a file `${base_directory}/test-stream/0.ndjson` with data
 
 ### 2. Start OpenSearch with the Plugin
 
+We need to load the ingestion-fs plugin and also must specify the path.repo setting to allow OpenSearch to read from
+the local file system under `${base_directory}`.
+
 ```
-./gradlew run -PinstalledPlugins="['ingestion-fs']"
+./gradlew run -PinstalledPlugins="['ingestion-fs']" -Dtests.opensearch.path.repo="${base_directory}"
 ```
 
 ### 3. Create a pull-based index


### PR DESCRIPTION
### Description
Instead of using java.io.File, we can use java.nio.Path for a cleaner, more modern Java I/O experience.

### Related Issues
N/A

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
