### PR TITLE
Introduce primaryTerm and inSynAllocationIds in IndexRoutingTable

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/RoutingTableIncrementalDiff.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RoutingTableIncrementalDiff.java
@@ -99,6 +99,7 @@ public class RoutingTableIncrementalDiff implements Diff<RoutingTable>, StringKe
 
         private final Index index;
 
+        // TODO: Add primary term and in-sync allocation ids to remote diff
         public IndexRoutingTableIncrementalDiff(Index index, IndexRoutingTable before, IndexRoutingTable after) {
             this.index = index;
             this.indexShardRoutingTables = DiffableUtils.diff(before.getShards(), after.getShards(), DiffableUtils.getIntKeySerializer());
@@ -114,6 +115,7 @@ public class RoutingTableIncrementalDiff implements Diff<RoutingTable>, StringKe
 
         @Override
         public IndexRoutingTable apply(IndexRoutingTable part) {
+            // TODO: fix this for remote publication
             return new IndexRoutingTable(index, indexShardRoutingTables.apply(part.getShards()));
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
First PR for https://github.com/opensearch-project/OpenSearch/issues/20062: Introduce primaryTerms and inSyncAllocationIds fields in IndexRoutingTable  to make IndexRoutingTable the source of truth for these fields instead of IndexMetadata.

Changes
- Added primaryTerms and inSyncAllocationIds fields
- Added getters, builder methods, serialization (version-gated with Version.V_3_4_0), validation, equals/hashCode/toString
- Validation is lenient (only validates if fields are populated)

**Not Included**
- Remote publication cluster diff serialization changes.
- Fields remain unpopulated (null/empty by default). Future PR will populate these fields from IndexMetadata and migrate read locations to use IndexRoutingTable as the source of truth.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [Y] Functionality includes testing - Existing test suite.
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~~
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cluster routing now tracks and exposes primary terms and in-sync allocation IDs to improve shard-state visibility and management.
  * Validation and serialization updated for compatibility with version 3.4.0 and later, and diagnostic output now includes the new routing metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->