### PR TITLE
Support new and old signature for ActionPlugin.getRestHandlerWrapper

### DIFF
--- a/server/src/main/java/org/opensearch/plugins/ActionPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/ActionPlugin.java
@@ -150,6 +150,32 @@ public interface ActionPlugin {
      * Note: Only one installed plugin may implement a rest wrapper.
      */
     default UnaryOperator<RestHandler> getRestHandlerWrapper(ThreadContext threadContext, Set<RestHeaderDefinition> headersToCopy) {
+        return this.getRestHandlerWrapper(threadContext);
+    }
+
+    /**
+     * Returns a function used to wrap each rest request before handling the request.
+     * The returned {@link UnaryOperator} is called for every incoming rest request and receives
+     * the original rest handler as it's input. This allows adding arbitrary functionality around
+     * rest request handlers to do for instance logging or authentication.
+     * A simple example of how to only allow GET request is here:
+     * <pre>
+     * {@code
+     *    UnaryOperator<RestHandler> getRestHandlerWrapper(ThreadContext threadContext) {
+     *      return originalHandler -> (RestHandler) (request, channel, client) -> {
+     *        if (request.method() != Method.GET) {
+     *          throw new IllegalStateException("only GET requests are allowed");
+     *        }
+     *        originalHandler.handleRequest(request, channel, client);
+     *      };
+     *    }
+     * }
+     * </pre>
+     *
+     * Note: Only one installed plugin may implement a rest wrapper.
+     */
+    @Deprecated(forRemoval = true)
+    default UnaryOperator<RestHandler> getRestHandlerWrapper(ThreadContext threadContext) {
         return null;
     }
 


### PR DESCRIPTION
### Description

This re-introduces the old signature for ActionPlugin.getRestHandlerWrapper to ensure that plugins can define either one or the other.

### Related Issues

Resolves https://github.com/opensearch-project/OpenSearch/pull/19875#issuecomment-3492787706

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
