### PR TITLE
Improve experience when no issue component is selected

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -13,22 +13,40 @@ jobs:
         with:
           script: |
             const { issue, repository } = context.payload;
-            const { number, body } = issue;
+            const { number, body, user } = issue;
             const { owner, name } = repository;
             const regex = /###\sRelated\scomponent\n\n(\w.*)\n/gm;
             let match;
+
             while ( ( match = regex.exec( body ) ) ) {
               const [ , component_label ] = match;
-              await github.rest.issues.addLabels( {
+
+              let label
+              // Check if the component label is "_No response_"
+              if (component_label.trim() === "_No response_") {
+                // Add a comment tagging the user
+                await github.rest.issues.createComment({
+                  owner: owner.login,
+                  repo: name,
+                  issue_number: number,
+                  body: `@${user.login} Please reply to this comment with the relevant component to ensure it gets properly triaged:\n\n- Build\n- Clients\n- Cluster Manager\n- Extensions\n- Indexing:Performance\n- Indexing:Replication\n- Indexing\n- Libraries\n- Other\n- Plugins\n- Search:Aggregations\n- Search:Performance\n- Search:Query Capabilities\n- Search:Query Insights\n- Search:Relevance\n- Search:Remote Search\n- Search:Resiliency\n- Search:Searchable Snapshots\n- Search\n- Storage:Durability\n- Storage:Performance\n- Storage:Remote\n- Storage:Snapshots\n- Storage\n\nReply with the component name, and we'll label this issue appropriately.`
+                });
+                label = 'missing-component'
+              } else {
+                label = component_label
+              }
+              await github.rest.issues.addLabels({
                 owner: owner.login,
                 repo: name,
                 issue_number: number,
-                labels: [ `${ component_label }` ],
-              } );
+                labels: [label]
+              });
             }
-            github.rest.issues.addLabels({
+
+            // Always add the untriaged label
+            await github.rest.issues.addLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               labels: ['untriaged']
-            })
+            });


### PR DESCRIPTION
Our current issue template includes a dropdown for component with an empty first selection. As far as I can tell this is necessary because otherwise it would default to the first selection which would lead to many inappropriately tagged issues for that component. I can not figure out a way to make the selection empty-by-default and also force the user to make a selection before submitting the issue. The work-around here is to tag the requester and ask them to reply with the component.

See https://github.com/andrross/OpenSearch/issues/214 for a test of this behavior on my user fork.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced issue triage automation workflow to improve handling of incomplete issue submissions and missing component information.
  * Refined automatic labeling system with conditional logic for missing component responses, including issue author notifications.
  * Ensures consistent application of "untriaged" status during the triage process for better issue tracking and organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->