### PR TITLE
Remove affiliation column for emeritus maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -44,16 +44,16 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Emeritus
 
-| Maintainer               | GitHub ID                                   | Affiliation |
-| ------------------------ | ------------------------------------------- | ----------- |
-| Megha Sai Kavikondala    | [meghasaik](https://github.com/meghasaik)   | Amazon      |
-| Xue Zhou                 | [xuezhou25](https://github.com/xuezhou25)   | Amazon      |
-| Kartik Ganesh            | [kartg](https://github.com/kartg)           | Amazon      |
-| Abbas Hussain            | [abbashus](https://github.com/abbashus)     | Meta        |
-| Himanshu Setia           | [setiah](https://github.com/setiah)         | Amazon      |
-| Ryan Bogan               | [ryanbogan](https://github.com/ryanbogan)   | Amazon      |
-| Rabi Panda               | [adnapibar](https://github.com/adnapibar)   | Independent |
-| Tianli Feng              | [tlfeng](https://github.com/tlfeng)         | Amazon      |
-| Suraj Singh              | [dreamer-89](https://github.com/dreamer-89) | Amazon      |
-| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)         | Independent |
-| Vacha Shah               | [VachaShah](https://github.com/VachaShah)   | Independent |
+| Maintainer               | GitHub ID                                   |
+| ------------------------ | ------------------------------------------- |
+| Megha Sai Kavikondala    | [meghasaik](https://github.com/meghasaik)   |
+| Xue Zhou                 | [xuezhou25](https://github.com/xuezhou25)   |
+| Kartik Ganesh            | [kartg](https://github.com/kartg)           |
+| Abbas Hussain            | [abbashus](https://github.com/abbashus)     |
+| Himanshu Setia           | [setiah](https://github.com/setiah)         |
+| Ryan Bogan               | [ryanbogan](https://github.com/ryanbogan)   |
+| Rabi Panda               | [adnapibar](https://github.com/adnapibar)   |
+| Tianli Feng              | [tlfeng](https://github.com/tlfeng)         |
+| Suraj Singh              | [dreamer-89](https://github.com/dreamer-89) |
+| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)         |
+| Vacha Shah               | [VachaShah](https://github.com/VachaShah)   |


### PR DESCRIPTION
Emeritus maintainers are not active in the project, therefore I don't see a lot of value in tracking their affiliation.

This list is definitely out of date. It's not clear to me if it should be the user's current affiliation or their affiliation when they were active in the project. Either way it seems better to me to just remove it. Please let me know if anyone disagrees.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
