### PR TITLE
Fix content dropping in html_strip character filter (#20554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Move Randomness from server to libs/common ([#20570](https://github.com/opensearch-project/OpenSearch/pull/20570))
 
 ### Fixed
+- Fix content dropping in html_strip character filter when attribute values end with = ([#20554](https://github.com/opensearch-project/OpenSearch/issues/20554))
 - Fix flaky test failures in ShardsLimitAllocationDeciderIT ([#20375](https://github.com/opensearch-project/OpenSearch/pull/20375))
 - Prevent criteria update for context aware indices ([#20250](https://github.com/opensearch-project/OpenSearch/pull/20250))
 - Update EncryptedBlobContainer to adhere limits while listing blobs in specific sort order if wrapped blob container supports ([#20514](https://github.com/opensearch-project/OpenSearch/pull/20514))

--- a/modules/analysis-common/src/main/java/org/opensearch/analysis/common/HtmlStripCharFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/opensearch/analysis/common/HtmlStripCharFilterFactory.java
@@ -33,6 +33,7 @@
 package org.opensearch.analysis.common;
 
 import org.apache.lucene.analysis.charfilter.HTMLStripCharFilter;
+import org.apache.lucene.analysis.pattern.PatternReplaceCharFilter;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 import org.opensearch.index.IndexSettings;
@@ -41,12 +42,14 @@ import org.opensearch.index.analysis.AbstractCharFilterFactory;
 import java.io.Reader;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.unmodifiableSet;
 import static org.opensearch.common.util.set.Sets.newHashSet;
 
 public class HtmlStripCharFilterFactory extends AbstractCharFilterFactory {
     private final Set<String> escapedTags;
+    private static final Pattern EQUALS_QUOTE_PATTERN = Pattern.compile("=(?=[\\\"\\s])");
 
     HtmlStripCharFilterFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
         super(indexSettings, name);
@@ -60,6 +63,6 @@ public class HtmlStripCharFilterFactory extends AbstractCharFilterFactory {
 
     @Override
     public Reader create(Reader tokenStream) {
-        return new HTMLStripCharFilter(tokenStream, escapedTags);
+        return new HTMLStripCharFilter(new PatternReplaceCharFilter(EQUALS_QUOTE_PATTERN, "&#61;", tokenStream), escapedTags);
     }
 }

--- a/modules/analysis-common/src/test/java/org/opensearch/analysis/common/HtmlStripCharFilterTests.java
+++ b/modules/analysis-common/src/test/java/org/opensearch/analysis/common/HtmlStripCharFilterTests.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analysis.common;
+
+import org.apache.lucene.analysis.charfilter.HTMLStripCharFilter;
+import org.apache.lucene.analysis.pattern.PatternReplaceCharFilter;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.StringReader;
+import java.io.Reader;
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+public class HtmlStripCharFilterTests extends OpenSearchTestCase {
+    private static final Pattern EQUALS_QUOTE_PATTERN = Pattern.compile("=(?=[\\\"\\s])");
+
+    public void testHtmlStripWithEqualsAtEndOfAttribute() throws IOException {
+        String input = "<a href=\"https://www.example.com/?test=\">example</a> this gets discarded<a href=\"https://www.example.com/\">example2</a> continues here";
+        assertHtmlStrip(input, "example", "this gets discarded", "example2");
+    }
+
+    public void testHtmlStripWithEqualsNotAtEnd() throws IOException {
+        String input = "<a href=\"https://www.example.com/?test=foo\">example</a> this should work<a href=\"https://www.example.com/\">example2</a>";
+        assertHtmlStrip(input, "example", "this should work", "example2");
+    }
+
+    public void testHtmlStripWithSpaceAfterEquals() throws IOException {
+        String input = "<a href=\"https://www.example.com/?test= \">example</a> this might work<a href=\"https://www.example.com/\">example2</a>";
+        assertHtmlStrip(input, "example", "this might work", "example2");
+    }
+
+    public void testHtmlStripWithEntityEquals() throws IOException {
+        String input = "<a href=\"https://www.example.com/?test&#61;\">example</a> this should work<a href=\"https://www.example.com/\">example2</a>";
+        assertHtmlStrip(input, "example", "this should work", "example2");
+    }
+
+    private void assertHtmlStrip(String input, String... expectedSubstrings) throws IOException {
+        Reader reader = new HTMLStripCharFilter(
+            new PatternReplaceCharFilter(EQUALS_QUOTE_PATTERN, "&#61;", new StringReader(input)),
+            null
+        );
+        StringBuilder sb = new StringBuilder();
+        char[] buffer = new char[1024];
+        int len;
+        while ((len = reader.read(buffer)) != -1) {
+            sb.append(buffer, 0, len);
+        }
+        String output = sb.toString();
+        for (String expected : expectedSubstrings) {
+            assertTrue("Output should contain '" + expected + "'. Output was: " + output, output.contains(expected));
+        }
+    }
+}

--- a/modules/ingest-common/src/main/java/org/opensearch/ingest/common/HtmlStripProcessor.java
+++ b/modules/ingest-common/src/main/java/org/opensearch/ingest/common/HtmlStripProcessor.java
@@ -33,15 +33,18 @@
 package org.opensearch.ingest.common;
 
 import org.apache.lucene.analysis.charfilter.HTMLStripCharFilter;
+import org.apache.lucene.analysis.pattern.PatternReplaceCharFilter;
 import org.opensearch.OpenSearchException;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public final class HtmlStripProcessor extends AbstractStringProcessor<String> {
 
     public static final String TYPE = "html_strip";
+    private static final Pattern EQUALS_QUOTE_PATTERN = Pattern.compile("=(?=[\\\"\\s])");
 
     HtmlStripProcessor(String tag, String description, String field, boolean ignoreMissing, String targetField) {
         super(tag, description, ignoreMissing, targetField, field);
@@ -55,7 +58,11 @@ public final class HtmlStripProcessor extends AbstractStringProcessor<String> {
         }
 
         StringBuilder builder = new StringBuilder();
-        try (HTMLStripCharFilter filter = new HTMLStripCharFilter(new StringReader(value))) {
+        try (
+            HTMLStripCharFilter filter = new HTMLStripCharFilter(
+                new PatternReplaceCharFilter(EQUALS_QUOTE_PATTERN, "&#61;", new StringReader(value))
+            )
+        ) {
             int ch;
             while ((ch = filter.read()) != -1) {
                 builder.append((char) ch);

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/HtmlStripProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/HtmlStripProcessorTests.java
@@ -48,4 +48,13 @@ public class HtmlStripProcessorTests extends AbstractStringProcessorTestCase<Str
     protected String expectedResult(String input) {
         return "\ntest" + input + "\ntest";
     }
+
+    public void testHtmlStripWithEqualsAtEndOfAttribute() {
+        AbstractStringProcessor<String> processor = newProcessor("field", false, "target");
+        String input = "<a href=\"https://www.example.com/?test=\">example</a> this gets discarded<a href=\"https://www.example.com/\">example2</a> continues here";
+        String output = processor.process(input);
+        assertTrue("Output should contain 'this gets discarded'. Output was: " + output, output.contains("this gets discarded"));
+        assertTrue("Output should contain 'example'. Output was: " + output, output.contains("example"));
+        assertTrue("Output should contain 'example2'. Output was: " + output, output.contains("example2"));
+    }
 }


### PR DESCRIPTION
### Description
This PR fixes a bug in the `html_strip` character filter (and ingest processor) where content was being incorrectly dropped when an HTML attribute value ended with an equals sign (`=`).

The root cause is a parsing issue in Lucene's `HTMLStripCharFilter`. To resolve this without forking the Lucene class, this change introduces a pre-processing step using `PatternReplaceCharFilter`. It identifies the problematic pattern (an equals sign followed by a double quote or whitespace) and escapes it to the HTML entity `&#61;`. Since `HTMLStripCharFilter` decodes entities in its output text, this workaround is transparent to users while ensuring correct HTML stripping.

### Related Issues
Resolves #20554

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).