### PR TITLE
Memory leak fix

### DIFF
--- a/plugins/engine-datafusion/.gitignore
+++ b/plugins/engine-datafusion/.gitignore
@@ -24,6 +24,9 @@ hs_err_pid*
 Thumbs.db
 
 # Rust
+target/
+Cargo.lock
+
 jni/target/
 jni/Cargo.lock
 

--- a/plugins/engine-datafusion/jni/src/lib.rs
+++ b/plugins/engine-datafusion/jni/src/lib.rs
@@ -446,3 +446,21 @@ pub extern "system" fn Java_org_opensearch_datafusion_RecordBatchStream_getSchem
         }
     }
 }
+
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_RecordBatchStream_closeStream(
+    mut env: JNIEnv,
+    _class: JClass,
+    stream: jlong
+) {
+    let _ = unsafe { Box::from_raw(stream as *mut SendableRecordBatchStream) };
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_DataFusionQueryJNI_closeGlobalRuntime(
+    _env: JNIEnv,
+    _class: JClass,
+    runtime: jlong
+) {
+    let _ = unsafe { Box::from_raw(runtime as *mut RuntimeEnv) };
+}


### PR DESCRIPTION
We were not closing the stream and rootallocator which was causing OOM in the process. We need to make sure we are unpinning the boxed memory like below in final block for the rust pointers: 

```
let _ = unsafe { Box::from_raw(runtime as *mut RuntimeEnv) };
```

Earlier allocation graphs:
<img width="1351" height="945" alt="image" src="https://github.com/user-attachments/assets/9dd5e95d-4809-4bed-a3dd-12b7ff11f1b0" />

New Allocation graphs:
<img width="1347" height="941" alt="image" src="https://github.com/user-attachments/assets/3f830404-72f7-4755-8219-b1b0ba438a40" />


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
