### PR TITLE
Fixed a flaky test that is order dependent

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/ShardsLimitAllocationDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/ShardsLimitAllocationDeciderIT.java
@@ -247,6 +247,9 @@ public class ShardsLimitAllocationDeciderIT extends ParameterizedStaticSettingsO
             .build();
         createIndex("test1", indexSettingsWithLimit);
 
+        // Ensure test1 primaries are assigned; replicas can remain unassigned (yellow)
+        ensureYellow("test1");
+
         // Create the second index with 4 shards and 1 replica
         createIndex(
             "test2",


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Allocation is concurrent and order-dependent. Sometimes test2/test3 fill up node capacity (the 6-shards-per-node cap) before all three test1 primaries get a slot. Then one test1 primary stays unassigned too, and you see 16 (or even 14) assigned instead of 17.

### Related Issues
Resolves #19726 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test synchronization for shard allocation scenarios to ensure proper primary assignment.
  * Improved test resilience for directory operations with robust error handling for file system edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->