### PR TITLE
Fix AsyncRecordBatchIterator whenComplete

### DIFF
--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/search/AsyncRecordBatchIterator.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/search/AsyncRecordBatchIterator.java
@@ -32,8 +32,9 @@ public class AsyncRecordBatchIterator {
             return;
         }
 
-        stream.loadNextBatch().whenComplete((result, throwable) -> {
+        stream.loadNextBatch().whenCompleteAsync((result, throwable) -> {
             if (throwable != null) {
+                hasNext = false;
                 listener.onFailure(new RuntimeException("Failed to load next batch", throwable));
             } else {
                 hasNext = result;


### PR DESCRIPTION
Currently when we are calling the whenComplete, the context doesn't change and we are recursively going over the same function in the same thread which is causing the thread to panic and fail. The PR makes it to whenCompleteAsync which makes the action async.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
