### PR TITLE
[Backport 2.19] Add case sensitivity as an argument to XContentMapValues.filter (#19976)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 
 ### Changed
+- Make XContentMapValues.filter case insensitive ([#19976](https://github.com/opensearch-project/OpenSearch/pull/19976))

--- a/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java
@@ -254,7 +254,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         this.includes = includes;
         this.excludes = excludes;
         final boolean filtered = CollectionUtils.isEmpty(includes) == false || CollectionUtils.isEmpty(excludes) == false;
-        this.filter = enabled && filtered ? XContentMapValues.filter(includes, excludes) : null;
+        this.filter = enabled && filtered ? XContentMapValues.filter(includes, excludes, true) : null;
         this.complete = enabled && CollectionUtils.isEmpty(includes) && CollectionUtils.isEmpty(excludes);
 
         // Set parameters for recovery source
@@ -264,7 +264,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         final boolean recoverySourcefiltered = CollectionUtils.isEmpty(recoverySourceIncludes) == false
             || CollectionUtils.isEmpty(recoverySourceExcludes) == false;
         this.recoverySourceFilter = this.recoverySourceEnabled && recoverySourcefiltered
-            ? XContentMapValues.filter(recoverySourceIncludes, recoverySourceExcludes)
+            ? XContentMapValues.filter(recoverySourceIncludes, recoverySourceExcludes, true)
             : null;
     }
 

--- a/server/src/main/java/org/opensearch/rest/RestRequestFilter.java
+++ b/server/src/main/java/org/opensearch/rest/RestRequestFilter.java
@@ -76,7 +76,8 @@ public interface RestRequestFilter {
                         Map<String, Object> transformedSource = XContentMapValues.filter(
                             result.v2(),
                             null,
-                            fields.toArray(Strings.EMPTY_ARRAY)
+                            fields.toArray(Strings.EMPTY_ARRAY),
+                            false
                         );
                         try {
                             XContentBuilder xContentBuilder = XContentBuilder.builder(result.v1().xContent()).map(transformedSource);

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
@@ -271,7 +271,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
      */
     public Function<Map<String, ?>, Map<String, Object>> getFilter() {
         if (filter == null) {
-            filter = XContentMapValues.filter(includes, excludes);
+            filter = XContentMapValues.filter(includes, excludes, true);
         }
         return filter;
     }

--- a/server/src/test/java/org/opensearch/common/xcontent/support/XContentMapValuesTests.java
+++ b/server/src/test/java/org/opensearch/common/xcontent/support/XContentMapValuesTests.java
@@ -60,6 +60,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -627,6 +628,92 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         Map<String, Object> expected = new HashMap<>();
         expected.put("photosCount", 2);
         assertEquals(expected, filtered);
+    }
+
+    public void testCaseInsensitive_ExcludeLeafUnderObject() {
+        Map<String, Object> doc = new HashMap<>();
+        Map<String, Object> book = new HashMap<>();
+        book.put("Title", "The Hobbit"); // mixed case
+        book.put("Author", "Tolkien");
+        doc.put("book", book);
+
+        // filter should be case insensitive: "book.title" should remove "Title"
+        Map<String, Object> filtered = XContentMapValues.filter(doc, new String[0], new String[] { "book.title" }, false);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> outBook = (Map<String, Object>) filtered.get("book");
+        assertThat(filtered, hasKey("book"));
+        assertThat(outBook, hasKey("Author"));
+        assertThat(outBook, not(hasKey("Title")));
+    }
+
+    public void testCaseInsensitive_WildcardAnyDepth_ArraysAndObjects() {
+        Map<String, Object> b1 = new HashMap<>();
+        b1.put("TITLE", "Dune"); // upper case
+        b1.put("YEAR", "1965");
+
+        Map<String, Object> b2 = new HashMap<>();
+        b2.put("title", "Foundation"); // lower case
+        b2.put("year", "1951");
+
+        Map<String, Object> shelf1 = new HashMap<>();
+        shelf1.put("book", b1);
+        Map<String, Object> shelf2 = new HashMap<>();
+        shelf2.put("book", b2);
+
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("shelves", Arrays.asList(shelf1, shelf2));
+
+        // filter should be case insensitive: drop any *.title anywhere
+        Map<String, Object> filtered = XContentMapValues.filter(doc, new String[0], new String[] { "*.title" }, false);
+
+        @SuppressWarnings("unchecked")
+        List<?> shelves = (List<?>) filtered.get("shelves");
+        assertThat(shelves, hasSize(2));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> outBook1 = (Map<String, Object>) ((Map<String, Object>) shelves.get(0)).get("book");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> outBook2 = (Map<String, Object>) ((Map<String, Object>) shelves.get(1)).get("book");
+
+        assertThat(outBook1, not(hasKey("TITLE")));
+        assertThat(outBook2, not(hasKey("title")));
+        assertThat(outBook1, hasKey("YEAR"));
+        assertThat(outBook2, hasKey("year"));
+    }
+
+    public void testCaseInsensitive_IncludeExcludePrecedence() {
+        Map<String, Object> book = new HashMap<>();
+        book.put("Title", "Dune");
+        book.put("Genre", "Sci-Fi");
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("book", book);
+
+        // filter should be case insensitive: includes book.*, but excludes book.title ⇒ exclude wins
+        Map<String, Object> filtered = XContentMapValues.filter(doc, new String[] { "book.*" }, new String[] { "book.title" }, false);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> outBook = (Map<String, Object>) filtered.get("book");
+        assertThat(filtered, hasKey("book"));
+        assertThat(outBook, hasKey("Genre"));
+        assertThat(outBook, not(hasKey("Title"))); // excluded despite include
+    }
+
+    public void testCaseInsensitive_MixedCaseInclude() {
+        Map<String, Object> obj = new HashMap<>();
+        obj.put("FieldOne", 1);
+        obj.put("fieldTwo", 2);
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("MyObj", obj);
+
+        // filter should be case insensitive: mixed-case include should match
+        Map<String, Object> filtered = XContentMapValues.filter(doc, new String[] { "myobj.fieldtwo" }, new String[0], false);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> outObj = (Map<String, Object>) filtered.get("MyObj");
+        assertThat(filtered, hasKey("MyObj"));
+        assertThat(outObj, not(hasKey("FieldOne")));
+        assertThat(outObj, hasKey("fieldTwo"));
     }
 
     private static Map<String, Object> toMap(Builder test, XContentType xContentType, boolean humanReadable) throws IOException {


### PR DESCRIPTION
(cherry picked from commit ab4bd6937c3866e8e9fedf88479485a2c6e47ca3)


### Description

Backport #19976 to 2.19.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
