### PR TITLE
Added changes to populate file handle stats in Cluster Info

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterInfo.java
@@ -44,7 +44,9 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.store.remote.filecache.AggregateFileCacheStats;
+import org.opensearch.monitor.process.ProcessStats;
 import org.opensearch.node.NodeResourceUsageStats;
+
 
 import java.io.IOException;
 import java.util.Collections;
@@ -54,7 +56,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * ClusterInfo is an object representing a map of nodes to {@link DiskUsage} and {@link NodeResourceUsageStats}
+ * ClusterInfo is an object representing a map of nodes to {@link DiskUsage} ,{@link ProcessStats} and {@link NodeResourceUsageStats}
  * and a map of shard ids to shard sizes, see
  * <code>InternalClusterInfoService.shardIdentifierFromRouting(String)</code>
  * for the key used in the shardSizes map
@@ -71,11 +73,15 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
     final Map<NodeAndPath, ReservedSpace> reservedSpace;
     final Map<String, AggregateFileCacheStats> nodeFileCacheStats;
     private final Map<String, NodeResourceUsageStats> nodeResourceUsageStats;
+    private final Map<String, ProcessStats> nodeProcessStats;
+
+
+
     private long avgTotalBytes;
     private long avgFreeByte;
 
     protected ClusterInfo() {
-        this(Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
+        this(Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
     }
 
     /**
@@ -87,6 +93,7 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
      * @param routingToDataPath the shard routing to datapath mapping
      * @param reservedSpace reserved space per shard broken down by node and data path
      * @param nodeFileCacheStats node file cache stats
+     * @param nodeProcessStats node process stats
      * @see #shardIdentifierFromRouting
      */
     @Deprecated(forRemoval = true)
@@ -96,9 +103,11 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
         final Map<String, Long> shardSizes,
         final Map<ShardRouting, String> routingToDataPath,
         final Map<NodeAndPath, ReservedSpace> reservedSpace,
-        final Map<String, AggregateFileCacheStats> nodeFileCacheStats
+        final Map<String, AggregateFileCacheStats> nodeFileCacheStats,
+        final Map<String, ProcessStats> nodeProcessStats
+
     ) {
-        this(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, routingToDataPath, reservedSpace, nodeFileCacheStats, Map.of());
+        this(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, routingToDataPath, reservedSpace, nodeFileCacheStats,Map.of(), Map.of());
     }
 
     /**
@@ -118,7 +127,9 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
         final Map<ShardRouting, String> routingToDataPath,
         final Map<NodeAndPath, ReservedSpace> reservedSpace,
         final Map<String, AggregateFileCacheStats> nodeFileCacheStats,
-        final Map<String, NodeResourceUsageStats> nodeResourceUsageStats
+        final Map<String, NodeResourceUsageStats> nodeResourceUsageStats,
+        final Map<String, ProcessStats> nodeProcessStats  
+
     ) {
         this.leastAvailableSpaceUsage = leastAvailableSpaceUsage;
         this.shardSizes = shardSizes;
@@ -127,6 +138,8 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
         this.reservedSpace = reservedSpace;
         this.nodeFileCacheStats = nodeFileCacheStats;
         this.nodeResourceUsageStats = nodeResourceUsageStats;
+        this.nodeProcessStats = nodeProcessStats;  
+
         calculateAvgFreeAndTotalBytes(mostAvailableSpaceUsage);
     }
 
@@ -153,6 +166,12 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
             this.nodeResourceUsageStats = in.readMap(StreamInput::readString, NodeResourceUsageStats::new);
         } else {
             this.nodeResourceUsageStats = Map.of();
+        }
+
+         if (in.getVersion().onOrAfter(Version.V_2_8_0)) {
+            this.nodeProcessStats = in.readMap(StreamInput::readString, ProcessStats::new);
+        } else {
+            this.nodeProcessStats = Map.of();
         }
 
         calculateAvgFreeAndTotalBytes(mostAvailableSpaceUsage);
@@ -202,6 +221,9 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
         if (out.getVersion().onOrAfter(Version.V_3_2_0)) {
             out.writeMap(this.nodeResourceUsageStats, StreamOutput::writeString, (o, v) -> v.writeTo(o));
         }
+        if (out.getVersion().onOrAfter(Version.V_2_8_0)) {
+            out.writeMap(this.nodeProcessStats, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        }
     }
 
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -228,6 +250,12 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
                     NodeResourceUsageStats resourceUsageStats = nodeResourceUsageStats.get(c.getKey());
                     if (resourceUsageStats != null) {
                         resourceUsageStats.toXContent(builder, params);
+                    }
+                    builder.endObject();
+                    builder.startObject("node_process_stats");
+                    ProcessStats processStats = nodeProcessStats.get(c.getKey());
+                    if (processStats != null) {
+                        processStats.toXContent(builder, params);
                     }
                     builder.endObject();
                 }
@@ -293,6 +321,13 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
      */
     public Map<String, NodeResourceUsageStats> getNodeResourceUsageStats() {
         return Collections.unmodifiableMap(this.nodeResourceUsageStats);
+    }
+    
+      /**
+     * Returns a node id to process stats mapping.
+     */
+    public Map<String, ProcessStats> getNodeProcessStats() {
+        return Collections.unmodifiableMap(this.nodeProcessStats);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/opensearch/cluster/InternalClusterInfoService.java
@@ -59,6 +59,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.index.store.StoreStats;
 import org.opensearch.index.store.remote.filecache.AggregateFileCacheStats;
+import org.opensearch.monitor.process.ProcessStats;
 import org.opensearch.monitor.fs.FsInfo;
 import org.opensearch.node.NodeResourceUsageStats;
 import org.opensearch.node.NodesResourceUsageStats;
@@ -116,6 +117,8 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
     private volatile Map<String, DiskUsage> mostAvailableSpaceUsages;
     private volatile Map<String, AggregateFileCacheStats> nodeFileCacheStats;
     private volatile Map<String, NodeResourceUsageStats> nodeResourceUsageStats;
+    private volatile Map<String, ProcessStats> nodeProcessStats ;
+
     private volatile IndicesStatsSummary indicesStatsSummary;
     // null if this node is not currently the cluster-manager
     private final AtomicReference<RefreshAndRescheduleRunnable> refreshAndRescheduleRunnable = new AtomicReference<>();
@@ -130,6 +133,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         this.mostAvailableSpaceUsages = Map.of();
         this.nodeFileCacheStats = Map.of();
         this.nodeResourceUsageStats = Map.of();
+        this.nodeProcessStats = Map.of();
         this.indicesStatsSummary = IndicesStatsSummary.EMPTY;
         this.threadPool = threadPool;
         this.client = client;
@@ -202,6 +206,11 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                     newNodeResourceUsageStats.remove(removedNode.getId());
                     nodeResourceUsageStats = Collections.unmodifiableMap(newNodeResourceUsageStats);
                 }
+                if (nodeProcessStats.containsKey(removedNode.getId())) {
+                    Map<String, ProcessStats> newNodeProcessStats = new HashMap<>(nodeProcessStats);
+                    newNodeProcessStats.remove(removedNode.getId());
+                    nodeProcessStats = Collections.unmodifiableMap(newNodeProcessStats);
+                }
             }
         }
     }
@@ -223,7 +232,8 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
             indicesStatsSummary.shardRoutingToDataPath,
             indicesStatsSummary.reservedSpace,
             nodeFileCacheStats,
-            nodeResourceUsageStats
+            nodeResourceUsageStats,
+            nodeProcessStats
         );
     }
 
@@ -238,6 +248,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         nodesStatsRequest.addMetric(NodesStatsRequest.Metric.FS.metricName());
         nodesStatsRequest.addMetric(NodesStatsRequest.Metric.FILE_CACHE_STATS.metricName());
         nodesStatsRequest.addMetric(NodesStatsRequest.Metric.RESOURCE_USAGE_STATS.metricName());
+        nodesStatsRequest.addMetric(NodesStatsRequest.Metric.PROCESS.metricName());
         nodesStatsRequest.timeout(fetchTimeout);
         client.admin().cluster().nodesStats(nodesStatsRequest, new LatchedActionListener<>(listener, latch));
         return latch;
@@ -287,6 +298,12 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                         .collect(Collectors.toMap(nodeStats -> nodeStats.getNode().getId(), NodeStats::getFileCacheStats))
                 );
 
+                nodeProcessStats = Collections.unmodifiableMap(
+                        adjustNodesStats(nodesStatsResponse.getNodes()).stream()
+                                .filter(nodeStats -> nodeStats.getProcess() != null)
+                                .collect(Collectors.toMap(nodeStats -> nodeStats.getNode().getId(), NodeStats::getProcess))
+                );
+
                 final Map<String, NodeResourceUsageStats> nodeResourceUsageStatsBuilder = new HashMap<>();
                 fillNodeResourceUsageStatsPerNode(logger, adjustNodesStats(nodesStatsResponse.getNodes()), nodeResourceUsageStatsBuilder);
 
@@ -309,6 +326,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
                     leastAvailableSpaceUsages = Map.of();
                     mostAvailableSpaceUsages = Map.of();
                     nodeResourceUsageStats = Map.of();
+                    nodeProcessStats = Map.of();   
                 }
             }
         });

--- a/server/src/main/java/org/opensearch/monitor/process/ProcessStats.java
+++ b/server/src/main/java/org/opensearch/monitor/process/ProcessStats.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.monitor.process;
 
+import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -45,8 +46,9 @@ import java.io.IOException;
 /**
  * Holds stats for the process
  *
- * @opensearch.internal
+ * @opensearch.api
  */
+@PublicApi(since = "2.8.0")
 public class ProcessStats implements Writeable, ToXContentFragment {
 
     private final long timestamp;
@@ -140,8 +142,9 @@ public class ProcessStats implements Writeable, ToXContentFragment {
     /**
      * Process memory information.
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "2.8.0")
     public static class Mem implements Writeable {
 
         private final long totalVirtual;
@@ -167,8 +170,9 @@ public class ProcessStats implements Writeable, ToXContentFragment {
     /**
      * Process CPU information.
      *
-     * @opensearch.internal
+     * @opensearch.api
      */
+    @PublicApi(since = "2.8.0")
     public static class Cpu implements Writeable {
 
         private final short percent;

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
@@ -1399,7 +1399,7 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
                 }
             }
         });
-        return new ClusterInfo(diskUsages, null, shardSizes, null, reservedSpace, fileCacheStats, Map.of());
+        return new ClusterInfo(diskUsages, null, shardSizes, null, reservedSpace, fileCacheStats, Map.of() , Map.of());
     }
 
     private static AggregateFileCacheStats createAggregateFileCacheStats(long totalCacheSize, long active, long used) {

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/IndexShardConstraintDeciderOverlapTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/IndexShardConstraintDeciderOverlapTests.java
@@ -178,7 +178,7 @@ public class IndexShardConstraintDeciderOverlapTests extends OpenSearchAllocatio
             final Map<String, Long> shardSizes,
             final Map<NodeAndPath, ReservedSpace> reservedSpace
         ) {
-            super(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, null, reservedSpace, Map.of(), nodeResourceUsageStats);
+            super(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, null, reservedSpace, Map.of(), nodeResourceUsageStats , Map.of());
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteShardsBalancerBaseTestCase.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/RemoteShardsBalancerBaseTestCase.java
@@ -290,7 +290,7 @@ public abstract class RemoteShardsBalancerBaseTestCase extends OpenSearchAllocat
             final Map<String, NodeResourceUsageStats> nodeResourceUsages,
             final Map<String, Long> shardSizes
         ) {
-            super(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, null, Map.of(), Map.of(), nodeResourceUsages);
+            super(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, null, Map.of(), Map.of(), nodeResourceUsages,Map.of());
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -1598,7 +1598,8 @@ public class DiskThresholdDeciderTests extends OpenSearchAllocationTestCase {
                 null,
                 reservedSpace,
                 nodeFileCacheStats,
-                nodeResourceUsages
+                nodeResourceUsages,
+                Map.of()
             );
         }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -134,6 +134,7 @@ public class DiskThresholdDeciderUnitTests extends OpenSearchAllocationTestCase 
             Map.of(),
             Map.of(),
             Map.of(),
+            Map.of(),
             Map.of()
         );
         RoutingAllocation allocation = new RoutingAllocation(
@@ -215,6 +216,7 @@ public class DiskThresholdDeciderUnitTests extends OpenSearchAllocationTestCase 
             leastAvailableUsages,
             mostAvailableUsage,
             shardSizes,
+            Map.of(),
             Map.of(),
             Map.of(),
             Map.of(),
@@ -341,6 +343,7 @@ public class DiskThresholdDeciderUnitTests extends OpenSearchAllocationTestCase 
             mostAvailableUsage,
             shardSizes,
             shardRoutingMap,
+            Map.of(),
             Map.of(),
             Map.of(),
             Map.of()

--- a/server/src/test/java/org/opensearch/indices/tiering/TieringRequestValidatorTests.java
+++ b/server/src/test/java/org/opensearch/indices/tiering/TieringRequestValidatorTests.java
@@ -171,7 +171,7 @@ public class TieringRequestValidatorTests extends OpenSearchTestCase {
         Map<String, DiskUsage> diskUsages = diskUsages(1, 100, 50);
         final Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test_index][0][p]", 10L); // 10 bytes
-        ClusterInfo clusterInfo = new ClusterInfo(diskUsages, null, shardSizes, null, null, Map.of(), Map.of());
+        ClusterInfo clusterInfo = new ClusterInfo(diskUsages, null, shardSizes, null, null, Map.of(), Map.of(), Map.of());
         assertEquals(10, getIndexPrimaryStoreSize(clusterState, clusterInfo, indexName));
     }
 
@@ -185,7 +185,7 @@ public class TieringRequestValidatorTests extends OpenSearchTestCase {
         Map<String, DiskUsage> diskUsages = diskUsages(1, 100, 50);
         final Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test_index][0][p]", 10L); // 10 bytes
-        ClusterInfo clusterInfo = new ClusterInfo(diskUsages, null, shardSizes, null, null, Map.of(), Map.of());
+        ClusterInfo clusterInfo = new ClusterInfo(diskUsages, null, shardSizes, null, null, Map.of(), Map.of(), Map.of());
         TieringValidationResult tieringValidationResult = new TieringValidationResult(indices);
         validateEligibleNodesCapacity(clusterInfo, clusterState, tieringValidationResult);
         assertEquals(indices, tieringValidationResult.getAcceptedIndices());
@@ -202,7 +202,7 @@ public class TieringRequestValidatorTests extends OpenSearchTestCase {
         Map<String, DiskUsage> diskUsages = diskUsages(1, 100, 10);
         final Map<String, Long> shardSizes = new HashMap<>();
         shardSizes.put("[test_index][0][p]", 20L); // 20 bytes
-        ClusterInfo clusterInfo = new ClusterInfo(diskUsages, null, shardSizes, null, null, Map.of(), Map.of());
+        ClusterInfo clusterInfo = new ClusterInfo(diskUsages, null, shardSizes, null, null, Map.of(), Map.of(), Map.of());
         TieringValidationResult tieringValidationResult = new TieringValidationResult(indices);
         validateEligibleNodesCapacity(clusterInfo, clusterState, tieringValidationResult);
         assertEquals(indices.size(), tieringValidationResult.getRejectedIndices().size());
@@ -305,7 +305,7 @@ public class TieringRequestValidatorTests extends OpenSearchTestCase {
 
     private static ClusterInfo clusterInfo(int noOfNodes, long totalBytes, long freeBytes) {
         final Map<String, DiskUsage> diskUsages = diskUsages(noOfNodes, totalBytes, freeBytes);
-        return new ClusterInfo(diskUsages, null, null, null, null, Map.of(), Map.of());
+        return new ClusterInfo(diskUsages, null, null, null, null, Map.of(), Map.of(), Map.of());
     }
 
     private static Map<String, DiskUsage> diskUsages(int noOfWarmNodes, long totalBytes, long freeBytes) {

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -476,7 +476,7 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                 )
             );
         }
-        ClusterInfo clusterInfo = new ClusterInfo(Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), nodeFileCacheStats, Map.of());
+        ClusterInfo clusterInfo = new ClusterInfo(Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), nodeFileCacheStats, Map.of(), Map.of());
         testClusterNodes.nodes.values().forEach(node -> when(node.getMockClusterInfoService().getClusterInfo()).thenReturn(clusterInfo));
 
         final StepListener<CreateSnapshotResponse> createSnapshotResponseListener = new StepListener<>();

--- a/test/framework/src/main/java/org/opensearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/MockInternalClusterInfoService.java
@@ -1,3 +1,4 @@
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -164,7 +165,8 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
                 delegate.routingToDataPath,
                 delegate.reservedSpace,
                 delegate.nodeFileCacheStats,
-                delegate.getNodeResourceUsageStats()
+                delegate.getNodeResourceUsageStats(),
+                delegate.getNodeProcessStats()
             );
         }
 


### PR DESCRIPTION
### Description
Added process statistics to ClusterInfo to enable cluster-wide visibility into node-level metrics including CPU, memory, and open file descriptors, collected alongside existing disk and resource usage stats.


### Related Issues
Resolves #20111 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Process statistics collection integrated into cluster monitoring to track node-level metrics
  * File descriptor usage threshold monitoring with automatic read-only index marking when node usage exceeds 85%
  * Process statistics now included in cluster information serialization and output formats

* **Tests**
  * Added integration tests validating process statistics collection and recovery behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->