### PR TITLE
Fix PartialAggregationOptimizer for multi-partition plans

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -97,9 +97,6 @@ ${error.file}
 # Allow jcmd to attach to the process (required for 'jcmd VM.native_memory' commands)
 -XX:+UnlockDiagnosticVMOptions
 
--agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006
-
-
 # Enabling debug logs for Allocators in Arrow
 -Darrow.memory.debug.allocator=true
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

- Fix PartialAggregationOptimizer for multi-partition plans by removing FinalPartion agg exec layer
- ~Use partial for all aggs - not just approx distinct to make the plan more simple and consistent for all aggs~ (Keeping back dc check for now)
- Dead code removal with changes
- Tested dc with/without other metrics, with/without group by fields, with/without aliases
- Tested above queries with partition values 1 and above

**Problem:**
With multi-partition setups, DataFusion generates a two-level aggregation plan:

```
ProjectionExec
  CoalescePartitionsExec
    FinalPartitioned AggregateExec    ← merges intermediate state → final values (this was problematic layer) 
      CoalesceBatchesExec
        RepartitionExec (Hash)
          RepartitionExec (RoundRobin)
            Partial AggregateExec     ← raw input → intermediate state
              DataSourceExec
```

The old optimizer converted the `FinalPartitioned` aggregate to `Partial` mode, creating two stacked `Partial` aggregates. The top one received intermediate state (e.g. HLL binary registers) from the bottom `Partial` and tried to interpret it as raw input → `Cast error: Casting from Binary to Int64 not supported`.

Single-partition plans worked because DataFusion skips the repartition/Final layer entirely.

**Fix:**
Instead of converting `FinalPartitioned` to `Partial`, simply remove the `FinalPartitioned` node and return its child. This preserves the repartition/coalesce layers for correct group-by locations while keeping the output in intermediate (partial) form. The Java side already handles merging partial results for all aggs.

Resulting plan:
```
ProjectionExec
  CoalescePartitionsExec
    CoalesceBatchesExec
      RepartitionExec (Hash)          ← preserved
        RepartitionExec (RoundRobin)  ← preserved
          Partial AggregateExec       ← preserved
            DataSourceExec
```

~Also generalized the optimizer to apply to all aggregation types (not just `approx_distinct`), since partial and single mode produce equivalent intermediate state for all aggregates, and the Java side merges all of them.~

---



Existing plan:

```
[DEBUG] Before: ProjectionExec: expr=[min(test-grab-index.common_passenger_id)@1 as min(common_passenger_id), auth.metadata.instance_id@0 as auth.metadata.instance_id, count(Int64(1))@2 as agg_for_doc_count]
  CoalescePartitionsExec: fetch=10000
    AggregateExec: mode=FinalPartitioned, gby=[auth.metadata.instance_id@0 as auth.metadata.instance_id], aggr=[min(test-grab-index.common_passenger_id), count(Int64(1))]
      CoalesceBatchesExec: target_batch_size=8192
        RepartitionExec: partitioning=Hash([auth.metadata.instance_id@0], 2), input_partitions=2
          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
            AggregateExec: mode=Partial, gby=[auth.metadata.instance_id@0 as auth.metadata.instance_id], aggr=[min(test-grab-index.common_passenger_id), count(Int64(1))]
              DataSourceExec: file_groups={1 group: [[Users/kusandes/workplace/opensearch/OpenSearch/build/testclusters/runTask-0/data/nodes/0/indices/JiZBefTzTj-Sh7378LfMFw/0/parquet/_parquet_file_generation_0.parquet]]}, projection=[auth.metadata.instance_id, common_passenger_id], file_type=parquet

[DEBUG] After: ProjectionExec: expr=[min(test-grab-index.common_passenger_id)@1 as min(common_passenger_id), auth.metadata.instance_id@0 as auth.metadata.instance_id, count(Int64(1))@2 as agg_for_doc_count]
  CoalescePartitionsExec: fetch=10000
    <Layer to be removed - start> 
    AggregateExec: mode=FinalPartitioned, gby=[auth.metadata.instance_id@0 as auth.metadata.instance_id], aggr=[min(test-grab-index.common_passenger_id), count(Int64(1))]
    <Layer to be removed - end>
      CoalesceBatchesExec: target_batch_size=8192
        RepartitionExec: partitioning=Hash([auth.metadata.instance_id@0], 2), input_partitions=2
          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1
            AggregateExec: mode=Partial, gby=[auth.metadata.instance_id@0 as auth.metadata.instance_id], aggr=[min(test-grab-index.common_passenger_id), count(Int64(1))]
              DataSourceExec: file_groups={1 group: [[Users/kusandes/workplace/opensearch/OpenSearch/build/testclusters/runTask-0/data/nodes/0/indices/JiZBefTzTj-Sh7378LfMFw/0/parquet/_parquet_file_generation_0.parquet]]}, projection=[auth.metadata.instance_id, common_passenger_id], file_type=parquet
 ```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
