### PR TITLE
[2.19] Bulk update of HDFS test fixture dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `log4j` from 2.21.0 to 2.25.3 ([#20308](https://github.com/opensearch-project/OpenSearch/pull/20308))
 - Bump netty from 4.1.25.Final to 4.1.31.Final ([#20744](https://github.com/opensearch-project/OpenSearch/pull/20744))
 - Bump shadow-gradle-plugin from 8.1.1 to 8.3.10 ([#20569](https://github.com/opensearch-project/OpenSearch/pull/20569))
+- Update HDFS test fixture dependencies ([#20768](https://github.com/opensearch-project/OpenSearch/pull/20768))
 
 ### Deprecated
 

--- a/test/fixtures/hdfs-fixture/build.gradle
+++ b/test/fixtures/hdfs-fixture/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     exclude module: 'jettison'
     exclude module: 'netty'
     exclude module: 'guava'
+    exclude module: 'protobuf-java'
     exclude group: 'org.codehaus.jackson'
     exclude group: "org.bouncycastle"
     exclude group: "com.squareup.okhttp3"
@@ -57,40 +58,41 @@ dependencies {
     exclude module: "org.eclipse.jetty"
     exclude group: "commons-lang"
     exclude group: "org.jsonschema2pojo"
+    exclude group: "com.microsoft.sqlserver"
   }
-  api "dnsjava:dnsjava:3.6.2"
+  api "dnsjava:dnsjava:3.6.4"
   api "org.codehaus.jettison:jettison:${versions.jettison}"
   api "org.apache.commons:commons-compress:${versions.commonscompress}"
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
   api "io.netty:netty-all:${versions.netty}"
-  api 'com.google.code.gson:gson:2.11.0'
+  api "com.google.code.gson:gson:2.13.2"
   api "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:${versions.jackson}"
   api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
   api "com.fasterxml.woodstox:woodstox-core:${versions.woodstox}"
   api "net.minidev:json-smart:${versions.json_smart}"
   api "org.mockito:mockito-core:${versions.mockito}"
-  api "com.google.protobuf:protobuf-java:3.22.2"
+  api "com.google.protobuf:protobuf-java:${versions.protobuf}"
   api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
   api "org.eclipse.jetty:jetty-server:${versions.jetty}"
   api "org.eclipse.jetty.websocket:javax-websocket-server-impl:${versions.jetty}"
-  api 'org.apache.zookeeper:zookeeper:3.9.3'
-  api "org.apache.commons:commons-text:1.13.0"
-  api "commons-net:commons-net:3.11.1"
-  api "ch.qos.logback:logback-core:1.5.16"
-  api "ch.qos.logback:logback-classic:1.5.15"
-  api "org.jboss.xnio:xnio-nio:3.8.16.Final"
-  api 'org.jline:jline:3.28.0'
-  api 'org.apache.commons:commons-configuration2:2.11.0'
-  api 'com.nimbusds:nimbus-jose-jwt:10.3'
-  api ('org.apache.kerby:kerb-admin:2.1.0') {
+  api 'org.apache.zookeeper:zookeeper:3.9.4'
+  api "org.apache.commons:commons-text:1.15.0"
+  api "commons-net:commons-net:3.12.0"
+  api "ch.qos.logback:logback-core:1.5.27"
+  api "ch.qos.logback:logback-classic:1.5.27"
+  api "org.jboss.xnio:xnio-nio:3.8.17.Final"
+  api 'org.jline:jline:3.30.6'
+  api 'org.apache.commons:commons-configuration2:2.13.0'
+  api 'com.nimbusds:nimbus-jose-jwt:10.8'
+  api ('org.apache.kerby:kerb-admin:2.1.1') {
     exclude group: "org.jboss.xnio"
     exclude group: "org.jline"
   }
   runtimeOnly "com.google.guava:guava:${versions.guava}"
-  runtimeOnly("com.squareup.okhttp3:okhttp:4.12.0") {
+  runtimeOnly("com.squareup.okhttp3:okhttp:5.3.2") {
     exclude group: "com.squareup.okio"
   }
-  runtimeOnly "com.squareup.okio:okio:3.10.2"
-  runtimeOnly "org.xerial.snappy:snappy-java:1.1.10.7"
+  runtimeOnly "com.squareup.okio:okio:3.16.4"
+  runtimeOnly "org.xerial.snappy:snappy-java:1.1.10.8"
 }


### PR DESCRIPTION
This commit brings the HDFS test fixture dependencies up to parity with what exists on the main branch.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
