### PR TITLE
Update minimum JDK requirement from 11 to 21 in DEVELOPER_GUIDE.md

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -76,16 +76,11 @@ Fork [opensearch-project/OpenSearch](https://github.com/opensearch-project/OpenS
 
 #### JDK
 
-OpenSearch recommends building with the [Temurin/Adoptium](https://adoptium.net/temurin/releases/) distribution. JDK 11 is the minimum supported, and JDK-24 is the newest supported. You must have a supported JDK installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-21`.
+OpenSearch recommends building with the [Temurin/Adoptium](https://adoptium.net/temurin/releases/) distribution. JDK 21 is the minimum required to build, and JDK 24 is the newest supported. You must have a supported JDK installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-21`.
 
-Download Java 11 from [here](https://adoptium.net/releases.html?variant=openjdk11).
+Download Java 21 from [here](https://adoptium.net/temurin/releases/?version=21).
 
-
-In addition, certain backward compatibility tests check out and compile the previous major version of OpenSearch, and therefore require installing [JDK 11](https://adoptium.net/temurin/releases/?version=11) and [JDK 17](https://adoptium.net/temurin/releases/?version=17) and setting the `JAVA11_HOME` and `JAVA17_HOME` environment variables. More to that, since 8.10 release, Gradle has deprecated the usage of the any JDKs below JDK-16. For smooth development experience, the recommendation is to install at least [JDK 17](https://adoptium.net/temurin/releases/?version=17) or [JDK 21](https://adoptium.net/temurin/releases/?version=21). If you still want to build with JDK-11 only, please add `-Dorg.gradle.warning.mode=none` when invoking any Gradle build task from command line, for example:
-
-```
-./gradlew check -Dorg.gradle.warning.mode=none
-```
+In addition, certain backward compatibility tests check out and compile the previous major version of OpenSearch, and therefore require installing [JDK 11](https://adoptium.net/temurin/releases/?version=11) and [JDK 17](https://adoptium.net/temurin/releases/?version=17) and setting the `JAVA11_HOME` and `JAVA17_HOME` environment variables.
 
 By default, the test tasks use bundled JDK runtime, configured in version catalog [gradle/libs.versions.toml](gradle/libs.versions.toml), and set to JDK 24 (non-LTS).
 


### PR DESCRIPTION
### Description

Updates the JDK requirements section in DEVELOPER_GUIDE.md to match the actual build enforcement in `buildSrc/build.gradle` (lines 77-78), which throws a `GradleException` if `JavaVersion.current() < JavaVersion.VERSION_21`.

**Changes:**
- Updated minimum JDK version from "JDK 11" to "JDK 21"
- Fixed inconsistent formatting ("JDK-24" → "JDK 24")
- Updated Adoptium download link to point to Java 21 instead of Java 11
- Removed misleading paragraph suggesting builds work with JDK 11 using `-Dorg.gradle.warning.mode=none` (the buildSrc check fails before Gradle reaches that point)
- Preserved backward compatibility testing notes for `JAVA11_HOME` and `JAVA17_HOME` environment variables

This documentation mismatch caused confusing build errors for developers using JDK 11, as reported in #13109.

### Related Issues

Resolves #13109

### Check List
- [x] Functionality includes testing.
  - _Documentation-only change; no functional code modified_
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
  - _N/A - no API changes_
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
  - _N/A - this is internal developer documentation_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
```

---

**Commit should have the DCO sign-off:**
```
Signed-off-by: Oscar Neira <osc.neira.m@gmail.com>