### PR TITLE
Fix a flaky test for issue 20058

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/snapshots/CloneSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/snapshots/CloneSnapshotIT.java
@@ -177,16 +177,8 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         createIndex(remoteStoreEnabledIndexName, remoteStoreEnabledIndexSettings);
         indexRandomDocs(remoteStoreEnabledIndexName, randomIntBetween(5, 10));
 
-        assertBusy(
-            () -> client().admin()
-                .cluster()
-                .prepareHealth()
-                .setWaitForStatus(org.opensearch.cluster.health.ClusterHealthStatus.YELLOW) // don't require GREEN
-                .setWaitForNoInitializingShards(true)
-                .setWaitForNoRelocatingShards(true)
-                .setTimeout(TimeValue.timeValueSeconds(60))
-                .get()
-        );
+        ensureYellow(indexName, remoteStoreEnabledIndexName);
+        client().admin().cluster().prepareHealth().setWaitForNoInitializingShards(true).setWaitForNoRelocatingShards(true).get();
 
         final String snapshot = "snapshot";
         createFullSnapshot(snapshotRepoName, snapshot);
@@ -194,16 +186,8 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         indexRandomDocs(indexName, randomIntBetween(20, 100));
 
-        assertBusy(
-            () -> client().admin()
-                .cluster()
-                .prepareHealth()
-                .setWaitForStatus(org.opensearch.cluster.health.ClusterHealthStatus.YELLOW)
-                .setWaitForNoInitializingShards(true)
-                .setWaitForNoRelocatingShards(true)
-                .setTimeout(TimeValue.timeValueSeconds(60))
-                .get()
-        );
+        ensureYellow(indexName, remoteStoreEnabledIndexName);
+        client().admin().cluster().prepareHealth().setWaitForNoInitializingShards(true).setWaitForNoRelocatingShards(true).get();
 
         final String shallowSnapshot = "shallow-snapshot";
         createFullSnapshot(shallowSnapshotRepoName, shallowSnapshot);
@@ -211,16 +195,8 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         if (randomBoolean()) {
             assertAcked(admin().indices().prepareDelete(indexName));
-            assertBusy(
-                () -> client().admin()
-                    .cluster()
-                    .prepareHealth()
-                    .setWaitForStatus(org.opensearch.cluster.health.ClusterHealthStatus.YELLOW)
-                    .setWaitForNoInitializingShards(true)
-                    .setWaitForNoRelocatingShards(true)
-                    .setTimeout(TimeValue.timeValueSeconds(60))
-                    .get()
-            );
+            ensureYellow(remoteStoreEnabledIndexName);
+            client().admin().cluster().prepareHealth().setWaitForNoInitializingShards(true).setWaitForNoRelocatingShards(true).get();
         }
 
         final String sourceSnapshot = shallowSnapshot;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix a flaky test where there's a timing/race where the snapshot sometimes starts while one primary shard is still initializing/relocating, so createFullSnapshot() observes totalShards=11 but only successfulShards=10.


### Related Issues
Resolves #20058 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced snapshot cloning test stability by adding cluster health waits around key steps and replacing direct checks with polling assertions for lock file counts, reducing flakiness during snapshot, shallow-snapshot, and clone operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->