### PR TITLE
Fix: Write .liv files to disk for segment replication and remote store

### DIFF
--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -594,9 +594,11 @@ public class InternalEngine extends Engine {
         OpenSearchReaderManager internalReaderManager = null;
         try {
             try {
+                // For segment replication and remote store, write all deletes to disk (.liv files) so they can be replicated
+                final boolean writeAllDeletes = engineConfig.getIndexSettings().isSegRepEnabledOrRemoteNode();
                 // We always open reader on parent IndexWriter.
                 final OpenSearchDirectoryReader directoryReader = OpenSearchDirectoryReader.wrap(
-                    DirectoryReader.open(documentIndexWriter.getAccumulatingIndexWriter()),
+                    DirectoryReader.open(documentIndexWriter.getAccumulatingIndexWriter(), true, writeAllDeletes),
                     shardId
                 );
                 internalReaderManager = new OpenSearchReaderManager(directoryReader);


### PR DESCRIPTION
## Description

This PR fixes a critical bug in segment replication and remote store that causes `NullPointerException` during background merge operations when processing k-NN vector fields with document deletions.

### Problem

When using **SEGMENT replication** or **remote store** with **k-NN vectors**, the index becomes RED during background merge with the following error:

```
java.lang.NullPointerException: Cannot read field "values" because "this.current" is null
  at org.apache.lucene.codecs.KnnVectorsWriter$MergedFloat32VectorValues.vectorValue(KnnVectorsWriter.java:225)
```

### Root Cause

`DirectoryReader.open()` is called with only one parameter (IndexWriter), which defaults to `writeAllDeletes=false`. This keeps deletion information in memory only and does NOT write `.liv` (live documents) files to disk.

**Impact on Segment Replication:**
1. Primary shard: Deletions stored in memory only (no `.liv` files written to disk)
2. Segment replication: Copies only disk files (`.vec`, `.cfs`, etc.) but NOT `.liv` files
3. Replica shard: Missing deletion metadata
4. Background merge: Lucene assumes all documents are live (no deletion bitmap available)
5. k-NN merge: Tries to access deleted document's vector → NPE (vector data is NULL)

### The Fix

Set `writeAllDeletes=true` when opening DirectoryReader for segment replication and remote store:

```java
final boolean writeAllDeletes = engineConfig.getIndexSettings().isSegRepEnabledOrRemoteNode();
DirectoryReader.open(documentIndexWriter.getAccumulatingIndexWriter(), true, writeAllDeletes);
```

This ensures `.liv` files are written to disk during refresh and replicated to replica shards.

### Impact

**Affected Users:**
- Any cluster using SEGMENT replication OR remote store
- With k-NN vector fields
- That performs document deletions or updates

**Severity:** HIGH
- Index becomes RED (unavailable)
- Requires manual shard restoration

### Related Issues

- Related to #20572

### Additional Notes

This fix aligns OpenSearch's behavior with Lucene's design intent: when using file-based replication (segment replication, remote store), deletion information must be persisted to disk via `.liv` files. The current default (`writeAllDeletes=false`) is optimized for document replication where each replica independently manages deletions.

The fix applies to:
- **Segment replication**: Explicitly enabled via `index.replication.type=SEGMENT`
- **Remote store**: Implicitly requires similar behavior as segment replication

**Backward Compatibility:** This change only affects segment replication and remote store scenarios. Document replication (default) behavior is unchanged.