### PR TITLE
Fix :build-tools:integTest fails on Mac and aarch64 Ubuntu

### DIFF
--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/DistributionDownloadPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/DistributionDownloadPluginFuncTest.groovy
@@ -30,6 +30,7 @@
 package org.opensearch.gradle
 
 
+import org.opensearch.gradle.Architecture
 import org.opensearch.gradle.fixtures.AbstractGradleFuncTest
 import org.opensearch.gradle.transform.SymbolicLinkPreservingUntarTransform
 import org.gradle.testkit.runner.TaskOutcome
@@ -65,6 +66,7 @@ class DistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
         given:
         def version = VersionProperties.getOpenSearch()
         def platform = OpenSearchDistribution.Platform.LINUX
+        def arch = Architecture.current().name().toLowerCase()
 
         buildFile << applyPluginAndSetupDistro(version, platform)
         buildFile << """
@@ -83,7 +85,7 @@ class DistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.task(":setupDistro").outcome == TaskOutcome.SUCCESS
-        result.output.count("Unpacking opensearch-${version}-linux-x64.tar.gz " +
+        result.output.count("Unpacking opensearch-${version}-linux-${arch}.tar.gz " +
             "using SymbolicLinkPreservingUntarTransform.") == 0
     }
 
@@ -91,6 +93,7 @@ class DistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
         given:
         def version = VersionProperties.getOpenSearch()
         def platform = OpenSearchDistribution.Platform.LINUX
+        def arch = Architecture.current().name().toLowerCase()
 
         3.times {
             testProjectDir.newFolder("sub-$it")
@@ -122,7 +125,7 @@ class DistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.tasks.size() == 3
-        result.output.count("Unpacking opensearch-${version}-linux-x64.tar.gz " +
+        result.output.count("Unpacking opensearch-${version}-linux-${arch}.tar.gz " +
                 "using SymbolicLinkPreservingUntarTransform.") == 1
     }
 

--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/DistributionDownloadFixture.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/fixtures/DistributionDownloadFixture.groovy
@@ -30,6 +30,7 @@
 package org.opensearch.gradle.fixtures
 
 
+import org.opensearch.gradle.Architecture
 import org.opensearch.gradle.OpenSearchDistribution
 import org.opensearch.gradle.Version
 import org.opensearch.gradle.VersionProperties
@@ -66,11 +67,12 @@ class DistributionDownloadFixture {
     private static String urlPath(String version, OpenSearchDistribution.Platform platform) {
         String fileType = ((platform == OpenSearchDistribution.Platform.LINUX ||
                 platform == OpenSearchDistribution.Platform.DARWIN)) ? "tar.gz" : "zip"
+        String arch = Architecture.current().name().toLowerCase()
         if (Version.fromString(version).onOrAfter(Version.fromString("1.0.0"))) {
             if (version.contains("SNAPSHOT")) {
-                return "/snapshots/core/opensearch/${version}/opensearch-min-${version}-${platform}-x64-latest.$fileType"
+                return "/snapshots/core/opensearch/${version}/opensearch-min-${version}-${platform}-${arch}-latest.$fileType"
             }
-            return "/releases/core/opensearch/${version}/opensearch-min-${version}-${platform}-x64.$fileType"
+            return "/releases/core/opensearch/${version}/opensearch-min-${version}-${platform}-${arch}.$fileType"
         } else {
             return "/downloads/elasticsearch/elasticsearch-oss-${version}-${platform}-x86_64.$fileType"
         }

--- a/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/opensearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
@@ -29,6 +29,7 @@
 
 package org.opensearch.gradle.internal
 
+import org.opensearch.gradle.Architecture
 import org.opensearch.gradle.VersionProperties
 import org.opensearch.gradle.fixtures.AbstractGradleFuncTest
 import org.gradle.testkit.runner.GradleRunner
@@ -59,7 +60,8 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
     def "resolves current version from local build"() {
         given:
         internalBuild()
-        localDistroSetup()
+        def archive = archiveTask()
+        localDistroSetup(archive)
         def distroVersion = VersionProperties.getOpenSearch()
         buildFile << """
             apply plugin: 'opensearch.internal-distribution-download'
@@ -82,7 +84,7 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
         def result = gradleRunner("setupDistro", '-g', testProjectDir.newFolder('GUH').path).build()
 
         then:
-        result.task(":distribution:archives:linux-tar:buildExpanded").outcome == TaskOutcome.SUCCESS
+        result.task(":distribution:archives:${archive}:buildExpanded").outcome == TaskOutcome.SUCCESS
         result.task(":setupDistro").outcome == TaskOutcome.SUCCESS
         assertExtractedDistroIsCreated("build/distro", 'current-marker.txt')
     }
@@ -150,30 +152,31 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
         settingsFile << """
         include ':distribution:bwc:minor'
         """
+        def archive = archiveTask()
         def bwcSubProjectFolder = testProjectDir.newFolder("distribution", "bwc", "minor")
         new File(bwcSubProjectFolder, 'bwc-marker.txt') << "bwc=minor"
         new File(bwcSubProjectFolder, 'build.gradle') << """
             apply plugin:'base'
 
             // packed distro
-            configurations.create("linux-tar")
+            configurations.create("${archive}")
             tasks.register("buildBwcTask", Tar) {
                 from('bwc-marker.txt')
                 archiveExtension = "tar.gz"
                 compression = Compression.GZIP
             }
             artifacts {
-                it.add("linux-tar", buildBwcTask)
+                it.add("${archive}", buildBwcTask)
             }
 
             // expanded distro
-            configurations.create("expanded-linux-tar")
+            configurations.create("expanded-${archive}")
             def expandedTask = tasks.register("buildBwcExpandedTask", Copy) {
                 from('bwc-marker.txt')
                 into('build/install/opensearch-distro')
             }
             artifacts {
-                it.add("expanded-linux-tar", file('build/install')) {
+                it.add("expanded-${archive}", file('build/install')) {
                     builtBy expandedTask
                     type = 'directory'
                 }
@@ -181,11 +184,15 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
         """
     }
 
-    private void localDistroSetup() {
+    private String archiveTask() {
+        return Architecture.current() == Architecture.X64 ? "linux-tar" : "linux-${Architecture.current().name().toLowerCase()}-tar"; 
+    }
+
+    private void localDistroSetup(def archive) {
         settingsFile << """
-        include ":distribution:archives:linux-tar"
+        include ":distribution:archives:${archive}"
         """
-        def bwcSubProjectFolder = testProjectDir.newFolder("distribution", "archives", "linux-tar")
+        def bwcSubProjectFolder = testProjectDir.newFolder("distribution", "archives", "${archive}")
         new File(bwcSubProjectFolder, 'current-marker.txt') << "current"
         new File(bwcSubProjectFolder, 'build.gradle') << """
             import org.gradle.api.internal.artifacts.ArtifactAttributes;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix `:build-tools:integTest` that fails on Mac and aarch64 Ubuntu

### Related Issues
Closes https://github.com/opensearch-project/OpenSearch/issues/19826
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
