### PR TITLE
Injecting count sub agg if absent to ensure doc_count is correct

### DIFF
--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -1310,6 +1310,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             if (request.scroll() != null) {
                 context.scrollContext().scroll = request.scroll();
             }
+            // FIXME : We don't need to do both, but commenting the one on Datafusion Context hangs up the JVM need to debug.
             parseSource(context, request.source(), includeAggregations);
             parseSource(context.getOriginalContext(), request.source(), includeAggregations);
 
@@ -1633,11 +1634,6 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         context.terminateAfter(source.terminateAfter());
         if (source.aggregations() != null && includeAggregations) {
             try {
-                // If the user has not specified any count agg and there is none in DSL, then add it.
-                if (source.queryPlanIR() != null) {
-                    SearchEngineResultConversionUtils.addValueCountIfAbsent(context, source);
-                    logger.info("Modified DSL to add value count, DSL after modification {}", source);
-                }
                 AggregatorFactories factories = source.aggregations().build(queryShardContext, null);
                 context.aggregations(new SearchContextAggregations(factories, multiBucketConsumerService.create()));
             } catch (IOException e) {


### PR DESCRIPTION
Equivalent SQL plugin Commit : https://github.com/vinaykpud/sql/commit/99bdc4869f46208ba76382d6a7447faf5bc934a3

The merging of InternalAggregation at the Coordinator heavily relies on `doc_count` parameter. 

Consider a PPL query that doesn't have count sub aggregation
```
source=hits | stats sum(EventID) by Browser
```

In this case, we can only mock the doc_count as the Datafusion query doesn't have the sub agg. 

Now, we are adding count sub agg in the SQL plugin if it's absent and the request contains aggregation.

In this PR, we are handling the same in core opensearch to populate `doc_count` correctly. 