### PR TITLE
Add cluster.blocks.read.auto_release setting

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -494,14 +494,19 @@ public class DiskThresholdMonitor {
     }
 
     private void handleReadBlocks(ClusterState state, Set<String> indicesToBlockRead, ActionListener<Void> listener) {
-        final Set<String> indicesToReleaseReadBlock = StreamSupport.stream(
-            Spliterators.spliterator(state.routingTable().indicesRouting().entrySet(), 0),
-            false
-        )
-            .map(Map.Entry::getKey)
-            .filter(index -> indicesToBlockRead.contains(index) == false)
-            .filter(index -> state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_BLOCK))
-            .collect(Collectors.toSet());
+        final Set<String> indicesToReleaseReadBlock;
+        if (diskThresholdSettings.isReadBlockAutoReleaseEnabled()) {
+            indicesToReleaseReadBlock = StreamSupport.stream(
+                Spliterators.spliterator(state.routingTable().indicesRouting().entrySet(), 0),
+                false
+            )
+                .map(Map.Entry::getKey)
+                .filter(index -> indicesToBlockRead.contains(index) == false)
+                .filter(index -> state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_BLOCK))
+                .collect(Collectors.toSet());
+        } else {
+            indicesToReleaseReadBlock = Set.of();
+        }
 
         if (indicesToReleaseReadBlock.isEmpty() == false) {
             updateIndicesReadBlock(indicesToReleaseReadBlock, listener, false);

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -493,6 +493,9 @@ public class DiskThresholdMonitor {
             .execute(ActionListener.map(wrappedListener, r -> null));
     }
 
+    /**
+     * Handles releasing or blocking read access to indices based on disk threshold status.
+     */
     private void handleReadBlocks(ClusterState state, Set<String> indicesToBlockRead, ActionListener<Void> listener) {
         final Set<String> indicesToReleaseReadBlock;
         if (diskThresholdSettings.isReadBlockAutoReleaseEnabled()) {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -114,6 +114,12 @@ public class DiskThresholdSettings {
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
+    public static final Setting<Boolean> CLUSTER_READ_BLOCK_AUTO_RELEASE = Setting.boolSetting(
+        "cluster.blocks.read.auto_release",
+        true,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
 
     private volatile String lowWatermarkRaw;
     private volatile String highWatermarkRaw;
@@ -123,6 +129,7 @@ public class DiskThresholdSettings {
     private volatile ByteSizeValue freeBytesThresholdHigh;
     private volatile boolean includeRelocations;
     private volatile boolean createIndexBlockAutoReleaseEnabled;
+    private volatile boolean readBlockAutoReleaseEnabled;
     private volatile boolean enabled;
     private volatile boolean warmThresholdEnabled;
     private volatile TimeValue rerouteInterval;
@@ -153,6 +160,7 @@ public class DiskThresholdSettings {
         this.enabled = CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.get(settings);
         this.warmThresholdEnabled = CLUSTER_ROUTING_ALLOCATION_WARM_DISK_THRESHOLD_ENABLED_SETTING.get(settings);
         this.createIndexBlockAutoReleaseEnabled = CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE.get(settings);
+        this.readBlockAutoReleaseEnabled = CLUSTER_READ_BLOCK_AUTO_RELEASE.get(settings);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING, this::setLowWatermark);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING, this::setHighWatermark);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING, this::setFloodStage);
@@ -164,6 +172,7 @@ public class DiskThresholdSettings {
             this::setWarmThresholdEnabled
         );
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE, this::setCreateIndexBlockAutoReleaseEnabled);
+        clusterSettings.addSettingsUpdateConsumer(CLUSTER_READ_BLOCK_AUTO_RELEASE, this::setReadBlockAutoReleaseEnabled);
     }
 
     /**
@@ -365,6 +374,10 @@ public class DiskThresholdSettings {
         this.createIndexBlockAutoReleaseEnabled = createIndexBlockAutoReleaseEnabled;
     }
 
+    private void setReadBlockAutoReleaseEnabled(boolean readBlockAutoReleaseEnabled) {
+        this.readBlockAutoReleaseEnabled = readBlockAutoReleaseEnabled;
+    }
+
     /**
      * Gets the raw (uninterpreted) low watermark value as found in the settings.
      */
@@ -421,6 +434,10 @@ public class DiskThresholdSettings {
 
     public boolean isCreateIndexBlockAutoReleaseEnabled() {
         return createIndexBlockAutoReleaseEnabled;
+    }
+
+    public boolean isReadBlockAutoReleaseEnabled() {
+        return readBlockAutoReleaseEnabled;
     }
 
     String describeLowThreshold() {

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -114,6 +114,10 @@ public class DiskThresholdSettings {
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
+    /**
+     * Identifies if OpenSearch should automatically release read-only blocks on indices
+     * when disk usage falls below the threshold.
+     */
     public static final Setting<Boolean> CLUSTER_READ_BLOCK_AUTO_RELEASE = Setting.boolSetting(
         "cluster.blocks.read.auto_release",
         true,
@@ -436,6 +440,9 @@ public class DiskThresholdSettings {
         return createIndexBlockAutoReleaseEnabled;
     }
 
+    /**
+     * Returns true if auto-release of read-only blocks is enabled.
+     */
     public boolean isReadBlockAutoReleaseEnabled() {
         return readBlockAutoReleaseEnabled;
     }

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -360,6 +360,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_WARM_DISK_THRESHOLD_ENABLED_SETTING,
                 DiskThresholdSettings.CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE,
+                DiskThresholdSettings.CLUSTER_READ_BLOCK_AUTO_RELEASE,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS_SETTING,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING,
                 FileCacheThresholdSettings.CLUSTER_FILECACHE_ACTIVEUSAGE_THRESHOLD_ENABLED_SETTING,

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
@@ -865,6 +865,79 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
         assertEquals(countUnblockBlocksCalled.get(), 1);
     }
 
+    public void testReadBlockAutoReleaseDisabled() {
+        AtomicReference<Set<String>> indicesToBlockRead = new AtomicReference<>();
+        AtomicReference<Set<String>> indicesToReleaseReadBlock = new AtomicReference<>();
+
+        AllocationService allocation = createAllocationService(
+            Settings.builder().put("cluster.routing.allocation.node_concurrent_recoveries", 10).build()
+        );
+
+        IndexMetadata indexMetadata = IndexMetadata.builder("test_read_block")
+            .settings(settings(Version.CURRENT).put(IndexMetadata.INDEX_BLOCKS_READ_SETTING.getKey(), true))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+
+        Metadata metadata = Metadata.builder().put(indexMetadata, false).build();
+        RoutingTable routingTable = RoutingTable.builder().addAsNew(metadata.index("test_read_block")).build();
+
+        DiscoveryNode warmNode = newNode("warm_node", Collections.singleton(DiscoveryNodeRole.WARM_ROLE));
+
+        final ClusterState clusterState = applyStartedShardsUntilNoChange(
+            ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+                .metadata(metadata)
+                .routingTable(routingTable)
+                .nodes(DiscoveryNodes.builder().add(warmNode))
+                .blocks(ClusterBlocks.builder().addBlocks(indexMetadata).build())
+                .build(),
+            allocation
+        );
+
+        assertTrue(clusterState.blocks().indexBlocked(ClusterBlockLevel.READ, "test_read_block"));
+
+        Settings settings = Settings.builder().put("cluster.blocks.read.auto_release", false).build();
+
+        DiskThresholdMonitor monitor = new DiskThresholdMonitor(
+            settings,
+            () -> clusterState,
+            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            null,
+            () -> 0L,
+            (reason, priority, listener) -> listener.onResponse(clusterState),
+            () -> 2.0
+        ) {
+            @Override
+            protected void updateIndicesReadOnly(Set<String> indicesToUpdate, ActionListener<Void> listener, boolean readOnly) {
+                listener.onResponse(null);
+            }
+
+            @Override
+            protected void updateIndicesReadBlock(Set<String> indicesToUpdate, ActionListener<Void> listener, boolean readBlock) {
+                if (readBlock) {
+                    indicesToBlockRead.set(indicesToUpdate);
+                } else {
+                    indicesToReleaseReadBlock.set(indicesToUpdate);
+                }
+                listener.onResponse(null);
+            }
+
+            @Override
+            protected void setIndexCreateBlock(ActionListener<Void> listener, boolean indexCreateBlock) {
+                listener.onResponse(null);
+            }
+        };
+
+        // Node is healthy (free space 40 > 30 threshold)
+        Map<String, DiskUsage> builder = new HashMap<>();
+        builder.put("warm_node", new DiskUsage("warm_node", "warm_node", "/foo/bar", 200, 40));
+
+        monitor.onNewInfo(clusterInfo(builder));
+
+        // Since auto-release is disabled, indicesToReleaseReadBlock should remain null even though node is healthy
+        assertNull(indicesToReleaseReadBlock.get());
+    }
+
     public void testWarmNodeLowStageWatermarkBreach() {
         AllocationService allocation = createAllocationService(
             Settings.builder().put("cluster.routing.allocation.node_concurrent_recoveries", 10).build()


### PR DESCRIPTION
Addresses #20539

## Problem
`DiskThresholdMonitor` unconditionally auto-releases `index.blocks.read` on all indices, even when manually set by users. This setting was added to support warm node file cache threshold protection, but the implementation assumes `index.blocks.read` is only used by the system.

Unlike `cluster.blocks.create_index` which has `cluster.blocks.create_index.auto_release` to control this behavior, there is no equivalent setting for `index.blocks.read`.

## Solution
Add `cluster.blocks.read.auto_release` setting to control read block auto-release behavior, following the same pattern as `cluster.blocks.create_index.auto_release`.

## Changes
```diff
+ public static final Setting<Boolean> CLUSTER_READ_BLOCK_AUTO_RELEASE = Setting.boolSetting(
+     "cluster.blocks.read.auto_release",
+     true,
+     Setting.Property.Dynamic,
+     Setting.Property.NodeScope
+ );

+ private volatile boolean readBlockAutoReleaseEnabled;

+ public boolean isReadBlockAutoReleaseEnabled() {
+     return readBlockAutoReleaseEnabled;
+ }
```

In `DiskThresholdMonitor.handleReadBlocks()`:
```diff
+ if (diskThresholdSettings.isReadBlockAutoReleaseEnabled()) {
      indicesToReleaseReadBlock = StreamSupport.stream(...)
          .filter(index -> indicesToBlockRead.contains(index) == false)
          .filter(index -> state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_BLOCK))
          .collect(Collectors.toSet());
+ } else {
+     indicesToReleaseReadBlock = Set.of();
+ }
```

## Usage
Users can disable auto-release to preserve manually-set read blocks:
```json
PUT /_cluster/settings
{
  "persistent": {
    "cluster.blocks.read.auto_release": false
  }
}
```

## Testing
- Set `index.blocks.read: true` manually on an index
- With default setting (true): block is auto-released
- With `cluster.blocks.read.auto_release: false`: block persists
- Warm node file cache protection still works (sets blocks that get auto-released)

## Impact
- Default behavior unchanged (auto-release enabled)
- Users can now control read block auto-release
- Manually-set read blocks can persist until explicitly removed