### PR TITLE
Prevent calling filterFields multiple times on indices with the same mappings in GET _mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Refactor the RefreshStats class to use the Builder pattern instead of constructors ([#19835](https://github.com/opensearch-project/OpenSearch/pull/19835))
 - Refactor the DocStats and StoreStats class to use the Builder pattern instead of constructors ([#19863](https://github.com/opensearch-project/OpenSearch/pull/19863))
 - Pass registry of headers from ActionPlugin.getRestHeaders to ActionPlugin.getRestHandlerWrapper ([#19875](https://github.com/opensearch-project/OpenSearch/pull/19875))
+- Prevent calling filterFields multiple times on indices with the same mappings in GET _mapping ([#19914](https://github.com/opensearch-project/OpenSearch/pull/19914))
 
 ### Fixed
 - Fix Allocation and Rebalance Constraints of WeightFunction are incorrectly reset ([#19012](https://github.com/opensearch-project/OpenSearch/pull/19012))

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataTests.java
@@ -67,12 +67,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.opensearch.cluster.DataStreamTestHelper.createBackingIndex;
 import static org.opensearch.cluster.DataStreamTestHelper.createFirstBackingIndex;
 import static org.opensearch.cluster.DataStreamTestHelper.createTimestampField;
 import static org.opensearch.cluster.metadata.Metadata.Builder.validateDataStreams;
+import static org.opensearch.plugins.MapperPlugin.NOOP_FIELD_PREDICATE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -806,7 +808,7 @@ public class MetadataTests extends OpenSearchTestCase {
                 if (index.equals("index2")) {
                     return field -> false;
                 }
-                return MapperPlugin.NOOP_FIELD_PREDICATE;
+                return NOOP_FIELD_PREDICATE;
             });
 
             assertIndexMappingsNoFields(mappings, "index2");
@@ -988,78 +990,79 @@ public class MetadataTests extends OpenSearchTestCase {
         assertLeafs(subFieldsDef, subFields);
     }
 
-    private static final String FIND_MAPPINGS_TEST_ITEM = "{\n"
-        + "  \"_doc\": {\n"
-        + "      \"_routing\": {\n"
-        + "        \"required\":true\n"
-        + "      },"
-        + "      \"_source\": {\n"
-        + "        \"enabled\":false\n"
-        + "      },"
-        + "      \"properties\": {\n"
-        + "        \"name\": {\n"
-        + "          \"properties\": {\n"
-        + "            \"first\": {\n"
-        + "              \"type\": \"keyword\"\n"
-        + "            },\n"
-        + "            \"last\": {\n"
-        + "              \"type\": \"keyword\"\n"
-        + "            }\n"
-        + "          }\n"
-        + "        },\n"
-        + "        \"birth\": {\n"
-        + "          \"type\": \"date\"\n"
-        + "        },\n"
-        + "        \"age\": {\n"
-        + "          \"type\": \"integer\"\n"
-        + "        },\n"
-        + "        \"ip\": {\n"
-        + "          \"type\": \"ip\"\n"
-        + "        },\n"
-        + "        \"suggest\" : {\n"
-        + "          \"type\": \"completion\"\n"
-        + "        },\n"
-        + "        \"address\": {\n"
-        + "          \"type\": \"object\",\n"
-        + "          \"properties\": {\n"
-        + "            \"street\": {\n"
-        + "              \"type\": \"keyword\"\n"
-        + "            },\n"
-        + "            \"location\": {\n"
-        + "              \"type\": \"geo_point\"\n"
-        + "            },\n"
-        + "            \"area\": {\n"
-        + "              \"type\": \"geo_shape\",  \n"
-        + "              \"tree\": \"quadtree\",\n"
-        + "              \"precision\": \"1m\"\n"
-        + "            }\n"
-        + "          }\n"
-        + "        },\n"
-        + "        \"properties\": {\n"
-        + "          \"type\": \"nested\",\n"
-        + "          \"properties\": {\n"
-        + "            \"key\" : {\n"
-        + "              \"type\": \"text\",\n"
-        + "              \"fields\": {\n"
-        + "                \"keyword\" : {\n"
-        + "                  \"type\" : \"keyword\"\n"
-        + "                }\n"
-        + "              }\n"
-        + "            },\n"
-        + "            \"value\" : {\n"
-        + "              \"type\": \"text\",\n"
-        + "              \"fields\": {\n"
-        + "                \"keyword\" : {\n"
-        + "                  \"type\" : \"keyword\"\n"
-        + "                }\n"
-        + "              }\n"
-        + "            }\n"
-        + "          }\n"
-        + "        }\n"
-        + "      }\n"
-        + "    }\n"
-        + "  }\n"
-        + "}";
+    private static final String FIND_MAPPINGS_TEST_ITEM = """
+        {
+          "_doc": {
+              "_routing": {
+                "required":true
+              },
+              "_source": {
+                "enabled":false
+              },
+              "properties": {
+                "name": {
+                  "properties": {
+                    "first": {
+                      "type": "keyword"
+                    },
+                    "last": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "birth": {
+                  "type": "date"
+                },
+                "age": {
+                  "type": "integer"
+                },
+                "ip": {
+                  "type": "ip"
+                },
+                "suggest" : {
+                  "type": "completion"
+                },
+                "address": {
+                  "type": "object",
+                  "properties": {
+                    "street": {
+                      "type": "keyword"
+                    },
+                    "location": {
+                      "type": "geo_point"
+                    },
+                    "area": {
+                      "type": "geo_shape",
+                      "tree": "quadtree",
+                      "precision": "1m"
+                    }
+                  }
+                },
+                "properties": {
+                  "type": "nested",
+                  "properties": {
+                    "key" : {
+                      "type": "text",
+                      "fields": {
+                        "keyword" : {
+                          "type" : "keyword"
+                        }
+                      }
+                    },
+                    "value" : {
+                      "type": "text",
+                      "fields": {
+                        "keyword" : {
+                          "type" : "keyword"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }""";
 
     public void testTransientSettingsOverridePersistentSettings() {
         final Setting setting = Setting.simpleString("key");
@@ -1657,4 +1660,91 @@ public class MetadataTests extends OpenSearchTestCase {
             assertEquals(previousMetadata.version() + 1, newMetadata.version());
         }
     }
+
+    public void testFindMappingsDedupeWithDefinedPredicates() throws Exception {
+        // Base mapping (mappingA)
+        final String mappingA = FIND_MAPPINGS_TEST_ITEM;
+
+        // Modified mapping with an additional field (mappingB)
+        @SuppressWarnings("unchecked")
+        Map<String, Object> mapA = XContentHelper.convertToMap(JsonXContent.jsonXContent, FIND_MAPPINGS_TEST_ITEM, false);
+        Map<String, Object> doc = (Map<String, Object>) mapA.get("_doc");
+        Map<String, Object> props = (Map<String, Object>) doc.get("properties");
+        props.put("extra_keyword_field", Map.of("type", "keyword"));
+
+        final String mappingB;
+        try (XContentBuilder builder = JsonXContent.contentBuilder()) {
+            builder.map(mapA);
+            mappingB = builder.toString();
+        }
+
+        // Build metadata with 4 indices:
+        // - index1, index2, index3 → mappingA
+        // - index4 → mappingB
+        final Metadata metadata = Metadata.builder()
+            .put(
+                IndexMetadata.builder("index1")
+                    .settings(settings(Version.CURRENT))
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .putMapping(mappingA)
+            )
+            .put(
+                IndexMetadata.builder("index2")
+                    .settings(settings(Version.CURRENT))
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .putMapping(mappingA)
+            )
+            .put(
+                IndexMetadata.builder("index3")
+                    .settings(settings(Version.CURRENT))
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .putMapping(mappingA)
+            )
+            .put(
+                IndexMetadata.builder("index4")
+                    .settings(settings(Version.CURRENT))
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+                    .putMapping(mappingB)
+            )
+            .build();
+
+        final Predicate<String> pShared = MapperPlugin.NOOP_FIELD_PREDICATE; // returns true for all fields
+        final Predicate<String> pOther = f -> !"extra_keyword_field".equals(f); // filters out just that field
+
+        // Apply findMappings with different predicates per index
+        Map<String, MappingMetadata> result = metadata.findMappings(
+            new String[] { "index1", "index2", "index3", "index4" },
+            index -> switch (index) {
+                case "index1", "index2" -> pShared; // same predicate + same mapping
+                case "index3" -> pOther;            // different predicate, same mapping
+                case "index4" -> pShared;           // same predicate, but different mapping
+                default -> MapperPlugin.NOOP_FIELD_PREDICATE;
+            }
+        );
+
+        MappingMetadata m1 = result.get("index1");
+        MappingMetadata m2 = result.get("index2");
+        MappingMetadata m3 = result.get("index3");
+        MappingMetadata m4 = result.get("index4");
+
+        // Same mapping bytes + same predicate → MUST dedupe (same object)
+        assertEquals("index1 and index2 must share the MappingMetadata instance", m1, m2);
+
+        // Same mapping bytes + different predicate → MUST NOT dedupe
+        assertNotEquals("index1 and index3 must not share because predicate differs", m1, m3);
+
+        // Different mapping bytes + same predicate → MUST NOT dedupe
+        assertNotEquals("index1 and index4 must not share because mapping differs", m1, m4);
+
+        // Shared predicate keeps all fields (NOOP filter)
+        assertTrue(m1.source().string().contains("extra_keyword_field"));
+
+        // pOther removes "extra_keyword_field" from index3
+        assertFalse(m3.source().string().contains("extra_keyword_field"));
+    }
+
 }


### PR DESCRIPTION
### Description

The PR contains a slight optimization for handling GET _mapping API when a fieldFilter is present (particularly in cases where the user has FLS restrictions on indices). The changes in this PR will filter the mappings once for indices which share the same mappings such as in cases with rollover indices. 

There are still many issues with the GET _mapping API and its memory consumption, but the changes in this PR present one further optimization that can be done to improve the performance of this API in some cases. 

### Related Issues

Related to https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10047

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
