### PR TITLE
Add IntelliJ run configurations for multi-node gradle clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ CLAUDE.md
 .cursor*
 
 # intellij files
-.idea/
+.idea/*
 *.iml
 *.ipr
 *.iws
@@ -12,7 +12,10 @@ out/
 
 # include shared intellij config
 !.idea/inspectionProfiles/Project_Default.xml
+!.idea/runConfigurations/
+.idea/runConfigurations/*
 !.idea/runConfigurations/Debug_OpenSearch.xml
+!.idea/runConfigurations/Debug_OpenSearch_Multinode_*.xml
 !.idea/vcs.xml
 !.idea/icon.svg
 

--- a/.idea/runConfigurations/Debug_OpenSearch_Multinode_1.xml
+++ b/.idea/runConfigurations/Debug_OpenSearch_Multinode_1.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug OpenSearch Multinode 1" type="Remote">
+    <module name="OpenSearch.server.main" />
+    <option name="USE_SOCKET_TRANSPORT" value="true" />
+    <option name="SERVER_MODE" value="true" />
+    <option name="SHMEM_ADDRESS" />
+    <option name="HOST" value="localhost" />
+    <option name="PORT" value="5005" />
+    <option name="AUTO_RESTART" value="true" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="5005" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Debug_OpenSearch_Multinode_2.xml
+++ b/.idea/runConfigurations/Debug_OpenSearch_Multinode_2.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug OpenSearch Multinode 2" type="Remote">
+    <module name="OpenSearch.server.main" />
+    <option name="USE_SOCKET_TRANSPORT" value="true" />
+    <option name="SERVER_MODE" value="true" />
+    <option name="SHMEM_ADDRESS" />
+    <option name="HOST" value="localhost" />
+    <option name="PORT" value="5006" />
+    <option name="AUTO_RESTART" value="true" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="5006" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Debug_OpenSearch_Multinode_3.xml
+++ b/.idea/runConfigurations/Debug_OpenSearch_Multinode_3.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug OpenSearch Multinode 3" type="Remote">
+    <module name="OpenSearch.server.main" />
+    <option name="USE_SOCKET_TRANSPORT" value="true" />
+    <option name="SERVER_MODE" value="true" />
+    <option name="SHMEM_ADDRESS" />
+    <option name="HOST" value="localhost" />
+    <option name="PORT" value="5007" />
+    <option name="AUTO_RESTART" value="true" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="5007" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add IntelliJ run configurations for multi-node gradle test clusters to enable debugging support. This change includes three new run configuration files that allow developers to debug multi-node test clusters directly from IntelliJ IDEA, improving the development experience for testing distributed OpenSearch functionality.

### Related Issues
Resolves #19342

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
