### PR TITLE
Fix file-based ingestion flaky test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix issue with updating core with a patch number other than 0 ([#19377](https://github.com/opensearch-project/OpenSearch/pull/19377))
 - [Java Agent] Allow JRT protocol URLs in protection domain extraction ([#19683](https://github.com/opensearch-project/OpenSearch/pull/19683))
 - Fix potential concurrent modification exception when updating allocation filters ([#19701])(https://github.com/opensearch-project/OpenSearch/pull/19701))
+- Fix file-based ingestion consumer to handle start point beyond max line number([#19757])(https://github.com/opensearch-project/OpenSearch/pull/19757))
 
 ### Dependencies
 - Update to Gradle 9.1 ([#19575](https://github.com/opensearch-project/OpenSearch/pull/19575))

--- a/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FilePartitionConsumer.java
+++ b/plugins/ingestion-fs/src/main/java/org/opensearch/plugin/ingestion/fs/FilePartitionConsumer.java
@@ -90,6 +90,7 @@ public class FilePartitionConsumer implements IngestionShardConsumer<FileOffset,
             }
 
             while (currentLineInReader < startLine && reader.readLine() != null) {
+                lastReadLine = currentLineInReader;
                 currentLineInReader++;
             }
 


### PR DESCRIPTION
### Description
File-based ingestion is a test implementation, mainly for local testing. `FileBasedIngestionSingleNodeTests.testFileIngestionFromLatestPointer` has been marked a flaky test. The reason for this is the file-based consumer doesn't track the last read line if the start point is beyond the number of lines in the file. This results in reading the entire file in the next iteration, causing the flaky test. 

The flaky test could be reproduced locally with some changes, and this PR fixes this bug.

### Related Issues
Resolves #19723

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
