### PR TITLE
Native library loader fix

### DIFF
--- a/modules/parquet-data-format/build.gradle
+++ b/modules/parquet-data-format/build.gradle
@@ -212,8 +212,8 @@ tasks.register('copyNativeLib', Copy) {
   dependsOn buildRust
   from "src/main/rust/target/release"
   into "src/main/resources/native"
-  include "**/libparquet_dataformat_jni.*"
-  include "**/parquet_dataformat_jni.dll"
+  include "libparquet_dataformat_jni.*"
+  include "parquet_dataformat_jni.dll"
 
   // Set strategy to avoid errors on duplicate files
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
@@ -226,7 +226,7 @@ tasks.register('copyNativeLib', Copy) {
     def archDir = arch.contains('aarch64') || arch.contains('arm64') ? 'aarch64' :
       arch.contains('64') ? 'x86_64' : 'x86'
 
-    file.path = "${osDir}/${archDir}/${file.name}"
+    file.path = "${osDir}-${archDir}/${file.name}"
   }
 
   doLast {

--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/bridge/NativeLibraryLoader.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/bridge/NativeLibraryLoader.java
@@ -73,8 +73,9 @@ public final class NativeLibraryLoader {
     }
 
     private static void loadFromResources(String providedPath, String libraryName) throws IOException {
-        String libName = System.mapLibraryName(libraryName);
-        String resourcePath = Paths.get("/", providedPath, libName).toString();
+        String platformDir = PlatformHelper.getPlatformDirectory();
+        String libName = PlatformHelper.getPlatformLibraryName(libraryName);
+        String resourcePath = Paths.get("/", providedPath, platformDir, libName).toString();
         try (InputStream is = NativeLibraryLoader.class.getResourceAsStream(resourcePath)) {
             if (is == null) {
                 throw new IOException("Native library not found: " + resourcePath);


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

PR fixes the below issue: 
```
»  Caused by: java.io.IOException: Native library not found: /Users/abandeji/Public/workplace/OpenSearch/build/testclusters/runTask-0/distro/3.3.0-ARCHIVE/native/macos-arm64/libparquet_dataformat_jni.dylib/libparquet_dataformat_jni.dylib
»       at com.parquet.parquetdataformat.bridge.NativeLibraryLoader.loadFromResources(NativeLibraryLoader.java:80)
»       at com.parquet.parquetdataformat.bridge.NativeLibraryLoader.load(NativeLibraryLoader.java:68)
»       ... 25 more
```
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
