### PR TITLE
Add replica-only node type for read scalability

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterModule.java
@@ -77,6 +77,7 @@ import org.opensearch.cluster.routing.allocation.decider.ReplicaAfterPrimaryActi
 import org.opensearch.cluster.routing.allocation.decider.ResizeAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.RestoreInProgressAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
+import org.opensearch.cluster.routing.allocation.decider.ReplicaOnlyAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.SearchReplicaAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.opensearch.cluster.routing.allocation.decider.SnapshotInProgressAllocationDecider;
@@ -396,6 +397,7 @@ public class ClusterModule extends AbstractModule {
         addAllocationDecider(deciders, new RestoreInProgressAllocationDecider());
         addAllocationDecider(deciders, new FilterAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new SearchReplicaAllocationDecider());
+        addAllocationDecider(deciders, new ReplicaOnlyAllocationDecider());
         addAllocationDecider(deciders, new SameShardAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new DiskThresholdDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new WarmDiskThresholdDecider(settings, clusterSettings));

--- a/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/opensearch/cluster/node/DiscoveryNode.java
@@ -130,6 +130,10 @@ public class DiscoveryNode implements VerifiableWriteable, ToXContentFragment {
         return getRolesFromSettings(settings).stream().allMatch(DiscoveryNodeRole.WARM_ROLE::equals);
     }
 
+    public static boolean isReplicaOnlyNode(Settings settings) {
+        return hasRole(settings, DiscoveryNodeRole.REPLICA_ONLY_ROLE);
+    }
+
     private final String nodeName;
     private final String nodeId;
     private final String ephemeralId;
@@ -540,6 +544,15 @@ public class DiscoveryNode implements VerifiableWriteable, ToXContentFragment {
      */
     public boolean isSearchNode() {
         return roles.contains(DiscoveryNodeRole.SEARCH_ROLE);
+    }
+
+    /**
+     * Returns whether the node is a replica-only node.
+     *
+     * @return true if the node contains a replica_only role, false otherwise
+     */
+    public boolean isReplicaOnlyNode() {
+        return roles.contains(DiscoveryNodeRole.REPLICA_ONLY_ROLE);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/allocator/LocalShardsBalancer.java
@@ -765,6 +765,15 @@ public class LocalShardsBalancer extends ShardsBalancer {
     private Map<String, BalancedShardsAllocator.ModelNode> buildModelFromAssigned() {
         Map<String, BalancedShardsAllocator.ModelNode> nodes = new HashMap<>();
         for (RoutingNode rn : routingNodes) {
+            // EXCLUDE replica-only nodes from rebalancing calculations
+            // These nodes are managed solely by auto-expand replica logic
+            if (rn.node().isReplicaOnlyNode()) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Excluding replica-only node [{}] from rebalancing model", rn.nodeId());
+                }
+                continue;
+            }
+
             BalancedShardsAllocator.ModelNode node = new BalancedShardsAllocator.ModelNode(rn);
             nodes.put(rn.nodeId(), node);
             for (ShardRouting shard : rn) {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ReplicaOnlyAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/ReplicaOnlyAllocationDecider.java
@@ -1,0 +1,140 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.routing.allocation.decider;
+
+import org.opensearch.cluster.metadata.AutoExpandReplicas;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.routing.RoutingNode;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.allocation.RoutingAllocation;
+
+/**
+ * This allocation decider ensures that replica-only nodes follow strict allocation rules:
+ * <ul>
+ *   <li>Replica-only nodes never host primary shards</li>
+ *   <li>Replica-only nodes only host replica shards from indices with auto_expand_replicas: 0-all</li>
+ *   <li>Primary shards are never promoted on replica-only nodes</li>
+ *   <li>Regular data nodes are not affected by replica-only node presence</li>
+ * </ul>
+ *
+ * @opensearch.internal
+ */
+public class ReplicaOnlyAllocationDecider extends AllocationDecider {
+
+    public static final String NAME = "replica_only";
+
+    @Override
+    public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        return canAllocate(shardRouting, node.node(), allocation);
+    }
+
+    @Override
+    public Decision canRemain(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        return canAllocate(shardRouting, node.node(), allocation);
+    }
+
+    @Override
+    public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        // CRITICAL: Never allow primary allocation to replica-only nodes, even with force
+        if (node.node().isReplicaOnlyNode()) {
+            return allocation.decision(
+                Decision.NO,
+                NAME,
+                "primary shard [%s] cannot be force allocated to replica-only node [%s]",
+                shardRouting.shardId(),
+                node.nodeId()
+            );
+        }
+        return allocation.decision(Decision.YES, NAME, "node is not a replica-only node");
+    }
+
+    @Override
+    public Decision shouldAutoExpandToNode(IndexMetadata indexMetadata, DiscoveryNode node, RoutingAllocation allocation) {
+        if (!node.isReplicaOnlyNode()) {
+            // Regular data nodes participate in auto-expand for all indices
+            return allocation.decision(Decision.YES, NAME, "node [%s] is a data node, eligible for auto-expand", node.getId());
+        }
+
+        // Replica-only nodes only participate in 0-all auto-expand
+        AutoExpandReplicas autoExpandReplicas = AutoExpandReplicas.SETTING.get(indexMetadata.getSettings());
+        boolean isAutoExpandAll = autoExpandReplicas.isEnabled()
+            && autoExpandReplicas.getMaxReplicas() == Integer.MAX_VALUE
+            && autoExpandReplicas.toString().startsWith("0-");
+
+        if (isAutoExpandAll) {
+            return allocation.decision(
+                Decision.YES,
+                NAME,
+                "replica-only node [%s] is eligible for auto-expand replicas from index [%s] with auto_expand_replicas: 0-all",
+                node.getId(),
+                indexMetadata.getIndex().getName()
+            );
+        } else {
+            return allocation.decision(
+                Decision.NO,
+                NAME,
+                "replica-only node [%s] is not eligible for index [%s] without auto_expand_replicas: 0-all",
+                node.getId(),
+                indexMetadata.getIndex().getName()
+            );
+        }
+    }
+
+    private Decision canAllocate(ShardRouting shardRouting, DiscoveryNode node, RoutingAllocation allocation) {
+        boolean isReplicaOnlyNode = node.isReplicaOnlyNode();
+
+        // Case 1: Primary shard allocation
+        if (shardRouting.primary()) {
+            if (isReplicaOnlyNode) {
+                return allocation.decision(
+                    Decision.NO,
+                    NAME,
+                    "primary shard [%s] cannot be allocated to replica-only node [%s]",
+                    shardRouting.shardId(),
+                    node.getId()
+                );
+            }
+            // Allow primaries on regular data nodes
+            return allocation.decision(Decision.YES, NAME, "node [%s] is a data node, can host primary shard", node.getId());
+        }
+
+        // Case 2: Replica shard allocation
+        IndexMetadata indexMetadata = allocation.metadata().getIndexSafe(shardRouting.index());
+        AutoExpandReplicas autoExpandReplicas = AutoExpandReplicas.SETTING.get(indexMetadata.getSettings());
+        boolean isAutoExpandAll = autoExpandReplicas.isEnabled()
+            && autoExpandReplicas.getMaxReplicas() == Integer.MAX_VALUE
+            && autoExpandReplicas.toString().startsWith("0-");
+
+        if (isReplicaOnlyNode) {
+            if (isAutoExpandAll) {
+                return allocation.decision(
+                    Decision.YES,
+                    NAME,
+                    "replica shard [%s] from auto-expand (0-all) index can be allocated to replica-only node [%s]",
+                    shardRouting.shardId(),
+                    node.getId()
+                );
+            } else {
+                return allocation.decision(
+                    Decision.NO,
+                    NAME,
+                    "replica shard [%s] cannot be allocated to replica-only node [%s] "
+                        + "because index [%s] does not have auto_expand_replicas: 0-all",
+                    shardRouting.shardId(),
+                    node.getId(),
+                    indexMetadata.getIndex().getName()
+                );
+            }
+        }
+
+        // Regular data nodes can host any replica
+        return allocation.decision(Decision.YES, NAME, "node [%s] is a data node, can host replica shard", node.getId());
+    }
+}

--- a/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleTests.java
+++ b/server/src/test/java/org/opensearch/cluster/node/DiscoveryNodeRoleTests.java
@@ -159,4 +159,41 @@ public class DiscoveryNodeRoleTests extends OpenSearchTestCase {
         assertEquals(roleName.toLowerCase(Locale.ROOT), dynamicRole.roleName());
         assertEquals(roleNameAbbreviation.toLowerCase(Locale.ROOT), dynamicRole.roleNameAbbreviation());
     }
+
+    public void testReplicaOnlyRoleIsDedicated() {
+        // replica_only role cannot coexist with any other role
+        final IllegalArgumentException e1 = expectThrows(
+            IllegalArgumentException.class,
+            () -> DiscoveryNodeRole.REPLICA_ONLY_ROLE.validateRole(Arrays.asList(DiscoveryNodeRole.REPLICA_ONLY_ROLE, DiscoveryNodeRole.DATA_ROLE))
+        );
+        assertThat(e1, hasToString(containsString("replica_only role must be the only role")));
+
+        final IllegalArgumentException e2 = expectThrows(
+            IllegalArgumentException.class,
+            () -> DiscoveryNodeRole.REPLICA_ONLY_ROLE.validateRole(
+                Arrays.asList(DiscoveryNodeRole.REPLICA_ONLY_ROLE, DiscoveryNodeRole.CLUSTER_MANAGER_ROLE)
+            )
+        );
+        assertThat(e2, hasToString(containsString("replica_only role must be the only role")));
+
+        final IllegalArgumentException e3 = expectThrows(
+            IllegalArgumentException.class,
+            () -> DiscoveryNodeRole.REPLICA_ONLY_ROLE.validateRole(Arrays.asList(DiscoveryNodeRole.REPLICA_ONLY_ROLE, DiscoveryNodeRole.INGEST_ROLE))
+        );
+        assertThat(e3, hasToString(containsString("replica_only role must be the only role")));
+
+        // replica_only role by itself should not throw
+        DiscoveryNodeRole.REPLICA_ONLY_ROLE.validateRole(Arrays.asList(DiscoveryNodeRole.REPLICA_ONLY_ROLE));
+    }
+
+    public void testReplicaOnlyRoleProperties() {
+        assertEquals("replica_only", DiscoveryNodeRole.REPLICA_ONLY_ROLE.roleName());
+        assertEquals("ro", DiscoveryNodeRole.REPLICA_ONLY_ROLE.roleNameAbbreviation());
+        assertTrue(DiscoveryNodeRole.REPLICA_ONLY_ROLE.canContainData());
+        assertNull(DiscoveryNodeRole.REPLICA_ONLY_ROLE.legacySetting());
+    }
+
+    public void testReplicaOnlyRoleInBuiltInRoles() {
+        assertTrue(DiscoveryNodeRole.BUILT_IN_ROLES.contains(DiscoveryNodeRole.REPLICA_ONLY_ROLE));
+    }
 }

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/ReplicaOnlyAllocationDeciderTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/decider/ReplicaOnlyAllocationDeciderTests.java
@@ -1,0 +1,343 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.routing.allocation.decider;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.EmptyClusterInfoService;
+import org.opensearch.cluster.OpenSearchAllocationTestCase;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.cluster.routing.RecoverySource;
+import org.opensearch.cluster.routing.RoutingNode;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.UnassignedInfo;
+import org.opensearch.cluster.routing.allocation.AllocationService;
+import org.opensearch.cluster.routing.allocation.RoutingAllocation;
+import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.snapshots.EmptySnapshotsInfoService;
+import org.opensearch.test.gateway.TestGatewayAllocator;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS;
+
+public class ReplicaOnlyAllocationDeciderTests extends OpenSearchAllocationTestCase {
+
+    private ReplicaOnlyAllocationDecider decider;
+    private AllocationDeciders allocationDeciders;
+    private ClusterState clusterState;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        decider = new ReplicaOnlyAllocationDecider();
+
+        Set<org.opensearch.common.settings.Setting<?>> settings = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.builder().build(), settings);
+
+        allocationDeciders = new AllocationDeciders(
+            Arrays.asList(decider, new SameShardAllocationDecider(Settings.EMPTY, clusterSettings), new ReplicaAfterPrimaryActiveAllocationDecider())
+        );
+
+        AllocationService service = new AllocationService(
+            allocationDeciders,
+            new TestGatewayAllocator(),
+            new BalancedShardsAllocator(Settings.EMPTY),
+            EmptyClusterInfoService.INSTANCE,
+            EmptySnapshotsInfoService.INSTANCE
+        );
+
+        // Create a cluster with 2 nodes: one regular data node, one replica-only node
+        DiscoveryNode dataNode = newNode("data-node", Collections.singleton(DiscoveryNodeRole.DATA_ROLE));
+        DiscoveryNode replicaOnlyNode = newNode("replica-only-node", Collections.singleton(DiscoveryNodeRole.REPLICA_ONLY_ROLE));
+
+        Metadata metadata = Metadata.builder()
+            .put(
+                IndexMetadata.builder("auto-expand-index")
+                    .settings(
+                        settings(Version.CURRENT).put(SETTING_AUTO_EXPAND_REPLICAS, "0-all")
+                    )
+                    .numberOfShards(1)
+                    .numberOfReplicas(1)
+            )
+            .put(IndexMetadata.builder("regular-index").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+            .build();
+
+        clusterState = ClusterState.builder(org.opensearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .nodes(org.opensearch.cluster.node.DiscoveryNodes.builder().add(dataNode).add(replicaOnlyNode))
+            .build();
+
+        clusterState = ClusterState.builder(clusterState)
+            .routingTable(org.opensearch.cluster.routing.RoutingTable.builder().addAsNew(metadata.index("auto-expand-index")).addAsNew(metadata.index("regular-index")).build())
+            .build();
+    }
+
+    public void testPrimaryCannotAllocateToReplicaOnlyNode() {
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState.getRoutingNodes(), clusterState, null, null, 0);
+        allocation.debugDecision(true);
+
+        ShardRouting primaryShard = ShardRouting.newUnassigned(
+            clusterState.routingTable().index("auto-expand-index").shard(0).shardId(),
+            true,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+        );
+
+        RoutingNode replicaOnlyNode = clusterState.getRoutingNodes().node("replica-only-node");
+        RoutingNode dataNode = clusterState.getRoutingNodes().node("data-node");
+
+        // Primary cannot be allocated to replica-only node
+        Decision decision = decider.canAllocate(primaryShard, replicaOnlyNode, allocation);
+        assertEquals(Decision.Type.NO, decision.type());
+        assertTrue(decision.toString(), decision.toString().contains("primary shard"));
+        assertTrue(decision.toString(), decision.toString().contains("replica-only"));
+
+        // Primary can be allocated to data node
+        decision = decider.canAllocate(primaryShard, dataNode, allocation);
+        assertEquals(Decision.Type.YES, decision.type());
+    }
+
+    public void testReplicaCanAllocateToReplicaOnlyNodeWithAutoExpandAll() {
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState.getRoutingNodes(), clusterState, null, null, 0);
+        allocation.debugDecision(true);
+
+        ShardRouting replicaShard = ShardRouting.newUnassigned(
+            clusterState.routingTable().index("auto-expand-index").shard(0).shardId(),
+            false,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+        );
+
+        RoutingNode replicaOnlyNode = clusterState.getRoutingNodes().node("replica-only-node");
+
+        // Replica from auto-expand 0-all index CAN be allocated to replica-only node
+        Decision decision = decider.canAllocate(replicaShard, replicaOnlyNode, allocation);
+        assertEquals(Decision.Type.YES, decision.type());
+        assertTrue(decision.toString(), decision.toString().contains("auto-expand"));
+    }
+
+    public void testReplicaCannotAllocateToReplicaOnlyNodeWithoutAutoExpandAll() {
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState.getRoutingNodes(), clusterState, null, null, 0);
+        allocation.debugDecision(true);
+
+        ShardRouting replicaShard = ShardRouting.newUnassigned(
+            clusterState.routingTable().index("regular-index").shard(0).shardId(),
+            false,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+        );
+
+        RoutingNode replicaOnlyNode = clusterState.getRoutingNodes().node("replica-only-node");
+        RoutingNode dataNode = clusterState.getRoutingNodes().node("data-node");
+
+        // Replica from regular index CANNOT be allocated to replica-only node
+        Decision decision = decider.canAllocate(replicaShard, replicaOnlyNode, allocation);
+        assertEquals(Decision.Type.NO, decision.type());
+        assertTrue(decision.toString(), decision.toString().contains("does not have auto_expand_replicas"));
+
+        // Replica from regular index CAN be allocated to data node
+        decision = decider.canAllocate(replicaShard, dataNode, allocation);
+        assertEquals(Decision.Type.YES, decision.type());
+    }
+
+    public void testForceAllocatePrimaryBlocked() {
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState.getRoutingNodes(), clusterState, null, null, 0);
+        allocation.debugDecision(true);
+
+        ShardRouting primaryShard = ShardRouting.newUnassigned(
+            clusterState.routingTable().index("auto-expand-index").shard(0).shardId(),
+            true,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+        );
+
+        RoutingNode replicaOnlyNode = clusterState.getRoutingNodes().node("replica-only-node");
+        RoutingNode dataNode = clusterState.getRoutingNodes().node("data-node");
+
+        // Force allocation of primary is STILL blocked on replica-only node
+        Decision decision = decider.canForceAllocatePrimary(primaryShard, replicaOnlyNode, allocation);
+        assertEquals(Decision.Type.NO, decision.type());
+        assertTrue(decision.toString(), decision.toString().contains("cannot be force allocated"));
+
+        // Force allocation allowed on data node
+        decision = decider.canForceAllocatePrimary(primaryShard, dataNode, allocation);
+        assertEquals(Decision.Type.YES, decision.type());
+    }
+
+    public void testCanRemainFollowsSameLogic() {
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState.getRoutingNodes(), clusterState, null, null, 0);
+        allocation.debugDecision(true);
+
+        RoutingNode replicaOnlyNode = clusterState.getRoutingNodes().node("replica-only-node");
+        RoutingNode dataNode = clusterState.getRoutingNodes().node("data-node");
+
+        // Primary cannot remain on replica-only node
+        ShardRouting primaryShard = ShardRouting.newUnassigned(
+            clusterState.routingTable().index("auto-expand-index").shard(0).shardId(),
+            true,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+        );
+        Decision decision = decider.canRemain(primaryShard, replicaOnlyNode, allocation);
+        assertEquals(Decision.Type.NO, decision.type());
+
+        // Replica from auto-expand index CAN remain on replica-only node
+        ShardRouting autoExpandReplica = ShardRouting.newUnassigned(
+            clusterState.routingTable().index("auto-expand-index").shard(0).shardId(),
+            false,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+        );
+        decision = decider.canRemain(autoExpandReplica, replicaOnlyNode, allocation);
+        assertEquals(Decision.Type.YES, decision.type());
+
+        // Replica from regular index CANNOT remain on replica-only node
+        ShardRouting regularReplica = ShardRouting.newUnassigned(
+            clusterState.routingTable().index("regular-index").shard(0).shardId(),
+            false,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+        );
+        decision = decider.canRemain(regularReplica, replicaOnlyNode, allocation);
+        assertEquals(Decision.Type.NO, decision.type());
+    }
+
+    public void testShouldAutoExpandToNodeForAutoExpandAllIndex() {
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState.getRoutingNodes(), clusterState, null, null, 0);
+        allocation.debugDecision(true);
+
+        IndexMetadata autoExpandIndex = clusterState.metadata().index("auto-expand-index");
+        DiscoveryNode replicaOnlyNode = clusterState.nodes().get("replica-only-node");
+        DiscoveryNode dataNode = clusterState.nodes().get("data-node");
+
+        // Replica-only node SHOULD be included for auto-expand 0-all index
+        Decision decision = decider.shouldAutoExpandToNode(autoExpandIndex, replicaOnlyNode, allocation);
+        assertEquals(Decision.Type.YES, decision.type());
+        assertTrue(decision.toString(), decision.toString().contains("eligible for auto-expand"));
+
+        // Data node always included
+        decision = decider.shouldAutoExpandToNode(autoExpandIndex, dataNode, allocation);
+        assertEquals(Decision.Type.YES, decision.type());
+    }
+
+    public void testShouldAutoExpandToNodeForNonAutoExpandIndex() {
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState.getRoutingNodes(), clusterState, null, null, 0);
+        allocation.debugDecision(true);
+
+        IndexMetadata regularIndex = clusterState.metadata().index("regular-index");
+        DiscoveryNode replicaOnlyNode = clusterState.nodes().get("replica-only-node");
+        DiscoveryNode dataNode = clusterState.nodes().get("data-node");
+
+        // Replica-only node should NOT be included for non-auto-expand index
+        Decision decision = decider.shouldAutoExpandToNode(regularIndex, replicaOnlyNode, allocation);
+        assertEquals(Decision.Type.NO, decision.type());
+        assertTrue(decision.toString(), decision.toString().contains("without auto_expand_replicas: 0-all"));
+
+        // Data node still included
+        decision = decider.shouldAutoExpandToNode(regularIndex, dataNode, allocation);
+        assertEquals(Decision.Type.YES, decision.type());
+    }
+
+    public void testRegularDataNodeAcceptsAllShards() {
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState.getRoutingNodes(), clusterState, null, null, 0);
+        allocation.debugDecision(true);
+
+        RoutingNode dataNode = clusterState.getRoutingNodes().node("data-node");
+
+        // Regular data node can accept primaries
+        ShardRouting primaryShard = ShardRouting.newUnassigned(
+            clusterState.routingTable().index("auto-expand-index").shard(0).shardId(),
+            true,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+        );
+        Decision decision = decider.canAllocate(primaryShard, dataNode, allocation);
+        assertEquals(Decision.Type.YES, decision.type());
+
+        // Regular data node can accept replicas from auto-expand index
+        ShardRouting autoExpandReplica = ShardRouting.newUnassigned(
+            clusterState.routingTable().index("auto-expand-index").shard(0).shardId(),
+            false,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+        );
+        decision = decider.canAllocate(autoExpandReplica, dataNode, allocation);
+        assertEquals(Decision.Type.YES, decision.type());
+
+        // Regular data node can accept replicas from regular index
+        ShardRouting regularReplica = ShardRouting.newUnassigned(
+            clusterState.routingTable().index("regular-index").shard(0).shardId(),
+            false,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+        );
+        decision = decider.canAllocate(regularReplica, dataNode, allocation);
+        assertEquals(Decision.Type.YES, decision.type());
+    }
+
+    public void testAutoExpandWithDifferentSettings() {
+        // Test auto-expand with different settings (0-5, 1-all, etc.)
+        Metadata metadata = Metadata.builder()
+            .put(
+                IndexMetadata.builder("auto-expand-0-5")
+                    .settings(settings(Version.CURRENT).put(SETTING_AUTO_EXPAND_REPLICAS, "0-5"))
+                    .numberOfShards(1)
+                    .numberOfReplicas(1)
+            )
+            .put(
+                IndexMetadata.builder("auto-expand-1-all")
+                    .settings(settings(Version.CURRENT).put(SETTING_AUTO_EXPAND_REPLICAS, "1-all"))
+                    .numberOfShards(1)
+                    .numberOfReplicas(1)
+            )
+            .build();
+
+        ClusterState testState = ClusterState.builder(clusterState).metadata(metadata).build();
+        testState = ClusterState.builder(testState)
+            .routingTable(
+                org.opensearch.cluster.routing.RoutingTable.builder()
+                    .addAsNew(metadata.index("auto-expand-0-5"))
+                    .addAsNew(metadata.index("auto-expand-1-all"))
+                    .build()
+            )
+            .build();
+
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, testState.getRoutingNodes(), testState, null, null, 0);
+        RoutingNode replicaOnlyNode = testState.getRoutingNodes().node("replica-only-node");
+
+        // auto-expand 0-5: NOT 0-all, should be blocked
+        ShardRouting replica05 = ShardRouting.newUnassigned(
+            testState.routingTable().index("auto-expand-0-5").shard(0).shardId(),
+            false,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+        );
+        Decision decision = decider.canAllocate(replica05, replicaOnlyNode, allocation);
+        assertEquals(Decision.Type.NO, decision.type());
+
+        // auto-expand 1-all: NOT 0-all, should be blocked
+        ShardRouting replica1all = ShardRouting.newUnassigned(
+            testState.routingTable().index("auto-expand-1-all").shard(0).shardId(),
+            false,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+        );
+        decision = decider.canAllocate(replica1all, replicaOnlyNode, allocation);
+        assertEquals(Decision.Type.NO, decision.type());
+    }
+}


### PR DESCRIPTION
This commit introduces a new `replica_only` node role that provides read scalability without impacting the write path or triggering cluster rebalancing, enabling cost-effective horizontal scaling for read-heavy workloads.

## Motivation

Organizations often need to scale read capacity independently from write capacity. Traditional approaches of adding more data nodes cause:
- Unwanted shard rebalancing across the cluster
- Increased write coordination overhead
- Higher infrastructure costs for full-featured data nodes

The replica-only node type addresses these challenges by:
- Providing read-only shard hosting without participating in primary shard allocation or rebalancing
- Enabling cheap, ephemeral nodes that can be added/removed without cluster disruption
- Supporting integration with object stores (S3, etc.) for pulling index data on-demand

## Why Auto-Expand Replicas 0-all Only

The replica-only node type exclusively supports indices with `index.auto_expand_replicas: 0-all` for several critical reasons:

1. **Dynamic Replica Management**: Auto-expand automatically adjusts replica counts when replica-only nodes join/leave, eliminating manual intervention and preventing under-replication

2. **No Manual Rebalancing**: Without auto-expand, adding replica-only nodes would require manual replica count adjustments and could trigger rebalancing on data nodes

3. **Predictable Behavior**: The 0-all setting guarantees one copy per eligible node, making replica distribution deterministic and transparent

4. **Operational Safety**: Prevents accidental allocation of critical production indices to nodes that may be ephemeral or have different SLAs

## High-Level Design

### Core Components

1. **New Node Role (DiscoveryNodeRole.REPLICA_ONLY_ROLE)**
   - Role name: `replica_only`
   - Dedicated role that cannot coexist with any other role

2. **Allocation Decider (ReplicaOnlyAllocationDecider)**
   - Blocks ALL primary shard allocation to replica-only nodes
- Blocks replica allocation unless index has auto_expand_replicas: 0-all
   - Prevents force allocation of primaries (safety guarantee)

3. **Rebalancing Prevention (LocalShardsBalancer)**
   - Excludes replica-only nodes from rebalancing model entirely
- Adding/removing replica-only nodes causes zero data node rebalancing
   - Maintains cluster balance stability

4. **Replica Promotion Prevention (RoutingNodes)**
   - Blocks promotion of replicas to primaries on replica-only nodes
   - Cluster enters YELLOW/RED state when primary fails and only replica-only nodes have copies
   - Ensures data integrity by requiring regular data node for primaries

## Design Concerns Addressed

### 1. Data Integrity and Cluster Health
What happens if primary fails and only replica-only nodes have copies?

Replicas on replica-only nodes NEVER promote to primaries. The cluster enters YELLOW/RED state and waits for a regular data node. This prevents data loss scenarios where an ephemeral node becomes the source of truth.

### 2. Rebalancing Isolation
Will replica-only nodes trigger rebalancing on production data nodes?

Replica-only nodes are completely excluded from the BalancedShardsAllocator model. They are invisible to the balancer, ensuring zero rebalancing impact when nodes join/leave.

### 3. Role Transitions
What happens if a data node transitions to replica-only role?

- Primary shards are relocated to other data nodes
- Replicas from non-auto-expand indices are relocated out
- Replicas from auto-expand 0-all indices remain
- All transitions are safe with no data loss (canRemain() enforcement)

### 4. Recovery Code Paths
Could recovery logic accidentally create primaries on replica-only nodes?

No, via multiple layers of protection:
- AllocationDecider blocks at allocation time
- canForceAllocatePrimary() blocks forced allocation
- promoteReplicaToPrimary() has explicit replica-only check

### 5. Auto-Expand Node Counting
How do replica-only nodes integrate with auto-expand replica counting?

shouldAutoExpandToNode() in ReplicaOnlyAllocationDecider is automatically called by
AutoExpandReplicas.getDesiredNumberOfReplicas().
Replica-only nodes are counted only for 0-all indices, ensuring correct replica counts.

## Configuration Example

Node configuration:
```yaml
node.roles: [replica_only]
```

Index configuration:
```json
PUT /my-index
{
  "settings": {
    "index.auto_expand_replicas": "0-all"
  }
}
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new replica-only node role enabling nodes dedicated to storing replica shards only.

* **Bug Fixes**
  * Enhanced shard allocation logic to prevent primary shards from being assigned to replica-only nodes.
  * Added safeguards to prevent replica promotion on replica-only nodes.
  * Excluded replica-only nodes from rebalancing calculations.

* **Tests**
  * Added comprehensive test coverage for replica-only node functionality and allocation rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->