### PR TITLE
Term query I/O concurrency optimization

### DIFF
--- a/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/opensearch/search/query/TopDocsCollectorContext.java
@@ -468,17 +468,19 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
                 totalHitsSupplier = () -> new TotalHits(0, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
                 hitCount = -1;
             } else {
+                boolean shouldShortcutTotalHitCount = shouldShortcutTotalHitCount(hasFilterCollector, reader.hasDeletions(), query);
                 // implicit total hit counts are valid only when there is no filter collector in the chain
-                this.hitCount = hasFilterCollector ? -1 : shortcutTotalHitCount(reader, query);
-                if (this.hitCount == -1) {
+                if (!shouldShortcutTotalHitCount) {
                     topDocsCollector = createCollector(sortAndFormats, numHits, searchAfter, trackTotalHitsUpTo);
                     topDocsSupplier = new CachedSupplier<>(topDocsCollector::topDocs);
+                    hitCount = -1;
                     totalHitsSupplier = () -> topDocsSupplier.get().totalHits;
                 } else {
                     // don't compute hit counts via the collector
                     topDocsCollector = createCollector(sortAndFormats, numHits, searchAfter, 1);
                     topDocsSupplier = new CachedSupplier<>(topDocsCollector::topDocs);
-                    totalHitsSupplier = () -> new TotalHits(this.hitCount, TotalHits.Relation.EQUAL_TO);
+                    hitCount = 0;
+                    totalHitsSupplier = shortcutTotalHitCountSupplier(reader, query);
                 }
             }
             MaxScoreCollector maxScoreCollector = null;
@@ -509,6 +511,11 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
             }
 
             this.collector = MultiCollector.wrap(topDocsCollector, maxScoreCollector);
+        }
+
+        private Supplier<TotalHits> shortcutTotalHitCountSupplier(IndexReader reader, Query query) throws IOException {
+            long shortcutTotalHitCnt = shortcutTotalHitCount(reader, query);
+            return () -> (new TotalHits(shortcutTotalHitCnt, TotalHits.Relation.EQUAL_TO));
         }
 
         private class SimpleTopDocsCollectorManager
@@ -621,7 +628,7 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
                 if (hitCount == -1) {
                     totalHits = topDocs.totalHits;
                 } else {
-                    totalHits = new TotalHits(hitCount, TotalHits.Relation.EQUAL_TO);
+                    totalHits = totalHitsSupplier.get();
                 }
             }
 
@@ -765,21 +772,7 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
      * -1 otherwise.
      */
     static int shortcutTotalHitCount(IndexReader reader, Query query) throws IOException {
-        while (true) {
-            // remove wrappers that don't matter for counts
-            // this is necessary so that we don't only optimize match_all
-            // queries but also match_all queries that are nested in
-            // a constant_score query
-            if (query instanceof ConstantScoreQuery constantScoreQuery) {
-                query = constantScoreQuery.getQuery();
-            } else if (query instanceof BoostQuery boostQuery) {
-                query = boostQuery.getQuery();
-            } else if (query instanceof ApproximateScoreQuery approximateScoreQuery) {
-                query = approximateScoreQuery.getOriginalQuery();
-            } else {
-                break;
-            }
-        }
+        query = removeWrappersFromQuery(query);
         if (query.getClass() == MatchAllDocsQuery.class) {
             return reader.numDocs();
         } else if (query.getClass() == TermQuery.class && reader.hasDeletions() == false) {
@@ -815,6 +808,35 @@ public abstract class TopDocsCollectorContext extends QueryCollectorContext impl
         } else {
             return -1;
         }
+    }
+
+    static boolean shouldShortcutTotalHitCount(boolean hasFilterCollector, boolean hasDeletions, Query query) {
+        if (hasFilterCollector) {
+            return false;
+        }
+        query = removeWrappersFromQuery(query);
+        return (query.getClass() == MatchAllDocsQuery.class) ||
+            (query.getClass() == TermQuery.class && hasDeletions == false) ||
+            (query.getClass() == FieldExistsQuery.class && hasDeletions == false);
+    }
+
+    static Query removeWrappersFromQuery(Query query) {
+        while (true) {
+            // remove wrappers that don't matter for counts
+            // this is necessary so that we don't only optimize match_all
+            // queries but also match_all queries that are nested in
+            // a constant_score query
+            if (query instanceof ConstantScoreQuery constantScoreQuery) {
+                query = constantScoreQuery.getQuery();
+            } else if (query instanceof BoostQuery boostQuery) {
+                query = boostQuery.getQuery();
+            } else if (query instanceof ApproximateScoreQuery approximateScoreQuery) {
+                query = approximateScoreQuery.getOriginalQuery();
+            } else {
+                break;
+            }
+        }
+        return query;
     }
 
     /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized search query hit count computation to improve execution efficiency. The system now strategically bypasses redundant processing for specific query patterns, reducing computational overhead and enabling faster search results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->