### PR TITLE
Fixed StringIndexOutOfBoundsException caused by empty index expressions

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -1111,6 +1111,7 @@ public class IndexNameExpressionResolver {
                 String expression = expressions.get(i);
                 if (Strings.isEmpty(expression)) {
                     context.addResolutionError(indexNotFoundException(expression));
+                    continue;
                 }
                 validateAliasOrIndex(context, expression);
                 if (aliasOrIndexExists(context, options, metadata, expression)) {

--- a/server/src/test/java/org/opensearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -2112,6 +2112,22 @@ public class IndexNameExpressionResolverTests extends OpenSearchTestCase {
         assertEquals("Invalid index name [_foo], must not start with '_'.", iine.getMessage());
     }
 
+    public void testInvalidEmptyIndex() {
+        Metadata.Builder mdBuilder = Metadata.builder().put(indexBuilder("test"));
+        ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
+        IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(
+            state,
+            IndicesOptions.lenientExpandOpen(),
+            false
+        );
+
+        IndexNotFoundException indexNotFoundException = expectThrows(
+            IndexNotFoundException.class,
+            () -> indexNameExpressionResolver.concreteIndexNames(context, "")
+        );
+        assertEquals("no such index []", indexNotFoundException.getMessage());
+    }
+
     public void testIgnoreThrottled() {
         Metadata.Builder mdBuilder = Metadata.builder()
             .put(


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

This fixes a regression introduced by #18523 ; calling `IndexNameExpressionResolver.concreteIndices()` with an index expression containing an empty string should throw an `IndexNotFoundException`. However, this regressed to throwing a `StringIndexOutOfBoundsException`. This change fixes the issue.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
