### PR TITLE
Fix AllocationConstraintsTests

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationConstraintsTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/AllocationConstraintsTests.java
@@ -203,7 +203,7 @@ public class AllocationConstraintsTests extends OpenSearchAllocationTestCase {
         when(node.getNodeId()).thenReturn("test-node");
 
         long expectedWeight = (shardCount >= (int) Math.ceil(avgPerIndexShardsPerNode)) ? CONSTRAINT_WEIGHT : 0;
-        expectedWeight += perIndexPrimaryShardCount > (int) Math.ceil(avgPerIndexPrimaryShardsPerNode) ? CONSTRAINT_WEIGHT : 0;
+        expectedWeight += perIndexPrimaryShardCount >= (int) Math.ceil(avgPerIndexPrimaryShardsPerNode) ? CONSTRAINT_WEIGHT : 0;
         expectedWeight += primaryShardsPerNode >= (int) Math.ceil(avgPrimaryShardsPerNode) ? constraintWeight : 0;
         assertEquals(expectedWeight, constraints.weight(balancer, node, indexName, constraintWeight));
     }


### PR DESCRIPTION
The test is verifying [this constraint logic][1], which uses greater than or equal to the rounded average primary shards per node value rather than strictly greater than. I verified this by running 50k iterations, which would reliably fail many times before this change:

```
./gradlew ':server:test' --tests 'org.opensearch.cluster.routing.allocation.AllocationConstraintsTests.testAllConstraints' -Dtests.iters=50000
```

[1]: https://github.com/opensearch-project/OpenSearch/blob/bb45f0343553944627b18a3fd8fa0b79d0991b69/server/src/main/java/org/opensearch/cluster/routing/allocation/ConstraintTypes.java#L73

### Related Issues
Resolves #15831

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shard allocation constraint calculation to properly enforce limits when shard counts reach the threshold, not just when exceeding it.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->