### PR TITLE
Fix flaky slowlog test

### DIFF
--- a/server/src/test/java/org/opensearch/action/search/SearchRequestSlowLogTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestSlowLogTests.java
@@ -88,27 +88,25 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
 
     public void testMultipleSlowLoggersUseSingleLog4jLogger() {
         LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        String loggerName = SearchRequestSlowLog.CLUSTER_SEARCH_REQUEST_SLOWLOG_PREFIX + ".SearchRequestSlowLog";
 
-        new MockSearchPhaseContext(1);
         ClusterService clusterService1 = ClusterServiceUtils.createClusterService(
             Settings.EMPTY,
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
             null
         );
         new SearchRequestSlowLog(clusterService1);
-        int numberOfLoggersBefore = context.getLoggers().size();
+        Logger logger1 = context.getLogger(loggerName);
 
-        new MockSearchPhaseContext(1);
         ClusterService clusterService2 = ClusterServiceUtils.createClusterService(
             Settings.EMPTY,
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
             null
         );
-        new SearchRequestOperationsCompositeListenerFactory();
         new SearchRequestSlowLog(clusterService2);
+        Logger logger2 = context.getLogger(loggerName);
 
-        int numberOfLoggersAfter = context.getLoggers().size();
-        assertThat(numberOfLoggersAfter, equalTo(numberOfLoggersBefore));
+        assertSame(logger1, logger2);
     }
 
     public void testOnRequestEnd() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The `testMultipleSlowLoggersUseSingleLog4jLogger` test was flaky because it compared total logger counts in the LoggerContext before and after creating SearchRequestSlowLog instances. Other code paths (ClusterService creation, test framework, parallel tests) could register additional loggers between measurements, causing intermittent failures.

Fixed by directly verifying the same logger instance is reused via assertSame(logger1, logger2) instead of counting total loggers.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/20665

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
