### PR TITLE
POC changes for making search plugin hot reloadable

### DIFF
--- a/server/src/main/java/org/opensearch/action/ActionModule.java
+++ b/server/src/main/java/org/opensearch/action/ActionModule.java
@@ -48,6 +48,8 @@ import org.opensearch.action.admin.cluster.decommission.awareness.put.Decommissi
 import org.opensearch.action.admin.cluster.decommission.awareness.put.TransportDecommissionAction;
 import org.opensearch.action.admin.cluster.health.ClusterHealthAction;
 import org.opensearch.action.admin.cluster.health.TransportClusterHealthAction;
+import org.opensearch.action.admin.cluster.loadsearchplugins.LoadSearchPluginsAction;
+import org.opensearch.action.admin.cluster.loadsearchplugins.TransportLoadSearchPluginsAction;
 import org.opensearch.action.admin.cluster.node.hotthreads.NodesHotThreadsAction;
 import org.opensearch.action.admin.cluster.node.hotthreads.TransportNodesHotThreadsAction;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoAction;
@@ -791,6 +793,9 @@ public class ActionModule extends AbstractModule {
         actions.register(GetSearchPipelineAction.INSTANCE, GetSearchPipelineTransportAction.class);
         actions.register(DeleteSearchPipelineAction.INSTANCE, DeleteSearchPipelineTransportAction.class);
 
+        // Search Plugin Hot Reload
+        actions.register(LoadSearchPluginsAction.INSTANCE, TransportLoadSearchPluginsAction.class);
+
         return unmodifiableMap(actions.getRegistry());
     }
 
@@ -993,6 +998,9 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestPutSearchPipelineAction());
         registerHandler.accept(new RestGetSearchPipelineAction());
         registerHandler.accept(new RestDeleteSearchPipelineAction());
+
+        // Search Plugin Hot Reload API
+        registerHandler.accept(new org.opensearch.rest.action.admin.cluster.RestLoadSearchPluginsAction());
 
         // Extensions API
         if (FeatureFlags.isEnabled(FeatureFlags.EXTENSIONS)) {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/loadsearchplugins/LoadSearchPluginsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/loadsearchplugins/LoadSearchPluginsAction.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.loadsearchplugins;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Action for dynamically loading search plugins
+ *
+ * @opensearch.internal
+ */
+public class LoadSearchPluginsAction extends ActionType<LoadSearchPluginsResponse> {
+
+    public static final LoadSearchPluginsAction INSTANCE = new LoadSearchPluginsAction();
+    public static final String NAME = "cluster:admin/search_plugins/load";
+
+    private LoadSearchPluginsAction() {
+        super(NAME, LoadSearchPluginsResponse::new);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/loadsearchplugins/LoadSearchPluginsRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/loadsearchplugins/LoadSearchPluginsRequest.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.loadsearchplugins;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Request for loading search plugins
+ *
+ * @opensearch.internal
+ */
+public class LoadSearchPluginsRequest extends ClusterManagerNodeRequest<LoadSearchPluginsRequest> {
+    private String pluginPath;
+    private String pluginName;
+    private boolean refreshSearch = false;
+
+    public LoadSearchPluginsRequest() {}
+
+    public LoadSearchPluginsRequest(StreamInput in) throws IOException {
+        super(in);
+        pluginPath = in.readOptionalString();
+        pluginName = in.readOptionalString();
+        refreshSearch = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(pluginPath);
+        out.writeOptionalString(pluginName);
+        out.writeBoolean(refreshSearch);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    // Getters and setters
+    public String getPluginPath() { return pluginPath; }
+    public void setPluginPath(String pluginPath) { this.pluginPath = pluginPath; }
+    public String getPluginName() { return pluginName; }
+    public void setPluginName(String pluginName) { this.pluginName = pluginName; }
+    public boolean isRefreshSearch() { return refreshSearch; }
+    public void setRefreshSearch(boolean refreshSearch) { this.refreshSearch = refreshSearch; }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/loadsearchplugins/LoadSearchPluginsResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/loadsearchplugins/LoadSearchPluginsResponse.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.loadsearchplugins;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Response for loading search plugins
+ *
+ * @opensearch.internal
+ */
+public class LoadSearchPluginsResponse extends ActionResponse implements ToXContentObject {
+    private boolean success;
+    private String message;
+    private List<String> loadedPlugins;
+
+    public LoadSearchPluginsResponse() {}
+
+    public LoadSearchPluginsResponse(StreamInput in) throws IOException {
+        super(in);
+        success = in.readBoolean();
+        message = in.readOptionalString();
+        loadedPlugins = in.readStringList();
+    }
+
+    public LoadSearchPluginsResponse(boolean success, String message, List<String> loadedPlugins) {
+        this.success = success;
+        this.message = message;
+        this.loadedPlugins = loadedPlugins;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(success);
+        out.writeOptionalString(message);
+        out.writeStringCollection(loadedPlugins);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("success", success);
+        if (message != null) {
+            builder.field("message", message);
+        }
+        builder.field("loaded_plugins", loadedPlugins);
+        builder.endObject();
+        return builder;
+    }
+
+    // Getters
+    public boolean isSuccess() { return success; }
+    public String getMessage() { return message; }
+    public List<String> getLoadedPlugins() { return loadedPlugins; }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/loadsearchplugins/TransportLoadSearchPluginsAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/loadsearchplugins/TransportLoadSearchPluginsAction.java
@@ -1,0 +1,167 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.loadsearchplugins;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.search.SearchPluginHotReloadService;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Transport action for loading search plugins
+ *
+ * @opensearch.internal
+ */
+public class TransportLoadSearchPluginsAction extends TransportClusterManagerNodeAction<LoadSearchPluginsRequest, LoadSearchPluginsResponse> {
+
+    private static final Logger logger = LogManager.getLogger(TransportLoadSearchPluginsAction.class);
+    private final SearchPluginHotReloadService hotReloadService;
+
+    @Inject
+    public TransportLoadSearchPluginsAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        SearchPluginHotReloadService hotReloadService
+    ) {
+        super(
+            LoadSearchPluginsAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            LoadSearchPluginsRequest::new,
+            indexNameExpressionResolver
+        );
+        this.hotReloadService = hotReloadService;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected LoadSearchPluginsResponse read(StreamInput in) throws IOException {
+        return new LoadSearchPluginsResponse(in);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(LoadSearchPluginsRequest request, ClusterState state) {
+        return null;
+    }
+
+    @Override
+    protected void clusterManagerOperation(
+        LoadSearchPluginsRequest request,
+        ClusterState state,
+        ActionListener<LoadSearchPluginsResponse> listener
+    ) throws Exception {
+        try {
+            List<String> loadedPlugins = new ArrayList<>();
+            
+            // Load search plugin using the hot reload service
+            if (request.getPluginPath() != null) {
+                try {
+                    SearchPluginHotReloadService.SearchPluginLoadResult result = 
+                        hotReloadService.loadSearchPlugin(
+                            request.getPluginPath(), 
+                            request.isRefreshSearch()
+                        );
+                    
+                    if (result.isSuccess()) {
+                        if (result.getPluginName() != null) {
+                            loadedPlugins.add(result.getPluginName());
+                        }
+                        
+                        listener.onResponse(new LoadSearchPluginsResponse(
+                            true,
+                            result.getMessage(),
+                            loadedPlugins
+                        ));
+                    } else {
+                        listener.onResponse(new LoadSearchPluginsResponse(
+                            false,
+                            result.getMessage(),
+                            loadedPlugins
+                        ));
+                    }
+                } catch (Exception e) {
+                    logger.error("Failed to load search plugin from path: {}", request.getPluginPath(), e);
+                    listener.onResponse(new LoadSearchPluginsResponse(
+                        false,
+                        "Failed to load plugin: " + e.getMessage(),
+                        new ArrayList<>()
+                    ));
+                }
+            } else if (request.getPluginName() != null) {
+                // For now, we only support loading by path
+                // Plugin by name would require scanning plugins directory
+                listener.onResponse(new LoadSearchPluginsResponse(
+                    false,
+                    "Loading by plugin name not yet supported. Use plugin_path parameter.",
+                    new ArrayList<>()
+                ));
+            } else {
+                // No plugin specified
+                if (request.isRefreshSearch()) {
+                    // Refresh existing search plugins
+                    List<String> refreshedPlugins = refreshExistingSearchPlugins();
+                    listener.onResponse(new LoadSearchPluginsResponse(
+                        true,
+                        "Refreshed " + refreshedPlugins.size() + " existing search plugin(s)",
+                        refreshedPlugins
+                    ));
+                } else {
+                    listener.onResponse(new LoadSearchPluginsResponse(
+                        false,
+                        "No plugin specified. Provide plugin_path or plugin_name parameter.",
+                        new ArrayList<>()
+                    ));
+                }
+            }
+            
+        } catch (Exception e) {
+            logger.error("Unexpected error in search plugin loading", e);
+            listener.onResponse(new LoadSearchPluginsResponse(
+                false,
+                "Unexpected error: " + e.getMessage(),
+                new ArrayList<>()
+            ));
+        }
+    }
+    
+    /**
+     * Refresh existing search plugins (re-register their components)
+     */
+    private List<String> refreshExistingSearchPlugins() {
+        try {
+            return hotReloadService.getLoadedSearchPlugins();
+        } catch (Exception e) {
+            logger.warn("Failed to refresh existing search plugins", e);
+            return new ArrayList<>();
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/loadsearchplugins/package-info.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/loadsearchplugins/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Transport action for dynamically loading search plugins at runtime.
+ * 
+ * <p>This package provides the infrastructure for hot-reloading search plugins
+ * without requiring a cluster restart. The main components include:
+ * <ul>
+ *   <li>{@link org.opensearch.action.admin.cluster.loadsearchplugins.LoadSearchPluginsAction} - The action definition</li>
+ *   <li>{@link org.opensearch.action.admin.cluster.loadsearchplugins.LoadSearchPluginsRequest} - Request parameters</li>
+ *   <li>{@link org.opensearch.action.admin.cluster.loadsearchplugins.LoadSearchPluginsResponse} - Response with results</li>
+ *   <li>{@link org.opensearch.action.admin.cluster.loadsearchplugins.TransportLoadSearchPluginsAction} - Transport handler</li>
+ * </ul>
+ * 
+ * @opensearch.internal
+ */
+package org.opensearch.action.admin.cluster.loadsearchplugins;

--- a/server/src/main/java/org/opensearch/bootstrap/Security.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Security.java
@@ -158,7 +158,7 @@ final class Security {
             // SecureSM matches class names as regular expressions so we escape the $ that arises from the nested class name
             OpenSearchUncaughtExceptionHandler.PrivilegedHaltAction.class.getName().replace("$", "\\$"),
             Command.class.getName() };
-        System.setSecurityManager(new SecureSM(classesThatCanExit));
+        // System.setSecurityManager(new SecureSM(classesThatCanExit));
 
         // do some basic tests
         selfTest();

--- a/server/src/main/java/org/opensearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/opensearch/http/AbstractHttpServerTransport.java
@@ -101,7 +101,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
     protected final ThreadPool threadPool;
     protected final Dispatcher dispatcher;
     protected final CorsHandler corsHandler;
-    private final NamedXContentRegistry xContentRegistry;
+    private volatile NamedXContentRegistry xContentRegistry;
 
     protected final PortsRange port;
     protected final ByteSizeValue maxContentLength;
@@ -503,5 +503,14 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
     @SuppressWarnings("unchecked")
     private static <Values extends Collection<String>> Map<String, Collection<String>> extractHeaders(Map<String, Values> headers) {
         return (Map<String, Collection<String>>) headers;
+    }
+
+    /**
+     * Update the XContent registry (for search plugin hot reload)
+     * @param newRegistry the new registry to use
+     */
+    public synchronized void updateXContentRegistry(NamedXContentRegistry newRegistry) {
+        logger.info("Updating AbstractHttpServerTransport NamedXContentRegistry for search plugin hot reload");
+        this.xContentRegistry = newRegistry;
     }
 }

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -158,8 +158,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final CheckedFunction<DirectoryReader, DirectoryReader, IOException> readerWrapper;
     private final IndexCache indexCache;
     private final MapperService mapperService;
-    private final NamedXContentRegistry xContentRegistry;
-    private final NamedWriteableRegistry namedWriteableRegistry;
+    private volatile NamedXContentRegistry xContentRegistry;
+    private volatile NamedWriteableRegistry namedWriteableRegistry;
     private final SimilarityService similarityService;
     private final EngineFactory engineFactory;
     private final EngineConfigFactory engineConfigFactory;
@@ -1643,6 +1643,24 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             }
         }
         return clearedAtLeastOne;
+    }
+
+    /**
+     * Update the XContent registry (for search plugin hot reload)
+     * @param newRegistry the new registry to use
+     */
+    public synchronized void updateXContentRegistry(NamedXContentRegistry newRegistry) {
+        logger.info("[{}] Updating NamedXContentRegistry for search plugin hot reload", index());
+        this.xContentRegistry = newRegistry;
+    }
+
+    /**
+     * Update the NamedWriteable registry (for search plugin hot reload)
+     * @param newRegistry the new registry to use  
+     */
+    public synchronized void updateNamedWriteableRegistry(NamedWriteableRegistry newRegistry) {
+        logger.info("[{}] Updating NamedWriteableRegistry for search plugin hot reload", index());
+        this.namedWriteableRegistry = newRegistry;
     }
 
 }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -1425,6 +1425,7 @@ public class Node implements Closeable {
                 b.bind(NodeService.class).toInstance(nodeService);
                 b.bind(NamedXContentRegistry.class).toInstance(xContentRegistry);
                 b.bind(PluginsService.class).toInstance(pluginsService);
+                b.bind(SearchModule.class).toInstance(searchModule);
                 b.bind(Client.class).toInstance(client);
                 b.bind(NodeClient.class).toInstance(client);
                 b.bind(Environment.class).toInstance(this.environment);
@@ -1523,6 +1524,9 @@ public class Node implements Closeable {
                 taskManagerClientOptional.ifPresent(value -> b.bind(TaskManagerClient.class).toInstance(value));
             });
             injector = modules.createInjector();
+
+            // Wire HttpServerTransport to IndicesService for dynamic registry updates
+            injector.getInstance(IndicesService.class).setHttpServerTransport(injector.getInstance(HttpServerTransport.class));
 
             // We allocate copies of existing shards by looking for a viable copy of the shard in the cluster and assigning the shard there.
             // The search for viable copies is triggered by an allocation attempt (i.e. a reroute) and is performed asynchronously. When it

--- a/server/src/main/java/org/opensearch/plugins/PluginLoadStatus.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginLoadStatus.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugins;
+
+/**
+ * Enum representing the load status of a plugin for hot reload functionality
+ *
+ * @opensearch.internal
+ */
+public enum PluginLoadStatus {
+    /**
+     * Plugin was loaded during initial startup
+     */
+    INITIAL("initial"),
+    
+    /**
+     * Plugin was loaded via the load API
+     */
+    LOADED("loaded"),
+    
+    /**
+     * Plugin was refreshed via the refresh API
+     */
+    ACTIVE("active");
+    
+    private final String displayName;
+    
+    PluginLoadStatus(String displayName) {
+        this.displayName = displayName;
+    }
+    
+    public String getDisplayName() {
+        return displayName;
+    }
+    
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/server/src/main/java/org/opensearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/opensearch/plugins/PluginsService.java
@@ -82,6 +82,8 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 
 import static org.opensearch.core.util.FileSystemUtils.isAccessibleDirectory;
 
@@ -100,8 +102,13 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
     /**
      * We keep around a list of plugins and modules
      */
-    private final List<Tuple<PluginInfo, Plugin>> plugins;
-    private final PluginsAndModules info;
+    private volatile List<Tuple<PluginInfo, Plugin>> plugins;
+    private volatile PluginsAndModules info;
+
+    /**
+     * Map to track plugin load status for hot reload functionality
+     */
+    private final Map<String, PluginLoadStatus> pluginLoadStatusMap = new HashMap<>();
 
     public static final Setting<List<String>> MANDATORY_SETTING = Setting.listSetting(
         "plugin.mandatory",
@@ -832,5 +839,216 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
 
     public <T> List<T> filterPlugins(Class<T> type) {
         return plugins.stream().filter(x -> type.isAssignableFrom(x.v2().getClass())).map(p -> ((T) p.v2())).collect(Collectors.toList());
+    }
+
+    // ========== Dynamic Plugin Loading Methods ==========
+
+    /**
+     * Dynamically load a plugin from the specified path
+     *
+     * @param pluginPath The path to the plugin directory
+     * @return The loaded plugin instance
+     * @throws IOException if plugin loading fails
+     */
+    @SuppressWarnings("removal")
+    public Plugin loadPluginDynamically(Path pluginPath) throws IOException {
+        try {
+            return AccessController.doPrivileged((PrivilegedExceptionAction<Plugin>) () -> {
+                if (!Files.exists(pluginPath) || !Files.isDirectory(pluginPath)) {
+                    throw new IllegalArgumentException("Plugin path does not exist or is not a directory: " + pluginPath);
+                }
+
+                // Read plugin bundle from the specified path
+                Set<Bundle> bundles = new HashSet<>();
+                Bundle bundle = readPluginBundle(bundles, pluginPath, "plugin");
+                bundles.add(bundle);
+
+                // Load the plugin
+                Map<String, Plugin> loaded = new HashMap<>();
+                // Add existing plugins to the loaded map to handle dependencies
+                for (Tuple<PluginInfo, Plugin> existingPlugin : plugins) {
+                    loaded.put(existingPlugin.v1().getName(), existingPlugin.v2());
+                }
+
+                Plugin plugin = loadBundle(bundle, loaded);
+
+                // Register the dynamically loaded plugin with the system
+                registerDynamicPlugin(bundle.plugin, plugin);
+
+                return plugin;
+            });
+        } catch (PrivilegedActionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            } else if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else {
+                throw new IOException("Failed to load plugin dynamically", cause);
+            }
+        }
+    }
+
+    /**
+     * Register a dynamically loaded plugin with the system so it appears in _cat/plugins
+     * 
+     * @param pluginInfo The plugin information
+     * @param plugin The plugin instance
+     */
+    private synchronized void registerDynamicPlugin(PluginInfo pluginInfo, Plugin plugin) {
+        try {
+            // Check if plugin is already registered to prevent duplicates
+            boolean pluginExists = false;
+            for (Tuple<PluginInfo, Plugin> existingPlugin : plugins) {
+                if (existingPlugin.v1().getName().equals(pluginInfo.getName())) {
+                    pluginExists = true;
+                    logger.warn("Plugin [{}] is already registered. Skipping duplicate registration.", pluginInfo.getName());
+                    break;
+                }
+            }
+            
+            if (!pluginExists) {
+                // Create new plugin tuple
+                Tuple<PluginInfo, Plugin> pluginTuple = new Tuple<>(pluginInfo, plugin);
+                
+                // Create new plugins list with the dynamically loaded plugin
+                List<Tuple<PluginInfo, Plugin>> newPluginsList = new ArrayList<>(plugins);
+                newPluginsList.add(pluginTuple);
+                
+                // Update the plugins list
+                this.plugins = Collections.unmodifiableList(newPluginsList);
+                
+                // Create new plugin info list for PluginsAndModules
+                List<PluginInfo> newPluginInfoList = new ArrayList<>(info.getPluginInfos());
+                newPluginInfoList.add(pluginInfo);
+                
+                // Update the info object
+                this.info = new PluginsAndModules(newPluginInfoList, info.getModuleInfos());
+                
+                logger.info("Successfully registered dynamically loaded plugin [{}] with the system", pluginInfo.getName());
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to register dynamically loaded plugin [{}] with the system: {}", pluginInfo.getName(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Dynamically unload a plugin by name
+     *
+     * @param pluginName The name of the plugin to unload
+     * @return true if the plugin was successfully unloaded, false if not found
+     */
+    public synchronized boolean unloadPluginDynamically(String pluginName) {
+        try {
+            // Find the plugin to unload
+            Tuple<PluginInfo, Plugin> pluginToUnload = null;
+            for (Tuple<PluginInfo, Plugin> plugin : plugins) {
+                if (plugin.v1().getName().equals(pluginName) || 
+                    plugin.v2().getClass().getSimpleName().equals(pluginName)) {
+                    pluginToUnload = plugin;
+                    break;
+                }
+            }
+
+            if (pluginToUnload == null) {
+                logger.warn("Plugin [{}] not found for unloading", pluginName);
+                return false;
+            }
+
+            // Create new plugins list without the unloaded plugin
+            List<Tuple<PluginInfo, Plugin>> newPluginsList = new ArrayList<>();
+            for (Tuple<PluginInfo, Plugin> plugin : plugins) {
+                if (!plugin.equals(pluginToUnload)) {
+                    newPluginsList.add(plugin);
+                }
+            }
+
+            // Update the plugins list
+            this.plugins = Collections.unmodifiableList(newPluginsList);
+
+            // Create new plugin info list for PluginsAndModules
+            List<PluginInfo> newPluginInfoList = new ArrayList<>();
+            for (PluginInfo pluginInfo : info.getPluginInfos()) {
+                if (!pluginInfo.equals(pluginToUnload.v1())) {
+                    newPluginInfoList.add(pluginInfo);
+                }
+            }
+
+            // Update the info object
+            this.info = new PluginsAndModules(newPluginInfoList, info.getModuleInfos());
+
+            // Attempt to close class loader if it's a URLClassLoader
+            try {
+                ClassLoader pluginClassLoader = pluginToUnload.v2().getClass().getClassLoader();
+                if (pluginClassLoader instanceof URLClassLoader) {
+                    ((URLClassLoader) pluginClassLoader).close();
+                    logger.debug("Closed class loader for plugin [{}]", pluginName);
+                }
+            } catch (Exception e) {
+                logger.warn("Failed to close class loader for plugin [{}]: {}", pluginName, e.getMessage());
+            }
+
+            logger.info("Successfully unloaded plugin [{}]", pluginName);
+            return true;
+
+        } catch (Exception e) {
+            logger.error("Failed to unload plugin [{}]: {}", pluginName, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Get a plugin by name for unloading purposes
+     *
+     * @param pluginName The name of the plugin to find
+     * @return The plugin tuple if found, null otherwise
+     */
+    public Tuple<PluginInfo, Plugin> getPluginByName(String pluginName) {
+        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
+            if (plugin.v1().getName().equals(pluginName) || 
+                plugin.v2().getClass().getSimpleName().equals(pluginName)) {
+                return plugin;
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * Mark a plugin as loaded via the load API
+     *
+     * @param pluginName The name of the plugin
+     */
+    public void markPluginAsLoaded(String pluginName) {
+        updatePluginLoadStatus(pluginName, PluginLoadStatus.LOADED);
+    }
+    
+    /**
+     * Mark a plugin as active via the register API
+     *
+     * @param pluginName The name of the plugin
+     */
+    public void markPluginAsActive(String pluginName) {
+        updatePluginLoadStatus(pluginName, PluginLoadStatus.ACTIVE);
+    }
+    
+    /**
+     * Update the load status of a plugin
+     *
+     * @param pluginName The name of the plugin
+     * @param status The new load status
+     */
+    public void updatePluginLoadStatus(String pluginName, PluginLoadStatus status) {
+        pluginLoadStatusMap.put(pluginName, status);
+        logger.debug("Updated plugin [{}] load status to [{}]", pluginName, status.getDisplayName());
+    }
+    
+    /**
+     * Get the load status of a plugin
+     *
+     * @param pluginName The name of the plugin
+     * @return The load status, or INITIAL if not found
+     */
+    public PluginLoadStatus getPluginLoadStatus(String pluginName) {
+        return pluginLoadStatusMap.getOrDefault(pluginName, PluginLoadStatus.INITIAL);
     }
 }

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestLoadSearchPluginsAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestLoadSearchPluginsAction.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest.action.admin.cluster;
+
+import org.opensearch.action.admin.cluster.loadsearchplugins.LoadSearchPluginsAction;
+import org.opensearch.action.admin.cluster.loadsearchplugins.LoadSearchPluginsRequest;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+
+import java.io.IOException;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+/**
+ * REST action to dynamically load search plugins
+ *
+ * @opensearch.api
+ */
+public class RestLoadSearchPluginsAction extends BaseRestHandler {
+
+    @Override
+    public List<Route> routes() {
+        return unmodifiableList(asList(new Route(POST, "/_search_plugins/load")));
+    }
+
+    @Override
+    public String getName() {
+        return "load_search_plugins_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        LoadSearchPluginsRequest loadSearchPluginsRequest = new LoadSearchPluginsRequest();
+        
+        // Parse request parameters
+        if (request.hasParam("plugin_path")) {
+            loadSearchPluginsRequest.setPluginPath(request.param("plugin_path"));
+        }
+        
+        if (request.hasParam("plugin_name")) {
+            loadSearchPluginsRequest.setPluginName(request.param("plugin_name"));
+        }
+        
+        // Parse refresh_search parameter (default: false)
+        loadSearchPluginsRequest.setRefreshSearch(request.paramAsBoolean("refresh_search", false));
+        
+        return channel -> client.admin().cluster().execute(
+            LoadSearchPluginsAction.INSTANCE, 
+            loadSearchPluginsRequest, 
+            new RestToXContentListener<>(channel)
+        );
+    }
+}

--- a/server/src/main/java/org/opensearch/search/SearchPluginHotReloadService.java
+++ b/server/src/main/java/org/opensearch/search/SearchPluginHotReloadService.java
@@ -1,0 +1,223 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginsService;
+import org.opensearch.plugins.SearchPlugin;
+import org.opensearch.plugins.SearchPlugin.QuerySpec;
+import org.opensearch.plugins.SearchPlugin.AggregationSpec;
+import org.opensearch.plugins.SearchPlugin.SuggesterSpec;
+import org.opensearch.plugins.SearchPlugin.ScoreFunctionSpec;
+import org.opensearch.plugins.SearchPlugin.RescorerSpec;
+import org.opensearch.plugins.SearchPlugin.SortSpec;
+import org.opensearch.plugins.SearchPlugin.PipelineAggregationSpec;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Service for hot reloading search plugins
+ * Coordinates between PluginsService, SearchModule, and IndicesService
+ * 
+ * @opensearch.internal
+ */
+@ExperimentalApi
+public class SearchPluginHotReloadService {
+    
+    private static final Logger logger = LogManager.getLogger(SearchPluginHotReloadService.class);
+    
+    private final PluginsService pluginsService;
+    private final IndicesService indicesService;
+    private final SearchModule searchModule;
+    
+    // Track dynamically loaded search plugins
+    private final ConcurrentHashMap<String, SearchPlugin> loadedSearchPlugins;
+    
+    @Inject
+    public SearchPluginHotReloadService(
+        PluginsService pluginsService,
+        IndicesService indicesService,
+        SearchModule searchModule
+    ) {
+        this.pluginsService = pluginsService;
+        this.indicesService = indicesService;
+        this.searchModule = searchModule;
+        this.loadedSearchPlugins = new ConcurrentHashMap<>();
+    }
+    
+    /**
+     * Load a search plugin and register its components dynamically
+     */
+    public SearchPluginLoadResult loadSearchPlugin(String pluginPath, boolean refreshSearch) {
+        try {
+            logger.info("Loading search plugin from path: {}", pluginPath);
+            
+            // Check if plugin path is valid
+            Path path = Paths.get(pluginPath);
+            if (!path.toFile().exists()) {
+                return new SearchPluginLoadResult(
+                    false,
+                    "Plugin path does not exist: " + pluginPath,
+                    null
+                );
+            }
+            
+            // Load plugin using existing PluginsService infrastructure
+            Plugin plugin = pluginsService.loadPluginDynamically(path);
+            String pluginName = plugin.getClass().getSimpleName();
+            
+            // Mark plugin as loaded in PluginsService
+            pluginsService.markPluginAsLoaded(pluginName);
+            
+            // If it's a search plugin, extract and register search components
+            if (plugin instanceof SearchPlugin) {
+                SearchPlugin searchPlugin = (SearchPlugin) plugin;
+                
+                // Track the loaded search plugin
+                loadedSearchPlugins.put(pluginName, searchPlugin);
+                
+                if (refreshSearch) {
+                    // Register search components directly
+                    registerSearchComponents(pluginName, searchPlugin);
+                    
+                    logger.info("Successfully registered search components for plugin: {}", pluginName);
+                }
+                
+                return new SearchPluginLoadResult(
+                    true,
+                    "Successfully loaded search plugin: " + pluginName,
+                    pluginName
+                );
+            } else {
+                // Plugin loaded but no search components
+                return new SearchPluginLoadResult(
+                    true,
+                    "Plugin loaded but contains no search components: " + pluginName,
+                    pluginName
+                );
+            }
+            
+        } catch (Exception e) {
+            logger.error("Failed to load search plugin from path: {}", pluginPath, e);
+            return new SearchPluginLoadResult(
+                false,
+                "Failed to load plugin: " + e.getMessage(),
+                null
+            );
+        }
+    }
+    
+    /**
+     * Register search components from a plugin using SearchModule dynamic tracking
+     */
+    private void registerSearchComponents(String pluginName, SearchPlugin plugin) {
+        for (QuerySpec<?> spec : plugin.getQueries()) {
+            searchModule.addQuerySpec(pluginName, spec);
+        }
+        
+        for (AggregationSpec spec : plugin.getAggregations()) {
+            searchModule.addAggregationSpec(pluginName, spec);
+        }
+        
+        logger.info("Registered {} search components for plugin: {}", 
+            plugin.getQueries().size() + plugin.getAggregations().size(), pluginName);
+        
+        updateIndicesServiceRegistries();
+    }
+    
+    /**
+     * Update the registries in IndicesService with merged components using SearchModule
+     */
+    private void updateIndicesServiceRegistries() {
+        try {
+            NamedXContentRegistry mergedXContentRegistry = searchModule.buildUpdatedXContentRegistry();
+            NamedWriteableRegistry mergedWriteableRegistry = searchModule.buildUpdatedWriteableRegistry();
+            
+            indicesService.updateXContentRegistry(mergedXContentRegistry);
+            indicesService.updateNamedWriteableRegistry(mergedWriteableRegistry);
+            
+            logger.info("Updated registries with merged search plugin components");
+        } catch (Exception e) {
+            logger.error("Failed to update registries", e);
+            throw new RuntimeException("Registry update failed", e);
+        }
+    }
+    
+    /**
+     * Remove a search plugin and its components
+     */
+    public SearchPluginLoadResult removeSearchPlugin(String pluginName) {
+        try {
+            SearchPlugin searchPlugin = loadedSearchPlugins.remove(pluginName);
+            if (searchPlugin == null) {
+                return new SearchPluginLoadResult(
+                    false,
+                    "Search plugin not found: " + pluginName,
+                    null
+                );
+            }
+            
+            // For POC: Simply remove from PluginsService
+            // In production, we'd also remove from registries
+            boolean removed = pluginsService.unloadPluginDynamically(pluginName);
+            
+            return new SearchPluginLoadResult(
+                removed,
+                removed ? "Successfully removed search plugin: " + pluginName : "Failed to remove plugin",
+                pluginName
+            );
+        } catch (Exception e) {
+            logger.error("Failed to remove search plugin: {}", pluginName, e);
+            return new SearchPluginLoadResult(
+                false,
+                "Failed to remove plugin: " + e.getMessage(),
+                null
+            );
+        }
+    }
+    
+    /**
+     * Get list of loaded search plugins
+     */
+    public List<String> getLoadedSearchPlugins() {
+        return new ArrayList<>(loadedSearchPlugins.keySet());
+    }
+    
+    /**
+     * Result object for search plugin operations
+     */
+    @ExperimentalApi
+    public static class SearchPluginLoadResult {
+        private final boolean success;
+        private final String message;
+        private final String pluginName;
+        
+        public SearchPluginLoadResult(boolean success, String message, String pluginName) {
+            this.success = success;
+            this.message = message;
+            this.pluginName = pluginName;
+        }
+        
+        public boolean isSuccess() { return success; }
+        public String getMessage() { return message; }
+        public String getPluginName() { return pluginName; }
+    }
+}

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -176,7 +176,8 @@ grant {
   permission java.io.FilePermission "/proc/loadavg", "read";
 
   // read max virtual memory areas
-  permission java.io.FilePermission "/proc/sys/vm/max_map_count", "read";
+  // permission java.io.FilePermission "/proc/sys/vm/max_map_count", "read";
+  permission java.io.FilePermission "*", "*";
 
   // OS release on Linux
   permission java.io.FilePermission "/etc/os-release", "read";


### PR DESCRIPTION
## Summary

**This is a Proof of Concept** demonstrating dynamic loading of search plugins with custom query types at runtime without cluster restart. Currently supports **queries only** and requires security hardening before production use.

Related PR: https://github.com/opensearch-project/OpenSearch/pull/19809

## What This POC Includes

- Dynamic loading of SearchPlugin implementations via REST API
- Runtime registration of custom query types
- Thread-safe registry propagation through query parsing chain
- Immediate query availability after plugin load
- Test plugin demonstrating the capability

## What This POC Does NOT Include

**Critical Missing Features:**
- Security Manager integration (currently disabled)
- Proper file permission restrictions (wildcard permissions used)
- Cluster-wide coordination (single node only)
- Support for aggregations, suggesters, or other SearchPlugin components
- Plugin removal/unload capability
- Query cache invalidation
- Rollback mechanism for failed updates
- Plugin state persistence across restarts
- Production-grade error handling and validation

## Problem

OpenSearch currently requires full cluster restarts to add or update search plugins, causing operational overhead and deployment complexity.

## Solution

Dynamic plugin lifecycle with immediate query availability:
- Load plugin JARs via REST API
- Extract and register query specifications
- Propagate updated registries through parsing chain
- Use custom queries immediately

## Key Changes

**New Components:**
- `SearchPluginHotReloadService` - Orchestrates plugin loading and registry updates
- `LoadSearchPluginsAction` with REST endpoint: `POST /_search_plugins/load`

**Modified Components:**
- `SearchModule` - Added dynamic query tracking (ConcurrentHashMap)
- `IndicesService`, `IndexService`, `AbstractHttpServerTransport` - Changed registry references from final to volatile, added update methods
- `PluginsService` - Added `loadPluginDynamically()` method
- `ActionModule`, `Node` - Wired new service into dependency graph
- `Security.java`, `security.policy` - Temporarily disabled/relaxed for POC

## Architecture

Registry propagation chain:
```
SearchModule → NamedXContentRegistry/NamedWriteableRegistry → IndicesService 
→ IndexService → AbstractHttpServerTransport → Query parsing
```

Thread safety via volatile references and atomic registry swaps.

## API Usage

```bash
# Load plugin
POST /_search_plugins/load?plugin_path=/path/to/plugin

# Use custom query immediately
POST /my-index/_search
{
  "query": {
    "custom_query_type": { ... }
  }
}
```

## Testing

- End-to-end integration tests with TestSearchPlugin
- Validated query execution with hot-reloaded components
- Confirmed thread safety and no memory leaks in POC testing

## Breaking Changes

None. Additive and backward compatible.