### PR TITLE
Introducing indexing & deletion strategy planner interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added TopN selection logic for streaming terms aggregations ([#20481](https://github.com/opensearch-project/OpenSearch/pull/20481))
 - Added support for Intra Segment Search ([#19704](https://github.com/opensearch-project/OpenSearch/pull/19704))
 - Introduce AdditionalCodecs and EnginePlugin::getAdditionalCodecs hook to allow additional Codec registration ([#20411](https://github.com/opensearch-project/OpenSearch/pull/20411))
+- Introduced strategy planner interfaces for indexing and deletion ([#20585](https://github.com/opensearch-project/OpenSearch/pull/20585))
 
 ### Changed
 - Move Randomness from server to libs/common ([#20570](https://github.com/opensearch-project/OpenSearch/pull/20570))

--- a/server/src/main/java/org/opensearch/index/engine/DeletionStrategy.java
+++ b/server/src/main/java/org/opensearch/index/engine/DeletionStrategy.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import org.opensearch.common.lucene.uid.Versions;
+import org.opensearch.index.seqno.SequenceNumbers;
+
+import java.util.Objects;
+
+/**
+ * The deletion strategy
+ *
+ * @opensearch.internal
+ */
+public final class DeletionStrategy extends OperationStrategy {
+
+    public final boolean currentlyDeleted;
+
+    private DeletionStrategy(
+        boolean deleteFromEngine,
+        boolean addStaleOpToEngine,
+        boolean currentlyDeleted,
+        long versionOfDeletion,
+        int reservedDocs,
+        Engine.DeleteResult earlyResultOnPreflightError
+    ) {
+        super(deleteFromEngine, addStaleOpToEngine, versionOfDeletion, earlyResultOnPreflightError, reservedDocs);
+        assert (deleteFromEngine && earlyResultOnPreflightError != null) == false
+            : "can only delete from engine or have a preflight result but not both."
+                + "deleteFromEngine: "
+                + deleteFromEngine
+                + "  earlyResultOnPreFlightError:"
+                + earlyResultOnPreflightError;
+        assert reservedDocs == 0 || deleteFromEngine || addStaleOpToEngine : reservedDocs;
+        this.currentlyDeleted = currentlyDeleted;
+    }
+
+    static DeletionStrategy skipDueToVersionConflict(VersionConflictEngineException e, long currentVersion, boolean currentlyDeleted) {
+        final Engine.DeleteResult deleteResult = new Engine.DeleteResult(
+            e,
+            currentVersion,
+            SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+            SequenceNumbers.UNASSIGNED_SEQ_NO,
+            currentlyDeleted == false
+        );
+        return new DeletionStrategy(false, false, currentlyDeleted, Versions.NOT_FOUND, 0, deleteResult);
+    }
+
+    static DeletionStrategy processNormally(boolean currentlyDeleted, long versionOfDeletion, int reservedDocs) {
+        return new DeletionStrategy(true, false, currentlyDeleted, versionOfDeletion, reservedDocs, null);
+
+    }
+
+    static DeletionStrategy processButSkipEngine(boolean currentlyDeleted, long versionOfDeletion) {
+        return new DeletionStrategy(false, false, currentlyDeleted, versionOfDeletion, 0, null);
+    }
+
+    static DeletionStrategy processAsStaleOp(long versionOfDeletion) {
+        return new DeletionStrategy(false, true, false, versionOfDeletion, 0, null);
+    }
+
+    static DeletionStrategy failAsTooManyDocs(Exception e) {
+        final Engine.DeleteResult deleteResult = new Engine.DeleteResult(
+            e,
+            Versions.NOT_FOUND,
+            SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+            SequenceNumbers.UNASSIGNED_SEQ_NO,
+            false
+        );
+        return new DeletionStrategy(false, false, false, Versions.NOT_FOUND, 0, deleteResult);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        DeletionStrategy that = (DeletionStrategy) o;
+        return currentlyDeleted == that.currentlyDeleted;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), currentlyDeleted);
+    }
+
+    @Override
+    public String toString() {
+        return "DeletionStrategy{"
+            + "currentlyDeleted="
+            + currentlyDeleted
+            + ", executeOpOnEngine="
+            + executeOpOnEngine
+            + ", addStaleOpToEngine="
+            + addStaleOpToEngine
+            + ", version="
+            + version
+            + ", earlyResultOnPreFlightError="
+            + earlyResultOnPreFlightError
+            + ", reservedDocs="
+            + reservedDocs
+            + '}';
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/DeletionStrategyPlanner.java
+++ b/server/src/main/java/org/opensearch/index/engine/DeletionStrategyPlanner.java
@@ -1,0 +1,146 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import org.opensearch.common.CheckedBiFunction;
+import org.opensearch.common.CheckedFunction;
+import org.opensearch.common.lucene.uid.Versions;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.seqno.SequenceNumbers;
+
+import java.io.IOException;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * Plans execution strategies for deletion operations.
+ * The planner produces {@link DeletionStrategy} instances that guide the engine's
+ * execution of delete operations on both primary and replica shards.
+ *
+ * @opensearch.internal
+ */
+public class DeletionStrategyPlanner implements OperationStrategyPlanner<Engine.Delete, DeletionStrategy> {
+
+    private final IndexSettings indexSettings;
+    private final ShardId shardId;
+    private final Predicate<Engine.Operation> hasBeenProcessedBefore;
+    private final CheckedFunction<Engine.Operation, OpVsEngineDocStatus, IOException> opVsEngineDocStatusFunction;
+    private final CheckedBiFunction<Engine.Operation, Boolean, VersionValue, IOException> docVersionSupplier;
+    private final BiFunction<Engine.Operation, Integer, Exception> tryAcquireInFlightDocs;
+    private final Supplier<Boolean> incrementVersionLookup;
+
+    public DeletionStrategyPlanner(
+        IndexSettings indexSettings,
+        ShardId shardId,
+        Predicate<Engine.Operation> hasBeenProcessedBefore,
+        CheckedFunction<Engine.Operation, OpVsEngineDocStatus, IOException> opVsEngineDocStatusFunction,
+        CheckedBiFunction<Engine.Operation, Boolean, VersionValue, IOException> docVersionSupplier,
+        BiFunction<Engine.Operation, Integer, Exception> tryAcquireInFlightDocs,
+        Supplier<Boolean> incrementVersionLookup
+    ) {
+        this.indexSettings = indexSettings;
+        this.shardId = shardId;
+        this.hasBeenProcessedBefore = hasBeenProcessedBefore;
+        this.opVsEngineDocStatusFunction = opVsEngineDocStatusFunction;
+        this.docVersionSupplier = docVersionSupplier;
+        this.tryAcquireInFlightDocs = tryAcquireInFlightDocs;
+        this.incrementVersionLookup = incrementVersionLookup;
+    }
+
+    @Override
+    public DeletionStrategy planOperationAsPrimary(Engine.Delete delete) throws IOException {
+        assert delete.origin() == Engine.Operation.Origin.PRIMARY : "planing as primary but got " + delete.origin();
+        // resolve operation from external to internal
+        final VersionValue versionValue = docVersionSupplier.apply(delete, delete.getIfSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO);
+        assert incrementVersionLookup.get();
+        final long currentVersion;
+        final boolean currentlyDeleted;
+        if (versionValue == null) {
+            currentVersion = Versions.NOT_FOUND;
+            currentlyDeleted = true;
+        } else {
+            currentVersion = versionValue.version;
+            currentlyDeleted = versionValue.isDelete();
+        }
+        final DeletionStrategy plan;
+        if (delete.getIfSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO && currentlyDeleted) {
+            final VersionConflictEngineException e = new VersionConflictEngineException(
+                shardId,
+                delete.id(),
+                delete.getIfSeqNo(),
+                delete.getIfPrimaryTerm(),
+                SequenceNumbers.UNASSIGNED_SEQ_NO,
+                SequenceNumbers.UNASSIGNED_PRIMARY_TERM
+            );
+            plan = DeletionStrategy.skipDueToVersionConflict(e, currentVersion, true);
+        } else if (delete.getIfSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO
+            && (versionValue.seqNo != delete.getIfSeqNo() || versionValue.term != delete.getIfPrimaryTerm())) {
+                final VersionConflictEngineException e = new VersionConflictEngineException(
+                    shardId,
+                    delete.id(),
+                    delete.getIfSeqNo(),
+                    delete.getIfPrimaryTerm(),
+                    versionValue.seqNo,
+                    versionValue.term
+                );
+                plan = DeletionStrategy.skipDueToVersionConflict(e, currentVersion, currentlyDeleted);
+            } else if (delete.versionType().isVersionConflictForWrites(currentVersion, delete.version(), currentlyDeleted)) {
+                final VersionConflictEngineException e = new VersionConflictEngineException(
+                    shardId,
+                    delete,
+                    currentVersion,
+                    currentlyDeleted
+                );
+                plan = DeletionStrategy.skipDueToVersionConflict(e, currentVersion, currentlyDeleted);
+            } else {
+                final Exception reserveError = tryAcquireInFlightDocs.apply(delete, 1);
+                if (reserveError != null) {
+                    plan = DeletionStrategy.failAsTooManyDocs(reserveError);
+                } else {
+                    final long versionOfDeletion = delete.versionType().updateVersion(currentVersion, delete.version());
+                    plan = DeletionStrategy.processNormally(currentlyDeleted, versionOfDeletion, 1);
+                }
+            }
+        return plan;
+    }
+
+    @Override
+    public DeletionStrategy planOperationAsNonPrimary(Engine.Delete delete) throws IOException {
+        assert assertNonPrimaryOrigin(delete);
+        final DeletionStrategy plan;
+        if (hasBeenProcessedBefore.test(delete)) {
+            // the operation seq# was processed thus this operation was already put into lucene
+            // this can happen during recovery where older operations are sent from the translog that are already
+            // part of the lucene commit (either from a peer recovery or a local translog)
+            // or due to concurrent indexing & recovery. For the former it is important to skip lucene as the operation in
+            // question may have been deleted in an out of order op that is not replayed.
+            // See testRecoverFromStoreWithOutOfOrderDelete for an example of local recovery
+            // See testRecoveryWithOutOfOrderDelete for an example of peer recovery
+            plan = DeletionStrategy.processButSkipEngine(false, delete.version());
+        } else {
+            boolean segRepEnabled = indexSettings.isSegRepEnabledOrRemoteNode();
+            final OpVsEngineDocStatus opVsLucene = opVsEngineDocStatusFunction.apply(delete);
+            if (opVsLucene == OpVsEngineDocStatus.OP_STALE_OR_EQUAL) {
+                if (segRepEnabled) {
+                    // For segrep based indices, we can't completely rely on localCheckpointTracker
+                    // as the preserved checkpoint may not have all the operations present in lucene
+                    // we don't need to index it again as stale op as it would create multiple documents for same seq no
+                    plan = DeletionStrategy.processButSkipEngine(false, delete.version());
+                } else {
+                    plan = DeletionStrategy.processAsStaleOp(delete.version());
+                }
+            } else {
+                plan = DeletionStrategy.processNormally(opVsLucene == OpVsEngineDocStatus.DOC_NOT_FOUND, delete.version(), 0);
+            }
+        }
+        return plan;
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/IndexingStrategy.java
+++ b/server/src/main/java/org/opensearch/index/engine/IndexingStrategy.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import org.opensearch.common.lucene.uid.Versions;
+
+import java.util.Objects;
+
+/**
+ * The indexing strategy
+ *
+ * @opensearch.internal
+ */
+public final class IndexingStrategy extends OperationStrategy {
+
+    public final boolean currentNotFoundOrDeleted;
+    public final boolean useUpdateDocument;
+
+    private IndexingStrategy(
+        boolean currentNotFoundOrDeleted,
+        boolean useUpdateDocument,
+        boolean indexIntoEngine,
+        boolean addStaleOpToEngine,
+        long versionForIndexing,
+        int reservedDocs,
+        Engine.IndexResult earlyResultOnPreFlightError
+    ) {
+        super(indexIntoEngine, addStaleOpToEngine, versionForIndexing, earlyResultOnPreFlightError, reservedDocs);
+        assert useUpdateDocument == false || indexIntoEngine : "use update is set to true, but we're not indexing into engine";
+        assert (indexIntoEngine && earlyResultOnPreFlightError != null) == false
+            : "can only index into engine or have a preflight result but not both."
+                + "indexIntoEngine: "
+                + indexIntoEngine
+                + "  earlyResultOnPreFlightError:"
+                + earlyResultOnPreFlightError;
+        assert reservedDocs == 0 || indexIntoEngine || addStaleOpToEngine : reservedDocs;
+        this.currentNotFoundOrDeleted = currentNotFoundOrDeleted;
+        this.useUpdateDocument = useUpdateDocument;
+    }
+
+    static IndexingStrategy optimizedAppendOnly(long versionForIndexing, int reservedDocs) {
+        return new IndexingStrategy(true, false, true, false, versionForIndexing, reservedDocs, null);
+    }
+
+    static IndexingStrategy skipDueToVersionConflict(
+        VersionConflictEngineException e,
+        boolean currentNotFoundOrDeleted,
+        long currentVersion
+    ) {
+        final Engine.IndexResult result = new Engine.IndexResult(e, currentVersion);
+        return new IndexingStrategy(currentNotFoundOrDeleted, false, false, false, Versions.NOT_FOUND, 0, result);
+    }
+
+    static IndexingStrategy processNormally(boolean currentNotFoundOrDeleted, long versionForIndexing, int reservedDocs) {
+        return new IndexingStrategy(
+            currentNotFoundOrDeleted,
+            currentNotFoundOrDeleted == false,
+            true,
+            false,
+            versionForIndexing,
+            reservedDocs,
+            null
+        );
+    }
+
+    static IndexingStrategy processButSkipEngine(boolean currentNotFoundOrDeleted, long versionForIndexing) {
+        return new IndexingStrategy(currentNotFoundOrDeleted, false, false, false, versionForIndexing, 0, null);
+    }
+
+    static IndexingStrategy processAsStaleOp(long versionForIndexing) {
+        return new IndexingStrategy(false, false, false, true, versionForIndexing, 0, null);
+    }
+
+    static IndexingStrategy failAsTooManyDocs(Exception e) {
+        final Engine.IndexResult result = new Engine.IndexResult(e, Versions.NOT_FOUND);
+        return new IndexingStrategy(false, false, false, false, Versions.NOT_FOUND, 0, result);
+    }
+
+    static IndexingStrategy failAsIndexAppendOnly(Engine.IndexResult result, long versionForIndexing, int reservedDocs) {
+        return new IndexingStrategy(false, false, false, true, versionForIndexing, reservedDocs, result);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        IndexingStrategy that = (IndexingStrategy) o;
+        return currentNotFoundOrDeleted == that.currentNotFoundOrDeleted && useUpdateDocument == that.useUpdateDocument;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), currentNotFoundOrDeleted, useUpdateDocument);
+    }
+
+    @Override
+    public String toString() {
+        return "IndexingStrategy{"
+            + "currentNotFoundOrDeleted="
+            + currentNotFoundOrDeleted
+            + ", useUpdateDocument="
+            + useUpdateDocument
+            + ", executeOpOnEngine="
+            + executeOpOnEngine
+            + ", addStaleOpToEngine="
+            + addStaleOpToEngine
+            + ", version="
+            + version
+            + ", earlyResultOnPreFlightError="
+            + earlyResultOnPreFlightError
+            + ", reservedDocs="
+            + reservedDocs
+            + '}';
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/IndexingStrategyPlanner.java
+++ b/server/src/main/java/org/opensearch/index/engine/IndexingStrategyPlanner.java
@@ -1,0 +1,257 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.common.CheckedBiFunction;
+import org.opensearch.common.CheckedFunction;
+import org.opensearch.common.lucene.uid.Versions;
+import org.opensearch.core.index.AppendOnlyIndexOperationRetryException;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.VersionType;
+import org.opensearch.index.seqno.SequenceNumbers;
+
+import java.io.IOException;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * Plans execution strategies for indexing operations.
+ * The planner produces {@link IndexingStrategy} instances that guide the engine's
+ * execution of index operations on both primary and replica shards.
+ *
+ * @opensearch.internal
+ */
+public class IndexingStrategyPlanner implements OperationStrategyPlanner<Engine.Index, IndexingStrategy> {
+
+    private final IndexSettings indexSettings;
+    private final ShardId shardId;
+    private final LiveVersionMap versionMap;
+    private final Supplier<Long> maxUnsafeAutoIdTimestampSupplier;
+    private final Supplier<Long> maxSeqNoOfUpdatesOrDeletesSupplier;
+    private final Supplier<Long> processedCheckpointSupplier;
+    private final Predicate<Engine.Operation> hasBeenProcessedBefore;
+    private final CheckedFunction<Engine.Operation, OpVsEngineDocStatus, IOException> opVsEngineDocStatusFunction;
+    private final CheckedBiFunction<Engine.Operation, Boolean, VersionValue, IOException> docVersionSupplier;
+    private final BiConsumer<Long, Boolean> updateAutoIdTimestampConsumer;
+    private final BiFunction<Engine.Operation, Integer, Exception> tryAcquireInFlightDocs;
+
+    public IndexingStrategyPlanner(
+        IndexSettings indexSettings,
+        ShardId shardId,
+        LiveVersionMap versionMap,
+        Supplier<Long> maxUnsafeAutoIdTimestampSupplier,
+        Supplier<Long> maxSeqNoOfUpdatesOrDeletesSupplier,
+        Supplier<Long> processedCheckpointSupplier,
+        Predicate<Engine.Operation> hasBeenProcessedBefore,
+        CheckedFunction<Engine.Operation, OpVsEngineDocStatus, IOException> opVsEngineDocStatusFunction,
+        CheckedBiFunction<Engine.Operation, Boolean, VersionValue, IOException> docVersionSupplier,
+        BiConsumer<Long, Boolean> updateAutoIdTimestampConsumer,
+        BiFunction<Engine.Operation, Integer, Exception> tryAcquireInFlightDocs
+    ) {
+        this.indexSettings = indexSettings;
+        this.shardId = shardId;
+        this.versionMap = versionMap;
+        this.maxUnsafeAutoIdTimestampSupplier = maxUnsafeAutoIdTimestampSupplier;
+        this.maxSeqNoOfUpdatesOrDeletesSupplier = maxSeqNoOfUpdatesOrDeletesSupplier;
+        this.processedCheckpointSupplier = processedCheckpointSupplier;
+        this.hasBeenProcessedBefore = hasBeenProcessedBefore;
+        this.opVsEngineDocStatusFunction = opVsEngineDocStatusFunction;
+        this.docVersionSupplier = docVersionSupplier;
+        this.updateAutoIdTimestampConsumer = updateAutoIdTimestampConsumer;
+        this.tryAcquireInFlightDocs = tryAcquireInFlightDocs;
+    }
+
+    @Override
+    public IndexingStrategy planOperationAsPrimary(Engine.Index index) throws IOException {
+        assert index.origin() == Engine.Operation.Origin.PRIMARY : "planing as primary but origin isn't. got " + index.origin();
+        final int reservingDocs = index.parsedDoc().docs().size();
+        final IndexingStrategy plan;
+        // resolve an external operation into an internal one which is safe to replay
+        final boolean canOptimizeAddDocument = canOptimizeAddDocument(index);
+        if (canOptimizeAddDocument && mayHaveBeenIndexedBefore(index) == false) {
+            final Exception reserveError = tryAcquireInFlightDocs.apply(index, reservingDocs);
+            if (reserveError != null) {
+                plan = IndexingStrategy.failAsTooManyDocs(reserveError);
+            } else {
+                plan = IndexingStrategy.optimizedAppendOnly(1L, reservingDocs);
+            }
+        } else {
+            versionMap.enforceSafeAccess();
+            // resolves incoming version
+            final VersionValue versionValue = docVersionSupplier.apply(index, true);
+            final long currentVersion;
+            final boolean currentNotFoundOrDeleted;
+            if (versionValue == null) {
+                currentVersion = Versions.NOT_FOUND;
+                currentNotFoundOrDeleted = true;
+            } else {
+                currentVersion = versionValue.version;
+                currentNotFoundOrDeleted = versionValue.isDelete();
+            }
+            if (index.getIfSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO && currentNotFoundOrDeleted) {
+                final VersionConflictEngineException e = new VersionConflictEngineException(
+                    shardId,
+                    index.id(),
+                    index.getIfSeqNo(),
+                    index.getIfPrimaryTerm(),
+                    SequenceNumbers.UNASSIGNED_SEQ_NO,
+                    SequenceNumbers.UNASSIGNED_PRIMARY_TERM
+                );
+                plan = IndexingStrategy.skipDueToVersionConflict(e, true, currentVersion);
+            } else if (index.getIfSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO
+                && (versionValue.seqNo != index.getIfSeqNo() || versionValue.term != index.getIfPrimaryTerm())) {
+                    final VersionConflictEngineException e = new VersionConflictEngineException(
+                        shardId,
+                        index.id(),
+                        index.getIfSeqNo(),
+                        index.getIfPrimaryTerm(),
+                        versionValue.seqNo,
+                        versionValue.term
+                    );
+                    plan = IndexingStrategy.skipDueToVersionConflict(e, currentNotFoundOrDeleted, currentVersion);
+                } else if (index.versionType().isVersionConflictForWrites(currentVersion, index.version(), currentNotFoundOrDeleted)) {
+                    final VersionConflictEngineException e = new VersionConflictEngineException(
+                        shardId,
+                        index,
+                        currentVersion,
+                        currentNotFoundOrDeleted
+                    );
+                    plan = IndexingStrategy.skipDueToVersionConflict(e, currentNotFoundOrDeleted, currentVersion);
+                } else {
+                    final Exception reserveError = tryAcquireInFlightDocs.apply(index, reservingDocs);
+                    if (reserveError != null) {
+                        plan = IndexingStrategy.failAsTooManyDocs(reserveError);
+                    } else if (currentVersion >= 1 && indexSettings.getIndexMetadata().isAppendOnlyIndex()) {
+                        // Retry happens for indexing requests for append only indices, since we are rejecting update requests
+                        // at Transport layer itself. So for any retry, we are reconstructing response from already indexed
+                        // document version for append only index.
+                        AppendOnlyIndexOperationRetryException retryException = new AppendOnlyIndexOperationRetryException(
+                            "Indexing operation retried for append only indices"
+                        );
+                        final Engine.IndexResult result = new Engine.IndexResult(
+                            retryException,
+                            currentVersion,
+                            versionValue.term,
+                            versionValue.seqNo
+                        );
+                        plan = IndexingStrategy.failAsIndexAppendOnly(result, currentVersion, 0);
+                    } else {
+                        plan = IndexingStrategy.processNormally(
+                            currentNotFoundOrDeleted,
+                            canOptimizeAddDocument ? 1L : index.versionType().updateVersion(currentVersion, index.version()),
+                            reservingDocs
+                        );
+                    }
+                }
+        }
+        return plan;
+    }
+
+    @Override
+    public IndexingStrategy planOperationAsNonPrimary(Engine.Index index) throws IOException {
+        assert assertNonPrimaryOrigin(index);
+        // needs to maintain the auto_id timestamp in case this replica becomes primary
+        if (canOptimizeAddDocument(index)) {
+            mayHaveBeenIndexedBefore(index);
+        }
+        final IndexingStrategy plan;
+        // unlike the primary, replicas don't really care to about creation status of documents
+        // this allows to ignore the case where a document was found in the live version maps in
+        // a delete state and return false for the created flag in favor of code simplicity
+        final long maxSeqNoOfUpdatesOrDeletes = maxSeqNoOfUpdatesOrDeletesSupplier.get();
+        if (hasBeenProcessedBefore.test(index)) {
+            // the operation seq# was processed and thus the same operation was already put into lucene
+            // this can happen during recovery where older operations are sent from the translog that are already
+            // part of the lucene commit (either from a peer recovery or a local translog)
+            // or due to concurrent indexing & recovery. For the former it is important to skip lucene as the operation in
+            // question may have been deleted in an out of order op that is not replayed.
+            // See testRecoverFromStoreWithOutOfOrderDelete for an example of local recovery
+            // See testRecoveryWithOutOfOrderDelete for an example of peer recovery
+            plan = IndexingStrategy.processButSkipEngine(false, index.version());
+        } else if (maxSeqNoOfUpdatesOrDeletes <= processedCheckpointSupplier.get()) {
+            // see Engine#getMaxSeqNoOfUpdatesOrDeletes for the explanation of the optimization using sequence numbers
+            assert maxSeqNoOfUpdatesOrDeletes < index.seqNo() : index.seqNo() + ">=" + maxSeqNoOfUpdatesOrDeletes;
+            plan = IndexingStrategy.optimizedAppendOnly(index.version(), 0);
+        } else {
+            boolean segRepEnabled = indexSettings.isSegRepEnabledOrRemoteNode();
+            versionMap.enforceSafeAccess();
+            final OpVsEngineDocStatus opVsEngine = opVsEngineDocStatusFunction.apply(index);
+            if (opVsEngine == OpVsEngineDocStatus.OP_STALE_OR_EQUAL) {
+                if (segRepEnabled) {
+                    // For segrep based indices, we can't completely rely on localCheckpointTracker
+                    // as the preserved checkpoint may not have all the operations present in lucene
+                    // we don't need to index it again as stale op as it would create multiple documents for same seq no
+                    plan = IndexingStrategy.processButSkipEngine(false, index.version());
+                } else {
+                    plan = IndexingStrategy.processAsStaleOp(index.version());
+                }
+            } else {
+                plan = IndexingStrategy.processNormally(opVsEngine == OpVsEngineDocStatus.DOC_NOT_FOUND, index.version(), 0);
+            }
+        }
+        return plan;
+    }
+
+    protected boolean canOptimizeAddDocument(Engine.Index index) {
+        if (index.getAutoGeneratedIdTimestamp() != IndexRequest.UNSET_AUTO_GENERATED_TIMESTAMP) {
+            assert index.getAutoGeneratedIdTimestamp() >= 0 : "autoGeneratedIdTimestamp must be positive but was: "
+                + index.getAutoGeneratedIdTimestamp();
+            switch (index.origin()) {
+                case PRIMARY:
+                    assert assertPrimaryCanOptimizeAddDocument(index);
+                    return true;
+                case PEER_RECOVERY:
+                case REPLICA:
+                    assert index.version() == 1 && index.versionType() == null : "version: "
+                        + index.version()
+                        + " type: "
+                        + index.versionType();
+                    return true;
+                case LOCAL_TRANSLOG_RECOVERY:
+                case LOCAL_RESET:
+                    assert index.isRetry();
+                    return true; // allow to optimize in order to update the max safe time stamp
+                default:
+                    throw new IllegalArgumentException("unknown origin " + index.origin());
+            }
+        }
+        return false;
+    }
+
+    protected boolean assertPrimaryCanOptimizeAddDocument(final Engine.Index index) {
+        assert (index.version() == Versions.MATCH_DELETED || index.version() == Versions.MATCH_ANY)
+            && index.versionType() == VersionType.INTERNAL : "version: " + index.version() + " type: " + index.versionType();
+        return true;
+    }
+
+    /**
+     * returns true if the indexing operation may have already be processed by this engine.
+     * Note that it is OK to rarely return true even if this is not the case. However a `false`
+     * return value must always be correct.
+     *
+     */
+    private boolean mayHaveBeenIndexedBefore(Engine.Index index) {
+        assert canOptimizeAddDocument(index);
+        final boolean mayHaveBeenIndexBefore;
+        if (index.isRetry()) {
+            mayHaveBeenIndexBefore = true;
+            updateAutoIdTimestampConsumer.accept(index.getAutoGeneratedIdTimestamp(), true);
+            assert maxUnsafeAutoIdTimestampSupplier.get() >= index.getAutoGeneratedIdTimestamp();
+        } else {
+            // in this case we force
+            mayHaveBeenIndexBefore = maxUnsafeAutoIdTimestampSupplier.get() >= index.getAutoGeneratedIdTimestamp();
+            updateAutoIdTimestampConsumer.accept(index.getAutoGeneratedIdTimestamp(), false);
+        }
+        return mayHaveBeenIndexBefore;
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/OpVsEngineDocStatus.java
+++ b/server/src/main/java/org/opensearch/index/engine/OpVsEngineDocStatus.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+/**
+ * the status of the current doc version in engine, compared to the version in an incoming
+ * operation
+ */
+public enum OpVsEngineDocStatus {
+    /** the op is more recent than the one that last modified the doc found in engine*/
+    OP_NEWER,
+    /** the op is older or the same as the one that last modified the doc found in engine*/
+    OP_STALE_OR_EQUAL,
+    /** no doc was found in engine */
+    DOC_NOT_FOUND
+}

--- a/server/src/main/java/org/opensearch/index/engine/OperationStrategy.java
+++ b/server/src/main/java/org/opensearch/index/engine/OperationStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Encapsulates the execution strategy for an engine operation (e.g. indexing or deletion).
+ *
+ * @opensearch.internal
+ */
+public class OperationStrategy {
+
+    public final boolean executeOpOnEngine;
+    public final boolean addStaleOpToEngine;
+    public final long version;
+    public final Optional<Engine.Result> earlyResultOnPreFlightError;
+    public final int reservedDocs;
+
+    public OperationStrategy(
+        boolean executeOpOnEngine,
+        boolean addStaleOpToEngine,
+        long version,
+        Engine.Result earlyResultOnPreFlightError,
+        int reservedDocs
+    ) {
+        this.executeOpOnEngine = executeOpOnEngine;
+        this.addStaleOpToEngine = addStaleOpToEngine;
+        this.version = version;
+        this.reservedDocs = reservedDocs;
+        this.earlyResultOnPreFlightError = earlyResultOnPreFlightError == null
+            ? Optional.empty()
+            : Optional.of(earlyResultOnPreFlightError);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OperationStrategy that = (OperationStrategy) o;
+        return executeOpOnEngine == that.executeOpOnEngine
+            && addStaleOpToEngine == that.addStaleOpToEngine
+            && version == that.version
+            && reservedDocs == that.reservedDocs;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(executeOpOnEngine, addStaleOpToEngine, version, reservedDocs);
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/OperationStrategyPlanner.java
+++ b/server/src/main/java/org/opensearch/index/engine/OperationStrategyPlanner.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import java.io.IOException;
+
+/**
+ * Plans the execution strategy for engine operations based on the shard's role.
+ * This interface defines how operations (indexing, deletion) should be processed
+ * differently depending on whether the shard is acting as a primary or replica.
+ *
+ * @opensearch.internal
+ */
+public interface OperationStrategyPlanner<T extends Engine.Operation, V extends OperationStrategy> {
+
+    /**
+     * Plans the execution strategy for an operation on a primary shard.
+     *
+     * @param operation the operation to plan (index or delete)
+     * @return the strategy for executing this operation on the primary
+     * @throws IOException if an I/O error occurs during planning
+     */
+    V planOperationAsPrimary(T operation) throws IOException;
+
+    /**
+     * Plans the execution strategy for an operation on a non-primary (replica) shard.
+     *
+     * @param operation the operation to plan (index or delete)
+     * @return the strategy for executing this operation on the replica
+     * @throws IOException if an I/O error occurs during planning
+     */
+    V planOperationAsNonPrimary(T operation) throws IOException;
+
+    default boolean assertNonPrimaryOrigin(final T operation) {
+        assert operation.origin() != Engine.Operation.Origin.PRIMARY : "planing as primary but got " + operation.origin();
+        return true;
+    }
+}

--- a/server/src/test/java/org/opensearch/index/engine/DeletionStrategyPlannerTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DeletionStrategyPlannerTests.java
@@ -1,0 +1,334 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.lucene.uid.Versions;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.VersionType;
+import org.opensearch.test.IndexSettingsModule;
+
+import java.io.IOException;
+
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+
+public class DeletionStrategyPlannerTests extends EngineTestCase {
+
+    public void testPlanOperationAsPrimary() throws IOException {
+        DeletionStrategyPlanner planner = constructDeletionStrategyPlanner(new DeleteVersionValue(1L, 5L, 1L, 1L));
+
+        Engine.Delete delete = new Engine.Delete(
+            "1",
+            newUid("1"),
+            UNASSIGNED_SEQ_NO,
+            primaryTerm.get(),
+            1L,
+            VersionType.INTERNAL,
+            Engine.Operation.Origin.PRIMARY,
+            System.currentTimeMillis(),
+            UNASSIGNED_SEQ_NO,
+            0L
+        );
+        DeletionStrategy plannedStrategy = planner.planOperationAsPrimary(delete);
+        DeletionStrategy expectedStrategy = DeletionStrategy.processNormally(true, 2, 1);
+
+        assertEquals(expectedStrategy, plannedStrategy);
+    }
+
+    public void testPlanOperationAsPrimaryFailAsTooManyDocs() throws IOException {
+        Exception reserveError = new IllegalStateException("Too many documents");
+        DeletionStrategyPlanner planner = new DeletionStrategyPlanner(
+            engine.engineConfig.getIndexSettings(),
+            engine.shardId,
+            op -> false,
+            op -> OpVsEngineDocStatus.DOC_NOT_FOUND,
+            (op, refresh) -> new DeleteVersionValue(1L, 5L, 1L, 1L),
+            (op, docs) -> reserveError,
+            () -> true
+        );
+
+        Engine.Delete delete = new Engine.Delete(
+            "1",
+            newUid("1"),
+            UNASSIGNED_SEQ_NO,
+            primaryTerm.get(),
+            1L,
+            VersionType.INTERNAL,
+            Engine.Operation.Origin.PRIMARY,
+            System.currentTimeMillis(),
+            UNASSIGNED_SEQ_NO,
+            0L
+        );
+        DeletionStrategy plannedStrategy = planner.planOperationAsPrimary(delete);
+        DeletionStrategy expectedStrategy = DeletionStrategy.failAsTooManyDocs(reserveError);
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertTrue(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsPrimaryVersionConflict() throws IOException {
+        DeletionStrategyPlanner planner = constructDeletionStrategyPlanner(new IndexVersionValue(null, 1L, 1L, 1L));
+
+        Engine.Delete delete = new Engine.Delete(
+            "1",
+            newUid("1"),
+            UNASSIGNED_SEQ_NO,
+            primaryTerm.get(),
+            2L,
+            VersionType.INTERNAL,
+            Engine.Operation.Origin.PRIMARY,
+            System.currentTimeMillis(),
+            UNASSIGNED_SEQ_NO,
+            1L
+        );
+        DeletionStrategy plannedStrategy = planner.planOperationAsPrimary(delete);
+
+        assertFalse(plannedStrategy.executeOpOnEngine);
+        assertFalse(plannedStrategy.currentlyDeleted);
+        assertFalse(plannedStrategy.addStaleOpToEngine);
+        assertEquals(Versions.NOT_FOUND, plannedStrategy.version);
+        assertEquals(0, plannedStrategy.reservedDocs);
+        assertTrue(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsPrimaryVersionConflictDocumentDeleted() throws IOException {
+        DeletionStrategyPlanner planner = constructDeletionStrategyPlanner(new DeleteVersionValue(1L, 5L, 1L, 1L));
+
+        Engine.Delete delete = new Engine.Delete(
+            "1",
+            newUid("1"),
+            UNASSIGNED_SEQ_NO,
+            primaryTerm.get(),
+            2L,
+            VersionType.INTERNAL,
+            Engine.Operation.Origin.PRIMARY,
+            System.currentTimeMillis(),
+            UNASSIGNED_SEQ_NO,
+            1L
+        );
+        DeletionStrategy plannedStrategy = planner.planOperationAsPrimary(delete);
+
+        assertFalse(plannedStrategy.executeOpOnEngine);
+        assertTrue(plannedStrategy.currentlyDeleted);
+        assertFalse(plannedStrategy.addStaleOpToEngine);
+        assertEquals(Versions.NOT_FOUND, plannedStrategy.version);
+        assertEquals(0, plannedStrategy.reservedDocs);
+        assertTrue(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsPrimaryVersionConflictSeqNoMismatch() throws IOException {
+        VersionValue versionValue = new IndexVersionValue(null, 2L, 10L, 2L);
+        DeletionStrategyPlanner planner = constructDeletionStrategyPlanner(versionValue);
+
+        Engine.Delete delete = new Engine.Delete(
+            "1",
+            newUid("1"),
+            5L,
+            primaryTerm.get(),
+            1L,
+            VersionType.INTERNAL,
+            Engine.Operation.Origin.PRIMARY,
+            System.currentTimeMillis(),
+            5L,
+            1L
+        );
+        DeletionStrategy plannedStrategy = planner.planOperationAsPrimary(delete);
+
+        assertFalse(plannedStrategy.executeOpOnEngine);
+        assertFalse(plannedStrategy.currentlyDeleted);
+        assertFalse(plannedStrategy.addStaleOpToEngine);
+        assertEquals(Versions.NOT_FOUND, plannedStrategy.version);
+        assertEquals(0, plannedStrategy.reservedDocs);
+        assertTrue(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsPrimaryVersionConflictForWrites() throws IOException {
+        DeletionStrategyPlanner planner = constructDeletionStrategyPlanner(new DeleteVersionValue(1L, 5L, 1L, 1L));
+
+        Engine.Delete delete = new Engine.Delete(
+            "1",
+            newUid("1"),
+            1L,
+            primaryTerm.get(),
+            3L,
+            VersionType.EXTERNAL,
+            Engine.Operation.Origin.PRIMARY,
+            System.currentTimeMillis(),
+            1L,
+            0L
+        );
+        DeletionStrategy plannedStrategy = planner.planOperationAsPrimary(delete);
+
+        assertFalse(plannedStrategy.executeOpOnEngine);
+        assertTrue(plannedStrategy.currentlyDeleted);
+        assertFalse(plannedStrategy.addStaleOpToEngine);
+        assertEquals(Versions.NOT_FOUND, plannedStrategy.version);
+        assertEquals(0, plannedStrategy.reservedDocs);
+        assertTrue(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsNonPrimaryProcessedBefore() throws IOException {
+        DeletionStrategyPlanner planner = constructDeletionStrategyPlannerForNonPrimary(true, OpVsEngineDocStatus.DOC_NOT_FOUND);
+
+        Engine.Delete delete = new Engine.Delete(
+            "1",
+            newUid("1"),
+            10L,
+            primaryTerm.get(),
+            1L,
+            null,
+            Engine.Operation.Origin.REPLICA,
+            System.currentTimeMillis(),
+            UNASSIGNED_SEQ_NO,
+            0L
+        );
+        DeletionStrategy plannedStrategy = planner.planOperationAsNonPrimary(delete);
+        DeletionStrategy expectedStrategy = DeletionStrategy.processButSkipEngine(false, delete.version());
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsNonPrimaryProcessAsStaleOp() throws IOException {
+        DeletionStrategyPlanner planner = constructDeletionStrategyPlannerForNonPrimary(false, OpVsEngineDocStatus.OP_STALE_OR_EQUAL);
+
+        Engine.Delete delete = new Engine.Delete(
+            "1",
+            newUid("1"),
+            UNASSIGNED_SEQ_NO,
+            primaryTerm.get(),
+            1L,
+            null,
+            Engine.Operation.Origin.REPLICA,
+            System.currentTimeMillis(),
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM
+        );
+        DeletionStrategy plannedStrategy = planner.planOperationAsNonPrimary(delete);
+        DeletionStrategy expectedStrategy = DeletionStrategy.processAsStaleOp(delete.version());
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsNonPrimaryProcessNormally() throws IOException {
+        DeletionStrategyPlanner planner = constructDeletionStrategyPlannerForNonPrimary(false, OpVsEngineDocStatus.DOC_NOT_FOUND);
+
+        Engine.Delete delete = new Engine.Delete(
+            "1",
+            newUid("1"),
+            UNASSIGNED_SEQ_NO,
+            primaryTerm.get(),
+            1L,
+            null,
+            Engine.Operation.Origin.REPLICA,
+            System.currentTimeMillis(),
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM
+        );
+        DeletionStrategy plannedStrategy = planner.planOperationAsNonPrimary(delete);
+        DeletionStrategy expectedStrategy = DeletionStrategy.processNormally(true, delete.version(), 0);
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsNonPrimaryProcessNormallyDocumentExists() throws IOException {
+        DeletionStrategyPlanner planner = new DeletionStrategyPlanner(
+            replicaEngine.engineConfig.getIndexSettings(),
+            replicaEngine.shardId,
+            op -> false,
+            op -> OpVsEngineDocStatus.OP_NEWER,
+            (op, refresh) -> null,
+            (op, docs) -> null,
+            () -> true
+        );
+
+        Engine.Delete delete = new Engine.Delete(
+            "1",
+            newUid("1"),
+            UNASSIGNED_SEQ_NO,
+            primaryTerm.get(),
+            1L,
+            null,
+            Engine.Operation.Origin.REPLICA,
+            System.currentTimeMillis(),
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM
+        );
+        DeletionStrategy plannedStrategy = planner.planOperationAsNonPrimary(delete);
+        DeletionStrategy expectedStrategy = DeletionStrategy.processNormally(false, delete.version(), 0);
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsNonPrimaryWithSegRepEnabled() throws IOException {
+        Settings.Builder settings = Settings.builder()
+            .put(defaultSettings.getSettings())
+            .put(IndexMetadata.INDEX_REPLICATION_TYPE_SETTING.getKey(), "SEGMENT");
+        final IndexMetadata indexMetadata = IndexMetadata.builder(defaultSettings.getIndexMetadata()).settings(settings).build();
+        final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(indexMetadata);
+        EngineConfig engineConfig = config(indexSettings, store, createTempDir(), newMergePolicy(), null);
+
+        DeletionStrategyPlanner planner = new DeletionStrategyPlanner(
+            engineConfig.getIndexSettings(),
+            replicaEngine.shardId,
+            op -> false,
+            op -> OpVsEngineDocStatus.OP_STALE_OR_EQUAL,
+            (op, refresh) -> null,
+            (op, docs) -> null,
+            () -> true
+        );
+
+        Engine.Delete delete = new Engine.Delete(
+            "1",
+            newUid("1"),
+            10L,
+            primaryTerm.get(),
+            UNASSIGNED_SEQ_NO,
+            null,
+            Engine.Operation.Origin.REPLICA,
+            System.currentTimeMillis(),
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM
+        );
+        DeletionStrategy plannedStrategy = planner.planOperationAsNonPrimary(delete);
+        DeletionStrategy expectedStrategy = DeletionStrategy.processButSkipEngine(false, delete.version());
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    private DeletionStrategyPlanner constructDeletionStrategyPlanner(VersionValue versionValue) {
+        return new DeletionStrategyPlanner(
+            engine.engineConfig.getIndexSettings(),
+            engine.shardId,
+            op -> false,
+            op -> OpVsEngineDocStatus.DOC_NOT_FOUND,
+            (op, refresh) -> versionValue,
+            (op, docs) -> null,
+            () -> true
+        );
+    }
+
+    private DeletionStrategyPlanner constructDeletionStrategyPlannerForNonPrimary(boolean processedBefore, OpVsEngineDocStatus docStatus) {
+        return new DeletionStrategyPlanner(
+            replicaEngine.engineConfig.getIndexSettings(),
+            replicaEngine.shardId,
+            op -> processedBefore,
+            op -> docStatus,
+            (op, refresh) -> null,
+            (op, docs) -> null,
+            () -> true
+        );
+    }
+}

--- a/server/src/test/java/org/opensearch/index/engine/IndexingStrategyPlannerTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/IndexingStrategyPlannerTests.java
@@ -1,0 +1,378 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.CheckedBiFunction;
+import org.opensearch.common.lucene.uid.Versions;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.VersionType;
+import org.opensearch.index.mapper.ParsedDocument;
+import org.opensearch.test.IndexSettingsModule;
+
+import java.io.IOException;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+
+public class IndexingStrategyPlannerTests extends EngineTestCase {
+
+    public void testPlanOperationAsPrimaryWithNewDocumentProcessedNormally() throws IOException {
+        IndexingStrategyPlanner planner = constructDefaultIndexingStrategyPlanner();
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = new Engine.Index(newUid(doc), primaryTerm.get(), doc);
+        IndexingStrategy plannedStrategy = planner.planOperationAsPrimary(index);
+        IndexingStrategy expectedStrategy = IndexingStrategy.processNormally(true, 1, 1);
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsPrimaryWithExistingDocumentProcessedNormally() throws IOException {
+        VersionValue versionValue = new IndexVersionValue(null, randomLong(), 5L, 1L);
+        IndexingStrategyPlanner planner = constructIndexingStrategyPlanner(versionValue);
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = new Engine.Index(newUid(doc), primaryTerm.get(), doc);
+        IndexingStrategy plannedStrategy = planner.planOperationAsPrimary(index);
+        IndexingStrategy expectedStrategy = IndexingStrategy.processNormally(false, versionValue.version + 1, 1);
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsPrimaryOptimizedAppendOnly() throws IOException {
+        IndexingStrategyPlanner planner = constructDefaultIndexingStrategyPlanner();
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = indexForDoc(doc);
+        IndexingStrategy plannedStrategy = planner.planOperationAsPrimary(index);
+        IndexingStrategy expectedStrategy = IndexingStrategy.optimizedAppendOnly(1L, 1);
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsPrimaryFailingWithTooManyDocs() throws IOException {
+        Exception tooManyDocsException = new RuntimeException("too many docs");
+        IndexingStrategyPlanner planner = constructIndexingStrategyPlanner(tooManyDocsException);
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = indexForDoc(
+            doc,
+            UNASSIGNED_SEQ_NO,
+            Versions.MATCH_ANY,
+            VersionType.INTERNAL,
+            randomLongBetween(1, Long.MAX_VALUE),
+            0
+        );
+        IndexingStrategy plannedStrategy = planner.planOperationAsPrimary(index);
+        IndexingStrategy expectedStrategy = IndexingStrategy.failAsTooManyDocs(tooManyDocsException);
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertTrue(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsPrimaryVersionConflictDocumentNotFound() throws IOException {
+        IndexingStrategyPlanner planner = constructDefaultIndexingStrategyPlanner();
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = indexForDoc(doc, 5L, 1L, VersionType.INTERNAL, IndexRequest.UNSET_AUTO_GENERATED_TIMESTAMP, 1L);
+        IndexingStrategy plannedStrategy = planner.planOperationAsPrimary(index);
+
+        assertFalse(plannedStrategy.executeOpOnEngine);
+        assertFalse(plannedStrategy.useUpdateDocument);
+        assertFalse(plannedStrategy.addStaleOpToEngine);
+        assertEquals(Versions.NOT_FOUND, plannedStrategy.version);
+        assertTrue(plannedStrategy.currentNotFoundOrDeleted);
+        assertEquals(0, plannedStrategy.reservedDocs);
+        assertTrue(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsPrimaryVersionConflictSeqNoMismatch() throws IOException {
+        IndexingStrategyPlanner planner = constructIndexingStrategyPlanner(new IndexVersionValue(null, 2L, 10L, 2L));
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = indexForDoc(doc, 5L, 1L, VersionType.INTERNAL, IndexRequest.UNSET_AUTO_GENERATED_TIMESTAMP, 1L);
+        IndexingStrategy plannedStrategy = planner.planOperationAsPrimary(index);
+
+        assertFalse(plannedStrategy.executeOpOnEngine);
+        assertFalse(plannedStrategy.useUpdateDocument);
+        assertFalse(plannedStrategy.addStaleOpToEngine);
+        assertEquals(Versions.NOT_FOUND, plannedStrategy.version);
+        assertFalse(plannedStrategy.currentNotFoundOrDeleted);
+        assertEquals(0, plannedStrategy.reservedDocs);
+        assertTrue(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsPrimaryVersionConflictForWrites() throws IOException {
+        IndexingStrategyPlanner planner = constructIndexingStrategyPlanner(new IndexVersionValue(null, 5L, 10L, 1L));
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = indexForDoc(doc, UNASSIGNED_SEQ_NO, 3L, VersionType.EXTERNAL, IndexRequest.UNSET_AUTO_GENERATED_TIMESTAMP, 0L);
+        IndexingStrategy plannedStrategy = planner.planOperationAsPrimary(index);
+
+        assertFalse(plannedStrategy.executeOpOnEngine);
+        assertFalse(plannedStrategy.useUpdateDocument);
+        assertFalse(plannedStrategy.addStaleOpToEngine);
+        assertEquals(Versions.NOT_FOUND, plannedStrategy.version);
+        assertFalse(plannedStrategy.currentNotFoundOrDeleted);
+        assertEquals(0, plannedStrategy.reservedDocs);
+        assertTrue(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsPrimaryAppendOnlyIndexRetry() throws IOException {
+        Settings.Builder settings = Settings.builder()
+            .put(defaultSettings.getSettings())
+            .put(IndexMetadata.INDEX_APPEND_ONLY_ENABLED_SETTING.getKey(), "true");
+        final IndexMetadata indexMetadata = IndexMetadata.builder(defaultSettings.getIndexMetadata()).settings(settings).build();
+        final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(indexMetadata);
+        EngineConfig engineConfig = config(indexSettings, store, createTempDir(), newMergePolicy(), null);
+
+        IndexingStrategyPlanner planner = constructIndexingStrategyPlanner(engineConfig, new IndexVersionValue(null, 5L, 10L, 1L));
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = indexForDoc(
+            doc,
+            UNASSIGNED_SEQ_NO,
+            Versions.MATCH_ANY,
+            VersionType.INTERNAL,
+            IndexRequest.UNSET_AUTO_GENERATED_TIMESTAMP,
+            0L
+        );
+        IndexingStrategy plannedStrategy = planner.planOperationAsPrimary(index);
+
+        assertFalse(plannedStrategy.executeOpOnEngine);
+        assertFalse(plannedStrategy.useUpdateDocument);
+        assertTrue(plannedStrategy.addStaleOpToEngine);
+        assertEquals(5L, plannedStrategy.version);
+        assertFalse(plannedStrategy.currentNotFoundOrDeleted);
+        assertEquals(0, plannedStrategy.reservedDocs);
+        assertTrue(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsNonPrimaryProcessedBefore() throws IOException {
+        IndexingStrategyPlanner planner = constructIndexingStrategyPlanner(
+            operation -> true,
+            (operation, aBoolean) -> null,
+            (operation, integer) -> null
+        );
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = replicaIndexForDoc(doc, 1L, 10L, false);
+        IndexingStrategy plannedStrategy = planner.planOperationAsNonPrimary(index);
+        IndexingStrategy expectedStrategy = IndexingStrategy.processButSkipEngine(false, index.version());
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsNonPrimaryOptimizedAppendOnly() throws IOException {
+        IndexingStrategyPlanner planner = new IndexingStrategyPlanner(
+            engine.engineConfig.getIndexSettings(),
+            engine.shardId,
+            engine.versionMap,
+            () -> 0L,
+            () -> 5L,
+            () -> 10L,
+            op -> false,
+            op -> OpVsEngineDocStatus.DOC_NOT_FOUND,
+            (op, refresh) -> null,
+            (timestamp, append) -> {},
+            (op, docs) -> null
+        );
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = replicaIndexForDoc(doc, 1L, 15L, false);
+        IndexingStrategy plannedStrategy = planner.planOperationAsNonPrimary(index);
+        IndexingStrategy expectedStrategy = IndexingStrategy.optimizedAppendOnly(index.version(), 0);
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsNonPrimaryProcessAsStaleOp() throws IOException {
+        IndexingStrategyPlanner planner = new IndexingStrategyPlanner(
+            engine.engineConfig.getIndexSettings(),
+            engine.shardId,
+            engine.versionMap,
+            () -> 0L,
+            () -> 15L,
+            () -> 10L,
+            op -> false,
+            op -> OpVsEngineDocStatus.OP_STALE_OR_EQUAL,
+            (op, refresh) -> null,
+            (timestamp, append) -> {},
+            (op, docs) -> null
+        );
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = replicaIndexForDoc(doc, 1L, 12L, false);
+        IndexingStrategy plannedStrategy = planner.planOperationAsNonPrimary(index);
+        IndexingStrategy expectedStrategy = IndexingStrategy.processAsStaleOp(index.version());
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsNonPrimaryProcessNormally() throws IOException {
+        IndexingStrategyPlanner planner = new IndexingStrategyPlanner(
+            engine.engineConfig.getIndexSettings(),
+            engine.shardId,
+            engine.versionMap,
+            () -> 0L,
+            () -> 15L,
+            () -> 10L,
+            op -> false,
+            op -> OpVsEngineDocStatus.DOC_NOT_FOUND,
+            (op, refresh) -> null,
+            (timestamp, append) -> {},
+            (op, docs) -> null
+        );
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = replicaIndexForDoc(doc, 1L, 12L, false);
+        IndexingStrategy plannedStrategy = planner.planOperationAsNonPrimary(index);
+        IndexingStrategy expectedStrategy = IndexingStrategy.processNormally(true, index.version(), 0);
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsNonPrimaryProcessNormallyDocumentExists() throws IOException {
+        IndexingStrategyPlanner planner = new IndexingStrategyPlanner(
+            engine.engineConfig.getIndexSettings(),
+            engine.shardId,
+            engine.versionMap,
+            () -> 0L,
+            () -> 15L,
+            () -> 10L,
+            op -> false,
+            op -> OpVsEngineDocStatus.OP_NEWER,
+            (op, refresh) -> null,
+            (timestamp, append) -> {},
+            (op, docs) -> null
+        );
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = replicaIndexForDoc(doc, 1L, 12L, false);
+        IndexingStrategy plannedStrategy = planner.planOperationAsNonPrimary(index);
+        IndexingStrategy expectedStrategy = IndexingStrategy.processNormally(false, index.version(), 0);
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    public void testPlanOperationAsNonPrimaryWithSegRepEnabled() throws IOException {
+        Settings.Builder settings = Settings.builder()
+            .put(defaultSettings.getSettings())
+            .put(IndexMetadata.INDEX_REPLICATION_TYPE_SETTING.getKey(), "SEGMENT");
+        final IndexMetadata indexMetadata = IndexMetadata.builder(defaultSettings.getIndexMetadata()).settings(settings).build();
+        final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(indexMetadata);
+        EngineConfig engineConfig = config(indexSettings, store, createTempDir(), newMergePolicy(), null);
+
+        IndexingStrategyPlanner planner = new IndexingStrategyPlanner(
+            engineConfig.getIndexSettings(),
+            engine.shardId,
+            engine.versionMap,
+            () -> 0L,
+            () -> 15L,
+            () -> 10L,
+            op -> false,
+            op -> OpVsEngineDocStatus.OP_STALE_OR_EQUAL,
+            (op, refresh) -> null,
+            (timestamp, append) -> {},
+            (op, docs) -> null
+        );
+
+        ParsedDocument doc = testParsedDocument("1", null, testDocument(), B_1, null);
+        Engine.Index index = replicaIndexForDoc(doc, 1L, 12L, false);
+        IndexingStrategy plannedStrategy = planner.planOperationAsNonPrimary(index);
+        IndexingStrategy expectedStrategy = IndexingStrategy.processButSkipEngine(false, index.version());
+
+        assertEquals(expectedStrategy, plannedStrategy);
+        assertFalse(plannedStrategy.earlyResultOnPreFlightError.isPresent());
+    }
+
+    private Engine.Index indexForDoc(
+        ParsedDocument doc,
+        long seqNo,
+        long version,
+        VersionType versionType,
+        long autoGeneratedIdTimestamp,
+        long ifPrimaryTerm
+    ) {
+        return new Engine.Index(
+            newUid(doc),
+            doc,
+            seqNo,
+            primaryTerm.get(),
+            version,
+            versionType,
+            Engine.Operation.Origin.PRIMARY,
+            System.nanoTime(),
+            autoGeneratedIdTimestamp,
+            false,
+            seqNo,
+            ifPrimaryTerm
+        );
+    }
+
+    private IndexingStrategyPlanner constructDefaultIndexingStrategyPlanner() {
+        return constructIndexingStrategyPlanner(operation -> false, (operation, aBoolean) -> null, (op, docs) -> null);
+    }
+
+    private IndexingStrategyPlanner constructIndexingStrategyPlanner(VersionValue versionValue) {
+        return constructIndexingStrategyPlanner(operation -> false, (operation, aBoolean) -> versionValue, (op, docs) -> null);
+    }
+
+    private IndexingStrategyPlanner constructIndexingStrategyPlanner(Exception e) {
+        return constructIndexingStrategyPlanner(operation -> false, (operation, aBoolean) -> null, (op, docs) -> e);
+    }
+
+    private IndexingStrategyPlanner constructIndexingStrategyPlanner(EngineConfig engineConfig, VersionValue versionValue) {
+        return new IndexingStrategyPlanner(
+            engineConfig.getIndexSettings(),
+            engine.shardId,
+            engine.versionMap,
+            () -> 0L,
+            () -> 0L,
+            () -> 0L,
+            operation -> false,
+            op -> OpVsEngineDocStatus.DOC_NOT_FOUND,
+            (operation, aBoolean) -> versionValue,
+            (timestamp, append) -> {},
+            (op, docs) -> null
+        );
+    }
+
+    private IndexingStrategyPlanner constructIndexingStrategyPlanner(
+        Predicate<Engine.Operation> hasBeenProcessedBefore,
+        CheckedBiFunction<Engine.Operation, Boolean, VersionValue, IOException> docVersionSupplier,
+        BiFunction<Engine.Operation, Integer, Exception> tryAcquireInFlightDocs
+    ) {
+        return new IndexingStrategyPlanner(
+            engine.engineConfig.getIndexSettings(),
+            engine.shardId,
+            engine.versionMap,
+            () -> 0L,
+            () -> 0L,
+            () -> 0L,
+            hasBeenProcessedBefore,
+            op -> OpVsEngineDocStatus.DOC_NOT_FOUND,
+            docVersionSupplier,
+            (timestamp, append) -> {},
+            tryAcquireInFlightDocs
+        );
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

- Introduce Strategy Planner Interfaces

Refactor indexing and deletion planning logic into dedicated planner interfaces responsible for primary and non-primary execution. Default planner implementations would encapsulate the existing InternalEngine behavior, while enabling alternative engines to provide custom planners or reuse shared implementations.

- Delegate Planning via Composition

Update Engine implementations to delegate planning decisions to injected planner instances. The default behavior for InternalEngine should remain unchanged, ensuring backward compatibility.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->
[[Feature Request] Refactor Engine internals to decouple operation/result types and introduce pluggable planning strategies](https://github.com/opensearch-project/OpenSearch/issues/20583)

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
