### PR TITLE
Add support for field level segment stats in opensearch stats api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add metrics for the merged segment warmer feature ([#18929](https://github.com/opensearch-project/OpenSearch/pull/18929))
 - Add pointer based lag metric in pull-based ingestion ([#19635](https://github.com/opensearch-project/OpenSearch/pull/19635))
 - Introduced internal API for retrieving metadata about requested indices from transport actions  ([#18523](https://github.com/opensearch-project/OpenSearch/pull/18523))
+- Add field-level segment statistics to _stats API ([#19747](https://github.com/opensearch-project/OpenSearch/pull/19747))
 
 ### Changed
 - Faster `terms` query creation for `keyword` field with index and docValues enabled ([#19350](https://github.com/opensearch-project/OpenSearch/pull/19350))

--- a/server/src/internalClusterTest/java/org/opensearch/index/autoforcemerge/AutoForceMergeManagerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/autoforcemerge/AutoForceMergeManagerIT.java
@@ -86,7 +86,7 @@ public class AutoForceMergeManagerIT extends RemoteStoreBaseIntegTestCase {
         assertNotNull(shard);
 
         // Before stats
-        SegmentsStats segmentsStatsBefore = shard.segmentStats(false, false);
+        SegmentsStats segmentsStatsBefore = shard.segmentStats(false, false, false);
 
         // This is to make sure auto force merge action gets triggered multiple times ang gets successful at least once.
         Thread.sleep(TimeValue.parseTimeValue(SCHEDULER_INTERVAL, "test").getMillis() * 3);
@@ -94,7 +94,7 @@ public class AutoForceMergeManagerIT extends RemoteStoreBaseIntegTestCase {
         flushAndRefresh(INDEX_NAME_1);
 
         // After stats
-        SegmentsStats segmentsStatsAfter = shard.segmentStats(false, false);
+        SegmentsStats segmentsStatsAfter = shard.segmentStats(false, false, false);
         assertEquals(segmentsStatsBefore.getCount(), segmentsStatsAfter.getCount());
 
         // Deleting the index (so that ref count drops to zero for all the files) and then pruning the cache to clear it to avoid any file
@@ -123,9 +123,9 @@ public class AutoForceMergeManagerIT extends RemoteStoreBaseIntegTestCase {
         }
         IndexShard shard = getIndexShard(dataNode, INDEX_NAME_1);
         assertNotNull(shard);
-        SegmentsStats segmentsStatsBefore = shard.segmentStats(false, false);
+        SegmentsStats segmentsStatsBefore = shard.segmentStats(false, false, false);
         Thread.sleep(TimeValue.parseTimeValue(SCHEDULER_INTERVAL, "test").getMillis() * 3);
-        SegmentsStats segmentsStatsAfter = shard.segmentStats(false, false);
+        SegmentsStats segmentsStatsAfter = shard.segmentStats(false, false, false);
         assertEquals(segmentsStatsBefore.getCount(), segmentsStatsAfter.getCount());
         assertAcked(client().admin().indices().prepareDelete(INDEX_NAME_1).get());
     }
@@ -150,9 +150,9 @@ public class AutoForceMergeManagerIT extends RemoteStoreBaseIntegTestCase {
         }
         IndexShard shard = getIndexShard(dataNode, INDEX_NAME_1);
         assertNotNull(shard);
-        SegmentsStats segmentsStatsBefore = shard.segmentStats(false, false);
-        waitUntil(() -> shard.segmentStats(false, false).getCount() == SEGMENT_COUNT, 1, TimeUnit.MINUTES);
-        SegmentsStats segmentsStatsAfter = shard.segmentStats(false, false);
+        SegmentsStats segmentsStatsBefore = shard.segmentStats(false, false, false);
+        waitUntil(() -> shard.segmentStats(false, false, false).getCount() == SEGMENT_COUNT, 1, TimeUnit.MINUTES);
+        SegmentsStats segmentsStatsAfter = shard.segmentStats(false, false, false);
         assertTrue((int) segmentsStatsBefore.getCount() > segmentsStatsAfter.getCount());
         assertEquals((int) SEGMENT_COUNT, segmentsStatsAfter.getCount());
         assertAcked(client().admin().indices().prepareDelete(INDEX_NAME_1).get());
@@ -211,26 +211,26 @@ public class AutoForceMergeManagerIT extends RemoteStoreBaseIntegTestCase {
         assertNotNull(shard4);
         assertNotNull(shard5);
 
-        SegmentsStats segmentsStatsForShard1Before = shard1.segmentStats(false, false);
-        SegmentsStats segmentsStatsForShard2Before = shard2.segmentStats(false, false);
-        SegmentsStats segmentsStatsForShard3Before = shard3.segmentStats(false, false);
-        SegmentsStats segmentsStatsForShard4Before = shard4.segmentStats(false, false);
-        SegmentsStats segmentsStatsForShard5Before = shard5.segmentStats(false, false);
+        SegmentsStats segmentsStatsForShard1Before = shard1.segmentStats(false, false, false);
+        SegmentsStats segmentsStatsForShard2Before = shard2.segmentStats(false, false, false);
+        SegmentsStats segmentsStatsForShard3Before = shard3.segmentStats(false, false, false);
+        SegmentsStats segmentsStatsForShard4Before = shard4.segmentStats(false, false, false);
+        SegmentsStats segmentsStatsForShard5Before = shard5.segmentStats(false, false, false);
         AtomicLong totalSegmentsBefore = new AtomicLong(
             segmentsStatsForShard1Before.getCount() + segmentsStatsForShard2Before.getCount() + segmentsStatsForShard3Before.getCount()
                 + segmentsStatsForShard4Before.getCount() + segmentsStatsForShard5Before.getCount()
         );
         assertTrue(totalSegmentsBefore.get() > 5);
-        waitUntil(() -> shard1.segmentStats(false, false).getCount() == SEGMENT_COUNT, 1, TimeUnit.MINUTES);
-        waitUntil(() -> shard2.segmentStats(false, false).getCount() == SEGMENT_COUNT, 1, TimeUnit.MINUTES);
-        waitUntil(() -> shard3.segmentStats(false, false).getCount() == SEGMENT_COUNT, 1, TimeUnit.MINUTES);
-        waitUntil(() -> shard4.segmentStats(false, false).getCount() == SEGMENT_COUNT, 1, TimeUnit.MINUTES);
-        waitUntil(() -> shard5.segmentStats(false, false).getCount() == SEGMENT_COUNT, 1, TimeUnit.MINUTES);
-        SegmentsStats segmentsStatsForShard1After = shard1.segmentStats(false, false);
-        SegmentsStats segmentsStatsForShard2After = shard2.segmentStats(false, false);
-        SegmentsStats segmentsStatsForShard3After = shard3.segmentStats(false, false);
-        SegmentsStats segmentsStatsForShard4After = shard4.segmentStats(false, false);
-        SegmentsStats segmentsStatsForShard5After = shard5.segmentStats(false, false);
+        waitUntil(() -> shard1.segmentStats(false, false, false).getCount() == SEGMENT_COUNT, 1, TimeUnit.MINUTES);
+        waitUntil(() -> shard2.segmentStats(false, false, false).getCount() == SEGMENT_COUNT, 1, TimeUnit.MINUTES);
+        waitUntil(() -> shard3.segmentStats(false, false, false).getCount() == SEGMENT_COUNT, 1, TimeUnit.MINUTES);
+        waitUntil(() -> shard4.segmentStats(false, false, false).getCount() == SEGMENT_COUNT, 1, TimeUnit.MINUTES);
+        waitUntil(() -> shard5.segmentStats(false, false, false).getCount() == SEGMENT_COUNT, 1, TimeUnit.MINUTES);
+        SegmentsStats segmentsStatsForShard1After = shard1.segmentStats(false, false, false);
+        SegmentsStats segmentsStatsForShard2After = shard2.segmentStats(false, false, false);
+        SegmentsStats segmentsStatsForShard3After = shard3.segmentStats(false, false, false);
+        SegmentsStats segmentsStatsForShard4After = shard4.segmentStats(false, false, false);
+        SegmentsStats segmentsStatsForShard5After = shard5.segmentStats(false, false, false);
         AtomicLong totalSegmentsAfter = new AtomicLong(
             segmentsStatsForShard1After.getCount() + segmentsStatsForShard2After.getCount() + segmentsStatsForShard3After.getCount()
                 + segmentsStatsForShard4After.getCount() + segmentsStatsForShard5After.getCount()

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStats.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStats.java
@@ -227,7 +227,11 @@ public class CommonStats implements Writeable, ToXContentFragment {
                         completion = indexShard.completionStats(flags.completionDataFields());
                         break;
                     case Segments:
-                        segments = indexShard.segmentStats(flags.includeSegmentFileSizes(), flags.includeUnloadedSegments());
+                        segments = indexShard.segmentStats(
+                            flags.includeSegmentFileSizes(),
+                            flags.includeUnloadedSegments(),
+                            flags.includeFieldLevelSegmentFileSizes()
+                        );
                         break;
                     case Translog:
                         translog = indexShard.translogStats();

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -62,6 +62,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
     private String[] completionDataFields = null;
     private boolean includeSegmentFileSizes = false;
     private boolean includeUnloadedSegments = false;
+    private boolean includeFieldLevelSegmentFileSizes = false;
     private boolean includeAllShardIndexingPressureTrackers = false;
     private boolean includeOnlyTopIndexingPressureMetrics = false;
     // Used for metric CACHE_STATS, to determine which caches to report stats for
@@ -104,6 +105,9 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         if (in.getVersion().onOrAfter(Version.V_2_17_0)) {
             includeIndicesStatsByLevel = in.readBoolean();
         }
+        if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
+            includeFieldLevelSegmentFileSizes = in.readBoolean();
+        }
     }
 
     @Override
@@ -131,6 +135,9 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         if (out.getVersion().onOrAfter(Version.V_2_17_0)) {
             out.writeBoolean(includeIndicesStatsByLevel);
         }
+        if (out.getVersion().onOrAfter(Version.V_3_0_0)) {
+            out.writeBoolean(includeFieldLevelSegmentFileSizes);
+        }
     }
 
     /**
@@ -143,6 +150,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         completionDataFields = null;
         includeSegmentFileSizes = false;
         includeUnloadedSegments = false;
+        includeFieldLevelSegmentFileSizes = false;
         includeAllShardIndexingPressureTrackers = false;
         includeOnlyTopIndexingPressureMetrics = false;
         includeCaches = EnumSet.allOf(CacheType.class);
@@ -160,6 +168,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         completionDataFields = null;
         includeSegmentFileSizes = false;
         includeUnloadedSegments = false;
+        includeFieldLevelSegmentFileSizes = false;
         includeAllShardIndexingPressureTrackers = false;
         includeOnlyTopIndexingPressureMetrics = false;
         includeCaches = EnumSet.noneOf(CacheType.class);
@@ -223,6 +232,11 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         return this;
     }
 
+    public CommonStatsFlags includeFieldLevelSegmentFileSizes(boolean includeFieldLevelSegmentFileSizes) {
+        this.includeFieldLevelSegmentFileSizes = includeFieldLevelSegmentFileSizes;
+        return this;
+    }
+
     public CommonStatsFlags includeUnloadedSegments(boolean includeUnloadedSegments) {
         this.includeUnloadedSegments = includeUnloadedSegments;
         return this;
@@ -267,6 +281,10 @@ public class CommonStatsFlags implements Writeable, Cloneable {
 
     public boolean includeSegmentFileSizes() {
         return this.includeSegmentFileSizes;
+    }
+
+    public boolean includeFieldLevelSegmentFileSizes() {
+        return this.includeFieldLevelSegmentFileSizes;
     }
 
     public void setIncludeIndicesStatsByLevel(boolean includeIndicesStatsByLevel) {

--- a/server/src/main/java/org/opensearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -292,6 +292,11 @@ public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> {
         return this;
     }
 
+    public IndicesStatsRequest includeFieldLevelSegmentFileSizes(boolean includeFieldLevelSegmentFileSizes) {
+        flags.includeFieldLevelSegmentFileSizes(includeFieldLevelSegmentFileSizes);
+        return this;
+    }
+
     public IndicesStatsRequest includeUnloadedSegments(boolean includeUnloadedSegments) {
         flags.includeUnloadedSegments(includeUnloadedSegments);
         return this;

--- a/server/src/main/java/org/opensearch/common/FieldFileStats.java
+++ b/server/src/main/java/org/opensearch/common/FieldFileStats.java
@@ -1,0 +1,213 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common;
+
+import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A reusable class to encode field → {extension → file size} mappings for segment statistics.
+ * This class provides per-field disk consumption breakdown by file extension.
+ *
+ * @opensearch.api
+ */
+@PublicApi(since = "3.0.0")
+public final class FieldFileStats implements Writeable, Iterable<Map.Entry<String, Map<String, Long>>> {
+
+    private final Map<String, Map<String, Long>> stats;
+
+    /**
+     * Creates a new FieldFileStats instance
+     *
+     * @param stats the field to extension to size mapping
+     */
+    public FieldFileStats(Map<String, Map<String, Long>> stats) {
+        this.stats = Objects.requireNonNull(stats, "stats must be non-null");
+        assert stats.containsKey(null) == false : "stats cannot contain null field names";
+    }
+
+    /**
+     * Creates a new FieldFileStats instance from a stream
+     *
+     * @param input the stream input
+     * @throws IOException if an I/O error occurs
+     */
+    public FieldFileStats(StreamInput input) throws IOException {
+        int fieldCount = input.readVInt();
+        this.stats = new HashMap<>(fieldCount);
+
+        for (int i = 0; i < fieldCount; i++) {
+            String fieldName = input.readString();
+            int extensionCount = input.readVInt();
+            Map<String, Long> extensionSizes = new HashMap<>(extensionCount);
+
+            for (int j = 0; j < extensionCount; j++) {
+                String extension = input.readString();
+                long size = input.readVLong();
+                extensionSizes.put(extension, size);
+            }
+
+            stats.put(fieldName, extensionSizes);
+        }
+    }
+
+    /**
+     * Adds / merges the given field file stats into this stats instance
+     *
+     * @param fieldFileStats the stats to merge
+     */
+    public void add(FieldFileStats fieldFileStats) {
+        for (final var fieldEntry : fieldFileStats.stats.entrySet()) {
+            String fieldName = fieldEntry.getKey();
+            Map<String, Long> otherExtensions = fieldEntry.getValue();
+
+            stats.compute(fieldName, (k, existingExtensions) -> {
+                if (existingExtensions == null) {
+                    return new HashMap<>(otherExtensions);
+                } else {
+                    for (Map.Entry<String, Long> extEntry : otherExtensions.entrySet()) {
+                        existingExtensions.merge(extEntry.getKey(), extEntry.getValue(), Long::sum);
+                    }
+                    return existingExtensions;
+                }
+            });
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(stats.size());
+
+        for (Map.Entry<String, Map<String, Long>> fieldEntry : stats.entrySet()) {
+            out.writeString(fieldEntry.getKey());
+            Map<String, Long> extensionSizes = fieldEntry.getValue();
+            out.writeVInt(extensionSizes.size());
+
+            for (Map.Entry<String, Long> extEntry : extensionSizes.entrySet()) {
+                out.writeString(extEntry.getKey());
+                out.writeVLong(extEntry.getValue());
+            }
+        }
+    }
+
+    /**
+     * Generates x-content into the given builder for field-level file statistics.
+     * Output format:
+     * <pre>
+     * "field_level_file_sizes": {
+     *   "fieldName": {
+     *     "extension": {
+     *       "size_in_bytes": 12345,
+     *       "size": "12kb"
+     *     }
+     *   }
+     * }
+     * </pre>
+     *
+     * @param builder the builder to generate on
+     * @param key the top level key for this stats object
+     * @throws IOException if an I/O error occurs
+     */
+    public void toXContent(XContentBuilder builder, String key) throws IOException {
+        builder.startObject(key);
+        for (final var fieldEntry : stats.entrySet()) {
+            builder.startObject(fieldEntry.getKey());
+            for (final var extEntry : fieldEntry.getValue().entrySet()) {
+                builder.startObject(extEntry.getKey());
+                builder.humanReadableField("size_in_bytes", "size", new ByteSizeValue(extEntry.getValue()));
+                builder.endObject();
+            }
+            builder.endObject();
+        }
+        builder.endObject();
+    }
+
+    /**
+     * Creates a deep copy of this stats instance
+     *
+     * @return a new copy of this FieldFileStats
+     */
+    public FieldFileStats copy() {
+        Map<String, Map<String, Long>> copiedStats = new HashMap<>(stats.size());
+        for (Map.Entry<String, Map<String, Long>> entry : stats.entrySet()) {
+            copiedStats.put(entry.getKey(), new HashMap<>(entry.getValue()));
+        }
+        return new FieldFileStats(copiedStats);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FieldFileStats that = (FieldFileStats) o;
+        return Objects.equals(stats, that.stats);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stats);
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, Map<String, Long>>> iterator() {
+        return stats.entrySet().iterator();
+    }
+
+    /**
+     * Returns the file size in bytes for a specific field and extension,
+     * or 0 if the field/extension combination is not present
+     *
+     * @param field the field name
+     * @param extension the file extension
+     * @return the size in bytes
+     */
+    public long get(String field, String extension) {
+        Map<String, Long> extensions = stats.get(field);
+        return extensions != null ? extensions.getOrDefault(extension, 0L) : 0L;
+    }
+
+    /**
+     * Returns all extension sizes for a given field
+     *
+     * @param field the field name
+     * @return map of extension to size, or null if field not present
+     */
+    public Map<String, Long> getField(String field) {
+        return stats.get(field);
+    }
+
+    /**
+     * Returns true if the given field is in the stats
+     *
+     * @param field the field name
+     * @return true if field exists
+     */
+    public boolean containsField(String field) {
+        return stats.containsKey(field);
+    }
+
+    /**
+     * Returns the total number of fields tracked
+     *
+     * @return the number of fields
+     */
+    public int getFieldCount() {
+        return stats.size();
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NoOpEngine.java
@@ -82,7 +82,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
         try (DirectoryReader reader = openDirectory(directory, config.getIndexSettings().isSoftDeleteEnabled(), config.getLeafSorter())) {
             for (LeafReaderContext ctx : reader.getContext().leaves()) {
                 SegmentReader segmentReader = Lucene.segmentReader(ctx.reader());
-                fillSegmentStats(segmentReader, true, segmentsStats);
+                fillSegmentStats(segmentReader, true, false, segmentsStats);
             }
             this.docsStats = docsStats(reader);
         } catch (IOException e) {
@@ -137,7 +137,11 @@ public final class NoOpEngine extends ReadOnlyEngine {
     }
 
     @Override
-    public SegmentsStats segmentsStats(boolean includeSegmentFileSizes, boolean includeUnloadedSegments) {
+    public SegmentsStats segmentsStats(
+        boolean includeSegmentFileSizes,
+        boolean includeUnloadedSegments,
+        boolean includeFieldLevelSegmentFileSizes
+    ) {
         if (includeUnloadedSegments) {
             final SegmentsStats stats = new SegmentsStats();
             stats.add(this.segmentsStats);
@@ -146,7 +150,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
             }
             return stats;
         } else {
-            return super.segmentsStats(includeSegmentFileSizes, includeUnloadedSegments);
+            return super.segmentsStats(includeSegmentFileSizes, includeUnloadedSegments, includeFieldLevelSegmentFileSizes);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -1579,8 +1579,16 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return mergeStats;
     }
 
-    public SegmentsStats segmentStats(boolean includeSegmentFileSizes, boolean includeUnloadedSegments) {
-        SegmentsStats segmentsStats = getEngine().segmentsStats(includeSegmentFileSizes, includeUnloadedSegments);
+    public SegmentsStats segmentStats(
+        boolean includeSegmentFileSizes,
+        boolean includeUnloadedSegments,
+        boolean includeFieldLevelSegmentFileSizes
+    ) {
+        SegmentsStats segmentsStats = getEngine().segmentsStats(
+            includeSegmentFileSizes,
+            includeUnloadedSegments,
+            includeFieldLevelSegmentFileSizes
+        );
         segmentsStats.addBitsetMemoryInBytes(shardBitsetFilterCache.getMemorySizeInBytes());
         // Populate remote_store stats only if the index is remote store backed
         if (indexSettings().isAssignedOnRemoteNode()) {

--- a/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndicesStatsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndicesStatsAction.java
@@ -158,6 +158,7 @@ public class RestIndicesStatsAction extends BaseRestHandler {
         if (indicesStatsRequest.segments()) {
             indicesStatsRequest.includeSegmentFileSizes(request.paramAsBoolean("include_segment_file_sizes", false));
             indicesStatsRequest.includeUnloadedSegments(request.paramAsBoolean("include_unloaded_segments", false));
+            indicesStatsRequest.includeFieldLevelSegmentFileSizes(request.paramAsBoolean("include_field_level_segment_file_sizes", false));
         }
 
         return channel -> client.admin().indices().stats(indicesStatsRequest, new RestToXContentListener<>(channel));

--- a/server/src/test/java/org/opensearch/common/FieldFileStatsTests.java
+++ b/server/src/test/java/org/opensearch/common/FieldFileStatsTests.java
@@ -1,0 +1,240 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FieldFileStatsTests extends OpenSearchTestCase {
+
+    private FieldFileStats createStats() {
+        Map<String, Map<String, Long>> stats = new HashMap<>();
+
+        Map<String, Long> field1Extensions = new HashMap<>();
+        field1Extensions.put("tim", 1000L);
+        field1Extensions.put("tip", 500L);
+        stats.put("field1", field1Extensions);
+
+        Map<String, Long> field2Extensions = new HashMap<>();
+        field2Extensions.put("dvd", 2000L);
+        stats.put("field2", field2Extensions);
+
+        return new FieldFileStats(stats);
+    }
+
+    public void testEmptyStats() {
+        Map<String, Map<String, Long>> empty = new HashMap<>();
+        FieldFileStats stats = new FieldFileStats(empty);
+        assertEquals(0, stats.getFieldCount());
+    }
+
+    public void testGetField() {
+        FieldFileStats stats = createStats();
+
+        Map<String, Long> field1 = stats.getField("field1");
+        assertNotNull(field1);
+        assertEquals(Long.valueOf(1000L), field1.get("tim"));
+        assertEquals(Long.valueOf(500L), field1.get("tip"));
+
+        Map<String, Long> field2 = stats.getField("field2");
+        assertNotNull(field2);
+        assertEquals(Long.valueOf(2000L), field2.get("dvd"));
+
+        assertNull(stats.getField("nonexistent"));
+    }
+
+    public void testGet() {
+        FieldFileStats stats = createStats();
+
+        assertEquals(1000L, stats.get("field1", "tim"));
+        assertEquals(500L, stats.get("field1", "tip"));
+        assertEquals(2000L, stats.get("field2", "dvd"));
+
+        assertEquals(0L, stats.get("field1", "nonexistent"));
+        assertEquals(0L, stats.get("nonexistent", "tim"));
+    }
+
+    public void testContainsField() {
+        FieldFileStats stats = createStats();
+
+        assertTrue(stats.containsField("field1"));
+        assertTrue(stats.containsField("field2"));
+        assertFalse(stats.containsField("nonexistent"));
+    }
+
+    public void testGetFieldCount() {
+        FieldFileStats stats = createStats();
+        assertEquals(2, stats.getFieldCount());
+
+        Map<String, Map<String, Long>> empty = new HashMap<>();
+        FieldFileStats emptyStats = new FieldFileStats(empty);
+        assertEquals(0, emptyStats.getFieldCount());
+    }
+
+    public void testAddFieldFileStats() {
+        Map<String, Map<String, Long>> stats1Map = new HashMap<>();
+        Map<String, Long> field1Ext = new HashMap<>();
+        field1Ext.put("tim", 1000L);
+        stats1Map.put("field1", field1Ext);
+
+        Map<String, Long> field2Ext = new HashMap<>();
+        field2Ext.put("dvd", 2000L);
+        stats1Map.put("field2", field2Ext);
+
+        FieldFileStats stats1 = new FieldFileStats(stats1Map);
+
+        Map<String, Map<String, Long>> stats2Map = new HashMap<>();
+        Map<String, Long> field1Ext2 = new HashMap<>();
+        field1Ext2.put("tim", 500L); // Should be added to existing
+        stats2Map.put("field1", field1Ext2);
+
+        Map<String, Long> field3Ext = new HashMap<>();
+        field3Ext.put("doc", 3000L); // New field
+        stats2Map.put("field3", field3Ext);
+
+        FieldFileStats stats2 = new FieldFileStats(stats2Map);
+
+        stats1.add(stats2);
+
+        assertEquals(3, stats1.getFieldCount());
+        assertEquals(1500L, stats1.get("field1", "tim")); // 1000 + 500
+        assertEquals(2000L, stats1.get("field2", "dvd"));
+        assertEquals(3000L, stats1.get("field3", "doc"));
+    }
+
+    public void testCopy() {
+        FieldFileStats original = createStats();
+        FieldFileStats copy = original.copy();
+
+        assertNotSame(original, copy);
+        assertEquals(original.getFieldCount(), copy.getFieldCount());
+        assertEquals(original.get("field1", "tim"), copy.get("field1", "tim"));
+        assertEquals(original.get("field1", "tip"), copy.get("field1", "tip"));
+        assertEquals(original.get("field2", "dvd"), copy.get("field2", "dvd"));
+
+        // Modifying copy should not affect original
+        Map<String, Map<String, Long>> newFieldMap = new HashMap<>();
+        Map<String, Long> newFieldExt = new HashMap<>();
+        newFieldExt.put("nvd", 4000L);
+        newFieldMap.put("field3", newFieldExt);
+        FieldFileStats additionalStats = new FieldFileStats(newFieldMap);
+
+        copy.add(additionalStats);
+
+        assertEquals(2, original.getFieldCount());
+        assertEquals(3, copy.getFieldCount());
+        assertFalse(original.containsField("field3"));
+        assertTrue(copy.containsField("field3"));
+    }
+
+    public void testSerialization() throws IOException {
+        FieldFileStats original = createStats();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        FieldFileStats deserialized = new FieldFileStats(in);
+
+        assertEquals(original.getFieldCount(), deserialized.getFieldCount());
+        assertEquals(original.get("field1", "tim"), deserialized.get("field1", "tim"));
+        assertEquals(original.get("field1", "tip"), deserialized.get("field1", "tip"));
+        assertEquals(original.get("field2", "dvd"), deserialized.get("field2", "dvd"));
+        assertEquals(original, deserialized);
+    }
+
+    public void testSerializationEmpty() throws IOException {
+        Map<String, Map<String, Long>> empty = new HashMap<>();
+        FieldFileStats original = new FieldFileStats(empty);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        FieldFileStats deserialized = new FieldFileStats(in);
+
+        assertEquals(0, deserialized.getFieldCount());
+        assertEquals(original, deserialized);
+    }
+
+    public void testToXContent() throws IOException {
+        FieldFileStats stats = createStats();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+        builder.startObject();
+        stats.toXContent(builder, "field_level_file_sizes");
+        builder.endObject();
+
+        String json = builder.toString();
+
+        assertTrue(json.contains("field_level_file_sizes"));
+        assertTrue(json.contains("field1"));
+        assertTrue(json.contains("field2"));
+        assertTrue(json.contains("tim"));
+        assertTrue(json.contains("tip"));
+        assertTrue(json.contains("dvd"));
+        assertTrue(json.contains("size_in_bytes"));
+        assertTrue(json.contains("\"size_in_bytes\" : 1000"));
+        assertTrue(json.contains("\"size_in_bytes\" : 500"));
+        assertTrue(json.contains("\"size_in_bytes\" : 2000"));
+    }
+
+    public void testToXContentEmpty() throws IOException {
+        Map<String, Map<String, Long>> empty = new HashMap<>();
+        FieldFileStats stats = new FieldFileStats(empty);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+        builder.startObject();
+        stats.toXContent(builder, "field_level_file_sizes");
+        builder.endObject();
+
+        String json = builder.toString();
+
+        assertTrue(json.contains("field_level_file_sizes"));
+        assertTrue(json.contains("{ }"));
+    }
+
+    public void testIterator() {
+        FieldFileStats stats = createStats();
+
+        int count = 0;
+        for (Map.Entry<String, Map<String, Long>> entry : stats) {
+            assertNotNull(entry.getKey());
+            assertNotNull(entry.getValue());
+            count++;
+        }
+        assertEquals(2, count);
+    }
+
+    public void testEquals() {
+        FieldFileStats stats1 = createStats();
+        FieldFileStats stats2 = createStats();
+        FieldFileStats stats3 = new FieldFileStats(new HashMap<>());
+
+        assertEquals(stats1, stats2);
+        assertNotEquals(stats1, stats3);
+        assertEquals(stats1, stats1);
+        assertNotEquals(stats1, null);
+        assertNotEquals(stats1, "not a FieldFileStats");
+    }
+
+    public void testHashCode() {
+        FieldFileStats stats1 = createStats();
+        FieldFileStats stats2 = createStats();
+
+        assertEquals(stats1.hashCode(), stats2.hashCode());
+    }
+}

--- a/server/src/test/java/org/opensearch/index/autoforcemerge/AutoForceMergeManagerTests.java
+++ b/server/src/test/java/org/opensearch/index/autoforcemerge/AutoForceMergeManagerTests.java
@@ -898,7 +898,7 @@ public class AutoForceMergeManagerTests extends OpenSearchTestCase {
 
         when(shard.shardId()).thenReturn(shardId1);
         when(shard.translogStats()).thenReturn(translogStats);
-        when(shard.segmentStats(false, false)).thenReturn(segmentsStats);
+        when(shard.segmentStats(false, false, false)).thenReturn(segmentsStats);
         when(shard.routingEntry()).thenReturn(shardRouting);
         when(shardRouting.primary()).thenReturn(true);
         when(shard.state()).thenReturn(IndexShardState.STARTED);

--- a/server/src/test/java/org/opensearch/index/engine/NRTReplicationEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/NRTReplicationEngineTests.java
@@ -69,7 +69,7 @@ public class NRTReplicationEngineTests extends EngineTestCase {
                 // refresh to create a lot of segments.
                 engine.refresh("test");
             }
-            assertEquals(2, engine.segmentsStats(false, false).getCount());
+            assertEquals(2, engine.segmentsStats(false, false, false).getCount());
             // wipe the nrt directory initially so we can sync with primary.
             Lucene.cleanLuceneIndex(nrtEngineStore.directory());
             for (String file : engine.getLatestSegmentInfos().files(true)) {
@@ -445,7 +445,7 @@ public class NRTReplicationEngineTests extends EngineTestCase {
                 // refresh to create a lot of segments.
                 engine.refresh("test");
             }
-            assertEquals(2, engine.segmentsStats(false, false).getCount());
+            assertEquals(2, engine.segmentsStats(false, false, false).getCount());
             // wipe the nrt directory initially so we can sync with primary.
             Lucene.cleanLuceneIndex(nrtEngineStore.directory());
             assertFalse(
@@ -464,7 +464,7 @@ public class NRTReplicationEngineTests extends EngineTestCase {
             // merge primary down to 1 segment
             engine.forceMerge(true, 1, false, false, false, UUIDs.randomBase64UUID());
             // we expect a 3rd segment to be created after merge.
-            assertEquals(3, engine.segmentsStats(false, false).getCount());
+            assertEquals(3, engine.segmentsStats(false, false, false).getCount());
             final Collection<String> latestPrimaryFiles = engine.getLatestSegmentInfos().files(false);
 
             // copy new segments in and load reader.

--- a/server/src/test/java/org/opensearch/index/engine/NoOpEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/NoOpEngineTests.java
@@ -168,7 +168,7 @@ public class NoOpEngineTests extends EngineTestCase {
             final SegmentsStats expectedSegmentStats;
             try (InternalEngine engine = createEngine(config)) {
                 expectedDocStats = engine.docStats();
-                expectedSegmentStats = engine.segmentsStats(includeFileSize, true);
+                expectedSegmentStats = engine.segmentsStats(includeFileSize, true, false);
             }
 
             try (NoOpEngine noOpEngine = new NoOpEngine(config)) {
@@ -176,14 +176,14 @@ public class NoOpEngineTests extends EngineTestCase {
                 assertEquals(expectedDocStats.getDeleted(), noOpEngine.docStats().getDeleted());
                 assertEquals(expectedDocStats.getTotalSizeInBytes(), noOpEngine.docStats().getTotalSizeInBytes());
                 assertEquals(expectedDocStats.getAverageSizeInBytes(), noOpEngine.docStats().getAverageSizeInBytes());
-                assertEquals(expectedSegmentStats.getCount(), noOpEngine.segmentsStats(includeFileSize, true).getCount());
+                assertEquals(expectedSegmentStats.getCount(), noOpEngine.segmentsStats(includeFileSize, true, false).getCount());
                 // don't compare memory in bytes since we load the index with term-dict off-heap
                 assertEquals(
                     expectedSegmentStats.getFileSizes().size(),
-                    noOpEngine.segmentsStats(includeFileSize, true).getFileSizes().size()
+                    noOpEngine.segmentsStats(includeFileSize, true, false).getFileSizes().size()
                 );
 
-                assertEquals(0, noOpEngine.segmentsStats(includeFileSize, false).getFileSizes().size());
+                assertEquals(0, noOpEngine.segmentsStats(includeFileSize, false, false).getFileSizes().size());
             } catch (AssertionError e) {
                 logger.error(config.getMergePolicy());
                 throw e;

--- a/server/src/test/java/org/opensearch/index/replication/IndexLevelReplicationTests.java
+++ b/server/src/test/java/org/opensearch/index/replication/IndexLevelReplicationTests.java
@@ -257,8 +257,8 @@ public class IndexLevelReplicationTests extends OpenSearchIndexLevelReplicationT
             IndexShard replica = shards.addReplica();
             shards.recoverReplica(replica);
 
-            SegmentsStats segmentsStats = replica.segmentStats(false, false);
-            SegmentsStats primarySegmentStats = shards.getPrimary().segmentStats(false, false);
+            SegmentsStats segmentsStats = replica.segmentStats(false, false, false);
+            SegmentsStats primarySegmentStats = shards.getPrimary().segmentStats(false, false, false);
             assertNotEquals(IndexRequest.UNSET_AUTO_GENERATED_TIMESTAMP, primarySegmentStats.getMaxUnsafeAutoIdTimestamp());
             assertEquals(primarySegmentStats.getMaxUnsafeAutoIdTimestamp(), segmentsStats.getMaxUnsafeAutoIdTimestamp());
             assertNotEquals(Long.MAX_VALUE, segmentsStats.getMaxUnsafeAutoIdTimestamp());

--- a/server/src/test/java/org/opensearch/indices/recovery/LocalStorePeerRecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/LocalStorePeerRecoverySourceHandlerTests.java
@@ -663,7 +663,7 @@ public class LocalStorePeerRecoverySourceHandlerTests extends OpenSearchTestCase
         final StartRecoveryRequest request = getStartRecoveryRequest();
         final IndexShard shard = mock(IndexShard.class);
         when(shard.seqNoStats()).thenReturn(mock(SeqNoStats.class));
-        when(shard.segmentStats(anyBoolean(), anyBoolean())).thenReturn(mock(SegmentsStats.class));
+        when(shard.segmentStats(anyBoolean(), anyBoolean(), anyBoolean())).thenReturn(mock(SegmentsStats.class));
         when(shard.isRelocatedPrimary()).thenReturn(true);
         when(shard.acquireSafeIndexCommit()).thenReturn(mock(GatedCloseable.class));
         doAnswer(invocation -> {
@@ -759,7 +759,7 @@ public class LocalStorePeerRecoverySourceHandlerTests extends OpenSearchTestCase
         final StartRecoveryRequest request = getStartRecoveryRequest();
         final IndexShard shard = mock(IndexShard.class);
         when(shard.seqNoStats()).thenReturn(mock(SeqNoStats.class));
-        when(shard.segmentStats(anyBoolean(), anyBoolean())).thenReturn(mock(SegmentsStats.class));
+        when(shard.segmentStats(anyBoolean(), anyBoolean(), anyBoolean())).thenReturn(mock(SegmentsStats.class));
         when(shard.isRelocatedPrimary()).thenReturn(false);
         final org.opensearch.index.shard.ReplicationGroup replicationGroup = mock(org.opensearch.index.shard.ReplicationGroup.class);
         final IndexShardRoutingTable routingTable = mock(IndexShardRoutingTable.class);
@@ -860,7 +860,7 @@ public class LocalStorePeerRecoverySourceHandlerTests extends OpenSearchTestCase
         final StartRecoveryRequest request = getStartRecoveryRequest();
         final IndexShard shard = mock(IndexShard.class);
         when(shard.seqNoStats()).thenReturn(mock(SeqNoStats.class));
-        when(shard.segmentStats(anyBoolean(), anyBoolean())).thenReturn(mock(SegmentsStats.class));
+        when(shard.segmentStats(anyBoolean(), anyBoolean(), anyBoolean())).thenReturn(mock(SegmentsStats.class));
         when(shard.isRelocatedPrimary()).thenReturn(false);
         when(shard.getRetentionLeases()).thenReturn(mock(RetentionLeases.class));
         final org.opensearch.index.shard.ReplicationGroup replicationGroup = mock(org.opensearch.index.shard.ReplicationGroup.class);

--- a/server/src/test/java/org/opensearch/indices/recovery/RemoteStorePeerRecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/opensearch/indices/recovery/RemoteStorePeerRecoverySourceHandlerTests.java
@@ -123,7 +123,7 @@ public class RemoteStorePeerRecoverySourceHandlerTests extends OpenSearchIndexLe
         final StartRecoveryRequest request = getStartRecoveryRequest();
         final IndexShard shard = mock(IndexShard.class);
         when(shard.seqNoStats()).thenReturn(mock(SeqNoStats.class));
-        when(shard.segmentStats(anyBoolean(), anyBoolean())).thenReturn(mock(SegmentsStats.class));
+        when(shard.segmentStats(anyBoolean(), anyBoolean(), anyBoolean())).thenReturn(mock(SegmentsStats.class));
         when(shard.isRelocatedPrimary()).thenReturn(false);
         final org.opensearch.index.shard.ReplicationGroup replicationGroup = mock(org.opensearch.index.shard.ReplicationGroup.class);
         final IndexShardRoutingTable routingTable = mock(IndexShardRoutingTable.class);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

## Summary

This PR adds field-level disk consumption statistics to the `_stats` API, allowing users to understand how much disk space each field consumes in their Lucene segment files. This feature helps identify which fields are taking up the most space and enables better index optimization decisions.

## Related Issue

Resolves #12113

## Motivation

Users currently have segment-level file size statistics but lack visibility into which fields contribute to disk usage. This makes it difficult to:
- Identify high-cardinality fields consuming excessive disk space
- Optimize field mappings based on actual storage costs
- Make informed decisions about field deletion or type changes

## Implementation Details

### Approach

The implementation uses **proportional attribution** to calculate field-level statistics:
1. For each segment, read `FieldInfos` to determine which fields use which file types
2. Get existing file sizes by extension (`.tim`, `.dvd`, `.doc`, etc.)
3. Divide each file's size equally among all fields that use that file type

## Testing
### Stats API Call 
`curl -X GET "http://localhost:9200/my-index/_stats/segments?include_field_level_segment_file_sizes=true"`

### Output
`
{
  "_shards": {
    "total": 6,
    "successful": 3,
    "failed": 0
  },
  "_all": {
    "primaries": {
      "segments": {
        "count": 3,
        "memory_in_bytes": 0,
        "terms_memory_in_bytes": 0,
        "stored_fields_memory_in_bytes": 0,
        "term_vectors_memory_in_bytes": 0,
        "norms_memory_in_bytes": 0,
        "points_memory_in_bytes": 0,
        "doc_values_memory_in_bytes": 0,
        "index_writer_memory_in_bytes": 0,
        "version_map_memory_in_bytes": 0,
        "fixed_bit_set_memory_in_bytes": 0,
        "max_unsafe_auto_id_timestamp": -1,
        "remote_store": {
          "upload": {
            "total_upload_size": {
              "started_bytes": 0,
              "succeeded_bytes": 0,
              "failed_bytes": 0
            },
            "refresh_size_lag": {
              "total_bytes": 0,
              "max_bytes": 0
            },
            "max_refresh_time_lag_in_millis": 0,
            "total_time_spent_in_millis": 0,
            "pressure": {
              "total_rejections": 0
            }
          },
          "download": {
            "total_download_size": {
              "started_bytes": 0,
              "succeeded_bytes": 0,
              "failed_bytes": 0
            },
            "total_time_spent_in_millis": 0
          }
        },
        "segment_replication": {
          "max_bytes_behind": 0,
          "total_bytes_behind": 0,
          "max_replication_lag": 0
        },
        "file_sizes": {},
        "field_level_file_sizes": {
          "_seq_no": {
            "kdi": {
              "size_in_bytes": 69
            },
            "dvd": {
              "size_in_bytes": 48
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "kdm": {
              "size_in_bytes": 249
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "kdd": {
              "size_in_bytes": 129
            },
            "dvm": {
              "size_in_bytes": 358
            },
            "fdx": {
              "size_in_bytes": 18
            }
          },
          "author": {
            "dvd": {
              "size_in_bytes": 48
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "doc": {
              "size_in_bytes": 66
            },
            "tim": {
              "size_in_bytes": 340
            },
            "dvm": {
              "size_in_bytes": 358
            },
            "tip": {
              "size_in_bytes": 84
            },
            "fdx": {
              "size_in_bytes": 18
            }
          },
          "_source": {
            "fnm": {
              "size_in_bytes": 315
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "fdx": {
              "size_in_bytes": 18
            }
          },
          "_id": {
            "doc": {
              "size_in_bytes": 66
            },
            "tim": {
              "size_in_bytes": 340
            },
            "tip": {
              "size_in_bytes": 84
            },
            "fdx": {
              "size_in_bytes": 18
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "fdt": {
              "size_in_bytes": 202
            }
          },
          "title": {
            "nvm": {
              "size_in_bytes": 207
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "pos": {
              "size_in_bytes": 177
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "doc": {
              "size_in_bytes": 66
            },
            "tim": {
              "size_in_bytes": 340
            },
            "tip": {
              "size_in_bytes": 84
            },
            "fdx": {
              "size_in_bytes": 18
            },
            "nvd": {
              "size_in_bytes": 94
            }
          },
          "publish_date": {
            "kdi": {
              "size_in_bytes": 69
            },
            "dvd": {
              "size_in_bytes": 48
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "kdm": {
              "size_in_bytes": 249
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "kdd": {
              "size_in_bytes": 129
            },
            "dvm": {
              "size_in_bytes": 358
            },
            "fdx": {
              "size_in_bytes": 18
            }
          },
          "_version": {
            "dvm": {
              "size_in_bytes": 358
            },
            "dvd": {
              "size_in_bytes": 48
            },
            "fdx": {
              "size_in_bytes": 18
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "fdt": {
              "size_in_bytes": 202
            }
          },
          "_primary_term": {
            "dvm": {
              "size_in_bytes": 358
            },
            "dvd": {
              "size_in_bytes": 48
            },
            "fdx": {
              "size_in_bytes": 18
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "fdt": {
              "size_in_bytes": 202
            }
          },
          "views": {
            "kdi": {
              "size_in_bytes": 69
            },
            "dvd": {
              "size_in_bytes": 48
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "kdm": {
              "size_in_bytes": 249
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "kdd": {
              "size_in_bytes": 129
            },
            "dvm": {
              "size_in_bytes": 358
            },
            "fdx": {
              "size_in_bytes": 18
            }
          },
          "content": {
            "nvm": {
              "size_in_bytes": 207
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "pos": {
              "size_in_bytes": 177
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "doc": {
              "size_in_bytes": 66
            },
            "tim": {
              "size_in_bytes": 340
            },
            "tip": {
              "size_in_bytes": 84
            },
            "fdx": {
              "size_in_bytes": 18
            },
            "nvd": {
              "size_in_bytes": 94
            }
          }
        }
      }
    },
    "total": {
      "segments": {
        "count": 3,
        "memory_in_bytes": 0,
        "terms_memory_in_bytes": 0,
        "stored_fields_memory_in_bytes": 0,
        "term_vectors_memory_in_bytes": 0,
        "norms_memory_in_bytes": 0,
        "points_memory_in_bytes": 0,
        "doc_values_memory_in_bytes": 0,
        "index_writer_memory_in_bytes": 0,
        "version_map_memory_in_bytes": 0,
        "fixed_bit_set_memory_in_bytes": 0,
        "max_unsafe_auto_id_timestamp": -1,
        "remote_store": {
          "upload": {
            "total_upload_size": {
              "started_bytes": 0,
              "succeeded_bytes": 0,
              "failed_bytes": 0
            },
            "refresh_size_lag": {
              "total_bytes": 0,
              "max_bytes": 0
            },
            "max_refresh_time_lag_in_millis": 0,
            "total_time_spent_in_millis": 0,
            "pressure": {
              "total_rejections": 0
            }
          },
          "download": {
            "total_download_size": {
              "started_bytes": 0,
              "succeeded_bytes": 0,
              "failed_bytes": 0
            },
            "total_time_spent_in_millis": 0
          }
        },
        "segment_replication": {
          "max_bytes_behind": 0,
          "total_bytes_behind": 0,
          "max_replication_lag": 0
        },
        "file_sizes": {},
        "field_level_file_sizes": {
          "_seq_no": {
            "kdi": {
              "size_in_bytes": 69
            },
            "dvd": {
              "size_in_bytes": 48
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "kdm": {
              "size_in_bytes": 249
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "kdd": {
              "size_in_bytes": 129
            },
            "dvm": {
              "size_in_bytes": 358
            },
            "fdx": {
              "size_in_bytes": 18
            }
          },
          "author": {
            "dvd": {
              "size_in_bytes": 48
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "doc": {
              "size_in_bytes": 66
            },
            "tim": {
              "size_in_bytes": 340
            },
            "dvm": {
              "size_in_bytes": 358
            },
            "tip": {
              "size_in_bytes": 84
            },
            "fdx": {
              "size_in_bytes": 18
            }
          },
          "_source": {
            "fnm": {
              "size_in_bytes": 315
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "fdx": {
              "size_in_bytes": 18
            }
          },
          "_id": {
            "doc": {
              "size_in_bytes": 66
            },
            "tim": {
              "size_in_bytes": 340
            },
            "tip": {
              "size_in_bytes": 84
            },
            "fdx": {
              "size_in_bytes": 18
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "fdt": {
              "size_in_bytes": 202
            }
          },
          "title": {
            "nvm": {
              "size_in_bytes": 207
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "pos": {
              "size_in_bytes": 177
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "doc": {
              "size_in_bytes": 66
            },
            "tim": {
              "size_in_bytes": 340
            },
            "tip": {
              "size_in_bytes": 84
            },
            "fdx": {
              "size_in_bytes": 18
            },
            "nvd": {
              "size_in_bytes": 94
            }
          },
          "publish_date": {
            "kdi": {
              "size_in_bytes": 69
            },
            "dvd": {
              "size_in_bytes": 48
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "kdm": {
              "size_in_bytes": 249
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "kdd": {
              "size_in_bytes": 129
            },
            "dvm": {
              "size_in_bytes": 358
            },
            "fdx": {
              "size_in_bytes": 18
            }
          },
          "_version": {
            "dvm": {
              "size_in_bytes": 358
            },
            "dvd": {
              "size_in_bytes": 48
            },
            "fdx": {
              "size_in_bytes": 18
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "fdt": {
              "size_in_bytes": 202
            }
          },
          "_primary_term": {
            "dvm": {
              "size_in_bytes": 358
            },
            "dvd": {
              "size_in_bytes": 48
            },
            "fdx": {
              "size_in_bytes": 18
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "fdt": {
              "size_in_bytes": 202
            }
          },
          "views": {
            "kdi": {
              "size_in_bytes": 69
            },
            "dvd": {
              "size_in_bytes": 48
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "kdm": {
              "size_in_bytes": 249
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "kdd": {
              "size_in_bytes": 129
            },
            "dvm": {
              "size_in_bytes": 358
            },
            "fdx": {
              "size_in_bytes": 18
            }
          },
          "content": {
            "nvm": {
              "size_in_bytes": 207
            },
            "fnm": {
              "size_in_bytes": 315
            },
            "pos": {
              "size_in_bytes": 177
            },
            "fdt": {
              "size_in_bytes": 202
            },
            "doc": {
              "size_in_bytes": 66
            },
            "tim": {
              "size_in_bytes": 340
            },
            "tip": {
              "size_in_bytes": 84
            },
            "fdx": {
              "size_in_bytes": 18
            },
            "nvd": {
              "size_in_bytes": 94
            }
          }
        }
      }
    }
  },
  "indices": {
    "my-index": {
      "uuid": "QjqlEhehSRS8pI4xr6_gbg",
      "primaries": {
        "segments": {
          "count": 3,
          "memory_in_bytes": 0,
          "terms_memory_in_bytes": 0,
          "stored_fields_memory_in_bytes": 0,
          "term_vectors_memory_in_bytes": 0,
          "norms_memory_in_bytes": 0,
          "points_memory_in_bytes": 0,
          "doc_values_memory_in_bytes": 0,
          "index_writer_memory_in_bytes": 0,
          "version_map_memory_in_bytes": 0,
          "fixed_bit_set_memory_in_bytes": 0,
          "max_unsafe_auto_id_timestamp": -1,
          "remote_store": {
            "upload": {
              "total_upload_size": {
                "started_bytes": 0,
                "succeeded_bytes": 0,
                "failed_bytes": 0
              },
              "refresh_size_lag": {
                "total_bytes": 0,
                "max_bytes": 0
              },
              "max_refresh_time_lag_in_millis": 0,
              "total_time_spent_in_millis": 0,
              "pressure": {
                "total_rejections": 0
              }
            },
            "download": {
              "total_download_size": {
                "started_bytes": 0,
                "succeeded_bytes": 0,
                "failed_bytes": 0
              },
              "total_time_spent_in_millis": 0
            }
          },
          "segment_replication": {
            "max_bytes_behind": 0,
            "total_bytes_behind": 0,
            "max_replication_lag": 0
          },
          "file_sizes": {},
          "field_level_file_sizes": {
            "_seq_no": {
              "kdi": {
                "size_in_bytes": 69
              },
              "dvd": {
                "size_in_bytes": 48
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "kdm": {
                "size_in_bytes": 249
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "kdd": {
                "size_in_bytes": 129
              },
              "dvm": {
                "size_in_bytes": 358
              },
              "fdx": {
                "size_in_bytes": 18
              }
            },
            "author": {
              "dvd": {
                "size_in_bytes": 48
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "doc": {
                "size_in_bytes": 66
              },
              "tim": {
                "size_in_bytes": 340
              },
              "dvm": {
                "size_in_bytes": 358
              },
              "tip": {
                "size_in_bytes": 84
              },
              "fdx": {
                "size_in_bytes": 18
              }
            },
            "_source": {
              "fnm": {
                "size_in_bytes": 315
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "fdx": {
                "size_in_bytes": 18
              }
            },
            "_id": {
              "doc": {
                "size_in_bytes": 66
              },
              "tim": {
                "size_in_bytes": 340
              },
              "tip": {
                "size_in_bytes": 84
              },
              "fdx": {
                "size_in_bytes": 18
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "fdt": {
                "size_in_bytes": 202
              }
            },
            "title": {
              "nvm": {
                "size_in_bytes": 207
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "pos": {
                "size_in_bytes": 177
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "doc": {
                "size_in_bytes": 66
              },
              "tim": {
                "size_in_bytes": 340
              },
              "tip": {
                "size_in_bytes": 84
              },
              "fdx": {
                "size_in_bytes": 18
              },
              "nvd": {
                "size_in_bytes": 94
              }
            },
            "publish_date": {
              "kdi": {
                "size_in_bytes": 69
              },
              "dvd": {
                "size_in_bytes": 48
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "kdm": {
                "size_in_bytes": 249
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "kdd": {
                "size_in_bytes": 129
              },
              "dvm": {
                "size_in_bytes": 358
              },
              "fdx": {
                "size_in_bytes": 18
              }
            },
            "_version": {
              "dvm": {
                "size_in_bytes": 358
              },
              "dvd": {
                "size_in_bytes": 48
              },
              "fdx": {
                "size_in_bytes": 18
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "fdt": {
                "size_in_bytes": 202
              }
            },
            "_primary_term": {
              "dvm": {
                "size_in_bytes": 358
              },
              "dvd": {
                "size_in_bytes": 48
              },
              "fdx": {
                "size_in_bytes": 18
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "fdt": {
                "size_in_bytes": 202
              }
            },
            "views": {
              "kdi": {
                "size_in_bytes": 69
              },
              "dvd": {
                "size_in_bytes": 48
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "kdm": {
                "size_in_bytes": 249
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "kdd": {
                "size_in_bytes": 129
              },
              "dvm": {
                "size_in_bytes": 358
              },
              "fdx": {
                "size_in_bytes": 18
              }
            },
            "content": {
              "nvm": {
                "size_in_bytes": 207
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "pos": {
                "size_in_bytes": 177
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "doc": {
                "size_in_bytes": 66
              },
              "tim": {
                "size_in_bytes": 340
              },
              "tip": {
                "size_in_bytes": 84
              },
              "fdx": {
                "size_in_bytes": 18
              },
              "nvd": {
                "size_in_bytes": 94
              }
            }
          }
        }
      },
      "total": {
        "segments": {
          "count": 3,
          "memory_in_bytes": 0,
          "terms_memory_in_bytes": 0,
          "stored_fields_memory_in_bytes": 0,
          "term_vectors_memory_in_bytes": 0,
          "norms_memory_in_bytes": 0,
          "points_memory_in_bytes": 0,
          "doc_values_memory_in_bytes": 0,
          "index_writer_memory_in_bytes": 0,
          "version_map_memory_in_bytes": 0,
          "fixed_bit_set_memory_in_bytes": 0,
          "max_unsafe_auto_id_timestamp": -1,
          "remote_store": {
            "upload": {
              "total_upload_size": {
                "started_bytes": 0,
                "succeeded_bytes": 0,
                "failed_bytes": 0
              },
              "refresh_size_lag": {
                "total_bytes": 0,
                "max_bytes": 0
              },
              "max_refresh_time_lag_in_millis": 0,
              "total_time_spent_in_millis": 0,
              "pressure": {
                "total_rejections": 0
              }
            },
            "download": {
              "total_download_size": {
                "started_bytes": 0,
                "succeeded_bytes": 0,
                "failed_bytes": 0
              },
              "total_time_spent_in_millis": 0
            }
          },
          "segment_replication": {
            "max_bytes_behind": 0,
            "total_bytes_behind": 0,
            "max_replication_lag": 0
          },
          "file_sizes": {},
          "field_level_file_sizes": {
            "_seq_no": {
              "kdi": {
                "size_in_bytes": 69
              },
              "dvd": {
                "size_in_bytes": 48
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "kdm": {
                "size_in_bytes": 249
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "kdd": {
                "size_in_bytes": 129
              },
              "dvm": {
                "size_in_bytes": 358
              },
              "fdx": {
                "size_in_bytes": 18
              }
            },
            "author": {
              "dvd": {
                "size_in_bytes": 48
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "doc": {
                "size_in_bytes": 66
              },
              "tim": {
                "size_in_bytes": 340
              },
              "dvm": {
                "size_in_bytes": 358
              },
              "tip": {
                "size_in_bytes": 84
              },
              "fdx": {
                "size_in_bytes": 18
              }
            },
            "_source": {
              "fnm": {
                "size_in_bytes": 315
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "fdx": {
                "size_in_bytes": 18
              }
            },
            "_id": {
              "doc": {
                "size_in_bytes": 66
              },
              "tim": {
                "size_in_bytes": 340
              },
              "tip": {
                "size_in_bytes": 84
              },
              "fdx": {
                "size_in_bytes": 18
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "fdt": {
                "size_in_bytes": 202
              }
            },
            "title": {
              "nvm": {
                "size_in_bytes": 207
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "pos": {
                "size_in_bytes": 177
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "doc": {
                "size_in_bytes": 66
              },
              "tim": {
                "size_in_bytes": 340
              },
              "tip": {
                "size_in_bytes": 84
              },
              "fdx": {
                "size_in_bytes": 18
              },
              "nvd": {
                "size_in_bytes": 94
              }
            },
            "publish_date": {
              "kdi": {
                "size_in_bytes": 69
              },
              "dvd": {
                "size_in_bytes": 48
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "kdm": {
                "size_in_bytes": 249
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "kdd": {
                "size_in_bytes": 129
              },
              "dvm": {
                "size_in_bytes": 358
              },
              "fdx": {
                "size_in_bytes": 18
              }
            },
            "_version": {
              "dvm": {
                "size_in_bytes": 358
              },
              "dvd": {
                "size_in_bytes": 48
              },
              "fdx": {
                "size_in_bytes": 18
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "fdt": {
                "size_in_bytes": 202
              }
            },
            "_primary_term": {
              "dvm": {
                "size_in_bytes": 358
              },
              "dvd": {
                "size_in_bytes": 48
              },
              "fdx": {
                "size_in_bytes": 18
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "fdt": {
                "size_in_bytes": 202
              }
            },
            "views": {
              "kdi": {
                "size_in_bytes": 69
              },
              "dvd": {
                "size_in_bytes": 48
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "kdm": {
                "size_in_bytes": 249
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "kdd": {
                "size_in_bytes": 129
              },
              "dvm": {
                "size_in_bytes": 358
              },
              "fdx": {
                "size_in_bytes": 18
              }
            },
            "content": {
              "nvm": {
                "size_in_bytes": 207
              },
              "fnm": {
                "size_in_bytes": 315
              },
              "pos": {
                "size_in_bytes": 177
              },
              "fdt": {
                "size_in_bytes": 202
              },
              "doc": {
                "size_in_bytes": 66
              },
              "tim": {
                "size_in_bytes": 340
              },
              "tip": {
                "size_in_bytes": 84
              },
              "fdx": {
                "size_in_bytes": 18
              },
              "nvd": {
                "size_in_bytes": 94
              }
            }
          }
        }
      }
    }
  }
}
`


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
