### PR TITLE
Ensuring Datafusion errors don't crash the JVM

### DIFF
--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DatafusionEngine.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DatafusionEngine.java
@@ -209,16 +209,22 @@ public class DatafusionEngine extends SearchExecEngine<DatafusionContext, Datafu
                 collector.collect(stream);
             }
 
+            logger.info("Final Results:");
             for (Map.Entry<String, Object[]> entry : finalRes.entrySet()) {
                 logger.info("{}: {}", entry.getKey(), java.util.Arrays.toString(entry.getValue()));
             }
 
         } catch (Exception exception) {
             logger.error("Failed to execute Substrait query plan", exception);
+            throw new RuntimeException(exception);
         } finally {
             try {
-                stream.close();
-                allocator.close();
+                if (stream != null) {
+                    stream.close();
+                }
+                if (allocator != null) {
+                    allocator.close();
+                }
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
We are propagating the errors from DataFusion out as RuntimeException without it leading to a JVM Crash by unwinding errors. 

To simulate the error commented out the fix in SQL plugin to make Timestamp field work https://github.com/vinaykpud/sql/blob/feature/substrait-plan/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java#L182-L202 

Fetch and Aggregation queries are working as before. 

## BEFORE
```
» Table path: file:///Users/anijainc/Desktop/BLRBackups/AOS_Search/DataFusionPOC/res/nodes/0/indices/dbKKdf0GTsai_0NirxcYdg/1/
» Files: [ObjectMeta { location: Path { raw: "Users/anijainc/Desktop/BLRBackups/AOS_Search/DataFusionPOC/res/nodes/0/indices/dbKKdf0GTsai_0NirxcYdg/1/_parquet_file_generation_0.parquet" }, last_modified: 2025-11-12T21:28:36.507984922Z, size: 4546, e_tag: None, version: None }]
» Table path: file:///Users/anijainc/Desktop/BLRBackups/AOS_Search/DataFusionPOC/res/nodes/0/indices/dbKKdf0GTsai_0NirxcYdg/0/
» Files: [ObjectMeta { location: Path { raw: "Users/anijainc/Desktop/BLRBackups/AOS_Search/DataFusionPOC/res/nodes/0/indices/dbKKdf0GTsai_0NirxcYdg/0/_parquet_file_generation_0.parquet" }, last_modified: 2025-11-12T21:28:36.483670877Z, size: 4310, e_tag: None, version: None }, ObjectMeta { location: Path { raw: "Users/anijainc/Desktop/BLRBackups/AOS_Search/DataFusionPOC/res/nodes/0/indices/dbKKdf0GTsai_0NirxcYdg/0/_parquet_file_generation_1.parquet" }, last_modified: 2025-11-12T21:28:36.516569155Z, size: 4500, e_tag: None, version: None }]
» SUBSTRAIT Rust: Failed to convert Substrait plan: Substrait error: Field 'timestamp' in Substrait schema has a different type (Utf8) than the corresponding field in the table schema (Timestamp(Millisecond, None)).
» SUBSTRAIT Rust: Failed to convert Substrait plan: Substrait error: Field 'timestamp' in Substrait schema has a different type (Utf8) than the corresponding field in the table schema (Timestamp(Millisecond, None)).
» [2025-11-12T21:28:38.684330Z] [BUILD] Stopping node

=== Standard error of node node{::runTask-0} ===
» ↓ last 40 non error or warning messages from /Users/anijainc/Desktop/GithubWorkspaces/DataFusionPOC/DataFusion_OS/OpenSearch/build/testclusters/runTask-0/logs/opensearch.stderr.log ↓
» WARNING: Using incubator modules: jdk.incubator.vector
» WARNING: Unknown module: org.apache.arrow.memory.core specified to --add-opens
» WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
» WARNING: sun.misc.Unsafe::objectFieldOffset has been called by net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction
» WARNING: Please consider reporting this to the maintainers of class net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction
» WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
» WARNING: A restricted method in java.lang.System has been called
» WARNING: java.lang.System::load has been called by com.sun.jna.Native in an unnamed module (file:/Users/anijainc/Desktop/GithubWorkspaces/DataFusionPOC/DataFusion_OS/OpenSearch/build/testclusters/runTask-0/distro/3.3.0-ARCHIVE/lib/jna-5.16.0.jar)
» WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
» WARNING: Restricted methods will be blocked in a future release unless native access is enabled
»
»
» thread '<unnamed>' panicked at jni/src/lib.rs:530:27:
» null pointer dereference occurred
» note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
» thread caused non-unwinding panic. aborting.
»
» thread '<unnamed>' panicked at jni/src/lib.rs:530:27:
» null pointer dereference occurred
» thread caused non-unwinding panic. aborting.

> Task :run FAILED

FAILURE: Build failed with an exception. How can prevent JVM from crashing from such errors in Datafusion
```


## AFTER 
Exceptions are propagated out and doesn't cause crash 
```
[2025-11-12T14:20:34,892][INFO ][o.o.a.s.TransportSearchAction] [runTask-0] Search request received is {"from":0,"size":0,"timeout":"1m","aggregations":{"category":{"terms":{"field":"category","size":10000,"min_doc_count":1,"shard_min_doc_count":0,"show_term_doc_count_error":false,"order":{"_key":"asc"}},"aggregations":{"total_qty":{"sum":{"field":"quantity"}}}}},"query_plan_ir":"Ch4IARIaL2Z1bmN0aW9uc19hcml0aG1ldGljLnlhbWwSERoPCAEQARoHc3VtOmkzMiABGtECEs4CCrYCGrMCCgIKABKnAiqkAgoCCgASjQIqigIKAgoAEvMBOvABCgYSBAoCAgMSzwEizAEKAgoAEpsBOpgBCgYSBAoCBgcSdgp0CgIKABJeCgZhbW91bnQKCHF1YW50aXR5CghjYXRlZ29yeQoGcmVnaW9uCgVwcmljZQoJdGltZXN0YW1wEiYKBCoCEAEKBCoCEAEKBGICEAEKBGICEAEKBFoCEAEKBGICEAEYAToOCgx0ZXN0X2dyb3VwYnkaChIICgQSAggCIgAaChIICgQSAggBIgAaCgoIEgYKAhIAIgAiHAoaCAEgAyoEOgIQATABOgwaChIICgQSAggBIgAaChIICgQSAggBIgAaCBIGCgISACIAGg4KChIICgQSAggBIgAQARoOCgoSCAoEEgIIASIAEAEYACCQThIJdG90YWxfcXR5EghjYXRlZ29yeTISEE0qDnN1YnN0cmFpdC1qYXZhQi8IARIrZXh0ZW5zaW9uOmlvLnN1YnN0cmFpdDpmdW5jdGlvbnNfYXJpdGhtZXRpYw=="}
Table path: file:///Users/anijainc/Desktop/BLRBackups/AOS_Search/DataFusionPOC/res/nodes/0/indices/DfzKd-UkSPeKel1mgU2m2w/1/
Files: [ObjectMeta { location: Path { raw: "Users/anijainc/Desktop/BLRBackups/AOS_Search/DataFusionPOC/res/nodes/0/indices/DfzKd-UkSPeKel1mgU2m2w/1/_parquet_file_generation_0.parquet" }, last_modified: 2025-11-12T22:20:31.986619262Z, size: 4546, e_tag: None, version: None }]
Table path: file:///Users/anijainc/Desktop/BLRBackups/AOS_Search/DataFusionPOC/res/nodes/0/indices/DfzKd-UkSPeKel1mgU2m2w/0/
Files: [ObjectMeta { location: Path { raw: "Users/anijainc/Desktop/BLRBackups/AOS_Search/DataFusionPOC/res/nodes/0/indices/DfzKd-UkSPeKel1mgU2m2w/0/_parquet_file_generation_0.parquet" }, last_modified: 2025-11-12T22:20:31.985794053Z, size: 4520, e_tag: None, version: None }]
SUBSTRAIT Rust: Failed to convert Substrait plan: Substrait error: Field 'timestamp' in Substrait schema has a different type (Utf8) than the corresponding field in the table schema (Timestamp(Millisecond, None)).
[2025-11-12T14:20:34,895][ERROR][o.o.d.DatafusionEngine   ] [runTask-0] Failed to execute Substrait query plan
java.lang.RuntimeException: Failed to convert Substrait plan: Substrait error: Field 'timestamp' in Substrait schema has a different type (Utf8) than the corresponding field in the table schema (Timestamp(Millisecond, None)).
        at org.opensearch.datafusion.DataFusionQueryJNI.executeQueryPhase(Native Method) ~[engine-datafusion-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.datafusion.search.DatafusionSearcher.search(DatafusionSearcher.java:67) ~[engine-datafusion-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.datafusion.DatafusionEngine.executeQueryPhase(DatafusionEngine.java:176) [engine-datafusion-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.datafusion.DatafusionEngine.executeQueryPhase(DatafusionEngine.java:58) [engine-datafusion-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.search.SearchService.executeQueryPhase(SearchService.java:853) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.search.SearchService$2.lambda$onResponse$0(SearchService.java:791) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.ActionRunnable.lambda$supply$0(ActionRunnable.java:74) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.ActionRunnable$2.doRun(ActionRunnable.java:89) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.threadpool.TaskAwareRunnable.doRun(TaskAwareRunnable.java:78) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:59) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:975) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095) [?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619) [?:?]
        at java.base/java.lang.Thread.run(Thread.java:1447) [?:?]
SUBSTRAIT Rust: Failed to convert Substrait plan: Substrait error: Field 'timestamp' in Substrait schema has a different type (Utf8) than the corresponding field in the table schema (Timestamp(Millisecond, None)).
[2025-11-12T14:20:34,895][ERROR][o.o.d.DatafusionEngine   ] [runTask-0] Failed to execute Substrait query plan
java.lang.RuntimeException: Failed to convert Substrait plan: Substrait error: Field 'timestamp' in Substrait schema has a different type (Utf8) than the corresponding field in the table schema (Timestamp(Millisecond, None)).
        at org.opensearch.datafusion.DataFusionQueryJNI.executeQueryPhase(Native Method) ~[engine-datafusion-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.datafusion.search.DatafusionSearcher.search(DatafusionSearcher.java:67) ~[engine-datafusion-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.datafusion.DatafusionEngine.executeQueryPhase(DatafusionEngine.java:176) [engine-datafusion-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.datafusion.DatafusionEngine.executeQueryPhase(DatafusionEngine.java:58) [engine-datafusion-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.search.SearchService.executeQueryPhase(SearchService.java:853) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.search.SearchService$2.lambda$onResponse$0(SearchService.java:791) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.ActionRunnable.lambda$supply$0(ActionRunnable.java:74) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.ActionRunnable$2.doRun(ActionRunnable.java:89) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.threadpool.TaskAwareRunnable.doRun(TaskAwareRunnable.java:78) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:59) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:975) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095) [?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619) [?:?]
        at java.base/java.lang.Thread.run(Thread.java:1447) [?:?]
[2025-11-12T14:20:34,896][ERROR][o.o.s.p.r.RestPPLQueryAction] [runTask-0] Error happened during query handling
java.lang.RuntimeException: java.sql.SQLException: exception while executing query: all shards failed
        at org.opensearch.sql.opensearch.executor.OpenSearchExecutionEngine.lambda$execute$2(OpenSearchExecutionEngine.java:217) ~[opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:74) ~[?:?]
        at org.opensearch.sql.opensearch.executor.OpenSearchExecutionEngine.lambda$execute$1(OpenSearchExecutionEngine.java:209) ~[opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.opensearch.sql.opensearch.client.OpenSearchNodeClient.schedule(OpenSearchNodeClient.java:222) ~[opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.opensearch.sql.opensearch.executor.OpenSearchExecutionEngine.execute(OpenSearchExecutionEngine.java:207) ~[opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.opensearch.sql.executor.QueryService.lambda$executeWithCalcite$1(QueryService.java:107) ~[opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:74) ~[?:?]
        at org.opensearch.sql.executor.QueryService.lambda$executeWithCalcite$0(QueryService.java:96) [opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.opensearch.sql.calcite.CalcitePlanContext.run(CalcitePlanContext.java:125) [opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.opensearch.sql.executor.QueryService.executeWithCalcite(QueryService.java:93) [opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.opensearch.sql.executor.QueryService.execute(QueryService.java:70) [opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.opensearch.sql.executor.execution.QueryPlan.execute(QueryPlan.java:66) [opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.opensearch.sql.opensearch.executor.OpenSearchQueryManager.lambda$submit$0(OpenSearchQueryManager.java:28) [opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.opensearch.sql.opensearch.executor.OpenSearchQueryManager.lambda$withCurrentContext$0(OpenSearchQueryManager.java:42) [opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:916) [opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095) [?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619) [?:?]
        at java.base/java.lang.Thread.run(Thread.java:1447) [?:?]
Caused by: java.sql.SQLException: exception while executing query: all shards failed
        at org.apache.calcite.avatica.Helper.createException(Helper.java:56) ~[opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.apache.calcite.avatica.Helper.createException(Helper.java:41) ~[opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.apache.calcite.avatica.AvaticaConnection.executeQueryInternal(AvaticaConnection.java:579) ~[opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.apache.calcite.avatica.AvaticaPreparedStatement.executeQuery(AvaticaPreparedStatement.java:137) ~[opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        at org.opensearch.sql.opensearch.executor.OpenSearchExecutionEngine.lambda$execute$2(OpenSearchExecutionEngine.java:213) ~[opensearch-sql-3.3.0.0-SNAPSHOT.jar:3.3.0.0-SNAPSHOT]
        ... 17 more
Caused by: org.opensearch.action.search.SearchPhaseExecutionException: all shards failed
        at org.opensearch.action.search.AbstractSearchAsyncAction.onPhaseFailure(AbstractSearchAsyncAction.java:808) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.search.AbstractSearchAsyncAction.executeNextPhase(AbstractSearchAsyncAction.java:428) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.search.AbstractSearchAsyncAction.onPhaseDone(AbstractSearchAsyncAction.java:848) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:581) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:376) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:104) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:75) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:760) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.transport.TransportService$9.handleException(TransportService.java:1826) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.transport.TransportService$ContextRestoreResponseHandler.handleException(TransportService.java:1607) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.transport.TransportService$DirectResponseChannel.processException(TransportService.java:1721) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.transport.TransportService$DirectResponseChannel.sendResponse(TransportService.java:1695) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.transport.TaskTransportChannel.sendResponse(TaskTransportChannel.java:95) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.transport.TransportChannel.sendErrorResponse(TransportChannel.java:102) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.support.ChannelActionListener.onFailure(ChannelActionListener.java:70) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.ActionRunnable.onFailure(ActionRunnable.java:104) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:54) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.threadpool.TaskAwareRunnable.doRun(TaskAwareRunnable.java:78) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:59) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:975) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        ... 3 more
Caused by: org.opensearch.OpenSearchException$3: java.lang.RuntimeException: Failed to convert Substrait plan: Substrait error: Field 'timestamp' in Substrait schema has a different type (Utf8) than the corresponding field in the table schema (Timestamp(Millisecond, None)).
        at org.opensearch.OpenSearchException.guessRootCauses(OpenSearchException.java:710) ~[opensearch-core-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.search.AbstractSearchAsyncAction.executeNextPhase(AbstractSearchAsyncAction.java:426) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.search.AbstractSearchAsyncAction.onPhaseDone(AbstractSearchAsyncAction.java:848) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.search.AbstractSearchAsyncAction.onShardFailure(AbstractSearchAsyncAction.java:581) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.search.AbstractSearchAsyncAction$1.onFailure(AbstractSearchAsyncAction.java:376) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.search.SearchExecutionStatsCollector.onFailure(SearchExecutionStatsCollector.java:104) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.ActionListenerResponseHandler.handleException(ActionListenerResponseHandler.java:75) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.search.SearchTransportService$ConnectionCountingHandler.handleException(SearchTransportService.java:760) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.transport.TransportService$9.handleException(TransportService.java:1826) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.transport.TransportService$ContextRestoreResponseHandler.handleException(TransportService.java:1607) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.transport.TransportService$DirectResponseChannel.processException(TransportService.java:1721) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.transport.TransportService$DirectResponseChannel.sendResponse(TransportService.java:1695) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.transport.TaskTransportChannel.sendResponse(TaskTransportChannel.java:95) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.transport.TransportChannel.sendErrorResponse(TransportChannel.java:102) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.support.ChannelActionListener.onFailure(ChannelActionListener.java:70) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.ActionRunnable.onFailure(ActionRunnable.java:104) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:54) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.threadpool.TaskAwareRunnable.doRun(TaskAwareRunnable.java:78) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:59) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:975) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        ... 3 more
Caused by: java.lang.RuntimeException: java.lang.RuntimeException: Failed to convert Substrait plan: Substrait error: Field 'timestamp' in Substrait schema has a different type (Utf8) than the corresponding field in the table schema (Timestamp(Millisecond, None)).
        at org.opensearch.datafusion.DatafusionEngine.executeQueryPhase(DatafusionEngine.java:219) ~[?:?]
        at org.opensearch.datafusion.DatafusionEngine.executeQueryPhase(DatafusionEngine.java:58) ~[?:?]
        at org.opensearch.search.SearchService.executeQueryPhase(SearchService.java:853) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.search.SearchService$2.lambda$onResponse$0(SearchService.java:791) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.ActionRunnable.lambda$supply$0(ActionRunnable.java:74) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.ActionRunnable$2.doRun(ActionRunnable.java:89) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.threadpool.TaskAwareRunnable.doRun(TaskAwareRunnable.java:78) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:59) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:975) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        ... 3 more
Caused by: java.lang.RuntimeException: Failed to convert Substrait plan: Substrait error: Field 'timestamp' in Substrait schema has a different type (Utf8) than the corresponding field in the table schema (Timestamp(Millisecond, None)).
        at org.opensearch.datafusion.DataFusionQueryJNI.executeQueryPhase(Native Method) ~[?:?]
        at org.opensearch.datafusion.search.DatafusionSearcher.search(DatafusionSearcher.java:67) ~[?:?]
        at org.opensearch.datafusion.DatafusionEngine.executeQueryPhase(DatafusionEngine.java:176) ~[?:?]
        at org.opensearch.datafusion.DatafusionEngine.executeQueryPhase(DatafusionEngine.java:58) ~[?:?]
        at org.opensearch.search.SearchService.executeQueryPhase(SearchService.java:853) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.search.SearchService$2.lambda$onResponse$0(SearchService.java:791) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.ActionRunnable.lambda$supply$0(ActionRunnable.java:74) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.action.ActionRunnable$2.doRun(ActionRunnable.java:89) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.threadpool.TaskAwareRunnable.doRun(TaskAwareRunnable.java:78) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:59) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:975) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
        ... 3 more
```