### PR TITLE
Modifying VSRPoolTests to use inbuilt createTempDir and removing arrow.memory.debug.allocator option from jvm.options

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -97,9 +97,6 @@ ${error.file}
 # Allow jcmd to attach to the process (required for 'jcmd VM.native_memory' commands)
 -XX:+UnlockDiagnosticVMOptions
 
-# Enabling debug logs for Allocators in Arrow
--Darrow.memory.debug.allocator=true
-
 # For cases with high memory-mapped file counts, a lower value can improve stability and
 # prevent issues like "leaked" maps or performance degradation. A value of 1 effectively
 # disables the shared Arena pooling and uses a confined Arena for each MMapDirectory

--- a/modules/parquet-data-format/src/test/java/com/parquet/parquetdataformat/vsr/VSRManagerTests.java
+++ b/modules/parquet-data-format/src/test/java/com/parquet/parquetdataformat/vsr/VSRManagerTests.java
@@ -57,7 +57,7 @@ public class VSRManagerTests extends OpenSearchTestCase {
         Field nameField = new Field("name", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
         testSchema = new Schema(Arrays.asList(idField, nameField));
 
-        testFileName = "test-file-" + System.currentTimeMillis() + ".parquet";
+        testFileName = createTempDir().resolve("test-file-" + System.currentTimeMillis() + ".parquet").toString();
     }
 
     @Override


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
