### PR TITLE
added filter to both pagination strategies

### DIFF
--- a/server/src/main/java/org/opensearch/action/pagination/IndexPaginationStrategy.java
+++ b/server/src/main/java/org/opensearch/action/pagination/IndexPaginationStrategy.java
@@ -49,6 +49,7 @@ public class IndexPaginationStrategy implements PaginationStrategy<String> {
     }
 
     public IndexPaginationStrategy(PageParams pageParams, ClusterState clusterState, Predicate<IndexMetadata> authorizationFilter) {
+        Objects.requireNonNull(authorizationFilter, "authorizationFilter must not be null");
 
         IndexStrategyToken requestedToken = Objects.isNull(pageParams.getRequestedToken()) || pageParams.getRequestedToken().isEmpty()
             ? null

--- a/server/src/main/java/org/opensearch/action/pagination/IndexPaginationStrategy.java
+++ b/server/src/main/java/org/opensearch/action/pagination/IndexPaginationStrategy.java
@@ -45,6 +45,10 @@ public class IndexPaginationStrategy implements PaginationStrategy<String> {
     private final List<String> requestedIndices;
 
     public IndexPaginationStrategy(PageParams pageParams, ClusterState clusterState) {
+        this(pageParams, clusterState, metadata -> true);
+    }
+
+    public IndexPaginationStrategy(PageParams pageParams, ClusterState clusterState, Predicate<IndexMetadata> authorizationFilter) {
 
         IndexStrategyToken requestedToken = Objects.isNull(pageParams.getRequestedToken()) || pageParams.getRequestedToken().isEmpty()
             ? null
@@ -54,7 +58,8 @@ public class IndexPaginationStrategy implements PaginationStrategy<String> {
             clusterState,
             pageParams.getSort(),
             Objects.isNull(requestedToken) ? null : requestedToken.lastIndexName,
-            Objects.isNull(requestedToken) ? null : requestedToken.lastIndexCreationTime
+            Objects.isNull(requestedToken) ? null : requestedToken.lastIndexCreationTime,
+            authorizationFilter
         );
 
         // Trim sortedIndicesList to get the list of indices metadata to be sent as response
@@ -72,20 +77,12 @@ public class IndexPaginationStrategy implements PaginationStrategy<String> {
         ClusterState clusterState,
         String sortOrder,
         String lastIndexName,
-        Long lastIndexCreationTime
+        Long lastIndexCreationTime,
+        Predicate<IndexMetadata> authorizationFilter
     ) {
-        if (Objects.isNull(lastIndexName) || Objects.isNull(lastIndexCreationTime)) {
-            return PaginationStrategy.getSortedIndexMetadata(
-                clusterState,
-                PageParams.PARAM_ASC_SORT_VALUE.equals(sortOrder) ? ASC_COMPARATOR : DESC_COMPARATOR
-            );
-        } else {
-            return PaginationStrategy.getSortedIndexMetadata(
-                clusterState,
-                getMetadataFilter(sortOrder, lastIndexName, lastIndexCreationTime),
-                PageParams.PARAM_ASC_SORT_VALUE.equals(sortOrder) ? ASC_COMPARATOR : DESC_COMPARATOR
-            );
-        }
+        Comparator<IndexMetadata> comparator = PageParams.PARAM_ASC_SORT_VALUE.equals(sortOrder) ? ASC_COMPARATOR : DESC_COMPARATOR;
+        Predicate<IndexMetadata> paginationFilter = getMetadataFilter(sortOrder, lastIndexName, lastIndexCreationTime);
+        return PaginationStrategy.getSortedIndexMetadata(clusterState, paginationFilter.and(authorizationFilter), comparator);
     }
 
     private static Predicate<IndexMetadata> getMetadataFilter(String sortOrder, String lastIndexName, Long lastIndexCreationTime) {

--- a/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/cat/RestIndicesAction.java
@@ -196,7 +196,10 @@ public class RestIndicesAction extends AbstractListAction {
                                 @Override
                                 public void onResponse(ClusterStateResponse clusterStateResponse) {
                                     validateRequestLimit(clusterStateResponse, listener);
-                                    IndexPaginationStrategy paginationStrategy = getPaginationStrategy(clusterStateResponse);
+                                    IndexPaginationStrategy paginationStrategy = getPaginationStrategy(
+                                        clusterStateResponse,
+                                        getSettingsResponse
+                                    );
                                     // For non-paginated queries, indicesToBeQueried would be same as indices retrieved from
                                     // rest request and unresolved, while for paginated queries, it would be a list of indices
                                     // already resolved by ClusterStateRequest and to be displayed in a page.
@@ -1239,7 +1242,10 @@ public class RestIndicesAction extends AbstractListAction {
         return false;
     }
 
-    protected IndexPaginationStrategy getPaginationStrategy(ClusterStateResponse clusterStateResponse) {
+    protected IndexPaginationStrategy getPaginationStrategy(
+        ClusterStateResponse clusterStateResponse,
+        GetSettingsResponse getSettingsResponse
+    ) {
         return null;
     }
 

--- a/server/src/main/java/org/opensearch/rest/action/list/RestIndicesListAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/list/RestIndicesListAction.java
@@ -9,8 +9,10 @@
 package org.opensearch.rest.action.list;
 
 import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
+import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.opensearch.action.pagination.IndexPaginationStrategy;
 import org.opensearch.action.pagination.PageParams;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.breaker.ResponseLimitSettings;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
@@ -21,6 +23,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
@@ -84,8 +88,13 @@ public class RestIndicesListAction extends RestIndicesAction {
     }
 
     @Override
-    protected IndexPaginationStrategy getPaginationStrategy(ClusterStateResponse clusterStateResponse) {
-        return new IndexPaginationStrategy(pageParams, clusterStateResponse.getState());
+    protected IndexPaginationStrategy getPaginationStrategy(
+        ClusterStateResponse clusterStateResponse,
+        GetSettingsResponse getSettingsResponse
+    ) {
+        Set<String> authorizedIndices = getSettingsResponse.getIndexToSettings().keySet();
+        Predicate<IndexMetadata> authorizationFilter = metadata -> authorizedIndices.contains(metadata.getIndex().getName());
+        return new IndexPaginationStrategy(pageParams, clusterStateResponse.getState(), authorizationFilter);
     }
 
     // Public for testing

--- a/server/src/test/java/org/opensearch/action/pagination/IndexPaginationStrategyTests.java
+++ b/server/src/test/java/org/opensearch/action/pagination/IndexPaginationStrategyTests.java
@@ -354,6 +354,12 @@ public class IndexPaginationStrategyTests extends OpenSearchTestCase {
         }
     }
 
+    public void testNullAuthorizationFilterThrowsException() {
+        ClusterState clusterState = getRandomClusterState(List.of(1, 2, 3));
+        PageParams pageParams = new PageParams(null, PARAM_ASC_SORT_VALUE, 10);
+        expectThrows(NullPointerException.class, () -> new IndexPaginationStrategy(pageParams, clusterState, null));
+    }
+
     public void testFilteredPaginationExcludesUnauthorizedIndices() {
         // Create a cluster state with regular indices and system-like indices
         ClusterState clusterState = getRandomClusterState(List.of(1, 2, 3, 4, 5));

--- a/server/src/test/java/org/opensearch/action/pagination/IndexPaginationStrategyTests.java
+++ b/server/src/test/java/org/opensearch/action/pagination/IndexPaginationStrategyTests.java
@@ -25,6 +25,8 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.opensearch.action.pagination.PageParams.PARAM_ASC_SORT_VALUE;
@@ -352,6 +354,61 @@ public class IndexPaginationStrategyTests extends OpenSearchTestCase {
         }
     }
 
+    public void testFilteredPaginationExcludesUnauthorizedIndices() {
+        // Create a cluster state with regular indices and system-like indices
+        ClusterState clusterState = getRandomClusterState(List.of(1, 2, 3, 4, 5));
+        clusterState = addIndexToClusterState(clusterState, ".system-index", 6);
+        clusterState = addIndexToClusterState(clusterState, ".opendistro_security", 7);
+
+        // Simulate an authorization filter that only allows test-index-* indices
+        Set<String> authorizedIndices = Set.of("test-index-1", "test-index-2", "test-index-3", "test-index-4", "test-index-5");
+        Predicate<IndexMetadata> authFilter = metadata -> authorizedIndices.contains(metadata.getIndex().getName());
+
+        // First page: size=3, ascending
+        PageParams pageParams = new PageParams(null, PARAM_ASC_SORT_VALUE, 3);
+        IndexPaginationStrategy strategy = new IndexPaginationStrategy(pageParams, clusterState, authFilter);
+        assertEquals(3, strategy.getRequestedEntities().size());
+        assertEquals("test-index-1", strategy.getRequestedEntities().get(0));
+        assertEquals("test-index-2", strategy.getRequestedEntities().get(1));
+        assertEquals("test-index-3", strategy.getRequestedEntities().get(2));
+        assertNotNull(strategy.getResponseToken().getNextToken());
+        // System indices should not appear
+        assertFalse(strategy.getRequestedEntities().contains(".system-index"));
+        assertFalse(strategy.getRequestedEntities().contains(".opendistro_security"));
+
+        // Second page: should contain remaining authorized indices
+        pageParams = new PageParams(strategy.getResponseToken().getNextToken(), PARAM_ASC_SORT_VALUE, 3);
+        strategy = new IndexPaginationStrategy(pageParams, clusterState, authFilter);
+        assertEquals(2, strategy.getRequestedEntities().size());
+        assertEquals("test-index-4", strategy.getRequestedEntities().get(0));
+        assertEquals("test-index-5", strategy.getRequestedEntities().get(1));
+        assertNull(strategy.getResponseToken().getNextToken());
+        assertFalse(strategy.getRequestedEntities().contains(".system-index"));
+        assertFalse(strategy.getRequestedEntities().contains(".opendistro_security"));
+    }
+
+    public void testFilteredPaginationWithDescOrder() {
+        ClusterState clusterState = getRandomClusterState(List.of(1, 2, 3));
+        clusterState = addIndexToClusterState(clusterState, ".security-index", 4);
+
+        Set<String> authorizedIndices = Set.of("test-index-1", "test-index-2", "test-index-3");
+        Predicate<IndexMetadata> authFilter = metadata -> authorizedIndices.contains(metadata.getIndex().getName());
+
+        PageParams pageParams = new PageParams(null, PARAM_DESC_SORT_VALUE, 2);
+        IndexPaginationStrategy strategy = new IndexPaginationStrategy(pageParams, clusterState, authFilter);
+        assertEquals(2, strategy.getRequestedEntities().size());
+        assertEquals("test-index-3", strategy.getRequestedEntities().get(0));
+        assertEquals("test-index-2", strategy.getRequestedEntities().get(1));
+        assertNotNull(strategy.getResponseToken().getNextToken());
+        assertFalse(strategy.getRequestedEntities().contains(".security-index"));
+
+        pageParams = new PageParams(strategy.getResponseToken().getNextToken(), PARAM_DESC_SORT_VALUE, 2);
+        strategy = new IndexPaginationStrategy(pageParams, clusterState, authFilter);
+        assertEquals(1, strategy.getRequestedEntities().size());
+        assertEquals("test-index-1", strategy.getRequestedEntities().get(0));
+        assertNull(strategy.getResponseToken().getNextToken());
+    }
+
     /**
      * @param indexNumbers would be used to create indices having names with integer appended after foo, like foo1, foo2.
      * @return random clusterState consisting of indices having their creation times set to the integer used to name them.
@@ -368,9 +425,13 @@ public class IndexPaginationStrategyTests extends OpenSearchTestCase {
     }
 
     private ClusterState addIndexToClusterState(ClusterState clusterState, int indexNumber) {
-        IndexMetadata indexMetadata = IndexMetadata.builder("test-index-" + indexNumber)
+        return addIndexToClusterState(clusterState, "test-index-" + indexNumber, indexNumber);
+    }
+
+    private ClusterState addIndexToClusterState(ClusterState clusterState, String indexName, int creationOrder) {
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
             .settings(
-                settings(Version.CURRENT).put(SETTING_CREATION_DATE, Instant.now().plus(indexNumber, ChronoUnit.SECONDS).toEpochMilli())
+                settings(Version.CURRENT).put(SETTING_CREATION_DATE, Instant.now().plus(creationOrder, ChronoUnit.SECONDS).toEpochMilli())
             )
             .numberOfShards(between(1, 10))
             .numberOfReplicas(randomInt(20))

--- a/server/src/test/java/org/opensearch/rest/action/cat/RestIndicesActionTests.java
+++ b/server/src/test/java/org/opensearch/rest/action/cat/RestIndicesActionTests.java
@@ -309,4 +309,12 @@ public class RestIndicesActionTests extends OpenSearchTestCase {
             fail("Timestamp string is not a valid ISO-8601 date: " + timestampString);
         }
     }
+
+    public void testGetPaginationStrategyReturnsNullByDefault() {
+        final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        final Settings settings = Settings.builder().build();
+        final ResponseLimitSettings responseLimitSettings = new ResponseLimitSettings(clusterSettings, settings);
+        final RestIndicesAction action = new RestIndicesAction(responseLimitSettings);
+        assertNull(action.getPaginationStrategy(null, null));
+    }
 }

--- a/server/src/test/java/org/opensearch/rest/action/list/RestIndicesListActionTests.java
+++ b/server/src/test/java/org/opensearch/rest/action/list/RestIndicesListActionTests.java
@@ -1,0 +1,150 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.rest.action.list;
+
+import org.opensearch.Version;
+import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
+import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.opensearch.action.pagination.IndexPaginationStrategy;
+import org.opensearch.action.pagination.PageParams;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.routing.IndexRoutingTable;
+import org.opensearch.cluster.routing.RoutingTable;
+import org.opensearch.common.breaker.ResponseLimitSettings;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.action.pagination.PageParams.PARAM_ASC_SORT_VALUE;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
+
+public class RestIndicesListActionTests extends OpenSearchTestCase {
+
+    private RestIndicesListAction createAction() {
+        final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        final ResponseLimitSettings responseLimitSettings = new ResponseLimitSettings(clusterSettings, Settings.EMPTY);
+        return new RestIndicesListAction(responseLimitSettings);
+    }
+
+    public void testGetPaginationStrategyFiltersByGetSettingsResponse() {
+        // Build cluster state with 3 regular indices and 2 system indices
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().build())
+            .routingTable(RoutingTable.builder().build())
+            .build();
+        clusterState = addIndex(clusterState, "test-index-1", 1);
+        clusterState = addIndex(clusterState, "test-index-2", 2);
+        clusterState = addIndex(clusterState, "test-index-3", 3);
+        clusterState = addIndex(clusterState, ".opendistro_security", 4);
+        clusterState = addIndex(clusterState, ".system-index", 5);
+
+        ClusterStateResponse clusterStateResponse = new ClusterStateResponse(new ClusterName("test"), clusterState, false);
+
+        // GetSettingsResponse only contains authorized indices (simulating security plugin filtering)
+        Map<String, Settings> authorizedSettings = new HashMap<>();
+        authorizedSettings.put("test-index-1", Settings.EMPTY);
+        authorizedSettings.put("test-index-2", Settings.EMPTY);
+        authorizedSettings.put("test-index-3", Settings.EMPTY);
+        GetSettingsResponse getSettingsResponse = new GetSettingsResponse(authorizedSettings, Collections.emptyMap());
+
+        // Set pageParams and call getPaginationStrategy
+        RestIndicesListAction action = createAction();
+        action.pageParams = new PageParams(null, PARAM_ASC_SORT_VALUE, 10);
+
+        IndexPaginationStrategy strategy = action.getPaginationStrategy(clusterStateResponse, getSettingsResponse);
+
+        // Only authorized indices should be returned, system indices should be filtered out
+        assertNotNull(strategy);
+        assertEquals(3, strategy.getRequestedEntities().size());
+        assertTrue(strategy.getRequestedEntities().contains("test-index-1"));
+        assertTrue(strategy.getRequestedEntities().contains("test-index-2"));
+        assertTrue(strategy.getRequestedEntities().contains("test-index-3"));
+        assertFalse(strategy.getRequestedEntities().contains(".opendistro_security"));
+        assertFalse(strategy.getRequestedEntities().contains(".system-index"));
+        // All indices fit in one page, so no next token
+        assertNull(strategy.getResponseToken().getNextToken());
+    }
+
+    public void testGetPaginationStrategyPaginatesFilteredIndicesCorrectly() {
+        // Build cluster state with 5 regular indices and 2 system indices
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().build())
+            .routingTable(RoutingTable.builder().build())
+            .build();
+        clusterState = addIndex(clusterState, "test-index-1", 1);
+        clusterState = addIndex(clusterState, "test-index-2", 2);
+        clusterState = addIndex(clusterState, ".opendistro_security", 3);
+        clusterState = addIndex(clusterState, "test-index-3", 4);
+        clusterState = addIndex(clusterState, ".system-index", 5);
+        clusterState = addIndex(clusterState, "test-index-4", 6);
+        clusterState = addIndex(clusterState, "test-index-5", 7);
+
+        ClusterStateResponse clusterStateResponse = new ClusterStateResponse(new ClusterName("test"), clusterState, false);
+
+        Map<String, Settings> authorizedSettings = new HashMap<>();
+        authorizedSettings.put("test-index-1", Settings.EMPTY);
+        authorizedSettings.put("test-index-2", Settings.EMPTY);
+        authorizedSettings.put("test-index-3", Settings.EMPTY);
+        authorizedSettings.put("test-index-4", Settings.EMPTY);
+        authorizedSettings.put("test-index-5", Settings.EMPTY);
+        GetSettingsResponse getSettingsResponse = new GetSettingsResponse(authorizedSettings, Collections.emptyMap());
+
+        RestIndicesListAction action = createAction();
+
+        // First page: size=2
+        action.pageParams = new PageParams(null, PARAM_ASC_SORT_VALUE, 2);
+        IndexPaginationStrategy strategy = action.getPaginationStrategy(clusterStateResponse, getSettingsResponse);
+
+        assertEquals(2, strategy.getRequestedEntities().size());
+        assertEquals("test-index-1", strategy.getRequestedEntities().get(0));
+        assertEquals("test-index-2", strategy.getRequestedEntities().get(1));
+        assertNotNull(strategy.getResponseToken().getNextToken());
+
+        // Second page
+        action.pageParams = new PageParams(strategy.getResponseToken().getNextToken(), PARAM_ASC_SORT_VALUE, 2);
+        strategy = action.getPaginationStrategy(clusterStateResponse, getSettingsResponse);
+
+        assertEquals(2, strategy.getRequestedEntities().size());
+        assertEquals("test-index-3", strategy.getRequestedEntities().get(0));
+        assertEquals("test-index-4", strategy.getRequestedEntities().get(1));
+        assertNotNull(strategy.getResponseToken().getNextToken());
+
+        // Third page (last)
+        action.pageParams = new PageParams(strategy.getResponseToken().getNextToken(), PARAM_ASC_SORT_VALUE, 2);
+        strategy = action.getPaginationStrategy(clusterStateResponse, getSettingsResponse);
+
+        assertEquals(1, strategy.getRequestedEntities().size());
+        assertEquals("test-index-5", strategy.getRequestedEntities().get(0));
+        assertNull(strategy.getResponseToken().getNextToken());
+    }
+
+    private ClusterState addIndex(ClusterState clusterState, String indexName, int creationOrder) {
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+            .settings(
+                settings(Version.CURRENT).put(SETTING_CREATION_DATE, Instant.now().plus(creationOrder, ChronoUnit.SECONDS).toEpochMilli())
+            )
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        IndexRoutingTable.Builder indexRoutingTableBuilder = new IndexRoutingTable.Builder(indexMetadata.getIndex());
+        return ClusterState.builder(clusterState)
+            .metadata(Metadata.builder(clusterState.metadata()).put(indexMetadata, true).build())
+            .routingTable(RoutingTable.builder(clusterState.routingTable()).add(indexRoutingTableBuilder).build())
+            .build();
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- The _list/indices API fails with permission errors when system indices exist in the cluster, even for users with all_access role. The _cat/indices API works fine for the same user.  
- Fixed by using the security-filtered GetSettingsResponse (which only contains indices the user is authorized to access) as an authorization filter when building the pagination strategy. This ensures IndexPaginationStrategy only selects indices the user has permission to view, so the downstream IndicesStatsRequest and ClusterHealthRequest sub-requests never reference unauthorized system indices.

### Related Issues
Resolves #20291 

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
