### PR TITLE
Show heap percent threshold in cancellation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fallback to netty client if AWS Crt client is not available on the target platform / architecture ([#20698](https://github.com/opensearch-project/OpenSearch/pull/20698))
 - Fix ShardSearchFailure in transport-grpc ([#20641](https://github.com/opensearch-project/OpenSearch/pull/20641))
 - Fix TLS cert hot-reload for Arrow Flight transport ([#20732](https://github.com/opensearch-project/OpenSearch/pull/20732))
+- Fix misleading heap usage cancellation message in SearchBackpressureService ([#20779](https://github.com/opensearch-project/OpenSearch/pull/20779))
 
 ### Dependencies
 - Bump shadow-gradle-plugin from 8.3.9 to 9.3.1 ([#20569](https://github.com/opensearch-project/OpenSearch/pull/20569))

--- a/server/src/main/java/org/opensearch/search/backpressure/trackers/HeapUsageTracker.java
+++ b/server/src/main/java/org/opensearch/search/backpressure/trackers/HeapUsageTracker.java
@@ -84,11 +84,7 @@ public class HeapUsageTracker extends TaskResourceUsageTracker {
 
             return Optional.of(
                 new TaskCancellation.Reason(
-                    "heap usage exceeded ["
-                        + new ByteSizeValue((long) currentUsage)
-                        + " >= "
-                        + new ByteSizeValue((long) allowedUsage)
-                        + "]",
+                    "heap usage exceeded [" + new ByteSizeValue((long) currentUsage) + " >= " + new ByteSizeValue((long) threshold) + "]",
                     (int) (currentUsage / averageUsage)  // TODO: fine-tune the cancellation score/weight
                 )
             );

--- a/server/src/test/java/org/opensearch/search/backpressure/trackers/HeapUsageTrackerTests.java
+++ b/server/src/test/java/org/opensearch/search/backpressure/trackers/HeapUsageTrackerTests.java
@@ -70,7 +70,7 @@ public class HeapUsageTrackerTests extends OpenSearchTestCase {
         Optional<TaskCancellation.Reason> reason = tracker.checkAndMaybeGetCancellationReason(task);
         assertTrue(reason.isPresent());
         assertEquals(6, reason.get().getCancellationScore());
-        assertEquals("heap usage exceeded [300b >= 150b]", reason.get().getMessage());
+        assertEquals("heap usage exceeded [300b >= 0b]", reason.get().getMessage());
     }
 
     public void testSearchShardTaskEligibleForCancellation() {
@@ -100,7 +100,7 @@ public class HeapUsageTrackerTests extends OpenSearchTestCase {
         Optional<TaskCancellation.Reason> reason = tracker.checkAndMaybeGetCancellationReason(task);
         assertTrue(reason.isPresent());
         assertEquals(4, reason.get().getCancellationScore());
-        assertEquals("heap usage exceeded [200b >= 100b]", reason.get().getMessage());
+        assertEquals("heap usage exceeded [200b >= 0b]", reason.get().getMessage());
     }
 
     public void testNotEligibleForCancellation() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Fixes the confusing cancellation message in `HeapUsageTracker` reported
in #17947. The message previously showed the moving-average-based
`allowedUsage` value, which could be extremely small (hundreds of KB)
when historical tasks were lightweight. This made log messages like
`heap usage exceeded [3.4gb >= 800.5kb]` nonsensical to operators.

The cancellation condition requires both `currentUsage >= threshold`
(heap percent) and `currentUsage >= allowedUsage` (moving avg * variance)
to be true. The heap percent threshold is the more meaningful and
accurate threshold to display.

Before: `heap usage exceeded [3.4gb >= 800.5kb]`
After:  `heap usage exceeded [3.4gb >= 150mb]`

### Related Issues
Resolves #17947

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
