### PR TITLE
Restore default SHARD_PATH_TYPE to FIXED for S3 snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Move Randomness from server to libs/common ([#20570](https://github.com/opensearch-project/OpenSearch/pull/20570))
 
 ### Fixed
+- Fix S3 snapshots being uploaded outside of configured base_path by reverting default shard_path_type to FIXED ([#20523](https://github.com/opensearch-project/OpenSearch/issues/20523), [#20643](https://github.com/opensearch-project/OpenSearch/issues/20643))
 - Fix flaky test failures in ShardsLimitAllocationDeciderIT ([#20375](https://github.com/opensearch-project/OpenSearch/pull/20375))
 - Prevent criteria update for context aware indices ([#20250](https://github.com/opensearch-project/OpenSearch/pull/20250))
 - Update EncryptedBlobContainer to adhere limits while listing blobs in specific sort order if wrapped blob container supports ([#20514](https://github.com/opensearch-project/OpenSearch/pull/20514))

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -418,7 +418,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
     public static final Setting<PathType> SHARD_PATH_TYPE = new Setting<>(
         "shard_path_type",
-        PathType.HASHED_PREFIX.toString(),
+        PathType.FIXED.toString(),
         PathType::parseString
     );
 


### PR DESCRIPTION
### Description
This PR restores the default value of the `shard_path_type` setting from `HASHED_PREFIX` back to `FIXED` in `BlobStoreRepository`.

Starting from OpenSearch 3.2.0, `HASHED_PREFIX` became the default path strategy for snapshot repositories. While this provides performance benefits on S3 by distributing object prefixes, it has a side effect: the hash is prepended to the entire object path, causing data to be stored outside of the user-configured `base_path`. 

This change resolves critical issues reported in #20523 and #20643:
1. **Security/Permissions**: Many users restrict S3 IAM policies to the specific `base_path`. Writing outside this path results in `Access Denied` errors.
2. **Migration Consistency**: Users upgrading from previous versions expect their repository structure to remain within the same root directory.
3. **Predictability**: Reverting to `FIXED` as the default ensures all snapshot data stays within the `base_path` by default, while still allowing users to explicitly opt-in to `HASHED_PREFIX` if desired.

### Related Issues
Resolves #20523
Resolves #20643

### Check List
- [x] Functionality includes testing. (Verified via `BlobStoreRepositoryTests` and `SnapshotShardPathsTests`)
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).