### PR TITLE
fix for head + offset queries by upgrading arrow version

### DIFF
--- a/modules/parquet-data-format/build.gradle
+++ b/modules/parquet-data-format/build.gradle
@@ -107,11 +107,11 @@ dependencies {
   implementation project(':libs:opensearch-vectorized-exec-spi')
 
   // Apache Arrow dependencies (using stable version with unsafe allocator)
-  implementation 'org.apache.arrow:arrow-vector:17.0.0'
-  implementation 'org.apache.arrow:arrow-memory-core:17.0.0'
-  implementation 'org.apache.arrow:arrow-memory-unsafe:17.0.0'
-  implementation 'org.apache.arrow:arrow-format:17.0.0'
-  implementation 'org.apache.arrow:arrow-c-data:17.0.0'
+  implementation 'org.apache.arrow:arrow-vector:18.3.0'
+  implementation 'org.apache.arrow:arrow-memory-core:18.3.0'
+  implementation 'org.apache.arrow:arrow-memory-unsafe:18.3.0'
+  implementation 'org.apache.arrow:arrow-format:18.3.0'
+  implementation 'org.apache.arrow:arrow-c-data:18.3.0'
 
   // Checker Framework annotations (required by Arrow)
   implementation 'org.checkerframework:checker-qual:3.42.0'

--- a/plugins/engine-datafusion/build.gradle
+++ b/plugins/engine-datafusion/build.gradle
@@ -39,11 +39,11 @@ dependencies {
     api "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
 
     // Apache Arrow dependencies for memory management
-    implementation "org.apache.arrow:arrow-memory-core:17.0.0"
-    implementation "org.apache.arrow:arrow-memory-unsafe:17.0.0"
-    implementation "org.apache.arrow:arrow-vector:17.0.0"
-    implementation "org.apache.arrow:arrow-c-data:17.0.0"
-    implementation "org.apache.arrow:arrow-format:17.0.0"
+    implementation "org.apache.arrow:arrow-memory-core:18.3.0"
+    implementation "org.apache.arrow:arrow-memory-unsafe:18.3.0"
+    implementation "org.apache.arrow:arrow-vector:18.3.0"
+    implementation "org.apache.arrow:arrow-c-data:18.3.0"
+    implementation "org.apache.arrow:arrow-format:18.3.0"
     // SLF4J API for Arrow logging compatibility
     implementation "org.slf4j:slf4j-api:${versions.slf4j}"
     // CheckerFramework annotations required by Arrow 17.0.0

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/NativeBridge.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/NativeBridge.java
@@ -77,4 +77,10 @@ public final class NativeBridge {
 
     // Other methods
     public static native String getVersionInfo();
+
+    /**
+     * Test method: Creates a sliced StringArray and returns FFI pointers.
+     * Used to verify that sliced arrays across FFI boundary are handled correctly
+     **/
+    public static native void createTestSlicedArray(int offset, int length, ActionListener<long[]> listener);
 }

--- a/plugins/engine-datafusion/src/test/java/org/opensearch/datafusion/ArrowFFIBoundaryTests.java
+++ b/plugins/engine-datafusion/src/test/java/org/opensearch/datafusion/ArrowFFIBoundaryTests.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.datafusion;
+
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.datafusion.jni.NativeBridge;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests Arrow FFI boundary between Rust and Java.
+ * Verifies that sliced arrays (from LIMIT OFFSET queries) work correctly
+ * with Arrow 18.3.0's FFI handling.
+ * 
+ * Source array: ["zero", "one", "two", "three", "four"]
+ */
+public class ArrowFFIBoundaryTests extends OpenSearchTestCase {
+
+    // head 2 from 1 - skip first, take 2
+    public void testSliceOffset1Length2() throws Exception {
+        assertSlicedArray(1, 2, new String[]{"one", "two"});
+    }
+
+    // head 1 from 0 - no offset (baseline)
+    public void testSliceOffset0Length1() throws Exception {
+        assertSlicedArray(0, 1, new String[]{"zero"});
+    }
+
+    // head 2 from 3 - larger offset
+    public void testSliceOffset3Length2() throws Exception {
+        assertSlicedArray(3, 2, new String[]{"three", "four"});
+    }
+
+    // head 1 from 4 - last element only
+    public void testSliceOffset4Length1() throws Exception {
+        assertSlicedArray(4, 1, new String[]{"four"});
+    }
+
+    // head 3 from 1 - middle section
+    public void testSliceOffset1Length3() throws Exception {
+        assertSlicedArray(1, 3, new String[]{"one", "two", "three"});
+    }
+
+    private void assertSlicedArray(int offset, int length, String[] expected) throws Exception {
+        CompletableFuture<long[]> future = new CompletableFuture<>();
+        
+        NativeBridge.createTestSlicedArray(offset, length, new ActionListener<long[]>() {
+            @Override
+            public void onResponse(long[] pointers) {
+                future.complete(pointers);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+
+        long[] pointers = future.get(10, TimeUnit.SECONDS);
+
+        try (BufferAllocator allocator = new RootAllocator();
+             ArrowSchema arrowSchema = ArrowSchema.wrap(pointers[0]);
+             ArrowArray arrowArray = ArrowArray.wrap(pointers[1])) {
+            
+            try (VectorSchemaRoot root = Data.importVectorSchemaRoot(allocator, arrowArray, arrowSchema, null)) {
+                assertEquals("Row count mismatch", expected.length, root.getRowCount());
+                
+                VarCharVector dataVector = (VarCharVector) root.getVector("data");
+                for (int i = 0; i < expected.length; i++) {
+                    assertEquals("Value mismatch at index " + i, expected[i], new String(dataVector.get(i)));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The arrow arrays get sliced resulting in buffers having mismatches when passed to the java layer via FFI. So this fix includes compaction of variable length arrow arrays before passing via FFI

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
