### PR TITLE
Forbid use of Thread.sleep in :server:internalClusterTest

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/precommit/ForbiddenApisPrecommitPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/precommit/ForbiddenApisPrecommitPlugin.java
@@ -136,6 +136,22 @@ public class ForbiddenApisPrecommitPlugin extends PrecommitPlugin {
                     return null;
                 }
             });
+            // Add a closure to allow projects to optionally call `forbidSleep()` which will add the signatures
+            // to forbid all usages of `Thread.sleep`
+            ext.set("forbidSleep", new Closure<Void>(t) {
+                @Override
+                public Void call(Object... unused) {
+                    final List<String> signatures = new ArrayList<>();
+                    signatures.addAll(t.getSignatures());
+                    signatures.add(
+                        "java.lang.Thread#sleep(**) @ Fixed sleeps lead to non-deterministic test failures."
+                            + " Poll for whatever condition you're waiting for."
+                            + " Use helpers like `assertBusy` or the awaitility lib."
+                    );
+                    t.setSignatures(signatures);
+                    return null;
+                }
+            });
             // Use of the deprecated security manager APIs are pervasive so set them to warn
             // globally for all projects. Replacements for (most of) these APIs are available
             // so usages can move to the non-deprecated variants to avoid the warnings.

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -169,6 +169,8 @@ tasks.named("testingConventions").configure {
     }
 }
 
+tasks.named('forbiddenApisInternalClusterTest').configure { forbidSleep() }
+
 // Set to current version by default
 def japicmpCompareTarget = System.getProperty("japicmp.compare.version")
 if (japicmpCompareTarget == null) { /* use latest released version */

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/RemoteCloneIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/create/RemoteCloneIndexIT.java
@@ -49,6 +49,7 @@ import org.opensearch.action.admin.indices.shrink.ResizeType;
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.unit.ByteSizeValue;
@@ -227,6 +228,7 @@ public class RemoteCloneIndexIT extends RemoteStoreBaseIntegTestCase {
         createRepository(repoName, rmd.type(), settings);
     }
 
+    @SuppressForbidden(reason = "Waiting longer than timeout")
     public void testCreateCloneIndexFailure() throws ExecutionException, InterruptedException {
         asyncUploadMockFsRepo = false;
         Version version = VersionUtils.randomIndexCompatibleVersion(random());

--- a/server/src/internalClusterTest/java/org/opensearch/action/ingest/AsyncIngestProcessorIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/ingest/AsyncIngestProcessorIT.java
@@ -136,13 +136,6 @@ public class AsyncIngestProcessorIT extends OpenSearchSingleNodeTestCase {
                     public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
                         threadPool.generic().execute(() -> {
                             String id = (String) ingestDocument.getSourceAndMetadata().get("_id");
-                            if (usually()) {
-                                try {
-                                    Thread.sleep(10);
-                                } catch (InterruptedException e) {
-                                    // ignore
-                                }
-                            }
                             ingestDocument.setFieldValue("foo", "bar-" + id);
                             handler.accept(ingestDocument, null);
                         });

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterInfoServiceIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/ClusterInfoServiceIT.java
@@ -44,6 +44,7 @@ import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
@@ -149,6 +150,7 @@ public class ClusterInfoServiceIT extends OpenSearchIntegTestCase {
         );
     }
 
+    @SuppressForbidden(reason = "Fixed sleeps are prone to flakiness but no documented failures here")
     public void testClusterInfoServiceCollectsInformation() throws InterruptedException {
         Settings.Builder settingsBuilder = Settings.builder()
             .put(ResourceTrackerSettings.GLOBAL_JVM_USAGE_AC_WINDOW_DURATION_SETTING.getKey(), TimeValue.timeValueSeconds(1))
@@ -250,6 +252,7 @@ public class ClusterInfoServiceIT extends OpenSearchIntegTestCase {
         }
     }
 
+    @SuppressForbidden(reason = "Fixed sleeps are prone to flakiness but no documented failures here")
     public void testClusterInfoServiceCollectsNodeResourceStatsInformation() throws InterruptedException {
 
         // setting time window as ResourceUsageTracker needs atleast both of these to be ready to start collecting the
@@ -279,6 +282,7 @@ public class ClusterInfoServiceIT extends OpenSearchIntegTestCase {
         assertEquals(2, nodeResourceUsageStats.size());
     }
 
+    @SuppressForbidden(reason = "Fixed sleeps are prone to flakiness but no documented failures here")
     public void testClusterInfoServiceInformationClearOnError() throws InterruptedException {
         internalCluster().startNodes(
             2,

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/NodeJoinLeftIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/NodeJoinLeftIT.java
@@ -40,6 +40,7 @@ import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.cluster.NodeConnectionsService;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.MockEngineFactoryPlugin;
 import org.opensearch.indices.recovery.RecoverySettings;
@@ -75,6 +76,7 @@ import static org.hamcrest.Matchers.is;
  https://github.com/opensearch-project/OpenSearch/pull/15521 for context
  */
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
+@SuppressForbidden(reason = "Pending fix: https://github.com/opensearch-project/OpenSearch/issues/18972")
 public class NodeJoinLeftIT extends OpenSearchIntegTestCase {
 
     private TestLogsAppender testLogsAppender;

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/coordination/RareClusterStateIT.java
@@ -53,6 +53,7 @@ import org.opensearch.cluster.routing.ShardRoutingState;
 import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -219,6 +220,7 @@ public class RareClusterStateIT extends OpenSearchIntegTestCase {
         assertHitCount(client().prepareSearch("test").get(), 0);
     }
 
+    @SuppressForbidden(reason = "Best effort sleep, not critical to test logic")
     public void testDelayedMappingPropagationOnPrimary() throws Exception {
         // Here we want to test that things go well if there is a first request
         // that adds mappings but before mappings are propagated to all nodes
@@ -309,6 +311,7 @@ public class RareClusterStateIT extends OpenSearchIntegTestCase {
         assertEquals(1, docIndexResponse.get(10, TimeUnit.SECONDS).getShardInfo().getTotal());
     }
 
+    @SuppressForbidden(reason = "Best effort sleep, not critical to test logic")
     public void testDelayedMappingPropagationOnReplica() throws Exception {
         // This is essentially the same thing as testDelayedMappingPropagationOnPrimary
         // but for replicas

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/WeightedRoutingIT.java
@@ -335,15 +335,14 @@ public class WeightedRoutingIT extends OpenSearchIntegTestCase {
         logger.info("--> network disruption is started");
         networkDisruption.startDisrupting();
 
-        // wait for leader checker to fail
-        Thread.sleep(13000);
-
         // get api to fetch local weighted routing for a node in zone a or b
-        ClusterGetWeightedRoutingResponse weightedRoutingResponse = internalCluster().client(
-            randomFrom(nodes_in_zone_a.get(0), nodes_in_zone_b.get(0))
-        ).admin().cluster().prepareGetWeightedRouting().setAwarenessAttribute("zone").setRequestLocal(true).get();
-        assertEquals(weightedRouting, weightedRoutingResponse.weights());
-        assertFalse(weightedRoutingResponse.getDiscoveredClusterManager());
+        assertBusy(() -> {
+            ClusterGetWeightedRoutingResponse weightedRoutingResponse = internalCluster().client(
+                randomFrom(nodes_in_zone_a.get(0), nodes_in_zone_b.get(0))
+            ).admin().cluster().prepareGetWeightedRouting().setAwarenessAttribute("zone").setRequestLocal(true).get();
+            assertEquals(weightedRouting, weightedRoutingResponse.weights());
+            assertFalse(weightedRoutingResponse.getDiscoveredClusterManager());
+        }, 13, TimeUnit.SECONDS);
         logger.info("--> network disruption is stopped");
         networkDisruption.stopDisrupting();
 

--- a/server/src/internalClusterTest/java/org/opensearch/gateway/RecoverAfterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/gateway/RecoverAfterNodesIT.java
@@ -34,6 +34,7 @@ package org.opensearch.gateway;
 
 import org.opensearch.cluster.block.ClusterBlock;
 import org.opensearch.cluster.block.ClusterBlockLevel;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -74,6 +75,7 @@ public class RecoverAfterNodesIT extends OpenSearchIntegTestCase {
         return internalCluster().client(name);
     }
 
+    @SuppressForbidden(reason = "Sleeping longer than timeout")
     public void testRecoverAfterNodes() throws Exception {
         internalCluster().setBootstrapClusterManagerNodeIndex(0);
         logger.info("--> start node (1)");

--- a/server/src/internalClusterTest/java/org/opensearch/index/ShardIndexingPressureSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/ShardIndexingPressureSettingsIT.java
@@ -19,6 +19,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.collect.Tuple;
@@ -45,6 +46,7 @@ import java.util.stream.Stream;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 2, numClientNodes = 1)
+@SuppressForbidden(reason = "Need to fix: https://github.com/opensearch-project/OpenSearch/issues/14331")
 public class ShardIndexingPressureSettingsIT extends OpenSearchIntegTestCase {
 
     public static final String INDEX_NAME = "test_index";

--- a/server/src/internalClusterTest/java/org/opensearch/index/autoforcemerge/AutoForceMergeManagerIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/autoforcemerge/AutoForceMergeManagerIT.java
@@ -11,6 +11,7 @@ package org.opensearch.index.autoforcemerge;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.unit.ByteSizeUnit;
@@ -60,6 +61,7 @@ public class AutoForceMergeManagerIT extends RemoteStoreBaseIntegTestCase {
             .build();
     }
 
+    @SuppressForbidden(reason = "Sleeping longer than scheduled interval")
     public void testAutoForceMergeFeatureFlagDisabled() throws InterruptedException, ExecutionException {
 
         Settings clusterSettings = Settings.builder()
@@ -102,6 +104,7 @@ public class AutoForceMergeManagerIT extends RemoteStoreBaseIntegTestCase {
         assertAcked(client().admin().indices().prepareDelete(INDEX_NAME_1).get());
     }
 
+    @SuppressForbidden(reason = "Sleeping longer than scheduled interval")
     public void testAutoForceMergeTriggeringWithOneShardOfNonWarmCandidate() throws Exception {
         Settings clusterSettings = Settings.builder()
             .put(super.nodeSettings(0))

--- a/server/src/internalClusterTest/java/org/opensearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/mapper/DynamicMappingIT.java
@@ -129,7 +129,6 @@ public class DynamicMappingIT extends OpenSearchIntegTestCase {
         if (error.get() != null) {
             throw error.get();
         }
-        Thread.sleep(2000);
         GetMappingsResponse mappings = client().admin().indices().prepareGetMappings("index").get();
         for (int i = 0; i < indexThreads.length; ++i) {
             assertMappingsHaveField(mappings, "index", "field" + i);

--- a/server/src/internalClusterTest/java/org/opensearch/index/seqno/RetentionLeaseIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/seqno/RetentionLeaseIT.java
@@ -37,6 +37,7 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.action.support.replication.ReplicationResponse;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -216,6 +217,7 @@ public class RetentionLeaseIT extends OpenSearchIntegTestCase {
         }
     }
 
+    @SuppressForbidden(reason = "Sleeping longer than lease duration")
     public void testRetentionLeasesSyncOnExpiration() throws Exception {
         final int numberOfReplicas = 2 - scaledRandomIntBetween(0, 2);
         internalCluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -54,6 +54,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.opensearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.unit.TimeValue;
@@ -838,6 +839,7 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
             protected Query doToQuery(QueryShardContext context) {
                 return new TermQuery(new Term("k", "hello")) {
                     @Override
+                    @SuppressForbidden(reason = "Waiting 10x the timeout")
                     public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
                         // Create the weight before sleeping. Otherwise, TermStates.build() (in the call to super.createWeight()) will
                         // sometimes throw an exception on timeout, rather than timing out gracefully.

--- a/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/recovery/IndexRecoveryIT.java
@@ -73,6 +73,7 @@ import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Priority;
 import org.opensearch.common.SetOnce;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -1268,6 +1269,7 @@ public class IndexRecoveryIT extends OpenSearchIntegTestCase {
         redMockTransportService.addSendBehavior(blueMockTransportService, new StubbableTransport.SendRequestBehavior() {
             private final AtomicInteger count = new AtomicInteger();
 
+            @SuppressForbidden(reason = "Simulating disconnect after sending request with a delay")
             @Override
             public void sendRequest(
                 Transport.Connection connection,

--- a/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/stats/IndexStatsIT.java
@@ -380,7 +380,6 @@ public class IndexStatsIT extends ParameterizedStaticSettingsOpenSearchIntegTest
         assertThat(indicesStats.getTotal().getQueryCache().getMemorySizeInBytes(), greaterThan(0L));
 
         client().admin().indices().prepareClearCache().execute().actionGet();
-        Thread.sleep(100); // Make sure the filter cache entries have been removed...
         assertBusy(() -> {
             NodesStatsResponse postClearNodesStats = client().admin()
                 .cluster()

--- a/server/src/internalClusterTest/java/org/opensearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/store/IndicesStoreIntegrationIT.java
@@ -80,7 +80,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.Thread.sleep;
 import static org.opensearch.test.NodeRoles.nonClusterManagerNode;
 import static org.opensearch.test.NodeRoles.nonDataNode;
 import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
@@ -166,7 +165,7 @@ public class IndicesStoreIntegrationIT extends ParameterizedStaticSettingsOpenSe
         if (randomBoolean()) { // sometimes add cluster-state delay to trigger observers in IndicesStore.ShardActiveRequestHandler
             BlockClusterStateProcessing disruption = relocateAndBlockCompletion(logger, "test", 0, node_1, node_3);
             // wait a little so that cluster state observer is registered
-            sleep(50);
+            Thread.yield();
             logger.info("--> stopping disruption");
             disruption.stopDisrupting();
         } else {

--- a/server/src/internalClusterTest/java/org/opensearch/recovery/FullRollingRestartIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/recovery/FullRollingRestartIT.java
@@ -46,6 +46,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.RecoverySource;
 import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.common.Priority;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.collect.MapBuilder;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -538,6 +539,7 @@ public class FullRollingRestartIT extends ParameterizedStaticSettingsOpenSearchI
         }
     }
 
+    @SuppressForbidden(reason = "Need to fix: https://github.com/opensearch-project/OpenSearch/issues/20064")
     public void testDerivedSourceWithConcurrentUpdatesRollingRestart() throws Exception {
         String mapping = """
             {

--- a/server/src/internalClusterTest/java/org/opensearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/recovery/RelocationIT.java
@@ -928,7 +928,7 @@ public class RelocationIT extends ParameterizedStaticSettingsOpenSearchIntegTest
                     long id = totalDocCount.incrementAndGet();
                     client().prepareIndex("test").setId(String.valueOf(id)).setSource("name", "test" + id, "value", id).get();
                     initialDocCountLatch.countDown();
-                    Thread.sleep(10); // Small delay to prevent overwhelming
+                    Thread.yield(); // Small delay to prevent overwhelming
                 } catch (Exception e) {
                     logger.error("Error in background indexing", e);
                 }
@@ -1029,7 +1029,7 @@ public class RelocationIT extends ParameterizedStaticSettingsOpenSearchIntegTest
                     .execute()
                     .actionGet();
                 updatedDocs.add(docId);
-                Thread.sleep(10);
+                Thread.yield();
             } catch (Exception e) {
                 logger.warn("Error while updating doc with id = {}", docId, e);
             }

--- a/server/src/internalClusterTest/java/org/opensearch/recovery/SimpleRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/recovery/SimpleRecoveryIT.java
@@ -110,7 +110,6 @@ public class SimpleRecoveryIT extends ParameterizedStaticSettingsOpenSearchInteg
 
         // now start another one so we move some primaries
         allowNodes("test", 3);
-        Thread.sleep(200);
         logger.info("Running Cluster Health");
         ensureGreen();
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemotePrimaryRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotemigration/RemotePrimaryRelocationIT.java
@@ -15,6 +15,7 @@ import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesRespo
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.opensearch.common.Priority;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.query.QueryBuilders;
@@ -138,6 +139,7 @@ public class RemotePrimaryRelocationIT extends MigrationBaseTestCase {
         );
     }
 
+    @SuppressForbidden(reason = "Waiting longer than timeout")
     public void testMixedModeRelocation_RemoteSeedingFail() throws Exception {
         String docRepNode = internalCluster().startNode();
         ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteRestoreSnapshotIT.java
@@ -26,6 +26,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.RecoverySource;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.Settings;
@@ -99,6 +100,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 @ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+@SuppressForbidden(reason = "Need to fix: https://github.com/opensearch-project/OpenSearch/issues/14324")
 public class RemoteRestoreSnapshotIT extends RemoteSnapshotIT {
 
     public RemoteRestoreSnapshotIT(Settings nodeSettings) {

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBackpressureAndResiliencyIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreBackpressureAndResiliencyIT.java
@@ -138,7 +138,6 @@ public class RemoteStoreBackpressureAndResiliencyIT extends AbstractRemoteStoreM
             client().prepareIndex(INDEX_NAME).setSource(source, MediaTypeRegistry.JSON).get();
             refresh(INDEX_NAME);
         }
-        Thread.sleep(250);
         client().prepareIndex(INDEX_NAME).setSource(source, MediaTypeRegistry.JSON).get();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreMetadataIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreMetadataIT.java
@@ -199,7 +199,6 @@ public class RemoteStoreMetadataIT extends RemoteStoreBaseIntegTestCase {
         for (int i = 0; i < refreshCount; i++) {
             indexDocs();
             client().admin().indices().prepareRefresh(INDEX_NAME).get();
-            Thread.sleep(100);
         }
 
         RemoteStoreMetadataResponse response = client().admin().cluster().prepareRemoteStoreMetadata(INDEX_NAME, null).get();

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreStatsIT.java
@@ -680,7 +680,7 @@ public class RemoteStoreStatsIT extends RemoteStoreBaseIntegTestCase {
         ensureGreen(INDEX_NAME);
         long currentTimeNs = System.nanoTime();
         while (currentTimeNs == System.nanoTime()) {
-            Thread.sleep(10);
+            Thread.yield();
         }
 
         for (int i = 0; i < numOfShards; i++) {

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchCancellationIT.java
@@ -47,6 +47,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchScrollAction;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -606,6 +607,7 @@ public class SearchCancellationIT extends ParameterizedStaticSettingsOpenSearchI
      * @param milliseconds The minimum time to sleep
      * @throws InterruptedException if interrupted during sleep
      */
+    @SuppressForbidden(reason = "Waiting longer than timeout")
     private static void sleepForAtLeast(long milliseconds) throws InterruptedException {
         Thread.sleep(milliseconds + 100L);
     }

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchTimeoutIT.java
@@ -36,6 +36,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.plugins.Plugin;
@@ -131,6 +132,7 @@ public class SearchTimeoutIT extends ParameterizedStaticSettingsOpenSearchIntegT
         static final String SCRIPT_NAME = "search_timeout";
 
         @Override
+        @SuppressForbidden(reason = "Simulating a slow task by sleeping")
         public Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
             return Collections.singletonMap(SCRIPT_NAME, params -> {
                 try {

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/bucket/TermsDocCountErrorIT.java
@@ -228,7 +228,7 @@ public class TermsDocCountErrorIT extends ParameterizedStaticSettingsOpenSearchI
         // correctly calculated for concurrent segment search at the slice level.
         // See https://github.com/opensearch-project/OpenSearch/issues/11680"
         forceMerge(1);
-        Thread.sleep(5000); // Sleep 5s to ensure force merge completes
+        refresh();
     }
 
     private void assertDocCountErrorWithinBounds(int size, SearchResponse accurateResponse, SearchResponse testResponse) {

--- a/server/src/internalClusterTest/java/org/opensearch/search/backpressure/SearchBackpressureIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/backpressure/SearchBackpressureIT.java
@@ -18,6 +18,7 @@ import org.opensearch.action.search.SearchShardTask;
 import org.opensearch.action.search.SearchTask;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -438,6 +439,7 @@ public class SearchBackpressureIT extends ParameterizedStaticSettingsOpenSearchI
             });
         }
 
+        @SuppressForbidden(reason = "Simulating a slow task by sleeping")
         private void doWork(TestRequest<Task> request) throws InterruptedException {
             switch (request.getType()) {
                 case HIGH_CPU:

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SimpleQueryStringIT.java
@@ -744,7 +744,7 @@ public class SimpleQueryStringIT extends ParameterizedStaticSettingsOpenSearchIn
             client().prepareSearch("testdynamic").setQuery(qb).get();
         });
 
-        assert (e.getDetailedMessage().contains("maxClauseCount is set to " + (CLUSTER_MAX_CLAUSE_COUNT - 1)));
+        assertThat(e.getDetailedMessage(), containsString("maxClauseCount is set to " + (CLUSTER_MAX_CLAUSE_COUNT - 1)));
 
         // increase clause count by 2
         assertAcked(
@@ -753,8 +753,6 @@ public class SimpleQueryStringIT extends ParameterizedStaticSettingsOpenSearchIn
                 .prepareUpdateSettings()
                 .setTransientSettings(Settings.builder().put(INDICES_MAX_CLAUSE_COUNT_SETTING.getKey(), CLUSTER_MAX_CLAUSE_COUNT + 2))
         );
-
-        Thread.sleep(1);
 
         SearchResponse response = client().prepareSearch("testdynamic").setQuery(qb).get();
         assertHitCount(response, 1);

--- a/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/sort/FieldSortIT.java
@@ -47,6 +47,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Numbers;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
@@ -1249,6 +1250,7 @@ public class FieldSortIT extends ParameterizedDynamicSettingsOpenSearchIntegTest
         assertThat(searchResponse.getHits().getAt(2).getId(), equalTo("3"));
     }
 
+    @SuppressForbidden(reason = "WTF?")
     public void testSortMissingStrings() throws IOException, InterruptedException {
         assertAcked(
             prepareCreate("test").setMapping(

--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -478,8 +478,6 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             .cluster()
             .prepareDeleteSnapshot("test-repo", "test-snap")
             .execute();
-        // Make sure that abort makes some progress
-        Thread.sleep(100);
         unblockNode("test-repo", blockedNode);
         logger.info("--> stopping node [{}]", blockedNode);
         stopNode(blockedNode);

--- a/server/src/internalClusterTest/java/org/opensearch/update/UpdateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/update/UpdateIT.java
@@ -44,6 +44,7 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateRequestBuilder;
 import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -739,6 +740,7 @@ public class UpdateIT extends OpenSearchIntegTestCase {
             }
 
             @Override
+            @SuppressForbidden(reason = "Sleeping in a loop")
             public void run() {
                 try {
                     startLatch.await();

--- a/server/src/internalClusterTest/java/org/opensearch/versioning/SimpleVersioningIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/versioning/SimpleVersioningIT.java
@@ -40,6 +40,7 @@ import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionResponse;
@@ -172,6 +173,7 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
         assertThat(deleteResponse.getVersion(), equalTo(18L));
     }
 
+    @SuppressForbidden(reason = "Fixed sleeps are prone to flakiness but no documented failures here")
     public void testExternalVersioning() throws Exception {
         createIndex("test");
         ensureGreen();
@@ -801,6 +803,7 @@ public class SimpleVersioningIT extends OpenSearchIntegTestCase {
         }
     }
 
+    @SuppressForbidden(reason = "Fixed sleeps are prone to flakiness but no documented failures here")
     public void testDeleteNotLost() throws Exception {
 
         // We require only one shard for this test, so that the 2nd delete provokes pruning the deletes map:


### PR DESCRIPTION
### Description
This commit introduces enforcement to cause any future usage of Thread.sleep within :server:internalClusterTest to fail by default. It can still be overridden when necessary by using `@SuppressForbidden`.

For the existing usages of Thread.sleep(), I have either annotated them with some sort of rationale, replaced them with a polling alternative, or just removed them all together. I ran `./gradlew :server:internalClusterTest` 100 times over the weekend, and while it failed nearly half the time, none of the tests modified here were implicated.

### Related Issues
Related to #20004

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
