### PR TITLE
Relax field-level meta validation constraints

### DIFF
--- a/server/src/main/java/org/opensearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/opensearch/index/mapper/TypeParsers.java
@@ -64,6 +64,9 @@ public class TypeParsers {
     public static final String INDEX_OPTIONS_FREQS = "freqs";
     public static final String INDEX_OPTIONS_POSITIONS = "positions";
     public static final String INDEX_OPTIONS_OFFSETS = "offsets";
+    public static final int META_MAX_ENTRIES = 100;
+    public static final int META_MAX_KEY_LENGTH = 255;
+    public static final int META_MAX_VALUE_LENGTH = 10_000;
 
     public static void checkNull(String propName, Object propNode) {
         if (false == propName.equals("null_value") && propNode == null) {
@@ -86,26 +89,35 @@ public class TypeParsers {
         }
         @SuppressWarnings("unchecked")
         Map<String, ?> meta = (Map<String, ?>) metaObject;
-        if (meta.size() > 5) {
-            throw new MapperParsingException("[meta] can't have more than 5 entries, but got " + meta.size() + " on field [" + name + "]");
+        if (meta.size() > META_MAX_ENTRIES) {
+            throw new MapperParsingException(
+                "[meta] can't have more than " + META_MAX_ENTRIES + " entries, but got " + meta.size() + " on field [" + name + "]"
+            );
         }
-        for (String key : meta.keySet()) {
-            if (key.codePointCount(0, key.length()) > 20) {
+        for (Map.Entry<String, ?> entry : meta.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (key.codePointCount(0, key.length()) > META_MAX_KEY_LENGTH) {
                 throw new MapperParsingException(
-                    "[meta] keys can't be longer than 20 chars, but got [" + key + "] for field [" + name + "]"
+                    "[meta] keys can't be longer than " + META_MAX_KEY_LENGTH + " chars, but got [" + key + "] for field [" + name + "]"
                 );
             }
-        }
-        for (Object value : meta.values()) {
-            if (value instanceof String) {
-                String sValue = (String) value;
-                if (sValue.codePointCount(0, sValue.length()) > 50) {
+
+            if (value == null) {
+                throw new MapperParsingException("[meta] values can't be null (field [" + name + "])");
+            }
+            if (value instanceof String sValue) {
+                if (sValue.codePointCount(0, sValue.length()) > META_MAX_VALUE_LENGTH) {
                     throw new MapperParsingException(
-                        "[meta] values can't be longer than 50 chars, but got [" + value + "] for field [" + name + "]"
+                        "[meta] values can't be longer than "
+                            + META_MAX_VALUE_LENGTH
+                            + " chars, but got ["
+                            + value
+                            + "] for field ["
+                            + name
+                            + "]"
                     );
                 }
-            } else if (value == null) {
-                throw new MapperParsingException("[meta] values can't be null (field [" + name + "])");
             } else {
                 throw new MapperParsingException(
                     "[meta] values can only be strings, but got "

--- a/server/src/test/java/org/opensearch/index/mapper/TypeParsersTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/TypeParsersTests.java
@@ -117,23 +117,35 @@ public class TypeParsersTests extends OpenSearchTestCase {
         }
 
         {
+            String longKeyString = IntStream.range(0, TypeParsers.META_MAX_KEY_LENGTH + 1)
+                .mapToObj(Integer::toString)
+                .collect(Collectors.joining());
             MapperParsingException e = expectThrows(
                 MapperParsingException.class,
-                () -> TypeParsers.parseMeta("foo", Collections.singletonMap("veryloooooooooooongkey", 3L))
+                () -> TypeParsers.parseMeta("foo", Collections.singletonMap(longKeyString, 3L))
             );
-            assertEquals("[meta] keys can't be longer than 20 chars, but got [veryloooooooooooongkey] for field [foo]", e.getMessage());
+            assertEquals(
+                "[meta] keys can't be longer than "
+                    + TypeParsers.META_MAX_KEY_LENGTH
+                    + " chars, but got ["
+                    + longKeyString
+                    + "] for field [foo]",
+                e.getMessage()
+            );
         }
 
         {
             Map<String, String> meta = new HashMap<>();
-            meta.put("foo1", "3");
-            meta.put("foo2", "3");
-            meta.put("foo3", "3");
-            meta.put("foo4", "3");
-            meta.put("foo5", "3");
-            meta.put("foo6", "3");
+            for (int i = 0; i < TypeParsers.META_MAX_ENTRIES; i++) {
+                meta.put("foo" + i, "someValue");
+            }
+            meta.put("extraKey", "someValue");
+            assertTrue(TypeParsers.META_MAX_ENTRIES < meta.size());
             MapperParsingException e = expectThrows(MapperParsingException.class, () -> TypeParsers.parseMeta("foo", meta));
-            assertEquals("[meta] can't have more than 5 entries, but got 6 on field [foo]", e.getMessage());
+            assertEquals(
+                "[meta] can't have more than " + TypeParsers.META_MAX_ENTRIES + " entries, but got " + meta.size() + " on field [foo]",
+                e.getMessage()
+            );
         }
 
         {
@@ -158,12 +170,17 @@ public class TypeParsersTests extends OpenSearchTestCase {
         }
 
         {
-            String longString = IntStream.range(0, 51).mapToObj(Integer::toString).collect(Collectors.joining());
+            String longString = IntStream.range(0, TypeParsers.META_MAX_VALUE_LENGTH + 1)
+                .mapToObj(Integer::toString)
+                .collect(Collectors.joining());
             MapperParsingException e = expectThrows(
                 MapperParsingException.class,
                 () -> TypeParsers.parseMeta("foo", Collections.singletonMap("foo", longString))
             );
-            assertThat(e.getMessage(), Matchers.startsWith("[meta] values can't be longer than 50 chars"));
+            assertThat(
+                e.getMessage(),
+                Matchers.startsWith("[meta] values can't be longer than " + TypeParsers.META_MAX_VALUE_LENGTH + " chars")
+            );
         }
     }
 }


### PR DESCRIPTION
### Description
Restrictions on the field-level `meta` have been relaxed:
- meta accepts any number of entries as long as the following restrictions are met
- `meta`'s values must be Strings of any length
- `meta`'s values can **not** be nulls
- `meta`'s keys must be Strings of any length

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/19884

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
