### PR TITLE
[feature/datafusion] Enabling support for MultiTermAggs and NumericTermsAgg

### DIFF
--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/search/DatafusionContext.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/search/DatafusionContext.java
@@ -810,12 +810,12 @@ public class DatafusionContext extends SearchContext {
 
     @Override
     public Comparable<?> convertToComparable(Object rawValue) {
-        if (rawValue instanceof Number) {
-            return (Comparable) rawValue;
-        } else if (rawValue instanceof Text) {
-            return rawValue.toString();
-        } else {
-            throw new IllegalArgumentException("Conversion to Comparable not supported for type " + rawValue.getClass());
-        }
+        return switch (rawValue) {
+            case Number number -> (Comparable<?>) rawValue;
+            case Text text -> rawValue.toString();
+            case Boolean b -> (Comparable<?>) rawValue;
+            case null, default ->
+                throw new IllegalArgumentException("Conversion to Comparable not supported for type " + rawValue.getClass());
+        };
     }
 }


### PR DESCRIPTION
We are ensuring SQL plugin pushes down TermsAgg or MultiTermsAgg whenever the query has a sort on it. 

PPL query with Group by on multiple fields
```
curl --location --request POST 'http://localhost:9200/_plugins/_ppl' --header 'Content-Type: application/json' --data-raw '{
  "query": "source=index-7 | stats count(), sum(salary) as c by age, score | sort c"
}'
```
DSL generated
```
{"from":0,"size":0,"timeout":"1m","aggregations":{"age|score":{"multi_terms":{"terms":[{"field":"age"},{"field":"score"}],"size":10000,"min_doc_count":1,"shard_min_doc_count":0,"show_term_doc_count_error":false,"order":[{"_count":"desc"},{"_key":"asc"}]},"aggregations":{"count()":{"value_count":{"field":"_index"}},"c":{"sum":{"field":"salary"}}}}}}
```

PPL query
```
curl --location --request POST 'http://localhost:9200/_plugins/_ppl' --header 'Content-Type: application/json' --data-raw '{
  "query": "source=index-7 | stats count(), sum(salary) as c by age | sort c"
}'
```

DSL generated
```
{"from":0,"size":0,"timeout":"1m","aggregations":{"age":{"terms":{"field":"age","size":10000,"min_doc_count":1,"shard_min_doc_count":0,"show_term_doc_count_error":false,"order":[{"count()":"asc"},{"_key":"asc"}]},"aggregations":{"count()":{"value_count":{"field":"_index"}},"c":{"sum":{"field":"salary"}}}}}
```

This PR enables handling response for Numeric Terms agg for non decimal and decimal fields except UnsignedLong

It also enables response parsing for Multi Terms Aggregation. 

SQL plugin commit to enable MultiTerms aggregation https://github.com/vinaykpud/sql/commit/8506e5f5736c1487294c06b3e8647b59245720cf