### PR TITLE
Add resiliency and failure handling for Parquet merge

### DIFF
--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/merge/ParquetMergeExecutor.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/merge/ParquetMergeExecutor.java
@@ -8,10 +8,8 @@
 
 package com.parquet.parquetdataformat.merge;
 
-import org.opensearch.index.engine.exec.FileMetadata;
 import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.merge.MergeResult;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -27,8 +25,6 @@ public class ParquetMergeExecutor extends ParquetMerger {
 
     @Override
     public MergeResult merge(List<WriterFileSet> fileMetadataList, long writerGeneration) {
-        MergeResult result = strategy.mergeParquetFiles(fileMetadataList, writerGeneration);
-        strategy.postMerge();
-        return result;
+        return strategy.mergeParquetFiles(fileMetadataList, writerGeneration);
     }
 }

--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/merge/ParquetMergeStrategy.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/merge/ParquetMergeStrategy.java
@@ -8,12 +8,8 @@
 
 package com.parquet.parquetdataformat.merge;
 
-
-import org.opensearch.index.engine.exec.FileMetadata;
 import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.merge.MergeResult;
-
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -26,10 +22,4 @@ public interface ParquetMergeStrategy {
      */
     MergeResult mergeParquetFiles(List<WriterFileSet> files, long writerGeneration);
 
-    /**
-     * Optional post-merge hook.
-     */
-    default void postMerge() {
-        // No-op by default
-    }
 }

--- a/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/merge/RecordBatchMergeStrategy.java
+++ b/modules/parquet-data-format/src/main/java/com/parquet/parquetdataformat/merge/RecordBatchMergeStrategy.java
@@ -10,12 +10,16 @@ package com.parquet.parquetdataformat.merge;
 
 import com.parquet.parquetdataformat.engine.ParquetDataFormat;
 import com.parquet.parquetdataformat.engine.ParquetExecutionEngine;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.index.engine.exec.DataFormat;
 import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.merge.MergeResult;
 import org.opensearch.index.engine.exec.merge.RowId;
 import org.opensearch.index.engine.exec.merge.RowIdMapping;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,6 +33,9 @@ import static com.parquet.parquetdataformat.bridge.RustBridge.mergeParquetFilesI
  * Implements record-batch-based merging of Parquet files.
  */
 public class RecordBatchMergeStrategy implements ParquetMergeStrategy {
+
+    private static final Logger logger =
+        LogManager.getLogger(RecordBatchMergeStrategy.class);
 
     @Override
     public MergeResult mergeParquetFiles(List<WriterFileSet> files, long writerGeneration) {
@@ -45,27 +52,51 @@ public class RecordBatchMergeStrategy implements ParquetMergeStrategy {
         String mergedFilePath = getMergedFilePath(writerGeneration, outputDirectory);
         String mergedFileName = getMergedFileName(writerGeneration);
 
-        // Merge files in Rust
-        mergeParquetFilesInRust(filePaths, mergedFilePath);
+        try {
+            // Merge files in Rust
+            mergeParquetFilesInRust(filePaths, mergedFilePath);
 
-        // Build row ID mapping
-        Map<RowId, Long> rowIdMapping = new HashMap<>();
+            // Build row ID mapping
+            Map<RowId, Long> rowIdMapping = new HashMap<>();
 
-        WriterFileSet mergedWriterFileSet =
+            WriterFileSet mergedWriterFileSet =
             WriterFileSet.builder().directory(Path.of(outputDirectory)).addFile(mergedFileName).writerGeneration(writerGeneration).build();
 
+            Map<DataFormat, WriterFileSet> mergedWriterFileSetMap = Collections.singletonMap(
+                new ParquetDataFormat(),
+                mergedWriterFileSet
+            );
 
-        Map<DataFormat, WriterFileSet> mergedWriterFileSetMap = Collections.singletonMap(
-            new ParquetDataFormat(),
-            mergedWriterFileSet
-        );
+            return new MergeResult(new RowIdMapping(rowIdMapping, mergedFileName), mergedWriterFileSetMap);
 
-        return new MergeResult(new RowIdMapping(rowIdMapping, mergedFileName), mergedWriterFileSetMap);
+        } catch (Exception exception) {
+            logger.error(
+                () -> new ParameterizedMessage(
+                    "Merge failed while creating merged file [{}]",
+                    mergedFilePath
+                ),
+                exception
+            );
+            try {
+                Files.deleteIfExists(Path.of(mergedFilePath));
+                logger.info("Stale Merged File Deleted at : [{}]", mergedFilePath);
+            } catch (Exception innerException) {
+                logger.error(
+                    () -> new ParameterizedMessage(
+                        "Failed to delete stale merged file [{}]",
+                        mergedFilePath
+                    ),
+                    innerException
+                );
+
+            }
+            throw exception;
+        }
+
     }
 
     private String getMergedFileName(long generation) {
-        // TODO
-        // For debuging we have added extra "merged" in file name, later we can remove and keep same as writer
+        // TODO: For debugging we have added extra "merged" in file name, later we can remove and keep same as writer
         return ParquetExecutionEngine.FILE_NAME_PREFIX + "_merged_" + generation + ParquetExecutionEngine.FILE_NAME_EXT;
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/MergeFailedEngineException.java
+++ b/server/src/main/java/org/opensearch/index/engine/MergeFailedEngineException.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import org.opensearch.core.index.shard.ShardId;
+
+public class MergeFailedEngineException extends EngineException {
+    public MergeFailedEngineException(ShardId shardId, Throwable t) {
+        super(shardId, "Merge Failed", t);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManager.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/coord/CatalogSnapshotManager.java
@@ -117,7 +117,7 @@ public class CatalogSnapshotManager {
         segmentList.subList(newSegIdx, segmentList.size()).clear();
 
         // Either we found place to insert segment, or, we did
-        // not, but only because all segments we merged becamee
+        // not, but only because all segments we merged became
         // deleted while we are merging, in which case it should
         // be the case that the new segment is also all deleted,
         // we insert it at the beginning if it should not be dropped:

--- a/server/src/main/java/org/opensearch/index/engine/exec/coord/CompositeEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/coord/CompositeEngine.java
@@ -44,6 +44,7 @@ import org.opensearch.index.engine.SafeCommitInfo;
 import org.opensearch.index.engine.SearchExecEngine;
 import org.opensearch.index.engine.Segment;
 import org.opensearch.index.engine.VersionValue;
+import org.opensearch.index.engine.*;
 import org.opensearch.index.engine.exec.RefreshInput;
 import org.opensearch.index.engine.exec.RefreshResult;
 import org.opensearch.index.engine.exec.WriteResult;
@@ -716,7 +717,22 @@ public class CompositeEngine implements LifecycleAware, Closeable, Indexer, Chec
     }
 
     public synchronized void applyMergeChanges(MergeResult mergeResult, OneMerge oneMerge) {
-        catalogSnapshotManager.applyMergeResults(mergeResult, oneMerge);
+        try {
+            catalogSnapshotManager.applyMergeResults(mergeResult, oneMerge);
+        } catch (Exception ex) {
+            try {
+                logger.error(
+                    () -> new ParameterizedMessage(
+                        "Merge failed while registering merged files in Snapshot"
+                    ),
+                    ex
+                );
+                failEngine("Merge failed while registering merged files in Snapshot", ex);
+            } catch (Exception inner) {
+                ex.addSuppressed(inner);
+            }
+            throw new MergeFailedEngineException(shardId, ex);
+        }
     }
 
     public void triggerPossibleMerges() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds resilient failure handling to the Parquet merge, including cleanup of stale merged files. Also fails the shard when merge results cannot be applied due to catalog-snapshot Exceptions.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
