### PR TITLE
Prevent criteria update for context aware indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 ### Fixed
+- Prevent criteria update for context aware indices ([#20250](https://github.com/opensearch-project/OpenSearch/pull/20250))
 
 ### Dependencies
 

--- a/server/src/main/java/org/opensearch/index/engine/DocumentIndexWriter.java
+++ b/server/src/main/java/org/opensearch/index/engine/DocumentIndexWriter.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LiveIndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.ReferenceManager;
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.index.mapper.ParseContext;
 
@@ -92,4 +93,6 @@ public interface DocumentIndexWriter extends Closeable, ReferenceManager.Refresh
     boolean isWriteLockedByCurrentThread();
 
     Releasable obtainWriteLockOnAllMap();
+
+    boolean validateImmutableFieldNotUpdated(ParseContext.Document previousDocument, BytesRef currentUID);
 }

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -335,7 +335,8 @@ public abstract class Engine implements LifecycleAware, Closeable {
         VersionsAndSeqNoResolver.DocIdAndVersion docIdAndVersion = VersionsAndSeqNoResolver.loadDocIdAndVersion(
             searcher.getIndexReader(),
             uidTerm,
-            true
+            true,
+            null
         );
         assert docIdAndVersion != null;
         return docIdAndVersion.seqNo;
@@ -704,7 +705,7 @@ public abstract class Engine implements LifecycleAware, Closeable {
         final Engine.Searcher searcher = searcherFactory.apply("get", scope);
         final DocIdAndVersion docIdAndVersion;
         try {
-            docIdAndVersion = VersionsAndSeqNoResolver.loadDocIdAndVersion(searcher.getIndexReader(), get.uid(), true);
+            docIdAndVersion = VersionsAndSeqNoResolver.loadDocIdAndVersion(searcher.getIndexReader(), get.uid(), true, null);
         } catch (Exception e) {
             Releasables.closeWhileHandlingException(searcher);
             // TODO: A better exception goes here

--- a/server/src/main/java/org/opensearch/index/engine/LuceneIndexWriter.java
+++ b/server/src/main/java/org/opensearch/index/engine/LuceneIndexWriter.java
@@ -12,6 +12,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LiveIndexWriterConfig;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.index.mapper.ParseContext;
 
@@ -225,5 +226,9 @@ public class LuceneIndexWriter implements DocumentIndexWriter {
     @Override
     public Releasable obtainWriteLockOnAllMap() {
         return () -> {};
+    }
+
+    public boolean validateImmutableFieldNotUpdated(ParseContext.Document previousDocument, BytesRef currentUID) {
+        return false;
     }
 }

--- a/server/src/test/java/org/opensearch/common/lucene/uid/VersionsTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/uid/VersionsTests.java
@@ -77,7 +77,7 @@ public class VersionsTests extends OpenSearchTestCase {
         Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER));
         DirectoryReader directoryReader = OpenSearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "_na_", 1));
-        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()), nullValue());
+        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean(), null), nullValue());
 
         Document doc = new Document();
         doc.add(new Field(IdFieldMapper.NAME, "1", IdFieldMapper.Defaults.FIELD_TYPE));
@@ -86,7 +86,7 @@ public class VersionsTests extends OpenSearchTestCase {
         doc.add(new NumericDocValuesField(SeqNoFieldMapper.PRIMARY_TERM_NAME, randomLongBetween(1, Long.MAX_VALUE)));
         writer.updateDocument(new Term(IdFieldMapper.NAME, "1"), doc);
         directoryReader = reopen(directoryReader);
-        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version, equalTo(1L));
+        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean(), null).version, equalTo(1L));
 
         doc = new Document();
         Field uid = new Field(IdFieldMapper.NAME, "1", IdFieldMapper.Defaults.FIELD_TYPE);
@@ -97,7 +97,7 @@ public class VersionsTests extends OpenSearchTestCase {
         doc.add(new NumericDocValuesField(SeqNoFieldMapper.PRIMARY_TERM_NAME, randomLongBetween(1, Long.MAX_VALUE)));
         writer.updateDocument(new Term(IdFieldMapper.NAME, "1"), doc);
         directoryReader = reopen(directoryReader);
-        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version, equalTo(2L));
+        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean(), null).version, equalTo(2L));
 
         // test reuse of uid field
         doc = new Document();
@@ -109,11 +109,11 @@ public class VersionsTests extends OpenSearchTestCase {
         writer.updateDocument(new Term(IdFieldMapper.NAME, "1"), doc);
 
         directoryReader = reopen(directoryReader);
-        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version, equalTo(3L));
+        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean(), null).version, equalTo(3L));
 
         writer.deleteDocuments(new Term(IdFieldMapper.NAME, "1"));
         directoryReader = reopen(directoryReader);
-        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()), nullValue());
+        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean(), null), nullValue());
         directoryReader.close();
         writer.close();
         dir.close();
@@ -141,18 +141,18 @@ public class VersionsTests extends OpenSearchTestCase {
 
         writer.updateDocuments(new Term(IdFieldMapper.NAME, "1"), docs);
         DirectoryReader directoryReader = OpenSearchDirectoryReader.wrap(DirectoryReader.open(writer), new ShardId("foo", "_na_", 1));
-        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version, equalTo(5L));
+        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean(), null).version, equalTo(5L));
 
         version.setLongValue(6L);
         writer.updateDocuments(new Term(IdFieldMapper.NAME, "1"), docs);
         version.setLongValue(7L);
         writer.updateDocuments(new Term(IdFieldMapper.NAME, "1"), docs);
         directoryReader = reopen(directoryReader);
-        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()).version, equalTo(7L));
+        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean(), null).version, equalTo(7L));
 
         writer.deleteDocuments(new Term(IdFieldMapper.NAME, "1"));
         directoryReader = reopen(directoryReader);
-        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean()), nullValue());
+        assertThat(loadDocIdAndVersion(directoryReader, new Term(IdFieldMapper.NAME, "1"), randomBoolean(), null), nullValue());
         directoryReader.close();
         writer.close();
         dir.close();
@@ -172,10 +172,10 @@ public class VersionsTests extends OpenSearchTestCase {
         writer.addDocument(doc);
         DirectoryReader reader = DirectoryReader.open(writer);
         // should increase cache size by 1
-        assertEquals(87, loadDocIdAndVersion(reader, new Term(IdFieldMapper.NAME, "6"), randomBoolean()).version);
+        assertEquals(87, loadDocIdAndVersion(reader, new Term(IdFieldMapper.NAME, "6"), randomBoolean(), null).version);
         assertEquals(size + 1, VersionsAndSeqNoResolver.lookupStates.size());
         // should be cache hit
-        assertEquals(87, loadDocIdAndVersion(reader, new Term(IdFieldMapper.NAME, "6"), randomBoolean()).version);
+        assertEquals(87, loadDocIdAndVersion(reader, new Term(IdFieldMapper.NAME, "6"), randomBoolean(), null).version);
         assertEquals(size + 1, VersionsAndSeqNoResolver.lookupStates.size());
 
         reader.close();
@@ -198,11 +198,11 @@ public class VersionsTests extends OpenSearchTestCase {
         doc.add(new NumericDocValuesField(SeqNoFieldMapper.PRIMARY_TERM_NAME, randomLongBetween(1, Long.MAX_VALUE)));
         writer.addDocument(doc);
         DirectoryReader reader = DirectoryReader.open(writer);
-        assertEquals(87, loadDocIdAndVersion(reader, new Term(IdFieldMapper.NAME, "6"), randomBoolean()).version);
+        assertEquals(87, loadDocIdAndVersion(reader, new Term(IdFieldMapper.NAME, "6"), randomBoolean(), null).version);
         assertEquals(size + 1, VersionsAndSeqNoResolver.lookupStates.size());
         // now wrap the reader
         DirectoryReader wrapped = OpenSearchDirectoryReader.wrap(reader, new ShardId("bogus", "_na_", 5));
-        assertEquals(87, loadDocIdAndVersion(wrapped, new Term(IdFieldMapper.NAME, "6"), randomBoolean()).version);
+        assertEquals(87, loadDocIdAndVersion(wrapped, new Term(IdFieldMapper.NAME, "6"), randomBoolean(), null).version);
         // same size map: core cache key is shared
         assertEquals(size + 1, VersionsAndSeqNoResolver.lookupStates.size());
 

--- a/server/src/test/java/org/opensearch/index/engine/CompositeIndexWriterForAppendTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/CompositeIndexWriterForAppendTests.java
@@ -180,14 +180,10 @@ public class CompositeIndexWriterForAppendTests extends CriteriaBasedCompositeIn
             );
 
             Engine.Index operation = indexForDoc(createParsedDoc("id", null, DEFAULT_CRITERIA));
-            try (Releasable ignore1 = compositeIndexWriter.acquireLock(operation.uid().bytes())) {
-                compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
-            }
+            compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
 
             operation = indexForDoc(createParsedDoc("id2", null, "testingNewCriteria"));
-            try (Releasable ignore1 = compositeIndexWriter.acquireLock(operation.uid().bytes())) {
-                compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
-            }
+            compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
 
             compositeIndexWriter.beforeRefresh();
             compositeIndexWriter.afterRefresh(true);
@@ -348,7 +344,7 @@ public class CompositeIndexWriterForAppendTests extends CriteriaBasedCompositeIn
 
         String id = Integer.toString(randomIntBetween(1, 100));
         Engine.Index operation = indexForDoc(createParsedDoc(id, null, DEFAULT_CRITERIA));
-        try (Releasable ignore1 = compositeIndexWriter.acquireLock(operation.uid().bytes())) {
+        try {
             addDocException.set(new IOException("simulated"));
             expectThrows(IOException.class, () -> compositeIndexWriter.addDocuments(operation.docs(), operation.uid()));
         } finally {

--- a/server/src/test/java/org/opensearch/index/engine/CompositeIndexWriterForUpdateAndDeletesTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/CompositeIndexWriterForUpdateAndDeletesTests.java
@@ -9,7 +9,6 @@
 package org.opensearch.index.engine;
 
 import org.apache.lucene.index.DirectoryReader;
-import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.util.io.IOUtils;
 
 import java.io.IOException;
@@ -30,23 +29,19 @@ public class CompositeIndexWriterForUpdateAndDeletesTests extends CriteriaBasedC
                 indexWriterFactory
             );
             Engine.Index operation = indexForDoc(createParsedDoc(id, null, DEFAULT_CRITERIA));
-            try (Releasable ignore1 = compositeIndexWriter.acquireLock(operation.uid().bytes())) {
-                compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
-            }
+            compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
 
             compositeIndexWriter.beforeRefresh();
             compositeIndexWriter.afterRefresh(true);
-            try (Releasable ignore1 = compositeIndexWriter.acquireLock(operation.uid().bytes())) {
-                compositeIndexWriter.deleteDocument(
-                    operation.uid(),
-                    false,
-                    newDeleteTombstoneDoc(id),
-                    1,
-                    2,
-                    primaryTerm.get(),
-                    softDeletesField
-                );
-            }
+            compositeIndexWriter.deleteDocument(
+                operation.uid(),
+                false,
+                newDeleteTombstoneDoc(id),
+                1,
+                2,
+                primaryTerm.get(),
+                softDeletesField
+            );
 
             compositeIndexWriter.beforeRefresh();
             compositeIndexWriter.afterRefresh(true);
@@ -72,18 +67,16 @@ public class CompositeIndexWriterForUpdateAndDeletesTests extends CriteriaBasedC
                 indexWriterFactory
             );
             Engine.Index operation = indexForDoc(createParsedDoc(id, null, DEFAULT_CRITERIA));
-            try (Releasable ignore1 = compositeIndexWriter.acquireLock(operation.uid().bytes())) {
-                compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
-                compositeIndexWriter.deleteDocument(
-                    operation.uid(),
-                    false,
-                    newDeleteTombstoneDoc(id),
-                    1,
-                    2,
-                    primaryTerm.get(),
-                    softDeletesField
-                );
-            }
+            compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
+            compositeIndexWriter.deleteDocument(
+                operation.uid(),
+                false,
+                newDeleteTombstoneDoc(id),
+                1,
+                2,
+                primaryTerm.get(),
+                softDeletesField
+            );
 
             compositeIndexWriter.beforeRefresh();
             compositeIndexWriter.afterRefresh(true);
@@ -110,26 +103,22 @@ public class CompositeIndexWriterForUpdateAndDeletesTests extends CriteriaBasedC
                 indexWriterFactory
             );
             Engine.Index operation = indexForDoc(createParsedDoc(id, null, DEFAULT_CRITERIA));
-            try (Releasable ignore1 = compositeIndexWriter.acquireLock(operation.uid().bytes())) {
-                compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
-            }
+            compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
 
             compositeIndexWriter.beforeRefresh();
             compositeIndexWriter.afterRefresh(true);
 
             operation = indexForDoc(createParsedDoc(id, null, DEFAULT_CRITERIA));
-            try (Releasable ignore1 = compositeIndexWriter.acquireLock(operation.uid().bytes())) {
-                compositeIndexWriter.softUpdateDocuments(operation.uid(), operation.docs(), 2, 2, primaryTerm.get(), softDeletesField);
-                compositeIndexWriter.deleteDocument(
-                    operation.uid(),
-                    false,
-                    newDeleteTombstoneDoc(id),
-                    1,
-                    2,
-                    primaryTerm.get(),
-                    softDeletesField
-                );
-            }
+            compositeIndexWriter.softUpdateDocuments(operation.uid(), operation.docs(), 2, 2, primaryTerm.get(), softDeletesField);
+            compositeIndexWriter.deleteDocument(
+                operation.uid(),
+                false,
+                newDeleteTombstoneDoc(id),
+                1,
+                2,
+                primaryTerm.get(),
+                softDeletesField
+            );
 
             compositeIndexWriter.beforeRefresh();
             compositeIndexWriter.afterRefresh(true);
@@ -154,9 +143,7 @@ public class CompositeIndexWriterForUpdateAndDeletesTests extends CriteriaBasedC
         );
 
         Engine.Index operation = indexForDoc(createParsedDoc(id, null, DEFAULT_CRITERIA));
-        try (Releasable ignore1 = compositeIndexWriter.acquireLock(operation.uid().bytes())) {
-            compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
-        }
+        compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
 
         CompositeIndexWriter.CriteriaBasedIndexWriterLookup lock = compositeIndexWriter.acquireNewReadLock();
         CountDownLatch latch = new CountDownLatch(1);
@@ -207,17 +194,13 @@ public class CompositeIndexWriterForUpdateAndDeletesTests extends CriteriaBasedC
                 indexWriterFactory
             );
             Engine.Index operation = indexForDoc(createParsedDoc(id, null, DEFAULT_CRITERIA));
-            try (Releasable ignore1 = compositeIndexWriter.acquireLock(operation.uid().bytes())) {
-                compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
-            }
+            compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
 
             compositeIndexWriter.beforeRefresh();
             compositeIndexWriter.afterRefresh(true);
             operation = indexForDoc(createParsedDoc(id, null, DEFAULT_CRITERIA));
 
-            try (Releasable ignore1 = compositeIndexWriter.acquireLock(operation.uid().bytes())) {
-                compositeIndexWriter.softUpdateDocuments(operation.uid(), operation.docs(), 2, 2, primaryTerm.get(), softDeletesField);
-            }
+            compositeIndexWriter.softUpdateDocuments(operation.uid(), operation.docs(), 2, 2, primaryTerm.get(), softDeletesField);
 
             compositeIndexWriter.beforeRefresh();
             compositeIndexWriter.afterRefresh(true);
@@ -243,15 +226,10 @@ public class CompositeIndexWriterForUpdateAndDeletesTests extends CriteriaBasedC
                 indexWriterFactory
             );
             Engine.Index operation = indexForDoc(createParsedDoc(id, null, DEFAULT_CRITERIA));
-            try (Releasable ignore1 = compositeIndexWriter.acquireLock(operation.uid().bytes())) {
-                compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
-            }
+            compositeIndexWriter.addDocuments(operation.docs(), operation.uid());
 
             operation = indexForDoc(createParsedDoc(id, null, DEFAULT_CRITERIA));
-            try (Releasable ignore1 = compositeIndexWriter.acquireLock(operation.uid().bytes())) {
-                compositeIndexWriter.softUpdateDocuments(operation.uid(), operation.docs(), 2, 2, primaryTerm.get(), softDeletesField);
-            }
-
+            compositeIndexWriter.softUpdateDocuments(operation.uid(), operation.docs(), 2, 2, primaryTerm.get(), softDeletesField);
             compositeIndexWriter.beforeRefresh();
             compositeIndexWriter.afterRefresh(true);
             try (DirectoryReader directoryReader = DirectoryReader.open(compositeIndexWriter.getAccumulatingIndexWriter())) {

--- a/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/EngineTestCase.java
@@ -379,9 +379,9 @@ public abstract class EngineTestCase extends OpenSearchTestCase {
         }
     }
 
-    protected static ParseContext.Document testContextSpecificDocument() {
+    protected static ParseContext.Document testContextSpecificDocument(String groupingCriteria) {
         ParseContext.Document doc = testDocumentWithTextField("criteria");
-        doc.setGroupingCriteria("grouping_criteria");
+        doc.setGroupingCriteria(groupingCriteria);
         return doc;
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This modification prevents updates to fields that determine a document's grouping criteria. By blocking such updates, we eliminate the need for complex version synchronization across multiple IndexWriters. This approach simplifies version management, since the latest version of a document will always reside in the group-specific writer marked for refresh, while the previous version may be either in old or parent IndexWriter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent grouping criteria updates for context-aware enabled indices. System now validates and blocks operations that would attempt to modify existing grouping criteria, ensuring consistency across index operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->