### PR TITLE
Fix a flaky test that forces materialization to hit cache

### DIFF
--- a/server/src/test/java/org/opensearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -185,6 +185,10 @@ public class IndexFieldDataServiceTests extends OpenSearchSingleNodeTestCase {
         LeafFieldData loadField1 = ifd1.load(leafReaderContext);
         LeafFieldData loadField2 = ifd2.load(leafReaderContext);
 
+        // Force materialization so both hit the shared cache
+        loadField1.getBytesValues();
+        loadField2.getBytesValues();
+
         assertEquals(2, indicesService.getIndicesFieldDataCache().getCache().count());
 
         // Remove index


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
`IndexFieldData#load(LeafReaderContext)` does not always build and insert the heavy field-data into the shared cache immediately. For some field types/implementations it returns a lightweight wrapper that defers the expensive build until you actually access the values, or until a global/agg path forces construction.

### Related Issues
Resolves #19730 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved index field data cache validation testing by implementing explicit materialization of field data instances prior to cache state assertions. This ensures comprehensive and accurate verification of cache behavior during test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->