### PR TITLE
Handling all numeric types for simple metric aggregations

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/AvgAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/AvgAggregator.java
@@ -282,20 +282,9 @@ class AvgAggregator extends NumericMetricsAggregator.SingleValue implements Star
     }
 
     @Override
-    public List<InternalAggregation> convert(Map<String, Object[]> shardResult) {
-        Object[] counts = shardResult.get(name + "_count");
-        Object[] sums = shardResult.get(name + "_sum");
-        List<InternalAggregation> results = new ArrayList<>(counts.length);
-        for (int i = 0; i < counts.length; i++) {
-            results.add(new InternalAvg(name, (Long) sums[i], (Long) counts[i], format, metadata()));
-        }
-        return results;
-    }
-
-    @Override
     public InternalAggregation convertRow(Map<String, Object[]> shardResult, int row) {
         Object[] counts = shardResult.get(name + "_count");
         Object[] sums = shardResult.get(name + "_sum");
-        return new InternalAvg(name, (Long) sums[row], (Long) counts[row], format, metadata());
+        return new InternalAvg(name, ((Number) sums[row]).doubleValue(), ((Number) sums[row]).longValue(), format, metadata());
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/MaxAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/MaxAggregator.java
@@ -287,6 +287,6 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue implements Star
     @Override
     public InternalAggregation convertRow(Map<String, Object[]> shardResult, int row) {
         Object[] values = shardResult.get(name);
-        return new InternalMax(name, (Long) values[row], formatter, metadata());
+        return new InternalMax(name, ((Number) values[row]).doubleValue(), formatter, metadata());
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/MinAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/MinAggregator.java
@@ -278,6 +278,6 @@ class MinAggregator extends NumericMetricsAggregator.SingleValue implements Star
     @Override
     public InternalAggregation convertRow(Map<String, Object[]> shardResult, int row) {
         Object[] values = shardResult.get(name);
-        return new InternalMin(name, (Long) values[row], format, metadata());
+        return new InternalMin(name, ((Number) values[row]).doubleValue(), format, metadata());
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/SumAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/SumAggregator.java
@@ -222,6 +222,6 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue implemen
     @Override
     public InternalAggregation convertRow(Map<String, Object[]> shardResult, int row) {
         Object[] values = shardResult.get(name);
-        return new InternalSum(name, (Long) values[row], format, metadata());
+        return new InternalSum(name, ((Number) values[row]).doubleValue(), format, metadata());
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/ValueCountAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/ValueCountAggregator.java
@@ -216,6 +216,6 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue i
     @Override
     public InternalAggregation convertRow(Map<String, Object[]> shardResult, int row) {
             Object[] values = shardResult.get(name);
-            return new InternalValueCount(name, (Long) values[row], metadata());
+            return new InternalValueCount(name, ((Number) values[row]).longValue(), metadata());
     }
 }


### PR DESCRIPTION
```
curl --location --request DELETE 'localhost:9200/index-7'

# Create index with multiple field types
curl --location --request PUT 'http://localhost:9200/index-7' \
--header 'Content-Type: application/json' \
--data-raw '{
    "settings": {
        "number_of_shards": 1,
        "number_of_replicas": 0,
        "refresh_interval": -1
    },
    "mappings": {
        "properties": {
            "id": {
                "type": "keyword"
            },
            "name": {
                "type": "text"
            },
            "age": {
                "type": "integer"
            },
            "salary": {
                "type": "long"
            },
            "score": {
                "type": "double"
            },
            "active": {
                "type": "boolean"
            }
        }
    }
}'

# Bulk index documents with different field types
curl --location --request POST 'http://localhost:9200/_bulk' \
--header 'Content-Type: application/json' \
--data-raw '{"index":{"_index":"index-7"}}
{"id":"1","name":"Alice","age":30,"salary":75000,"score":95.5,"active":true}
{"index":{"_index":"index-7"}}
{"id":"2","name":"Bob","age":25,"salary":60000,"score":88.3,"active":true}
{"index":{"_index":"index-7"}}
{"id":"3","name":"Charlie","age":35,"salary":90000,"score":92.7,"active":false}
{"index":{"_index":"index-7"}}
{"id":"4","name":"Diana","age":28,"salary":70000,"score":89.1,"active":true}
'

curl localhost:9200/index-7/_refresh

curl --location --request POST 'http://localhost:9200/_plugins/_ppl' \
--header 'Content-Type: application/json' \
--data-raw '{
  "query": "source=index-7 | stats count(), min(age) as min, max(age) as max, avg(age) as avg"
}'


curl --location --request POST 'http://localhost:9200/_plugins/_ppl' --header 'Content-Type: application/json' --data-raw '{
  "query": "source=index-7 |  stats count(), min(score) as min, max(score) as max, avg(age) as avg, sum(score) as ss"
}'

```