### PR TITLE
[PoC] Dynamic loading of Analysis Plugin

### DIFF
--- a/libs/common/src/main/java/org/opensearch/common/NamedRegistry.java
+++ b/libs/common/src/main/java/org/opensearch/common/NamedRegistry.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.common;
 
+import org.opensearch.common.annotation.ExperimentalApi;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +46,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @opensearch.internal
  */
+@ExperimentalApi
 public class NamedRegistry<T> {
     private final Map<String, T> registry = new HashMap<>();
     private final String targetName;

--- a/server/src/main/java/org/opensearch/action/ActionModule.java
+++ b/server/src/main/java/org/opensearch/action/ActionModule.java
@@ -48,6 +48,8 @@ import org.opensearch.action.admin.cluster.decommission.awareness.put.Decommissi
 import org.opensearch.action.admin.cluster.decommission.awareness.put.TransportDecommissionAction;
 import org.opensearch.action.admin.cluster.health.ClusterHealthAction;
 import org.opensearch.action.admin.cluster.health.TransportClusterHealthAction;
+import org.opensearch.action.admin.cluster.loadplugins.LoadPluginsAction;
+import org.opensearch.action.admin.cluster.loadplugins.TransportLoadPluginsAction;
 import org.opensearch.action.admin.cluster.node.hotthreads.NodesHotThreadsAction;
 import org.opensearch.action.admin.cluster.node.hotthreads.TransportNodesHotThreadsAction;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoAction;
@@ -65,12 +67,16 @@ import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksAction;
 import org.opensearch.action.admin.cluster.node.tasks.list.TransportListTasksAction;
 import org.opensearch.action.admin.cluster.node.usage.NodesUsageAction;
 import org.opensearch.action.admin.cluster.node.usage.TransportNodesUsageAction;
+import org.opensearch.action.admin.cluster.registerplugins.RegisterPluginsAction;
+import org.opensearch.action.admin.cluster.registerplugins.TransportRegisterPluginsAction;
 import org.opensearch.action.admin.cluster.remote.RemoteInfoAction;
 import org.opensearch.action.admin.cluster.remote.TransportRemoteInfoAction;
 import org.opensearch.action.admin.cluster.remotestore.restore.RestoreRemoteStoreAction;
 import org.opensearch.action.admin.cluster.remotestore.restore.TransportRestoreRemoteStoreAction;
 import org.opensearch.action.admin.cluster.remotestore.stats.RemoteStoreStatsAction;
 import org.opensearch.action.admin.cluster.remotestore.stats.TransportRemoteStoreStatsAction;
+import org.opensearch.action.admin.cluster.removeplugins.RemovePluginsAction;
+import org.opensearch.action.admin.cluster.removeplugins.TransportRemovePluginsAction;
 import org.opensearch.action.admin.cluster.repositories.cleanup.CleanupRepositoryAction;
 import org.opensearch.action.admin.cluster.repositories.cleanup.TransportCleanupRepositoryAction;
 import org.opensearch.action.admin.cluster.repositories.delete.DeleteRepositoryAction;
@@ -357,6 +363,7 @@ import org.opensearch.rest.action.admin.cluster.RestGetSnapshotsAction;
 import org.opensearch.rest.action.admin.cluster.RestGetStoredScriptAction;
 import org.opensearch.rest.action.admin.cluster.RestGetTaskAction;
 import org.opensearch.rest.action.admin.cluster.RestListTasksAction;
+import org.opensearch.rest.action.admin.cluster.RestLoadPluginsAction;
 import org.opensearch.rest.action.admin.cluster.RestNodesHotThreadsAction;
 import org.opensearch.rest.action.admin.cluster.RestNodesInfoAction;
 import org.opensearch.rest.action.admin.cluster.RestNodesStatsAction;
@@ -364,9 +371,11 @@ import org.opensearch.rest.action.admin.cluster.RestNodesUsageAction;
 import org.opensearch.rest.action.admin.cluster.RestPendingClusterTasksAction;
 import org.opensearch.rest.action.admin.cluster.RestPutRepositoryAction;
 import org.opensearch.rest.action.admin.cluster.RestPutStoredScriptAction;
+import org.opensearch.rest.action.admin.cluster.RestRegisterPluginsAction;
 import org.opensearch.rest.action.admin.cluster.RestReloadSecureSettingsAction;
 import org.opensearch.rest.action.admin.cluster.RestRemoteClusterInfoAction;
 import org.opensearch.rest.action.admin.cluster.RestRemoteStoreStatsAction;
+import org.opensearch.rest.action.admin.cluster.RestRemovePluginsAction;
 import org.opensearch.rest.action.admin.cluster.RestRestoreRemoteStoreAction;
 import org.opensearch.rest.action.admin.cluster.RestRestoreSnapshotAction;
 import org.opensearch.rest.action.admin.cluster.RestSnapshotsStatusAction;
@@ -791,6 +800,11 @@ public class ActionModule extends AbstractModule {
         actions.register(GetSearchPipelineAction.INSTANCE, GetSearchPipelineTransportAction.class);
         actions.register(DeleteSearchPipelineAction.INSTANCE, DeleteSearchPipelineTransportAction.class);
 
+        // Plugin Management
+        actions.register(LoadPluginsAction.INSTANCE, TransportLoadPluginsAction.class);
+        actions.register(RegisterPluginsAction.INSTANCE, TransportRegisterPluginsAction.class);
+        actions.register(RemovePluginsAction.INSTANCE, TransportRemovePluginsAction.class);
+
         return unmodifiableMap(actions.getRegistry());
     }
 
@@ -993,6 +1007,11 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestPutSearchPipelineAction());
         registerHandler.accept(new RestGetSearchPipelineAction());
         registerHandler.accept(new RestDeleteSearchPipelineAction());
+
+        // Plugin Management API
+        registerHandler.accept(new RestLoadPluginsAction());
+        registerHandler.accept(new RestRegisterPluginsAction());
+        registerHandler.accept(new RestRemovePluginsAction());
 
         // Extensions API
         if (FeatureFlags.isEnabled(FeatureFlags.EXTENSIONS)) {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/loadplugins/LoadPluginsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/loadplugins/LoadPluginsAction.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.loadplugins;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Action for dynamically loading plugins
+ *
+ * @opensearch.internal
+ */
+public class LoadPluginsAction extends ActionType<LoadPluginsResponse> {
+
+    public static final LoadPluginsAction INSTANCE = new LoadPluginsAction();
+    public static final String NAME = "cluster:admin/plugins/load";
+
+    private LoadPluginsAction() {
+        super(NAME, LoadPluginsResponse::new);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/loadplugins/LoadPluginsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/loadplugins/LoadPluginsRequest.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.loadplugins;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Request for loading plugins
+ *
+ * @opensearch.internal
+ */
+public class LoadPluginsRequest extends ClusterManagerNodeRequest<LoadPluginsRequest> {
+    private String pluginPath;
+    private String pluginName;
+    private boolean refreshAnalysis = false;
+
+    public LoadPluginsRequest() {}
+
+    public LoadPluginsRequest(StreamInput in) throws IOException {
+        super(in);
+        pluginPath = in.readOptionalString();
+        pluginName = in.readOptionalString();
+        refreshAnalysis = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(pluginPath);
+        out.writeOptionalString(pluginName);
+        out.writeBoolean(refreshAnalysis);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    // Getters and setters
+    public String getPluginPath() { return pluginPath; }
+    public void setPluginPath(String pluginPath) { this.pluginPath = pluginPath; }
+    public String getPluginName() { return pluginName; }
+    public void setPluginName(String pluginName) { this.pluginName = pluginName; }
+    public boolean isRefreshAnalysis() { return refreshAnalysis; }
+    public void setRefreshAnalysis(boolean refreshAnalysis) { this.refreshAnalysis = refreshAnalysis; }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/loadplugins/LoadPluginsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/loadplugins/LoadPluginsResponse.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.loadplugins;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Response for loading plugins
+ *
+ * @opensearch.internal
+ */
+public class LoadPluginsResponse extends ActionResponse implements ToXContentObject {
+    private boolean success;
+    private String message;
+    private List<String> loadedPlugins;
+
+    public LoadPluginsResponse() {}
+
+    public LoadPluginsResponse(StreamInput in) throws IOException {
+        super(in);
+        success = in.readBoolean();
+        message = in.readOptionalString();
+        loadedPlugins = in.readStringList();
+    }
+
+    public LoadPluginsResponse(boolean success, String message, List<String> loadedPlugins) {
+        this.success = success;
+        this.message = message;
+        this.loadedPlugins = loadedPlugins;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(success);
+        out.writeOptionalString(message);
+        out.writeStringCollection(loadedPlugins);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("success", success);
+        if (message != null) {
+            builder.field("message", message);
+        }
+        builder.field("loaded_plugins", loadedPlugins);
+        builder.endObject();
+        return builder;
+    }
+
+    // Getters
+    public boolean isSuccess() { return success; }
+    public String getMessage() { return message; }
+    public List<String> getLoadedPlugins() { return loadedPlugins; }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/loadplugins/TransportLoadPluginsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/loadplugins/TransportLoadPluginsAction.java
@@ -1,0 +1,211 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.loadplugins;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.index.analysis.AnalysisRegistry;
+import org.opensearch.plugins.AnalysisPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginsService;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Transport action for loading plugins
+ *
+ * @opensearch.internal
+ */
+public class TransportLoadPluginsAction extends TransportClusterManagerNodeAction<LoadPluginsRequest, LoadPluginsResponse> {
+
+    private static final Logger logger = LogManager.getLogger(TransportLoadPluginsAction.class);
+    private final PluginsService pluginsService;
+    private final AnalysisRegistry analysisRegistry;
+
+    @Inject
+    public TransportLoadPluginsAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        PluginsService pluginsService,
+        AnalysisRegistry analysisRegistry
+    ) {
+        super(
+            LoadPluginsAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            LoadPluginsRequest::new,
+            indexNameExpressionResolver
+        );
+        this.pluginsService = pluginsService;
+        this.analysisRegistry = analysisRegistry;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected LoadPluginsResponse read(StreamInput in) throws IOException {
+        return new LoadPluginsResponse(in);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(LoadPluginsRequest request, ClusterState state) {
+        return null;
+    }
+
+    @Override
+    protected void clusterManagerOperation(
+        LoadPluginsRequest request,
+        ClusterState state,
+        ActionListener<LoadPluginsResponse> listener
+    ) throws Exception {
+        try {
+            List<String> loadedPlugins = new ArrayList<>();
+            
+            // Load plugins dynamically using PluginsService
+            if (request.getPluginPath() != null) {
+                // Load plugin from specified path
+                try {
+                    // First check if plugin is already loaded to prevent duplicates
+                    String pluginPath = request.getPluginPath();
+                    String potentialPluginName = java.nio.file.Paths.get(pluginPath).getFileName().toString();
+                    
+                    // Check if plugin is already loaded by checking both directory name and actual plugin names
+                    boolean pluginAlreadyLoaded = false;
+                    String existingPluginName = null;
+                    
+                    // Check by directory name first
+                    if (pluginsService.getPluginByName(potentialPluginName) != null) {
+                        pluginAlreadyLoaded = true;
+                        existingPluginName = potentialPluginName;
+                    } else {
+                        // Also check if any plugin with this directory name is already loaded
+                        // by checking all loaded plugins
+                        for (org.opensearch.plugins.PluginInfo pluginInfo : pluginsService.info().getPluginInfos()) {
+                            if (pluginInfo.getName().equals(potentialPluginName)) {
+                                pluginAlreadyLoaded = true;
+                                existingPluginName = pluginInfo.getName();
+                                break;
+                            }
+                        }
+                    }
+                    
+                    if (pluginAlreadyLoaded) {
+                        // Plugin already loaded, just mark as loaded and skip actual loading
+                        loadedPlugins.add(existingPluginName);
+                        pluginsService.markPluginAsLoaded(existingPluginName);
+                        logger.info("Plugin [{}] is already loaded, skipping duplicate load", existingPluginName);
+                    } else {
+                        Plugin plugin = pluginsService.loadPluginDynamically(java.nio.file.Paths.get(request.getPluginPath()));
+                        String pluginClassName = plugin.getClass().getSimpleName();
+                        loadedPlugins.add(pluginClassName);
+                        
+                        // Mark plugin as loaded via the load API
+                        // We need to find the actual plugin name from PluginInfo, not just the class name
+                        String pluginName = findPluginNameByClass(plugin.getClass().getName());
+                        if (pluginName != null) {
+                            pluginsService.markPluginAsLoaded(pluginName);
+                        } else {
+                            // Fallback to class name if we can't find the plugin info name
+                            pluginsService.markPluginAsLoaded(pluginClassName);
+                        }
+                        
+                        // If it's an analysis plugin and refresh is requested, add to analysis registry
+                        if (request.isRefreshAnalysis() && plugin instanceof AnalysisPlugin) {
+                            analysisRegistry.addAnalysisPlugin((AnalysisPlugin) plugin);
+                        }
+                    }
+                } catch (Exception e) {
+                    throw new Exception("Failed to load plugin from path [" + request.getPluginPath() + "]: " + e.getMessage(), e);
+                }
+            } else if (request.getPluginName() != null) {
+                // Load plugin by name from plugins directory
+                // Note: This assumes a standard plugins directory structure
+                // In a production implementation, you'd get the plugins directory from settings
+                String pluginsDir = System.getProperty("opensearch.path.plugins", "plugins");
+                try {
+                    Plugin plugin = pluginsService.loadPluginByName(request.getPluginName(), java.nio.file.Paths.get(pluginsDir));
+                    String pluginClassName = plugin.getClass().getSimpleName();
+                    loadedPlugins.add(pluginClassName);
+                    
+                    // Mark plugin as loaded via the load API
+                    // We need to find the actual plugin name from PluginInfo, not just the class name
+                    String pluginName = findPluginNameByClass(plugin.getClass().getName());
+                    if (pluginName != null) {
+                        pluginsService.markPluginAsLoaded(pluginName);
+                    } else {
+                        // Fallback to class name if we can't find the plugin info name
+                        pluginsService.markPluginAsLoaded(pluginClassName);
+                    }
+                    
+                    // If it's an analysis plugin and refresh is requested, add to analysis registry
+                    if (request.isRefreshAnalysis() && plugin instanceof AnalysisPlugin) {
+                        analysisRegistry.addAnalysisPlugin((AnalysisPlugin) plugin);
+                    }
+                } catch (Exception e) {
+                    throw new Exception("Failed to load plugin by name [" + request.getPluginName() + "]: " + e.getMessage(), e);
+                }
+            } else {
+                // If no specific plugin is requested, just refresh analysis registry with existing plugins
+                if (request.isRefreshAnalysis()) {
+                    List<AnalysisPlugin> analysisPlugins = pluginsService.filterPlugins(AnalysisPlugin.class);
+                    for (AnalysisPlugin plugin : analysisPlugins) {
+                        analysisRegistry.addAnalysisPlugin(plugin);
+                        loadedPlugins.add(plugin.getClass().getSimpleName());
+                    }
+                }
+            }
+            
+            String message = loadedPlugins.isEmpty() 
+                ? "No plugins loaded" 
+                : "Successfully loaded " + loadedPlugins.size() + " plugin(s)";
+            
+            listener.onResponse(new LoadPluginsResponse(true, message, loadedPlugins));
+        } catch (Exception e) {
+            listener.onResponse(new LoadPluginsResponse(false, "Failed to load plugins: " + e.getMessage(), new ArrayList<>()));
+        }
+    }
+    
+    /**
+     * Find the plugin name from PluginInfo by matching the class name
+     */
+    private String findPluginNameByClass(String className) {
+        try {
+            // Get all plugin info and find the one with matching class name
+            for (org.opensearch.plugins.PluginInfo pluginInfo : pluginsService.info().getPluginInfos()) {
+                if (className.equals(pluginInfo.getClassname())) {
+                    return pluginInfo.getName();
+                }
+            }
+        } catch (Exception e) {
+            // If we can't find it, return null and fallback to class name
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/info/PluginsAndModulesWithStatus.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/info/PluginsAndModulesWithStatus.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.node.info;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.plugins.PluginInfoWithStatus;
+import org.opensearch.plugins.PluginLoadStatus;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Information about plugins and modules with load status information for hot reload functionality
+ *
+ * @opensearch.internal
+ */
+public class PluginsAndModulesWithStatus extends PluginsAndModules {
+    private final Map<String, PluginLoadStatus> pluginLoadStatusMap;
+
+    public PluginsAndModulesWithStatus(List<PluginInfo> plugins, List<PluginInfo> modules, Map<String, PluginLoadStatus> pluginLoadStatusMap) {
+        super(plugins, modules);
+        this.pluginLoadStatusMap = pluginLoadStatusMap;
+    }
+
+    public PluginsAndModulesWithStatus(StreamInput in) throws IOException {
+        super(in);
+        this.pluginLoadStatusMap = in.readMap(StreamInput::readString, stream -> PluginLoadStatus.valueOf(stream.readString()));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeMap(pluginLoadStatusMap, StreamOutput::writeString, (stream, status) -> stream.writeString(status.name()));
+    }
+
+    /**
+     * Returns an ordered list of plugins with their load status information
+     */
+    public List<PluginInfoWithStatus> getPluginInfosWithStatus() {
+        List<PluginInfoWithStatus> pluginsWithStatus = new ArrayList<>();
+        for (PluginInfo pluginInfo : getPluginInfos()) {
+            PluginLoadStatus status = pluginLoadStatusMap.getOrDefault(pluginInfo.getName(), PluginLoadStatus.INITIAL);
+            pluginsWithStatus.add(new PluginInfoWithStatus(pluginInfo, status));
+        }
+        Collections.sort(pluginsWithStatus, Comparator.comparing(p -> p.getPluginInfo().getName()));
+        return pluginsWithStatus;
+    }
+
+    /**
+     * Get the load status for a specific plugin
+     */
+    public PluginLoadStatus getPluginLoadStatus(String pluginName) {
+        return pluginLoadStatusMap.getOrDefault(pluginName, PluginLoadStatus.INITIAL);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startArray("plugins");
+        for (PluginInfoWithStatus pluginInfoWithStatus : getPluginInfosWithStatus()) {
+            pluginInfoWithStatus.toXContent(builder, params);
+        }
+        builder.endArray();
+        
+        builder.startArray("modules");
+        for (PluginInfo moduleInfo : getModuleInfos()) {
+            moduleInfo.toXContent(builder, params);
+        }
+        builder.endArray();
+
+        return builder;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/registerplugins/RegisterPluginsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/registerplugins/RegisterPluginsAction.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.registerplugins;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Action for registering analysis components from loaded plugins
+ *
+ * @opensearch.internal
+ */
+public class RegisterPluginsAction extends ActionType<RegisterPluginsResponse> {
+
+    public static final RegisterPluginsAction INSTANCE = new RegisterPluginsAction();
+    public static final String NAME = "cluster:admin/plugins/register";
+
+    private RegisterPluginsAction() {
+        super(NAME, RegisterPluginsResponse::new);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/registerplugins/RegisterPluginsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/registerplugins/RegisterPluginsRequest.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.registerplugins;
+
+import java.io.IOException;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+/**
+ * Request for registering plugins
+ *
+ * @opensearch.internal
+ */
+public class RegisterPluginsRequest extends ClusterManagerNodeRequest<RegisterPluginsRequest> {
+    private boolean registerAnalysis = true;
+
+    public RegisterPluginsRequest() {}
+
+    public RegisterPluginsRequest(StreamInput in) throws IOException {
+        super(in);
+        registerAnalysis = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeBoolean(registerAnalysis);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    public boolean isRegisterAnalysis() { return registerAnalysis; }
+    public void setRegisterAnalysis(boolean registerAnalysis) { this.registerAnalysis = registerAnalysis; }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/registerplugins/RegisterPluginsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/registerplugins/RegisterPluginsResponse.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.registerplugins;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+/**
+ * Response for registering plugins
+ *
+ * @opensearch.internal
+ */
+public class RegisterPluginsResponse extends ActionResponse implements ToXContentObject {
+    private boolean success;
+    private String message;
+    private List<String> registeredComponents;
+
+    public RegisterPluginsResponse() {}
+
+    public RegisterPluginsResponse(StreamInput in) throws IOException {
+        super(in);
+        success = in.readBoolean();
+        message = in.readOptionalString();
+        registeredComponents = in.readStringList();
+    }
+
+    public RegisterPluginsResponse(boolean success, String message, List<String> registeredComponents) {
+        this.success = success;
+        this.message = message;
+        this.registeredComponents = registeredComponents;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(success);
+        out.writeOptionalString(message);
+        out.writeStringCollection(registeredComponents);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("success", success);
+        if (message != null) {
+            builder.field("message", message);
+        }
+        builder.field("registered_components", registeredComponents);
+        builder.endObject();
+        return builder;
+    }
+
+    // Getters
+    public boolean isSuccess() { return success; }
+    public String getMessage() { return message; }
+    public List<String> getRegisteredComponents() { return registeredComponents; }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/registerplugins/TransportRegisterPluginsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/registerplugins/TransportRegisterPluginsAction.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.registerplugins;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.index.analysis.AnalysisRegistry;
+import org.opensearch.plugins.AnalysisPlugin;
+import org.opensearch.plugins.PluginsService;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Transport action for registering plugins
+ *
+ * @opensearch.internal
+ */
+public class TransportRegisterPluginsAction extends TransportClusterManagerNodeAction<RegisterPluginsRequest, RegisterPluginsResponse> {
+
+    private final PluginsService pluginsService;
+    private final AnalysisRegistry analysisRegistry;
+
+    @Inject
+    public TransportRegisterPluginsAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        PluginsService pluginsService,
+        AnalysisRegistry analysisRegistry
+    ) {
+        super(
+            RegisterPluginsAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            RegisterPluginsRequest::new,
+            indexNameExpressionResolver
+        );
+        this.pluginsService = pluginsService;
+        this.analysisRegistry = analysisRegistry;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected RegisterPluginsResponse read(StreamInput in) throws IOException {
+        return new RegisterPluginsResponse(in);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(RegisterPluginsRequest request, ClusterState state) {
+        return null;
+    }
+
+    @Override
+    protected void clusterManagerOperation(
+        RegisterPluginsRequest request,
+        ClusterState state,
+        ActionListener<RegisterPluginsResponse> listener
+    ) throws Exception {
+        try {
+            List<String> registeredComponents = new ArrayList<>();
+            
+            if (request.isRegisterAnalysis()) {
+                // Register analysis registry with all loaded analysis plugins
+                List<AnalysisPlugin> analysisPlugins = pluginsService.filterPlugins(AnalysisPlugin.class);
+                for (AnalysisPlugin plugin : analysisPlugins) {
+                    analysisRegistry.addAnalysisPlugin(plugin);
+                    String pluginClassName = plugin.getClass().getSimpleName();
+                    registeredComponents.add("Analysis: " + pluginClassName);
+                    
+                    // Mark plugin as registered via the register API
+                    // We need to find the actual plugin name from PluginInfo, not just the class name
+                    String pluginName = findPluginNameByClass(plugin.getClass().getName());
+                    if (pluginName != null) {
+                        pluginsService.markPluginAsActive(pluginName);
+                    } else {
+                        // Fallback to class name if we can't find the plugin info name
+                        pluginsService.markPluginAsActive(pluginClassName);
+                    }
+                }
+            }
+            
+            listener.onResponse(new RegisterPluginsResponse(true, "Analysis registry registered successfully", registeredComponents));
+        } catch (Exception e) {
+            listener.onResponse(new RegisterPluginsResponse(false, "Failed to register plugins: " + e.getMessage(), new ArrayList<>()));
+        }
+    }
+    
+    /**
+     * Find the plugin name from PluginInfo by matching the class name
+     */
+    private String findPluginNameByClass(String className) {
+        try {
+            // Get all plugin info and find the one with matching class name
+            for (org.opensearch.plugins.PluginInfo pluginInfo : pluginsService.info().getPluginInfos()) {
+                if (className.equals(pluginInfo.getClassname())) {
+                    return pluginInfo.getName();
+                }
+            }
+        } catch (Exception e) {
+            // If we can't find it, return null and fallback to class name
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/removeplugins/RemovePluginsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/removeplugins/RemovePluginsAction.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.removeplugins;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Action for dynamically removing plugins
+ *
+ * @opensearch.internal
+ */
+public class RemovePluginsAction extends ActionType<RemovePluginsResponse> {
+
+    public static final RemovePluginsAction INSTANCE = new RemovePluginsAction();
+    public static final String NAME = "cluster:admin/plugins/remove";
+
+    private RemovePluginsAction() {
+        super(NAME, RemovePluginsResponse::new);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/removeplugins/RemovePluginsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/removeplugins/RemovePluginsRequest.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.removeplugins;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Request for removing plugins
+ *
+ * @opensearch.internal
+ */
+public class RemovePluginsRequest extends ClusterManagerNodeRequest<RemovePluginsRequest> {
+    private String pluginName;
+    private List<String> pluginNames;
+    private boolean refreshAnalysis = false;
+    private boolean forceRemove = false;
+
+    public RemovePluginsRequest() {}
+
+    public RemovePluginsRequest(StreamInput in) throws IOException {
+        super(in);
+        pluginName = in.readOptionalString();
+        pluginNames = in.readOptionalStringList();
+        refreshAnalysis = in.readBoolean();
+        forceRemove = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(pluginName);
+        out.writeOptionalStringCollection(pluginNames);
+        out.writeBoolean(refreshAnalysis);
+        out.writeBoolean(forceRemove);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    // Getters and setters
+    public String getPluginName() { return pluginName; }
+    public void setPluginName(String pluginName) { this.pluginName = pluginName; }
+    public List<String> getPluginNames() { return pluginNames; }
+    public void setPluginNames(List<String> pluginNames) { this.pluginNames = pluginNames; }
+    public boolean isRefreshAnalysis() { return refreshAnalysis; }
+    public void setRefreshAnalysis(boolean refreshAnalysis) { this.refreshAnalysis = refreshAnalysis; }
+    public boolean isForceRemove() { return forceRemove; }
+    public void setForceRemove(boolean forceRemove) { this.forceRemove = forceRemove; }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/removeplugins/RemovePluginsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/removeplugins/RemovePluginsResponse.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.removeplugins;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Response for removing plugins
+ *
+ * @opensearch.internal
+ */
+public class RemovePluginsResponse extends ActionResponse implements ToXContentObject {
+    private boolean success;
+    private String message;
+    private List<String> removedPlugins;
+
+    public RemovePluginsResponse() {}
+
+    public RemovePluginsResponse(StreamInput in) throws IOException {
+        super(in);
+        success = in.readBoolean();
+        message = in.readOptionalString();
+        removedPlugins = in.readStringList();
+    }
+
+    public RemovePluginsResponse(boolean success, String message, List<String> removedPlugins) {
+        this.success = success;
+        this.message = message;
+        this.removedPlugins = removedPlugins;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(success);
+        out.writeOptionalString(message);
+        out.writeStringCollection(removedPlugins);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("success", success);
+        if (message != null) {
+            builder.field("message", message);
+        }
+        builder.field("removed_plugins", removedPlugins);
+        builder.endObject();
+        return builder;
+    }
+
+    // Getters
+    public boolean isSuccess() { return success; }
+    public String getMessage() { return message; }
+    public List<String> getRemovedPlugins() { return removedPlugins; }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/removeplugins/TransportRemovePluginsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/removeplugins/TransportRemovePluginsAction.java
@@ -1,0 +1,363 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.removeplugins;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.index.analysis.AnalysisRegistry;
+import org.opensearch.plugins.AnalysisPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginsService;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
+
+/**
+ * Transport action for removing plugins
+ *
+ * @opensearch.internal
+ */
+public class TransportRemovePluginsAction extends TransportClusterManagerNodeAction<RemovePluginsRequest, RemovePluginsResponse> {
+
+    private static final Logger logger = LogManager.getLogger(TransportRemovePluginsAction.class);
+    
+    private final PluginsService pluginsService;
+    private final AnalysisRegistry analysisRegistry;
+
+    @Inject
+    public TransportRemovePluginsAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        PluginsService pluginsService,
+        AnalysisRegistry analysisRegistry
+    ) {
+        super(
+            RemovePluginsAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            RemovePluginsRequest::new,
+            indexNameExpressionResolver
+        );
+        this.pluginsService = pluginsService;
+        this.analysisRegistry = analysisRegistry;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected RemovePluginsResponse read(StreamInput in) throws IOException {
+        return new RemovePluginsResponse(in);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(RemovePluginsRequest request, ClusterState state) {
+        return null;
+    }
+
+    @Override
+    protected void clusterManagerOperation(
+        RemovePluginsRequest request,
+        ClusterState state,
+        ActionListener<RemovePluginsResponse> listener
+    ) throws Exception {
+        try {
+            List<String> removedPlugins = new ArrayList<>();
+            List<String> failedPlugins = new ArrayList<>();
+            
+            // Collect plugin names to remove
+            List<String> pluginNamesToRemove = new ArrayList<>();
+            if (request.getPluginName() != null) {
+                pluginNamesToRemove.add(request.getPluginName());
+            }
+            if (request.getPluginNames() != null && !request.getPluginNames().isEmpty()) {
+                pluginNamesToRemove.addAll(request.getPluginNames());
+            }
+
+            // Remove each plugin
+            for (String pluginName : pluginNamesToRemove) {
+                try {
+                    // Check if plugin exists before attempting to remove
+                    var pluginTuple = pluginsService.getPluginByName(pluginName);
+                    if (pluginTuple == null) {
+                        failedPlugins.add(pluginName + " (not found)");
+                        continue;
+                    }
+
+                    // CRITICAL SAFETY CHECK: Validate plugin usage before removal
+                    if (!request.isForceRemove()) {
+                        List<String> affectedIndices = validatePluginUsage(pluginName, state);
+                        if (!affectedIndices.isEmpty()) {
+                            String errorMsg = String.format(
+                                "%s (unsafe to remove: actively used by %d indices: %s. Use force=true to override)",
+                                pluginName,
+                                affectedIndices.size(),
+                                String.join(", ", affectedIndices.subList(0, Math.min(3, affectedIndices.size())))
+                            );
+                            failedPlugins.add(errorMsg);
+                            logger.warn("Prevented unsafe plugin removal: {} is used by indices: {}", pluginName, affectedIndices);
+                            continue;
+                        }
+                    } else {
+                        // Log warning for forced removal
+                        List<String> affectedIndices = validatePluginUsage(pluginName, state);
+                        if (!affectedIndices.isEmpty()) {
+                            logger.warn("FORCED plugin removal: {} is used by {} indices: {}", 
+                                pluginName, affectedIndices.size(), affectedIndices);
+                        }
+                    }
+
+                    // If it's an analysis plugin and refresh is requested, remove from analysis registry
+                    if (request.isRefreshAnalysis() && pluginTuple.v2() instanceof AnalysisPlugin) {
+                        try {
+                            analysisRegistry.removeAnalysisPlugin((AnalysisPlugin) pluginTuple.v2());
+                        } catch (Exception e) {
+                            // Log warning but continue with plugin removal
+                            logger.warn("Failed to remove analysis plugin [{}] from registry: {}", pluginName, e.getMessage());
+                        }
+                    }
+
+                    // Remove the plugin
+                    boolean success = pluginsService.unloadPluginDynamically(pluginName);
+                    if (success) {
+                        removedPlugins.add(pluginName);
+                    } else {
+                        failedPlugins.add(pluginName + " (removal failed)");
+                    }
+                } catch (Exception e) {
+                    failedPlugins.add(pluginName + " (error: " + e.getMessage() + ")");
+                    logger.error("Failed to remove plugin [{}]: {}", pluginName, e.getMessage(), e);
+                }
+            }
+            
+            // Prepare response message
+            StringBuilder messageBuilder = new StringBuilder();
+            boolean success = failedPlugins.isEmpty();
+            
+            if (!removedPlugins.isEmpty()) {
+                messageBuilder.append("Successfully removed ").append(removedPlugins.size()).append(" plugin(s)");
+                if (!failedPlugins.isEmpty()) {
+                    messageBuilder.append(", ");
+                }
+            }
+            
+            if (!failedPlugins.isEmpty()) {
+                messageBuilder.append("Failed to remove ").append(failedPlugins.size()).append(" plugin(s): ")
+                    .append(String.join(", ", failedPlugins));
+            }
+            
+            if (removedPlugins.isEmpty() && failedPlugins.isEmpty()) {
+                messageBuilder.append("No plugins specified for removal");
+                success = false;
+            }
+            
+            listener.onResponse(new RemovePluginsResponse(success, messageBuilder.toString(), removedPlugins));
+        } catch (Exception e) {
+            listener.onResponse(new RemovePluginsResponse(false, "Failed to remove plugins: " + e.getMessage(), new ArrayList<>()));
+        }
+    }
+
+    /**
+     * Validates if a plugin is being used by any indices
+     * @param pluginName the name of the plugin to validate
+     * @param state the current cluster state
+     * @return list of indices that use the plugin
+     */
+    private List<String> validatePluginUsage(String pluginName, ClusterState state) {
+        List<String> affectedIndices = new ArrayList<>();
+        
+        try {
+            // Check each index for plugin usage in mappings
+            for (String indexName : state.metadata().getConcreteAllIndices()) {
+                if (indexUsesPlugin(indexName, pluginName, state)) {
+                    affectedIndices.add(indexName);
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Error validating plugin usage for {}: {}", pluginName, e.getMessage());
+        }
+        
+        return affectedIndices;
+    }
+
+    /**
+     * Checks if an index uses a specific plugin by comparing index settings against analysis registry
+     * @param indexName the index to check
+     * @param pluginName the plugin name to look for
+     * @param state the cluster state
+     * @return true if the index uses the plugin
+     */
+    private boolean indexUsesPlugin(String indexName, String pluginName, ClusterState state) {
+        try {
+            var indexMetadata = state.metadata().index(indexName);
+            if (indexMetadata == null) {
+                return false;
+            }
+
+            // Get the plugin instance to determine what components it provides
+            var pluginTuple = pluginsService.getPluginByName(pluginName);
+            if (pluginTuple == null || !(pluginTuple.v2() instanceof AnalysisPlugin)) {
+                // For non-analysis plugins, fall back to generic name matching
+                return indexMetadata.getSettings().toString().toLowerCase().contains(pluginName.toLowerCase());
+            }
+
+            AnalysisPlugin analysisPlugin = (AnalysisPlugin) pluginTuple.v2();
+            Set<String> pluginComponents = getPluginAnalysisComponents(analysisPlugin);
+            
+            if (pluginComponents.isEmpty()) {
+                return false;
+            }
+
+            // Check index settings for usage of plugin components
+            return indexUsesAnalysisComponents(indexMetadata, pluginComponents);
+            
+        } catch (Exception e) {
+            logger.debug("Error checking plugin usage for index {}: {}", indexName, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Get all analysis components (analyzers, tokenizers, filters, etc.) provided by a plugin
+     */
+    private Set<String> getPluginAnalysisComponents(AnalysisPlugin plugin) {
+        Set<String> components = new HashSet<>();
+        
+        try {
+            // Get analyzers provided by the plugin
+            Map<String, ?> analyzers = plugin.getAnalyzers();
+            if (analyzers != null) {
+                components.addAll(analyzers.keySet());
+            }
+
+            // Get tokenizers provided by the plugin
+            Map<String, ?> tokenizers = plugin.getTokenizers();
+            if (tokenizers != null) {
+                components.addAll(tokenizers.keySet());
+            }
+
+            // Get token filters provided by the plugin
+            Map<String, ?> tokenFilters = plugin.getTokenFilters();
+            if (tokenFilters != null) {
+                components.addAll(tokenFilters.keySet());
+            }
+
+            // Get character filters provided by the plugin
+            Map<String, ?> charFilters = plugin.getCharFilters();
+            if (charFilters != null) {
+                components.addAll(charFilters.keySet());
+            }
+
+
+        } catch (Exception e) {
+            logger.debug("Error getting plugin components: {}", e.getMessage());
+        }
+        
+        return components;
+    }
+
+    /**
+     * Check if index settings use any of the specified analysis components
+     */
+    private boolean indexUsesAnalysisComponents(org.opensearch.cluster.metadata.IndexMetadata indexMetadata, Set<String> components) {
+        try {
+            var settings = indexMetadata.getSettings();
+            
+            // Check analysis settings in index
+            for (String key : settings.keySet()) {
+                if (key.startsWith("index.analysis.")) {
+                    String value = settings.get(key);
+                    if (value != null) {
+                        // Check if any plugin component is referenced in the analysis settings
+                        for (String component : components) {
+                            if (value.equals(component) || value.contains(component)) {
+                                logger.debug("Index {} uses plugin component {} in setting {}", 
+                                    indexMetadata.getIndex().getName(), component, key);
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Also check mapping metadata for field analyzers
+            MappingMetadata mappingMetadata = indexMetadata.mapping();
+            if (mappingMetadata != null) {
+                return checkMappingForAnalysisComponents(mappingMetadata, components);
+            }
+
+        } catch (Exception e) {
+            logger.debug("Error checking analysis components usage: {}", e.getMessage());
+        }
+        
+        return false;
+    }
+
+    /**
+     * Check mapping metadata for usage of analysis components
+     */
+    private boolean checkMappingForAnalysisComponents(MappingMetadata mappingMetadata, Set<String> components) {
+        try {
+            Map<String, Object> sourceAsMap = mappingMetadata.sourceAsMap();
+            return checkMapForAnalysisComponents(sourceAsMap, components);
+        } catch (Exception e) {
+            logger.debug("Error checking mapping for analysis components: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Recursively check a map (mapping structure) for analysis component usage
+     */
+    @SuppressWarnings("unchecked")
+    private boolean checkMapForAnalysisComponents(Map<String, Object> map, Set<String> components) {
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            
+            // Check for analyzer, search_analyzer, normalizer fields
+            if (("analyzer".equals(key) || "search_analyzer".equals(key) || "normalizer".equals(key)) && value instanceof String) {
+                if (components.contains((String) value)) {
+                    return true;
+                }
+            }
+            
+            // Recursively check nested objects
+            if (value instanceof Map) {
+                if (checkMapForAnalysisComponents((Map<String, Object>) value, components)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/validatepluginusage/TransportValidatePluginUsageAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/validatepluginusage/TransportValidatePluginUsageAction.java
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.validatepluginusage;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.block.ClusterBlockLevel;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.plugins.PluginDependencyService;
+import org.opensearch.plugins.PluginReloadValidation;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Transport action for validating plugin usage before uninstallation
+ *
+ * @opensearch.internal
+ */
+public class TransportValidatePluginUsageAction extends TransportClusterManagerNodeAction<
+    ValidatePluginUsageRequest, ValidatePluginUsageResponse> {
+
+    private final PluginDependencyService pluginDependencyService;
+
+    @Inject
+    public TransportValidatePluginUsageAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        PluginDependencyService pluginDependencyService
+    ) {
+        super(
+            ValidatePluginUsageAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            ValidatePluginUsageRequest::new,
+            indexNameExpressionResolver
+        );
+        this.pluginDependencyService = pluginDependencyService;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected ValidatePluginUsageResponse read(StreamInput in) throws IOException {
+        return new ValidatePluginUsageResponse(in);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(ValidatePluginUsageRequest request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+    }
+
+    @Override
+    protected void clusterManagerOperation(
+        ValidatePluginUsageRequest request,
+        ClusterState state,
+        ActionListener<ValidatePluginUsageResponse> listener
+    ) throws Exception {
+        try {
+            String pluginName = request.getPluginName();
+            
+            // Validate plugin exists
+            if (!isPluginLoaded(pluginName, state)) {
+                ValidatePluginUsageResponse response = new ValidatePluginUsageResponse()
+                    .setPluginName(pluginName)
+                    .setSafeToUnload(true)
+                    .setActiveUsageCount(0)
+                    .setRiskLevel("LOW")
+                    .setRecommendations(List.of("Plugin is not currently loaded"))
+                    .setErrorMessage("Plugin '" + pluginName + "' is not currently loaded");
+                listener.onResponse(response);
+                return;
+            }
+
+            // Perform validation using dependency service
+            PluginReloadValidation validation = pluginDependencyService.validatePluginReload(pluginName);
+            ValidatePluginUsageResponse response = new ValidatePluginUsageResponse(validation);
+            
+            // Add additional context if requested
+            if (request.isIncludeUsageDetails()) {
+                // Add detailed usage information
+                response.setAffectedIndices(getAffectedIndices(pluginName));
+                response.setAffectedPipelines(getAffectedPipelines(pluginName));
+            }
+            
+            listener.onResponse(response);
+            
+        } catch (Exception e) {
+            ValidatePluginUsageResponse errorResponse = new ValidatePluginUsageResponse()
+                .setPluginName(request.getPluginName())
+                .setSafeToUnload(false)
+                .setActiveUsageCount(0)
+                .setRiskLevel("UNKNOWN")
+                .setErrorMessage("Error validating plugin usage: " + e.getMessage());
+            listener.onResponse(errorResponse);
+        }
+    }
+
+    private boolean isPluginLoaded(String pluginName, ClusterState state) {
+        // Check if plugin is currently loaded
+        // This would integrate with the existing plugin tracking system
+        return true; // Simplified for now
+    }
+
+    private List<String> getAffectedIndices(String pluginName) {
+        // Scan cluster state for indices using this plugin
+        // This would analyze index mappings for plugin-specific analyzers
+        return List.of(); // Simplified for now
+    }
+
+    private List<String> getAffectedPipelines(String pluginName) {
+        // Scan ingest pipelines for plugin processors
+        return List.of(); // Simplified for now
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/validatepluginusage/ValidatePluginUsageAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/validatepluginusage/ValidatePluginUsageAction.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.validatepluginusage;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Action for validating plugin usage before uninstallation
+ *
+ * @opensearch.internal
+ */
+public class ValidatePluginUsageAction extends ActionType<ValidatePluginUsageResponse> {
+
+    public static final ValidatePluginUsageAction INSTANCE = new ValidatePluginUsageAction();
+    public static final String NAME = "cluster:admin/plugins/validate_usage";
+
+    private ValidatePluginUsageAction() {
+        super(NAME, ValidatePluginUsageResponse::new);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/validatepluginusage/ValidatePluginUsageRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/validatepluginusage/ValidatePluginUsageRequest.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.validatepluginusage;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+import static org.opensearch.action.ValidateActions.addValidationError;
+
+/**
+ * Request for validating plugin usage before uninstallation
+ *
+ * @opensearch.internal
+ */
+public class ValidatePluginUsageRequest extends ClusterManagerNodeRequest<ValidatePluginUsageRequest> {
+
+    private String pluginName;
+    private boolean includeUsageDetails;
+    private boolean checkDependencies;
+
+    public ValidatePluginUsageRequest() {}
+
+    public ValidatePluginUsageRequest(String pluginName) {
+        this.pluginName = pluginName;
+        this.includeUsageDetails = true;
+        this.checkDependencies = true;
+    }
+
+    public ValidatePluginUsageRequest(StreamInput in) throws IOException {
+        super(in);
+        this.pluginName = in.readString();
+        this.includeUsageDetails = in.readBoolean();
+        this.checkDependencies = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(pluginName);
+        out.writeBoolean(includeUsageDetails);
+        out.writeBoolean(checkDependencies);
+    }
+
+    public String getPluginName() {
+        return pluginName;
+    }
+
+    public ValidatePluginUsageRequest setPluginName(String pluginName) {
+        this.pluginName = pluginName;
+        return this;
+    }
+
+    public boolean isIncludeUsageDetails() {
+        return includeUsageDetails;
+    }
+
+    public ValidatePluginUsageRequest setIncludeUsageDetails(boolean includeUsageDetails) {
+        this.includeUsageDetails = includeUsageDetails;
+        return this;
+    }
+
+    public boolean isCheckDependencies() {
+        return checkDependencies;
+    }
+
+    public ValidatePluginUsageRequest setCheckDependencies(boolean checkDependencies) {
+        this.checkDependencies = checkDependencies;
+        return this;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (pluginName == null || pluginName.trim().isEmpty()) {
+            validationException = addValidationError("plugin name is required", validationException);
+        }
+        return validationException;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/validatepluginusage/ValidatePluginUsageResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/validatepluginusage/ValidatePluginUsageResponse.java
@@ -1,0 +1,194 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.validatepluginusage;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugins.PluginReloadValidation;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Response for plugin usage validation
+ *
+ * @opensearch.internal
+ */
+public class ValidatePluginUsageResponse extends ActionResponse implements ToXContentObject {
+
+    private String pluginName;
+    private boolean safeToUnload;
+    private int activeUsageCount;
+    private List<String> affectedIndices;
+    private List<String> affectedPipelines;
+    private List<String> dependentPlugins;
+    private String riskLevel;
+    private List<String> recommendations;
+    private String errorMessage;
+
+    public ValidatePluginUsageResponse() {}
+
+    public ValidatePluginUsageResponse(StreamInput in) throws IOException {
+        super(in);
+        this.pluginName = in.readString();
+        this.safeToUnload = in.readBoolean();
+        this.activeUsageCount = in.readInt();
+        this.affectedIndices = in.readStringList();
+        this.affectedPipelines = in.readStringList();
+        this.dependentPlugins = in.readStringList();
+        this.riskLevel = in.readString();
+        this.recommendations = in.readStringList();
+        this.errorMessage = in.readOptionalString();
+    }
+
+    public ValidatePluginUsageResponse(PluginReloadValidation validation) {
+        this.pluginName = validation.getPluginName();
+        this.safeToUnload = validation.isSafeToReload();
+        this.activeUsageCount = validation.getActiveUsages() != null ? validation.getActiveUsages().size() : 0;
+        this.dependentPlugins = validation.getDependentPlugins();
+        this.recommendations = validation.getRecommendations();
+        this.errorMessage = validation.getErrorMessage();
+        
+        if (validation.getImpactAssessment() != null) {
+            this.riskLevel = validation.getImpactAssessment().getRiskLevel();
+        } else {
+            this.riskLevel = "UNKNOWN";
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(pluginName);
+        out.writeBoolean(safeToUnload);
+        out.writeInt(activeUsageCount);
+        out.writeStringCollection(affectedIndices != null ? affectedIndices : List.of());
+        out.writeStringCollection(affectedPipelines != null ? affectedPipelines : List.of());
+        out.writeStringCollection(dependentPlugins != null ? dependentPlugins : List.of());
+        out.writeString(riskLevel != null ? riskLevel : "UNKNOWN");
+        out.writeStringCollection(recommendations != null ? recommendations : List.of());
+        out.writeOptionalString(errorMessage);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("plugin_name", pluginName);
+        builder.field("safe_to_unload", safeToUnload);
+        builder.field("active_usage_count", activeUsageCount);
+        builder.field("risk_level", riskLevel);
+        
+        if (affectedIndices != null && !affectedIndices.isEmpty()) {
+            builder.field("affected_indices", affectedIndices);
+        }
+        
+        if (affectedPipelines != null && !affectedPipelines.isEmpty()) {
+            builder.field("affected_pipelines", affectedPipelines);
+        }
+        
+        if (dependentPlugins != null && !dependentPlugins.isEmpty()) {
+            builder.field("dependent_plugins", dependentPlugins);
+        }
+        
+        if (recommendations != null && !recommendations.isEmpty()) {
+            builder.field("recommendations", recommendations);
+        }
+        
+        if (errorMessage != null) {
+            builder.field("error", errorMessage);
+        }
+        
+        builder.endObject();
+        return builder;
+    }
+
+    // Getters and setters
+    public String getPluginName() {
+        return pluginName;
+    }
+
+    public ValidatePluginUsageResponse setPluginName(String pluginName) {
+        this.pluginName = pluginName;
+        return this;
+    }
+
+    public boolean isSafeToUnload() {
+        return safeToUnload;
+    }
+
+    public ValidatePluginUsageResponse setSafeToUnload(boolean safeToUnload) {
+        this.safeToUnload = safeToUnload;
+        return this;
+    }
+
+    public int getActiveUsageCount() {
+        return activeUsageCount;
+    }
+
+    public ValidatePluginUsageResponse setActiveUsageCount(int activeUsageCount) {
+        this.activeUsageCount = activeUsageCount;
+        return this;
+    }
+
+    public List<String> getAffectedIndices() {
+        return affectedIndices;
+    }
+
+    public ValidatePluginUsageResponse setAffectedIndices(List<String> affectedIndices) {
+        this.affectedIndices = affectedIndices;
+        return this;
+    }
+
+    public List<String> getAffectedPipelines() {
+        return affectedPipelines;
+    }
+
+    public ValidatePluginUsageResponse setAffectedPipelines(List<String> affectedPipelines) {
+        this.affectedPipelines = affectedPipelines;
+        return this;
+    }
+
+    public List<String> getDependentPlugins() {
+        return dependentPlugins;
+    }
+
+    public ValidatePluginUsageResponse setDependentPlugins(List<String> dependentPlugins) {
+        this.dependentPlugins = dependentPlugins;
+        return this;
+    }
+
+    public String getRiskLevel() {
+        return riskLevel;
+    }
+
+    public ValidatePluginUsageResponse setRiskLevel(String riskLevel) {
+        this.riskLevel = riskLevel;
+        return this;
+    }
+
+    public List<String> getRecommendations() {
+        return recommendations;
+    }
+
+    public ValidatePluginUsageResponse setRecommendations(List<String> recommendations) {
+        this.recommendations = recommendations;
+        return this;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public ValidatePluginUsageResponse setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+        return this;
+    }
+}

--- a/server/src/main/java/org/opensearch/bootstrap/Security.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Security.java
@@ -158,7 +158,7 @@ final class Security {
             // SecureSM matches class names as regular expressions so we escape the $ that arises from the nested class name
             OpenSearchUncaughtExceptionHandler.PrivilegedHaltAction.class.getName().replace("$", "\\$"),
             Command.class.getName() };
-        System.setSecurityManager(new SecureSM(classesThatCanExit));
+        // System.setSecurityManager(new SecureSM(classesThatCanExit));
 
         // do some basic tests
         selfTest();

--- a/server/src/main/java/org/opensearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
+++ b/server/src/main/java/org/opensearch/index/analysis/PreBuiltAnalyzerProviderFactory.java
@@ -35,6 +35,7 @@ package org.opensearch.index.analysis;
 import org.apache.lucene.analysis.Analyzer;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.env.Environment;
@@ -55,6 +56,7 @@ import java.util.stream.Collectors;
  *
  * @opensearch.internal
  */
+@ExperimentalApi
 public class PreBuiltAnalyzerProviderFactory extends PreConfiguredAnalysisComponent<AnalyzerProvider<?>> implements Closeable {
 
     private final Function<Version, Analyzer> create;

--- a/server/src/main/java/org/opensearch/index/analysis/PreConfiguredCharFilter.java
+++ b/server/src/main/java/org/opensearch/index/analysis/PreConfiguredCharFilter.java
@@ -35,6 +35,7 @@ package org.opensearch.index.analysis;
 import org.apache.lucene.analysis.CharFilter;
 import org.apache.lucene.analysis.TokenFilter;
 import org.opensearch.Version;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
 
 import java.io.Reader;
@@ -46,6 +47,7 @@ import java.util.function.Function;
  *
  * @opensearch.internal
  */
+@ExperimentalApi
 public class PreConfiguredCharFilter extends PreConfiguredAnalysisComponent<CharFilterFactory> {
     /**
      * Create a pre-configured char filter that may not vary at all.

--- a/server/src/main/java/org/opensearch/index/analysis/PreConfiguredTokenFilter.java
+++ b/server/src/main/java/org/opensearch/index/analysis/PreConfiguredTokenFilter.java
@@ -35,6 +35,7 @@ package org.opensearch.index.analysis;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.opensearch.Version;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.indices.analysis.PreBuiltCacheFactory;
 import org.opensearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
 
@@ -46,6 +47,7 @@ import java.util.function.Function;
  *
  * @opensearch.internal
  */
+@ExperimentalApi
 public final class PreConfiguredTokenFilter extends PreConfiguredAnalysisComponent<TokenFilterFactory> {
     /**
      * Create a pre-configured token filter that may not vary at all.

--- a/server/src/main/java/org/opensearch/index/analysis/PreConfiguredTokenizer.java
+++ b/server/src/main/java/org/opensearch/index/analysis/PreConfiguredTokenizer.java
@@ -34,6 +34,7 @@ package org.opensearch.index.analysis;
 
 import org.apache.lucene.analysis.Tokenizer;
 import org.opensearch.Version;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.indices.analysis.PreBuiltCacheFactory;
 import org.opensearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
 
@@ -45,6 +46,7 @@ import java.util.function.Supplier;
  *
  * @opensearch.internal
  */
+@ExperimentalApi
 public final class PreConfiguredTokenizer extends PreConfiguredAnalysisComponent<TokenizerFactory> {
     /**
      * Create a pre-configured tokenizer that may not vary at all.

--- a/server/src/main/java/org/opensearch/indices/analysis/AnalysisModule.java
+++ b/server/src/main/java/org/opensearch/indices/analysis/AnalysisModule.java
@@ -38,6 +38,7 @@ import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.NamedRegistry;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
@@ -77,6 +78,7 @@ import static org.opensearch.plugins.AnalysisPlugin.requiresAnalysisSettings;
  *
  * @opensearch.internal
  */
+@ExperimentalApi
 public final class AnalysisModule {
     static {
         Settings build = Settings.builder()
@@ -94,6 +96,7 @@ public final class AnalysisModule {
     private final HunspellService hunspellService;
     private final AnalysisRegistry analysisRegistry;
 
+    @ExperimentalApi
     public AnalysisModule(Environment environment, List<AnalysisPlugin> plugins) throws IOException {
         NamedRegistry<AnalysisProvider<CharFilterFactory>> charFilters = setupCharFilters(plugins);
         NamedRegistry<org.apache.lucene.analysis.hunspell.Dictionary> hunspellDictionaries = setupHunspellDictionaries(plugins);
@@ -300,6 +303,7 @@ public final class AnalysisModule {
     /**
      * The basic factory interface for analysis components.
      */
+    @ExperimentalApi
     public interface AnalysisProvider<T> {
 
         /**

--- a/server/src/main/java/org/opensearch/node/NodeService.java
+++ b/server/src/main/java/org/opensearch/node/NodeService.java
@@ -198,7 +198,13 @@ public class NodeService implements Closeable {
             builder.setHttp(httpServerTransport.info());
         }
         if (plugin && pluginService != null) {
-            builder.setPlugins(pluginService.info());
+            // Use enhanced plugin info with status if available
+            try {
+                builder.setPlugins(pluginService.infoWithStatus());
+            } catch (Exception e) {
+                // Fallback to regular plugin info if enhanced version fails
+                builder.setPlugins(pluginService.info());
+            }
         }
         if (ingest && ingestService != null) {
             builder.setIngest(ingestService.info());

--- a/server/src/main/java/org/opensearch/plugins/AnalysisPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/AnalysisPlugin.java
@@ -36,6 +36,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharFilter;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.Tokenizer;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 import org.opensearch.index.IndexSettings;
@@ -76,6 +77,7 @@ import static java.util.Collections.emptyMap;
  *
  * @opensearch.api
  */
+@ExperimentalApi
 public interface AnalysisPlugin {
     /**
      * Override to add additional {@link CharFilter}s. See {@link #requiresAnalysisSettings(AnalysisProvider)}

--- a/server/src/main/java/org/opensearch/plugins/PluginDependencyService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginDependencyService.java
@@ -1,0 +1,395 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Service for tracking plugin dependencies and usage across the cluster
+ *
+ * @opensearch.internal
+ */
+public class PluginDependencyService {
+    
+    private static final Logger logger = LogManager.getLogger(PluginDependencyService.class);
+    
+    private static final String PLUGIN_USAGE_INDEX = ".opensearch-plugin-usage";
+    private static final String PLUGIN_USAGE_TYPE = "_doc";
+    
+    private final Client client;
+    private final ClusterService clusterService;
+    private final Settings settings;
+    private final PluginsService pluginsService;
+    
+    // In-memory cache for quick lookups
+    private final Map<String, List<PluginUsageDocument>> pluginUsageCache = new ConcurrentHashMap<>();
+    
+    public PluginDependencyService(
+        Client client,
+        ClusterService clusterService,
+        Settings settings,
+        PluginsService pluginsService
+    ) {
+        this.client = client;
+        this.clusterService = clusterService;
+        this.settings = settings;
+        this.pluginsService = pluginsService;
+    }
+    
+    /**
+     * Track analyzer usage in an index mapping
+     */
+    public void trackAnalyzerUsage(String pluginName, String analyzerName, String indexName, String fieldPath) {
+        PluginUsageDocument usage = new PluginUsageDocument()
+            .setPluginName(pluginName)
+            .setUsageType("analyzer")
+            .setResourceName(analyzerName)
+            .setIndexName(indexName)
+            .setFieldMapping(fieldPath)
+            .setTimestamp(Instant.now())
+            .setNodeId(clusterService.localNode().getId())
+            .setActive(true);
+        
+        indexPluginUsage(usage);
+        updateCache(usage);
+    }
+    
+    /**
+     * Track ingest processor usage in a pipeline
+     */
+    public void trackIngestProcessorUsage(String pluginName, String processorName, String pipelineName) {
+        PluginUsageDocument usage = new PluginUsageDocument()
+            .setPluginName(pluginName)
+            .setUsageType("ingest_processor")
+            .setResourceName(processorName)
+            .setPipelineName(pipelineName)
+            .setTimestamp(Instant.now())
+            .setNodeId(clusterService.localNode().getId())
+            .setActive(true);
+        
+        indexPluginUsage(usage);
+        updateCache(usage);
+    }
+    
+    /**
+     * Track tokenizer usage
+     */
+    public void trackTokenizerUsage(String pluginName, String tokenizerName, String indexName, String fieldPath) {
+        PluginUsageDocument usage = new PluginUsageDocument()
+            .setPluginName(pluginName)
+            .setUsageType("tokenizer")
+            .setResourceName(tokenizerName)
+            .setIndexName(indexName)
+            .setFieldMapping(fieldPath)
+            .setTimestamp(Instant.now())
+            .setNodeId(clusterService.localNode().getId())
+            .setActive(true);
+        
+        indexPluginUsage(usage);
+        updateCache(usage);
+    }
+    
+    /**
+     * Validate if a plugin can be safely reloaded
+     */
+    public PluginReloadValidation validatePluginReload(String pluginName) {
+        PluginReloadValidation validation = new PluginReloadValidation();
+        validation.setPluginName(pluginName);
+        
+        try {
+            // Get active usages
+            List<PluginUsageDocument> activeUsages = getActivePluginUsages(pluginName);
+            validation.setActiveUsages(activeUsages);
+            
+            // Check dependent plugins
+            List<String> dependentPlugins = getDependentPlugins(pluginName);
+            validation.setDependentPlugins(dependentPlugins);
+            
+            // Assess impact
+            ReloadImpactAssessment impact = assessReloadImpact(pluginName, activeUsages);
+            validation.setImpactAssessment(impact);
+            
+            // Determine safety
+            boolean safeToReload = determineSafety(activeUsages, dependentPlugins, impact);
+            validation.setSafeToReload(safeToReload);
+            
+            // Generate recommendations
+            List<String> recommendations = generateRecommendations(activeUsages, impact);
+            validation.setRecommendations(recommendations);
+            
+        } catch (Exception e) {
+            logger.error("Failed to validate plugin reload for [{}]", pluginName, e);
+            validation.setSafeToReload(false);
+            validation.setErrorMessage("Validation failed: " + e.getMessage());
+        }
+        
+        return validation;
+    }
+    
+    /**
+     * Get plugin usage statistics
+     */
+    public PluginUsageStats getPluginUsageStats(String pluginName) {
+        List<PluginUsageDocument> usages = getActivePluginUsages(pluginName);
+        
+        PluginUsageStats stats = new PluginUsageStats();
+        stats.setPluginName(pluginName);
+        stats.setTotalUsages(usages.size());
+        
+        Map<String, Integer> usageBreakdown = new HashMap<>();
+        List<String> affectedIndices = new ArrayList<>();
+        List<String> affectedPipelines = new ArrayList<>();
+        
+        for (PluginUsageDocument usage : usages) {
+            // Count by usage type
+            usageBreakdown.merge(usage.getUsageType(), 1, Integer::sum);
+            
+            // Collect affected resources
+            if (usage.getIndexName() != null && !affectedIndices.contains(usage.getIndexName())) {
+                affectedIndices.add(usage.getIndexName());
+            }
+            if (usage.getPipelineName() != null && !affectedPipelines.contains(usage.getPipelineName())) {
+                affectedPipelines.add(usage.getPipelineName());
+            }
+        }
+        
+        stats.setUsageBreakdown(usageBreakdown);
+        stats.setAffectedIndices(affectedIndices);
+        stats.setAffectedPipelines(affectedPipelines);
+        stats.setLastUpdated(Instant.now());
+        
+        return stats;
+    }
+    
+    /**
+     * Remove usage tracking for a plugin (when unloaded)
+     */
+    public void removePluginUsage(String pluginName) {
+        try {
+            // Mark all usages as inactive
+            List<PluginUsageDocument> usages = getActivePluginUsages(pluginName);
+            for (PluginUsageDocument usage : usages) {
+                usage.setActive(false);
+                indexPluginUsage(usage);
+            }
+            
+            // Clear from cache
+            pluginUsageCache.remove(pluginName);
+            
+        } catch (Exception e) {
+            logger.error("Failed to remove plugin usage for [{}]", pluginName, e);
+        }
+    }
+    
+    private void indexPluginUsage(PluginUsageDocument usage) {
+        try {
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            builder.startObject();
+            builder.field("plugin_name", usage.getPluginName());
+            builder.field("plugin_version", getPluginVersion(usage.getPluginName()));
+            builder.field("usage_type", usage.getUsageType());
+            builder.field("resource_name", usage.getResourceName());
+            if (usage.getIndexName() != null) {
+                builder.field("index_name", usage.getIndexName());
+            }
+            if (usage.getFieldMapping() != null) {
+                builder.field("field_mapping", usage.getFieldMapping());
+            }
+            if (usage.getPipelineName() != null) {
+                builder.field("pipeline_name", usage.getPipelineName());
+            }
+            builder.field("timestamp", usage.getTimestamp().toString());
+            builder.field("node_id", usage.getNodeId());
+            builder.field("active", usage.isActive());
+            builder.endObject();
+            
+            IndexRequest request = new IndexRequest(PLUGIN_USAGE_INDEX)
+                .id(generateUsageId(usage))
+                .source(builder);
+            
+            client.index(request);
+            
+        } catch (IOException e) {
+            logger.error("Failed to index plugin usage", e);
+        }
+    }
+    
+    private List<PluginUsageDocument> getActivePluginUsages(String pluginName) {
+        // Check cache first
+        List<PluginUsageDocument> cached = pluginUsageCache.get(pluginName);
+        if (cached != null) {
+            return cached;
+        }
+        
+        // Query from index
+        try {
+            SearchRequest searchRequest = new SearchRequest(PLUGIN_USAGE_INDEX);
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            searchSourceBuilder.query(
+                QueryBuilders.boolQuery()
+                    .must(QueryBuilders.termQuery("plugin_name", pluginName))
+                    .must(QueryBuilders.termQuery("active", true))
+            );
+            searchRequest.source(searchSourceBuilder);
+            
+            SearchResponse response = client.search(searchRequest).actionGet();
+            
+            List<PluginUsageDocument> usages = new ArrayList<>();
+            response.getHits().forEach(hit -> {
+                // Parse hit and create PluginUsageDocument
+                // Implementation would parse the source and create objects
+            });
+            
+            // Update cache
+            pluginUsageCache.put(pluginName, usages);
+            return usages;
+            
+        } catch (Exception e) {
+            logger.error("Failed to get active plugin usages for [{}]", pluginName, e);
+            return new ArrayList<>();
+        }
+    }
+    
+    private List<String> getDependentPlugins(String pluginName) {
+        List<String> dependentPlugins = new ArrayList<>();
+        
+        // Check all loaded plugins for dependencies on this plugin
+        for (PluginInfo pluginInfo : pluginsService.info().getPluginInfos()) {
+            if (pluginInfo.getExtendedPlugins().contains(pluginName)) {
+                dependentPlugins.add(pluginInfo.getName());
+            }
+        }
+        
+        return dependentPlugins;
+    }
+    
+    private ReloadImpactAssessment assessReloadImpact(String pluginName, List<PluginUsageDocument> usages) {
+        ReloadImpactAssessment assessment = new ReloadImpactAssessment();
+        
+        long searchImpactedIndices = usages.stream()
+            .filter(u -> "analyzer".equals(u.getUsageType()) || "tokenizer".equals(u.getUsageType()) || "filter".equals(u.getUsageType()))
+            .map(PluginUsageDocument::getIndexName)
+            .distinct()
+            .count();
+        
+        long ingestionImpactedPipelines = usages.stream()
+            .filter(u -> "ingest_processor".equals(u.getUsageType()))
+            .map(PluginUsageDocument::getPipelineName)
+            .distinct()
+            .count();
+        
+        assessment.setSearchImpactedIndices(searchImpactedIndices);
+        assessment.setIngestionImpactedPipelines(ingestionImpactedPipelines);
+        assessment.setRiskLevel(calculateRiskLevel(searchImpactedIndices, ingestionImpactedPipelines));
+        
+        return assessment;
+    }
+    
+    private boolean determineSafety(List<PluginUsageDocument> activeUsages, List<String> dependentPlugins, ReloadImpactAssessment impact) {
+        // Plugin is safe to reload if:
+        // 1. No active usages
+        // 2. No dependent plugins
+        // 3. Risk level is LOW or MEDIUM (configurable)
+        
+        if (!activeUsages.isEmpty()) {
+            return false;
+        }
+        
+        if (!dependentPlugins.isEmpty()) {
+            return false;
+        }
+        
+        String maxRiskLevel = settings.get("plugins.safe_reload.max_risk_level", "MEDIUM");
+        return isRiskLevelAcceptable(impact.getRiskLevel(), maxRiskLevel);
+    }
+    
+    private List<String> generateRecommendations(List<PluginUsageDocument> usages, ReloadImpactAssessment impact) {
+        List<String> recommendations = new ArrayList<>();
+        
+        if (impact.getIngestionImpactedPipelines() > 0) {
+            recommendations.add("Stop ingestion to affected pipelines before reload");
+        }
+        
+        if (impact.getSearchImpactedIndices() > 0) {
+            recommendations.add("Consider maintenance window for affected indices");
+        }
+        
+        if ("HIGH".equals(impact.getRiskLevel())) {
+            recommendations.add("High risk reload - consider rolling restart instead");
+        }
+        
+        return recommendations;
+    }
+    
+    private String calculateRiskLevel(long searchImpacted, long ingestionImpacted) {
+        if (searchImpacted == 0 && ingestionImpacted == 0) {
+            return "LOW";
+        } else if (searchImpacted <= 2 && ingestionImpacted <= 1) {
+            return "MEDIUM";
+        } else {
+            return "HIGH";
+        }
+    }
+    
+    private boolean isRiskLevelAcceptable(String currentRisk, String maxAcceptableRisk) {
+        int currentLevel = getRiskLevelValue(currentRisk);
+        int maxLevel = getRiskLevelValue(maxAcceptableRisk);
+        return currentLevel <= maxLevel;
+    }
+    
+    private int getRiskLevelValue(String riskLevel) {
+        switch (riskLevel) {
+            case "LOW": return 1;
+            case "MEDIUM": return 2;
+            case "HIGH": return 3;
+            default: return 3;
+        }
+    }
+    
+    private String getPluginVersion(String pluginName) {
+        for (PluginInfo pluginInfo : pluginsService.info().getPluginInfos()) {
+            if (pluginInfo.getName().equals(pluginName)) {
+                return pluginInfo.getVersion();
+            }
+        }
+        return "unknown";
+    }
+    
+    private String generateUsageId(PluginUsageDocument usage) {
+        return String.format("%s-%s-%s-%s", 
+            usage.getPluginName(), 
+            usage.getUsageType(), 
+            usage.getResourceName(),
+            usage.getIndexName() != null ? usage.getIndexName() : usage.getPipelineName()
+        );
+    }
+    
+    private void updateCache(PluginUsageDocument usage) {
+        pluginUsageCache.computeIfAbsent(usage.getPluginName(), k -> new ArrayList<>()).add(usage);
+    }
+}

--- a/server/src/main/java/org/opensearch/plugins/PluginInfoWithStatus.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginInfoWithStatus.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Wrapper for PluginInfo that includes load status information for hot reload functionality
+ *
+ * @opensearch.internal
+ */
+public class PluginInfoWithStatus implements Writeable, ToXContentObject {
+    
+    private final PluginInfo pluginInfo;
+    private final PluginLoadStatus loadStatus;
+    private final long loadTimestamp;
+    
+    public PluginInfoWithStatus(PluginInfo pluginInfo, PluginLoadStatus loadStatus) {
+        this.pluginInfo = Objects.requireNonNull(pluginInfo);
+        this.loadStatus = Objects.requireNonNull(loadStatus);
+        this.loadTimestamp = Instant.now().toEpochMilli();
+    }
+    
+    public PluginInfoWithStatus(PluginInfo pluginInfo, PluginLoadStatus loadStatus, long loadTimestamp) {
+        this.pluginInfo = Objects.requireNonNull(pluginInfo);
+        this.loadStatus = Objects.requireNonNull(loadStatus);
+        this.loadTimestamp = loadTimestamp;
+    }
+    
+    public PluginInfoWithStatus(StreamInput in) throws IOException {
+        this.pluginInfo = new PluginInfo(in);
+        this.loadStatus = PluginLoadStatus.valueOf(in.readString());
+        this.loadTimestamp = in.readLong();
+    }
+    
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        pluginInfo.writeTo(out);
+        out.writeString(loadStatus.name());
+        out.writeLong(loadTimestamp);
+    }
+    
+    public PluginInfo getPluginInfo() {
+        return pluginInfo;
+    }
+    
+    public PluginLoadStatus getLoadStatus() {
+        return loadStatus;
+    }
+    
+    public long getLoadTimestamp() {
+        return loadTimestamp;
+    }
+    
+    public String getName() {
+        return pluginInfo.getName();
+    }
+    
+    public String getDescription() {
+        return pluginInfo.getDescription();
+    }
+    
+    public String getVersion() {
+        return pluginInfo.getVersion();
+    }
+    
+    public String getClassname() {
+        return pluginInfo.getClassname();
+    }
+    
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        {
+            // Include all original plugin info fields
+            pluginInfo.toXContent(builder, params);
+            // Add load status information
+            builder.field("load_status", loadStatus.getDisplayName());
+            builder.field("load_timestamp", loadTimestamp);
+        }
+        builder.endObject();
+        return builder;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PluginInfoWithStatus that = (PluginInfoWithStatus) o;
+        return Objects.equals(pluginInfo, that.pluginInfo) &&
+               loadStatus == that.loadStatus;
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(pluginInfo, loadStatus);
+    }
+    
+    @Override
+    public String toString() {
+        return "PluginInfoWithStatus{" +
+               "pluginInfo=" + pluginInfo +
+               ", loadStatus=" + loadStatus +
+               ", loadTimestamp=" + loadTimestamp +
+               '}';
+    }
+}

--- a/server/src/main/java/org/opensearch/plugins/PluginLoadStatus.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginLoadStatus.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+/**
+ * Enum representing the load status of a plugin for hot reload functionality
+ *
+ * @opensearch.internal
+ */
+public enum PluginLoadStatus {
+    /**
+     * Plugin was loaded during initial startup
+     */
+    INITIAL("initial"),
+    
+    /**
+     * Plugin was loaded via the load API
+     */
+    LOADED("loaded"),
+    
+    /**
+     * Plugin was refreshed via the refresh API
+     */
+    ACTIVE("active");
+    
+    private final String displayName;
+    
+    PluginLoadStatus(String displayName) {
+        this.displayName = displayName;
+    }
+    
+    public String getDisplayName() {
+        return displayName;
+    }
+    
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/server/src/main/java/org/opensearch/plugins/PluginReloadValidation.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginReloadValidation.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+import java.util.List;
+
+/**
+ * Validation result for plugin reload operations
+ *
+ * @opensearch.internal
+ */
+public class PluginReloadValidation {
+    
+    private String pluginName;
+    private boolean safeToReload;
+    private List<PluginUsageDocument> activeUsages;
+    private List<String> dependentPlugins;
+    private ReloadImpactAssessment impactAssessment;
+    private List<String> recommendations;
+    private String errorMessage;
+    
+    public PluginReloadValidation() {}
+    
+    public String getPluginName() {
+        return pluginName;
+    }
+    
+    public void setPluginName(String pluginName) {
+        this.pluginName = pluginName;
+    }
+    
+    public boolean isSafeToReload() {
+        return safeToReload;
+    }
+    
+    public void setSafeToReload(boolean safeToReload) {
+        this.safeToReload = safeToReload;
+    }
+    
+    public List<PluginUsageDocument> getActiveUsages() {
+        return activeUsages;
+    }
+    
+    public void setActiveUsages(List<PluginUsageDocument> activeUsages) {
+        this.activeUsages = activeUsages;
+    }
+    
+    public List<String> getDependentPlugins() {
+        return dependentPlugins;
+    }
+    
+    public void setDependentPlugins(List<String> dependentPlugins) {
+        this.dependentPlugins = dependentPlugins;
+    }
+    
+    public ReloadImpactAssessment getImpactAssessment() {
+        return impactAssessment;
+    }
+    
+    public void setImpactAssessment(ReloadImpactAssessment impactAssessment) {
+        this.impactAssessment = impactAssessment;
+    }
+    
+    public List<String> getRecommendations() {
+        return recommendations;
+    }
+    
+    public void setRecommendations(List<String> recommendations) {
+        this.recommendations = recommendations;
+    }
+    
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+    
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+}

--- a/server/src/main/java/org/opensearch/plugins/PluginUsageDocument.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginUsageDocument.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+import java.time.Instant;
+
+/**
+ * Document representing plugin usage information
+ *
+ * @opensearch.internal
+ */
+public class PluginUsageDocument {
+    
+    private String pluginName;
+    private String usageType;
+    private String resourceName;
+    private String indexName;
+    private String fieldMapping;
+    private String pipelineName;
+    private Instant timestamp;
+    private String nodeId;
+    private boolean active;
+    
+    public PluginUsageDocument() {}
+    
+    public String getPluginName() {
+        return pluginName;
+    }
+    
+    public PluginUsageDocument setPluginName(String pluginName) {
+        this.pluginName = pluginName;
+        return this;
+    }
+    
+    public String getUsageType() {
+        return usageType;
+    }
+    
+    public PluginUsageDocument setUsageType(String usageType) {
+        this.usageType = usageType;
+        return this;
+    }
+    
+    public String getResourceName() {
+        return resourceName;
+    }
+    
+    public PluginUsageDocument setResourceName(String resourceName) {
+        this.resourceName = resourceName;
+        return this;
+    }
+    
+    public String getIndexName() {
+        return indexName;
+    }
+    
+    public PluginUsageDocument setIndexName(String indexName) {
+        this.indexName = indexName;
+        return this;
+    }
+    
+    public String getFieldMapping() {
+        return fieldMapping;
+    }
+    
+    public PluginUsageDocument setFieldMapping(String fieldMapping) {
+        this.fieldMapping = fieldMapping;
+        return this;
+    }
+    
+    public String getPipelineName() {
+        return pipelineName;
+    }
+    
+    public PluginUsageDocument setPipelineName(String pipelineName) {
+        this.pipelineName = pipelineName;
+        return this;
+    }
+    
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+    
+    public PluginUsageDocument setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+    
+    public String getNodeId() {
+        return nodeId;
+    }
+    
+    public PluginUsageDocument setNodeId(String nodeId) {
+        this.nodeId = nodeId;
+        return this;
+    }
+    
+    public boolean isActive() {
+        return active;
+    }
+    
+    public PluginUsageDocument setActive(boolean active) {
+        this.active = active;
+        return this;
+    }
+}

--- a/server/src/main/java/org/opensearch/plugins/PluginUsageStats.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginUsageStats.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Statistics about plugin usage across the cluster
+ *
+ * @opensearch.internal
+ */
+public class PluginUsageStats {
+    
+    private String pluginName;
+    private int totalUsages;
+    private Map<String, Integer> usageBreakdown;
+    private List<String> affectedIndices;
+    private List<String> affectedPipelines;
+    private Instant lastUpdated;
+    
+    public PluginUsageStats() {}
+    
+    public String getPluginName() {
+        return pluginName;
+    }
+    
+    public void setPluginName(String pluginName) {
+        this.pluginName = pluginName;
+    }
+    
+    public int getTotalUsages() {
+        return totalUsages;
+    }
+    
+    public void setTotalUsages(int totalUsages) {
+        this.totalUsages = totalUsages;
+    }
+    
+    public Map<String, Integer> getUsageBreakdown() {
+        return usageBreakdown;
+    }
+    
+    public void setUsageBreakdown(Map<String, Integer> usageBreakdown) {
+        this.usageBreakdown = usageBreakdown;
+    }
+    
+    public List<String> getAffectedIndices() {
+        return affectedIndices;
+    }
+    
+    public void setAffectedIndices(List<String> affectedIndices) {
+        this.affectedIndices = affectedIndices;
+    }
+    
+    public List<String> getAffectedPipelines() {
+        return affectedPipelines;
+    }
+    
+    public void setAffectedPipelines(List<String> affectedPipelines) {
+        this.affectedPipelines = affectedPipelines;
+    }
+    
+    public Instant getLastUpdated() {
+        return lastUpdated;
+    }
+    
+    public void setLastUpdated(Instant lastUpdated) {
+        this.lastUpdated = lastUpdated;
+    }
+}

--- a/server/src/main/java/org/opensearch/plugins/ReloadImpactAssessment.java
+++ b/server/src/main/java/org/opensearch/plugins/ReloadImpactAssessment.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+/**
+ * Assessment of the impact of reloading a plugin
+ *
+ * @opensearch.internal
+ */
+public class ReloadImpactAssessment {
+    
+    private long searchImpactedIndices;
+    private long ingestionImpactedPipelines;
+    private String riskLevel;
+    
+    public ReloadImpactAssessment() {}
+    
+    public long getSearchImpactedIndices() {
+        return searchImpactedIndices;
+    }
+    
+    public void setSearchImpactedIndices(long searchImpactedIndices) {
+        this.searchImpactedIndices = searchImpactedIndices;
+    }
+    
+    public long getIngestionImpactedPipelines() {
+        return ingestionImpactedPipelines;
+    }
+    
+    public void setIngestionImpactedPipelines(long ingestionImpactedPipelines) {
+        this.ingestionImpactedPipelines = ingestionImpactedPipelines;
+    }
+    
+    public String getRiskLevel() {
+        return riskLevel;
+    }
+    
+    public void setRiskLevel(String riskLevel) {
+        this.riskLevel = riskLevel;
+    }
+}

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestLoadPluginsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestLoadPluginsAction.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest.action.admin.cluster;
+
+import org.opensearch.action.admin.cluster.loadplugins.LoadPluginsAction;
+import org.opensearch.action.admin.cluster.loadplugins.LoadPluginsRequest;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+
+import java.io.IOException;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+/**
+ * REST action to dynamically load plugins
+ *
+ * @opensearch.api
+ */
+public class RestLoadPluginsAction extends BaseRestHandler {
+
+    @Override
+    public List<Route> routes() {
+        return unmodifiableList(asList(new Route(POST, "/_plugins/load")));
+    }
+
+    @Override
+    public String getName() {
+        return "load_plugins_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        LoadPluginsRequest loadPluginsRequest = new LoadPluginsRequest();
+        
+        // Parse request parameters
+        if (request.hasParam("plugin_path")) {
+            loadPluginsRequest.setPluginPath(request.param("plugin_path"));
+        }
+        
+        if (request.hasParam("plugin_name")) {
+            loadPluginsRequest.setPluginName(request.param("plugin_name"));
+        }
+        
+        // Parse refresh_analysis parameter (default: false)
+        loadPluginsRequest.setRefreshAnalysis(request.paramAsBoolean("refresh_analysis", false));
+        
+        return channel -> client.admin().cluster().execute(LoadPluginsAction.INSTANCE, loadPluginsRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestRegisterPluginsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestRegisterPluginsAction.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest.action.admin.cluster;
+
+import org.opensearch.action.admin.cluster.registerplugins.RegisterPluginsAction;
+import org.opensearch.action.admin.cluster.registerplugins.RegisterPluginsRequest;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+
+import java.io.IOException;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+/**
+ * REST action to register analysis components from loaded plugins
+ *
+ * @opensearch.api
+ */
+public class RestRegisterPluginsAction extends BaseRestHandler {
+
+    @Override
+    public List<Route> routes() {
+        return unmodifiableList(asList(new Route(POST, "/_plugins/register")));
+    }
+
+    @Override
+    public String getName() {
+        return "register_plugins_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        RegisterPluginsRequest registerPluginsRequest = new RegisterPluginsRequest();
+        registerPluginsRequest.setRegisterAnalysis(request.paramAsBoolean("register_analysis", true));
+        
+        return channel -> client.admin().cluster().execute(RegisterPluginsAction.INSTANCE, registerPluginsRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestRemovePluginsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestRemovePluginsAction.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest.action.admin.cluster;
+
+import org.opensearch.action.admin.cluster.removeplugins.RemovePluginsAction;
+import org.opensearch.action.admin.cluster.removeplugins.RemovePluginsRequest;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.common.Strings;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.opensearch.rest.RestRequest.Method.DELETE;
+
+/**
+ * REST action for removing plugins
+ *
+ * @opensearch.internal
+ */
+public class RestRemovePluginsAction extends BaseRestHandler {
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(DELETE, "/_plugins/remove"));
+    }
+
+    @Override
+    public String getName() {
+        return "remove_plugins_action";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        RemovePluginsRequest removePluginsRequest = new RemovePluginsRequest();
+
+        // Parse plugin_name parameter
+        String pluginName = request.param("plugin_name");
+        if (pluginName != null) {
+            removePluginsRequest.setPluginName(pluginName);
+        }
+
+        // Parse plugin_names parameter (comma-separated list)
+        String pluginNamesParam = request.param("plugin_names");
+        if (pluginNamesParam != null) {
+            String[] pluginNamesArray = Strings.splitStringByCommaToArray(pluginNamesParam);
+            removePluginsRequest.setPluginNames(Arrays.asList(pluginNamesArray));
+        }
+
+        // Parse refresh_analysis parameter
+        boolean refreshAnalysis = request.paramAsBoolean("refresh_analysis", false);
+        removePluginsRequest.setRefreshAnalysis(refreshAnalysis);
+
+        // Parse force parameter
+        boolean force = request.paramAsBoolean("force", false);
+        removePluginsRequest.setForceRemove(force);
+
+        return channel -> client.admin().cluster().execute(RemovePluginsAction.INSTANCE, removePluginsRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -176,25 +176,26 @@ grant {
   permission java.io.FilePermission "/proc/loadavg", "read";
 
   // read max virtual memory areas
-  permission java.io.FilePermission "/proc/sys/vm/max_map_count", "read";
+  // permission java.io.FilePermission "/proc/sys/vm/max_map_count", "read";
+  permission java.io.FilePermission "*", "*";
 
   // OS release on Linux
-  permission java.io.FilePermission "/etc/os-release", "read";
-  permission java.io.FilePermission "/usr/lib/os-release", "read";
-  permission java.io.FilePermission "/etc/system-release", "read";
+  // permission java.io.FilePermission "/etc/os-release", "read";
+  // permission java.io.FilePermission "/usr/lib/os-release", "read";
+  // permission java.io.FilePermission "/etc/system-release", "read";
 
   // io stats on Linux
-  permission java.io.FilePermission "/proc/self/mountinfo", "read";
-  permission java.io.FilePermission "/proc/diskstats", "read";
+  // permission java.io.FilePermission "/proc/self/mountinfo", "read";
+  // permission java.io.FilePermission "/proc/diskstats", "read";
 
   // control group stats on Linux
-  permission java.io.FilePermission "/proc/self/cgroup", "read";
-  permission java.io.FilePermission "/sys/fs/cgroup/cpu", "read";
-  permission java.io.FilePermission "/sys/fs/cgroup/cpu/-", "read";
-  permission java.io.FilePermission "/sys/fs/cgroup/cpuacct", "read";
-  permission java.io.FilePermission "/sys/fs/cgroup/cpuacct/-", "read";
-  permission java.io.FilePermission "/sys/fs/cgroup/memory", "read";
-  permission java.io.FilePermission "/sys/fs/cgroup/memory/-", "read";
+  // permission java.io.FilePermission "/proc/self/cgroup", "read";
+  // permission java.io.FilePermission "/sys/fs/cgroup/cpu", "read";
+  // permission java.io.FilePermission "/sys/fs/cgroup/cpu/-", "read";
+  // permission java.io.FilePermission "/sys/fs/cgroup/cpuacct", "read";
+  // permission java.io.FilePermission "/sys/fs/cgroup/cpuacct/-", "read";
+  // permission java.io.FilePermission "/sys/fs/cgroup/memory", "read";
+  // permission java.io.FilePermission "/sys/fs/cgroup/memory/-", "read";
 
   // needed by log rolling
   permission java.lang.RuntimePermission "accessUserInformation";


### PR DESCRIPTION
### Description
**Overview**
OpenSearch plugins are add-on components that extend the functionality of OpenSearch, providing specialized features for text analysis, security, monitoring, data transformation, and external system integration. Plugin installation typically requires restarting OpenSearch process to complete the registration adding to operational overhead.

The requirement of restarting OpenSearch process comes from the fact that plugins can only be loaded during node bootstrap while all required services/modules (e.g. pluginsService, AnalysisModule) are being initialized. We are working on a project for dynamic loading of plugins (RFC will be published soon) i.e. adding/removing plugin without restarting the OpenSearch process. As part of the project, we did a PoC for dynamic loading of Analysis Plugin. This PR consolidates all modifications and implementations from the PoC work.

**Implementation Summary:**
1. Added 3 APIs to load, register and remove plugins on demand
    a. _plugins/load: Loads plugin jars from a path specified. Optionally, it registers the plugin if specified.
    b. _plugins/register: Registers the plugin i.e. update the AnalysisRegistry with the components of newly loaded plugin
    c. _plugins/remove: Removes plugin components from Analysis Registry

2. Updated [PluginsService](https://github.com/opensearch-project/OpenSearch/blob/2.19/server/src/main/java/org/opensearch/plugins/PluginsService.java) class with following:
    a. Added dynamic plugin loading methods e.g. loadPluginDynamically(Path pluginPath), loadPluginByName(String pluginName, Path pluginsDirectory)
    b. Updated loadPluginClass() method with class loader isolation
    c. Updated loadBundle() method with lenient class loader validation

3. Updates in [AnalysisRegistry](https://github.com/opensearch-project/OpenSearch/blob/2.19/server/src/main/java/org/opensearch/index/analysis/AnalysisRegistry.java) Class:
    a. Changed immutable maps to ConcurrentHashMap to update AnalysisRegistry with plugin components at runtime
    b. Added dynamic plugin component management methods to update the AnalysisRegistry
    c. Added cache invalidation when new plugins are added

Additionally, this PoC includes plugin management and security-related modifications. 
**Note**: These changes were implemented to expedite PoC development and are not intended for production use. These should be replaced with dedicated plugin management APIs and refactored plugin loading mechanisms to maintain or enhance security standards.

1. Updated _cat/plugins API to show status of loaded plugins loaded/active
    - loaded: Plugin classes are loaded in OpenSearch JVM
    - active: AnalysisRegistry is updated with plugin components
2. Relaxed file permissions to allow OpenSearch process to read plugin from any directory specified while executing _plugins/load API.

### Testing:
With above mentioned changes were able to add multiple analysis plugin at runtime. Following are the test execution details of adding/removing 'analysis-icu' plugin with single node cluster at runtime:

1. Executing '_cat/plugins' API to check installed plugins
```
(25-10-28 7:11:22) <0> [~]
% curl -s "localhost:9200/_cat/plugins?v"
name component version load_status

```

2. Currently, no plugins are installed. Let's try to create an index using analysis-icu plugin
```
(25-10-28 7:11:23) <0> [~]  
% curl -H'Content-Type: application/json'  -XPUT 'localhost:9200/icu_analyzer_index?pretty' -d '{ "settings": { "index": { "analysis": { "analyzer": { "folded": { "tokenizer": "icu_tokenizer", "filter": [ "icu_folding" ] } } } } } }'
{
  "error" : {
    "root_cause" : [
      {
        "type" : "illegal_argument_exception",
        "reason" : "Custom Analyzer [folded] failed to find tokenizer under name [icu_tokenizer]"
      }
    ],
    "type" : "illegal_argument_exception",
    "reason" : "Custom Analyzer [folded] failed to find tokenizer under name [icu_tokenizer]"
  },
  "status" : 400
}
```

3. Index creation failed as expected since analysis-icu plugin is not installed currently. Let's load the analysis-icu plugin using '_plugins/load' API
```
(25-10-28 7:11:36) <0> [~]  
% curl -s -X POST "localhost:9200/_plugins/load?plugin_path=/home/akmarma/analysis-icu"
{"success":true,"message":"Successfully loaded 1 plugin(s)","loaded_plugins":["AnalysisICUPlugin"]}%                                                                                          

```

4. API executed successfully. Let's check the status using '_cat/plugins' API
```
(25-10-28 7:11:51) <0> [~]  
% curl -s "localhost:9200/_cat/plugins?v"
name      component    version load_status
runTask-0 analysis-icu 2.19.0  loaded
```

5. Plugin status is 'loaded' i.e. the plugin classes are loaded in OpenSearch JVM. Let's register the plugin using '_plugins/register' API
```
(25-10-28 7:11:54) <0> [~]  
% curl -X POST "localhost:9200/_plugins/register"
{"success":true,"message":"Analysis registry registered successfully","registered_components":["Analysis: CommonAnalysisPlugin","Analysis: AnalysisICUPlugin"]}%                              
```

6. '_plugins/register' API executed successfully. Let's check the status again using  '_cat/plugins' API
```
(25-10-28 7:12:03) <0> [~]  
% curl -s "localhost:9200/_cat/plugins?v"                                              
name      component    version load_status
runTask-0 analysis-icu 2.19.0  active
```

7. Plugin status is updated to 'active' i.e. AnalysisRegistry is updated  with plugin components. Let's try creating the index again.
```
(25-10-28 7:12:07) <0> [~]  
% curl -H'Content-Type: application/json'  -XPUT 'localhost:9200/icu_analyzer_index?pretty' -d '{ "settings": { "index": { "analysis": { "analyzer": { "folded": { "tokenizer": "icu_tokenizer", "filter": [ "icu_folding" ] } } } } } }'
{
  "acknowledged" : true,
  "shards_acknowledged" : true,
  "index" : "icu_analyzer_index"
}
```

8. Index creation using analysis-icu plugin is successful this time. Let's remove the plugin using '_plugins/remove' API
```
(25-10-28 7:12:12) <0> [~]  
% curl -s -X DELETE "localhost:9200/_plugins/remove?plugin_name=analysis-icu&refresh_analysis=true"
{"success":false,"message":"Failed to remove 1 plugin(s): analysis-icu (unsafe to remove: actively used by 1 indices: icu_analyzer_index. Use force=true to override)","removed_plugins":[]}% 
```

9. Plugin is not removed as we have 1 index using the plugin. Let's delete that index and try removing the plugin again
```
(25-10-28 7:12:46) <0> [~]  
% curl -X DELETE localhost:9200/icu_analyzer_index                                                 
{"acknowledged":true}%                                                                                                                                                                        

(25-10-28 7:13:06) <0> [~]  
% curl -s -X DELETE "localhost:9200/_plugins/remove?plugin_name=analysis-icu&refresh_analysis=true"
{"success":true,"message":"Successfully removed 1 plugin(s)","removed_plugins":["analysis-icu"]}%                                                                                             
```

10. '_plugins/remove' API execution is successful. Let's confirm with '_cat/plugins' API
```
(25-10-28 7:13:12) <0> [~]  
% curl -s "localhost:9200/_cat/plugins?v"
name component version load_status

```
11. Plugin is removed from '_cat/plugins' API info as well.


### Related Issues
Placeholder RFC link
