### PR TITLE
Adding ability to prefetch docs in fetch phase

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -297,6 +297,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.INDEX_DERIVED_SOURCE_SETTING,
                 IndexSettings.INDEX_DERIVED_SOURCE_TRANSLOG_ENABLED_SETTING,
 
+                IndexSettings.PREFETCH_DOCS_DURING_FETCH_ENABLED,
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {
                     Map<String, Settings> groups = s.getAsGroups();

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -866,6 +866,13 @@ public final class IndexSettings {
         Property.Dynamic
     );
 
+    public static final Setting<Boolean> PREFETCH_DOCS_DURING_FETCH_ENABLED = Setting.boolSetting(
+            "index.prefetch_docs.fetch_phase.enabled",
+            true,
+            Property.IndexScope,
+            Property.Dynamic
+    );
+
     private final Index index;
     private final Version version;
     private final Logger logger;
@@ -1013,6 +1020,11 @@ public final class IndexSettings {
      * Denotes whether search via star tree index is enabled for this index
      */
     private volatile boolean isStarTreeIndexEnabled;
+
+    /**
+     * Denotes whether prefetch of docs during fetch phase is enabled for this index
+     */
+    private volatile boolean prefetchDocsEnabled;
 
     /**
      * Returns the default search fields for this index.
@@ -1185,6 +1197,8 @@ public final class IndexSettings {
             TieredMergePolicyProvider.INDEX_COMPOUND_FORMAT_SETTING,
             tieredMergePolicyProvider::setNoCFSRatio
         );
+        prefetchDocsEnabled = scopedSettings.get(PREFETCH_DOCS_DURING_FETCH_ENABLED);
+        scopedSettings.addSettingsUpdateConsumer(PREFETCH_DOCS_DURING_FETCH_ENABLED, this::setPrefetchDocsEnabled);
         scopedSettings.addSettingsUpdateConsumer(
             TieredMergePolicyProvider.INDEX_MERGE_POLICY_DELETES_PCT_ALLOWED_SETTING,
             tieredMergePolicyProvider::setDeletesPctAllowed
@@ -2279,5 +2293,13 @@ public final class IndexSettings {
 
     public boolean isDerivedSourceEnabled() {
         return derivedSourceEnabled;
+    }
+
+    public boolean isPrefetchDocsEnabled() {
+        return this.prefetchDocsEnabled;
+    }
+
+    private void setPrefetchDocsEnabled(boolean prefetchDocsEnabled) {
+        this.prefetchDocsEnabled = prefetchDocsEnabled;
     }
 }

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -222,6 +222,7 @@ final class DefaultSearchContext extends SearchContext {
     private final int cardinalityAggregationPruningThreshold;
     private final int bucketSelectionStrategyFactor;
     private final boolean keywordIndexOrDocValuesEnabled;
+    private final boolean prefetchDocsForFetchPhaseEnabled;
 
     private boolean isStreamSearch;
     private StreamSearchChannelListener listener;
@@ -291,6 +292,7 @@ final class DefaultSearchContext extends SearchContext {
         this.concurrentSearchDeciderFactories = concurrentSearchDeciderFactories;
         this.keywordIndexOrDocValuesEnabled = evaluateKeywordIndexOrDocValuesEnabled();
         this.isStreamSearch = isStreamSearch;
+        this.prefetchDocsForFetchPhaseEnabled = this.indexService.getIndexSettings().isPrefetchDocsEnabled();
     }
 
     DefaultSearchContext(
@@ -765,6 +767,11 @@ final class DefaultSearchContext extends SearchContext {
     public SearchContext collapse(CollapseContext collapse) {
         this.collapse = collapse;
         return this;
+    }
+
+    @Override
+    public boolean isPrefetchDocsEnabled() {
+        return prefetchDocsForFetchPhaseEnabled;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -594,4 +594,12 @@ public abstract class SearchContext implements Releasable {
         return false;
     }
 
+    /**
+     * Returns whether document prefetching is enabled during the fetch phase.
+     * Subclasses should override this method to respect the index-level setting.
+     * @return false by default; subclasses may return a value based on index settings
+     */
+    public boolean isPrefetchDocsEnabled() {
+        return false;
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adding ability to prefetch docs in fetch phase

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/18780

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

Performance result for 

| Size | With Prefetch P50 (ms) | Without Prefetch P50 (ms) | With Prefetch P90 (ms) | Without Prefetch P90 (ms) | With Prefetch P100 (ms) | Without Prefetch P100 (ms) |
|------|------------------------|---------------------------|-------------------------|---------------------------|-------------------------|----------------------------|
| Default | 450.869 | 482.155 | 502.351 | 493.867 | 513.384 | 499.374 |
| 100 | 505.812 | 652.855 | 530.202 | 727.217 | 563.502 | 743.535 |
| 1000 | 1914.27 | 4127.89 | 1966.09 | 4298.37 | 1972.7 | 4676.91 |

Fetch Phase Cost (Arthas) for size as 10:
| Configuration | P50 (ms) | P90 (ms) | P99 (ms) | P100 (ms) |
|---------------|----------|----------|----------|-----------|
| With Prefetch | 14.703235 | 22.755569 | 94.606265 | 106.321523 |
| Without Prefetch | 29.532539 | 36.979982 | 98.615315 | 112.293080 |

For different queries,
| Query | With Prefetch P50 (ms) | Without Prefetch P50 (ms) | With Prefetch P90 (ms) | Without Prefetch P90 (ms) | With Prefetch P100 (ms) | Without Prefetch P100 (ms) |
|-------|------------------------|---------------------------|-------------------------|---------------------------|-------------------------|----------------------------|
| term | 468.926 | 474.929 | 476.166 | 525.064 | 511.542 | 677.766 |
| asc_sort_timestamp | 590.812 | 603.017 | 612.373 | 659.616 | 623.102 | 717.948 |
| desc_sort_timestamp | 578.757 | 643.036 | 592.766 | 701.633 | 605.739 | 747.248 |

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document prefetching added to the search fetch phase to improve fetch performance.
  * New dynamic index-level setting to enable/disable prefetching (enabled by default); can be updated at runtime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->