### PR TITLE
Replace usages of java.security.AccessController in modules/

### DIFF
--- a/modules/lang-mustache/src/main/java/org/opensearch/script/mustache/MustacheScriptEngine.java
+++ b/modules/lang-mustache/src/main/java/org/opensearch/script/mustache/MustacheScriptEngine.java
@@ -46,12 +46,11 @@ import org.opensearch.script.ScriptContext;
 import org.opensearch.script.ScriptEngine;
 import org.opensearch.script.ScriptException;
 import org.opensearch.script.TemplateScript;
+import org.opensearch.secure_sm.AccessController;
 
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -128,17 +127,13 @@ public final class MustacheScriptEngine implements ScriptEngine {
             this.params = params;
         }
 
-        @SuppressWarnings("removal")
         @Override
         public String execute() {
             final StringWriter writer = new StringWriter();
             try {
                 // crazy reflection here
                 SpecialPermission.check();
-                AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    template.execute(writer, params);
-                    return null;
-                });
+                AccessController.doPrivileged(() -> template.execute(writer, params));
             } catch (Exception e) {
                 logger.error((Supplier<?>) () -> new ParameterizedMessage("Error running {}", template), e);
                 throw new GeneralScriptException("Error running " + template, e);

--- a/modules/lang-painless/spi/src/main/java/org/opensearch/painless/spi/AllowlistLoader.java
+++ b/modules/lang-painless/spi/src/main/java/org/opensearch/painless/spi/AllowlistLoader.java
@@ -33,6 +33,7 @@
 package org.opensearch.painless.spi;
 
 import org.opensearch.painless.spi.annotation.AllowlistAnnotationParser;
+import org.opensearch.secure_sm.AccessController;
 
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
@@ -40,8 +41,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -513,8 +512,7 @@ public final class AllowlistLoader {
             }
         }
 
-        @SuppressWarnings("removal")
-        ClassLoader loader = AccessController.doPrivileged((PrivilegedAction<ClassLoader>) resource::getClassLoader);
+        ClassLoader loader = AccessController.doPrivileged(resource::getClassLoader);
 
         return new Allowlist(loader, allowlistClasses, allowlistStatics, allowlistClassBindings, Collections.emptyList());
     }

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/LambdaBootstrap.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/LambdaBootstrap.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.painless;
 
+import org.opensearch.secure_sm.AccessController;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Handle;
@@ -45,8 +46,6 @@ import java.lang.invoke.LambdaConversionException;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import static java.lang.invoke.MethodHandles.Lookup;
 import static org.opensearch.painless.WriterConstants.CLASS_VERSION;
@@ -501,15 +500,12 @@ public final class LambdaBootstrap {
      * Defines the {@link Class} for the lambda class using the same {@link Compiler.Loader}
      * that originally defined the class for the Painless script.
      */
-    @SuppressWarnings("removal")
     private static Class<?> createLambdaClass(Compiler.Loader loader, ClassWriter cw, Type lambdaClassType) {
 
         byte[] classBytes = cw.toByteArray();
         // DEBUG:
         // new ClassReader(classBytes).accept(new TraceClassVisitor(new PrintWriter(System.out)), ClassReader.SKIP_DEBUG);
-        return AccessController.doPrivileged(
-            (PrivilegedAction<Class<?>>) () -> loader.defineLambda(lambdaClassType.getClassName(), classBytes)
-        );
+        return AccessController.doPrivileged(() -> loader.defineLambda(lambdaClassType.getClassName(), classBytes));
     }
 
     /**

--- a/modules/lang-painless/src/main/java/org/opensearch/painless/lookup/PainlessLookupBuilder.java
+++ b/modules/lang-painless/src/main/java/org/opensearch/painless/lookup/PainlessLookupBuilder.java
@@ -45,6 +45,7 @@ import org.opensearch.painless.spi.AllowlistInstanceBinding;
 import org.opensearch.painless.spi.AllowlistMethod;
 import org.opensearch.painless.spi.annotation.InjectConstantAnnotation;
 import org.opensearch.painless.spi.annotation.NoImportAnnotation;
+import org.opensearch.secure_sm.AccessController;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.commons.GeneratorAdapter;
@@ -58,9 +59,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.security.AccessController;
 import java.security.CodeSource;
-import java.security.PrivilegedAction;
 import java.security.SecureClassLoader;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
@@ -2189,13 +2188,9 @@ public final class PainlessLookupBuilder {
             bridgeClassWriter.visitEnd();
 
             try {
-                @SuppressWarnings("removal")
-                BridgeLoader bridgeLoader = AccessController.doPrivileged(new PrivilegedAction<BridgeLoader>() {
-                    @Override
-                    public BridgeLoader run() {
-                        return new BridgeLoader(javaMethod.getDeclaringClass().getClassLoader());
-                    }
-                });
+                BridgeLoader bridgeLoader = AccessController.doPrivileged(
+                    () -> new BridgeLoader(javaMethod.getDeclaringClass().getClassLoader())
+                );
 
                 Class<?> bridgeClass = bridgeLoader.defineBridge(bridgeClassName.replace('/', '.'), bridgeClassWriter.toByteArray());
                 Method bridgeMethod = bridgeClass.getMethod(

--- a/modules/lang-painless/src/test/java/org/opensearch/painless/DocFieldsPhaseTests.java
+++ b/modules/lang-painless/src/test/java/org/opensearch/painless/DocFieldsPhaseTests.java
@@ -32,15 +32,13 @@
 
 package org.opensearch.painless;
 
-import org.opensearch.painless.Compiler.Loader;
 import org.opensearch.painless.lookup.PainlessLookup;
 import org.opensearch.painless.lookup.PainlessLookupBuilder;
 import org.opensearch.painless.spi.Allowlist;
 import org.opensearch.painless.symbol.ScriptScope;
 import org.opensearch.script.ScriptContext;
+import org.opensearch.secure_sm.AccessController;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +46,6 @@ import java.util.Map;
 public class DocFieldsPhaseTests extends ScriptTestCase {
     PainlessLookup lookup = PainlessLookupBuilder.buildFromAllowlists(Allowlist.BASE_ALLOWLISTS);
 
-    @SuppressWarnings("removal")
     ScriptScope compile(String script) {
         Compiler compiler = new Compiler(
             MockDocTestScript.CONTEXT.instanceClazz,
@@ -58,12 +55,7 @@ public class DocFieldsPhaseTests extends ScriptTestCase {
         );
 
         // Create our loader (which loads compiled code with no permissions).
-        final Compiler.Loader loader = AccessController.doPrivileged(new PrivilegedAction<Loader>() {
-            @Override
-            public Compiler.Loader run() {
-                return compiler.createLoader(getClass().getClassLoader());
-            }
-        });
+        final Compiler.Loader loader = AccessController.doPrivileged(() -> compiler.createLoader(getClass().getClassLoader()));
 
         return compiler.compile(loader, "test", script, new CompilerSettings());
     }

--- a/modules/repository-url/src/main/java/org/opensearch/common/blobstore/url/URLBlobContainer.java
+++ b/modules/repository-url/src/main/java/org/opensearch/common/blobstore/url/URLBlobContainer.java
@@ -38,6 +38,7 @@ import org.opensearch.common.blobstore.BlobMetadata;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.blobstore.DeleteResult;
 import org.opensearch.common.blobstore.support.AbstractBlobContainer;
+import org.opensearch.secure_sm.AccessController;
 
 import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
@@ -46,9 +47,6 @@ import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.NoSuchFileException;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.List;
 import java.util.Map;
 
@@ -160,14 +158,9 @@ public class URLBlobContainer extends AbstractBlobContainer {
         throw new UnsupportedOperationException("URL repository doesn't support this operation");
     }
 
-    @SuppressWarnings("removal")
     @SuppressForbidden(reason = "We call connect in doPrivileged and provide SocketPermission")
     private static InputStream getInputStream(URL url) throws IOException {
-        try {
-            return AccessController.doPrivileged((PrivilegedExceptionAction<InputStream>) url::openStream);
-        } catch (PrivilegedActionException e) {
-            throw (IOException) e.getCause();
-        }
+        return AccessController.doPrivilegedChecked(url::openStream);
     }
 
 }

--- a/modules/systemd/src/main/java/org/opensearch/systemd/Libsystemd.java
+++ b/modules/systemd/src/main/java/org/opensearch/systemd/Libsystemd.java
@@ -34,20 +34,15 @@ package org.opensearch.systemd;
 
 import com.sun.jna.Native;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
+import org.opensearch.secure_sm.AccessController;
 
 /**
  * Provides access to the native method sd_notify from libsystemd.
  */
-@SuppressWarnings("removal")
 class Libsystemd {
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
-            Native.register(Libsystemd.class, "libsystemd.so.0");
-            return null;
-        });
+        AccessController.doPrivileged(() -> Native.register(Libsystemd.class, "libsystemd.so.0"));
     }
 
     /**

--- a/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/ssl/SecureNetty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/transport/netty4/ssl/SecureNetty4Transport.java
@@ -43,6 +43,7 @@ import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.indices.breaker.CircuitBreakerService;
 import org.opensearch.plugins.SecureTransportSettingsProvider;
 import org.opensearch.plugins.TransportExceptionHandler;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.SharedGroupFactory;
@@ -55,8 +56,6 @@ import javax.net.ssl.SSLException;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
@@ -256,7 +255,6 @@ public class SecureNetty4Transport extends Netty4Transport {
         private final DiscoveryNode node;
         private SSLConnectionTestResult connectionTestResult;
 
-        @SuppressWarnings("removal")
         public SSLClientChannelInitializer(DiscoveryNode node) {
             this.node = node;
 
@@ -272,9 +270,7 @@ public class SecureNetty4Transport extends Netty4Transport {
                     node.getAddress().getAddress(),
                     node.getAddress().getPort()
                 );
-                connectionTestResult = AccessController.doPrivileged(
-                    (PrivilegedAction<SSLConnectionTestResult>) sslConnectionTestUtil::testConnection
-                );
+                connectionTestResult = AccessController.doPrivileged(sslConnectionTestUtil::testConnection);
             }
         }
 


### PR DESCRIPTION
### Description

This PR replaces usages of `java.security.AccessController` in the modules/ dir

### Related Issues

Related to https://github.com/opensearch-project/OpenSearch/issues/18339

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified security execution patterns and modernized code constructs across multiple modules for improved maintainability and consistency.

* **Chores**
  * Removed deprecated language patterns and cleaned up legacy code structures to align with current development standards and best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->