### PR TITLE
Include FIPS build param in maven snapshots publication

### DIFF
--- a/.github/workflows/publish-maven-snapshots.yml
+++ b/.github/workflows/publish-maven-snapshots.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Publish snapshots to maven
         run: |
-          ./gradlew publishNebulaPublicationToSnapshotsRepository
+          ./gradlew publishNebulaPublicationToSnapshotsRepository -Pcrypto.standard=FIPS-140-3


### PR DESCRIPTION
### Description

Resolves issues seen in plugins that use the `INTEG_TEST` test distribution for running testclusters. `INTEG_TEST` will pull the artifacts from maven and they need to be published with the FIPS build param to match min distribution.

```
testClusters.integTest {
    testDistribution = 'INTEG_TEST'

    ...
}
```

### Related Issues

Fixes: https://github.com/opensearch-project/job-scheduler/actions/runs/22586152793/job/65431513056?pr=887

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
