### PR TITLE
Fix toBuilder method in EngineConfig to include mergedSegmentTransfer…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix ClassCastException in FlightClientChannel for requests larger than 16KB ([#20010](https://github.com/opensearch-project/OpenSearch/pull/20010))
 - Fix GRPC Bulk ([#19937](https://github.com/opensearch-project/OpenSearch/pull/19937))
 - Fix node bootstrap error when enable stream transport and remote cluster state ([#19948](https://github.com/opensearch-project/OpenSearch/pull/19948))
+- Fix toBuilder method in EngineConfig to include mergedSegmentTransferTracker([20105](https://github.com/opensearch-project/OpenSearch/pull/20105))
 
 ### Dependencies
 - Bump Apache Lucene from 10.3.1 to 10.3.2 ([#20026](https://github.com/opensearch-project/OpenSearch/pull/20026))

--- a/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/opensearch/index/engine/EngineConfig.java
@@ -354,7 +354,8 @@ public final class EngineConfig {
             .leafSorter(this.leafSorter)
             .documentMapperForTypeSupplier(this.documentMapperForTypeSupplier)
             .indexReaderWarmer(this.indexReaderWarmer)
-            .clusterApplierService(this.clusterApplierService);
+            .clusterApplierService(this.clusterApplierService)
+            .mergedSegmentTransferTracker(this.mergedSegmentTransferTracker);
     }
 
     /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Recently a [change](https://github.com/opensearch-project/OpenSearch/pull/18929) was introduced to Include `MergedSegmentTransferTracker` in EngineConfig, but the builder method was not updated, leading to consumers of builder method returning `null` when getMergedSegmentTransferTracker() is invoked. This is leading to `_cat/indices` api not able to fill details properly. 

Currently the builder method is used by `opensearch-storage-encryption` plugin. 

Error earlier in `_cat/indices` call - 
```
2025-11-26T09:05:39,618][DEBUG][o.o.a.a.i.s.TransportIndicesStatsAction][58cb8e866462db649c30b67b616dc2f5] #[java.lang.NullPointerException]#[indices:monitor/stats] failed to execute operation for shard [[enc][0], node[ggkokXB2TOewTaL-6gu37w], [P], s[STARTED], a[id=Z_jU9sA9RwSmskOJY4_aOA]]
java.lang.NullPointerException: Cannot invoke "org.opensearch.index.merge.MergedSegmentTransferTracker.stats()" because "this.mergedSegmentTransferTracker" is null
        at org.opensearch.index.engine.OpenSearchConcurrentMergeScheduler.stats(OpenSearchConcurrentMergeScheduler.java:220)
        at org.opensearch.index.engine.InternalEngine.getMergeStats(InternalEngine.java:2635)
        at org.opensearch.index.shard.IndexShard.mergeStats(IndexShard.java:1660)
        at org.opensearch.action.admin.indices.stats.CommonStats.<init>(CommonStats.java:209)        at org.opensearch.action.admin.indices.stats.TransportIndicesStatsAction.shardOperation(TransportIndicesStatsAction.java:141)        at org.opensearch.action.admin.indices.stats.TransportIndicesStatsAction.shardOperation(TransportIndicesStatsAction.java:67)        at org.opensearch.action.support.broadcast.node.TransportBroadcastByNodeAction$BroadcastByNodeTransportRequestHandler.onShardOperation(TransportBroadcastByNodeAction.java:504)        at org.opensearch.action.support.broadcast.node.TransportBroadcastByNodeAction$BroadcastByNodeTransportRequestHandler.messageReceived(TransportBroadcastByNodeAction.java:476)        at org.opensearch.action.support.broadcast.node.TransportBroadcastByNodeAction$BroadcastByNodeTransportRequestHandler.messageReceived(TransportBroadcastByNodeAction.java:463)        at com.amazonaws.elasticsearch.ccs.CrossClusterRequestInterceptor$CrossClusterRequestHandler.messageReceived(CrossClusterRequestInterceptor.java:155)
        at org.opensearch.indexmanagement.rollup.interceptor.RollupInterceptor$interceptHandler$1.messageReceived(RollupInterceptor.kt:118)
        at org.opensearch.performanceanalyzer.transport.PerformanceAnalyzerTransportRequestHandler.messageReceived(PerformanceAnalyzerTransportRequestHandler.java:44)
        at org.opensearch.performanceanalyzer.transport.RTFPerformanceAnalyzerTransportRequestHandler.messageReceived(RTFPerformanceAnalyzerTransportRequestHandler.java:92)
        at com.amazonaws.elasticsearch.iam.IamTransportRequestHandler.messageReceived(IamTransportRequestHandler.java:69)
        at org.opensearch.wlm.WorkloadManagementTransportInterceptor$RequestHandler.messageReceived(WorkloadManagementTransportInterceptor.java:63)
        at org.opensearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:108)
        at org.opensearch.transport.TransportService$7.doRun(TransportService.java:1140)
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:984)
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

Response  `_cat/indices`
```
% curl localhost:9200/_cat/indices?v
health status index                          uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   .plugins-ml-config             ZLIVDoVOSZmyf3AFz5ONOQ   1   0          1            0        4kb            4kb
green  open   .plugins-ml-jobs               zAzD0FCCRlGEvTorgIldiA   1   0          1            0     12.3kb         12.3kb
green  open   enc2                           aQVN34HfQBOE_0jBkchvOw   1   0
green  open   .opendistro-job-scheduler-lock RQf2uCR1Toa4DvdH_cosog   1   0          1            0       12kb           12kb
green  open   enc                            aRRST582RVOdcRbURp891A   1   0

```

After adding missing `MergedSegmentTransferTracker`, `_cat/indices` working as expected

```
% curl localhost:9200/_cat/indices?v
health status index                          uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   .plugins-ml-config             ZLIVDoVOSZmyf3AFz5ONOQ   1   0          1            0        4kb            4kb
green  open   .plugins-ml-jobs               zAzD0FCCRlGEvTorgIldiA   1   0          1            0     12.3kb         12.3kb
green  open   enc2                           aQVN34HfQBOE_0jBkchvOw   1   0          0            0       208b           208b
green  open   .opendistro-job-scheduler-lock RQf2uCR1Toa4DvdH_cosog   1   0          1            0      4.9kb          4.9kb
green  open   enc                            aRRST582RVOdcRbURp891A   1   0          0            0       208b           208b
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where engine configuration objects were not properly preserving all internal state when cloned, ensuring complete configuration transfers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->