### PR TITLE
Changing reference to Indexer for flushOnIdle

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -3316,8 +3316,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * indexing operation, so we can flush the index.
      */
     public void flushOnIdle(long inactiveTimeNS) {
-        Engine engineOrNull = getEngineOrNull();
-        if (engineOrNull != null && System.nanoTime() - engineOrNull.getLastWriteNanos() >= inactiveTimeNS) {
+        Indexer indexerOrNull = getIndexerOrNull();
+        if (indexerOrNull != null && System.nanoTime() - indexerOrNull.getLastWriteNanos() >= inactiveTimeNS) {
             boolean wasActive = active.getAndSet(false);
             if (wasActive) {
                 logger.debug("flushing shard on inactive");
@@ -4248,16 +4248,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return getIndexer();
     }
 
-    public CheckpointState getCheckpointStateOrNull() {
-        return getEngineOrNull();
-    }
-
     public StatsHolder getStatsHolderOrNull() {
         return indexSettings.isOptimizedIndex() ? getIndexingExecutionCoordinator() : currentEngineReference.get();
-    }
-
-    public IndexingThrottler getIndexingThrottlerOrNull() {
-        return getEngineOrNull();
     }
 
     /**


### PR DESCRIPTION
### Description
- Fixing flushOnIdle to reference Indexer instead of Engine.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
