### PR TITLE
fix flaky SegmentReplicationSuiteIT#testFullRestartDuringReplication

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4036,7 +4036,15 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     // Only used for initializing segment replication CopyState
     public long getLastRefreshedCheckpoint() {
         Engine engine = getEngine();
-        assert engine instanceof InternalEngine;
+        if (false == engine instanceof InternalEngine) {
+            throw new IllegalStateException(
+                String.format(
+                    Locale.ROOT,
+                    "The type of Engine must be InternalEngine, but the current type is %s.",
+                    engine.getClass().getSimpleName()
+                )
+            );
+        }
         return ((InternalEngine) engine).lastRefreshedCheckpoint();
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
I found a flaky test in [gradle test](https://build.ci.opensearch.org/job/gradle-check/70532/).
I reproduced this test locally. The exception information is as follows:

```
java.lang.AssertionError
	at __randomizedtesting.SeedInfo.seed([22B1A9F191227F55]:0)
	at org.opensearch.index.shard.IndexShard.getLastRefreshedCheckpoint(IndexShard.java:4037)
	at org.opensearch.indices.replication.common.CopyState.<init>(CopyState.java:42)
	at org.opensearch.indices.replication.SegmentReplicationSourceHandler.<init>(SegmentReplicationSourceHandler.java:96)
	at org.opensearch.indices.replication.OngoingSegmentReplications.lambda$prepareForReplication$0(OngoingSegmentReplications.java:107)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1724)
	at org.opensearch.indices.replication.OngoingSegmentReplications.prepareForReplication(OngoingSegmentReplications.java:95)
	at org.opensearch.indices.replication.SegmentReplicationSourceService$CheckpointInfoRequestHandler.messageReceived(SegmentReplicationSourceService.java:138)
	at org.opensearch.indices.replication.SegmentReplicationSourceService$CheckpointInfoRequestHandler.messageReceived(SegmentReplicationSourceService.java:126)
	at org.opensearch.wlm.WorkloadManagementTransportInterceptor$RequestHandler.messageReceived(WorkloadManagementTransportInterceptor.java:63)
	at org.opensearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:108)
	at org.opensearch.transport.TransportService$7.doRun(TransportService.java:1140)
	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:975)
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
```

### Reproduce
Approximately one issue occurs every `100` runs of the test command.

```
REPRODUCE WITH: ./gradlew ':server:internalClusterTest' --tests 'org.opensearch.indices.replication.SegmentReplicationSuiteIT.testFullRestartDuringReplication' -Dtests.seed=22B1A9F191227F55 -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=da-Latn-DK -Dtests.timezone=Australia/Brisbane -Druntime.java=25
```

### Analysis

When a replica is promoted, there is a time gap between being selected as the primary shard and setting the engine to `InternalEngine`. I added logs, which also illustrates this point.

```
[2026-02-10T16:46:38,872][INFO ][o.o.c.r.RoutingNodes     ] [node_s5] promoteReplicaToPrimary [[test-idx-1][6], node[pJjL1JsRQm270G_kSEokOQ], [R], s[STARTED], a[id=d-8zkeLaT1uJRZNKZA0Jzg]]
[2026-02-10T16:46:39,182][INFO ][o.o.i.s.IndexShard       ] [node_s5] [test-idx-1][6] getLastRefreshedCheckpoint isPrimaryMode false, state STARTED, engine NRTReplicationEngine
```

### Solution
Use `Exception` instead of `assert`. The test was run `1000` times repeatedly without any issues.

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
