### PR TITLE
Add sessionConfigOption in listingOptions to enable cache stat use

### DIFF
--- a/plugins/engine-datafusion/jni/src/query_executor.rs
+++ b/plugins/engine-datafusion/jni/src/query_executor.rs
@@ -88,7 +88,7 @@ pub async fn execute_query_with_cross_rt_stream(
     config.options_mut().execution.batch_size = 1024;
 
     let state = datafusion::execution::SessionStateBuilder::new()
-        .with_config(config)
+        .with_config(config.clone())
         .with_runtime_env(Arc::from(runtime_env))
         .with_default_features()
         //.with_physical_optimizer_rule(Arc::new(ProjectRowIdOptimizer)) // TODO : uncomment this after fix
@@ -102,6 +102,7 @@ pub async fn execute_query_with_cross_rt_stream(
     let listing_options = ListingOptions::new(Arc::new(file_format))
         .with_file_extension(".parquet")
         .with_files_metadata(files_meta)
+        .with_session_config_options(&config)
         .with_table_partition_cols(vec![("row_base".to_string(), DataType::Int64)]);
 
     let resolved_schema = match listing_options


### PR DESCRIPTION
The change enables listingTable to use the statistics cache and improves the below query in clickbench:

```
|                                       50th percentile latency |                  q01-count-all |     61.6266 |     37.1507 | -39.72% :green_circle: | -24.4759 |     ms |
|                                       90th percentile latency |                  q01-count-all |     66.7697 |     39.8231 | -40.36% :green_circle: | -26.9467 |     ms |
|                                      100th percentile latency |                  q01-count-all |     68.2335 |      40.866 | -40.11% :green_circle: | -27.3675 |     ms |
|                                  50th percentile service time |                  q01-count-all |     59.6996 |     35.0527 | -41.28% :green_circle: | -24.6469 |     ms |
|                                  90th percentile service time |                  q01-count-all |     64.9818 |     37.8915 | -41.69% :green_circle: | -27.0903 |     ms |
|                                 100th percentile service time |                  q01-count-all |     66.0713 |     39.3423 | -40.45% :green_circle: | -26.7291 |     ms |

```

```
|                                       50th percentile latency |          q07-min-max-eventdate |     173.704 |     29.7593 | -82.87% :green_circle: | -143.945 |     ms |
|                                       90th percentile latency |          q07-min-max-eventdate |     177.317 |     33.7337 | -80.98% :green_circle: | -143.584 |     ms |
|                                      100th percentile latency |          q07-min-max-eventdate |     177.476 |     33.9469 | -80.87% :green_circle: | -143.529 |     ms |
|                                  50th percentile service time |          q07-min-max-eventdate |     170.702 |     27.7311 | -83.75% :green_circle: | -142.971 |     ms |
|                                  90th percentile service time |          q07-min-max-eventdate |     174.836 |     31.7746 | -81.83% :green_circle: | -143.061 |     ms |
|                                 100th percentile service time |          q07-min-max-eventdate |      175.22 |     32.2741 | -81.58% :green_circle: | -142.946 |     ms |
|
```



<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
