### PR TITLE
Add warmup phase for pull-based ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add intra segment support for single-value metric aggregations ([#20503](https://github.com/opensearch-project/OpenSearch/pull/20503))
 - Add ref_path support for package-based hunspell dictionary loading ([#20840](https://github.com/opensearch-project/OpenSearch/pull/20840))
 - Add support for enabling pluggable data formats, starting with phase-1 of decoupling shard from engine, and introducing basic abstractions ([#20675](https://github.com/opensearch-project/OpenSearch/pull/20675))
-- Add getWrappedScorer method to ProfileScorer for plugin access to wrapped scorers ([#20548](https://github.com/opensearch-project/OpenSearch/issues/20548))
-- Support expected cluster name with validation in CCS Sniff mode ([#20532](https://github.com/opensearch-project/OpenSearch/pull/20532))
-- Add security policy to allow `accessUnixDomainSocket` in `transport-grpc` module ([#20463](https://github.com/opensearch-project/OpenSearch/pull/20463))
-- Add range validations in query builder and field mapper ([#20497](https://github.com/opensearch-project/OpenSearch/issues/20497))
-- [Workload Management] Enhance Scroll API support for autotagging ([#20151](https://github.com/opensearch-project/OpenSearch/pull/20151))
-- Add indices to search request slowlog ([#20588](https://github.com/opensearch-project/OpenSearch/pull/20588))
-- Add warmup phase to wait for lag to catch up in pull-based ingestion before serving ([#20526](https://github.com/opensearch-project/OpenSearch/pull/20526))
 
 - Add warmup phase to wait for lag to catch up in pull-based ingestion before serving ([#20526](https://github.com/opensearch-project/OpenSearch/pull/20526))
 ### Changed

--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
@@ -107,7 +107,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", "test")
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.param.auto.offset.reset", "latest")
-                .put("ingestion_source.warmup.enabled", false)
                 .put("ingestion_source.all_active", true)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -136,7 +135,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", "test")
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.param.auto.offset.reset", "latest")
-                .put("ingestion_source.warmup.enabled", false)
                 .put("ingestion_source.all_active", true)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -272,7 +270,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.pointer.init.reset", "earliest")
-                .put("ingestion_source.warmup.enabled", false)
                 .put("ingestion_source.all_active", true)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -372,7 +369,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.pointer.init.reset", "earliest")
-                .put("ingestion_source.warmup.enabled", false)
                 .put("ingestion_source.all_active", true)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -425,7 +421,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.pointer.init.reset", "earliest")
-                .put("ingestion_source.warmup.enabled", false)
                 .put("ingestion_source.all_active", true)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -507,7 +502,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.pointer.init.reset", "earliest")
-                .put("ingestion_source.warmup.enabled", false)
                 .put("ingestion_source.all_active", true)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -548,7 +542,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.pointer.init.reset", "earliest")
                 .put("ingestion_source.pointer_based_lag_update_interval", "3s")
-                .put("ingestion_source.warmup.enabled", false)
                 .put("ingestion_source.all_active", true)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -620,7 +613,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.pointer.init.reset", "earliest")
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
-                .put("ingestion_source.warmup.enabled", false)
                 .put("ingestion_source.all_active", true)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -715,7 +707,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.pointer.init.reset", "earliest")
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
-                .put("ingestion_source.warmup.enabled", false)
                 .put("ingestion_source.all_active", true)
                 .put("index.periodic_flush_interval", "5s")
                 .build(),
@@ -751,7 +742,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.pointer.init.reset", "earliest")
                 .put("ingestion_source.mapper_type", "raw_payload")
                 .put("ingestion_source.error_strategy", "drop")
-                .put("ingestion_source.warmup.enabled", false)
                 .put("ingestion_source.all_active", true)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -869,7 +859,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.param.auto.offset.reset", "latest")
                 .put("ingestion_source.param.max.poll.records", "100")
-                .put("ingestion_source.warmup.enabled", false)
                 .put("ingestion_source.all_active", true)
                 .build(),
             mapping
@@ -980,7 +969,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.param.auto.offset.reset", "none")
-                .put("ingestion_source.warmup.enabled", false)
                 .put("ingestion_source.all_active", true)
                 .build(),
             mapping
@@ -1061,7 +1049,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.param.auto.offset.reset", "earliest")
-                .put("ingestion_source.warmup.enabled", false)
                 .put("ingestion_source.all_active", true)
                 .build(),
             mapping
@@ -1372,7 +1359,6 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.pointer.init.reset", "earliest")
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
-                .put("ingestion_source.warmup.enabled", true)
                 .put("ingestion_source.warmup.lag_threshold", 0)
                 .put("ingestion_source.warmup.timeout", "10m")
                 .put("ingestion_source.all_active", true)

--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/KafkaIngestionBaseIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/KafkaIngestionBaseIT.java
@@ -205,7 +205,6 @@ public class KafkaIngestionBaseIT extends OpenSearchIntegTestCase {
                 // set custom kafka consumer properties
                 .put("ingestion_source.param.fetch.min.bytes", 30000)
                 .put("ingestion_source.param.enable.auto.commit", false)
-                .put("ingestion_source.warmup.enabled", false)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
         );

--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/RemoteStoreKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/RemoteStoreKafkaIT.java
@@ -157,7 +157,6 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.internal_queue_size", "1000")
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
-                .put("ingestion_source.warmup.enabled", false)
                 .put("index.replication.type", "SEGMENT")
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -399,7 +398,6 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.pointer.init.reset", "earliest")
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
-                .put("ingestion_source.warmup.enabled", false)
                 .put("index.replication.type", "SEGMENT")
                 .put("index.gc_deletes", "0")
                 .build(),
@@ -512,7 +510,6 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.internal_queue_size", "1000")
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
-                .put("ingestion_source.warmup.enabled", false)
                 .put("index.replication.type", "SEGMENT")
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -558,7 +555,6 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.internal_queue_size", "1000")
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
-                .put("ingestion_source.warmup.enabled", false)
                 .put("index.replication.type", "SEGMENT")
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -677,7 +673,6 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.param.auto.offset.reset", "earliest")
-                .put("ingestion_source.warmup.enabled", false)
                 .put("index.routing.allocation.require._name", nodeA)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -729,7 +724,6 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.param.auto.offset.reset", "earliest")
-                .put("ingestion_source.warmup.enabled", false)
                 .put("index.routing.allocation.require._name", nodeA)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -793,7 +787,6 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.pointer.init.reset", "earliest")
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
-                .put("ingestion_source.warmup.enabled", false)
                 .put("index.replication.type", "SEGMENT")
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"
@@ -857,7 +850,6 @@ public class RemoteStoreKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.pointer.init.reset", "earliest")
                 .put("ingestion_source.param.topic", topicName)
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
-                .put("ingestion_source.warmup.enabled", false)
                 .put("index.replication.type", "SEGMENT")
                 .put("index.periodic_flush_interval", "5s")
                 .build(),

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSingleNodeTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSingleNodeTests.java
@@ -81,7 +81,6 @@ public class KafkaSingleNodeTests extends OpenSearchSingleNodeTestCase {
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("index.replication.type", "SEGMENT")
                 .put("ingestion_source.pointer_based_lag_update_interval", "0")
-                .put("ingestion_source.warmup.enabled", false)
                 .build(),
             mappings
         );
@@ -152,7 +151,6 @@ public class KafkaSingleNodeTests extends OpenSearchSingleNodeTestCase {
                 .put("ingestion_source.pointer.init.reset", "earliest")
                 .put("ingestion_source.param.topic", "unknownTopic")
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
-                .put("ingestion_source.warmup.enabled", false)
                 .put("index.replication.type", "SEGMENT")
                 .build(),
             mappings
@@ -176,7 +174,6 @@ public class KafkaSingleNodeTests extends OpenSearchSingleNodeTestCase {
                 .put("ingestion_source.param.auto.offset.reset", "none")
                 .put("ingestion_source.num_processor_threads", 5)
                 .put("index.replication.type", "SEGMENT")
-                .put("ingestion_source.warmup.enabled", false)
                 .build(),
             mappings
         );

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -1032,24 +1032,14 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     );
 
     /**
-     * Defines if warmup phase is enabled for pull-based ingestion. When enabled, shards will wait for
-     * lag to catch up before serving queries after node restart or shard relocation.
-     */
-    public static final String SETTING_INGESTION_SOURCE_WARMUP_ENABLED = "index.ingestion_source.warmup.enabled";
-    public static final Setting<Boolean> INGESTION_SOURCE_WARMUP_ENABLED_SETTING = Setting.boolSetting(
-        SETTING_INGESTION_SOURCE_WARMUP_ENABLED,
-        false,
-        Property.IndexScope,
-        Property.Final
-    );
-
-    /**
      * Defines the maximum time to wait for lag to catch up during warmup phase.
+     * A value of -1 means warmup is disabled (the default). A value >= 0 enables warmup with that timeout.
      */
     public static final String SETTING_INGESTION_SOURCE_WARMUP_TIMEOUT = "index.ingestion_source.warmup.timeout";
-    public static final Setting<TimeValue> INGESTION_SOURCE_WARMUP_TIMEOUT_SETTING = Setting.positiveTimeSetting(
+    public static final Setting<TimeValue> INGESTION_SOURCE_WARMUP_TIMEOUT_SETTING = Setting.timeSetting(
         SETTING_INGESTION_SOURCE_WARMUP_TIMEOUT,
-        new TimeValue(5, TimeUnit.MINUTES),
+        TimeValue.timeValueMillis(-1),
+        TimeValue.timeValueMillis(-1),
         Property.IndexScope,
         Property.Final
     );
@@ -1063,18 +1053,6 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         SETTING_INGESTION_SOURCE_WARMUP_LAG_THRESHOLD,
         100L,
         0L,
-        Property.IndexScope,
-        Property.Final
-    );
-
-    /**
-     * Defines if shard initialization should fail when warmup times out.
-     * If false, shard proceeds with a warning. If true, shard initialization fails.
-     */
-    public static final String SETTING_INGESTION_SOURCE_WARMUP_FAIL_ON_TIMEOUT = "index.ingestion_source.warmup.fail_on_timeout";
-    public static final Setting<Boolean> INGESTION_SOURCE_WARMUP_FAIL_ON_TIMEOUT_SETTING = Setting.boolSetting(
-        SETTING_INGESTION_SOURCE_WARMUP_FAIL_ON_TIMEOUT,
-        false,
         Property.IndexScope,
         Property.Final
     );
@@ -1351,10 +1329,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
             // Warmup settings
             final IngestionSource.WarmupConfig warmupConfig = new IngestionSource.WarmupConfig(
-                INGESTION_SOURCE_WARMUP_ENABLED_SETTING.get(settings),
                 INGESTION_SOURCE_WARMUP_TIMEOUT_SETTING.get(settings),
-                INGESTION_SOURCE_WARMUP_LAG_THRESHOLD_SETTING.get(settings),
-                INGESTION_SOURCE_WARMUP_FAIL_ON_TIMEOUT_SETTING.get(settings)
+                INGESTION_SOURCE_WARMUP_LAG_THRESHOLD_SETTING.get(settings)
             );
 
             return new IngestionSource.Builder(ingestionSourceType).setParams(ingestionSourceParams)

--- a/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IngestionSource.java
@@ -27,8 +27,6 @@ import static org.opensearch.cluster.metadata.IndexMetadata.INGESTION_SOURCE_MAX
 import static org.opensearch.cluster.metadata.IndexMetadata.INGESTION_SOURCE_NUM_PROCESSOR_THREADS_SETTING;
 import static org.opensearch.cluster.metadata.IndexMetadata.INGESTION_SOURCE_POINTER_BASED_LAG_UPDATE_INTERVAL_SETTING;
 import static org.opensearch.cluster.metadata.IndexMetadata.INGESTION_SOURCE_POLL_TIMEOUT;
-import static org.opensearch.cluster.metadata.IndexMetadata.INGESTION_SOURCE_WARMUP_ENABLED_SETTING;
-import static org.opensearch.cluster.metadata.IndexMetadata.INGESTION_SOURCE_WARMUP_FAIL_ON_TIMEOUT_SETTING;
 import static org.opensearch.cluster.metadata.IndexMetadata.INGESTION_SOURCE_WARMUP_LAG_THRESHOLD_SETTING;
 import static org.opensearch.cluster.metadata.IndexMetadata.INGESTION_SOURCE_WARMUP_TIMEOUT_SETTING;
 
@@ -250,11 +248,17 @@ public class IngestionSource {
 
     /**
      * Record encapsulating the warmup configuration for pull-based ingestion.
-     * When warmup is enabled, shards will wait for lag to catch up before serving queries
-     * after node restart or shard relocation.
+     * When warmup is enabled (timeout >= 0), shards will wait for lag to catch up before serving queries
+     * after node restart or shard relocation. A timeout of -1 means warmup is disabled.
      */
     @PublicApi(since = "3.6.0")
-    public record WarmupConfig(boolean enabled, TimeValue timeout, long lagThreshold, boolean failOnTimeout) {
+    public record WarmupConfig(TimeValue timeout, long lagThreshold) {
+        /**
+         * Returns true if warmup is enabled (timeout >= 0).
+         */
+        public boolean isEnabled() {
+            return timeout.millis() >= 0;
+        }
     }
 
     /**
@@ -278,10 +282,8 @@ public class IngestionSource {
         private IngestionMessageMapper.MapperType mapperType = INGESTION_SOURCE_MAPPER_TYPE_SETTING.getDefault(Settings.EMPTY);
         private Map<String, Object> mapperSettings = new HashMap<>();
         // Warmup configuration
-        private boolean warmupEnabled = INGESTION_SOURCE_WARMUP_ENABLED_SETTING.getDefault(Settings.EMPTY);
         private TimeValue warmupTimeout = INGESTION_SOURCE_WARMUP_TIMEOUT_SETTING.getDefault(Settings.EMPTY);
         private long warmupLagThreshold = INGESTION_SOURCE_WARMUP_LAG_THRESHOLD_SETTING.getDefault(Settings.EMPTY);
-        private boolean warmupFailOnTimeout = INGESTION_SOURCE_WARMUP_FAIL_ON_TIMEOUT_SETTING.getDefault(Settings.EMPTY);
 
         public Builder(String type) {
             this.type = type;
@@ -300,10 +302,8 @@ public class IngestionSource {
             this.mapperSettings = new HashMap<>(ingestionSource.mapperSettings);
             // Copy warmup config
             WarmupConfig wc = ingestionSource.warmupConfig;
-            this.warmupEnabled = wc.enabled();
             this.warmupTimeout = wc.timeout();
             this.warmupLagThreshold = wc.lagThreshold();
-            this.warmupFailOnTimeout = wc.failOnTimeout();
         }
 
         public Builder setPointerInitReset(PointerInitReset pointerInitReset) {
@@ -366,11 +366,6 @@ public class IngestionSource {
             return this;
         }
 
-        public Builder setWarmupEnabled(boolean warmupEnabled) {
-            this.warmupEnabled = warmupEnabled;
-            return this;
-        }
-
         public Builder setWarmupTimeout(TimeValue warmupTimeout) {
             this.warmupTimeout = warmupTimeout;
             return this;
@@ -381,21 +376,14 @@ public class IngestionSource {
             return this;
         }
 
-        public Builder setWarmupFailOnTimeout(boolean warmupFailOnTimeout) {
-            this.warmupFailOnTimeout = warmupFailOnTimeout;
-            return this;
-        }
-
         public Builder setWarmupConfig(WarmupConfig warmupConfig) {
-            this.warmupEnabled = warmupConfig.enabled();
             this.warmupTimeout = warmupConfig.timeout();
             this.warmupLagThreshold = warmupConfig.lagThreshold();
-            this.warmupFailOnTimeout = warmupConfig.failOnTimeout();
             return this;
         }
 
         public IngestionSource build() {
-            WarmupConfig warmupConfig = new WarmupConfig(warmupEnabled, warmupTimeout, warmupLagThreshold, warmupFailOnTimeout);
+            WarmupConfig warmupConfig = new WarmupConfig(warmupTimeout, warmupLagThreshold);
             return new IngestionSource(
                 type,
                 pointerInitReset,

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -292,10 +292,8 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexMetadata.INGESTION_SOURCE_POINTER_BASED_LAG_UPDATE_INTERVAL_SETTING,
                 IndexMetadata.INGESTION_SOURCE_MAPPER_TYPE_SETTING,
                 IndexMetadata.INGESTION_SOURCE_MAPPER_SETTINGS,
-                IndexMetadata.INGESTION_SOURCE_WARMUP_ENABLED_SETTING,
                 IndexMetadata.INGESTION_SOURCE_WARMUP_TIMEOUT_SETTING,
                 IndexMetadata.INGESTION_SOURCE_WARMUP_LAG_THRESHOLD_SETTING,
-                IndexMetadata.INGESTION_SOURCE_WARMUP_FAIL_ON_TIMEOUT_SETTING,
 
                 // Settings for search replica
                 IndexMetadata.INDEX_NUMBER_OF_SEARCH_REPLICAS_SETTING,

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -666,14 +666,13 @@ public class IngestionEngine extends InternalEngine {
 
     /**
      * Block until warmup is complete or timeout occurs.
-     * This method handles all warmup logic internally including timeout handling and error throwing.
+     * This method handles all warmup logic internally. On timeout, always logs a warning and proceeds.
      *
-     * @throws OpenSearchException if warmup times out and failOnTimeout is configured
      * @throws InterruptedException if the thread is interrupted while waiting
      */
     public void awaitWarmupComplete() throws InterruptedException {
         IngestionSource ingestionSource = engineConfig.getIndexSettings().getIndexMetadata().getIngestionSource();
-        if (ingestionSource == null || !ingestionSource.getWarmupConfig().enabled() || streamPoller.isPaused()) {
+        if (ingestionSource == null || !ingestionSource.getWarmupConfig().isEnabled() || streamPoller.isPaused()) {
             return;
         }
 
@@ -681,20 +680,7 @@ public class IngestionEngine extends InternalEngine {
         boolean completed = streamPoller.awaitWarmupComplete(timeoutMs);
 
         if (!completed) {
-            if (ingestionSource.getWarmupConfig().failOnTimeout()) {
-                throw new OpenSearchException(
-                    "Ingestion warmup timed out for shard after "
-                        + timeoutMs
-                        + "ms. "
-                        + "Configure warmup.fail_on_timeout=false to proceed with stale data."
-                );
-            }
-            // Log warning when proceeding despite timeout
-            logger.warn(
-                "Ingestion warmup timed out for shard after {}ms, proceeding with potentially stale data. "
-                    + "Set warmup.fail_on_timeout=true to fail shard initialization on timeout.",
-                timeoutMs
-            );
+            logger.warn("Ingestion warmup timed out for shard after {}ms, proceeding with potentially stale data.", timeoutMs);
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2489,8 +2489,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             getIndexer().refresh("post_recovery");
 
             // Wait for ingestion warmup if enabled (pull-based ingestion only)
-            Engine engine = getEngine();
-            handlePullBasedIngestionWarmup(engine);
+            handlePullBasedIngestionWarmup(getIndexer());
 
             synchronized (mutex) {
                 if (state == IndexShardState.CLOSED) {
@@ -2510,9 +2509,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * When warmup is enabled, this method blocks until the shard has caught up with the streaming source
      * or until the configured timeout is reached.
      *
-     * @param engine the engine to check for warmup
+     * @param indexer the indexer to check for warmup
      */
-    private void handlePullBasedIngestionWarmup(Engine engine) {
+    private void handlePullBasedIngestionWarmup(Indexer indexer) {
+        if (!(indexer instanceof EngineBackedIndexer)) {
+            return;
+        }
+        Engine engine = ((EngineBackedIndexer) indexer).getEngine();
         if (engine instanceof IngestionEngine) {
             IngestionEngine ingestionEngine = (IngestionEngine) engine;
             try {

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -180,7 +180,7 @@ public class DefaultStreamPoller implements StreamPoller {
         // handle initial poller states
         this.paused = initialState == State.PAUSED;
         // If warmup is disabled, mark as complete immediately
-        if (!warmupConfig.enabled()) {
+        if (!warmupConfig.isEnabled()) {
             this.warmupComplete = true;
         }
     }
@@ -213,7 +213,7 @@ public class DefaultStreamPoller implements StreamPoller {
         logger.info("Starting poller for shard {}", shardId);
 
         // Initialize warmup if enabled
-        if (warmupConfig.enabled() && !warmupComplete) {
+        if (warmupConfig.isEnabled() && !warmupComplete) {
             warmupStartTime = System.currentTimeMillis();
             state = State.WARMING_UP;
             logger.info("Starting warmup phase for index {} shard {}, waiting for lag to catch up", indexName, shardId);
@@ -237,7 +237,7 @@ public class DefaultStreamPoller implements StreamPoller {
                 updatePointerBasedLagIfNeeded();
 
                 // Check warmup status if not yet complete
-                if (!warmupComplete && warmupConfig.enabled()) {
+                if (!warmupComplete && warmupConfig.isEnabled()) {
                     updateWarmupStatus();
                 }
 
@@ -386,7 +386,7 @@ public class DefaultStreamPoller implements StreamPoller {
 
     @Override
     public boolean isWarmupComplete() {
-        return warmupComplete || !warmupConfig.enabled();
+        return warmupComplete || !warmupConfig.isEnabled();
     }
 
     /**
@@ -412,16 +412,9 @@ public class DefaultStreamPoller implements StreamPoller {
         this.state = newState;
     }
 
-    /**
-     * Returns true if shard initialization should fail when warmup times out.
-     */
-    public boolean isWarmupFailOnTimeout() {
-        return warmupConfig.failOnTimeout();
-    }
-
     @Override
     public boolean awaitWarmupComplete(long timeoutMs) throws InterruptedException {
-        if (!warmupConfig.enabled() || isWarmupComplete()) {
+        if (!warmupConfig.isEnabled() || isWarmupComplete()) {
             return true;
         }
 
@@ -740,12 +733,7 @@ public class DefaultStreamPoller implements StreamPoller {
         private IngestionMessageMapper.MapperType mapperType = IngestionMessageMapper.MapperType.DEFAULT;
         private Map<String, Object> mapperSettings = Collections.emptyMap();
         // Warmup configuration - default matches IndexMetadata settings
-        private IngestionSource.WarmupConfig warmupConfig = new IngestionSource.WarmupConfig(
-            false,
-            TimeValue.timeValueMinutes(5),
-            100L,
-            false
-        );
+        private IngestionSource.WarmupConfig warmupConfig = new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 100L);
 
         /**
          * Initialize the builder with mandatory parameters

--- a/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IngestionSourceTests.java
@@ -108,7 +108,7 @@ public class IngestionSourceTests extends OpenSearchTestCase {
             .setErrorStrategy(DROP)
             .build();
         String expected =
-            "IngestionSource{type='type',pointer_init_reset='PointerInitReset{type='RESET_BY_OFFSET', value=1000}',error_strategy='DROP', params={key=value}, maxPollSize=1000, pollTimeout=1000, numProcessorThreads=1, blockingQueueSize=100, allActiveIngestion=false, pointerBasedLagUpdateInterval=10s, mapperType='DEFAULT', mapperSettings={}, warmupConfig=WarmupConfig[enabled=false, timeout=5m, lagThreshold=100, failOnTimeout=false]}";
+            "IngestionSource{type='type',pointer_init_reset='PointerInitReset{type='RESET_BY_OFFSET', value=1000}',error_strategy='DROP', params={key=value}, maxPollSize=1000, pollTimeout=1000, numProcessorThreads=1, blockingQueueSize=100, allActiveIngestion=false, pointerBasedLagUpdateInterval=10s, mapperType='DEFAULT', mapperSettings={}, warmupConfig=WarmupConfig[timeout=-1, lagThreshold=100]}";
         assertEquals(expected, source.toString());
     }
 
@@ -182,30 +182,26 @@ public class IngestionSourceTests extends OpenSearchTestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("key", "value");
 
-        // Test with warmup configuration
+        // Test with warmup configuration (timeout >= 0 means enabled)
         IngestionSource source = new IngestionSource.Builder("type").setParams(params)
             .setPointerInitReset(pointerInitReset)
             .setErrorStrategy(DROP)
-            .setWarmupEnabled(true)
             .setWarmupTimeout(TimeValue.timeValueMinutes(10))
             .setWarmupLagThreshold(100)
-            .setWarmupFailOnTimeout(true)
             .build();
 
-        assertTrue("Warmup should be enabled", source.getWarmupConfig().enabled());
+        assertTrue("Warmup should be enabled", source.getWarmupConfig().isEnabled());
         assertEquals(TimeValue.timeValueMinutes(10), source.getWarmupConfig().timeout());
         assertEquals(100, source.getWarmupConfig().lagThreshold());
-        assertTrue("Should fail on timeout", source.getWarmupConfig().failOnTimeout());
     }
 
     public void testWarmupConfigurationDefaults() {
-        // Test default warmup values
+        // Test default warmup values (timeout=-1 means disabled)
         IngestionSource source = new IngestionSource.Builder("type").build();
 
-        assertFalse("Warmup should be disabled by default", source.getWarmupConfig().enabled());
-        assertEquals(TimeValue.timeValueMinutes(5), source.getWarmupConfig().timeout());
+        assertFalse("Warmup should be disabled by default", source.getWarmupConfig().isEnabled());
+        assertEquals(TimeValue.timeValueMillis(-1), source.getWarmupConfig().timeout());
         assertEquals(100, source.getWarmupConfig().lagThreshold());
-        assertFalse("Should not fail on timeout by default", source.getWarmupConfig().failOnTimeout());
     }
 
     public void testWarmupConfigurationEquality() {
@@ -213,21 +209,21 @@ public class IngestionSourceTests extends OpenSearchTestCase {
         params.put("key", "value");
 
         IngestionSource source1 = new IngestionSource.Builder("type").setParams(params)
-            .setWarmupEnabled(true)
+            .setWarmupTimeout(TimeValue.timeValueMinutes(10))
             .setWarmupLagThreshold(100)
             .build();
 
         IngestionSource source2 = new IngestionSource.Builder("type").setParams(params)
-            .setWarmupEnabled(true)
+            .setWarmupTimeout(TimeValue.timeValueMinutes(10))
             .setWarmupLagThreshold(100)
             .build();
 
         assertEquals(source1, source2);
         assertEquals(source1.hashCode(), source2.hashCode());
 
-        // Test inequality with different warmup settings
+        // Test inequality with different warmup settings (disabled vs enabled)
         IngestionSource source3 = new IngestionSource.Builder("type").setParams(params)
-            .setWarmupEnabled(false)
+            .setWarmupTimeout(TimeValue.timeValueMillis(-1))
             .setWarmupLagThreshold(100)
             .build();
 
@@ -235,52 +231,47 @@ public class IngestionSourceTests extends OpenSearchTestCase {
     }
 
     public void testWarmupConfigurationCopiedByBuilder() {
-        IngestionSource original = new IngestionSource.Builder("type").setWarmupEnabled(true)
-            .setWarmupTimeout(TimeValue.timeValueMinutes(10))
+        IngestionSource original = new IngestionSource.Builder("type").setWarmupTimeout(TimeValue.timeValueMinutes(10))
             .setWarmupLagThreshold(500)
-            .setWarmupFailOnTimeout(true)
             .build();
 
         // Create a copy using the copy constructor
         IngestionSource copy = new IngestionSource.Builder(original).build();
 
-        assertEquals(original.getWarmupConfig().enabled(), copy.getWarmupConfig().enabled());
         assertEquals(original.getWarmupConfig().timeout(), copy.getWarmupConfig().timeout());
         assertEquals(original.getWarmupConfig().lagThreshold(), copy.getWarmupConfig().lagThreshold());
-        assertEquals(original.getWarmupConfig().failOnTimeout(), copy.getWarmupConfig().failOnTimeout());
     }
 
     public void testWarmupConfigClass() {
-        IngestionSource.WarmupConfig config1 = new IngestionSource.WarmupConfig(true, TimeValue.timeValueMinutes(10), 100, true);
+        IngestionSource.WarmupConfig config1 = new IngestionSource.WarmupConfig(TimeValue.timeValueMinutes(10), 100);
 
-        assertEquals(true, config1.enabled());
+        assertTrue(config1.isEnabled());
         assertEquals(TimeValue.timeValueMinutes(10), config1.timeout());
         assertEquals(100, config1.lagThreshold());
-        assertEquals(true, config1.failOnTimeout());
 
         // Test equals and hashCode
-        IngestionSource.WarmupConfig config2 = new IngestionSource.WarmupConfig(true, TimeValue.timeValueMinutes(10), 100, true);
+        IngestionSource.WarmupConfig config2 = new IngestionSource.WarmupConfig(TimeValue.timeValueMinutes(10), 100);
         assertEquals(config1, config2);
         assertEquals(config1.hashCode(), config2.hashCode());
 
         // Test inequality
-        IngestionSource.WarmupConfig config3 = new IngestionSource.WarmupConfig(false, TimeValue.timeValueMinutes(10), 100, true);
+        IngestionSource.WarmupConfig config3 = new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 100);
         assertNotEquals(config1, config3);
+        assertFalse(config3.isEnabled());
 
         // Test toString
-        String expectedToString = "WarmupConfig[enabled=true, timeout=10m, lagThreshold=100, failOnTimeout=true]";
+        String expectedToString = "WarmupConfig[timeout=10m, lagThreshold=100]";
         assertEquals(expectedToString, config1.toString());
     }
 
     public void testSetWarmupConfig() {
-        IngestionSource.WarmupConfig warmupConfig = new IngestionSource.WarmupConfig(true, TimeValue.timeValueMinutes(15), 200, true);
+        IngestionSource.WarmupConfig warmupConfig = new IngestionSource.WarmupConfig(TimeValue.timeValueMinutes(15), 200);
 
         IngestionSource source = new IngestionSource.Builder("type").setWarmupConfig(warmupConfig).build();
 
         assertEquals(warmupConfig, source.getWarmupConfig());
-        assertTrue(source.getWarmupConfig().enabled());
+        assertTrue(source.getWarmupConfig().isEnabled());
         assertEquals(TimeValue.timeValueMinutes(15), source.getWarmupConfig().timeout());
         assertEquals(200, source.getWarmupConfig().lagThreshold());
-        assertTrue(source.getWarmupConfig().failOnTimeout());
     }
 }

--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -97,7 +97,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
         partitionedBlockingQueueContainer.startProcessorThreads();
     }
@@ -172,7 +172,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
         CountDownLatch latch = new CountDownLatch(2);
         doAnswer(invocation -> {
@@ -207,7 +207,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
 
         // Set up latch to wait for 2 messages to be processed
@@ -250,7 +250,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
         CountDownLatch latch = new CountDownLatch(1);
         doAnswer(invocation -> {
@@ -337,7 +337,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -401,7 +401,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -439,7 +439,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -513,7 +513,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
         poller.start();
         Thread.sleep(sleepTime);
@@ -584,7 +584,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
 
         poller.start();
@@ -628,7 +628,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
 
         // Start and wait for 2 messages to be processed
@@ -685,7 +685,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
 
         // Start poller
@@ -730,7 +730,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
 
         // When all queues return null and initialBatchStartPointer is null, getBatchStartPointer should return null
@@ -741,7 +741,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
 
     public void testWarmupDisabledBehavior() {
         // When warmup is disabled, isWarmupComplete should return true immediately
-        // The default poller in setUp has warmupEnabled=false
+        // The default poller in setUp has warmup disabled (timeout=-1)
         assertTrue(poller.isWarmupComplete()); // Warmup disabled means it's considered complete
 
         // Create another poller with warmup explicitly disabled
@@ -760,7 +760,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
 
         // Warmup should be considered complete when disabled
@@ -786,7 +786,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(true, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(300000), 0)
         );
 
         // Initially warmup is not complete
@@ -826,7 +826,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(true, TimeValue.timeValueMillis(500), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(500), 0)
         );
 
         warmupPoller.start();
@@ -855,7 +855,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(true, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(300000), 0)
         );
 
         // Initial state should be NONE
@@ -872,52 +872,6 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         assertTrue(warmupPoller.isWarmupComplete());
 
         warmupPoller.close();
-    }
-
-    public void testIsWarmupFailOnTimeout() {
-        // Test with fail on timeout = true
-        DefaultStreamPoller failOnTimeoutPoller = new DefaultStreamPoller(
-            new FakeIngestionSource.FakeIngestionShardPointer(0),
-            fakeConsumerFactory,
-            "",
-            0,
-            partitionedBlockingQueueContainer,
-            StreamPoller.ResetState.NONE,
-            "",
-            errorStrategy,
-            StreamPoller.State.NONE,
-            1000,
-            1000,
-            10000,
-            indexSettings,
-            new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(true, TimeValue.timeValueMillis(300000), 0, true)
-        );
-
-        assertTrue(failOnTimeoutPoller.isWarmupFailOnTimeout());
-        failOnTimeoutPoller.close();
-
-        // Test with fail on timeout = false
-        DefaultStreamPoller proceedOnTimeoutPoller = new DefaultStreamPoller(
-            new FakeIngestionSource.FakeIngestionShardPointer(0),
-            fakeConsumerFactory,
-            "",
-            0,
-            partitionedBlockingQueueContainer,
-            StreamPoller.ResetState.NONE,
-            "",
-            errorStrategy,
-            StreamPoller.State.NONE,
-            1000,
-            1000,
-            10000,
-            indexSettings,
-            new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(true, TimeValue.timeValueMillis(300000), 0, false)
-        );
-
-        assertFalse(proceedOnTimeoutPoller.isWarmupFailOnTimeout());
-        proceedOnTimeoutPoller.close();
     }
 
     public void testWarmupCompletesViaTimeoutWhenPointerLagNegative() throws InterruptedException, TimeoutException {
@@ -943,7 +897,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(true, TimeValue.timeValueMillis(500), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(500), 0)
         );
 
         warmupPoller.start();
@@ -979,7 +933,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(true, TimeValue.timeValueMillis(30000), 100, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(30000), 100)
         );
 
         warmupPoller.start();
@@ -1009,7 +963,7 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
             10000,
             indexSettings,
             new DefaultIngestionMessageMapper(),
-            new IngestionSource.WarmupConfig(false, TimeValue.timeValueMillis(300000), 0, false)
+            new IngestionSource.WarmupConfig(TimeValue.timeValueMillis(-1), 0)
         );
 
         // Should return immediately without blocking since warmup is disabled


### PR DESCRIPTION
## Description
In pull-based ingestion, when a new node is added or shard relocation happens, consumption starts from the previous checkpoint offset. During this time, the shard serves stale data until the lag is consumed.

This PR introduces a "warmup" phase that prevents shards from serving queries until they have caught up with the streaming source - analogous to how push-based replication waits for replicas to sync before serving.

Resolves #20506

## Solution
When warmup is enabled, a shard entering the `postRecovery` phase will block until:
1. The pointer-based lag drops to or below the configured threshold, OR
2. The timeout is reached (proceeds with warning)

This ensures data consistency for users who prefer correctness over immediate availability.

## New Settings
| Setting | Type | Default | Description |
|---------|------|---------|-------------|
| `index.ingestion_source.warmup.timeout` | TimeValue | **-1** (disabled) | Warmup wait time. `-1` = disabled, `>=0` = enabled with that timeout |
| `index.ingestion_source.warmup.lag_threshold` | long | **100** | Acceptable pointer-based message lag for warmup completion |

All settings are **Final** - set at index creation time, cannot be changed later.

## State Machine

```
Index Created -> WARMING_UP -> (lag <= threshold OR timeout) -> POLLING -> STARTED
```

During WARMING_UP:
- Poller is actively ingesting from the source (internally POLLING/PROCESSING)
- But externally reports state as `WARMING_UP` via `GET /{index}/ingestion/_state`
- Shard remains in `INITIALIZING` - does NOT serve search queries
- Search returns `503 all shards failed`
- If poller is paused, warmup is skipped immediately
- On timeout, warmup completes with a warning log (shard proceeds to serve)

## Usage Example

### Enable warmup with 5 minute timeout:
```json
{
  "settings": {
    "index.ingestion_source.warmup.timeout": "5m"
  }
}
```

### Custom warmup with lag threshold:
```json
{
  "settings": {
    "index.ingestion_source.warmup.timeout": "10m",
    "index.ingestion_source.warmup.lag_threshold": 50
  }
}
```

### Warmup disabled (default):
No settings needed. Default `timeout=-1` means warmup is disabled.

## Implementation Details
- Added `WarmupConfig` record class in `IngestionSource` with two fields: `timeout` and `lagThreshold`
- `timeout = -1` means warmup disabled; `timeout >= 0` means enabled
- Warmup blocking occurs in `IndexShard.postRecovery()` before transitioning to `POST_RECOVERY` state
- Timeout and error handling is encapsulated in `IngestionEngine.awaitWarmupComplete()`
- Uses `CountDownLatch` for thread-safe blocking/signaling
- `cachedPointerBasedLag` initialized to `-1` to prevent premature warmup completion before lag data is available
- Warmup state visible via `GET /{index}/ingestion/_state` API (`poller_state: WARMING_UP`)
- When poller is paused during warmup, warmup completes immediately (skipped)
- On timeout, warmup always proceeds with a warning log (no shard failure to avoid livelock)
