### PR TITLE
Fix Docker version extraction when prefixed with 'v' (on some systems / distributions)

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/docker/DockerSupportService.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/docker/DockerSupportService.java
@@ -116,7 +116,23 @@ public abstract class DockerSupportService implements BuildService<DockerSupport
                 lastResult = runCommand(execOperations, dockerPath, "version", "--format", "{{.Server.Version}}");
 
                 if (lastResult.isSuccess()) {
-                    version = Version.fromString(lastResult.stdout.trim(), Version.Mode.RELAXED);
+                    // On some systems, Docker reports version prefixed with 'v', on some without,
+                    // for example:
+                    //
+                    // $ docker info
+                    // Client: Docker Engine - Community
+                    // Version: v29.1.2
+                    // Context: default
+                    // Debug Mode: false
+                    //
+                    // $ docker info
+                    // Client:
+                    // Version: 28.2.2
+                    // Context: default
+                    // Debug Mode: false
+                    //
+                    final String versionString = lastResult.stdout.trim().replaceAll("^v", "");
+                    version = Version.fromString(versionString, Version.Mode.RELAXED);
 
                     isVersionHighEnough = version.onOrAfter(MINIMUM_DOCKER_VERSION);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

On some systems, Docker reports version prefixed with 'v', on some without, for example:

```
 $ docker info
 Client: Docker Engine - Community
 Version: v29.1.2
 Context: default
 Debug Mode: false
```

```
 $ docker info
 Client:
 Version: 28.2.2
 Context: default
 Debug Mode: false
```
### Related Issues

The build fails with:

```
* What went wrong:
A problem occurred evaluating project ':distribution:docker'.
> Failed to apply plugin 'opensearch.test.fixtures'.
   > Invalid version format: 'v29.1.2'. Should be major.minor.revision[-extra]
```

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
