### PR TITLE
Enable integ test case for context aware segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Move Randomness from server to libs/common ([#20570](https://github.com/opensearch-project/OpenSearch/pull/20570))
 - Use env variable (OPENSEARCH_FIPS_MODE) to enable opensearch to run in FIPS enforced mode instead of checking for existence of bcFIPS jars ([#20625](https://github.com/opensearch-project/OpenSearch/pull/20625))
 - Update streaming flag to use search request context ([#20530](https://github.com/opensearch-project/OpenSearch/pull/20530))
+- Enable integ test case for context aware segments ([#20457](https://github.com/opensearch-project/OpenSearch/pull/20457))
 
 ### Fixed
 - Fix flaky test failures in ShardsLimitAllocationDeciderIT ([#20375](https://github.com/opensearch-project/OpenSearch/pull/20375))

--- a/modules/transport-grpc/src/internalClusterTest/java/org/opensearch/transport/grpc/LoadExtendingPluginServicesIT.java
+++ b/modules/transport-grpc/src/internalClusterTest/java/org/opensearch/transport/grpc/LoadExtendingPluginServicesIT.java
@@ -108,6 +108,17 @@ public class LoadExtendingPluginServicesIT extends GrpcTransportBaseIT {
                 null,
                 List.of(GrpcPlugin.class.getName()),
                 false
+            ),
+            new PluginInfo(
+                ContextAwareIndexPlugin.class.getName(),
+                "classpath plugin",
+                "NA",
+                org.opensearch.Version.CURRENT,
+                "1.8",
+                ContextAwareIndexPlugin.class.getName(),
+                null,
+                Collections.emptyList(),
+                false
             )
         );
     }

--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/ConcurrentSearchTasksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/node/tasks/ConcurrentSearchTasksIT.java
@@ -15,6 +15,7 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.FeatureFlagSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.tasks.resourcetracker.ThreadResourceInfo;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchService;
@@ -67,6 +68,8 @@ public class ConcurrentSearchTasksIT extends AbstractTasksIT {
         for (Setting builtInFlag : FeatureFlagSettings.BUILT_IN_FEATURE_FLAGS) {
             featureSettings.put(builtInFlag.getKey(), builtInFlag.getDefaultRaw(Settings.EMPTY));
         }
+
+        featureSettings.put(FeatureFlags.CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_FLAG, true);
         return featureSettings.build();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/ShardsLimitAllocationDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/routing/allocation/decider/ShardsLimitAllocationDeciderIT.java
@@ -104,6 +104,7 @@ public class ShardsLimitAllocationDeciderIT extends ParameterizedStaticSettingsO
     protected Settings featureFlagSettings() {
         Settings.Builder featureSettings = Settings.builder();
         featureSettings.put(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG, true);
+        featureSettings.put(FeatureFlags.CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_FLAG, true);
         return featureSettings.build();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/shards/ClusterShardLimitIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/shards/ClusterShardLimitIT.java
@@ -140,6 +140,7 @@ public class ClusterShardLimitIT extends ParameterizedStaticSettingsOpenSearchIn
     protected Settings featureFlagSettings() {
         Settings.Builder featureSettings = Settings.builder();
         featureSettings.put(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG, true);
+        featureSettings.put(FeatureFlags.CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_FLAG, true);
         return featureSettings.build();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/index/shard/IndexShardIT.java
@@ -95,6 +95,7 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.DummyShardLock;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.InternalSettingsPlugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Assert;
@@ -664,7 +665,8 @@ public class IndexShardIT extends OpenSearchSingleNodeTestCase {
             getInstanceFromNode(CircuitBreakerService.class),
             env.nodeId(),
             getInstanceFromNode(ClusterService.class),
-            listener
+            listener,
+            new OpenSearchIntegTestCase.ContextAwareIndexOperationListener()
         );
         shardRef.set(newShard);
         recoverShard(newShard);

--- a/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/CircuitBreakerNoopIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/memory/breaker/CircuitBreakerNoopIT.java
@@ -34,6 +34,7 @@ package org.opensearch.indices.memory.breaker;
 
 import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -59,6 +60,7 @@ public class CircuitBreakerNoopIT extends OpenSearchIntegTestCase {
             .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_TYPE_SETTING.getKey(), "noop")
             // This is set low, because if the "noop" is not a noop, it will break
             .put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "10b")
+            .put(FeatureFlags.CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_FLAG, true)
             .build();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/indices/replication/WarmIndexSegmentReplicationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/replication/WarmIndexSegmentReplicationIT.java
@@ -157,6 +157,7 @@ public class WarmIndexSegmentReplicationIT extends SegmentReplicationBaseIT {
     protected Settings featureFlagSettings() {
         Settings.Builder featureSettings = Settings.builder();
         featureSettings.put(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG, true);
+        featureSettings.put(FeatureFlags.CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_FLAG, true);
         return featureSettings.build();
     }
 

--- a/server/src/internalClusterTest/java/org/opensearch/plugins/ClasspathPluginIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/plugins/ClasspathPluginIT.java
@@ -65,6 +65,17 @@ public class ClasspathPluginIT extends OpenSearchIntegTestCase {
                 null,
                 List.of(SampleExtensiblePlugin.class.getName()),
                 false
+            ),
+            new PluginInfo(
+                ContextAwareIndexPlugin.class.getName(),
+                "classpath plugin",
+                "NA",
+                org.opensearch.Version.CURRENT,
+                "1.8",
+                ContextAwareIndexPlugin.class.getName(),
+                null,
+                Collections.emptyList(),
+                false
             )
         );
     }

--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/WritableWarmIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/WritableWarmIT.java
@@ -77,6 +77,7 @@ public class WritableWarmIT extends RemoteStoreBaseIntegTestCase {
     protected Settings featureFlagSettings() {
         Settings.Builder featureSettings = Settings.builder();
         featureSettings.put(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG, true);
+        featureSettings.put(FeatureFlags.CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_FLAG, true);
         return featureSettings.build();
     }
 

--- a/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/FeatureFlagSettings.java
@@ -37,6 +37,7 @@ public class FeatureFlagSettings extends AbstractScopedSettings {
         FeatureFlags.REMOTE_STORE_MIGRATION_EXPERIMENTAL_SETTING,
         FeatureFlags.APPLICATION_BASED_CONFIGURATION_TEMPLATES_SETTING,
         FeatureFlags.TERM_VERSION_PRECOMMIT_ENABLE_SETTING,
-        FeatureFlags.STREAM_TRANSPORT_SETTING
+        FeatureFlags.STREAM_TRANSPORT_SETTING,
+        FeatureFlags.CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_SETTING
     );
 }

--- a/server/src/main/java/org/opensearch/index/engine/CompositeIndexWriter.java
+++ b/server/src/main/java/org/opensearch/index/engine/CompositeIndexWriter.java
@@ -40,6 +40,7 @@ import org.opensearch.index.store.Store;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -346,12 +347,12 @@ public class CompositeIndexWriter implements DocumentIndexWriter {
             public CriteriaBasedIndexWriterLookup tryAcquire() {
                 boolean locked = lock.tryLock();
                 if (locked) {
-                    assert addCurrentThread();
                     if (lookup.isClosed()) {
-                        this.close();
+                        lock.unlock();
                         return null;
                     }
 
+                    assert addCurrentThread();
                     return lookup;
                 } else {
                     return null;
@@ -543,16 +544,22 @@ public class CompositeIndexWriter implements DocumentIndexWriter {
     private void refreshDocumentsForParentDirectory(CriteriaBasedIndexWriterLookup oldMap) throws IOException {
         final Map<String, CompositeIndexWriter.DisposableIndexWriter> markForRefreshIndexWritersMap = oldMap.criteriaBasedIndexWriterMap;
         deletePreviousVersionsForUpdatedDocuments();
-        Directory directoryToCombine;
+        final List<Directory> directoryToCombine = new ArrayList<>();
+        final List<Path> childDirectoryPaths = new ArrayList<>();
+        final AtomicLong pendingNumDocsByOldChildWriter = new AtomicLong();
         for (CompositeIndexWriter.DisposableIndexWriter childDisposableWriter : markForRefreshIndexWritersMap.values()) {
-            directoryToCombine = childDisposableWriter.getIndexWriter().getDirectory();
+            directoryToCombine.add(childDisposableWriter.getIndexWriter().getDirectory());
             childDisposableWriter.getIndexWriter().close();
-            long pendingNumDocsByOldChildWriter = childDisposableWriter.getIndexWriter().getPendingNumDocs();
-            accumulatingIndexWriter.addIndexes(directoryToCombine);
-            Path childDirectoryPath = getLocalFSDirectory(directoryToCombine).getDirectory();
+            pendingNumDocsByOldChildWriter.addAndGet(childDisposableWriter.getIndexWriter().getPendingNumDocs());
+            Path childDirectoryPath = getLocalFSDirectory(childDisposableWriter.getIndexWriter().getDirectory()).getDirectory();
+            childDirectoryPaths.add(childDirectoryPath);
+        }
+
+        if (!directoryToCombine.isEmpty()) {
+            accumulatingIndexWriter.addIndexes(directoryToCombine.toArray(new Directory[0]));
             IOUtils.closeWhileHandlingException(directoryToCombine);
-            childWriterPendingNumDocs.addAndGet(-pendingNumDocsByOldChildWriter);
-            IOUtils.rm(childDirectoryPath);
+            childWriterPendingNumDocs.addAndGet(-pendingNumDocsByOldChildWriter.get());
+            IOUtils.rm(childDirectoryPaths.toArray(new Path[0]));
         }
 
         deleteDummyTombstoneEntry();

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -5011,7 +5011,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         // refresh. If the index is context aware enabled, search idle is not supported. This will ensure periodic sync
         // between child and parent IndexWriter.
         // task continues to upload to remote store periodically.
-        if (isRemoteTranslogEnabled() || indexSettings.isAssignedOnRemoteNode() || indexSettings.isContextAwareEnabled()) {
+        if (isRemoteTranslogEnabled() || indexSettings.isAssignedOnRemoteNode()) {
             return false;
         }
         return indexSettings.isSegRepEnabledOrRemoteNode() == false || indexSettings.getNumberOfReplicas() == 0;

--- a/server/src/test/java/org/opensearch/action/admin/indices/tiering/TransportHotToWarmTieringActionTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/tiering/TransportHotToWarmTieringActionTests.java
@@ -47,6 +47,7 @@ public class TransportHotToWarmTieringActionTests extends OpenSearchIntegTestCas
     protected Settings featureFlagSettings() {
         Settings.Builder featureSettings = Settings.builder();
         featureSettings.put(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG, true);
+        featureSettings.put(FeatureFlags.CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_FLAG, true);
         return featureSettings.build();
     }
 

--- a/test/framework/src/main/java/org/opensearch/remotestore/RemoteStoreBaseIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/remotestore/RemoteStoreBaseIntegTestCase.java
@@ -75,6 +75,7 @@ public class RemoteStoreBaseIntegTestCase extends OpenSearchIntegTestCase {
     protected static int REPLICA_COUNT = 1;
     protected static final String TOTAL_OPERATIONS = "total-operations";
     protected static final String REFRESHED_OR_FLUSHED_OPERATIONS = "refreshed-or-flushed-operations";
+    protected static final String FLUSHED_OPERATIONS = "flushed-operations";
     protected static final String MAX_SEQ_NO_TOTAL = "max-seq-no-total";
     protected static final String MAX_SEQ_NO_REFRESHED_OR_FLUSHED = "max-seq-no-refreshed-or-flushed";
 
@@ -101,10 +102,12 @@ public class RemoteStoreBaseIntegTestCase extends OpenSearchIntegTestCase {
         long maxSeqNo = -1;
         long maxSeqNoRefreshedOrFlushed = -1;
         int shardId = 0;
+        long flushCount = 0;
         Map<String, Long> indexingStats = new HashMap<>();
         for (int i = 0; i < numberOfIterations; i++) {
             if (invokeFlush) {
                 flushAndRefresh(index);
+                ++flushCount;
             } else {
                 refresh(index);
             }
@@ -133,6 +136,7 @@ public class RemoteStoreBaseIntegTestCase extends OpenSearchIntegTestCase {
 
         indexingStats.put(TOTAL_OPERATIONS, totalOperations);
         indexingStats.put(REFRESHED_OR_FLUSHED_OPERATIONS, refreshedOrFlushedOperations);
+        indexingStats.put(FLUSHED_OPERATIONS, flushCount);
         indexingStats.put(MAX_SEQ_NO_TOTAL, maxSeqNo);
         indexingStats.put(MAX_SEQ_NO_REFRESHED_OR_FLUSHED, maxSeqNoRefreshedOrFlushed);
         return indexingStats;

--- a/test/framework/src/main/java/org/opensearch/remotestore/RemoteStoreCoreTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/remotestore/RemoteStoreCoreTestCase.java
@@ -15,6 +15,7 @@ import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResp
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.action.admin.indices.recovery.RecoveryResponse;
+import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchPhaseExecutionException;
@@ -217,7 +218,7 @@ public class RemoteStoreCoreTestCase extends RemoteStoreBaseIntegTestCase {
         String dataNode = internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 10000L, -1));
         int numberOfIterations = randomIntBetween(1, 5);
-        indexData(numberOfIterations, true, INDEX_NAME);
+        Map<String, Long> indexingStats = indexData(numberOfIterations, true, INDEX_NAME);
         String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
         String shardPath = getShardLevelBlobPath(
             client(),
@@ -233,8 +234,25 @@ public class RemoteStoreCoreTestCase extends RemoteStoreBaseIntegTestCase {
         // Delete is async.
         assertBusy(() -> {
             int actualFileCount = getActualFileCount(segmentRepoPath, shardPath);
+            long extraMetadataFilesDueToFlush = 0;
+            GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings(INDEX_NAME).get();
+            Settings indexSettings = getSettingsResponse.getIndexToSettings().get(INDEX_NAME);
+            boolean isCASEnabled = IndexSettings.INDEX_CONTEXT_AWARE_ENABLED_SETTING.get(indexSettings);
+            if (isCASEnabled == true) {
+                // For CAS enabled domains, there will be an extra refresh for each OpenSearch flush call.
+                extraMetadataFilesDueToFlush += indexingStats.get(FLUSHED_OPERATIONS);
+            }
             if (numberOfIterations <= lastNMetadataFilesToKeep) {
-                MatcherAssert.assertThat(actualFileCount, is(oneOf(numberOfIterations - 1, numberOfIterations, numberOfIterations + 1)));
+                MatcherAssert.assertThat(
+                    actualFileCount,
+                    is(
+                        oneOf(
+                            numberOfIterations - 1 + extraMetadataFilesDueToFlush,
+                            numberOfIterations + extraMetadataFilesDueToFlush,
+                            numberOfIterations + 1 + extraMetadataFilesDueToFlush
+                        )
+                    )
+                );
             } else {
                 // As delete is async its possible that the file gets created before the deletion or after
                 // deletion.
@@ -244,7 +262,13 @@ public class RemoteStoreCoreTestCase extends RemoteStoreBaseIntegTestCase {
                 } else {
                     MatcherAssert.assertThat(
                         actualFileCount,
-                        is(oneOf(lastNMetadataFilesToKeep - 1, lastNMetadataFilesToKeep, lastNMetadataFilesToKeep + 1))
+                        is(
+                            oneOf(
+                                lastNMetadataFilesToKeep - 1 + extraMetadataFilesDueToFlush,
+                                lastNMetadataFilesToKeep + extraMetadataFilesDueToFlush,
+                                lastNMetadataFilesToKeep + 1 + extraMetadataFilesDueToFlush
+                            )
+                        )
                     );
                 }
             }
@@ -263,7 +287,7 @@ public class RemoteStoreCoreTestCase extends RemoteStoreBaseIntegTestCase {
         internalCluster().startDataOnlyNode();
         createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 10000l, -1));
         int numberOfIterations = randomIntBetween(1, 5);
-        indexData(numberOfIterations, false, INDEX_NAME);
+        Map<String, Long> indexingStats = indexData(numberOfIterations, false, INDEX_NAME);
         String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
         String shardPath = getShardLevelBlobPath(
             client(),
@@ -275,8 +299,25 @@ public class RemoteStoreCoreTestCase extends RemoteStoreBaseIntegTestCase {
             segmentsPathFixedPrefix
         ).buildAsString();
         int actualFileCount = getActualFileCount(segmentRepoPath, shardPath);
+        int extraMetadataFilesDueToFlush = 0;
+        GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings(INDEX_NAME).get();
+        Settings indexSettings = getSettingsResponse.getIndexToSettings().get(INDEX_NAME);
+        boolean isCASEnabled = IndexSettings.INDEX_CONTEXT_AWARE_ENABLED_SETTING.get(indexSettings);
+        if (isCASEnabled == true) {
+            // For CAS enabled domains, there will be an extra refresh for each OpenSearch flush call.
+            extraMetadataFilesDueToFlush += indexingStats.get(FLUSHED_OPERATIONS);
+        }
         // We also allow (numberOfIterations + 1) as index creation also triggers refresh.
-        MatcherAssert.assertThat(actualFileCount, is(oneOf(numberOfIterations - 1, numberOfIterations, numberOfIterations + 1)));
+        MatcherAssert.assertThat(
+            actualFileCount,
+            is(
+                oneOf(
+                    numberOfIterations - 1 + extraMetadataFilesDueToFlush,
+                    numberOfIterations + extraMetadataFilesDueToFlush,
+                    numberOfIterations + 1 + extraMetadataFilesDueToFlush
+                )
+            )
+        );
     }
 
     public void testStaleCommitDeletionWithMinSegmentFiles_3() throws Exception {
@@ -317,7 +358,7 @@ public class RemoteStoreCoreTestCase extends RemoteStoreBaseIntegTestCase {
 
         createIndex(INDEX_NAME, remoteStoreIndexSettings(1, 10000l, -1));
         int numberOfIterations = randomIntBetween(2, 5);
-        indexData(numberOfIterations, true, INDEX_NAME);
+        Map<String, Long> indexingStats = indexData(numberOfIterations, true, INDEX_NAME);
         String segmentsPathFixedPrefix = RemoteStoreSettings.CLUSTER_REMOTE_STORE_SEGMENTS_PATH_PREFIX.get(getNodeSettings());
         String shardPath = getShardLevelBlobPath(
             client(),
@@ -329,8 +370,19 @@ public class RemoteStoreCoreTestCase extends RemoteStoreBaseIntegTestCase {
             segmentsPathFixedPrefix
         ).buildAsString();
         int actualFileCount = getActualFileCount(segmentRepoPath, shardPath);
+        int extraMetadataFilesDueToFlush = 0;
+        GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings(INDEX_NAME).get();
+        Settings indexSettings = getSettingsResponse.getIndexToSettings().get(INDEX_NAME);
+        boolean isCASEnabled = IndexSettings.INDEX_CONTEXT_AWARE_ENABLED_SETTING.get(indexSettings);
+        if (isCASEnabled == true) {
+            // For CAS enabled domains, there will be an extra refresh for each OpenSearch flush call.
+            extraMetadataFilesDueToFlush += indexingStats.get(FLUSHED_OPERATIONS);
+        }
         // We also allow (numberOfIterations + 1) as index creation also triggers refresh.
-        MatcherAssert.assertThat(actualFileCount, is(oneOf(numberOfIterations, numberOfIterations + 1)));
+        MatcherAssert.assertThat(
+            actualFileCount,
+            is(oneOf(numberOfIterations + extraMetadataFilesDueToFlush, numberOfIterations + 1 + extraMetadataFilesDueToFlush))
+        );
     }
 
     protected int getActualFileCount(Path segmentRepoPath, String shardPath) throws IOException {

--- a/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -94,7 +94,6 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -155,7 +154,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ParameterizedStaticS
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(MockRepository.Plugin.class);
+        return List.of(MockRepository.Plugin.class, ContextAwareIndexPlugin.class);
     }
 
     @After

--- a/test/framework/src/main/java/org/opensearch/test/AbstractMultiClustersTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/AbstractMultiClustersTestCase.java
@@ -78,7 +78,7 @@ public abstract class AbstractMultiClustersTestCase extends OpenSearchTestCase {
     }
 
     protected Collection<Class<? extends Plugin>> nodePlugins(String clusterAlias) {
-        return Collections.emptyList();
+        return Collections.singletonList(OpenSearchIntegTestCase.ContextAwareIndexPlugin.class);
     }
 
     protected final Client client() {

--- a/test/framework/src/main/java/org/opensearch/test/ExternalTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/test/ExternalTestCluster.java
@@ -43,6 +43,7 @@ import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.common.transport.TransportAddress;
@@ -149,6 +150,8 @@ public final class ExternalTestCluster extends TestCluster {
             String transport = getTestTransportType();
             clientSettingsBuilder.put(NetworkModule.TRANSPORT_TYPE_KEY, transport);
         }
+
+        clientSettingsBuilder.put(FeatureFlags.CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_FLAG, true);
         Settings clientSettings = clientSettingsBuilder.build();
         MockNode node = new MockNode(clientSettings, pluginInfos, null, true);
         Client client = clientWrapper.apply(node.client());

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -134,13 +134,16 @@ import org.opensearch.index.MergeSchedulerConfig;
 import org.opensearch.index.MockEngineFactoryPlugin;
 import org.opensearch.index.TieredMergePolicyProvider;
 import org.opensearch.index.codec.CodecService;
+import org.opensearch.index.engine.Engine;
 import org.opensearch.index.engine.Segment;
 import org.opensearch.index.mapper.CompletionFieldMapper;
 import org.opensearch.index.mapper.MockFieldFilterPlugin;
+import org.opensearch.index.mapper.ParseContext;
 import org.opensearch.index.remote.RemoteStoreEnums;
 import org.opensearch.index.remote.RemoteStoreEnums.PathType;
 import org.opensearch.index.remote.RemoteStorePathStrategy;
 import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexingOperationListener;
 import org.opensearch.index.store.Store;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.indices.IndicesQueryCache;
@@ -224,6 +227,7 @@ import static org.opensearch.common.unit.TimeValue.timeValueMillis;
 import static org.opensearch.core.common.util.CollectionUtils.eagerPartition;
 import static org.opensearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
 import static org.opensearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.opensearch.index.IndexSettings.INDEX_CONTEXT_AWARE_ENABLED_SETTING;
 import static org.opensearch.index.IndexSettings.INDEX_DOC_ID_FUZZY_SET_ENABLED_SETTING;
 import static org.opensearch.index.IndexSettings.INDEX_DOC_ID_FUZZY_SET_FALSE_POSITIVE_PROBABILITY_SETTING;
 import static org.opensearch.index.IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING;
@@ -692,6 +696,10 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
             builder.put(INDEX_DOC_ID_FUZZY_SET_FALSE_POSITIVE_PROBABILITY_SETTING.getKey(), randomDoubleBetween(0.01, 0.50, true));
         }
 
+        if (randomBoolean()) {
+            builder.put(INDEX_CONTEXT_AWARE_ENABLED_SETTING.getKey(), true);
+        }
+
         return builder.build();
     }
 
@@ -709,6 +717,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         // Enabling Telemetry setting by default
         featureSettings.put(FeatureFlags.TELEMETRY_SETTING.getKey(), true);
         featureSettings.put(FeatureFlags.APPLICATION_BASED_CONFIGURATION_TEMPLATES_SETTING.getKey(), true);
+        featureSettings.put(FeatureFlags.CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_FLAG, true);
 
         return featureSettings.build();
     }
@@ -2010,7 +2019,19 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
      * Returns a collection of plugins that should be loaded on each node.
      */
     protected Collection<PluginInfo> additionalNodePlugins() {
-        return Collections.emptyList();
+        return Collections.singletonList(
+            new PluginInfo(
+                ContextAwareIndexPlugin.class.getName(),
+                "classpath plugin",
+                "NA",
+                org.opensearch.Version.CURRENT,
+                "1.8",
+                ContextAwareIndexPlugin.class.getName(),
+                null,
+                Collections.emptyList(),
+                false
+            )
+        );
     }
 
     private ExternalTestCluster buildExternalCluster(String clusterAddresses, String clusterName) throws IOException {
@@ -2989,5 +3010,29 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         RemoteStoreEnums.PathHashAlgorithm pathHashAlgorithm = pathType != PathType.FIXED ? FNV_1A_COMPOSITE_1 : null;
         BlobPath blobPath = pathType.path(shardPathInput, pathHashAlgorithm);
         return blobPath.buildAsString();
+    }
+
+    public static class ContextAwareIndexPlugin extends Plugin {
+
+        @Override
+        public void onIndexModule(IndexModule indexModule) {
+            Settings settings = indexModule.getSettings();
+            boolean isContextAwareEnabled = settings.getAsBoolean(INDEX_CONTEXT_AWARE_ENABLED_SETTING.getKey(), false);
+            if (isContextAwareEnabled == true) {
+                indexModule.addIndexOperationListener(new ContextAwareIndexOperationListener());
+            }
+        }
+    }
+
+    public static class ContextAwareIndexOperationListener implements IndexingOperationListener {
+        @Override
+        public Engine.Index preIndex(ShardId shardId, Engine.Index index) {
+            final List<ParseContext.Document> docs = index.docs();
+            for (ParseContext.Document doc : docs) {
+                doc.setGroupingCriteria("-1");
+            }
+
+            return index;
+        }
     }
 }

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchSingleNodeTestCase.java
@@ -275,6 +275,7 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
         plugins.add(MockScriptService.TestPlugin.class);
 
         plugins.add(MockTelemetryPlugin.class);
+        plugins.add(OpenSearchIntegTestCase.ContextAwareIndexPlugin.class);
         Node node = new MockNode(
             settingsBuilder.build(),
             plugins.stream()
@@ -486,6 +487,7 @@ public abstract class OpenSearchSingleNodeTestCase extends OpenSearchTestCase {
         }
         featureSettings.put(FeatureFlags.TELEMETRY_SETTING.getKey(), true);
         featureSettings.put(FeatureFlags.APPLICATION_BASED_CONFIGURATION_TEMPLATES_SETTING.getKey(), true);
+        featureSettings.put(FeatureFlags.CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_FLAG, true);
         return featureSettings.build();
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This PR fixes following:
* Enable all integ test for CAS.
* Enable searchIdle for CAS.
* Fix remote store test cases for CAS.
* Fix regresion due to excessive flushes during syncing child writers with parent writers.

