### PR TITLE
Add indices to search request slowlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support expected cluster name with validation in CCS Sniff mode ([#20532](https://github.com/opensearch-project/OpenSearch/pull/20532))
 - Add security policy to allow `accessUnixDomainSocket` in `transport-grpc` module ([#20463](https://github.com/opensearch-project/OpenSearch/pull/20463))
 - [Workload Management] Enhance Scroll API support for autotagging ([#20151](https://github.com/opensearch-project/OpenSearch/pull/20151))
+- Add indices to search request slowlog ([#20588](https://github.com/opensearch-project/OpenSearch/pull/20588))
 
 ### Changed
 - Move Randomness from server to libs/common ([#20570](https://github.com/opensearch-project/OpenSearch/pull/20570))

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestSlowLog.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestSlowLog.java
@@ -47,6 +47,7 @@ import org.opensearch.tasks.Task;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -187,6 +188,7 @@ public final class SearchRequestSlowLog extends SearchRequestOperationsListener 
             }
             messageFields.put("search_type", context.getRequest().searchType());
             messageFields.put("shards", searchRequestContext.formattedShardStats());
+            messageFields.put("indices", Arrays.toString(context.getRequest().indices()));
 
             if (context.getRequest().source() != null) {
                 String source = escapeJson(context.getRequest().source().toString(FORMAT_PARAMS));
@@ -213,6 +215,7 @@ public final class SearchRequestSlowLog extends SearchRequestOperationsListener 
             }
             sb.append("search_type[").append(context.getRequest().searchType()).append("], ");
             sb.append("shards[").append(searchRequestContext.formattedShardStats()).append("], ");
+            sb.append("indices").append(Arrays.toString(context.getRequest().indices())).append(", ");
             if (context.getRequest().source() != null) {
                 sb.append("source[").append(context.getRequest().source().toString(FORMAT_PARAMS)).append("], ");
             } else {


### PR DESCRIPTION
### Description
Add `indices` to search request slow log. This will help to identify requests present in the slow log when source alone is not enough.

### Testing
Sample requests & slow logs
```
% curl -X GET "http://localhost:9200/_search?pretty&phase_took" -H 'Content-Type: application/json' -d' 
{
  "query": {
    "match_all": {}
  }
}'
```

>[2026-02-10T07:55:50,919][WARN ][o.o.a.s.SearchRequestSlowLog] [runTask-0] took[13.6ms], took_millis[13], phase_took_millis[{}], total_hits[-1]search_type[QUERY_THEN_FETCH], shards[], indices[], source[{"query":{"match_all":{"boost":1.0}}}], id[], request_id[]

```
% curl -X GET "http://localhost:9200/*/_search?pretty&phase_took" -H 'Content-Type: application/json' -d' 
{
  "query": {
    "match_all": {}
  }
}'
```
>[2026-02-10T07:56:15,403][WARN ][o.o.a.s.SearchRequestSlowLog] [runTask-0] took[1.7ms], took_millis[1], phase_took_millis[{}], total_hits[-1]search_type[QUERY_THEN_FETCH], shards[], indices[*], source[{"query":{"match_all":{"boost":1.0}}}], id[], request_id[]

```
% curl -X GET "http://localhost:9200/index_1,index_2,my_index_*/_search?pretty&phase_took" -H 'Content-Type: application/json' -d' 
{                                      
  "query": {
    "match_all": {}
  }
}'
```
>[2026-02-10T07:58:07,922][WARN ][o.o.a.s.SearchRequestSlowLog] [runTask-0] took[32.1ms], took_millis[32], phase_took_millis[{expand=0, query=25, fetch=1}], total_hits[0 hits], search_type[QUERY_THEN_FETCH], shards[{total:2, successful:2, skipped:0, failed:0}], indices[index_1, index_2, my_index_*], source[{"query":{"match_all":{"boost":1.0}}}], id[], request_id[]

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/20531

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
