### PR TITLE
BUG: Fix NullPointerException in gRPC search response marshalling for…

### DIFF
--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/response/search/SearchHitsProtoUtils.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/proto/response/search/SearchHitsProtoUtils.java
@@ -69,14 +69,18 @@ public class SearchHitsProtoUtils {
     private static void processTotalHits(SearchHits hits, org.opensearch.protobufs.HitsMetadata.Builder hitsMetaData) {
         org.opensearch.protobufs.HitsMetadataTotal.Builder totalBuilder = org.opensearch.protobufs.HitsMetadataTotal.newBuilder();
 
+        if (hits.getTotalHits() == null) {
+            hitsMetaData.setTotal(totalBuilder.build());
+            return;
+        }
+
         // TODO need to pass parameters
         // boolean totalHitAsInt = params.paramAsBoolean(RestSearchAction.TOTAL_HITS_AS_INT_PARAM, false);
         boolean totalHitAsInt = false;
 
         if (totalHitAsInt) {
-            long total = hits.getTotalHits() == null ? -1 : hits.getTotalHits().value();
-            totalBuilder.setInt64(total);
-        } else if (hits.getTotalHits() != null) {
+            totalBuilder.setInt64(hits.getTotalHits().value());
+        } else {
             org.opensearch.protobufs.TotalHits.Builder totalHitsBuilder = org.opensearch.protobufs.TotalHits.newBuilder();
             totalHitsBuilder.setValue(hits.getTotalHits().value());
 


### PR DESCRIPTION
Description
This PR addresses a NullPointerException that occurs during gRPC search response marshalling when the totalHits field in the SearchResponse is null. This scenario happens when a search request is made with the track_total_hits parameter set to false.

The fix introduces a null check at the beginning of the processTotalHits method in [SearchHitsProtoUtils.java](code-assist-path:c:\Users\admin\OpenSearch\modules\transport-grpc\src\main\java\org\opensearch\transport\grpc\proto\response\search\SearchHitsProtoUtils.java). If hits.getTotalHits() is null, the method now correctly handles it by setting an empty total field in the protobuf message and returning early, thus preventing the NullPointerException.

Related Issues
Related to #20766
