### PR TITLE
Remove flaky assertion in FullClusterRestartIT.testRecovery

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/opensearch/upgrades/FullClusterRestartIT.java
@@ -793,7 +793,6 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
                 }
                 assertNotEquals("expected at least 1 current segment after translog recovery. segments:\n" + segmentsResponse,
                     0, numCurrentVersion);
-                assertNotEquals("expected at least 1 old segment. segments:\n" + segmentsResponse, 0, numBwcVersion);
             }
         }
     }


### PR DESCRIPTION
The test asserts that after a full cluster restart upgrade, at least one old version Lucene segment must still exist on the primary. This is not guaranteed because background merges can merge all old version segments into new segments before the assertion runs.

The remaining assertions still validate that translog replay occurred and produced at least one new-version segment on the primary.

### Related Issues
Resolves #15813


### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
