### PR TITLE
Make the default for cypto.standard to be FIPS-140-3

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -193,12 +193,6 @@ if (project != rootProject) {
   disableTasks('forbiddenApisMain', 'forbiddenApisTest', 'forbiddenApisIntegTest', 'forbiddenApisTestFixtures')
   jarHell.enabled = false
   thirdPartyAudit.enabled = false
-  if (org.opensearch.gradle.info.BuildParams.isInFipsJvm()) {
-    // We don't support running gradle with a JVM that is in FIPS 140 mode, so we don't test it.
-    // WaitForHttpResourceTests tests would fail as they use JKS/PKCS12 keystores
-    test.enabled = false
-    testingConventions.enabled = false
-  }
 
   configurations.register("distribution")
   configurations.register("reaper")

--- a/buildSrc/src/main/java/org/opensearch/gradle/info/FipsBuildParams.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/info/FipsBuildParams.java
@@ -8,9 +8,14 @@
 
 package org.opensearch.gradle.info;
 
+import java.util.Set;
 import java.util.function.Function;
+import java.util.logging.Logger;
 
 public class FipsBuildParams {
+
+    private static final Logger LOGGER = Logger.getLogger(FipsBuildParams.class.getName());
+    private static final Set<String> VALID_MODES = Set.of("FIPS-140-3", "any-supported", "none");
 
     @Deprecated
     public static final String FIPS_BUILD_PARAM_FOR_TESTS = "tests.fips.enabled";
@@ -23,10 +28,16 @@ public class FipsBuildParams {
         var fipsBuildParamForTests = Boolean.parseBoolean((String) fipsValue.apply(FIPS_BUILD_PARAM_FOR_TESTS));
         var fipsBuildParam = (String) fipsValue.apply(FIPS_BUILD_PARAM);
 
-        if (fipsBuildParamForTests || DEFAULT_FIPS_MODE.equals(fipsBuildParam)) {
+        if (fipsBuildParam != null && !VALID_MODES.contains(fipsBuildParam)) {
+            LOGGER.warning("Unrecognized crypto.standard value '" + fipsBuildParam + "'. Valid values: " + VALID_MODES);
+        }
+
+        if (fipsBuildParamForTests) {
             fipsMode = DEFAULT_FIPS_MODE;
-        } else {
+        } else if ("any-supported".equals(fipsBuildParam) || "none".equals(fipsBuildParam)) {
             fipsMode = "any-supported";
+        } else {
+            fipsMode = DEFAULT_FIPS_MODE;
         }
     }
 

--- a/buildSrc/src/test/java/org/opensearch/gradle/http/WaitForHttpResourceTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/http/WaitForHttpResourceTests.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.gradle.http;
 
+import org.opensearch.gradle.info.FipsBuildParams;
 import org.opensearch.gradle.test.GradleUnitTestCase;
 
 import java.io.File;
@@ -43,10 +44,12 @@ import java.security.cert.X509Certificate;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assume.assumeFalse;
 
 public class WaitForHttpResourceTests extends GradleUnitTestCase {
 
     public void testBuildTrustStoreFromFile() throws Exception {
+        assumeFalse("PKCS12 keystores not supported in FIPS mode", FipsBuildParams.isInFipsMode());
         final WaitForHttpResource http = new WaitForHttpResource(new URL("https://localhost/"));
         final URL ca = getClass().getResource("/ca.p12");
         assertThat(ca, notNullValue());

--- a/buildSrc/src/test/java/org/opensearch/gradle/info/FipsBuildParamsTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/info/FipsBuildParamsTests.java
@@ -22,9 +22,15 @@ public class FipsBuildParamsTests extends GradleUnitTestCase {
         assertTrue(FipsBuildParams.isInFipsMode());
 
         FipsBuildParams.init(param -> "FIPS-140-2");
-        assertFalse(FipsBuildParams.isInFipsMode());
+        assertTrue(FipsBuildParams.isInFipsMode()); // unrecognized defaults to FIPS
 
         FipsBuildParams.init(param -> null);
+        assertTrue(FipsBuildParams.isInFipsMode()); // null defaults to FIPS
+
+        FipsBuildParams.init(param -> "any-supported");
+        assertFalse(FipsBuildParams.isInFipsMode());
+
+        FipsBuildParams.init(param -> "none");
         assertFalse(FipsBuildParams.isInFipsMode());
     }
 
@@ -36,9 +42,15 @@ public class FipsBuildParamsTests extends GradleUnitTestCase {
         assertEquals("FIPS-140-3", FipsBuildParams.getFipsMode());
 
         FipsBuildParams.init(param -> "FIPS-140-2");
-        assertEquals("any-supported", FipsBuildParams.getFipsMode());
+        assertEquals("FIPS-140-3", FipsBuildParams.getFipsMode()); // unrecognized defaults to FIPS
 
         FipsBuildParams.init(param -> null);
+        assertEquals("FIPS-140-3", FipsBuildParams.getFipsMode()); // null defaults to FIPS
+
+        FipsBuildParams.init(param -> "any-supported");
+        assertEquals("any-supported", FipsBuildParams.getFipsMode());
+
+        FipsBuildParams.init(param -> "none");
         assertEquals("any-supported", FipsBuildParams.getFipsMode());
     }
 


### PR DESCRIPTION
### Description

Opening this in Draft initially.

This PR updates the default value of `crypto.standard` in FipsBuildParams to be `FIPS-140-3` from the current `any-supported`. I am proposing this change so that developers building from source would match the distribution if the min and default distribution will be built with `-Pcrypto.standard=FIPS-140-3` prospectively from 3.6 onwards.

Note: Some tests in the repo will be skipped when this param is present as they rely on non-FIPS compliant configurations for testing.

### Related Issues

Resolves https://github.com/opensearch-project/opensearch-build/issues/5979

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
