### PR TITLE
Make loggers to capture Search Request lifecycle info by default

### DIFF
--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/engine/ParquetExecutionEngine.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/engine/ParquetExecutionEngine.java
@@ -138,8 +138,8 @@ public class ParquetExecutionEngine implements IndexingExecutionEngine<ParquetDa
         long vsrMemory = arrowBufferPool.getTotalAllocatedBytes();
         String shardDataPath = shardPath.getDataPath().toString();
         long filteredArrowWriterMemory = RustBridge.getFilteredNativeBytesUsed(shardDataPath);
-        logger.info("Native memory used by VSR Buffer Pool: {}", vsrMemory);
-        logger.info("Native memory used by ArrowWriters in shard path {}: {}", shardDataPath, filteredArrowWriterMemory);
+        logger.debug("Native memory used by VSR Buffer Pool: {}", vsrMemory);
+        logger.debug("Native memory used by ArrowWriters in shard path {}: {}", shardDataPath, filteredArrowWriterMemory);
         return vsrMemory + filteredArrowWriterMemory;
     }
 

--- a/modules/parquet-data-format/src/main/rust/src/lib.rs
+++ b/modules/parquet-data-format/src/main/rust/src/lib.rs
@@ -191,8 +191,8 @@ impl NativeParquetWriter {
 
     fn get_filtered_writer_memory_usage(path_prefix: String) -> Result<usize, Box<dyn std::error::Error>> {
         let log_msg = format!("[RUST] get_filtered_writer_memory_usage called with prefix: {}\n", path_prefix);
-        println!("{}", log_msg.trim());
-        Self::log_to_file(&log_msg);
+//         println!("{}", log_msg.trim());
+//         Self::log_to_file(&log_msg);
 
         let mut total_memory = 0;
         let mut writer_count = 0;
@@ -216,8 +216,8 @@ impl NativeParquetWriter {
         }
 
         let total_msg = format!("[RUST] Total memory usage across {} filtered ArrowWriters (prefix: {}): {} bytes\n", writer_count, path_prefix, total_memory);
-        println!("{}", total_msg.trim());
-        Self::log_to_file(&total_msg);
+        //println!("{}", total_msg.trim());
+        //Self::log_to_file(&total_msg);
 
         Ok(total_memory)
     }

--- a/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.action.search;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.CollectionStatistics;
 import org.apache.lucene.search.FieldDoc;
@@ -90,6 +92,7 @@ import java.util.stream.Collectors;
  * @opensearch.internal
  */
 public final class SearchPhaseController {
+    private static final Logger LOGGER = LogManager.getLogger(SearchPhaseController.class);
     private static final ScoreDoc[] EMPTY_DOCS = new ScoreDoc[0];
 
     private final NamedWriteableRegistry namedWriteableRegistry;
@@ -530,6 +533,9 @@ public final class SearchPhaseController {
             reducedCompletionSuggestions = reducedSuggest.filter(CompletionSuggestion.class);
         }
         final InternalAggregations aggregations = reduceAggs(aggReduceContextBuilder, performFinalReduce, bufferedAggs);
+        if (aggregations != null) {
+            LOGGER.info("Final reduced aggregations: {}", aggregations.asMap());
+        }
         final SearchProfileShardResults shardResults = profileResults.isEmpty() ? null : new SearchProfileShardResults(profileResults);
         final SortedTopDocs sortedTopDocs = sortDocs(isScrollRequest, bufferedTopDocs, from, size, reducedCompletionSuggestions);
         final TotalHits totalHits = topDocsStats.getTotalHits();

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -324,7 +324,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             );
         }
         executeRequest(task, searchRequest, this::searchAsyncAction, listener);
-//        logger.info("Search request received is {}", searchRequest.source());
+        logger.info("Search request received is {}", searchRequest.source());
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/IndexingMemoryController.java
+++ b/server/src/main/java/org/opensearch/indices/IndexingMemoryController.java
@@ -429,7 +429,7 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
                 totalBytesUsed += shardBytesUsed;
             }
 
-            logger.info(
+            logger.debug(
                 "total indexing heap bytes used [{}] vs {} [{}], total native bytes used [{}] vs native buffer [{}], currently writing bytes [{}]",
                 new ByteSizeValue(totalBytesUsed),
                 INDEX_BUFFER_SIZE_SETTING.getKey(),
@@ -486,7 +486,7 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
                     }
                 }
 
-                logger.info(
+                logger.debug(
                     "now write some indexing buffers: total indexing heap bytes used [{}] vs {} [{}], "
                         + "total native bytes used [{}] vs native buffer [{}], currently writing bytes [{}], [{}] shards with non-zero indexing buffer",
                     new ByteSizeValue(totalBytesUsed),


### PR DESCRIPTION
The loggers changed to debug were getting printed even when no Search requests were running at a high rate hiding the other relevant logs. 

Making other loggers info to capture Search request lifecycle as info during initial development phase. 

We can explicitly comment during benchmarks if these do add significant latencies. 

