### PR TITLE
[Star Tree] Add date dimension support for range aggregation validation

### DIFF
--- a/server/src/main/java/org/opensearch/search/startree/StarTreeQueryContext.java
+++ b/server/src/main/java/org/opensearch/search/startree/StarTreeQueryContext.java
@@ -165,11 +165,13 @@ public class StarTreeQueryContext {
         CompositeDataCubeFieldType compositeIndexFieldInfo,
         RangeAggregatorFactory rangeAggregatorFactory
     ) {
-        // Validate request field is part of dimensions & is a numeric field
-        // TODO: Add support for date type ranges
+        // Validate request field is part of dimensions & is a numeric or date field
         return compositeIndexFieldInfo.getDimensions()
             .stream()
-            .anyMatch(dimension -> rangeAggregatorFactory.getField().equals(dimension.getField()) && dimension instanceof NumericDimension);
+            .anyMatch(
+                dimension -> rangeAggregatorFactory.getField().equals(dimension.getField())
+                    && (dimension instanceof NumericDimension || dimension instanceof DateDimension)
+            );
     }
 
     private StarTreeFilter getStarTreeFilter(


### PR DESCRIPTION
## Summary
- Extends star-tree range aggregation validation to support `DateDimension` in addition to `NumericDimension`
- Previously, range aggregations with star-tree optimization only worked with numeric fields
- Now date fields can also leverage star-tree indexes for range aggregations

## Changes
- `StarTreeQueryContext.java`: Updated `validateRangeAggregationSupport()` to accept `DateDimension`
- `SearchServiceStarTreeTests.java`: Updated test Case 6 to verify date field range aggregations use star-tree
- `CHANGELOG.md`: Added entry for this feature

## Test plan
- [x] Updated existing test case in `SearchServiceStarTreeTests.java`
- [x] All star-tree tests passing locally (`./gradlew :server:test --tests "org.opensearch.search.aggregations.startree.*"`)

## Related Issues
Resolves the TODO in `StarTreeQueryContext.java`: "Add support for date type ranges"