### PR TITLE
Fix allowed_warnings placement in system ingest processor YAML test

### DIFF
--- a/plugins/examples/system-ingest-processor/src/yamlRestTest/resources/rest-api-spec/test/example-system-ingest-processor/20_system_ingest_processor.yml
+++ b/plugins/examples/system-ingest-processor/src/yamlRestTest/resources/rest-api-spec/test/example-system-ingest-processor/20_system_ingest_processor.yml
@@ -111,6 +111,8 @@ teardown:
   - skip:
       features: allowed_warnings
   - do:
+      allowed_warnings:
+        - "index template [example-template] has index patterns [template-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [example-template] will take precedence during new index creation"
       # test v2 template
       indices.put_index_template:
         name: example-template
@@ -120,8 +122,6 @@ teardown:
             settings:
               index.example_system_ingest_processor_plugin.trigger_setting: true
   - do:
-      allowed_warnings:
-        - "index [template-index-1] matches multiple legacy templates [example-template, global], composable templates will only match a single template"
       index:
         index: template-index-1
         id: 1


### PR DESCRIPTION
The v2 index template test had allowed_warnings on the document index step, but the warning about overlapping template patterns is emitted during put_index_template for v2 composable templates, not at index time. Move allowed_warnings to the correct step with the actual warning message returned by the server.

### Related Issues
Resolves #18484

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
