### PR TITLE
Aligned platform directory with build script

### DIFF
--- a/libs/vectorized-exec-spi/src/main/java/org/opensearch/vectorized/execution/jni/PlatformHelper.java
+++ b/libs/vectorized-exec-spi/src/main/java/org/opensearch/vectorized/execution/jni/PlatformHelper.java
@@ -91,7 +91,7 @@ public class PlatformHelper {
         } else if (OS_ARCH.contains("x86")) {
             return "x86";
         } else if (OS_ARCH.contains("aarch64") || OS_ARCH.contains("arm64")) {
-            return "arm64";
+            return "aarch64";
         }
         return OS_ARCH;
     }


### PR DESCRIPTION
The build process in `parquet-dataformat` module always creates build directories with `aarch64` for both aarch64 and arm platforms. 

Ensuring the same gets used when discovering the native binary to be loaded. 

```
ll modules/parquet-data-format/build/resources/main/native/macos-aarch64/
total 22664
-rw-r--r--@ 1 anijainc  staff   427B Nov 17 10:58 libparquet_dataformat_jni.d
-rw-r--r--@ 1 anijainc  staff   966K Nov 17 10:58 libparquet_dataformat_jni.rlib
-rw-r--r--@ 1 anijainc  staff    10M Nov 17 10:58 libparquet_dataformat_jni.dylib
```

Otherwise it fails with error in finding native library 
```
»  Caused by: org.opensearch.vectorized.execution.jni.NativeLoaderException: Failed to load library 'parquet_dataformat_jni' from all attempted locations
»       at com.parquet.parquetdataformat.bridge.NativeLibraryLoader.load(NativeLibraryLoader.java:70)
»       at com.parquet.parquetdataformat.bridge.RustBridge.<clinit>(RustBridge.java:23)
»       ... 24 more
»  Caused by: java.io.IOException: Native library not found: /Users/anijainc/Desktop/GithubWorkspaces/Mustang/DataFusion_OS/OpenSearch/build/testclusters/runTask-0/distro/3.3.0-ARCHIVE/native/macos-arm64/libparquet_dataformat_jni.dylib/macos-arm64/libparquet_dataformat_jni.dylib
»       at com.parquet.parquetdataformat.bridge.NativeLibraryLoader.loadFromResources(NativeLibraryLoader.java:81)
»       at com.parquet.parquetdataformat.bridge.NativeLibraryLoader.load(NativeLibraryLoader.java:68)
»       ... 25 more
```