### PR TITLE
Fixed missing error propagation in IndexNameExpressionResolver

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -349,7 +349,7 @@ public class IndexNameExpressionResolver {
                     .withResolutionErrors(context.getResolutionErrors())
                     .withResolutionErrors(infe);
             } else {
-                return ResolvedIndices.Local.Concrete.empty();
+                return ResolvedIndices.Local.Concrete.empty().withResolutionErrors(context.getResolutionErrors());
             }
         }
 

--- a/server/src/test/java/org/opensearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -2128,6 +2128,26 @@ public class IndexNameExpressionResolverTests extends OpenSearchTestCase {
         assertEquals("no such index []", indexNotFoundException.getMessage());
     }
 
+    public void testIgnoreAliasesOnNonWildcardValue() {
+        Metadata.Builder mdBuilder = Metadata.builder()
+            .put(indexBuilder("my_index").state(State.OPEN).putAlias(AliasMetadata.builder("my_alias")));
+        ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
+
+        // when ignoreAliases is set, and an alias is specified in the index expression without using a wildcard,
+        // an exception is expected.
+        IndicesOptions ignoreAliasesOptions = IndicesOptions.fromOptions(false, true, true, false, true, false, true, false);
+
+        IllegalArgumentException illegalArgumentException = expectThrows(
+            IllegalArgumentException.class,
+            () -> indexNameExpressionResolver.concreteIndexNames(state, ignoreAliasesOptions, "my_alias*", "-my_alias")
+        );
+
+        assertEquals(
+            "The provided expression [my_alias] matches an alias, specify the corresponding concrete indices instead.",
+            illegalArgumentException.getMessage()
+        );
+    }
+
     public void testIgnoreThrottled() {
         Metadata.Builder mdBuilder = Metadata.builder()
             .put(


### PR DESCRIPTION

### Description

This fixes a very specific issue in `IndexNameExpressionResolver` that was introduced in #18523. For requests with allow_no_indices = true, and an empty result set of matching expresssions, errors that were encountered before in `WildcardExpressionResolver` were not propagated. 

This can happen only in very specific cases; the requirement that the result set is empty makes it necessary that the errors in `WildcardExpressionResolver` are triggered by negated expressions; otherwise, the result set of matching expressions would not be empty. 

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
