### PR TITLE
Avoid eager getByName in pom validation plugin

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/precommit/PomValidationPrecommitPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/precommit/PomValidationPrecommitPlugin.java
@@ -59,13 +59,8 @@ public class PomValidationPrecommitPlugin extends PrecommitPlugin {
             validateTask.configure(task -> {
                 task.dependsOn(generateMavenPom);
                 task.getPomFile().fileProvider(generateMavenPom.map(GenerateMavenPom::getDestination));
-                publishing.getPublications().all(publicationForPomGen -> {
-                    task.mustRunAfter(
-                        project.getTasks()
-                            .withType(GenerateMavenPom.class)
-                            .getByName("generatePomFileFor" + Util.capitalize(publicationForPomGen.getName()) + "Publication")
-                    );
-                });
+                // Force the validate to run after all generate tasks since they overwrite the same POM file
+                task.mustRunAfter(project.getTasks().withType(GenerateMavenPom.class));
             });
         });
 


### PR DESCRIPTION
The `getByName()` call is eager, which means this can fail non-deterministically if the dependent gradle tasks have not yet been configured. I ran into this error when doing other gradle refactorings. This change avoids the eager call while also avoiding the nested publications.all() call.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
