### PR TITLE
Fix the check for expected value of number of arenas for flight tranport

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/ServerConfig.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/bootstrap/ServerConfig.java
@@ -238,7 +238,10 @@ public class ServerConfig {
 
         @SuppressForbidden(reason = "required for netty allocator configuration")
         public static void init(Settings settings) {
-            checkSystemProperty("io.netty.allocator.numDirectArenas", "1");
+            int numArenas = Integer.parseInt(System.getProperty("io.netty.allocator.numDirectArenas"));
+            if (numArenas <= 0) {
+                throw new IllegalStateException("io.netty.allocator.numDirectArenas must be > 0");
+            }
             checkSystemProperty("io.netty.noUnsafe", "false");
             checkSystemProperty("io.netty.tryUnsafe", "true");
             checkSystemProperty("io.netty.tryReflectionSetAccessible", "true");


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Ideally, this check should have never been added as it prevents setting the number of direct arenas to more than 1.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
