### PR TITLE
[Backport 2.19] Bump shadow-gradle-plugin from 8.1.1 to 8.3.10 (#20569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Dependencies
 - Bump `log4j` from 2.21.0 to 2.25.3 ([#20308](https://github.com/opensearch-project/OpenSearch/pull/20308))
 - Bump netty from 4.1.25.Final to 4.1.31.Final ([#20744](https://github.com/opensearch-project/OpenSearch/pull/20744))
+- Bump shadow-gradle-plugin from 8.1.1 to 8.3.10 ([#20569](https://github.com/opensearch-project/OpenSearch/pull/20569))
 
 ### Deprecated
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -110,7 +110,7 @@ dependencies {
   api 'org.apache.rat:apache-rat:0.15'
   api "commons-io:commons-io:${props.getProperty('commonsio')}"
   api "net.java.dev.jna:jna:5.14.0"
-  api 'com.github.johnrengelman:shadow:8.1.1'
+  api 'com.gradleup.shadow:shadow-gradle-plugin:8.3.10'
   api 'org.jdom:jdom2:2.0.6.1'
   api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${props.getProperty('kotlin')}"
   api 'de.thetaphi:forbiddenapis:3.8'

--- a/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/PublishPlugin.java
@@ -33,7 +33,6 @@
 package org.opensearch.gradle;
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin;
-import com.github.jengelman.gradle.plugins.shadow.ShadowExtension;
 import groovy.util.Node;
 import groovy.util.NodeList;
 
@@ -103,8 +102,7 @@ public class PublishPlugin implements Plugin<Project> {
 
         project.getPluginManager().withPlugin("com.github.johnrengelman.shadow", plugin -> {
             MavenPublication publication = publishing.getPublications().maybeCreate("shadow", MavenPublication.class);
-            ShadowExtension shadow = project.getExtensions().getByType(ShadowExtension.class);
-            shadow.component(publication);
+            publication.from(project.getComponents().getByName("shadow"));
             // Workaround for https://github.com/johnrengelman/shadow/issues/334
             // Here we manually add any project dependencies in the "shadow" configuration to our generated POM
             publication.getPom().withXml(xml -> {


### PR DESCRIPTION
(cherry picked from commit 6b557db18f43399491f22b8391ff2ba2f29936fc)

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
