### PR TITLE
Consume same writer generation count in merge and write

### DIFF
--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/engine/ParquetExecutionEngine.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/engine/ParquetExecutionEngine.java
@@ -73,7 +73,7 @@ public class ParquetExecutionEngine implements IndexingExecutionEngine<ParquetDa
 
     public static final String FILE_NAME_PREFIX = "_parquet_file_generation";
     private static final Pattern FILE_PATTERN = Pattern.compile(".*_(\\d+)\\.parquet$", Pattern.CASE_INSENSITIVE);
-    private static final String FILE_NAME_EXT = ".parquet";
+    public static final String FILE_NAME_EXT = ".parquet";
 
     private final Supplier<Schema> schema;
     private final List<WriterFileSet> filesWrittenAlready = new ArrayList<>();

--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/merge/ParquetMergeExecutor.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/merge/ParquetMergeExecutor.java
@@ -24,8 +24,8 @@ public class ParquetMergeExecutor extends ParquetMerger {
     }
 
     @Override
-    public MergeResult merge(Collection<FileMetadata> fileMetadataList) {
-        MergeResult result = strategy.mergeParquetFiles(fileMetadataList);
+    public MergeResult merge(Collection<FileMetadata> fileMetadataList, long writerGeneration) {
+        MergeResult result = strategy.mergeParquetFiles(fileMetadataList, writerGeneration);
         strategy.postMerge();
         return result;
     }

--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/merge/ParquetMergeStrategy.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/merge/ParquetMergeStrategy.java
@@ -21,7 +21,7 @@ public interface ParquetMergeStrategy {
     /**
      * Performs the actual Parquet merge.
      */
-    MergeResult mergeParquetFiles(Collection<FileMetadata> files);
+    MergeResult mergeParquetFiles(Collection<FileMetadata> files, long writerGeneration);
 
     /**
      * Optional post-merge hook.

--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/merge/ParquetMerger.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/merge/ParquetMerger.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 
 public abstract class ParquetMerger implements Merger {
     @Override
-    public MergeResult merge(Collection<FileMetadata> fileMetadataList, RowIdMapping rowIdMapping) {
+    public MergeResult merge(Collection<FileMetadata> fileMetadataList, RowIdMapping rowIdMapping, long writerGeneration) {
         throw new UnsupportedOperationException("Not supported parquet as secondary data format yet.");
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/exec/Merger.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/Merger.java
@@ -19,7 +19,7 @@ public interface Merger {
      * @param fileMetadataList List of FileMetadata to merge
      * @return MergeResult - having RowIdMapping and mergedFileMetadata
      */
-    MergeResult merge(Collection<FileMetadata> fileMetadataList);
+    MergeResult merge(Collection<FileMetadata> fileMetadataList, long writerGeneration);
 
     /**
      *
@@ -27,5 +27,5 @@ public interface Merger {
      * @param rowIdMapping Mapping of old segment + old rowId to new rowId
      * @return MergeResult - having mergedFileMetadata
      */
-    MergeResult merge(Collection<FileMetadata> fileMetadataList, RowIdMapping rowIdMapping);
+    MergeResult merge(Collection<FileMetadata> fileMetadataList, RowIdMapping rowIdMapping, long writerGeneration);
 }

--- a/server/src/main/java/org/opensearch/index/engine/exec/WriterFileSet.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/WriterFileSet.java
@@ -88,19 +88,10 @@ public class WriterFileSet implements Serializable, Writeable {
             '}';
     }
 
-    /**
-     * TODO:
-     *
-     *
-     * equals method was introduced as part of merge.
-     * From merge we dont have generation information hence for equals ignoring check for generation for now.
-     * We can revisit this later, as today ParquetExecutionEngine stores the WriterFileSet itself, it should hold the
-     * FileMetadata as merge might be acting at fileMetadata no writerSet.
-     */
     @Override
     public boolean equals(Object o) {
         WriterFileSet other = (WriterFileSet) o;
-        return this.directory.equals(other.directory) && this.files.equals(other.files);
+        return this.directory.equals(other.directory) && this.files.equals(other.files) && this.getWriterGeneration() == other.getWriterGeneration();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/engine/exec/text/TextEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/text/TextEngine.java
@@ -127,7 +127,7 @@ public class TextEngine implements IndexingExecutionEngine<TextDF> {
     public static class TextMerger implements Merger {
 
         @Override
-        public MergeResult merge(Collection<FileMetadata> fileMetadataList) {
+        public MergeResult merge(Collection<FileMetadata> fileMetadataList, long writerGeneration) {
             // Here we will implementation of logic for merging files and reassign the row-ids
             // and creating the mapping of the old segment+id to new row id.
             //
@@ -136,7 +136,7 @@ public class TextEngine implements IndexingExecutionEngine<TextDF> {
         }
 
         @Override
-        public MergeResult merge(Collection<FileMetadata> fileMetadataList, RowIdMapping rowIdMapping) {
+        public MergeResult merge(Collection<FileMetadata> fileMetadataList, RowIdMapping rowIdMapping, long writerGeneration) {
             // Here we will have implementation of the merge logic where we will have the mapping of the old row id to new id
             // and merging the files.
             //


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Consume same writer generation count in merge and write

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
