### PR TITLE
Fixed a flaky test for issue 19847

### DIFF
--- a/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/ScaledFloatFieldMapperTests.java
@@ -107,18 +107,25 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
     }
 
     public void testScaledFloatWithStarTree() throws Exception {
+        // Use bounded scaling factors and bounded input values to avoid rare off-by-one rounding
+        // differences due to floating point precision in different encoding paths.
+        double scalingFactorField1 = randomDoubleBetween(0.001, 100.0, true);
+        double scalingFactorField2 = randomDoubleBetween(0.001, 100.0, true);
+        double scalingFactorField3 = randomDoubleBetween(0.001, 100.0, true);
 
-        double scalingFactorField1 = randomDouble() * 100;
-        double scalingFactorField2 = randomDouble() * 100;
-        double scalingFactorField3 = randomDouble() * 100;
+        // Limit fractional precision to reduce floating point edge cases
+        scalingFactorField1 = Math.round(scalingFactorField1 * 1_000d) / 1_000d;
+        scalingFactorField2 = Math.round(scalingFactorField2 * 1_000d) / 1_000d;
+        scalingFactorField3 = Math.round(scalingFactorField3 * 1_000d) / 1_000d;
 
         XContentBuilder mapping = getStarTreeMappingWithScaledFloat(scalingFactorField1, scalingFactorField2, scalingFactorField3);
         DocumentMapper mapper = createDocumentMapper(mapping);
         assertTrue(mapping.toString().contains("startree"));
 
-        long randomLongField1 = randomLong();
-        long randomLongField2 = randomLong();
-        long randomLongField3 = randomLong();
+        // Keep values in a range where scaling and rounding are deterministic across code paths
+        long randomLongField1 = randomLongBetween(-1_000_000_000_000L, 1_000_000_000_000L);
+        long randomLongField2 = randomLongBetween(-1_000_000_000_000L, 1_000_000_000_000L);
+        long randomLongField3 = randomLongBetween(-1_000_000_000_000L, 1_000_000_000_000L);
         ParsedDocument doc = mapper.parse(
             source(b -> b.field("field1", randomLongField1).field("field2", randomLongField2).field("field3", randomLongField3))
         );


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixed a flaky test which contains floating-point/rounding-edge flake: it's multiplying an arbitrary randomLong(), potentially very large by an arbitrary randomDouble()*100 high-precision fractional, and the scaled-float encoding path used by StarTree can round at a slightly different intermediate precision than the test’s expectation, producing an off-by-one long.

### Related Issues
Resolves #19847 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test stability by introducing bounded random value generation and explicit precision rounding controls to reduce floating-point variability in scaled float mapping tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->