### PR TITLE
Native memory leak fix + indexing perf regression fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,5 +11,6 @@
 *.crt binary
 *.p12 binary
 *.ttf binary
+*.parquet binary
 *.txt text=auto
 CHANGELOG.md merge=union

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -86,3 +86,16 @@ ${error.file}
 
 21-:-javaagent:agent/opensearch-agent.jar
 21-:--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
+
+# Heap size settings
+# -Xms32g
+# -Xmx32g
+
+# Enable native memory tracking
+-XX:NativeMemoryTracking=summary
+
+# Allow jcmd to attach to the process (required for 'jcmd VM.native_memory' commands)
+-XX:+UnlockDiagnosticVMOptions
+
+# Enabling debug logs for Allocators in Arrow
+-Darrow.memory.debug.allocator=true

--- a/modules/parquet-data-format/build.gradle
+++ b/modules/parquet-data-format/build.gradle
@@ -107,6 +107,9 @@ dependencies {
 
   // SLF4J logging implementation (required by Apache Arrow)
   implementation 'org.slf4j:slf4j-api:2.0.17'
+
+  // Bridge for slf4j<-->log4j compatibility
+  implementation "org.apache.logging.log4j:log4j-slf4j2-impl:2.23.1"
 }
 
 test {

--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/bridge/ArrowExport.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/bridge/ArrowExport.java
@@ -28,9 +28,11 @@ public record ArrowExport(ArrowArray arrowArray, ArrowSchema arrowSchema) implem
     @Override
     public void close() {
         if (arrowArray != null) {
+            arrowArray.release();
             arrowArray.close();
         }
         if (arrowSchema != null) {
+            arrowSchema.release();
             arrowSchema.close();
         }
     }

--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/memory/ArrowBufferPool.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/memory/ArrowBufferPool.java
@@ -15,44 +15,44 @@ import java.util.concurrent.atomic.AtomicLong;
  * based on OpenSearch settings and memory pressure conditions.
  */
 public class ArrowBufferPool {
-    
+
     private final Settings settings;
     private final long maxAllocation;
     private final long initReservation;
     private final AllocationListener allocationListener;
     private final MemoryPressureMonitor memoryMonitor;
-    
+
     // Track active allocators for monitoring and cleanup
     private final ConcurrentHashMap<String, BufferAllocator> activeAllocators;
     private final AtomicLong totalAllocated;
-    
+
     public ArrowBufferPool(Settings settings, MemoryPressureMonitor memoryMonitor) {
         this.settings = settings;
         this.memoryMonitor = memoryMonitor;
         this.activeAllocators = new ConcurrentHashMap<>();
         this.totalAllocated = new AtomicLong(0);
-        
+
         // Configure memory limits - parse size strings manually
         this.maxAllocation = parseByteSize(settings.get("parquet.memory.max_allocation", "1gb"));
         this.initReservation = parseByteSize(settings.get("parquet.memory.init_reservation", "100mb"));
-        
+
         // Set up allocation listener for monitoring
         this.allocationListener = new PoolAllocationListener();
     }
-    
+
     /**
      * Creates a new child allocator with the configured strategy and limits.
-     * 
+     *
      * @param name Unique name for the allocator
      * @return BufferAllocator configured with pool settings
      */
     public BufferAllocator createAllocator(String name) {
         return createAllocator(name, initReservation, maxAllocation);
     }
-    
+
     /**
      * Creates a new child allocator with custom limits.
-     * 
+     *
      * @param name Unique name for the allocator
      * @param reservation Initial reservation amount
      * @param maxBytes Maximum allocation limit
@@ -64,20 +64,20 @@ public class ArrowBufferPool {
             throw new OutOfMemoryError(
                 "Cannot create allocator '" + name + "': memory pressure too high");
         }
-        
+
         BufferAllocator rootAllocator = createRootAllocator();
-        BufferAllocator childAllocator = rootAllocator.newChildAllocator(
-            name, allocationListener, reservation, maxBytes);
-        
-        activeAllocators.put(name, childAllocator);
+        //BufferAllocator childAllocator = rootAllocator.newChildAllocator(
+        //    name, allocationListener, reservation, maxBytes);
+
+        activeAllocators.put(name, rootAllocator);
         totalAllocated.addAndGet(reservation);
-        
-        return childAllocator;
+
+        return rootAllocator;
     }
-    
+
     /**
      * Releases an allocator and cleans up resources.
-     * 
+     *
      * @param name Name of the allocator to release
      */
     public void releaseAllocator(String name) {
@@ -88,10 +88,10 @@ public class ArrowBufferPool {
             allocator.close();
         }
     }
-    
+
     /**
      * Gets current memory allocation statistics.
-     * 
+     *
      * @return AllocationStats with current usage information
      */
     public AllocationStats getStats() {
@@ -102,7 +102,7 @@ public class ArrowBufferPool {
             memoryMonitor.getCurrentPressure()
         );
     }
-    
+
     /**
      * Closes all active allocators and cleans up the pool.
      */
@@ -111,12 +111,12 @@ public class ArrowBufferPool {
         activeAllocators.clear();
         totalAllocated.set(0);
     }
-    
+
     private BufferAllocator createRootAllocator() {
         // Create a simple RootAllocator with basic settings
         return new RootAllocator(maxAllocation);
     }
-    
+
     /**
      * Simple byte size parser for configuration strings.
      */
@@ -124,10 +124,10 @@ public class ArrowBufferPool {
         if (sizeStr == null || sizeStr.trim().isEmpty()) {
             return 0;
         }
-        
+
         String trimmed = sizeStr.trim().toLowerCase();
         long multiplier = 1;
-        
+
         if (trimmed.endsWith("kb")) {
             multiplier = 1024;
             trimmed = trimmed.substring(0, trimmed.length() - 2);
@@ -140,53 +140,53 @@ public class ArrowBufferPool {
         } else if (trimmed.endsWith("b")) {
             trimmed = trimmed.substring(0, trimmed.length() - 1);
         }
-        
+
         try {
             return Long.parseLong(trimmed.trim()) * multiplier;
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid byte size format: " + sizeStr, e);
         }
     }
-    
+
     /**
      * Allocation listener that integrates with memory monitoring.
      */
     private class PoolAllocationListener implements AllocationListener {
-        
+
         @Override
         public void onPreAllocation(long size) {
             if (memoryMonitor.shouldRejectAllocation(size)) {
                 throw new OutOfMemoryError("Memory pressure too high for allocation of " + size + " bytes");
             }
         }
-        
+
         @Override
         public void onAllocation(long size) {
             memoryMonitor.recordAllocation(size);
         }
-        
+
         @Override
         public void onRelease(long size) {
             memoryMonitor.recordDeallocation(size);
         }
-        
+
         @Override
         public boolean onFailedAllocation(long size, AllocationOutcome outcome) {
             memoryMonitor.recordFailedAllocation(size, "FAILED");
             return false; // Don't retry
         }
-        
+
         @Override
         public void onChildAdded(BufferAllocator parentAllocator, BufferAllocator childAllocator) {
             // Track child allocator creation
         }
-        
+
         @Override
         public void onChildRemoved(BufferAllocator parentAllocator, BufferAllocator childAllocator) {
             // Track child allocator removal
         }
     }
-    
+
     /**
      * Allocation statistics for monitoring.
      */
@@ -195,20 +195,20 @@ public class ArrowBufferPool {
         private final long maxAllocation;
         private final int activeAllocators;
         private final double memoryPressure;
-        
-        public AllocationStats(long totalAllocated, long maxAllocation, 
+
+        public AllocationStats(long totalAllocated, long maxAllocation,
                              int activeAllocators, double memoryPressure) {
             this.totalAllocated = totalAllocated;
             this.maxAllocation = maxAllocation;
             this.activeAllocators = activeAllocators;
             this.memoryPressure = memoryPressure;
         }
-        
+
         public long getTotalAllocated() { return totalAllocated; }
         public long getMaxAllocation() { return maxAllocation; }
         public int getActiveAllocators() { return activeAllocators; }
         public double getMemoryPressure() { return memoryPressure; }
-        public double getUtilizationRatio() { 
+        public double getUtilizationRatio() {
             return maxAllocation > 0 ? (double) totalAllocated / maxAllocation : 0.0;
         }
     }

--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/vsr/VSRManager.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/vsr/VSRManager.java
@@ -148,8 +148,8 @@ public class VSRManager {
                 System.err.println("Warning: Failed to close/flush writer: " + e.getMessage());
             }
 
-            // Complete VSR processing and cleanup
-            vsrPool.completeVSR(managedVSR);
+            // Close VSR Pool
+            vsrPool.close();
             managedVSR = null;
 
         } catch (Exception e) {

--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/vsr/VSRPool.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/vsr/VSRPool.java
@@ -227,6 +227,9 @@ public class VSRPool {
             frozen.close();
         }
 
+        bufferPool.close();
+        memoryMonitor.close();
+
         // Close any remaining VSRs
         allVSRs.values().forEach(ManagedVSR::close);
         allVSRs.clear();

--- a/modules/parquet-data-format/src/main/rust/src/lib.rs
+++ b/modules/parquet-data-format/src/main/rust/src/lib.rs
@@ -11,6 +11,9 @@ use arrow::ffi::{FFI_ArrowSchema, FFI_ArrowArray};
 use std::fs::OpenOptions;
 use std::io::Write;
 use chrono::Utc;
+use parquet::basic::{Compression, ZstdLevel};
+use parquet::file::properties::WriterProperties;
+
 pub mod parquet_merge;
 pub use parquet_merge::*;
 
@@ -44,7 +47,10 @@ impl NativeParquetWriter {
         let file = File::create(&filename)?;
         let file_clone = file.try_clone()?;
         FILE_MANAGER.insert(filename.clone(), file_clone);
-        let writer = ArrowWriter::try_new(file, schema, None)?;
+        let props = WriterProperties::builder()
+            .set_compression(Compression::ZSTD(ZstdLevel::try_new(3).unwrap()))
+            .build();
+        let writer = ArrowWriter::try_new(file, schema, Some(props))?;
         WRITER_MANAGER.insert(filename, Arc::new(Mutex::new(writer)));
         Ok(())
     }

--- a/server/src/main/java/org/opensearch/index/engine/exec/composite/CompositeDataFormatWriter.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/composite/CompositeDataFormatWriter.java
@@ -86,7 +86,9 @@ public class CompositeDataFormatWriter implements Writer<CompositeDataFormatWrit
 
     @Override
     public void close() {
-
+        for (ImmutablePair<DataFormat, Writer<? extends DocumentInput<?>>> writerPair : writers) {
+            writerPair.getRight().close();
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/engine/exec/composite/CompositeIndexingExecutionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/composite/CompositeIndexingExecutionEngine.java
@@ -127,6 +127,7 @@ public class CompositeIndexingExecutionEngine implements IndexingExecutionEngine
                 FileInfos fileInfos = dataFormatWriter.flush(null);
                 fileInfos.getWriterFilesMap()
                     .forEach((key, value) -> refreshInputs.computeIfAbsent(key, dataFormat -> new RefreshInput()).add(value));
+                dataFormatWriter.close();
             }
 
             if (refreshInputs.isEmpty()) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

- Fix for native memory leak issue identified during indexing benchmarking (closing ParquetWriter and it's internal classes properly)
- Fixes slow indexing due to addition of same entry multiple time in DocumentWriterPool's ConcurrentQueue
- Added additional jvm arguments and dependencies for better native memory tracking and debugging of Arrow Allocators

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
