### PR TITLE
Bump shadow-gradle-plugin from 8.3.9 to 9.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix the regression of terms agg optimization at high cardinality ([#20623](https://github.com/opensearch-project/OpenSearch/pull/20623))
 
 ### Dependencies
+- Bump shadow-gradle-plugin from 8.3.9 to 9.3.1 ([#20569](https://github.com/opensearch-project/OpenSearch/pull/20569))
 - Bump `ch.qos.logback:logback-core` and `ch.qos.logback:logback-classic` from 1.5.24 to 1.5.27 ([#20525](https://github.com/opensearch-project/OpenSearch/pull/20525))
 - Bump `org.apache.commons:commons-text` from 1.14.0 to 1.15.0 ([#20576](https://github.com/opensearch-project/OpenSearch/pull/20576))
 - Bump `aws-actions/configure-aws-credentials` from 5 to 6 ([#20577](https://github.com/opensearch-project/OpenSearch/pull/20577))

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -111,7 +111,7 @@ dependencies {
   api 'org.apache.rat:apache-rat:0.15'
   api "commons-io:commons-io:${props.getProperty('commonsio')}"
   api "net.java.dev.jna:jna:5.16.0"
-  api 'com.gradleup.shadow:shadow-gradle-plugin:8.3.9'
+  api 'com.gradleup.shadow:shadow-gradle-plugin:9.3.1'
   api 'org.jdom:jdom2:2.0.6.1'
   api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${props.getProperty('kotlin')}"
   api 'de.thetaphi:forbiddenapis:3.10'

--- a/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
@@ -33,7 +33,6 @@
 package org.opensearch.gradle;
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin;
-import com.github.jengelman.gradle.plugins.shadow.ShadowExtension;
 import groovy.util.Node;
 import groovy.util.NodeList;
 
@@ -103,8 +102,7 @@ public class PublishPlugin implements Plugin<Project> {
 
         project.getPluginManager().withPlugin("com.github.johnrengelman.shadow", plugin -> {
             MavenPublication publication = publishing.getPublications().maybeCreate("shadow", MavenPublication.class);
-            ShadowExtension shadow = project.getExtensions().getByType(ShadowExtension.class);
-            shadow.component(publication);
+            publication.from(project.getComponents().getByName("shadow"));
             // Workaround for https://github.com/johnrengelman/shadow/issues/334
             // Here we manually add any project dependencies in the "shadow" configuration to our generated POM
             publication.getPom().withXml(xml -> {


### PR DESCRIPTION
This dependency update does make some breaking changes in some plugin build scripts. I'm going to try to work through those before this is pushed.

- https://github.com/opensearch-project/job-scheduler/pull/884
- https://github.com/opensearch-project/security/pull/5953
- https://github.com/opensearch-project/alerting/pull/2022
- https://github.com/opensearch-project/common-utils/pull/904
- https://github.com/opensearch-project/index-management/pull/1587
- https://github.com/opensearch-project/notifications/pull/1138

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
