### PR TITLE
Remapping WriterFileSet path while recovering CatalogSnapshot

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/exec/WriterFileSet.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/WriterFileSet.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class WriterFileSet implements Serializable, Writeable {
@@ -42,17 +43,11 @@ public class WriterFileSet implements Serializable, Writeable {
     }
 
     public WriterFileSet withDirectory(String newDirectory) {
-        WriterFileSet newFileSet = new WriterFileSet(Path.of(newDirectory), this.writerGeneration);
-
-        // Extract just the filename and reconstruct with new directory
-        for (String oldFilePath : this.files) {
-            Path oldPath = Path.of(oldFilePath);
-            String fileName = oldPath.getFileName().toString();
-            String newFilePath = Path.of(newDirectory, fileName).toString();
-            newFileSet.files.add(newFilePath);
-        }
-
-        return newFileSet;
+        return WriterFileSet.builder()
+            .directory(Path.of(newDirectory))
+            .writerGeneration(this.writerGeneration)
+            .addFiles(this.files)
+            .build();
     }
 
     /**
@@ -134,6 +129,11 @@ public class WriterFileSet implements Serializable, Writeable {
 
         public Builder addFile(String file) {
             this.files.add(file);
+            return this;
+        }
+
+        public Builder addFiles(Set<String> files) {
+            this.files.addAll(files);
             return this;
         }
 

--- a/server/src/main/java/org/opensearch/index/engine/exec/coord/CompositeEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/coord/CompositeEngine.java
@@ -213,6 +213,7 @@ public class CompositeEngine implements LifecycleAware, Indexer, CheckpointState
             final AtomicLong lastCommittedWriterGeneration = new AtomicLong(-1);
             this.compositeEngineCommitter.readLastCommittedCatalogSnapshot().ifPresent(lastCommittedCatalogSnapshot -> {
                 this.catalogSnapshot = lastCommittedCatalogSnapshot;
+                this.catalogSnapshot.remapPaths(shardPath.getDataPath());
                 lastCommittedWriterGeneration.set(lastCommittedCatalogSnapshot.getLastWriterGeneration());
             });
             // How to bring the Dataformat here? Currently, this means only Text and LuceneFormat can be used


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
1. Remapping WriterFileSet directory path while recovering from last committed CatalogSnapshot

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
