### PR TITLE
Reduce number of indices created in ClusterSettingsIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/settings/ClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/settings/ClusterSettingsIT.java
@@ -570,8 +570,7 @@ public class ClusterSettingsIT extends OpenSearchIntegTestCase {
     }
 
     public void testWithMultipleIndexCreationAndVerifySettingRegisteredOnce() {
-        int randomInt = randomIntBetween(10, 50);
-        for (int i = 0; i < randomInt; i++) {
+        for (int i = 0; i < 3; i++) {
             String indexName = "test" + i;
             assertAcked(prepareCreate(indexName).setSettings(Settings.builder().put(IndexMetadata.SETTING_BLOCKS_METADATA, true)));
             assertBlocked(client().admin().indices().prepareGetSettings(indexName), IndexMetadata.INDEX_METADATA_BLOCK);


### PR DESCRIPTION
When the number indices created in this test was sufficiently high, tests would frequently hit this failure at some point when creating a file:

```
Caused by: java.nio.file.FileSystemException: /var/jenkins/workspace/gradle-check/search/server/build/testrun/internalClusterTest/temp/org.opensearch.cluster.settings.ClusterSettingsIT_129BF1D803EFDA59-001/tempDir-002/node_s0/nodes/0/_state/_a1_Asserting_0.doc: Too many open files
  at org.apache.lucene.tests.mockfile.HandleLimitFS.onOpen(HandleLimitFS.java:67)
  at org.apache.lucene.tests.mockfile.HandleTrackingFS.callOpenHook(HandleTrackingFS.java:82)
  at org.apache.lucene.tests.mockfile.HandleTrackingFS.newOutputStream(HandleTrackingFS.java:163)
  at java.****/java.nio.file.Files.newOutputStream(Files.java:215)
```

This commit changes the random range from [10, 50] to be a fixed value of 3. This still gets the same coverage without unnecessarily increasing test runtime and introducing flakiness around file handle limits.

Resolves #20652

This flakiness was introduced by #20140

<img width="1063" height="425" alt="image" src="https://github.com/user-attachments/assets/2338d5b4-7f3d-4058-b53d-fe2526a7c936" />


### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
