### PR TITLE
Fix flaky RemoteRoutingTableServiceTests.testGetAsyncIndexRoutingTableDiffReadAction

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/routing/remote/RemoteRoutingTableServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/remote/RemoteRoutingTableServiceTests.java
@@ -611,14 +611,14 @@ public class RemoteRoutingTableServiceTests extends OpenSearchTestCase {
             compressor,
             Version.CURRENT
         );
-        when(blobContainer.readBlob(indexName)).thenReturn(
-            remoteRoutingTableDiff.remoteRoutingTableDiffFormat.serialize(diff, uploadedFileName, compressor).streamInput()
+        when(blobContainer.readBlob(indexName)).thenAnswer(
+            invocation -> remoteRoutingTableDiff.remoteRoutingTableDiffFormat.serialize(diff, uploadedFileName, compressor).streamInput()
         );
 
-        TestCapturingListener<Diff<RoutingTable>> listener = new TestCapturingListener<>();
-        CountDownLatch latch = new CountDownLatch(1);
-
         for (Version version : List.of(Version.CURRENT, Version.V_3_1_0, Version.V_3_2_0)) {
+            TestCapturingListener<Diff<RoutingTable>> listener = new TestCapturingListener<>();
+            CountDownLatch latch = new CountDownLatch(1);
+
             remoteRoutingTableService.getAsyncIndexRoutingTableDiffReadAction(
                 "cluster-uuid",
                 uploadedFileName,


### PR DESCRIPTION
The test was failing intermittently with CorruptStateException due to the mock returning the same stateful InputStream instance in a loop in a test case. Changed the mock from thenReturn() to thenAnswer() to generate a fresh input stream for each invocation.

Similarly, a CountdownLatch was being reused within the loop, but would have been blocking only on the first iteration. Moved the latch to be initialized inside each loop iteration.

### Related Issues
Resolves #14559

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
