### PR TITLE
Remove dead code related to java compatibility now that Java min version is 21

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchJavaPlugin.java
@@ -174,10 +174,7 @@ public class OpenSearchJavaPlugin implements Plugin<Project> {
                 // workaround for https://github.com/gradle/gradle/issues/14141
                 compileTask.getConventionMapping().map("sourceCompatibility", () -> java.getSourceCompatibility().toString());
                 compileTask.getConventionMapping().map("targetCompatibility", () -> java.getTargetCompatibility().toString());
-                // The '--release is available from JDK-9 and above
-                if (BuildParams.getRuntimeJavaVersion().compareTo(JavaVersion.VERSION_1_8) > 0) {
-                    compileOptions.getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
-                }
+                compileOptions.getRelease().set(releaseVersionProviderFromCompileTask(project, compileTask));
             });
             // also apply release flag to groovy, which is used in build-tools
             project.getTasks().withType(GroovyCompile.class).configureEach(compileTask -> {
@@ -271,9 +268,7 @@ public class OpenSearchJavaPlugin implements Plugin<Project> {
              * that the default will change to html5 in the future.
              */
             CoreJavadocOptions javadocOptions = (CoreJavadocOptions) javadoc.getOptions();
-            if (BuildParams.getRuntimeJavaVersion().compareTo(JavaVersion.VERSION_1_8) > 0) {
-                javadocOptions.addBooleanOption("html5", true);
-            }
+            javadocOptions.addBooleanOption("html5", true);
         });
 
         TaskProvider<Javadoc> javadoc = project.getTasks().withType(Javadoc.class).named("javadoc");

--- a/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchTestBasePlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchTestBasePlugin.java
@@ -40,7 +40,6 @@ import org.opensearch.gradle.jvm.JvmTestSuiteHelper;
 import org.opensearch.gradle.test.ErrorReportingTestListener;
 import org.opensearch.gradle.util.Util;
 import org.gradle.api.Action;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -106,15 +105,7 @@ public class OpenSearchTestBasePlugin implements Plugin<Project> {
                     mkdirs(test.getWorkingDir());
                     mkdirs(test.getWorkingDir().toPath().resolve("temp").toFile());
 
-                    // TODO remove once jvm.options are added to test system properties
-                    if (BuildParams.getRuntimeJavaVersion() == JavaVersion.VERSION_1_8) {
-                        test.systemProperty("java.locale.providers", "SPI,JRE");
-                    } else {
-                        test.systemProperty("java.locale.providers", "SPI,CLDR");
-                        if (test.getJavaVersion().compareTo(JavaVersion.VERSION_17) < 0) {
-                            test.jvmArgs("--illegal-access=warn");
-                        }
-                    }
+                    test.systemProperty("java.locale.providers", "SPI,CLDR");
                 }
             });
             test.getJvmArgumentProviders().add(nonInputProperties);


### PR DESCRIPTION
### Description

Remove dead code related to java compatibility now that Java min version is 21

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build consistency by unconditionally applying Java release flags to compilation tasks.
  * Extended release flag application to Groovy compilation for consistency.
  * Simplified test configuration by standardizing locale provider settings across all Java versions.
  * Enhanced Javadoc generation with HTML5 enablement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->