### PR TITLE
Added validation for parquet data fields

### DIFF
--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/engine/ParquetDataFormat.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/engine/ParquetDataFormat.java
@@ -47,7 +47,7 @@ public class ParquetDataFormat implements DataFormat {
 
     @Override
     public boolean isDataFormatSupported(String fieldTypeName) {
-        return ArrowFieldRegistry.getRegisteredFieldNames().contains(fieldTypeName);
+        return ArrowFieldRegistry.isFieldTypeSupported(fieldTypeName);
     }
 
     public static ParquetDataFormat PARQUET_DATA_FORMAT = new ParquetDataFormat();

--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/engine/ParquetDataFormat.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/engine/ParquetDataFormat.java
@@ -1,5 +1,6 @@
 package com.parquet.parquetdataformat.engine;
 
+import com.parquet.parquetdataformat.fields.ArrowFieldRegistry;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.engine.exec.DataFormat;
@@ -42,6 +43,11 @@ public class ParquetDataFormat implements DataFormat {
     @Override
     public void configureStore() {
 
+    }
+
+    @Override
+    public boolean isDataFormatSupported(String fieldTypeName) {
+        return ArrowFieldRegistry.getRegisteredFieldNames().contains(fieldTypeName);
     }
 
     public static ParquetDataFormat PARQUET_DATA_FORMAT = new ParquetDataFormat();

--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/fields/ArrowFieldRegistry.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/fields/ArrowFieldRegistry.java
@@ -135,6 +135,11 @@ public final class ArrowFieldRegistry {
     }
 
     /**
+     * Checks if a fieldtype is supported or not
+     */
+    public static boolean isFieldTypeSupported(String fieldType) { return FIELD_REGISTRY.containsKey(fieldType); }
+
+    /**
      * Returns the ParquetField implementation for the specified OpenSearch field type, or null if not found.
      */
     public static ParquetField getParquetField(String fieldType) {

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -91,6 +91,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.compositeindex.CompositeIndexSettings;
 import org.opensearch.index.compositeindex.CompositeIndexValidator;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeIndexSettings;
+import org.opensearch.index.engine.exec.DataFormat;
 import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.MapperService.MergeReason;

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -91,7 +91,6 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.compositeindex.CompositeIndexSettings;
 import org.opensearch.index.compositeindex.CompositeIndexValidator;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeIndexSettings;
-import org.opensearch.index.engine.exec.DataFormat;
 import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.MapperService.MergeReason;

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexUpgradeService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataIndexUpgradeService.java
@@ -227,7 +227,8 @@ public class MetadataIndexUpgradeService {
                     mapperRegistry,
                     () -> null,
                     () -> false,
-                    scriptService
+                    scriptService,
+                    null  // pluginsService not available in upgrade context
                 );
                 mapperService.merge(indexMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
             }

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -936,7 +936,8 @@ public final class IndexModule {
                 throw new UnsupportedOperationException("no index query shard context available");
             },
             () -> false,
-            scriptService
+            scriptService,
+            null  // pluginsService not available in this context
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -281,7 +281,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 // we parse all percolator queries as they would be parsed on shard 0
                 () -> newQueryShardContext(0, null, System::currentTimeMillis, null),
                 idFieldDataEnabled,
-                scriptService
+                scriptService,
+                pluginsService
             );
             this.indexFieldData = new IndexFieldDataService(
                 indexSettings,

--- a/server/src/main/java/org/opensearch/index/engine/exec/DataFormat.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/DataFormat.java
@@ -48,7 +48,7 @@ public interface DataFormat {
 
         @Override
         public boolean isDataFormatSupported(String fieldTypeName) {
-            return true;
+            return false;
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/exec/DataFormat.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/DataFormat.java
@@ -23,6 +23,8 @@ public interface DataFormat {
 
     void configureStore();
 
+    boolean isDataFormatSupported(String fieldTypeName);
+
     static class LuceneDataFormat implements DataFormat {
         @Override
         public Setting<Settings> dataFormatSettings() {
@@ -42,6 +44,11 @@ public interface DataFormat {
         @Override
         public void configureStore() {
 
+        }
+
+        @Override
+        public boolean isDataFormatSupported(String fieldTypeName) {
+            return true;
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/exec/coord/Any.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/coord/Any.java
@@ -50,7 +50,7 @@ public class Any implements DataFormat {
 
     @Override
     public boolean isDataFormatSupported(String fieldType) {
-        return dataFormats.stream().anyMatch(df -> df.isDataFormatSupported(fieldType));
+        return false;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/engine/exec/coord/Any.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/coord/Any.java
@@ -49,6 +49,11 @@ public class Any implements DataFormat {
     }
 
     @Override
+    public boolean isDataFormatSupported(String fieldType) {
+        return dataFormats.stream().anyMatch(df -> df.isDataFormatSupported(fieldType));
+    }
+
+    @Override
     public void configureStore() {
         for (DataFormat dataFormat : dataFormats) {
             dataFormat.configureStore();

--- a/server/src/main/java/org/opensearch/index/engine/exec/text/TextDF.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/text/TextDF.java
@@ -36,6 +36,6 @@ public class TextDF implements DataFormat {
 
     @Override
     public boolean isDataFormatSupported(String fieldTypeName) {
-        return true;
+        return false;
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/exec/text/TextDF.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/text/TextDF.java
@@ -33,4 +33,9 @@ public class TextDF implements DataFormat {
     public void configureStore() {
 
     }
+
+    @Override
+    public boolean isDataFormatSupported(String fieldTypeName) {
+        return true;
+    }
 }

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
@@ -92,7 +92,7 @@ public class DocumentMapper implements ToXContentFragment {
 
         public Builder(RootObjectMapper.Builder builder, MapperService mapperService) {
             final Settings indexSettings = mapperService.getIndexSettings().getSettings();
-            this.builderContext = new Mapper.BuilderContext(indexSettings, new ContentPath(1));
+            this.builderContext = new Mapper.BuilderContext(indexSettings, new ContentPath(1), mapperService.getPluginsService());
             this.rootObjectMapper = builder.build(builderContext);
 
             final DocumentMapper existingMapper = mapperService.documentMapper();
@@ -122,6 +122,10 @@ public class DocumentMapper implements ToXContentFragment {
             MetadataFieldMapper metadataMapper = mapper.build(builderContext);
             metadataMappers.put(metadataMapper.getClass(), metadataMapper);
             return this;
+        }
+
+        public Mapper.BuilderContext getBuilderContext() {
+            return builderContext;
         }
 
         public DocumentMapper build(MapperService mapperService) {

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapperParser.java
@@ -176,6 +176,7 @@ public class DocumentMapperParser {
         if (mapperService.getIndexSettings().isDerivedSourceEnabled()) {
             documentMapper.root().canDeriveSource();
         }
+        documentMapper.root().checkDataFormat(docBuilder.getBuilderContext());
         return documentMapper;
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/Mapper.java
@@ -44,6 +44,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.analysis.IndexAnalyzers;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.similarity.SimilarityProvider;
+import org.opensearch.plugins.PluginsService;
 import org.opensearch.script.ScriptService;
 
 import java.io.IOException;
@@ -69,11 +70,17 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
     public static class BuilderContext {
         private final Settings indexSettings;
         private final ContentPath contentPath;
+        private final PluginsService pluginsService;
 
         public BuilderContext(Settings indexSettings, ContentPath contentPath) {
+            this(indexSettings, contentPath, null);
+        }
+
+        public BuilderContext(Settings indexSettings, ContentPath contentPath, PluginsService pluginsService) {
             Objects.requireNonNull(indexSettings, "indexSettings is required");
             this.contentPath = contentPath;
             this.indexSettings = indexSettings;
+            this.pluginsService = pluginsService;
         }
 
         public ContentPath path() {
@@ -82,6 +89,10 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
         public Settings indexSettings() {
             return this.indexSettings;
+        }
+
+        public PluginsService pluginsService() {
+            return this.pluginsService;
         }
 
         public Version indexCreatedVersion() {
@@ -308,6 +319,10 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
      */
     public void canDeriveSource() {
         throw new UnsupportedOperationException("Derived source field is not supported for [" + name() + "] field");
+    }
+
+    public void checkDataFormat(BuilderContext context) {
+        // Default implementation - no validation
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MapperService.java
@@ -68,6 +68,7 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.similarity.SimilarityService;
 import org.opensearch.indices.InvalidTypeNameException;
 import org.opensearch.indices.mapper.MapperRegistry;
+import org.opensearch.plugins.PluginsService;
 import org.opensearch.script.ScriptService;
 
 import java.io.Closeable;
@@ -226,6 +227,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     private final BooleanSupplier idFieldDataEnabled;
 
+    private final PluginsService pluginsService;
+
     private volatile Set<CompositeMappedFieldType> compositeMappedFieldTypes;
     private volatile Set<String> fieldsPartOfCompositeMappings;
     private volatile Set<String> nestedFieldsPartOfCompositeMappings;
@@ -238,12 +241,14 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         MapperRegistry mapperRegistry,
         Supplier<QueryShardContext> queryShardContextSupplier,
         BooleanSupplier idFieldDataEnabled,
-        ScriptService scriptService
+        ScriptService scriptService,
+        PluginsService pluginsService
     ) {
         super(indexSettings);
 
         this.indexVersionCreated = indexSettings.getIndexVersionCreated();
         this.indexAnalyzers = indexAnalyzers;
+        this.pluginsService = pluginsService;
         this.documentParser = new DocumentMapperParser(
             indexSettings,
             this,
@@ -281,6 +286,10 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     public IndexAnalyzers getIndexAnalyzers() {
         return this.indexAnalyzers;
+    }
+
+    public PluginsService getPluginsService() {
+        return this.pluginsService;
     }
 
     public NamedAnalyzer getNamedAnalyzer(String analyzerName) {

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -81,6 +81,7 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
 
     /**
      * Creates a new ParametrizedFieldMapper
+     * All fields are currently hardcoded to validate against "parquet" data format
      */
     protected ParametrizedFieldMapper(String simpleName, MappedFieldType mappedFieldType, MultiFields multiFields, CopyTo copyTo) {
         super(simpleName, new FieldType(), mappedFieldType, multiFields, copyTo);
@@ -689,6 +690,8 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                     iterator.remove();
                     continue;
                 }
+                // TODO: Add "dataformat" parsing here when ready to support per-field data formats
+                // For now, all fields are hardcoded to validate against "parquet"
                 Parameter<?> parameter = deprecatedParamsMap.get(propName);
                 if (parameter != null) {
                     deprecationLogger.deprecate(

--- a/server/src/test/java/org/opensearch/index/codec/CodecTests.java
+++ b/server/src/test/java/org/opensearch/index/codec/CodecTests.java
@@ -210,7 +210,8 @@ public class CodecTests extends OpenSearchTestCase {
             mapperRegistry,
             () -> null,
             () -> false,
-            null
+            null,
+            null  // pluginsService
         );
         return new CodecService(service, indexSettings, LogManager.getLogger("test"));
     }

--- a/server/src/test/java/org/opensearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/TextFieldMapperTests.java
@@ -1123,7 +1123,8 @@ public class TextFieldMapperTests extends MapperTestCase {
                 throw new UnsupportedOperationException();
             },
             () -> true,
-            scriptService
+            scriptService,
+            null  // pluginsService
         );
 
         merge(mapperService, fieldMapping(b -> b.field("type", "text").field("store", false)));

--- a/test/framework/src/main/java/org/opensearch/index/MapperTestUtils.java
+++ b/test/framework/src/main/java/org/opensearch/index/MapperTestUtils.java
@@ -95,7 +95,8 @@ public class MapperTestUtils {
             mapperRegistry,
             () -> null,
             () -> false,
-            null
+            null,
+            null  // pluginsService
         );
     }
 
@@ -123,7 +124,8 @@ public class MapperTestUtils {
             mapperRegistry,
             () -> null,
             () -> false,
-            null
+            null,
+            null  // pluginsService
         );
     }
 

--- a/test/framework/src/main/java/org/opensearch/index/engine/TranslogHandler.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/TranslogHandler.java
@@ -89,7 +89,8 @@ public class TranslogHandler implements TranslogRecoveryRunner {
             mapperRegistry,
             () -> null,
             () -> false,
-            null
+            null,
+            null  // pluginsService
         );
     }
 

--- a/test/framework/src/main/java/org/opensearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/mapper/MapperServiceTestCase.java
@@ -163,7 +163,8 @@ public abstract class MapperServiceTestCase extends OpenSearchTestCase {
                 throw new UnsupportedOperationException();
             },
             () -> true,
-            scriptService
+            scriptService,
+            null  // pluginsService not available in test context
         );
         merge(mapperService, mapping);
         return mapperService;

--- a/test/framework/src/main/java/org/opensearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/AbstractBuilderTestCase.java
@@ -432,7 +432,8 @@ public abstract class AbstractBuilderTestCase extends OpenSearchTestCase {
                 mapperRegistry,
                 () -> createShardContext(null),
                 () -> false,
-                null
+                null,
+                null  // pluginsService
             );
             IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(nodeSettings, new IndexFieldDataCache.Listener() {
             },


### PR DESCRIPTION
### Description

This PR adds validation to ensure that field types defined in index mappings are compatible with the Parquet data format. When Parquet format is enabled, the system will now reject field mappings that use data types not supported by Parquet during the mapping definition phase.

### Testing

1. Valid Parquet mapping

```
curl -X PUT "localhost:9200/test-allowed-types" -H "Content-Type: application/json" -d '{
  "mappings": {
    "properties": {
      "name": {"type": "text"},
      "category": {"type": "keyword"},
      "age": {"type": "integer"},
      "salary": {"type": "long"},
      "score": {"type": "float"},
      "rating": {"type": "double"},
      "active": {"type": "boolean"},
      "created_date": {"type": "date"},
      "ip_address": {"type": "ip"}
    }
  }
}'
```
Response : 
```
{"acknowledged":true,"shards_acknowledged":true,"index":"test-allowed-types"}% 
```
2. Invalid Parquet Mapping 

```
curl -X PUT "localhost:9200/test-geo-point" -H "Content-Type: application/json" -d '{
  "mappings": {
    "properties": {
      "name": {"type": "text"},
      "location": {"type": "geo_point"}
    }
  }
}'
```
Response :
```
{"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"Field [user_agent] of type [geo_point] is not supported by data format [parquet]; Field [client_ip] of type [geo_point] is not supported by data format [parquet]"}],"type":"mapper_parsing_exception","reason":"Failed to parse mapping [_doc]: Field [user_agent] of type [geo_point] is not supported by data format [parquet]; Field [client_ip] of type [geo_point] is not supported by data format [parquet]","caused_by":{"type":"mapper_parsing_exception","reason":"Field [user_agent] of type [geo_point] is not supported by data format [parquet]; Field [client_ip] of type [geo_point] is not supported by data format [parquet]"}},"status":400}
```       