### PR TITLE
Add cluster.blocks.read.auto_release setting (#20539)

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -111,6 +111,15 @@ public class DiskThresholdMonitor {
      */
     private final Set<String> nodesOverHighThresholdAndRelocating = Sets.newConcurrentHashSet();
 
+    /**
+     * The names of the indices whose {@code index.blocks.read} block was applied by this monitor rather than by an operator. Because the
+     * monitor reuses the user-facing {@code index.blocks.read} setting, cluster state carries no record of which blocks it owns, so the
+     * distinction is tracked here. It is only consulted when {@link DiskThresholdSettings#INDEX_READ_BLOCK_AUTO_RELEASE} is disabled; on
+     * cluster-manager failover the set starts empty again, which errs towards leaving blocks in place rather than releasing an
+     * operator's.
+     */
+    private final Set<String> indicesWithMonitorAppliedReadBlock = Sets.newConcurrentHashSet();
+
     public DiskThresholdMonitor(
         Settings settings,
         Supplier<ClusterState> clusterStateSupplier,
@@ -494,6 +503,18 @@ public class DiskThresholdMonitor {
     }
 
     private void handleReadBlocks(ClusterState state, Set<String> indicesToBlockRead, ActionListener<Void> listener) {
+        final Set<String> indicesToApplyReadBlock = indicesToBlockRead.stream()
+            .filter(index -> !state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_BLOCK))
+            .collect(Collectors.toSet());
+
+        // Forget indices that no longer carry a read block, then claim the ones this monitor is about to block. An index that
+        // already had the block when the monitor decided to block it is never claimed, so an operator-set block stays unclaimed.
+        indicesWithMonitorAppliedReadBlock.removeIf(
+            index -> state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_BLOCK) == false
+        );
+        indicesWithMonitorAppliedReadBlock.addAll(indicesToApplyReadBlock);
+
+        final boolean autoReleaseEnabled = diskThresholdSettings.isIndexReadBlockAutoReleaseEnabled();
         final Set<String> indicesToReleaseReadBlock = StreamSupport.stream(
             Spliterators.spliterator(state.routingTable().indicesRouting().entrySet(), 0),
             false
@@ -501,6 +522,8 @@ public class DiskThresholdMonitor {
             .map(Map.Entry::getKey)
             .filter(index -> indicesToBlockRead.contains(index) == false)
             .filter(index -> state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_BLOCK))
+            // When auto-release is disabled the monitor still cleans up after itself, but leaves operator-set blocks alone.
+            .filter(index -> autoReleaseEnabled || indicesWithMonitorAppliedReadBlock.contains(index))
             .collect(Collectors.toSet());
 
         if (indicesToReleaseReadBlock.isEmpty() == false) {
@@ -510,9 +533,6 @@ public class DiskThresholdMonitor {
             listener.onResponse(null);
         }
 
-        final Set<String> indicesToApplyReadBlock = indicesToBlockRead.stream()
-            .filter(index -> !state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_BLOCK))
-            .collect(Collectors.toSet());
         logger.trace("Applying read block on indices: [{}]", indicesToApplyReadBlock);
         if (indicesToApplyReadBlock.isEmpty() == false) {
             updateIndicesReadBlock(indicesToApplyReadBlock, listener, true);

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -114,6 +114,18 @@ public class DiskThresholdSettings {
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
+    /**
+     * Controls whether the disk threshold monitor releases {@code index.blocks.read} blocks it did not apply itself. Because the monitor
+     * blocks reads through the same user-facing setting an operator would use, with the default of {@code true} it releases every read
+     * block once the warm node file cache search threshold clears, including blocks an operator set deliberately. Setting this to
+     * {@code false} narrows auto-release to the blocks the monitor applied, leaving operator-set blocks in place.
+     */
+    public static final Setting<Boolean> INDEX_READ_BLOCK_AUTO_RELEASE = Setting.boolSetting(
+        "cluster.blocks.read.auto_release",
+        true,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
 
     private volatile String lowWatermarkRaw;
     private volatile String highWatermarkRaw;
@@ -123,6 +135,7 @@ public class DiskThresholdSettings {
     private volatile ByteSizeValue freeBytesThresholdHigh;
     private volatile boolean includeRelocations;
     private volatile boolean createIndexBlockAutoReleaseEnabled;
+    private volatile boolean indexReadBlockAutoReleaseEnabled;
     private volatile boolean enabled;
     private volatile boolean warmThresholdEnabled;
     private volatile TimeValue rerouteInterval;
@@ -153,6 +166,7 @@ public class DiskThresholdSettings {
         this.enabled = CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.get(settings);
         this.warmThresholdEnabled = CLUSTER_ROUTING_ALLOCATION_WARM_DISK_THRESHOLD_ENABLED_SETTING.get(settings);
         this.createIndexBlockAutoReleaseEnabled = CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE.get(settings);
+        this.indexReadBlockAutoReleaseEnabled = INDEX_READ_BLOCK_AUTO_RELEASE.get(settings);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING, this::setLowWatermark);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING, this::setHighWatermark);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING, this::setFloodStage);
@@ -164,6 +178,7 @@ public class DiskThresholdSettings {
             this::setWarmThresholdEnabled
         );
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE, this::setCreateIndexBlockAutoReleaseEnabled);
+        clusterSettings.addSettingsUpdateConsumer(INDEX_READ_BLOCK_AUTO_RELEASE, this::setIndexReadBlockAutoReleaseEnabled);
     }
 
     /**
@@ -365,6 +380,10 @@ public class DiskThresholdSettings {
         this.createIndexBlockAutoReleaseEnabled = createIndexBlockAutoReleaseEnabled;
     }
 
+    private void setIndexReadBlockAutoReleaseEnabled(boolean indexReadBlockAutoReleaseEnabled) {
+        this.indexReadBlockAutoReleaseEnabled = indexReadBlockAutoReleaseEnabled;
+    }
+
     /**
      * Gets the raw (uninterpreted) low watermark value as found in the settings.
      */
@@ -421,6 +440,10 @@ public class DiskThresholdSettings {
 
     public boolean isCreateIndexBlockAutoReleaseEnabled() {
         return createIndexBlockAutoReleaseEnabled;
+    }
+
+    public boolean isIndexReadBlockAutoReleaseEnabled() {
+        return indexReadBlockAutoReleaseEnabled;
     }
 
     String describeLowThreshold() {

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -367,6 +367,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_WARM_DISK_THRESHOLD_ENABLED_SETTING,
                 DiskThresholdSettings.CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE,
+                DiskThresholdSettings.INDEX_READ_BLOCK_AUTO_RELEASE,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS_SETTING,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING,
                 FileCacheThresholdSettings.CLUSTER_FILECACHE_ACTIVEUSAGE_THRESHOLD_ENABLED_SETTING,

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
@@ -542,6 +542,249 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
         assertNull(indicesToReleaseReadOnlyBlock.get());
     }
 
+    public void testManuallySetReadBlockIsAutoReleased() {
+        Metadata metadata = Metadata.builder()
+            .put(
+                IndexMetadata.builder("test_index")
+                    .settings(settings(Version.CURRENT).put(IndexMetadata.INDEX_BLOCKS_READ_SETTING.getKey(), true))
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+            )
+            .build();
+        IndexMetadata indexMetadata = metadata.index("test_index");
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .metadata(metadata)
+            .routingTable(RoutingTable.builder().addAsNew(indexMetadata).build())
+            .blocks(ClusterBlocks.builder().addBlocks(indexMetadata).build())
+            .nodes(DiscoveryNodes.builder().add(newNode("node1")))
+            .build();
+
+        assertTrue(clusterState.blocks().hasIndexBlock("test_index", IndexMetadata.INDEX_READ_BLOCK));
+
+        AtomicReference<Set<String>> indicesToReleaseReadBlock = new AtomicReference<>();
+        DiskThresholdMonitor monitor = new DiskThresholdMonitor(
+            Settings.EMPTY,
+            () -> clusterState,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            null,
+            () -> 0L,
+            (reason, priority, listener) -> listener.onResponse(clusterState),
+            () -> 1.0
+        ) {
+            @Override
+            protected void updateIndicesReadBlock(Set<String> indicesToUpdate, ActionListener<Void> listener, boolean readBlock) {
+                if (readBlock == false) {
+                    indicesToReleaseReadBlock.set(indicesToUpdate);
+                }
+                listener.onResponse(null);
+            }
+
+            @Override
+            protected void updateIndicesReadOnly(Set<String> indicesToUpdate, ActionListener<Void> listener, boolean readOnly) {
+                listener.onResponse(null);
+            }
+
+            @Override
+            protected void setIndexCreateBlock(ActionListener<Void> listener, boolean indexCreateBlock) {
+                listener.onResponse(null);
+            }
+        };
+
+        // All disks are OK
+        Map<String, DiskUsage> usages = new HashMap<>();
+        usages.put("node1", new DiskUsage("node1", "node1", "/foo", 100, 50));
+
+        monitor.onNewInfo(new org.opensearch.cluster.ClusterInfo(usages, Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of()));
+
+        // Verification of Default behavior: It IS auto-released (because default is true)
+        assertNotNull("INDEX_READ_BLOCK should have been targeted for release (Default behavior)", indicesToReleaseReadBlock.get());
+        assertTrue(indicesToReleaseReadBlock.get().contains("test_index"));
+    }
+
+    public void testManuallySetReadBlockIsNotAutoReleasedWhenDisabled() {
+        Metadata metadata = Metadata.builder()
+            .put(
+                IndexMetadata.builder("test_index")
+                    .settings(settings(Version.CURRENT).put(IndexMetadata.INDEX_BLOCKS_READ_SETTING.getKey(), true))
+                    .numberOfShards(1)
+                    .numberOfReplicas(0)
+            )
+            .build();
+        IndexMetadata indexMetadata = metadata.index("test_index");
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .metadata(metadata)
+            .routingTable(RoutingTable.builder().addAsNew(indexMetadata).build())
+            .blocks(ClusterBlocks.builder().addBlocks(indexMetadata).build())
+            .nodes(DiscoveryNodes.builder().add(newNode("node1")))
+            .build();
+
+        assertTrue(clusterState.blocks().hasIndexBlock("test_index", IndexMetadata.INDEX_READ_BLOCK));
+
+        AtomicReference<Set<String>> indicesToReleaseReadBlock = new AtomicReference<>();
+        Settings settings = Settings.builder().put(DiskThresholdSettings.INDEX_READ_BLOCK_AUTO_RELEASE.getKey(), false).build();
+        DiskThresholdMonitor monitor = new DiskThresholdMonitor(
+            settings,
+            () -> clusterState,
+            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            null,
+            () -> 0L,
+            (reason, priority, listener) -> listener.onResponse(clusterState),
+            () -> 1.0
+        ) {
+            @Override
+            protected void updateIndicesReadBlock(Set<String> indicesToUpdate, ActionListener<Void> listener, boolean readBlock) {
+                if (readBlock == false) {
+                    indicesToReleaseReadBlock.set(indicesToUpdate);
+                }
+                listener.onResponse(null);
+            }
+
+            @Override
+            protected void updateIndicesReadOnly(Set<String> indicesToUpdate, ActionListener<Void> listener, boolean readOnly) {
+                listener.onResponse(null);
+            }
+
+            @Override
+            protected void setIndexCreateBlock(ActionListener<Void> listener, boolean indexCreateBlock) {
+                listener.onResponse(null);
+            }
+        };
+
+        // All disks are OK
+        Map<String, DiskUsage> usages = new HashMap<>();
+        usages.put("node1", new DiskUsage("node1", "node1", "/foo", 100, 50));
+
+        monitor.onNewInfo(new org.opensearch.cluster.ClusterInfo(usages, Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of()));
+
+        // Verification of Fix: It should NOT be auto-released
+        assertNull(
+            "INDEX_READ_BLOCK should NOT have been targeted for release when auto_release is disabled",
+            indicesToReleaseReadBlock.get()
+        );
+    }
+
+    /**
+     * With auto-release disabled the monitor must still clean up after itself: a read block it applied because the warm node file cache
+     * search threshold was breached has to be released once that threshold clears, while an operator-set block on a neighbouring index on
+     * the same node is left alone.
+     */
+    public void testMonitorAppliedReadBlockIsReleasedWhileOperatorSetBlockIsKept() {
+        AllocationService allocation = createAllocationService(
+            Settings.builder().put("cluster.routing.allocation.node_concurrent_recoveries", 10).build()
+        );
+        IndexMetadata.Builder monitorBlockedIndex = IndexMetadata.builder("monitor_blocked_index")
+            .settings(
+                settings(Version.CURRENT).put("index.store.type", "remote_snapshot")
+                    .put("index.routing.allocation.require._id", "warm_node")
+            )
+            .numberOfShards(1)
+            .numberOfReplicas(0);
+        IndexMetadata.Builder operatorBlockedIndex = IndexMetadata.builder("operator_blocked_index")
+            .settings(
+                settings(Version.CURRENT).put("index.store.type", "remote_snapshot")
+                    .put("index.routing.allocation.require._id", "warm_node")
+                    .put(IndexMetadata.INDEX_BLOCKS_READ_SETTING.getKey(), true)
+            )
+            .numberOfShards(1)
+            .numberOfReplicas(0);
+        Metadata metadata = Metadata.builder().put(monitorBlockedIndex).put(operatorBlockedIndex).build();
+        RoutingTable routingTable = RoutingTable.builder()
+            .addAsNew(metadata.index("monitor_blocked_index"))
+            .addAsNew(metadata.index("operator_blocked_index"))
+            .build();
+        DiscoveryNode warmNode = newNode("warm_node", Collections.singleton(DiscoveryNodeRole.WARM_ROLE));
+        final ClusterState breachingState = applyStartedShardsUntilNoChange(
+            ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+                .metadata(metadata)
+                .routingTable(routingTable)
+                .nodes(DiscoveryNodes.builder().add(warmNode))
+                .blocks(ClusterBlocks.builder().addBlocks(metadata.index("operator_blocked_index")).build())
+                .build(),
+            allocation
+        );
+
+        final AtomicReference<ClusterState> stateRef = new AtomicReference<>(breachingState);
+        final AtomicReference<Set<String>> blocked = new AtomicReference<>();
+        final AtomicReference<Set<String>> released = new AtomicReference<>();
+        final Settings settings = Settings.builder().put(DiskThresholdSettings.INDEX_READ_BLOCK_AUTO_RELEASE.getKey(), false).build();
+        DiskThresholdMonitor monitor = new DiskThresholdMonitor(
+            settings,
+            stateRef::get,
+            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            null,
+            () -> 0L,
+            (reason, priority, listener) -> listener.onResponse(null),
+            () -> 2.0
+        ) {
+            @Override
+            protected void updateIndicesReadBlock(Set<String> indicesToUpdate, ActionListener<Void> listener, boolean readBlock) {
+                (readBlock ? blocked : released).set(indicesToUpdate);
+                listener.onResponse(null);
+            }
+
+            @Override
+            protected void updateIndicesReadOnly(Set<String> indicesToUpdate, ActionListener<Void> listener, boolean readOnly) {
+                listener.onResponse(null);
+            }
+
+            @Override
+            protected void setIndexCreateBlock(ActionListener<Void> listener, boolean indexCreateBlock) {
+                listener.onResponse(null);
+            }
+        };
+
+        final Map<String, Long> shardSizes = new HashMap<>();
+        shardSizes.put("[monitor_blocked_index][0][p]", 86L);
+        shardSizes.put("[operator_blocked_index][0][p]", 86L);
+
+        // The search threshold is breached, so the monitor blocks reads on the index that is not blocked already.
+        monitor.onNewInfo(
+            new ClusterInfo(
+                Map.of("warm_node", new DiskUsage("warm_node", "warm_node", "/foo/bar", 200, 40)),
+                null,
+                shardSizes,
+                null,
+                Map.of(),
+                Map.of("warm_node", createAggregateFileCacheStats(100, 105, 110)),
+                Map.of()
+            )
+        );
+        assertThat(blocked.get(), contains("monitor_blocked_index"));
+        assertNull("no block should be released while the threshold is breached", released.get());
+
+        // The block the monitor applied is now visible in cluster state, indistinguishable from the operator's.
+        final IndexMetadata previous = breachingState.metadata().index("monitor_blocked_index");
+        final IndexMetadata blockedByMonitor = IndexMetadata.builder(previous)
+            .settings(Settings.builder().put(previous.getSettings()).put(IndexMetadata.INDEX_BLOCKS_READ_SETTING.getKey(), true))
+            .settingsVersion(previous.getSettingsVersion() + 1)
+            .build();
+        stateRef.set(
+            ClusterState.builder(breachingState)
+                .metadata(Metadata.builder(breachingState.metadata()).put(blockedByMonitor, true))
+                .blocks(ClusterBlocks.builder().blocks(breachingState.blocks()).updateBlocks(blockedByMonitor))
+                .build()
+        );
+        assertTrue(stateRef.get().blocks().hasIndexBlock("monitor_blocked_index", IndexMetadata.INDEX_READ_BLOCK));
+        assertTrue(stateRef.get().blocks().hasIndexBlock("operator_blocked_index", IndexMetadata.INDEX_READ_BLOCK));
+        blocked.set(null);
+
+        // The threshold clears.
+        monitor.onNewInfo(
+            new ClusterInfo(
+                Map.of("warm_node", new DiskUsage("warm_node", "warm_node", "/foo/bar", 200, 180)),
+                null,
+                shardSizes,
+                null,
+                Map.of(),
+                Map.of("warm_node", createAggregateFileCacheStats(100, 10, 89)),
+                Map.of()
+            )
+        );
+
+        assertThat(released.get(), contains("monitor_blocked_index"));
+        assertNull("no new block should be applied once the threshold clears", blocked.get());
+    }
+
     @TestLogging(value = "org.opensearch.cluster.routing.allocation.DiskThresholdMonitor:INFO", reason = "testing INFO/WARN logging")
     public void testDiskMonitorLogging() throws IllegalAccessException {
         final ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettingsTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettingsTests.java
@@ -58,8 +58,21 @@ public class DiskThresholdSettingsTests extends OpenSearchTestCase {
         assertEquals(60L, diskThresholdSettings.getRerouteInterval().seconds());
         assertTrue(diskThresholdSettings.isEnabled());
         assertTrue(diskThresholdSettings.includeRelocations());
+        assertTrue(diskThresholdSettings.isIndexReadBlockAutoReleaseEnabled());
         assertEquals(zeroBytes, diskThresholdSettings.getFreeBytesThresholdFloodStage());
         assertEquals(5.0D, diskThresholdSettings.getFreeDiskThresholdFloodStage(), 0.0D);
+    }
+
+    public void testIndexReadBlockAutoReleaseUpdate() {
+        ClusterSettings nss = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        DiskThresholdSettings diskThresholdSettings = new DiskThresholdSettings(Settings.EMPTY, nss);
+
+        assertTrue(diskThresholdSettings.isIndexReadBlockAutoReleaseEnabled());
+
+        Settings newSettings = Settings.builder().put(DiskThresholdSettings.INDEX_READ_BLOCK_AUTO_RELEASE.getKey(), false).build();
+        nss.applySettings(newSettings);
+
+        assertFalse(diskThresholdSettings.isIndexReadBlockAutoReleaseEnabled());
     }
 
     public void testUpdate() {


### PR DESCRIPTION
### Description
This PR fixes a bug in the `DiskThresholdMonitor` where it was unconditionally auto-releasing `index.blocks.read` on all indices, even when manually set by users.

This fix introduces a new dynamic cluster setting `cluster.blocks.read.auto_release` (defaulting to `true` for backward compatibility) that controls whether the cluster should automatically release read blocks. By setting this to `false`, users can ensure that manually-set read blocks persist until explicitly removed.

### Related Issues
Resolves #20539

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.