### PR TITLE
Changing path to match gradle native output dir

### DIFF
--- a/libs/vectorized-exec-spi/src/main/java/org/opensearch/vectorized/execution/jni/PlatformHelper.java
+++ b/libs/vectorized-exec-spi/src/main/java/org/opensearch/vectorized/execution/jni/PlatformHelper.java
@@ -87,7 +87,7 @@ public class PlatformHelper {
      */
     public static String getArchName() {
         if (OS_ARCH.contains("amd64") || OS_ARCH.contains("x86_64")) {
-            return "x64";
+            return "x86_64";
         } else if (OS_ARCH.contains("x86")) {
             return "x86";
         } else if (OS_ARCH.contains("aarch64") || OS_ARCH.contains("arm64")) {


### PR DESCRIPTION
Similar to https://github.com/opensearch-project/OpenSearch/pull/20028 

but for x86 environment

```
»  fatal error in thread [opensearch[runTask-0][scheduler][T#1]], exiting
»  java.lang.ExceptionInInitializerError
»       at com.parquet.parquetdataformat.engine.ParquetExecutionEngine.getNativeBytesUsed(ParquetExecutionEngine.java:160)
»       at java.base/java.util.stream.ReferencePipeline$5$1.accept(ReferencePipeline.java:249)
»       at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1716)
»       at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
»       at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
»       at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
»       at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
»       at java.base/java.util.stream.LongPipeline.reduce(LongPipeline.java:502)
»       at java.base/java.util.stream.LongPipeline.sum(LongPipeline.java:460)
»       at org.opensearch.index.engine.exec.composite.CompositeIndexingExecutionEngine.getNativeBytesUsed(CompositeIndexingExecutionEngine.java:164)
»       at org.opensearch.index.engine.exec.coord.CompositeEngine.getNativeBytesUsed(CompositeEngine.java:793)
»       at org.opensearch.index.shard.IndexShard.getNativeBytesUsed(IndexShard.java:3126)
»       at org.opensearch.indices.IndexingMemoryController.getNativeBytesUsed(IndexingMemoryController.java:269)
»       at org.opensearch.indices.IndexingMemoryController$ShardsIndicesStatusChecker.runUnlocked(IndexingMemoryController.java:421)
»       at org.opensearch.indices.IndexingMemoryController$ShardsIndicesStatusChecker.run(IndexingMemoryController.java:393)
»       at org.opensearch.threadpool.Scheduler$ReschedulingRunnable.doRun(Scheduler.java:246)
»       at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:975)
»       at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
»       at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
»       at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
»       at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:309)
»       at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)
»       at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)
»       at java.base/java.lang.Thread.run(Thread.java:1447)
»  Caused by: org.opensearch.vectorized.execution.jni.NativeLoaderException: Failed to load library 'parquet_dataformat_jni' from all attempted locations
»       at com.parquet.parquetdataformat.bridge.NativeLibraryLoader.load(NativeLibraryLoader.java:70)
»       at com.parquet.parquetdataformat.bridge.RustBridge.<clinit>(RustBridge.java:23)
»       ... 24 more
»  Caused by: java.io.IOException: Native library not found: /home/ec2-user/DatafusionFeature/OpenSearch/build/testclusters/runTask-0/distro/3.3.0-ARCHIVE/native/linux-x64/libparquet_dataformat_jni.so/linux-x64/libparquet_dataformat_jni.so
»       at com.parquet.parquetdataformat.bridge.NativeLibraryLoader.loadFromResources(NativeLibraryLoader.java:81)
»       at com.parquet.parquetdataformat.bridge.NativeLibraryLoader.load(NativeLibraryLoader.java:68)
»       ... 25 more

> Task :run FAILED

FAILURE: Build failed with an exception.
```

Generated native library
```
[ec2-user@ip-127-0-0-1 OpenSearch]$ ll modules/parquet-data-format/build/resources/main/native/linux-x86_64/
total 14464
-rw-r--r--. 1 ec2-user ec2-user      337 Nov 17 20:44 libparquet_dataformat_jni.d
-rw-r--r--. 1 ec2-user ec2-user  1488874 Nov 17 20:44 libparquet_dataformat_jni.rlib
-rw-r--r--. 1 ec2-user ec2-user 13312832 Nov 17 20:44 libparquet_dataformat_jni.so
```