### PR TITLE
Set Gradle warning mode back to fail

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,10 +26,7 @@ options.forkOptions.memoryMaximumSize=3g
 systemProp.org.gradle.dependency.duplicate.project.detection=false
 
 # Enforce the build to fail on deprecated gradle api usage
-# TODO: Waiting for https://github.com/google/protobuf-gradle-plugin/commit/894f2d25e2b511bc11661f4d23e47ee0671e82ad
-# to be released in the Protobuf gradle plugin, at which this point can be changed
-# back to `fail`
-systemProp.org.gradle.warning.mode=all
+systemProp.org.gradle.warning.mode=fail
 
 systemProp.jdk.tls.client.protocols=TLSv1.2,TLSv1.3
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -31,7 +31,7 @@
 import groovy.xml.XmlParser
 
 plugins {
-  id('com.google.protobuf') version 'latest.release'
+  id('com.google.protobuf') version '0.9.6'
   id('opensearch.build')
   id('opensearch.publish')
   id('opensearch.internal-cluster-test')


### PR DESCRIPTION
The protobuf gradle plugin has been updated to remove the gradle warning so we can change back to fail on gradle warnings. Also change the protobuf gradle plugin to use a specific version to make the build more reproducible.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Gradle build configuration to enforce stricter error handling for deprecated API usage, improving code quality and maintainability during development.
  * Updated protobuf plugin to a stable version for better reliability and improved system compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->