### PR TITLE
[Backport 2.19]  Fix IndexOutOfBoundsException when running include/exclude with non-existent prefix term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix illegal argument exception when creating a PIT ([#16781](https://github.com/opensearch-project/OpenSearch/pull/16781))
 - Fix the bug of Access denied error when rolling log files ([#18597](https://github.com/opensearch-project/OpenSearch/pull/18597))
 - Use ScoreDoc instead of FieldDoc when creating TopScoreDocCollectorManager to avoid unnecessary conversion ([#18802](https://github.com/opensearch-project/OpenSearch/pull/18802))
+- Fix IndexOutOfBoundsException when running include/exclude on non-existent prefix in terms aggregations ([#19637](https://github.com/opensearch-project/OpenSearch/pull/19637))
 
 ### Security
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/IncludeExclude.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/IncludeExclude.java
@@ -440,6 +440,10 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
                 if (startOrd < 0) {
                     // The prefix is not an exact match in the ordinals (can skip equal length below)
                     startOrd = -1 - startOrd;
+                    // Check bounds before calling lookupOrd to avoid IndexOutOfBoundsException
+                    if (startOrd >= length) {
+                        continue;
+                    }
                     // Make sure that the term at startOrd starts with prefix
                     BytesRef startTerm = globalOrdinals.lookupOrd(startOrd);
                     if (startTerm.length <= prefix.length
@@ -453,8 +457,8 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
                         )) {
                         continue;
                     }
-                }
-                if (startOrd >= length) {
+                } else if (startOrd >= length) {
+                    // Exact match found, but out of bounds
                     continue;
                 }
                 BytesRef next = nextBytesRef(prefix);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Backports https://github.com/opensearch-project/OpenSearch/pull/19637/

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
