### PR TITLE
AJ's Intrasegment Concurrent Search Experimenting 

### DIFF
--- a/distribution/src/config/opensearch.yml
+++ b/distribution/src/config/opensearch.yml
@@ -31,7 +31,7 @@
 # Path to directory where to store the data (separate multiple locations by comma):
 #
 #${path.data}
-path.data: aj/opensearch/opensearch-intrasegment-search-data
+path.data: ../../aj/opensearch/opensearch-intrasegment-search-data
 #
 # Path to log files:
 #

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -796,8 +796,10 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING, // deprecated
                 SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING,
                 SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_MODE,
-                SearchService.CONCURRENT_INTRA_SEGMENT_SEARCH_PARTITION_SIZE_SETTING,
-                SearchService.CLUSTER_INTRA_CONCURRENT_SEGMENT_SEARCH_MODE,
+                // Intra-segment search settings
+                SearchService.INTRA_SEGMENT_SEARCH_ENABLED,
+                SearchService.INTRA_SEGMENT_SEARCH_MIN_SEGMENT_SIZE,
+                SearchService.INTRA_SEGMENT_SEARCH_PARTITIONS_PER_SEGMENT,
 
                 RemoteStoreSettings.CLUSTER_REMOTE_INDEX_SEGMENT_METADATA_RETENTION_MAX_COUNT_SETTING,
                 RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING,

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -252,8 +252,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.INDEX_CONCURRENT_SEGMENT_SEARCH_SETTING, // deprecated
                 IndexSettings.INDEX_CONCURRENT_SEGMENT_SEARCH_MODE,
                 IndexSettings.INDEX_CONCURRENT_SEGMENT_SEARCH_MAX_SLICE_COUNT,
-                IndexSettings.INDEX_CONCURRENT_INTRA_SEGMENT_SEARCH_MODE,
-                IndexSettings.INDEX_CONCURRENT_INTRA_SEGMENT_PARTITION_SIZE,
                 IndexSettings.ALLOW_DERIVED_FIELDS,
 
                 // Settings for star tree index

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -75,11 +75,6 @@ import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_FIELD_NAME
 import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_NESTED_DOCS_LIMIT_SETTING;
 import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING;
 import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING;
-import static org.opensearch.search.SearchService.CONCURRENT_INTRA_SEGMENT_DEFAULT_PARTITION_SIZE_VALUE;
-import static org.opensearch.search.SearchService.CONCURRENT_INTRA_SEGMENT_MINIMUM_PARTITION_SIZE_VALUE;
-import static org.opensearch.search.SearchService.CONCURRENT_INTRA_SEGMENT_SEARCH_MODE_ALL;
-import static org.opensearch.search.SearchService.CONCURRENT_INTRA_SEGMENT_SEARCH_MODE_AUTO;
-import static org.opensearch.search.SearchService.CONCURRENT_INTRA_SEGMENT_SEARCH_MODE_NONE;
 import static org.opensearch.search.SearchService.CONCURRENT_SEGMENT_SEARCH_DEFAULT_SLICE_COUNT_VALUE;
 import static org.opensearch.search.SearchService.CONCURRENT_SEGMENT_SEARCH_MIN_SLICE_COUNT_VALUE;
 import static org.opensearch.search.SearchService.CONCURRENT_SEGMENT_SEARCH_MODE_ALL;
@@ -732,32 +727,6 @@ public final class IndexSettings {
                     throw new IllegalArgumentException("Setting value must be one of [all, none, auto]");
             }
         },
-        Property.Dynamic,
-        Property.IndexScope
-    );
-
-    public static final Setting<String> INDEX_CONCURRENT_INTRA_SEGMENT_SEARCH_MODE = Setting.simpleString(
-        "index.search.concurrent_intra_segment_search.mode",
-        CONCURRENT_INTRA_SEGMENT_SEARCH_MODE_NONE,
-        value -> {
-            switch (value) {
-                case CONCURRENT_INTRA_SEGMENT_SEARCH_MODE_ALL:
-                case CONCURRENT_INTRA_SEGMENT_SEARCH_MODE_NONE:
-                case CONCURRENT_INTRA_SEGMENT_SEARCH_MODE_AUTO:
-                    // valid setting
-                    break;
-                default:
-                    throw new IllegalArgumentException("Setting value must be one of [all, none, auto]");
-            }
-        },
-        Property.Dynamic,
-        Property.IndexScope
-    );
-
-    public static final Setting<Integer> INDEX_CONCURRENT_INTRA_SEGMENT_PARTITION_SIZE = Setting.intSetting(
-        "index.search.concurrent_intra_segment_search.partition_size",
-        CONCURRENT_INTRA_SEGMENT_DEFAULT_PARTITION_SIZE_VALUE,
-        CONCURRENT_INTRA_SEGMENT_MINIMUM_PARTITION_SIZE_VALUE,
         Property.Dynamic,
         Property.IndexScope
     );

--- a/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
@@ -579,11 +579,6 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public int getSegmentPartitionSize() {
-        return in.getSegmentPartitionSize();
-    }
-
-    @Override
     public boolean shouldUseTimeSeriesDescSortOptimization() {
         return in.shouldUseTimeSeriesDescSortOptimization();
     }
@@ -591,5 +586,20 @@ public abstract class FilteredSearchContext extends SearchContext {
     @Override
     public boolean getStarTreeIndexEnabled() {
         return in.getStarTreeIndexEnabled();
+    }
+
+    @Override
+    public boolean getIntraSegmentSearchEnabled() {
+        return in.getIntraSegmentSearchEnabled();
+    }
+
+    @Override
+    public int getIntraSegmentPartitionsPerSegment() {
+        return in.getIntraSegmentPartitionsPerSegment();
+    }
+
+    @Override
+    public int getIntraSegmentMinSegmentSize() {
+        return in.getIntraSegmentMinSegmentSize();
     }
 }

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -438,13 +438,6 @@ public abstract class SearchContext implements Releasable {
     }
 
     /**
-     * Returns intra segment concurrent search status for the search context
-     */
-    public boolean shouldUseIntraSegmentConcurrentSearch() {
-        return false;
-    }
-
-    /**
      * Returns local bucket count thresholds based on concurrent segment search status
      */
     public LocalBucketCountThresholds asLocalBucketCountThresholds(TermsAggregator.BucketCountThresholds bucketCountThresholds) {
@@ -528,10 +521,6 @@ public abstract class SearchContext implements Releasable {
 
     public abstract int getTargetMaxSliceCount();
 
-    public int getSegmentPartitionSize() {
-        return 2;
-    }
-
     @ExperimentalApi
     public long getStreamingMaxEstimatedBucketCount() {
         return 100_000L;
@@ -604,5 +593,11 @@ public abstract class SearchContext implements Releasable {
     public boolean setFlushModeIfAbsent(FlushMode flushMode) {
         return false;
     }
+
+    public abstract boolean getIntraSegmentSearchEnabled();
+
+    public abstract int getIntraSegmentPartitionsPerSegment();
+
+    public abstract int getIntraSegmentMinSegmentSize();
 
 }

--- a/server/src/main/java/org/opensearch/search/profile/query/QueryTimingType.java
+++ b/server/src/main/java/org/opensearch/search/profile/query/QueryTimingType.java
@@ -48,7 +48,8 @@ public enum QueryTimingType {
     SCORE,
     SHALLOW_ADVANCE,
     COMPUTE_MAX_SCORE,
-    SET_MIN_COMPETITIVE_SCORE;
+    SET_MIN_COMPETITIVE_SCORE,
+    SLICING;
 
     @Override
     public String toString() {


### PR DESCRIPTION
### Description
Following the implementations at #19704 and the work of @prudhvigodithi this PR is meant to share my experimentation with adding intra segment concurrent search and not meant for merging. This also added a profile field for timing slicing for comparing the overhead of slicing with the rest of the query. Additionally, there is logging to confirm that different slices are actually being executed in parallel.

### Related Issues
N/A

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
