### PR TITLE
Fix _index field sort failing with range query error in ApproximateMatchAllQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Harden detection of HTTP/3 support by ensuring Quic native libraries are available for the target platform ([#20680](https://github.com/opensearch-project/OpenSearch/pull/20680))
 - Fallback to netty client if AWS Crt client is not available on the target platform / architecture ([#20698](https://github.com/opensearch-project/OpenSearch/pull/20698))
 - Fix ShardSearchFailure in transport-grpc ([#20641](https://github.com/opensearch-project/OpenSearch/pull/20641))
+- Fix `_index` field sort causing IllegalArgumentException in ApproximateMatchAllQuery ([#20628](https://github.com/opensearch-project/OpenSearch/issues/20628))
 
 ### Dependencies
 - Bump shadow-gradle-plugin from 8.3.9 to 9.3.1 ([#20569](https://github.com/opensearch-project/OpenSearch/pull/20569))

--- a/server/src/main/java/org/opensearch/search/approximate/ApproximateMatchAllQuery.java
+++ b/server/src/main/java/org/opensearch/search/approximate/ApproximateMatchAllQuery.java
@@ -11,6 +11,7 @@ package org.opensearch.search.approximate;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
+import org.opensearch.index.mapper.ConstantFieldType;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.sort.FieldSortBuilder;
@@ -52,6 +53,10 @@ public class ApproximateMatchAllQuery extends ApproximateQuery {
                 && !primarySortField.fieldName().equals(FieldSortBuilder.ID_FIELD_NAME)) {
                 MappedFieldType mappedFieldType = context.getQueryShardContext().fieldMapper(primarySortField.fieldName());
                 if (mappedFieldType == null) {
+                    return false;
+                }
+                // Constant field types (e.g., _index) do not support range queries
+                if (mappedFieldType instanceof ConstantFieldType) {
                     return false;
                 }
                 Query rangeQuery = mappedFieldType.rangeQuery(null, null, false, false, null, null, null, context.getQueryShardContext());

--- a/server/src/test/java/org/opensearch/search/approximate/ApproximateMatchAllQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/approximate/ApproximateMatchAllQueryTests.java
@@ -13,6 +13,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.NumberFieldMapper;
@@ -160,6 +161,59 @@ public class ApproximateMatchAllQueryTests extends OpenSearchTestCase {
 
         searchContext.trackTotalHitsUpTo(SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO);
         assertTrue("Should approximate when track_total_hits is not accurate", approximateMatchAllQuery.canApproximate(searchContext));
+    }
+
+    public void testCannotApproximateWithConstantFieldType() {
+        ApproximateMatchAllQuery approximateMatchAllQuery = new ApproximateMatchAllQuery();
+
+        ShardSearchRequest[] shardSearchRequest = new ShardSearchRequest[1];
+
+        MapperService mockMapper = mock(MapperService.class);
+        String indexField = IndexFieldMapper.NAME;
+        MappedFieldType indexFieldType = new IndexFieldMapper().fieldType();
+        when(mockMapper.fieldType(indexField)).thenReturn(indexFieldType);
+
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+            .build();
+        IndexMetadata indexMetadata = new IndexMetadata.Builder("index").settings(settings).build();
+        QueryShardContext queryShardContext = new QueryShardContext(
+            0,
+            new IndexSettings(indexMetadata, settings),
+            BigArrays.NON_RECYCLING_INSTANCE,
+            null,
+            null,
+            mockMapper,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        TestSearchContext searchContext = new TestSearchContext(queryShardContext) {
+            @Override
+            public ShardSearchRequest request() {
+                return shardSearchRequest[0];
+            }
+        };
+
+        SearchSourceBuilder source = new SearchSourceBuilder();
+        shardSearchRequest[0] = new ShardSearchRequest(null, System.currentTimeMillis(), null);
+        shardSearchRequest[0].source(source);
+        source.sort(indexField, SortOrder.ASC);
+
+        assertFalse(
+            "Should not approximate when sort field is a ConstantFieldType like _index",
+            approximateMatchAllQuery.canApproximate(searchContext)
+        );
     }
 
 }

--- a/server/src/test/java/org/opensearch/search/approximate/ApproximateMatchAllQueryTests.java
+++ b/server/src/test/java/org/opensearch/search/approximate/ApproximateMatchAllQueryTests.java
@@ -13,6 +13,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.mapper.ConstantFieldType;
 import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
@@ -212,6 +213,63 @@ public class ApproximateMatchAllQueryTests extends OpenSearchTestCase {
 
         assertFalse(
             "Should not approximate when sort field is a ConstantFieldType like _index",
+            approximateMatchAllQuery.canApproximate(searchContext)
+        );
+
+        // Verify that rewrite throws IllegalStateException since no approximation was set
+        assertThrows(IllegalStateException.class, () -> approximateMatchAllQuery.rewrite(null));
+    }
+
+    public void testCannotApproximateWithAnyConstantFieldType() {
+        ApproximateMatchAllQuery approximateMatchAllQuery = new ApproximateMatchAllQuery();
+
+        ShardSearchRequest[] shardSearchRequest = new ShardSearchRequest[1];
+
+        MapperService mockMapper = mock(MapperService.class);
+        String constantField = "my_constant_keyword";
+        ConstantFieldType mockConstantFieldType = mock(ConstantFieldType.class);
+        when(mockConstantFieldType.name()).thenReturn(constantField);
+        when(mockMapper.fieldType(constantField)).thenReturn(mockConstantFieldType);
+
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+            .build();
+        IndexMetadata indexMetadata = new IndexMetadata.Builder("index").settings(settings).build();
+        QueryShardContext queryShardContext = new QueryShardContext(
+            0,
+            new IndexSettings(indexMetadata, settings),
+            BigArrays.NON_RECYCLING_INSTANCE,
+            null,
+            null,
+            mockMapper,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        TestSearchContext searchContext = new TestSearchContext(queryShardContext) {
+            @Override
+            public ShardSearchRequest request() {
+                return shardSearchRequest[0];
+            }
+        };
+
+        SearchSourceBuilder source = new SearchSourceBuilder();
+        shardSearchRequest[0] = new ShardSearchRequest(null, System.currentTimeMillis(), null);
+        shardSearchRequest[0].source(source);
+        source.sort(constantField, SortOrder.ASC);
+
+        assertFalse(
+            "Should not approximate when sort field is any ConstantFieldType subclass",
             approximateMatchAllQuery.canApproximate(searchContext)
         );
     }


### PR DESCRIPTION
### Description

When sorting by the `_index` metadata field, `ApproximateMatchAllQuery.canApproximate()` attempts to call `rangeQuery()` on the field type to optimize match-all queries. However, `_index` is an `IndexFieldType` which extends `ConstantFieldType`, and `ConstantFieldType` does not override `rangeQuery()` — so it falls through to `MappedFieldType.rangeQuery()`, which throws:

```
IllegalArgumentException: Field [_index] of type [_index] does not support range queries
```

Previously, only `_doc` and `_id` were excluded by hardcoded field name checks. This fix adds an `instanceof ConstantFieldType` check before the `rangeQuery()` call, which is more robust as it covers all current and future `ConstantFieldType` subclasses (e.g., `_index`, `ConstantKeywordFieldType`).

### Related Issues

Resolves #20628

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using `--signoff`

### Testing

Added `testCannotApproximateWithConstantFieldType()` in `ApproximateMatchAllQueryTests` to verify that sorting by `_index` (a `ConstantFieldType`) correctly returns `false` from `canApproximate()` instead of throwing an exception.