### PR TITLE
Debug Dockerfile flakiness related to openjdk-21-jre-headless

### DIFF
--- a/test/fixtures/azure-fixture/Dockerfile
+++ b/test/fixtures/azure-fixture/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
-RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-21-jre-headless
+RUN apt-get update -y
+RUN apt-get install -y openjdk-21-jre-headless
 ENTRYPOINT exec java -classpath "/fixture/shared/*" fixture.azure.AzureHttpFixture 0.0.0.0 8091 container
 EXPOSE 8091

--- a/test/fixtures/gcs-fixture/Dockerfile
+++ b/test/fixtures/gcs-fixture/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
-RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-21-jre-headless
+RUN apt-get update -y
+RUN apt-get install -y openjdk-21-jre-headless
 
 ARG port
 ARG bucket

--- a/test/fixtures/s3-fixture/Dockerfile
+++ b/test/fixtures/s3-fixture/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
-RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-21-jre-headless
+RUN apt-get update -y
+RUN apt-get install -y openjdk-21-jre-headless
 
 ARG fixtureClass
 ARG port

--- a/test/fixtures/s3-fixture/Dockerfile.eks
+++ b/test/fixtures/s3-fixture/Dockerfile.eks
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
-RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-21-jre-headless
+RUN apt-get update -y
+RUN apt-get install -y openjdk-21-jre-headless
 
 ARG fixtureClass
 ARG port


### PR DESCRIPTION
### Description

Trying to debug errors such as

```
> Task :test:fixtures:azure-fixture:composeBuild
The command '/bin/sh -c apt-get install -qqy openjdk-21-jre-headless' returned a non-zero code: 100
Service 'azure-fixture' failed to build : Build failed
```

that I cannot reproduce locally.

### Related Issues

See a few times today already. See https://build.ci.opensearch.org/job/gradle-check/69685/console for one such example.

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
