### PR TITLE
Remove child level directory on refresh for CompositeIndexWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - LeafReader should not remove SubReaderWrappers incase IndexWriter encounters a non aborting Exception ([#20193](https://github.com/opensearch-project/OpenSearch/pull/20193))
 - Fix Netty deprecation warnings in transport-reactor-netty4 module ([20429](https://github.com/opensearch-project/OpenSearch/pull/20429))
 - Fix stats aggregation returning zero results with `size:0`. ([20427](https://github.com/opensearch-project/OpenSearch/pull/20427))
+- Remove child level directory on refresh for CompositeIndexWriter ([#20326](https://github.com/opensearch-project/OpenSearch/pull/20326))
 
 ### Dependencies
 - Bump `com.google.auth:google-auth-library-oauth2-http` from 1.38.0 to 1.41.0 ([#20183](https://github.com/opensearch-project/OpenSearch/pull/20183))

--- a/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/store/remote/filecache/FileCacheTests.java
@@ -524,7 +524,6 @@ public class FileCacheTests extends OpenSearchTestCase {
             for (int j = 0; j < 10; j++) {
                 createFile(index + i, String.valueOf(j), "_" + j + "_block_" + j);
                 createWarmIndexFile(warmIndex + i, String.valueOf(j), "_" + j + "_block_" + j);
-                // Remove known extra files - "extra0" file is added by the ExtrasFS, which is part of Lucene's test framework
                 Files.deleteIfExists(
                     path.resolve(NodeEnvironment.CACHE_FOLDER)
                         .resolve(index + i)
@@ -532,6 +531,7 @@ public class FileCacheTests extends OpenSearchTestCase {
                         .resolve(RemoteSnapshotDirectoryFactory.LOCAL_STORE_LOCATION)
                         .resolve("extra0")
                 );
+                // Remove known extra files - "extra0" file is added by the ExtrasFS, which is part of Lucene's test framework
                 Files.deleteIfExists(
                     path.resolve(NodeEnvironment.INDICES_FOLDER)
                         .resolve(warmIndex + i)


### PR DESCRIPTION
### Description
Remove child level directory during refresh once child level IndexWriter is synced with parent IndexWriter.

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/19921


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Child index directories are now removed during refresh, preventing accumulation of orphaned on-disk directories.

* **Tests**
  * Added/updated tests to verify child directories are deleted after refresh and to validate concurrent indexing during refresh cycles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->