### PR TITLE
added yaml rest integration test & document-indexing test

### DIFF
--- a/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -209,6 +209,7 @@ public class SearchAsYouTypeFieldMapper extends ParametrizedFieldMapper {
             prefixft.setIndexOptions(fieldType.indexOptions());
             prefixft.setOmitNorms(true);
             prefixft.setStored(false);
+            prefixft.setStoreTermVectors(false);
             final String fullName = buildFullName(context);
             // wrap the root field's index analyzer with shingles and edge ngrams
             final Analyzer prefixIndexWrapper = SearchAsYouTypeAnalyzer.withShingleAndPrefix(

--- a/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/opensearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
@@ -382,6 +382,10 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
             assertFalse(prefixFieldMapper.fieldType.storeTermVectorOffsets());
             assertFalse(prefixFieldMapper.fieldType.storeTermVectorPositions());
             assertFalse(prefixFieldMapper.fieldType.storeTermVectorPayloads());
+
+            // Verify that actually indexing a document does not throw an exception,
+            // i.e. the _index_prefix subfield does not illegally inherit term vector flags.
+            mapper.parse(source(b -> b.field("field", "test text")));
         }
     }
 

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/search-as-you-type/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/search-as-you-type/10_basic.yml
@@ -1240,3 +1240,27 @@ setup:
 
   - match: { hits.total: 1 }
   - match: { hits.hits.0._source.a_field: "quick brown fox jump lazy dog" }
+
+---
+"index document with term_vector on search_as_you_type field":
+
+  - do:
+      indices.create:
+        index: test-term-vector-index
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              my_field:
+                type: search_as_you_type
+                term_vector: with_positions_offsets
+
+  - do:
+      index:
+        index: test-term-vector-index
+        id: 1
+        body:
+          my_field: "hello world"
+
+  - match: { result: created }

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/search-as-you-type/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/search-as-you-type/10_basic.yml
@@ -1245,6 +1245,11 @@ setup:
 "index document with term_vector on search_as_you_type field":
 
   - do:
+      indices.delete:
+        index: test-term-vector-index
+        ignore_unavailable: true
+
+  - do:
       indices.create:
         index: test-term-vector-index
         body:


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
- The bugs for this issue are search_as_you_type creates three subfields:                                                                                                                                        - ._2gram, ._3gram (ShingleFieldMapper): should inherit term_vector                                                                                                                            - ._index_prefix (PrefixFieldMapper): must NOT get term_vector; the prefix index structure is incompatible with term vector storage
- When term_vector offsets/positions flags were set on the root field, the _index_prefix subfield's Lucene FieldType could end up with offsets/positions flags set but storeTermVectors = false, which is an illegal combination that Lucene rejects at indexing time with an exception.
- The fix for this bug is adding YAML REST integration test and document-indexing test (regression risk). And explicitly call prefixft.setStoreTermVectors(false) when constructing the prefix field's FieldType SearchAsYouTypeFieldMapper.Builder.build(). Although new FieldType() defaults to false, the explicit call guards against any future refactoring that might copy or propagate the root field's FieldType settings.
### Related Issues
Resolves #1901 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
