### PR TITLE
Bump DataFusion version to v50.0.0

### DIFF
--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/search/DatafusionContext.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/search/DatafusionContext.java
@@ -110,7 +110,7 @@ public class DatafusionContext extends SearchContext {
         this.request = request;
         this.task = task;
         this.readEngine = engine;
-        this.engineSearcher = engine.acquireSearcher("search");//null;//TODO readerContext.contextEngineSearcher();
+        this.engineSearcher = (DatafusionSearcher) readerContext.acquireSearcher("search");//null;//TODO readerContext.contextEngineSearcher();
         this.queryResult = new QuerySearchResult(readerContext.id(), searchShardTarget, request);
         this.fetchResult = new FetchSearchResult(readerContext.id(), searchShardTarget);
         this.indexService = readerContext.indexService();

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/search/DatafusionReaderManager.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/search/DatafusionReaderManager.java
@@ -73,16 +73,14 @@ public class DatafusionReaderManager implements EngineReaderManager<DatafusionRe
 
     @Override
     public void afterRefresh(boolean didRefresh, CompositeEngine.ReleasableRef<CatalogSnapshot> catalogSnapshot) throws IOException {
-        if (didRefresh && catalogSnapshot != null) {
-            DatafusionReader old = this.current;
-            Collection<WriterFileSet> newFiles = catalogSnapshot.getRef().getSearchableFiles(dataFormat);
-            if(old !=null) {
-                release(old);
-                processFileChanges(old.files, newFiles);
-            } else {
-                processFileChanges(List.of(), newFiles);
-            }
-            this.current = new DatafusionReader(this.path, catalogSnapshot, catalogSnapshot.getRef().getSearchableFiles(dataFormat));
+        DatafusionReader old = this.current;
+        Collection<WriterFileSet> newFiles = catalogSnapshot.getRef().getSearchableFiles(dataFormat);
+        this.current = new DatafusionReader(this.path, catalogSnapshot, catalogSnapshot.getRef().getSearchableFiles(dataFormat));
+        if(old !=null) {
+            release(old);
+            processFileChanges(old.files, newFiles);
+        } else {
+            processFileChanges(List.of(), newFiles);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2180,18 +2180,20 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     /**
      * Acquires a point-in-time reader that can be used to create {@link Engine.Searcher}s on demand.
      */
-    public EngineSearcherSupplier<Engine.Searcher> acquireSearcherSupplier() {
+    public EngineSearcherSupplier<?> acquireSearcherSupplier() {
         return acquireSearcherSupplier(Engine.SearcherScope.EXTERNAL);
     }
 
     /**
      * Acquires a point-in-time reader that can be used to create {@link Engine.Searcher}s on demand.
      */
-    public Engine.SearcherSupplier acquireSearcherSupplier(Engine.SearcherScope scope) {
+    public EngineSearcherSupplier<?> acquireSearcherSupplier(Engine.SearcherScope scope) {
         readAllowed();
         markSearcherAccessed();
         final Engine engine = getEngine();
-        currentCompositeEngineReference.get().getPrimaryReadEngine().acquireSearcherSupplier(null, scope);
+        if(currentCompositeEngineReference.get() != null ) {
+            return currentCompositeEngineReference.get().getPrimaryReadEngine().acquireSearcherSupplier(null, scope);
+        }
         return engine.acquireSearcherSupplier(this::wrapSearcher, scope);
     }
 

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -258,7 +258,7 @@ final class DefaultSearchContext extends SearchContext {
         this.indexService = readerContext.indexService();
         this.indexShard = readerContext.indexShard();
         this.clusterService = clusterService;
-        this.engineSearcher = (Engine.Searcher) readerContext.acquireSearcher("search");
+        this.engineSearcher = (Engine.Searcher) indexShard.getEngine().acquireSearcher("search");
         this.concurrentSearchMode = evaluateConcurrentSearchMode(executor);
         this.searcher = new ContextIndexSearcher(
             engineSearcher.getIndexReader(),

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -960,7 +960,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             final SearchContext finalContext = context;
 
             // Prevent cleanup in this try-catch, will be handled in callback
-            readerContextRelease = null;
+           // readerContextRelease = null;
             context = null;
 
             // Execute native query async
@@ -988,6 +988,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                         processFailure(readerContext, exception);
                         onFailure(e);
                     } finally {
+                        finalRelease.close();
                         taskResourceTrackingService.writeTaskResourceUsage(task, clusterService.localNode().getId());
                     }
                 }
@@ -1268,7 +1269,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         IndexService indexService = indicesService.indexServiceSafe(request.shardId().getIndex());
         IndexShard shard = indexService.getShard(request.shardId().id());
         // TODO acquire search supplier
-        EngineSearcherSupplier<?> reader = shard.acquireSearcherSupplier();
+        EngineSearcherSupplier<?> reader = indexService.getShard(request.shardId().id()).acquireSearcherSupplier();
         return createAndPutReaderContext(request, indexService, shard, reader, keepStatesInContext);
     }
 

--- a/server/src/test/java/org/opensearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/opensearch/search/SearchServiceTests.java
@@ -838,7 +838,7 @@ public class SearchServiceTests extends OpenSearchSingleNodeTestCase {
                 try {
                     latch.await();
                     for (;;) {
-                        final EngineSearcherSupplier<Engine.Searcher> reader = indexShard.acquireSearcherSupplier();
+                        final EngineSearcherSupplier<Engine.Searcher> reader = (EngineSearcherSupplier<Engine.Searcher>) indexShard.acquireSearcherSupplier();
                         try {
                             searchService.createAndPutReaderContext(
                                 new ShardScrollRequestTest(indexShard.shardId()),


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- Bumping up DataFusion Version to v50.0.0 which supports Datafusion-Metadata Caching.
- Bumping up corresponding Arrow version from v55.2.0 to v56.2.0
- Renamed conflicting `CustomFileMeta` (initially `FileMetadata`)
- Updating test files to have indexed data including `rowId` changes

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
