### PR TITLE
WLM group custom search settings framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Introduced strategy planner interfaces for indexing and deletion ([#20585](https://github.com/opensearch-project/OpenSearch/pull/20585))
 - Implement FieldMappingIngestionMessageMapper for pull-based ingestion ([#20729](https://github.com/opensearch-project/OpenSearch/pull/20729))
 - Added support of WarmerRefreshListener in NRTReplicationEngine to trigger warmer after replication on replica shards ([#20650](https://github.com/opensearch-project/OpenSearch/pull/20650))
+- WLM group custom search settings - groundwork and timeout ([#20536](https://github.com/opensearch-project/OpenSearch/issues/20536))
 
 ### Changed
 - Make telemetry `Tags` immutable ([#20788](https://github.com/opensearch-project/OpenSearch/pull/20788))

--- a/plugins/workload-management/src/javaRestTest/java/org/opensearch/rest/WorkloadManagementRestIT.java
+++ b/plugins/workload-management/src/javaRestTest/java/org/opensearch/rest/WorkloadManagementRestIT.java
@@ -27,16 +27,16 @@ public class WorkloadManagementRestIT extends OpenSearchRestTestCase {
 
     public void testCreate() throws Exception {
         Response response = performOperation("PUT", "_wlm/workload_group", getCreateJson("analytics", "enforced", 0.4, 0.2));
-        assertEquals(response.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response.getStatusLine().getStatusCode());
         performOperation("DELETE", "_wlm/workload_group/analytics", null);
     }
 
     public void testMultipleCreate() throws Exception {
         Response response = performOperation("PUT", "_wlm/workload_group", getCreateJson("analytics2", "enforced", 0.4, 0.2));
-        assertEquals(response.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response.getStatusLine().getStatusCode());
 
         Response response2 = performOperation("PUT", "_wlm/workload_group", getCreateJson("users", "soft", 0.2, 0.1));
-        assertEquals(response2.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response2.getStatusLine().getStatusCode());
 
         assertThrows(
             ResponseException.class,
@@ -48,10 +48,10 @@ public class WorkloadManagementRestIT extends OpenSearchRestTestCase {
 
     public void testGet() throws Exception {
         Response response = performOperation("PUT", "_wlm/workload_group", getCreateJson("analytics3", "enforced", 0.4, 0.2));
-        assertEquals(response.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response.getStatusLine().getStatusCode());
 
         Response response2 = performOperation("GET", "_wlm/workload_group/analytics3", null);
-        assertEquals(response2.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response2.getStatusLine().getStatusCode());
         String responseBody2 = EntityUtils.toString(response2.getEntity());
         assertTrue(responseBody2.contains("\"name\":\"analytics3\""));
         assertTrue(responseBody2.contains("\"resiliency_mode\":\"enforced\""));
@@ -64,10 +64,10 @@ public class WorkloadManagementRestIT extends OpenSearchRestTestCase {
 
     public void testDelete() throws Exception {
         Response response = performOperation("PUT", "_wlm/workload_group", getCreateJson("analytics4", "enforced", 0.4, 0.2));
-        assertEquals(response.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response.getStatusLine().getStatusCode());
 
         Response response2 = performOperation("DELETE", "_wlm/workload_group/analytics4", null);
-        assertEquals(response2.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response2.getStatusLine().getStatusCode());
         assertTrue(EntityUtils.toString(response2.getEntity()).contains("\"acknowledged\":true"));
 
         assertThrows(ResponseException.class, () -> performOperation("DELETE", "_wlm/workload_group/analytics99", null));
@@ -75,22 +75,23 @@ public class WorkloadManagementRestIT extends OpenSearchRestTestCase {
 
     public void testUpdate() throws Exception {
         Response response = performOperation("PUT", "_wlm/workload_group", getCreateJson("analytics5", "enforced", 0.4, 0.2));
-        assertEquals(response.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response.getStatusLine().getStatusCode());
 
         Response response2 = performOperation("PUT", "_wlm/workload_group/analytics5", getUpdateJson("monitor", 0.41, 0.21));
-        assertEquals(response2.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response2.getStatusLine().getStatusCode());
         String responseBody2 = EntityUtils.toString(response2.getEntity());
         assertTrue(responseBody2.contains("\"name\":\"analytics5\""));
         assertTrue(responseBody2.contains("\"resiliency_mode\":\"monitor\""));
         assertTrue(responseBody2.contains("\"cpu\":0.41"));
         assertTrue(responseBody2.contains("\"memory\":0.21"));
 
-        String json = "{\n"
-            + "    \"resource_limits\": {\n"
-            + "        \"cpu\" : 1.1,\n"
-            + "        \"memory\" : -0.1\n"
-            + "    }\n"
-            + "}'";
+        String json = """
+            {
+                "resource_limits": {
+                    "cpu" : 1.1,
+                    "memory" : -0.1
+                }
+            }""";
         assertThrows(ResponseException.class, () -> performOperation("PUT", "_wlm/workload_group/analytics5", json));
         assertThrows(
             ResponseException.class,
@@ -101,13 +102,13 @@ public class WorkloadManagementRestIT extends OpenSearchRestTestCase {
 
     public void testCRUD() throws Exception {
         Response response = performOperation("PUT", "_wlm/workload_group", getCreateJson("analytics6", "enforced", 0.4, 0.2));
-        assertEquals(response.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response.getStatusLine().getStatusCode());
 
         Response response1 = performOperation("PUT", "_wlm/workload_group/analytics6", getUpdateJson("monitor", 0.41, 0.21));
-        assertEquals(response1.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response1.getStatusLine().getStatusCode());
 
         Response response2 = performOperation("GET", "_wlm/workload_group/analytics6", null);
-        assertEquals(response2.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response2.getStatusLine().getStatusCode());
         String responseBody2 = EntityUtils.toString(response2.getEntity());
         assertTrue(responseBody2.contains("\"name\":\"analytics6\""));
         assertTrue(responseBody2.contains("\"resiliency_mode\":\"monitor\""));
@@ -120,15 +121,15 @@ public class WorkloadManagementRestIT extends OpenSearchRestTestCase {
         );
 
         Response response4 = performOperation("PUT", "_wlm/workload_group", getCreateJson("users3", "monitor", 0.59, 0.79));
-        assertEquals(response4.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response4.getStatusLine().getStatusCode());
 
         Response response5 = performOperation("DELETE", "_wlm/workload_group/analytics6", null);
-        assertEquals(response5.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response5.getStatusLine().getStatusCode());
         String responseBody5 = EntityUtils.toString(response5.getEntity());
         assertTrue(responseBody5.contains("\"acknowledged\":true"));
 
         Response response6 = performOperation("GET", "_wlm/workload_group", null);
-        assertEquals(response6.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, response6.getStatusLine().getStatusCode());
         String responseBody6 = EntityUtils.toString(response6.getEntity());
         assertTrue(responseBody6.contains("\"workload_groups\""));
         assertTrue(responseBody6.contains("\"users3\""));
@@ -146,6 +147,44 @@ public class WorkloadManagementRestIT extends OpenSearchRestTestCase {
         assertOK(performOperation("GET", "_wlm/workload_group/", null));
     }
 
+    public void testSearchSettings() throws Exception {
+        // Create with search_settings
+        String createJson = """
+            {
+                "name": "search_test",
+                "resiliency_mode": "enforced",
+                "resource_limits": {"cpu": 0.3, "memory": 0.3},
+                "search_settings": {
+                    "timeout": "30s"
+                }
+            }""";
+        Response response = performOperation("PUT", "_wlm/workload_group", createJson);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        // Verify search_settings in GET response
+        Response getResponse = performOperation("GET", "_wlm/workload_group/search_test", null);
+        String responseBody = EntityUtils.toString(getResponse.getEntity());
+        assertTrue(responseBody.contains("\"search_settings\""));
+        assertTrue(responseBody.contains("\"timeout\":\"30s\""));
+
+        // Update search_settings
+        String updateJson = """
+            {
+                "search_settings": {
+                    "timeout": "1m"
+                }
+            }""";
+        Response updateResponse = performOperation("PUT", "_wlm/workload_group/search_test", updateJson);
+        assertEquals(200, updateResponse.getStatusLine().getStatusCode());
+
+        // Verify updated search_settings
+        Response getResponse2 = performOperation("GET", "_wlm/workload_group/search_test", null);
+        String responseBody2 = EntityUtils.toString(getResponse2.getEntity());
+        assertTrue(responseBody2.contains("\"timeout\":\"1m\""));
+
+        performOperation("DELETE", "_wlm/workload_group/search_test", null);
+    }
+
     static String getCreateJson(String name, String resiliencyMode, double cpu, double memory) {
         return "{\n"
             + "    \"name\": \""
@@ -161,7 +200,8 @@ public class WorkloadManagementRestIT extends OpenSearchRestTestCase {
             + "        \"memory\" : "
             + memory
             + "\n"
-            + "    }\n"
+            + "    },\n"
+            + "    \"search_settings\": {}\n"
             + "}";
     }
 

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/WorkloadManagementTestUtils.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/WorkloadManagementTestUtils.java
@@ -43,11 +43,15 @@ import static org.mockito.Mockito.mock;
 public class WorkloadManagementTestUtils {
     public static final String NAME_ONE = "workload_group_one";
     public static final String NAME_TWO = "workload_group_two";
+    public static final String NAME_THREE = "workload_group_three";
     public static final String _ID_ONE = "AgfUO5Ja9yfsYlONlYi3TQ==";
     public static final String _ID_TWO = "G5iIqHy4g7eK1qIAAAAIH53=1";
+    public static final String _ID_THREE = "H6jVP6Kb0zgtZmPOmZj4UQ==";
     public static final String NAME_NONE_EXISTED = "workload_group_none_existed";
     public static final long TIMESTAMP_ONE = 4513232413L;
     public static final long TIMESTAMP_TWO = 4513232415L;
+    public static final long TIMESTAMP_THREE = 4513232417L;
+    public static final Map<String, String> TEST_SEARCH_SETTINGS = Map.of("timeout", "30s");
     public static final WorkloadGroup workloadGroupOne = builder().name(NAME_ONE)
         ._id(_ID_ONE)
         .mutableWorkloadGroupFragment(
@@ -62,6 +66,18 @@ public class WorkloadManagementTestUtils {
             new MutableWorkloadGroupFragment(MutableWorkloadGroupFragment.ResiliencyMode.MONITOR, Map.of(ResourceType.MEMORY, 0.6))
         )
         .updatedAt(TIMESTAMP_TWO)
+        .build();
+
+    public static final WorkloadGroup workloadGroupWithSearchSettings = builder().name(NAME_THREE)
+        ._id(_ID_THREE)
+        .mutableWorkloadGroupFragment(
+            new MutableWorkloadGroupFragment(
+                MutableWorkloadGroupFragment.ResiliencyMode.ENFORCED,
+                Map.of(ResourceType.MEMORY, 0.5),
+                TEST_SEARCH_SETTINGS
+            )
+        )
+        .updatedAt(TIMESTAMP_THREE)
         .build();
 
     public static List<WorkloadGroup> workloadGroupList() {

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/CreateWorkloadGroupResponseTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/CreateWorkloadGroupResponseTests.java
@@ -59,7 +59,33 @@ public class CreateWorkloadGroupResponseTests extends OpenSearchTestCase {
             + "  \"resource_limits\" : {\n"
             + "    \"memory\" : 0.3\n"
             + "  },\n"
+            + "  \"search_settings\" : { },\n"
             + "  \"updated_at\" : 4513232413\n"
+            + "}";
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Test case to validate the toXContent method of CreateWorkloadGroupResponse with search settings.
+     */
+    public void testToXContentCreateWorkloadGroupWithSearchSettings() throws IOException {
+        XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
+        CreateWorkloadGroupResponse response = new CreateWorkloadGroupResponse(
+            WorkloadManagementTestUtils.workloadGroupWithSearchSettings,
+            RestStatus.OK
+        );
+        String actual = response.toXContent(builder, mock(ToXContent.Params.class)).toString();
+        String expected = "{\n"
+            + "  \"_id\" : \"H6jVP6Kb0zgtZmPOmZj4UQ==\",\n"
+            + "  \"name\" : \"workload_group_three\",\n"
+            + "  \"resiliency_mode\" : \"enforced\",\n"
+            + "  \"resource_limits\" : {\n"
+            + "    \"memory\" : 0.5\n"
+            + "  },\n"
+            + "  \"search_settings\" : {\n"
+            + "    \"timeout\" : \"30s\"\n"
+            + "  },\n"
+            + "  \"updated_at\" : 4513232417\n"
             + "}";
         assertEquals(expected, actual);
     }

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/GetWorkloadGroupResponseTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/GetWorkloadGroupResponseTests.java
@@ -97,6 +97,7 @@ public class GetWorkloadGroupResponseTests extends OpenSearchTestCase {
                   "resource_limits" : {
                     "memory" : 0.3
                   },
+                  "search_settings" : { },
                   "updated_at" : 4513232413
                 }
               ]
@@ -124,6 +125,7 @@ public class GetWorkloadGroupResponseTests extends OpenSearchTestCase {
                   "resource_limits" : {
                     "memory" : 0.3
                   },
+                  "search_settings" : { },
                   "updated_at" : 4513232413
                 },
                 {
@@ -133,6 +135,7 @@ public class GetWorkloadGroupResponseTests extends OpenSearchTestCase {
                   "resource_limits" : {
                     "memory" : 0.6
                   },
+                  "search_settings" : { },
                   "updated_at" : 4513232415
                 }
               ]
@@ -150,6 +153,35 @@ public class GetWorkloadGroupResponseTests extends OpenSearchTestCase {
         String expected = """
             {
               "workload_groups" : [ ]
+            }""";
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Test case to verify toXContent of GetWorkloadGroupResponse with search settings.
+     */
+    public void testToXContentGetWorkloadGroupWithSearchSettings() throws IOException {
+        List<WorkloadGroup> workloadGroupList = new ArrayList<>();
+        workloadGroupList.add(WorkloadManagementTestUtils.workloadGroupWithSearchSettings);
+        XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
+        GetWorkloadGroupResponse response = new GetWorkloadGroupResponse(workloadGroupList, RestStatus.OK);
+        String actual = response.toXContent(builder, mock(ToXContent.Params.class)).toString();
+        String expected = """
+            {
+              "workload_groups" : [
+                {
+                  "_id" : "H6jVP6Kb0zgtZmPOmZj4UQ==",
+                  "name" : "workload_group_three",
+                  "resiliency_mode" : "enforced",
+                  "resource_limits" : {
+                    "memory" : 0.5
+                  },
+                  "search_settings" : {
+                    "timeout" : "30s"
+                  },
+                  "updated_at" : 4513232417
+                }
+              ]
             }""";
         assertEquals(expected, actual);
     }

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/UpdateWorkloadGroupResponseTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/UpdateWorkloadGroupResponseTests.java
@@ -60,7 +60,33 @@ public class UpdateWorkloadGroupResponseTests extends OpenSearchTestCase {
             + "  \"resource_limits\" : {\n"
             + "    \"memory\" : 0.3\n"
             + "  },\n"
+            + "  \"search_settings\" : { },\n"
             + "  \"updated_at\" : 4513232413\n"
+            + "}";
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Test case to verify the toXContent method of UpdateWorkloadGroupResponse with search settings.
+     */
+    public void testToXContentUpdateWorkloadGroupWithSearchSettings() throws IOException {
+        XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
+        UpdateWorkloadGroupResponse response = new UpdateWorkloadGroupResponse(
+            WorkloadManagementTestUtils.workloadGroupWithSearchSettings,
+            RestStatus.OK
+        );
+        String actual = response.toXContent(builder, mock(ToXContent.Params.class)).toString();
+        String expected = "{\n"
+            + "  \"_id\" : \"H6jVP6Kb0zgtZmPOmZj4UQ==\",\n"
+            + "  \"name\" : \"workload_group_three\",\n"
+            + "  \"resiliency_mode\" : \"enforced\",\n"
+            + "  \"resource_limits\" : {\n"
+            + "    \"memory\" : 0.5\n"
+            + "  },\n"
+            + "  \"search_settings\" : {\n"
+            + "    \"timeout\" : \"30s\"\n"
+            + "  },\n"
+            + "  \"updated_at\" : 4513232417\n"
             + "}";
         assertEquals(expected, actual);
     }

--- a/server/src/main/java/org/opensearch/cluster/metadata/WorkloadGroup.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/WorkloadGroup.java
@@ -73,6 +73,15 @@ public class WorkloadGroup extends AbstractDiffable<WorkloadGroup> implements To
             throw new IllegalArgumentException("WorkloadGroup.updatedAtInMillis is not a valid epoch");
         }
 
+        // Normalize null searchSettings to empty map for storage
+        if (mutableWorkloadGroupFragment.getSearchSettings() == null) {
+            mutableWorkloadGroupFragment = new MutableWorkloadGroupFragment(
+                mutableWorkloadGroupFragment.getResiliencyMode(),
+                mutableWorkloadGroupFragment.getResourceLimits(),
+                new HashMap<>()
+            );
+        }
+
         this.name = name;
         this._id = _id;
         this.mutableWorkloadGroupFragment = mutableWorkloadGroupFragment;
@@ -104,10 +113,23 @@ public class WorkloadGroup extends AbstractDiffable<WorkloadGroup> implements To
         }
         final ResiliencyMode mode = Optional.ofNullable(mutableWorkloadGroupFragment.getResiliencyMode())
             .orElse(existingGroup.getResiliencyMode());
+        // Handle search_settings update:
+        // null = not specified (keep existing)
+        // empty map = explicitly clear (set to empty)
+        // non-empty map = replace with new values
+        final Map<String, String> mutableFragmentSearchSettings = mutableWorkloadGroupFragment.getSearchSettings();
+        final Map<String, String> updatedSearchSettings;
+        if (mutableFragmentSearchSettings == null) {
+            // Not specified - keep existing
+            updatedSearchSettings = new HashMap<>(existingGroup.getSearchSettings());
+        } else {
+            // Specified (empty or non-empty) - use the new value
+            updatedSearchSettings = new HashMap<>(mutableFragmentSearchSettings);
+        }
         return new WorkloadGroup(
             existingGroup.getName(),
             existingGroup.get_id(),
-            new MutableWorkloadGroupFragment(mode, updatedResourceLimits),
+            new MutableWorkloadGroupFragment(mode, updatedResourceLimits, updatedSearchSettings),
             Instant.now().getMillis()
         );
     }
@@ -177,6 +199,10 @@ public class WorkloadGroup extends AbstractDiffable<WorkloadGroup> implements To
 
     public Map<ResourceType, Double> getResourceLimits() {
         return getMutableWorkloadGroupFragment().getResourceLimits();
+    }
+
+    public Map<String, String> getSearchSettings() {
+        return getMutableWorkloadGroupFragment().getSearchSettings();
     }
 
     public String get_id() {

--- a/server/src/main/java/org/opensearch/wlm/MutableWorkloadGroupFragment.java
+++ b/server/src/main/java/org/opensearch/wlm/MutableWorkloadGroupFragment.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.wlm;
 
+import org.opensearch.Version;
 import org.opensearch.cluster.AbstractDiffable;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -18,9 +19,11 @@ import org.opensearch.core.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.function.Function;
 
 /**
@@ -31,17 +34,32 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
 
     public static final String RESILIENCY_MODE_STRING = "resiliency_mode";
     public static final String RESOURCE_LIMITS_STRING = "resource_limits";
+    public static final String SEARCH_SETTINGS_STRING = "search_settings";
     private ResiliencyMode resiliencyMode;
     private Map<ResourceType, Double> resourceLimits;
+    private Map<String, String> searchSettings;
 
-    public static final List<String> acceptedFieldNames = List.of(RESILIENCY_MODE_STRING, RESOURCE_LIMITS_STRING);
+    public static final List<String> acceptedFieldNames = List.of(RESILIENCY_MODE_STRING, RESOURCE_LIMITS_STRING, SEARCH_SETTINGS_STRING);
 
     public MutableWorkloadGroupFragment() {}
 
+    /**
+     * Constructor for tests only. Production code should use the full constructor below.
+     */
     public MutableWorkloadGroupFragment(ResiliencyMode resiliencyMode, Map<ResourceType, Double> resourceLimits) {
+        this(resiliencyMode, resourceLimits, new HashMap<>());
+    }
+
+    public MutableWorkloadGroupFragment(
+        ResiliencyMode resiliencyMode,
+        Map<ResourceType, Double> resourceLimits,
+        Map<String, String> searchSettings
+    ) {
         validateResourceLimits(resourceLimits);
+        WorkloadGroupSearchSettings.validateSearchSettings(searchSettings);
         this.resiliencyMode = resiliencyMode;
         this.resourceLimits = resourceLimits;
+        this.searchSettings = searchSettings;
     }
 
     public MutableWorkloadGroupFragment(StreamInput in) throws IOException {
@@ -52,6 +70,13 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         }
         String updatedResiliencyMode = in.readOptionalString();
         resiliencyMode = updatedResiliencyMode == null ? null : ResiliencyMode.fromName(updatedResiliencyMode);
+        if (in.getVersion().onOrAfter(Version.V_3_6_0)) {
+            // Read null marker: true means searchSettings is null (not specified)
+            boolean isNull = in.readBoolean();
+            searchSettings = isNull ? null : in.readMap(StreamInput::readString, StreamInput::readString);
+        } else {
+            searchSettings = new HashMap<>();
+        }
     }
 
     interface FieldParser<T> {
@@ -80,14 +105,20 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         }
     }
 
+    static class SearchSettingsParser implements FieldParser<Map<String, String>> {
+        public Map<String, String> parseField(XContentParser parser) throws IOException {
+            return parser.mapStrings();
+        }
+    }
+
     static class FieldParserFactory {
         static Optional<FieldParser<?>> fieldParserFor(String fieldName) {
-            if (fieldName.equals(RESOURCE_LIMITS_STRING)) {
-                return Optional.of(new ResourceLimitsParser());
-            } else if (fieldName.equals(RESILIENCY_MODE_STRING)) {
-                return Optional.of(new ResiliencyModeParser());
-            }
-            return Optional.empty();
+            return switch (fieldName) {
+                case RESILIENCY_MODE_STRING -> Optional.of(new ResiliencyModeParser());
+                case RESOURCE_LIMITS_STRING -> Optional.of(new ResourceLimitsParser());
+                case SEARCH_SETTINGS_STRING -> Optional.of(new SearchSettingsParser());
+                default -> Optional.empty();
+            };
         }
     }
 
@@ -111,23 +142,37 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         } catch (IOException e) {
             throw new IllegalStateException("writing error encountered for the field " + RESOURCE_LIMITS_STRING);
         }
+    }, SEARCH_SETTINGS_STRING, (builder) -> {
+        try {
+            builder.startObject(SEARCH_SETTINGS_STRING);
+            Map<String, String> settings = searchSettings != null ? searchSettings : Map.of();
+            Map<String, String> sortedSettingsMap = new TreeMap<>(settings);
+            for (Map.Entry<String, ?> e : sortedSettingsMap.entrySet()) {
+                builder.field(e.getKey(), e.getValue());
+            }
+            builder.endObject();
+            return null;
+        } catch (IOException e) {
+            throw new IllegalStateException("writing error encountered for the field " + SEARCH_SETTINGS_STRING);
+        }
     });
 
     public static boolean shouldParse(String field) {
         return FieldParserFactory.fieldParserFor(field).isPresent();
     }
 
+    @SuppressWarnings("unchecked")
     public void parseField(XContentParser parser, String field) {
         FieldParserFactory.fieldParserFor(field).ifPresent(fieldParser -> {
             try {
                 Object value = fieldParser.parseField(parser);
-                if (field.equals(RESILIENCY_MODE_STRING)) {
-                    setResiliencyMode((ResiliencyMode) value);
-                } else if (field.equals(RESOURCE_LIMITS_STRING)) {
-                    setResourceLimits((Map<ResourceType, Double>) value);
+                switch (field) {
+                    case RESILIENCY_MODE_STRING -> setResiliencyMode((ResiliencyMode) value);
+                    case RESOURCE_LIMITS_STRING -> setResourceLimits((Map<ResourceType, Double>) value);
+                    case SEARCH_SETTINGS_STRING -> setSearchSettings((Map<String, String>) value);
                 }
             } catch (IOException e) {
-                throw new IllegalArgumentException("parsing error encountered for the field " + field);
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "parsing error encountered for the field '%s'", field));
             }
         });
     }
@@ -145,6 +190,12 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
             out.writeMap(resourceLimits, ResourceType::writeTo, StreamOutput::writeDouble);
         }
         out.writeOptionalString(resiliencyMode == null ? null : resiliencyMode.getName());
+        if (out.getVersion().onOrAfter(Version.V_3_6_0)) {
+            out.writeBoolean(searchSettings == null);
+            if (searchSettings != null) {
+                out.writeMap(searchSettings, StreamOutput::writeString, StreamOutput::writeString);
+            }
+        }
     }
 
     public static void validateResourceLimits(Map<ResourceType, Double> resourceLimits) {
@@ -167,12 +218,14 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MutableWorkloadGroupFragment that = (MutableWorkloadGroupFragment) o;
-        return Objects.equals(resiliencyMode, that.resiliencyMode) && Objects.equals(resourceLimits, that.resourceLimits);
+        return Objects.equals(resiliencyMode, that.resiliencyMode)
+            && Objects.equals(resourceLimits, that.resourceLimits)
+            && Objects.equals(searchSettings, that.searchSettings);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(resiliencyMode, resourceLimits);
+        return Objects.hash(resiliencyMode, resourceLimits, searchSettings);
     }
 
     public ResiliencyMode getResiliencyMode() {
@@ -181,6 +234,10 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
 
     public Map<ResourceType, Double> getResourceLimits() {
         return resourceLimits;
+    }
+
+    public Map<String, String> getSearchSettings() {
+        return searchSettings;
     }
 
     /**
@@ -214,12 +271,17 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         }
     }
 
-    public void setResiliencyMode(ResiliencyMode resiliencyMode) {
+    void setResiliencyMode(ResiliencyMode resiliencyMode) {
         this.resiliencyMode = resiliencyMode;
     }
 
-    public void setResourceLimits(Map<ResourceType, Double> resourceLimits) {
+    void setResourceLimits(Map<ResourceType, Double> resourceLimits) {
         validateResourceLimits(resourceLimits);
         this.resourceLimits = resourceLimits;
+    }
+
+    void setSearchSettings(Map<String, String> searchSettings) {
+        WorkloadGroupSearchSettings.validateSearchSettings(searchSettings);
+        this.searchSettings = searchSettings;
     }
 }

--- a/server/src/main/java/org/opensearch/wlm/WorkloadGroupSearchSettings.java
+++ b/server/src/main/java/org/opensearch/wlm/WorkloadGroupSearchSettings.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.wlm;
+
+import org.opensearch.common.unit.TimeValue;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Registry of valid workload group search settings with their validators
+ */
+public class WorkloadGroupSearchSettings {
+
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private WorkloadGroupSearchSettings() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /**
+     * Enum defining valid workload group search settings with their validation logic.
+     * Settings are categorized as either query parameters or cluster settings.
+     */
+    public enum WlmSearchSetting {
+        // Query parameters (applied to SearchRequest)
+        /** Setting for search request timeout */
+        TIMEOUT("timeout", WorkloadGroupSearchSettings::validateTimeValue);
+
+        private final String settingName;
+        private final Function<String, String> validator;
+
+        WlmSearchSetting(String settingName, Function<String, String> validator) {
+            this.settingName = settingName;
+            this.validator = validator;
+        }
+
+        /**
+         * Returns the setting name.
+         * @return the setting name
+         */
+        public String getSettingName() {
+            return settingName;
+        }
+
+        /**
+         * Validates the given value for this setting.
+         * @param value the value to validate
+         * @throws IllegalArgumentException if the value is invalid
+         */
+        void validate(String value) {
+            String error = validator.apply(value);
+            if (error != null) {
+                throw new IllegalArgumentException("Invalid value '" + value + "' for " + settingName + ": " + error);
+            }
+        }
+
+        /**
+         * Finds a setting by its name.
+         * @param settingName the setting name
+         * @return the setting or null if not found
+         */
+        public static WlmSearchSetting fromKey(String settingName) {
+            for (WlmSearchSetting setting : values()) {
+                if (setting.settingName.equals(settingName)) {
+                    return setting;
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Validates all search settings in the provided map.
+     * @param searchSettings map of setting names to values
+     * @throws IllegalArgumentException if any setting is unknown or invalid
+     */
+    public static void validateSearchSettings(Map<String, String> searchSettings) {
+        if (searchSettings == null) {
+            return;
+        }
+        for (Map.Entry<String, String> entry : searchSettings.entrySet()) {
+            if (entry.getKey() == null) {
+                throw new IllegalArgumentException("Search setting key cannot be null");
+            }
+            if (entry.getValue() == null) {
+                throw new IllegalArgumentException("Search setting value cannot be null for key: " + entry.getKey());
+            }
+            WlmSearchSetting setting = WlmSearchSetting.fromKey(entry.getKey());
+            if (setting == null) {
+                throw new IllegalArgumentException("Unknown search setting: " + entry.getKey());
+            }
+            setting.validate(entry.getValue());
+        }
+    }
+
+    /**
+     * Validates a time value string.
+     * @param value the string to validate
+     * @return null if valid, error message if invalid
+     */
+    private static String validateTimeValue(String value) {
+        try {
+            TimeValue.parseTimeValue(value, "validation");
+            return null;
+        } catch (Exception e) {
+            return e.getMessage();
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/wlm/WorkloadGroupService.java
+++ b/server/src/main/java/org/opensearch/wlm/WorkloadGroupService.java
@@ -325,6 +325,15 @@ public class WorkloadGroupService extends AbstractLifecycleComponent
         return activeWorkloadGroups;
     }
 
+    /**
+     * Returns the workload group with the given ID, or null if not found.
+     * @param workloadGroupId the workload group identifier
+     * @return the WorkloadGroup or null
+     */
+    public WorkloadGroup getWorkloadGroupById(String workloadGroupId) {
+        return clusterService.state().metadata().workloadGroups().get(workloadGroupId);
+    }
+
     public Set<WorkloadGroup> getDeletedWorkloadGroups() {
         return deletedWorkloadGroups;
     }

--- a/server/src/main/java/org/opensearch/wlm/listeners/WorkloadGroupRequestOperationListener.java
+++ b/server/src/main/java/org/opensearch/wlm/listeners/WorkloadGroupRequestOperationListener.java
@@ -8,18 +8,27 @@
 
 package org.opensearch.wlm.listeners;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.action.search.SearchPhaseContext;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchRequestContext;
 import org.opensearch.action.search.SearchRequestOperationsListener;
+import org.opensearch.cluster.metadata.WorkloadGroup;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.wlm.WorkloadGroupSearchSettings;
 import org.opensearch.wlm.WorkloadGroupService;
 import org.opensearch.wlm.WorkloadGroupTask;
+
+import java.util.Map;
 
 /**
  * This listener is used to listen for request lifecycle events for a workloadGroup
  */
 public class WorkloadGroupRequestOperationListener extends SearchRequestOperationsListener {
 
+    private static final Logger logger = LogManager.getLogger(WorkloadGroupRequestOperationListener.class);
     private final WorkloadGroupService workloadGroupService;
     private final ThreadPool threadPool;
 
@@ -36,11 +45,59 @@ public class WorkloadGroupRequestOperationListener extends SearchRequestOperatio
     protected void onRequestStart(SearchRequestContext searchRequestContext) {
         final String workloadGroupId = threadPool.getThreadContext().getHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER);
         workloadGroupService.rejectIfNeeded(workloadGroupId);
+        applyWorkloadGroupSearchSettings(workloadGroupId, searchRequestContext.getRequest());
     }
 
     @Override
     protected void onRequestFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
         final String workloadGroupId = threadPool.getThreadContext().getHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER);
         workloadGroupService.incrementFailuresFor(workloadGroupId);
+    }
+
+    /**
+     * Applies workload group-specific search settings to the search request.
+     * Settings are only applied for workload groups that exist in cluster state.
+     *
+     * @param workloadGroupId the workload group identifier from thread context
+     * @param searchRequest the search request to modify
+     */
+    private void applyWorkloadGroupSearchSettings(String workloadGroupId, SearchRequest searchRequest) {
+        if (workloadGroupId == null) {
+            // Return if request contains no WLM group assignment (default group is added later)
+            return;
+        }
+
+        WorkloadGroup workloadGroup = workloadGroupService.getWorkloadGroupById(workloadGroupId);
+
+        if (workloadGroup == null) {
+            return;
+        }
+
+        // Loop through WLM group search settings and apply them as needed
+        for (Map.Entry<String, String> entry : workloadGroup.getSearchSettings().entrySet()) {
+            try {
+                WorkloadGroupSearchSettings.WlmSearchSetting settingKey = WorkloadGroupSearchSettings.WlmSearchSetting.fromKey(
+                    entry.getKey()
+                );
+                if (settingKey == null) continue;
+
+                switch (settingKey) {
+                    case TIMEOUT:
+                        // Only apply WLM timeout when the request has no explicit timeout
+                        if (searchRequest.source() != null && searchRequest.source().timeout() == null) {
+                            searchRequest.source()
+                                .timeout(
+                                    TimeValue.parseTimeValue(
+                                        entry.getValue(),
+                                        WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT.getSettingName()
+                                    )
+                                );
+                        }
+                        break;
+                }
+            } catch (Exception e) {
+                logger.error("Failed to apply workload group setting [{}={}]: {}", entry.getKey(), entry.getValue(), e);
+            }
+        }
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/metadata/WorkloadGroupMetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/WorkloadGroupMetadataTests.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.opensearch.cluster.metadata.WorkloadGroupTests.TEST_WLM_SEARCH_SETTINGS;
 import static org.opensearch.cluster.metadata.WorkloadGroupTests.createRandomWorkloadGroup;
 
 public class WorkloadGroupMetadataTests extends AbstractDiffableSerializationTestCase<Metadata.Custom> {
@@ -36,7 +37,8 @@ public class WorkloadGroupMetadataTests extends AbstractDiffableSerializationTes
                     "ajakgakg983r92_4242",
                     new MutableWorkloadGroupFragment(
                         MutableWorkloadGroupFragment.ResiliencyMode.ENFORCED,
-                        Map.of(ResourceType.MEMORY, 0.5)
+                        Map.of(ResourceType.MEMORY, 0.5),
+                        TEST_WLM_SEARCH_SETTINGS
                     ),
                     updatedAt
                 )
@@ -46,10 +48,11 @@ public class WorkloadGroupMetadataTests extends AbstractDiffableSerializationTes
         builder.startObject();
         workloadGroupMetadata.toXContent(builder, null);
         builder.endObject();
-        assertEquals(
-            "{\"ajakgakg983r92_4242\":{\"_id\":\"ajakgakg983r92_4242\",\"name\":\"test\",\"resiliency_mode\":\"enforced\",\"resource_limits\":{\"memory\":0.5},\"updated_at\":1720047207}}",
-            builder.toString()
-        );
+        String expected = "{\"ajakgakg983r92_4242\":{\"_id\":\"ajakgakg983r92_4242\",\"name\":\"test\","
+            + "\"resiliency_mode\":\"enforced\",\"resource_limits\":{\"memory\":0.5},"
+            + "\"search_settings\":{\"timeout\":\"30s\"},"
+            + "\"updated_at\":1720047207}}";
+        assertEquals(expected, builder.toString());
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/cluster/metadata/WorkloadGroupTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/WorkloadGroupTests.java
@@ -18,17 +18,20 @@ import org.opensearch.test.AbstractSerializingTestCase;
 import org.opensearch.wlm.MutableWorkloadGroupFragment;
 import org.opensearch.wlm.MutableWorkloadGroupFragment.ResiliencyMode;
 import org.opensearch.wlm.ResourceType;
+import org.opensearch.wlm.WorkloadGroupSearchSettings.WlmSearchSetting;
 import org.joda.time.Instant;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class WorkloadGroupTests extends AbstractSerializingTestCase<WorkloadGroup> {
 
     private static final List<ResiliencyMode> allowedModes = List.of(ResiliencyMode.SOFT, ResiliencyMode.ENFORCED, ResiliencyMode.MONITOR);
+    public static final Map<String, String> TEST_WLM_SEARCH_SETTINGS = Map.of(WlmSearchSetting.TIMEOUT.getSettingName(), "30s");
 
     static WorkloadGroup createRandomWorkloadGroup(String _id) {
         String name = randomAlphaOfLength(10);
@@ -44,7 +47,7 @@ public class WorkloadGroupTests extends AbstractSerializingTestCase<WorkloadGrou
     /**
      * Parses to a new instance using the provided {@link XContentParser}
      *
-     * @param parser
+     * @param parser the XContentParser
      */
     @Override
     protected WorkloadGroup doParseInstance(XContentParser parser) throws IOException {
@@ -127,7 +130,7 @@ public class WorkloadGroupTests extends AbstractSerializingTestCase<WorkloadGrou
     public void testWorkloadGroupInitiation() {
         WorkloadGroup workloadGroup = new WorkloadGroup(
             "analytics",
-            new MutableWorkloadGroupFragment(randomMode(), Map.of(ResourceType.MEMORY, 0.4))
+            new MutableWorkloadGroupFragment(randomMode(), Map.of(ResourceType.MEMORY, 0.4), TEST_WLM_SEARCH_SETTINGS)
         );
         assertNotNull(workloadGroup.getName());
         assertNotNull(workloadGroup.get_id());
@@ -136,6 +139,8 @@ public class WorkloadGroupTests extends AbstractSerializingTestCase<WorkloadGrou
         assertEquals(1, workloadGroup.getResourceLimits().size());
         assertTrue(allowedModes.contains(workloadGroup.getResiliencyMode()));
         assertTrue(workloadGroup.getUpdatedAtInMillis() != 0);
+        assertNotNull(workloadGroup.getSearchSettings());
+        assertEquals(TEST_WLM_SEARCH_SETTINGS, workloadGroup.getSearchSettings());
     }
 
     public void testIllegalWorkloadGroupName() {
@@ -224,18 +229,24 @@ public class WorkloadGroupTests extends AbstractSerializingTestCase<WorkloadGrou
         WorkloadGroup workloadGroup = new WorkloadGroup(
             "TestWorkloadGroup",
             workloadGroupId,
-            new MutableWorkloadGroupFragment(ResiliencyMode.ENFORCED, Map.of(ResourceType.CPU, 0.30, ResourceType.MEMORY, 0.40)),
+            new MutableWorkloadGroupFragment(
+                ResiliencyMode.ENFORCED,
+                Map.of(ResourceType.CPU, 0.30, ResourceType.MEMORY, 0.40),
+                TEST_WLM_SEARCH_SETTINGS
+            ),
             currentTimeInMillis
         );
         XContentBuilder builder = JsonXContent.contentBuilder();
         workloadGroup.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        assertEquals(
-            "{\"_id\":\""
-                + workloadGroupId
-                + "\",\"name\":\"TestWorkloadGroup\",\"resiliency_mode\":\"enforced\",\"resource_limits\":{\"cpu\":0.3,\"memory\":0.4},\"updated_at\":"
-                + currentTimeInMillis
-                + "}",
-            builder.toString()
+        String expected = String.format(
+            Locale.ROOT,
+            "{\"_id\":\"%s\",\"name\":\"TestWorkloadGroup\",\"resiliency_mode\":\"enforced\","
+                + "\"resource_limits\":{\"cpu\":0.3,\"memory\":0.4},"
+                + "\"search_settings\":{\"timeout\":\"30s\"},"
+                + "\"updated_at\":%d}",
+            workloadGroupId,
+            currentTimeInMillis
         );
+        assertEquals(expected, builder.toString());
     }
 }

--- a/server/src/test/java/org/opensearch/wlm/WorkloadGroupSearchSettingsTests.java
+++ b/server/src/test/java/org/opensearch/wlm/WorkloadGroupSearchSettingsTests.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.wlm;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class WorkloadGroupSearchSettingsTests extends OpenSearchTestCase {
+
+    public void testEnumSettingNames() {
+        assertEquals("timeout", WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT.getSettingName());
+    }
+
+    public void testFromKeyValidSettings() {
+        assertEquals(WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT, WorkloadGroupSearchSettings.WlmSearchSetting.fromKey("timeout"));
+    }
+
+    public void testFromKeyInvalidSetting() {
+        assertNull(WorkloadGroupSearchSettings.WlmSearchSetting.fromKey("invalid_setting"));
+        assertNull(WorkloadGroupSearchSettings.WlmSearchSetting.fromKey(""));
+        assertNull(WorkloadGroupSearchSettings.WlmSearchSetting.fromKey(null));
+    }
+
+    public void testValidateTimeValue() {
+        WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT.validate("30s");
+        WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT.validate("5m");
+        WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT.validate("1h");
+    }
+
+    public void testValidateInvalidTimeValue() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT.validate("invalid")
+        );
+        assertTrue(exception.getMessage().contains("Invalid value"));
+    }
+
+    public void testValidateSearchSettingsValid() {
+        Map<String, String> settings = new HashMap<>();
+        settings.put("timeout", "30s");
+
+        // Should not throw exception
+        WorkloadGroupSearchSettings.validateSearchSettings(settings);
+    }
+
+    public void testValidateSearchSettingsUnknownSetting() {
+        Map<String, String> settings = new HashMap<>();
+        settings.put("unknown_setting", "true");
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> WorkloadGroupSearchSettings.validateSearchSettings(settings)
+        );
+        assertTrue(exception.getMessage().contains("Unknown search setting: unknown_setting"));
+    }
+
+    public void testValidateSearchSettingsInvalidValue() {
+        Map<String, String> settings = new HashMap<>();
+        settings.put("timeout", "invalid_time");
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> WorkloadGroupSearchSettings.validateSearchSettings(settings)
+        );
+        assertTrue(exception.getMessage().contains("Invalid value"));
+    }
+
+    public void testValidateSearchSettingsEmpty() {
+        Map<String, String> settings = new HashMap<>();
+
+        // Should not throw exception for empty map
+        WorkloadGroupSearchSettings.validateSearchSettings(settings);
+    }
+}

--- a/server/src/test/java/org/opensearch/wlm/WorkloadGroupSearchSettingsTests.java
+++ b/server/src/test/java/org/opensearch/wlm/WorkloadGroupSearchSettingsTests.java
@@ -73,6 +73,33 @@ public class WorkloadGroupSearchSettingsTests extends OpenSearchTestCase {
         assertTrue(exception.getMessage().contains("Invalid value"));
     }
 
+    public void testValidateSearchSettingsNull() {
+        // Should not throw exception for null map
+        WorkloadGroupSearchSettings.validateSearchSettings(null);
+    }
+
+    public void testValidateSearchSettingsNullKey() {
+        Map<String, String> settings = new HashMap<>();
+        settings.put(null, "30s");
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> WorkloadGroupSearchSettings.validateSearchSettings(settings)
+        );
+        assertTrue(exception.getMessage().contains("Search setting key cannot be null"));
+    }
+
+    public void testValidateSearchSettingsNullValue() {
+        Map<String, String> settings = new HashMap<>();
+        settings.put("timeout", null);
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> WorkloadGroupSearchSettings.validateSearchSettings(settings)
+        );
+        assertTrue(exception.getMessage().contains("Search setting value cannot be null"));
+    }
+
     public void testValidateSearchSettingsEmpty() {
         Map<String, String> settings = new HashMap<>();
 

--- a/server/src/test/java/org/opensearch/wlm/listeners/WorkloadGroupRequestOperationListenerTests.java
+++ b/server/src/test/java/org/opensearch/wlm/listeners/WorkloadGroupRequestOperationListenerTests.java
@@ -304,6 +304,19 @@ public class WorkloadGroupRequestOperationListenerTests extends OpenSearchTestCa
         assertNull(mockSearchRequest.source());
     }
 
+    public void testApplySearchSettings_EmptySearchSettings() {
+        mockSearchRequest.source(new SearchSourceBuilder());
+
+        String wgId = "test-wg";
+        WorkloadGroup wg = createWorkloadGroup(wgId, Map.of());
+        when(workloadGroupService.getWorkloadGroupById(wgId)).thenReturn(wg);
+        testThreadPool.getThreadContext().putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, wgId);
+
+        sut.onRequestStart(mockSearchRequestContext);
+
+        assertNull(mockSearchRequest.source().timeout()); // No settings applied
+    }
+
     public void testApplySearchSettings_Timeout_WlmAppliedWhenNull() {
         mockSearchRequest.source(new SearchSourceBuilder());
         assertNull(mockSearchRequest.source().timeout());

--- a/server/src/test/java/org/opensearch/wlm/listeners/WorkloadGroupRequestOperationListenerTests.java
+++ b/server/src/test/java/org/opensearch/wlm/listeners/WorkloadGroupRequestOperationListenerTests.java
@@ -8,14 +8,20 @@
 
 package org.opensearch.wlm.listeners;
 
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchRequestContext;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.metadata.WorkloadGroup;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.wlm.MutableWorkloadGroupFragment;
 import org.opensearch.wlm.ResourceType;
 import org.opensearch.wlm.WorkloadGroupService;
 import org.opensearch.wlm.WorkloadGroupTask;
@@ -48,6 +54,8 @@ public class WorkloadGroupRequestOperationListenerTests extends OpenSearchTestCa
     Map<String, WorkloadGroupState> workloadGroupStateMap;
     String testWorkloadGroupId;
     WorkloadGroupRequestOperationListener sut;
+    SearchRequestContext mockSearchRequestContext;
+    SearchRequest mockSearchRequest;
 
     public void setUp() throws Exception {
         super.setUp();
@@ -63,6 +71,9 @@ public class WorkloadGroupRequestOperationListenerTests extends OpenSearchTestCa
         when(mockClusterState.metadata()).thenReturn(mockMetaData);
         workloadGroupService = mock(WorkloadGroupService.class);
         sut = new WorkloadGroupRequestOperationListener(workloadGroupService, testThreadPool);
+        mockSearchRequest = new SearchRequest();
+        mockSearchRequestContext = mock(SearchRequestContext.class);
+        when(mockSearchRequestContext.getRequest()).thenReturn(mockSearchRequest);
     }
 
     public void tearDown() throws Exception {
@@ -74,7 +85,7 @@ public class WorkloadGroupRequestOperationListenerTests extends OpenSearchTestCa
         final String testWorkloadGroupId = "asdgasgkajgkw3141_3rt4t";
         testThreadPool.getThreadContext().putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, testWorkloadGroupId);
         doThrow(OpenSearchRejectedExecutionException.class).when(workloadGroupService).rejectIfNeeded(testWorkloadGroupId);
-        assertThrows(OpenSearchRejectedExecutionException.class, () -> sut.onRequestStart(null));
+        assertThrows(OpenSearchRejectedExecutionException.class, () -> sut.onRequestStart(mockSearchRequestContext));
     }
 
     public void testNonRejectionCase() {
@@ -82,7 +93,7 @@ public class WorkloadGroupRequestOperationListenerTests extends OpenSearchTestCa
         testThreadPool.getThreadContext().putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, testWorkloadGroupId);
         doNothing().when(workloadGroupService).rejectIfNeeded(testWorkloadGroupId);
 
-        sut.onRequestStart(null);
+        sut.onRequestStart(mockSearchRequestContext);
     }
 
     public void testValidWorkloadGroupRequestFailure() throws IOException {
@@ -272,5 +283,77 @@ public class WorkloadGroupRequestOperationListenerTests extends OpenSearchTestCa
         when(mockClusterService.state()).thenReturn(state);
         when(state.metadata()).thenReturn(metadata);
         when(metadata.workloadGroups()).thenReturn(Collections.emptyMap());
+    }
+
+    // Tests for applyWorkloadGroupSearchSettings
+
+    public void testApplySearchSettings_NullWorkloadGroupId() {
+        // No workload group ID in thread context
+        sut.onRequestStart(mockSearchRequestContext);
+
+        // Request should remain unchanged - source is null, no timeout set
+        assertNull(mockSearchRequest.source());
+    }
+
+    public void testApplySearchSettings_WorkloadGroupNotFound() {
+        testThreadPool.getThreadContext().putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, "non-existent-id");
+        when(workloadGroupService.getWorkloadGroupById("non-existent-id")).thenReturn(null);
+
+        sut.onRequestStart(mockSearchRequestContext);
+
+        assertNull(mockSearchRequest.source());
+    }
+
+    public void testApplySearchSettings_Timeout_WlmAppliedWhenNull() {
+        mockSearchRequest.source(new SearchSourceBuilder());
+        assertNull(mockSearchRequest.source().timeout());
+
+        String wgId = "test-wg";
+        WorkloadGroup wg = createWorkloadGroup(wgId, Map.of("timeout", "1m"));
+        when(workloadGroupService.getWorkloadGroupById(wgId)).thenReturn(wg);
+        testThreadPool.getThreadContext().putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, wgId);
+
+        sut.onRequestStart(mockSearchRequestContext);
+
+        assertEquals(TimeValue.timeValueMinutes(1), mockSearchRequest.source().timeout());
+    }
+
+    public void testApplySearchSettings_Timeout_RequestAlreadySet() {
+        mockSearchRequest.source(new SearchSourceBuilder().timeout(TimeValue.timeValueSeconds(30)));
+
+        String wgId = "test-wg";
+        WorkloadGroup wg = createWorkloadGroup(wgId, Map.of("timeout", "10s"));
+        when(workloadGroupService.getWorkloadGroupById(wgId)).thenReturn(wg);
+        testThreadPool.getThreadContext().putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, wgId);
+
+        sut.onRequestStart(mockSearchRequestContext);
+
+        assertEquals(TimeValue.timeValueSeconds(30), mockSearchRequest.source().timeout()); // Request value preserved
+    }
+
+    public void testApplySearchSettings_Timeout_NullSource() {
+        assertNull(mockSearchRequest.source());
+
+        String wgId = "test-wg";
+        WorkloadGroup wg = createWorkloadGroup(wgId, Map.of("timeout", "30s"));
+        when(workloadGroupService.getWorkloadGroupById(wgId)).thenReturn(wg);
+        testThreadPool.getThreadContext().putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, wgId);
+
+        sut.onRequestStart(mockSearchRequestContext);
+
+        assertNull(mockSearchRequest.source()); // Should not throw, source remains null
+    }
+
+    private WorkloadGroup createWorkloadGroup(String id, Map<String, String> searchSettings) {
+        return new WorkloadGroup(
+            "test-name",
+            id,
+            new MutableWorkloadGroupFragment(
+                MutableWorkloadGroupFragment.ResiliencyMode.SOFT,
+                Map.of(ResourceType.MEMORY, 0.5),
+                searchSettings
+            ),
+            System.currentTimeMillis()
+        );
     }
 }


### PR DESCRIPTION
### Description

This PR adds the foundational infrastructure for defining custom search settings within a WLM group, along with the first setting implementation (`timeout`).

#### What's included

- `WorkloadGroupSearchSettings` enum with validation framework for search settings
- `search_settings` field in `MutableWorkloadGroupFragment` and `WorkloadGroup`
- `WorkloadGroupRequestOperationListener` integration to apply settings during request start
- `timeout` setting implementation

#### Supported setting (this PR)

**`timeout`** - Enforces a hard upper bound on how long a search is allowed to execute, helping keep latency predictable for a workload group and avoiding situations where slow or stalled queries tie up search threads. The WLM timeout is only applied when the request does not already have an explicit timeout set.

### Usage

Create WLM group with `search_settings`:

```bash
curl -XPUT "http://localhost:9200/_wlm/workload_group?pretty" -H 'Content-Type: application/json' -d'
{
  "name": "analytics",
  "resiliency_mode": "enforced",
  "resource_limits": {
    "cpu": 0.1,
    "memory": 0.1
  },
  "search_settings": {
    "timeout": "30s"
  }
}'
```

Update WLM group:
```
curl -XPUT "http://localhost:9200/_wlm/workload_group/analytics?pretty" -H 'Content-Type: application/json' -d'
{
  "search_settings": {
    "timeout": "1m"
  }
}'
```


### Related Issues
Part of https://github.com/opensearch-project/OpenSearch/issues/20555

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
