### PR TITLE
Add originalRequestBody field to SearchRequest and handle it in RestSearchAction

### DIFF
--- a/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
@@ -134,6 +134,9 @@ public class RestSearchAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         SearchRequest searchRequest = new SearchRequest();
+        if(request.hasContentOrSourceParam()){
+            searchRequest.setOriginalRequestBody(request.contentOrSourceParam().v2());
+        }
         /*
          * We have to pull out the call to `source().size(size)` because
          * _update_by_query and _delete_by_query uses this same parsing


### PR DESCRIPTION
### Description
This PR introduces a new field `originalRequestBody` to the `SearchRequest` class.  
It allows OpenSearch to retain the original raw JSON request body sent through the REST layer, before any parsing or system modification occurs.  

This enhancement enables downstream components (like Query Insights or analytics tools) to distinguish between:
- **User-provided query values**, and
- **System defaults or injected parameters**

#### Key changes:
- Added a new field `BytesReference originalRequestBody` to `SearchRequest`.
- Updated `writeTo()` and the constructor from `StreamInput` for proper serialization/deserialization.
- Modified `RestSearchAction` to capture and store the original body from `request.contentOrSourceParam().v2()`.
- Added two unit tests in `SearchRequestTests`:
  - `testOriginalRequestBodySerialization`
  - `testOriginalRequestBodyIsNullByDefault`

---

### Related Issues
Resolves [#19816](https://github.com/opensearch-project/OpenSearch/issues/19816)

---

### Check List
- [x] Functionality includes testing (`SearchRequestTests`)
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable. *(N/A — internal field only)*
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. *(N/A — internal change)*

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.  
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
