### PR TITLE
register translog read forward config

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -145,6 +145,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSortConfig.INDEX_SORT_MISSING_SETTING,
                 IndexSortConfig.INDEX_SORT_MODE_SETTING,
                 IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING,
+                IndexSettings.INDEX_TRANSLOG_READ_FORWARD_SETTING,
                 IndexSettings.INDEX_WARMER_ENABLED_SETTING,
                 IndexSettings.INDEX_REFRESH_INTERVAL_SETTING,
                 IndexSettings.INDEX_PERIODIC_FLUSH_INTERVAL_SETTING,


### PR DESCRIPTION
### Description
Registering the `INDEX_TRANSLOG_READ_FORWARD_SETTING` to the `IndexScopedSettings`, which fixed the unknow settings error:
```
{
  "error": {
    "root_cause": [
      {
        "type": "settings_exception",
        "reason": "unknown setting [index.translog.read_forward] please check that any required plugins are installed, or check the breaking changes documentation for removed settings"
      }
    ],
    "type": "settings_exception",
    "reason": "unknown setting [index.translog.read_forward] please check that any required plugins are installed, or check the breaking changes documentation for removed settings"
  },
  "status": 400
}
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The translog "read forward" index setting is now included as a built-in configuration option, simplifying enabling and management of read-forward behavior and improving consistency of index configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->