### PR TITLE
Fuzziness support for bool prefix type and fuzzy match queries

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/search/query/BoolPrefixFuzzinessIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/BoolPrefixFuzzinessIT.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.search.query;
+
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.index.query.MatchBoolPrefixQueryBuilder;
+import org.opensearch.index.query.MultiMatchQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
+
+public class BoolPrefixFuzzinessIT extends OpenSearchIntegTestCase {
+
+    public void testBoolPrefixWithFuzziness() {
+        assertAcked(
+            prepareCreate("test").setSettings(
+                Settings.builder()
+                    .put("index.analysis.analyzer.my_analyzer.tokenizer", "standard")
+                    .put("index.analysis.analyzer.my_analyzer.filter", "lowercase")
+                    .build()
+            ).setMapping(
+                "my_field",
+                "type=text,analyzer=my_analyzer"
+            )
+        );
+
+        client().prepareIndex("test").setId("1").setSource("my_field", "license").get();
+        refresh();
+        
+        // Debug: Check if the document exists
+        SearchResponse checkResponse = client().prepareSearch("test").get();
+        logger.info("Document check response: {}", checkResponse);
+
+        // Test with multi_match query
+        MultiMatchQueryBuilder multiMatchQuery = new MultiMatchQueryBuilder("lisence", "my_field")
+            .type(MultiMatchQueryBuilder.Type.BOOL_PREFIX)
+            .fuzziness(Fuzziness.ONE);
+        logger.info("Multi-match query: {}", multiMatchQuery);
+        
+        // Try a direct fuzzy query to see if it works
+        QueryBuilder fuzzyQuery = QueryBuilders.fuzzyQuery("my_field", "lisence").fuzziness(Fuzziness.ONE);
+        SearchResponse fuzzyResponse = client().prepareSearch("test")
+            .setQuery(fuzzyQuery)
+            .get();
+        logger.info("Response for direct fuzzy query: {}", fuzzyResponse);
+        
+        // Now try the multi_match query
+        SearchResponse response = client().prepareSearch("test")
+            .setQuery(multiMatchQuery)
+            .get();
+        logger.info("Response for multi_match query: {}", response);
+        assertHitCount(response, 1L);
+
+        // Test with match_bool_prefix query
+        response = client().prepareSearch("test")
+            .setQuery(
+                new MatchBoolPrefixQueryBuilder("my_field", "lisence")
+                    .fuzziness(Fuzziness.ONE)
+            )
+            .get();
+        logger.info("Response for match_bool_prefix query: {}", response);
+        assertHitCount(response, 1L);
+
+        // Test with multi_match query and multiple terms
+        response = client().prepareSearch("test")
+            .setQuery(
+                new MultiMatchQueryBuilder("opensarch lisence", "my_field")
+                    .type(MultiMatchQueryBuilder.Type.BOOL_PREFIX)
+                    .fuzziness(Fuzziness.ONE)
+            )
+            .get();
+        assertHitCount(response, 1L);
+
+        // Test with match_bool_prefix query and multiple terms
+        response = client().prepareSearch("test")
+            .setQuery(
+                new MatchBoolPrefixQueryBuilder("my_field", "opensarch lisence")
+                    .fuzziness(Fuzziness.ONE)
+            )
+            .get();
+        assertHitCount(response, 1L);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/query/MultiMatchQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/MultiMatchQueryBuilder.java
@@ -737,6 +737,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
             throw new ParsingException(parser.getTokenLocation(), "No text specified for multi_match query");
         }
 
+        // Allow fuzziness for BOOL_PREFIX but not for CROSS_FIELDS, PHRASE, or PHRASE_PREFIX
         if (fuzziness != null && (type == Type.CROSS_FIELDS || type == Type.PHRASE || type == Type.PHRASE_PREFIX)) {
             throw new ParsingException(
                 parser.getTokenLocation(),

--- a/server/src/test/java/org/opensearch/index/query/BoolPrefixFuzzinessTests.java
+++ b/server/src/test/java/org/opensearch/index/query/BoolPrefixFuzzinessTests.java
@@ -1,0 +1,140 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.query;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.Query;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.test.AbstractQueryTestCase;
+
+import java.io.IOException;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertBooleanSubQuery;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+public class BoolPrefixFuzzinessTests extends AbstractQueryTestCase<MultiMatchQueryBuilder> {
+
+    @Override
+    protected MultiMatchQueryBuilder doCreateTestQueryBuilder() {
+        return new MultiMatchQueryBuilder("test", TEXT_FIELD_NAME);
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(MultiMatchQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+        // Not used in this test
+    }
+
+    public void testBoolPrefixWithFuzziness() throws Exception {
+        QueryShardContext context = createShardContext();
+        
+        // Test with a single term
+        MultiMatchQueryBuilder builder = new MultiMatchQueryBuilder("foo", TEXT_FIELD_NAME);
+        builder.type(MultiMatchQueryBuilder.Type.BOOL_PREFIX);
+        builder.fuzziness(Fuzziness.ONE);
+        Query query = builder.toQuery(context);
+        
+        assertThat(query, instanceOf(BooleanQuery.class));
+        BooleanQuery booleanQuery = (BooleanQuery) query;
+        assertThat(booleanQuery.clauses().size(), equalTo(1));
+        
+        // Check the query structure directly
+        BooleanClause clause = booleanQuery.clauses().get(0);
+        Query innerQuery = clause.query();
+        
+        // The query should contain a FuzzyQuery
+        assertThat(innerQuery, instanceOf(FuzzyQuery.class));
+        FuzzyQuery fuzzyQuery = (FuzzyQuery) innerQuery;
+        assertThat(fuzzyQuery.getTerm(), equalTo(new Term(TEXT_FIELD_NAME, "foo")));
+        
+        // Test with multiple terms
+        builder = new MultiMatchQueryBuilder("foo bar", TEXT_FIELD_NAME);
+        builder.type(MultiMatchQueryBuilder.Type.BOOL_PREFIX);
+        builder.fuzziness(Fuzziness.ONE);
+        query = builder.toQuery(context);
+        
+        assertThat(query, instanceOf(BooleanQuery.class));
+        BooleanQuery multiTermQuery = (BooleanQuery) query;
+        assertThat(multiTermQuery.clauses().size(), equalTo(2));
+        
+        // Check first term
+        BooleanClause clause1 = multiTermQuery.clauses().get(0);
+        Query innerQuery1 = clause1.query();
+        assertThat(innerQuery1, instanceOf(FuzzyQuery.class));
+        FuzzyQuery fuzzyQuery1 = (FuzzyQuery) innerQuery1;
+        assertThat(fuzzyQuery1.getTerm(), equalTo(new Term(TEXT_FIELD_NAME, "foo")));
+        
+        // Check second term
+        BooleanClause clause2 = multiTermQuery.clauses().get(1);
+        Query innerQuery2 = clause2.query();
+        assertThat(innerQuery2, instanceOf(FuzzyQuery.class));
+        FuzzyQuery fuzzyQuery2 = (FuzzyQuery) innerQuery2;
+        assertThat(fuzzyQuery2.getTerm(), equalTo(new Term(TEXT_FIELD_NAME, "bar")));
+    }
+    
+    public void testBoolPrefixWithFuzzinessForMisspelledTerm() throws Exception {
+        QueryShardContext context = createShardContext();
+        
+        // Test with a misspelled term (similar to the user's scenario)
+        MultiMatchQueryBuilder builder = new MultiMatchQueryBuilder("lisence", TEXT_FIELD_NAME);
+        builder.type(MultiMatchQueryBuilder.Type.BOOL_PREFIX);
+        builder.fuzziness(Fuzziness.ONE);
+        Query query = builder.toQuery(context);
+        
+        assertThat(query, instanceOf(BooleanQuery.class));
+        BooleanQuery boolQuery = (BooleanQuery) query;
+        assertThat(boolQuery.clauses().size(), equalTo(1));
+        
+        // Check the query structure directly
+        BooleanClause clause = boolQuery.clauses().get(0);
+        Query innerQuery = clause.query();
+        
+        // The query should contain a FuzzyQuery
+        assertThat(innerQuery, instanceOf(FuzzyQuery.class));
+        FuzzyQuery fuzzyQuery = (FuzzyQuery) innerQuery;
+        assertThat(fuzzyQuery.getTerm(), equalTo(new Term(TEXT_FIELD_NAME, "lisence")));
+        
+        // Test with multiple fields
+        builder = new MultiMatchQueryBuilder("lisence", TEXT_FIELD_NAME, KEYWORD_FIELD_NAME);
+        builder.type(MultiMatchQueryBuilder.Type.BOOL_PREFIX);
+        builder.fuzziness(Fuzziness.ONE);
+        query = builder.toQuery(context);
+        
+        assertThat(query, instanceOf(BooleanQuery.class));
+        BooleanQuery multiFieldQuery = (BooleanQuery) query;
+        assertThat(multiFieldQuery.clauses().size(), equalTo(2));
+        
+        // Test with multiple terms including a misspelled one
+        builder = new MultiMatchQueryBuilder("opensarch lisence", TEXT_FIELD_NAME);
+        builder.type(MultiMatchQueryBuilder.Type.BOOL_PREFIX);
+        builder.fuzziness(Fuzziness.ONE);
+        query = builder.toQuery(context);
+        
+        assertThat(query, instanceOf(BooleanQuery.class));
+        BooleanQuery multiTermMisspelledQuery = (BooleanQuery) query;
+        assertThat(multiTermMisspelledQuery.clauses().size(), equalTo(2));
+        
+        // Check first term
+        BooleanClause clause1 = multiTermMisspelledQuery.clauses().get(0);
+        Query innerQuery1 = clause1.query();
+        assertThat(innerQuery1, instanceOf(FuzzyQuery.class));
+        FuzzyQuery fuzzyQuery1 = (FuzzyQuery) innerQuery1;
+        assertThat(fuzzyQuery1.getTerm(), equalTo(new Term(TEXT_FIELD_NAME, "opensarch")));
+        
+        // Check second term
+        BooleanClause clause2 = multiTermMisspelledQuery.clauses().get(1);
+        Query innerQuery2 = clause2.query();
+        assertThat(innerQuery2, instanceOf(FuzzyQuery.class));
+        FuzzyQuery fuzzyQuery2 = (FuzzyQuery) innerQuery2;
+        assertThat(fuzzyQuery2.getTerm(), equalTo(new Term(TEXT_FIELD_NAME, "lisence")));
+    }
+}

--- a/server/src/test/java/org/opensearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/MultiMatchQueryBuilderTests.java
@@ -330,6 +330,18 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
         }
     }
 
+    public void testToQueryBooleanPrefixWithFuzziness() throws IOException {
+        final MultiMatchQueryBuilder builder = new MultiMatchQueryBuilder("foo bar", TEXT_FIELD_NAME);
+        builder.type(Type.BOOL_PREFIX);
+        builder.fuzziness(Fuzziness.ONE);
+        final Query query = builder.toQuery(createShardContext());
+        assertThat(query, instanceOf(BooleanQuery.class));
+        final BooleanQuery booleanQuery = (BooleanQuery) query;
+        assertThat(booleanQuery.clauses(), hasSize(2));
+        assertThat(assertBooleanSubQuery(booleanQuery, FuzzyQuery.class, 0).getTerm(), equalTo(new Term(TEXT_FIELD_NAME, "foo")));
+        assertThat(assertBooleanSubQuery(booleanQuery, FuzzyQuery.class, 1).getTerm(), equalTo(new Term(TEXT_FIELD_NAME, "bar")));
+    }
+
     public void testFromJson() throws IOException {
         String json = "{\n"
             + "  \"multi_match\" : {\n"


### PR DESCRIPTION
Querying search_as_you_type fields with [the recommended](https://opensearch.org/docs/2.6/field-types/search-as-you-type/) multi_match bool_prefix query does not take into account any "fuzziness" value. This PR aims to fix issue.

### Description
[Describe what this change achieves]

### Related Issues
Addresses: #6777 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
