### PR TITLE
Update a misleading comment in the _doc get path

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -655,7 +655,8 @@ public class InternalEngine extends Engine {
                         );
                     }
                     if (get.isReadFromTranslog()) {
-                        // _GET calls deployed due to an update request will attempt to read from the translog first to guarantee the most recent version.
+                        // _GET calls deployed due to an update request will attempt to read from the translog first to guarantee the most
+                        // recent version.
                         // _GET calls invoked by API will also attempt to read from translog when realtime=true (which is the default).
                         if (versionValue.getLocation() != null) {
                             try {


### PR DESCRIPTION
### Description

Updating an out of date comment which was particularly confusing to me.

```
this is only used for updates - API _GET calls will always read form a reader for consistency
the update call doesn't need the consistency since it's source only + _parent but parent can go away in 7.0
```

Both portions of this comment seem to be deprecated and are a bit misleading. API _GET calls can take this code path and read directly from translog. This is the default it seems as `readFromTranslog` is [always true](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/get/ShardGetService.java#L230-L234) and `GetRequest` [defaults realtime to true](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/get/GetRequest.java#L83).

The second line is not clear to me at all. It seems update calls would be entirely concerned with consistency. In the case where we can't reach from translog we attempt `refreshIfNeeded` before fetching the document from the index.

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
