### PR TITLE
Forbid use of ClassLoader APIs for disabling assertions

### DIFF
--- a/buildSrc/src/main/resources/forbidden/opensearch-test-signatures.txt
+++ b/buildSrc/src/main/resources/forbidden/opensearch-test-signatures.txt
@@ -26,3 +26,8 @@ com.carrotsearch.randomizedtesting.annotations.Nightly @ We don't run nightly te
 org.junit.Test @defaultMessage Just name your test method testFooBar
 
 java.lang.Math#random() @ Use one of the various randomization methods from LuceneTestCase or OpenSearchTestCase for reproducibility
+
+@defaultMessage Disabling assertions is a JVM-wide setting and will break other tests
+java.lang.ClassLoader#setDefaultAssertionStatus(boolean)
+java.lang.ClassLoader#setPackageAssertionStatus(java.lang.String, boolean)
+java.lang.ClassLoader#setClassAssertionStatus(java.lang.String, boolean)


### PR DESCRIPTION
Programmatically disabling assertions in tests will disable assertions for all classes loaded in that JVM instance. This will cause suprious test failures in random tests depending on where and when they get executed.

See #19765 for a case where disabled assertions caused unrelated test failures that took several days to figure out.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
