### PR TITLE
fix removeMergingSegment function in CompositeMergePolicy

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/exec/WriterFileSet.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/WriterFileSet.java
@@ -110,8 +110,12 @@ public class WriterFileSet implements Serializable, Writeable {
 
     @Override
     public boolean equals(Object o) {
-        WriterFileSet other = (WriterFileSet) o;
-        return this.directory.equals(other.directory) && this.files.equals(other.files) && this.getWriterGeneration() == other.getWriterGeneration();
+        if (this == o) return true;
+        if (!(o instanceof WriterFileSet other)) return false;
+
+        return this.getWriterGeneration() == other.getWriterGeneration()
+            && this.directory.equals(other.directory)
+            && this.files.equals(other.files);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/engine/exec/merge/CompositeMergePolicy.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/merge/CompositeMergePolicy.java
@@ -27,15 +27,7 @@ import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 public class CompositeMergePolicy implements MergePolicy.MergeContext {
     private final MergePolicy luceneMergePolicy;
@@ -210,6 +202,7 @@ public class CompositeMergePolicy implements MergePolicy.MergeContext {
 
     private static class SegmentWrapper extends SegmentCommitInfo {
         private final long totalSizeBytes;
+        private final Segment segment;
 
         public SegmentWrapper(Segment segment, long totalSizeBytes, long totalNumDocs) throws IOException {
             super(
@@ -253,6 +246,7 @@ public class CompositeMergePolicy implements MergePolicy.MergeContext {
                 // id
                 UUID.randomUUID().toString().substring(0,16).getBytes());
             this.totalSizeBytes = totalSizeBytes;
+            this.segment = segment;
         }
 
         @Override
@@ -263,6 +257,21 @@ public class CompositeMergePolicy implements MergePolicy.MergeContext {
         @Override
         public int getDelCount() {
             return 0;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof SegmentWrapper other)) return false;
+
+            if (this.segment.getGeneration() != other.segment.getGeneration()) return false;
+            return Objects.equals(this.segment.getDFGroupedSearchableFiles(),
+                other.segment.getDFGroupedSearchableFiles());
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(segment.getGeneration());
         }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change fixes an issue in CompositeMergePolicy.removeMergingSegment() where segments could fail to be removed from the mergingSegments queue.
Previously, SegmentWrapper did not override equals() and hashCode(), so removal relied on object identity. Since removeMergingSegment() reconstructs new wrapper instances when removing, the lookup could fail even for logically identical segments.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
