### PR TITLE
[2.19] Force resolution to plexus-utils:3.5.1

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -111,6 +111,12 @@ dependencies {
   api "commons-io:commons-io:${props.getProperty('commonsio')}"
   api "net.java.dev.jna:jna:5.14.0"
   api 'com.gradleup.shadow:shadow-gradle-plugin:8.3.10'
+  constraints {
+    api('org.codehaus.plexus:plexus-utils') {
+      version { strictly '3.5.1' }
+      because 'plexus-utils 4.x is incompatible with Java 11'
+    }
+  }
   api 'org.jdom:jdom2:2.0.6.1'
   api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${props.getProperty('kotlin')}"
   api 'de.thetaphi:forbiddenapis:3.8'


### PR DESCRIPTION
The newer versions of plexus-utils are not compatible with Java 11.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
