### PR TITLE
Fix for concurrent queue not removing writers while polling

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/exec/queue/ConcurrentQueue.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/queue/ConcurrentQueue.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.engine.exec.queue;
 
+import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -32,7 +33,7 @@ public final class ConcurrentQueue<T> {
         this.concurrency = concurrency;
         this.queueSupplier = queueSupplier;
         locks = new Lock[concurrency];
-        @SuppressWarnings({"rawtypes", "unchecked"}) Queue<T>[] queues = new Queue[concurrency];
+        @SuppressWarnings({ "rawtypes", "unchecked" }) Queue<T>[] queues = new Queue[concurrency];
         this.queues = queues;
         for (int i = 0; i < concurrency; ++i) {
             locks[i] = new ReentrantLock();
@@ -77,8 +78,11 @@ public final class ConcurrentQueue<T> {
             final Queue<T> queue = queues[index];
             if (lock.tryLock()) {
                 try {
-                    for (T entry : queue) {
+                    Iterator<T> it = queue.iterator();
+                    while (it.hasNext()) {
+                        T entry = it.next();
                         if (predicate.test(entry)) {
+                            it.remove();
                             return entry;
                         }
                     }
@@ -93,8 +97,11 @@ public final class ConcurrentQueue<T> {
             final Queue<T> queue = queues[index];
             lock.lock();
             try {
-                for (T entry : queue) {
+                Iterator<T> it = queue.iterator();
+                while (it.hasNext()) {
+                    T entry = it.next();
                     if (predicate.test(entry)) {
+                        it.remove();
                         return entry;
                     }
                 }


### PR DESCRIPTION
### Description
This change removes the CompositeDataFormatWriter from ConcurrentQueue while polling. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
