### PR TITLE
Use TemporaryFolder JUnit @Rule to manage temporary folders in tests

### DIFF
--- a/distribution/tools/fips-demo-installer-cli/src/test/java/org/opensearch/tools/cli/fips/truststore/FipsTrustStoreCommandTestCase.java
+++ b/distribution/tools/fips-demo-installer-cli/src/test/java/org/opensearch/tools/cli/fips/truststore/FipsTrustStoreCommandTestCase.java
@@ -13,6 +13,8 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -24,6 +26,8 @@ import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
 public abstract class FipsTrustStoreCommandTestCase extends OpenSearchTestCase {
+    @ClassRule
+    public static TemporaryFolder tempFolder = new TemporaryFolder();
 
     protected StringWriter outputCapture;
     protected StringWriter errorCapture;
@@ -31,25 +35,15 @@ public abstract class FipsTrustStoreCommandTestCase extends OpenSearchTestCase {
     protected static Path sharedTempDir;
 
     @BeforeClass
+    @SuppressForbidden(reason = "the java.io.File is exposed by TemporaryFolder")
     static void setUpClass() throws Exception {
-        sharedTempDir = Files.createTempDirectory(Path.of(System.getProperty("java.io.tmpdir")), "system-command-test-");
+        sharedTempDir = tempFolder.newFolder().toPath();
         setProperties();
     }
 
     @AfterClass
     static void tearDownClass() throws Exception {
         clearProperties();
-        if (sharedTempDir != null && Files.exists(sharedTempDir)) {
-            try (var walk = Files.walk(sharedTempDir)) {
-                walk.sorted(java.util.Comparator.reverseOrder()).forEach(path -> {
-                    try {
-                        Files.delete(path);
-                    } catch (Exception e) {
-                        // Ignore
-                    }
-                });
-            }
-        }
     }
 
     @SuppressForbidden(reason = "set system properties as part of test setup")


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Use TemporaryFolder JUnit @Rule to manage temporary folders in tests

### Related Issues
This is a follow up on https://github.com/opensearch-project/OpenSearch/pull/18921 to replace custom folder management with JUnit in tests.

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
