### PR TITLE
Harden detection of HTTP/3 support by ensuring Quic native libraries are available for the target platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Update RemoteClusterStateCleanupManager to performed batched deletions of stale ClusterMetadataManifests and address deletion timeout issues ([#20566](https://github.com/opensearch-project/OpenSearch/pull/20566))
 - Fix the regression of terms agg optimization at high cardinality ([#20623](https://github.com/opensearch-project/OpenSearch/pull/20623))
 - Support Docker distribution builds for ppc64le, arm64 and s390x ([#20678](https://github.com/opensearch-project/OpenSearch/pull/20678))
+- Harden detection of HTTP/3 support by ensuring Quic native libraries are available for the target platform ([#20680](https://github.com/opensearch-project/OpenSearch/pull/20680))
 
 ### Dependencies
 - Bump shadow-gradle-plugin from 8.3.9 to 9.3.1 ([#20569](https://github.com/opensearch-project/OpenSearch/pull/20569))

--- a/libs/netty4/src/main/java/org/opensearch/http/netty4/http3/Http3Utils.java
+++ b/libs/netty4/src/main/java/org/opensearch/http/netty4/http3/Http3Utils.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.http.netty4.http3;
 
+import io.netty.handler.codec.quic.Quic;
+
 /**
  * Adapted from reactor.netty.http.internal.Http3 class
  */
@@ -22,7 +24,10 @@ public final class Http3Utils {
         } catch (Throwable t) {
             http3 = false;
         }
-        isHttp3Available = http3;
+        // Quic codec (which is used by HTTP/3 implementation) is provided by the
+        // native library and may not be available on all platforms (even if HTTP/3
+        // codec is present).
+        isHttp3Available = http3 && Quic.isAvailable();
     }
 
     private Http3Utils() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Harden detection of HTTP/3 support by ensuring Quic native libraries are available for the target platform.  I have got access to a few boxes where Quic is not available yet:

```
  1> Caused by: java.io.FileNotFoundException: META-INF/native/libnetty_quiche42_linux_ppcle_64.so
  1>    at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:189)
  1>    ... 40 more
  1>    Suppressed: java.lang.UnsatisfiedLinkError: no netty_quiche42_linux_ppcle_64 in java.library.path: /usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
  1>            at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2285)
  1>            at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:822)
  1>            at java.base/java.lang.System.loadLibrary(System.java:1685)
  1>            at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:38)
  1>            at io.netty.util.internal.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:395)
  1>            at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:166)
  1>            ... 40 more
  1>            Suppressed: java.lang.UnsatisfiedLinkError: no netty_quiche42_linux_ppcle_64 in java.library.path: /usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
  1>                    at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2285)
  1>                    at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:822)
  1>                    at java.base/java.lang.System.loadLibrary(System.java:1685)
  1>                    at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:38)
  1>                    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
  1>                    at java.base/java.lang.reflect.Method.invoke(Method.java:565)
  1>                    at io.netty.util.internal.NativeLibraryLoader$1.run(NativeLibraryLoader.java:421)
  1>                    at java.base/java.security.AccessController.doPrivileged(AccessController.java:74)
  1>                    at io.netty.util.internal.NativeLibraryLoader.loadLibraryByHelper(NativeLibraryLoader.java:413)
  1>                    at io.netty.util.internal.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:387)
  1>                    ... 41 more
```

All supported platforms are listed in the documentation: https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/network-settings/#experimental-http-settings

### Related Issues
N/A

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
