### PR TITLE
Wrong Translog repo being picked in case of disparity b/w index and node settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix stats aggregation returning zero results with `size:0`. ([20427](https://github.com/opensearch-project/OpenSearch/pull/20427))
 - Remove child level directory on refresh for CompositeIndexWriter ([#20326](https://github.com/opensearch-project/OpenSearch/pull/20326))
 - Fixes and refactoring in stream transport to make it more robust ([#20359](https://github.com/opensearch-project/OpenSearch/pull/20359))
-
+- Adding validation to check if Remote Store Translog Repo is enabled ([#20495](https://github.com/opensearch-project/OpenSearch/pull/20495))
 ### Dependencies
 - Bump `com.google.auth:google-auth-library-oauth2-http` from 1.38.0 to 1.41.0 ([#20183](https://github.com/opensearch-project/OpenSearch/pull/20183))
 - Bump `actions/checkout` from 5 to 6 ([#20186](https://github.com/opensearch-project/OpenSearch/pull/20186))

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -1572,7 +1572,7 @@ public final class IndexSettings {
      * Returns if remote translog store is enabled for this index.
      */
     public boolean isRemoteTranslogStoreEnabled() {
-        return remoteStoreTranslogRepository != null && remoteStoreTranslogRepository.isEmpty() == false;
+        return remoteStoreTranslogRepository != null && remoteStoreTranslogRepository.isEmpty() == false && assignedOnRemoteNode;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -719,6 +719,26 @@ public class IndexSettingsTests extends OpenSearchTestCase {
         assertThat(index.getDefaultFields(), equalTo(Arrays.asList("body", "title")));
     }
 
+    public void testRemoteTranslogStoreDisabledWhenNodeHasNoRemoteStoreAttributes() {
+        // Corner case: Index settings have repository configured but node attributes don't have remote repositories setup
+        IndexMetadata metadata = newIndexMeta(
+            "index",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY, "tlog-store")
+                .put(IndexSettings.INDEX_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING.getKey(), "200ms")
+                .build()
+        );
+        // Node settings without remote store attributes
+        Settings nodeSettings = Settings.EMPTY;
+        IndexSettings settings = new IndexSettings(metadata, nodeSettings);
+
+        // Verify repository is configured in index settings
+        assertEquals("tlog-store", settings.getRemoteStoreTranslogRepository());
+        // But remote translog should be disabled since node doesn't have remote store attributes
+        assertFalse("Remote translog should be disabled when node has no remote store attributes", settings.isRemoteTranslogStoreEnabled());
+    }
+
     public void testUpdateSoftDeletesFails() {
         IndexScopedSettings settings = new IndexScopedSettings(Settings.EMPTY, IndexScopedSettings.BUILT_IN_INDEX_SETTINGS);
         SettingsException error = expectThrows(

--- a/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerTests.java
+++ b/server/src/test/java/org/opensearch/index/seqno/ReplicationTrackerTests.java
@@ -1572,7 +1572,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
             .put(IndexMetadata.SETTING_REMOTE_STORE_ENABLED, "true")
             .put(IndexMetadata.SETTING_REMOTE_TRANSLOG_STORE_REPOSITORY, "translog-repo")
             .build();
-        final ReplicationTracker tracker = newTracker(primaryId, settings);
+        final ReplicationTracker tracker = newTracker(primaryId, updatedGlobalCheckpoint::set, () -> 0L, settings, true);
         tracker.updateFromClusterManager(randomNonNegativeLong(), ids(active.keySet()), routingTable(initializing.keySet(), primaryId));
         tracker.activatePrimaryMode(NO_OPS_PERFORMED);
         initializing.keySet().forEach(k -> markAsTrackingAndInSyncQuietly(tracker, k.getId(), NO_OPS_PERFORMED));


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
If the index settings have remote store repositories configured and remote store is not enabled in the cluster, wrong translog repository is being chosen because of missing validation.
Fix remote translog test by properly configuring remote node attributes


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
