### PR TITLE
fix to make lucene search path work

### DIFF
--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -772,6 +772,7 @@ final class DefaultSearchContext extends SearchContext {
         return collapse;
     }
 
+    @Override
     public SearchContext sliceBuilder(SliceBuilder sliceBuilder) {
         this.sliceBuilder = sliceBuilder;
         return this;
@@ -1051,6 +1052,7 @@ final class DefaultSearchContext extends SearchContext {
     /**
      * Evaluate if request should use concurrent search based on request and concurrent search deciders
      */
+    @Override
     public void evaluateRequestShouldUseConcurrentSearch() {
         if (sort != null && sort.isSortOnTimeSeriesField()) {
             requestShouldUseConcurrentSearch.set(false);
@@ -1067,6 +1069,7 @@ final class DefaultSearchContext extends SearchContext {
             }
     }
 
+    @Override
     public void setProfilers(Profilers profilers) {
         this.profilers = profilers;
     }

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -79,6 +79,7 @@ import org.opensearch.search.profile.Profilers;
 import org.opensearch.search.query.QuerySearchResult;
 import org.opensearch.search.query.ReduceableSearchResult;
 import org.opensearch.search.rescore.RescoreContext;
+import org.opensearch.search.slice.SliceBuilder;
 import org.opensearch.search.sort.SortAndFormats;
 import org.opensearch.search.streaming.FlushMode;
 import org.opensearch.search.suggest.SuggestionSearchContext;
@@ -254,6 +255,12 @@ public abstract class SearchContext implements Releasable {
     public abstract boolean hasScriptFields();
 
     public abstract ScriptFieldsContext scriptFields();
+    public void evaluateRequestShouldUseConcurrentSearch() {
+        // do nothing
+    }
+    public void setProfilers(Profilers profilers) {
+        // do nothing
+    }
 
     /**
      * A shortcut function to see whether there is a fetchSourceContext and it says the source is requested.
@@ -611,5 +618,10 @@ public abstract class SearchContext implements Releasable {
     // TODO : This should be a part of mapper given by DataFormat or SearchEngine as related to Field type.
     public Comparable convertToComparable(Object rawValue) {
         throw new UnsupportedOperationException("Engine doesn't implement response value conversion");
+    }
+
+    public SearchContext sliceBuilder(SliceBuilder slice) {
+        // do nothing
+        return this;
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Removing `getIndexingCoordinator` and making the search path use `getIndexer` . Also pulling some methods of `DefaultSearchContext` to base `SearchContext` to make Lucene searches work.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
