### PR TITLE
Fix segment replication checkpoint not published after engine reset

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -795,6 +795,14 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     if (currentRouting.initializing() && currentRouting.isRelocationTarget() == false && newRouting.active()) {
                         // the cluster-manager started a recovering primary, activate primary mode.
                         replicationTracker.activatePrimaryMode(getLocalCheckpoint());
+                        if (indexSettings.isSegRepLocalEnabled() && this.checkpointPublisher != null) {
+                            // Force publish checkpoint so replicas catch up to segments that existed before
+                            // the node restart. Without this, the internal refresh during engine construction
+                            // may have already opened the latest reader, causing subsequent external refreshes
+                            // to see no change and never trigger CheckpointRefreshListener.
+                            updateReplicationCheckpoint();
+                            checkpointPublisher.publish(this, getLatestReplicationCheckpoint());
+                        }
                         postActivatePrimaryMode();
                     }
                 } else {
@@ -2291,6 +2299,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      */
     public void resetToWriteableEngine() throws IOException, InterruptedException, TimeoutException {
         indexShardOperationPermits.blockOperations(30, TimeUnit.MINUTES, () -> { resetEngineToGlobalCheckpoint(); });
+        // Force update and publish checkpoint so replicas learn about segments that existed
+        // before the engine reset. See resetEngineToGlobalCheckpoint() in updateShardState()
+        // promotion path for the same pattern.
+        updateReplicationCheckpoint();
     }
 
     public MergedSegmentTransferTracker mergedSegmentTransferTracker() {


### PR DESCRIPTION
When a primary shard's engine is created or reset, the InternalEngine constructor performs an internal-only refresh during restoreVersionMapAndCheckpointTracker. This updates the local replication checkpoint via ReplicationCheckpointUpdater (an internal refresh listener), but does not trigger CheckpointRefreshListener (an external refresh listener) which is responsible for publishing the checkpoint to replicas.

If no new writes arrive after the engine starts, the external reader manager never observes a reader change, didRefresh remains false, and the checkpoint is never published. Replicas believe they are current and never request the missing segments, leaving them permanently stale.

The promotion path in updateShardState already handled this correctly with an explicit updateReplicationCheckpoint() and checkpointPublisher.publish() call after engine reset. Two other paths were missing the same fix:

1. Primary recovery after node restart (initializing -> active with same primary term): activatePrimaryMode() was called without publishing the checkpoint. This is the path hit during rolling upgrades.

2. resetToWriteableEngine() (relocation handoff): called resetEngineToGlobalCheckpoint() without updating or publishing the checkpoint afterward.

### Related Issues
Resolves #14302

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
