### PR TITLE
Mock correct method in SegmentReplicationTargetServiceTests

### DIFF
--- a/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
+++ b/server/src/test/java/org/opensearch/indices/replication/SegmentReplicationTargetServiceTests.java
@@ -673,8 +673,8 @@ public class SegmentReplicationTargetServiceTests extends IndexShardTestCase {
 
     public void testProcessLatestCheckpointIfCheckpointAhead() {
         SegmentReplicationTargetService service = spy(sut);
-        doNothing().when(service).startReplication(any());
         doReturn(mock(SegmentReplicationTarget.class)).when(service).startReplication(any(), any(), any());
+        doReturn(mock(SegmentReplicationTarget.class)).when(service).startReplication(any(), any(), anyBoolean(), any());
         service.updateLatestReceivedCheckpoint(aheadCheckpoint, replicaShard);
         service.processLatestReceivedCheckpoint(replicaShard, null);
         verify(service, times(1)).startReplication(eq(replicaShard), eq(aheadCheckpoint), anyBoolean(), any());


### PR DESCRIPTION
The test was mocking the wrong overload of startReplication(), which caused the real method to be invoke and would result in a failure + retry. The test assertion would then be racing with the retry and fail if the retry invoked startReplication() a second time.

Resolves #15829

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
