### PR TITLE
[3.3] Bump ch.qos.logback modules from 1.5.18 to 1.5.20 in HDFS test fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Java Agent] Allow JRT protocol URLs in protection domain extraction ([#19683](https://github.com/opensearch-project/OpenSearch/pull/19683))
 
 ### Dependencies
+- Bump ch.qos.logback modules from 1.5.18 to 1.5.20 in HDFS test fixture ([#19764](https://github.com/opensearch-project/OpenSearch/pull/19764))
 
 ### Deprecated
 

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -78,8 +78,8 @@ dependencies {
   api 'org.apache.zookeeper:zookeeper:3.9.3'
   api "org.apache.commons:commons-text:1.13.1"
   api "commons-net:commons-net:3.11.1"
-  api "ch.qos.logback:logback-core:1.5.18"
-  api "ch.qos.logback:logback-classic:1.5.18"
+  api "ch.qos.logback:logback-core:1.5.20"
+  api "ch.qos.logback:logback-classic:1.5.20"
   api "org.jboss.xnio:xnio-nio:3.8.17.Final"
   api 'org.jline:jline:3.30.5'
   api 'org.apache.commons:commons-configuration2:2.12.0'


### PR DESCRIPTION
### Description

Bump ch.qos.logback modules from 1.5.18 to 1.5.20 in HDFS test fixture

This is to address CVEs flagged in 1.5.18. See https://mvnrepository.com/artifact/ch.qos.logback/logback-core

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
