### PR TITLE
add null_value property for version type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Introduce AdditionalCodecs and EnginePlugin::getAdditionalCodecs hook to allow additional Codec registration ([#20411](https://github.com/opensearch-project/OpenSearch/pull/20411))
 - Introduced strategy planner interfaces for indexing and deletion ([#20585](https://github.com/opensearch-project/OpenSearch/pull/20585))
 - Implement FieldMappingIngestionMessageMapper for pull-based ingestion ([#20729](https://github.com/opensearch-project/OpenSearch/pull/20729))
+- Add null_value property for version type ([#20636](https://github.com/opensearch-project/OpenSearch/pull/20636))
 
 ### Changed
 - Move Randomness from server to libs/common ([#20570](https://github.com/opensearch-project/OpenSearch/pull/20570))

--- a/server/src/main/java/org/opensearch/index/mapper/SemanticVersionFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/SemanticVersionFieldMapper.java
@@ -61,6 +61,8 @@ public class SemanticVersionFieldMapper extends ParametrizedFieldMapper {
     }
 
     private final Map<String, String> meta;
+    private final SemanticVersion nullValue;
+    private final String nullValueAsString;
 
     protected SemanticVersionFieldMapper(
         String simpleName,
@@ -68,10 +70,13 @@ public class SemanticVersionFieldMapper extends ParametrizedFieldMapper {
         MappedFieldType mappedFieldType,
         MultiFields multiFields,
         CopyTo copyTo,
-        Map<String, String> meta
+        Map<String, String> meta,
+        Builder builder
     ) {
         super(simpleName, mappedFieldType, multiFields, copyTo);
         this.meta = meta;
+        this.nullValue = builder.parseNullValue();
+        this.nullValueAsString = builder.nullValue.getValue();
     }
 
     @Override
@@ -87,6 +92,12 @@ public class SemanticVersionFieldMapper extends ParametrizedFieldMapper {
         private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).isSearchable, true).alwaysSerialize();
         private final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).isStored, false);
+        private final Parameter<String> nullValue = Parameter.stringParam("null_value", false, m -> toMapper(m).nullValueAsString, null)
+            .acceptsNull();
+
+        private static SemanticVersionFieldMapper toMapper(FieldMapper m) {
+            return (SemanticVersionFieldMapper) m;
+        }
 
         private static SemanticVersionFieldType toType(FieldMapper m) {
             return (SemanticVersionFieldType) ((ParametrizedFieldMapper) m).mappedFieldType;
@@ -96,12 +107,26 @@ public class SemanticVersionFieldMapper extends ParametrizedFieldMapper {
             super(name);
         }
 
+        Builder nullValue(String nullValue) {
+            this.nullValue.setValue(nullValue);
+            return this;
+        }
+
+        private SemanticVersion parseNullValue() {
+            String nullValueAsString = nullValue.getValue();
+            if (nullValueAsString == null) {
+                return null;
+            }
+            return SemanticVersion.parse(nullValueAsString);
+        }
+
         @Override
         protected List<Parameter<?>> getParameters() {
             List<Parameter<?>> parameters = new ArrayList<>();
             parameters.add(indexed);
             parameters.add(hasDocValues);
             parameters.add(stored);
+            parameters.add(nullValue);
             parameters.add(meta);
             return parameters;
         }
@@ -122,11 +147,13 @@ public class SemanticVersionFieldMapper extends ParametrizedFieldMapper {
                     meta.getValue(),
                     indexed.getValue(),
                     hasDocValues.getValue(),
-                    stored.getValue()
+                    stored.getValue(),
+                    parseNullValue()
                 ),
                 multiFieldsBuilder.build(this, context),
                 copyTo.build(),
-                meta.getValue()
+                meta.getValue(),
+                this
             );
         }
     }
@@ -144,13 +171,15 @@ public class SemanticVersionFieldMapper extends ParametrizedFieldMapper {
         private final boolean isSearchable;
         private final boolean hasDocValues;
         private final boolean isStored;
+        private final SemanticVersion nullValue;
 
         public SemanticVersionFieldType(
             String name,
             Map<String, String> meta,
             boolean isSearchable,
             boolean hasDocValues,
-            boolean isStored
+            boolean isStored,
+            SemanticVersion nullValue
         ) {
             super(name, isSearchable, isStored, hasDocValues, TextSearchInfo.SIMPLE_MATCH_ONLY, meta);
             this.meta = meta;
@@ -158,6 +187,7 @@ public class SemanticVersionFieldMapper extends ParametrizedFieldMapper {
             this.isSearchable = isSearchable;
             this.hasDocValues = hasDocValues;
             this.isStored = isStored;
+            this.nullValue = nullValue;
         }
 
         @Override
@@ -327,7 +357,7 @@ public class SemanticVersionFieldMapper extends ParametrizedFieldMapper {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
-            return new SourceValueFetcher(name(), context, format) {
+            return new SourceValueFetcher(name(), context, nullValue) {
                 @Override
                 protected String parseSourceValue(Object value) {
                     return value.toString();
@@ -352,6 +382,9 @@ public class SemanticVersionFieldMapper extends ParametrizedFieldMapper {
     @Override
     protected void parseCreateField(ParseContext context) throws IOException {
         String value = context.parser().textOrNull();
+        if (value == null) {
+            value = nullValueAsString;
+        }
         if (value == null) {
             return;
         }

--- a/server/src/test/java/org/opensearch/index/mapper/SemanticVersionFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/SemanticVersionFieldMapperTests.java
@@ -706,7 +706,8 @@ public class SemanticVersionFieldMapperTests extends MapperTestCase {
             new HashMap<>(),
             true,  // isSearchable
             true,  // hasDocValues
-            false  // isStored
+            false,  // isStored
+            null   // nullValue
         );
 
         // Test termQuery with null value (should throw exception)
@@ -723,7 +724,8 @@ public class SemanticVersionFieldMapperTests extends MapperTestCase {
                 new HashMap<>(),
                 false,  // isSearchable
                 true,   // hasDocValues
-                false   // isStored
+                false,   // isStored
+                null    // nullValue
             );
 
         // Test termQuery - should use doc values query only
@@ -736,7 +738,8 @@ public class SemanticVersionFieldMapperTests extends MapperTestCase {
             new HashMap<>(),
             true,   // isSearchable
             false,  // hasDocValues
-            false   // isStored
+            false,   // isStored
+            null    // nullValue
         );
 
         // Test termQuery - should use index query only
@@ -749,7 +752,8 @@ public class SemanticVersionFieldMapperTests extends MapperTestCase {
             new HashMap<>(),
             false,  // isSearchable
             false,  // hasDocValues
-            false   // isStored
+            false,   // isStored
+            null    // nullValue
         );
 
         // Test termQuery - should throw exception
@@ -850,5 +854,123 @@ public class SemanticVersionFieldMapperTests extends MapperTestCase {
             () -> searchOnlyFieldType.fielddataBuilder("test_index", null)
         );
         assertThat(fieldDataException.getMessage(), containsString("does not have doc_values enabled"));
+    }
+
+    /**
+     * Test null_value parameter - when field value is null, it should be replaced with null_value
+     */
+    public void testNullValueParameter() throws Exception {
+        // Create mapper with null_value set to "1.0.0"
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "version");
+            b.field("store", true);
+            b.field("index", true);
+            b.field("null_value", "1.0.0");
+        }));
+
+        // Test that null value is replaced with null_value
+        ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));
+        IndexableField field = doc.rootDoc().getField("field");
+        assertNotNull("Field should exist when null_value is set", field);
+        assertEquals("1.0.0", field.stringValue());
+
+        // Note: missing field is NOT replaced with null_value, only explicit null values are
+        // This is consistent with other field mappers like IpFieldMapper
+    }
+
+    /**
+     * Test null_value with complex version format
+     */
+    public void testNullValueWithComplexVersion() throws Exception {
+        // Create mapper with null_value set to a complex version
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "version");
+            b.field("store", true);
+            b.field("index", true);
+            b.field("null_value", "2.0.0-alpha.1+build.123");
+        }));
+
+        ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));
+        IndexableField field = doc.rootDoc().getField("field");
+        assertNotNull("Field should exist", field);
+        assertEquals("2.0.0-alpha.1+build.123", field.stringValue());
+    }
+
+    /**
+     * Test that invalid null_value throws exception when trying to create index
+     */
+    public void testInvalidNullValue() throws Exception {
+        // Create mapper with invalid null_value
+        // When null_value is invalid , it should throw an exception
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "version");
+            b.field("store", true);
+            b.field("index", true);
+            b.field("null_value", "invalid-version");
+        })));
+        assertTrue(e.getCause().getMessage().contains("Invalid semantic version format"));
+    }
+
+    /**
+     * Test valueFetcher with null_value
+     */
+    public void testValueFetcherWithNullValue() throws Exception {
+        // Create field type with null_value
+        SemanticVersion nullVersion = SemanticVersion.parse("1.0.0");
+        SemanticVersionFieldMapper.SemanticVersionFieldType fieldType = new SemanticVersionFieldMapper.SemanticVersionFieldType(
+            "test_field",
+            new HashMap<>(),
+            true,
+            true,
+            false,
+            nullVersion
+        );
+
+        QueryShardContext mockContext = mock(QueryShardContext.class);
+        SearchLookup mockLookup = mock(SearchLookup.class);
+
+        // Test valueFetcher returns null_value when field is not in source
+        ValueFetcher fetcher = fieldType.valueFetcher(mockContext, mockLookup, null);
+        assertNotNull(fetcher);
+    }
+
+    /**
+     * Test that explicit value is not affected by null_value setting
+     */
+    public void testExplicitValueNotAffectedByNullValue() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "version");
+            b.field("store", true);
+            b.field("index", true);
+            b.field("null_value", "1.0.0");
+        }));
+
+        // Test that explicit value is preserved
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", "2.0.0")));
+        IndexableField field = doc.rootDoc().getField("field");
+        assertNotNull("Field should exist", field);
+        assertEquals("2.0.0", field.stringValue());
+    }
+
+    /**
+     * Test null_value mapping serialization
+     */
+    public void testNullValueMappingSerialization() throws IOException {
+        XContentBuilder mapping = fieldMapping(b -> {
+            b.field("type", "version");
+            b.field("store", true);
+            b.field("index", true);
+            b.field("null_value", "1.0.0");
+        });
+        DocumentMapper mapper = createDocumentMapper(mapping);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        mapper.mapping().toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        String mappingString = builder.toString();
+        assertTrue(mappingString.contains("\"type\":\"version\""));
+        assertTrue(mappingString.contains("\"null_value\":\"1.0.0\""));
     }
 }


### PR DESCRIPTION
### Description
add null_value property for version type

### Related Issues
[#20629](https://github.com/opensearch-project/OpenSearch/issues/20629)
[#11461](https://github.com/opensearch-project/documentation-website/pull/11461)
[#18454](https://github.com/opensearch-project/OpenSearch/pull/18454)

### Example


```
PUT test_versions
{
  "mappings": {
    "properties": {
      "version": {
        "type": "version",
        "null_value": "0.0.0"
      }
    }
  }
}
respose:
{
  "acknowledged": true,
  "shards_acknowledged": true,
  "index": "test_versions"
}
```

```
POST /test_versions/_doc
{
  "version":null
}

POST /test_versions/_doc
{
  "version":"1.1.1"
}
```

```
POST /test_versions/_search
{
  "query": {"match_all": {}}
}
respose:
{
  "took": 19,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 2,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "test_versions",
        "_id": "1ifJZZwBykOeY2eziuv2",
        "_score": 1,
        "_source": {
          "version": null
        }
      },
      {
        "_index": "test_versions",
        "_id": "1yfJZZwBykOeY2ezp-uM",
        "_score": 1,
        "_source": {
          "version": "1.1.1"
        }
      }
    ]
  }
}
```
```
POST /test_versions/_search
{
  "query": {"term": {
    "version": {
      "value": "0.0.0"
    }
  }}
}
response:
{
  "took": 13,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 0.31506687,
    "hits": [
      {
        "_index": "test_versions",
        "_id": "1ifJZZwBykOeY2eziuv2",
        "_score": 0.31506687,
        "_source": {
          "version": null
        }
      }
    ]
  }
}
```

