### PR TITLE
Fix sum aggregation to return null instead of 0 when all docs have null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Move pull-based ingestion classes from experimental to publicAPI ([#20704](https://github.com/opensearch-project/OpenSearch/pull/20704))
 
 ### Fixed
+- Fix sum aggregation to return `"value": null` instead of `"value": 0.0` when all documents have null/missing field values ([#17581](https://github.com/opensearch-project/OpenSearch/pull/17581))
 - Fix flaky test failures in ShardsLimitAllocationDeciderIT ([#20375](https://github.com/opensearch-project/OpenSearch/pull/20375))
 - Prevent criteria update for context aware indices ([#20250](https://github.com/opensearch-project/OpenSearch/pull/20250))
 - Update EncryptedBlobContainer to adhere limits while listing blobs in specific sort order if wrapped blob container supports ([#20514](https://github.com/opensearch-project/OpenSearch/pull/20514))

--- a/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/SumIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/aggregations/metrics/SumIT.java
@@ -43,6 +43,7 @@ import org.opensearch.search.aggregations.bucket.filter.Filter;
 import org.opensearch.search.aggregations.bucket.global.Global;
 import org.opensearch.search.aggregations.bucket.histogram.Histogram;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
+import org.opensearch.search.aggregations.support.AggregationInspectionHelper;
 import org.hamcrest.core.IsNull;
 
 import java.util.ArrayList;
@@ -364,6 +365,33 @@ public class SumIT extends AbstractNumericTestCase {
             equalTo(2L)
         );
         internalCluster().wipeIndices("cache_test_idx");
+    }
+
+    public void testAllNullFieldValues() throws Exception {
+        String indexName = "test_null_sum_idx";
+        assertAcked(prepareCreate(indexName).setMapping("value", "type=long"));
+
+        indexRandom(
+            true,
+            client().prepareIndex(indexName).setSource("other_field", 1),
+            client().prepareIndex(indexName).setSource("other_field", 2),
+            client().prepareIndex(indexName).setSource("other_field", 3)
+        );
+
+        SearchResponse response = client().prepareSearch(indexName)
+            .setQuery(matchAllQuery())
+            .addAggregation(sum("sum").field("value"))
+            .get();
+
+        assertHitCount(response, 3);
+
+        Sum sum = response.getAggregations().get("sum");
+        assertThat(sum, notNullValue());
+        assertThat(sum.getName(), equalTo("sum"));
+        assertThat(sum.getValue(), equalTo(0.0));
+        assertFalse(AggregationInspectionHelper.hasValue((InternalSum) sum));
+
+        internalCluster().wipeIndices(indexName);
     }
 
     public void testFieldAlias() {

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalStats.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalStats.java
@@ -235,7 +235,7 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
             builder.nullField(Fields.MIN);
             builder.nullField(Fields.MAX);
             builder.nullField(Fields.AVG);
-            builder.field(Fields.SUM, 0.0d);
+            builder.nullField(Fields.SUM);
         }
         otherStatsToXContent(builder, params);
         return builder;

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalSum.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/InternalSum.java
@@ -31,6 +31,7 @@
 
 package org.opensearch.search.aggregations.metrics;
 
+import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -49,10 +50,12 @@ import java.util.Objects;
  */
 public class InternalSum extends InternalNumericMetricsAggregation.SingleValue implements Sum {
     private final double sum;
+    private final long count;
 
-    public InternalSum(String name, double sum, DocValueFormat formatter, Map<String, Object> metadata) {
+    public InternalSum(String name, double sum, long count, DocValueFormat formatter, Map<String, Object> metadata) {
         super(name, metadata);
         this.sum = sum;
+        this.count = count;
         this.format = formatter;
     }
 
@@ -63,12 +66,23 @@ public class InternalSum extends InternalNumericMetricsAggregation.SingleValue i
         super(in);
         format = in.readNamedWriteable(DocValueFormat.class);
         sum = in.readDouble();
+        if (in.getVersion().onOrAfter(Version.V_3_6_0)) {
+            count = in.readVLong();
+        } else {
+            // Legacy nodes do not send count; default to 1 so that the sum
+            // is always rendered as a numeric value during mixed-version reduce,
+            // preserving the old behaviour until all nodes are upgraded.
+            count = 1;
+        }
     }
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeNamedWriteable(format);
         out.writeDouble(sum);
+        if (out.getVersion().onOrAfter(Version.V_3_6_0)) {
+            out.writeVLong(count);
+        }
     }
 
     @Override
@@ -86,30 +100,40 @@ public class InternalSum extends InternalNumericMetricsAggregation.SingleValue i
         return sum;
     }
 
+    public long getCount() {
+        return count;
+    }
+
     @Override
     public InternalSum reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
         // Compute the sum of double values with Kahan summation algorithm which is more
         // accurate than naive summation.
         CompensatedSum kahanSummation = new CompensatedSum(0, 0);
+        long count = 0;
         for (InternalAggregation aggregation : aggregations) {
-            double value = ((InternalSum) aggregation).sum;
-            kahanSummation.add(value);
+            InternalSum sum = (InternalSum) aggregation;
+            count += sum.count;
+            kahanSummation.add(sum.sum);
         }
-        return new InternalSum(name, kahanSummation.value(), format, getMetadata());
+        return new InternalSum(name, kahanSummation.value(), count, format, getMetadata());
     }
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
-        builder.field(CommonFields.VALUE.getPreferredName(), sum);
-        if (format != DocValueFormat.RAW) {
-            builder.field(CommonFields.VALUE_AS_STRING.getPreferredName(), format.format(sum).toString());
+        if (count != 0) {
+            builder.field(CommonFields.VALUE.getPreferredName(), sum);
+            if (format != DocValueFormat.RAW) {
+                builder.field(CommonFields.VALUE_AS_STRING.getPreferredName(), format.format(sum).toString());
+            }
+        } else {
+            builder.nullField(CommonFields.VALUE.getPreferredName());
         }
         return builder;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), sum);
+        return Objects.hash(super.hashCode(), sum, count);
     }
 
     @Override
@@ -119,6 +143,6 @@ public class InternalSum extends InternalNumericMetricsAggregation.SingleValue i
         if (super.equals(obj) == false) return false;
 
         InternalSum that = (InternalSum) obj;
-        return Objects.equals(sum, that.sum);
+        return Objects.equals(sum, that.sum) && count == that.count;
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/ParsedStats.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/ParsedStats.java
@@ -127,7 +127,7 @@ public class ParsedStats extends ParsedAggregation implements Stats {
             builder.nullField(Fields.MIN);
             builder.nullField(Fields.MAX);
             builder.nullField(Fields.AVG);
-            builder.field(Fields.SUM, 0.0d);
+            builder.nullField(Fields.SUM);
         }
         otherStatsToXContent(builder, params);
         return builder;

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/ParsedSum.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/ParsedSum.java
@@ -45,6 +45,8 @@ import java.io.IOException;
  */
 public class ParsedSum extends ParsedSingleValueNumericMetricsAggregation implements Sum {
 
+    private boolean hasValue = true;
+
     @Override
     public double getValue() {
         return value();
@@ -57,8 +59,8 @@ public class ParsedSum extends ParsedSingleValueNumericMetricsAggregation implem
 
     @Override
     protected XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
-        builder.field(CommonFields.VALUE.getPreferredName(), value);
-        if (valueAsString != null) {
+        builder.field(CommonFields.VALUE.getPreferredName(), hasValue ? value : null);
+        if (hasValue && valueAsString != null) {
             builder.field(CommonFields.VALUE_AS_STRING.getPreferredName(), valueAsString);
         }
         return builder;
@@ -67,7 +69,26 @@ public class ParsedSum extends ParsedSingleValueNumericMetricsAggregation implem
     private static final ObjectParser<ParsedSum, Void> PARSER = new ObjectParser<>(ParsedSum.class.getSimpleName(), true, ParsedSum::new);
 
     static {
-        declareSingleValueFields(PARSER, Double.NEGATIVE_INFINITY);
+        // Unlike sibling Parsed* classes, we cannot use declareSingleValueFields() here.
+        // That helper uses a sentinel double (e.g. POSITIVE_INFINITY) to represent null,
+        // but POSITIVE_INFINITY is a legitimate sum result (e.g. summing Double.MAX_VALUE
+        // values). We need a custom parser that tracks null via a boolean flag instead.
+        declareAggregationFields(PARSER);
+        PARSER.declareField((agg, val) -> {
+            if (val == null) {
+                agg.hasValue = false;
+                agg.value = Double.POSITIVE_INFINITY;
+            } else {
+                agg.hasValue = true;
+                agg.value = val;
+            }
+        }, (parser, context) -> {
+            if (parser.currentToken() == XContentParser.Token.VALUE_NUMBER || parser.currentToken() == XContentParser.Token.VALUE_STRING) {
+                return parser.doubleValue();
+            }
+            return null;
+        }, CommonFields.VALUE, ObjectParser.ValueType.DOUBLE_OR_NULL);
+        PARSER.declareString(ParsedSingleValueNumericMetricsAggregation::setValueAsString, CommonFields.VALUE_AS_STRING);
     }
 
     public static ParsedSum fromXContent(XContentParser parser, final String name) {

--- a/server/src/main/java/org/opensearch/search/aggregations/metrics/SumAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/metrics/SumAggregator.java
@@ -32,14 +32,20 @@
 package org.opensearch.search.aggregations.metrics;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.DocIdStream;
 import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.NumericUtils;
 import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.common.util.DoubleArray;
+import org.opensearch.common.util.LongArray;
 import org.opensearch.index.codec.composite.CompositeIndexFieldInfo;
 import org.opensearch.index.compositeindex.datacube.MetricStat;
+import org.opensearch.index.compositeindex.datacube.startree.index.StarTreeValues;
+import org.opensearch.index.compositeindex.datacube.startree.utils.StarTreeUtils;
+import org.opensearch.index.compositeindex.datacube.startree.utils.iterator.SortedNumericStarTreeValuesIterator;
 import org.opensearch.index.fielddata.SortedNumericDoubleValues;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.Aggregator;
@@ -56,6 +62,7 @@ import org.opensearch.search.startree.StarTreeQueryHelper;
 import java.io.IOException;
 import java.util.Map;
 
+import static org.opensearch.search.startree.StarTreeQueryHelper.getStarTreeFilteredValues;
 import static org.opensearch.search.startree.StarTreeQueryHelper.getSupportedStarTree;
 
 /**
@@ -68,6 +75,7 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue implemen
     private final ValuesSource.Numeric valuesSource;
     private final DocValueFormat format;
 
+    private LongArray counts;
     private DoubleArray sums;
     private DoubleArray compensations;
 
@@ -83,6 +91,7 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue implemen
         this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.Numeric) valuesSourceConfig.getValuesSource() : null;
         this.format = valuesSourceConfig.format();
         if (valuesSource != null) {
+            counts = context.bigArrays().newLongArray(1, true);
             sums = context.bigArrays().newDoubleArray(1, true);
             compensations = context.bigArrays().newDoubleArray(1, true);
         }
@@ -125,7 +134,9 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue implemen
             public void collect(int doc, long bucket) throws IOException {
                 if (values.advanceExact(doc)) {
                     setKahanSummation(bucket);
-                    for (int i = 0; i < values.docValueCount(); i++) {
+                    int valueCount = values.docValueCount();
+                    counts.increment(bucket, valueCount);
+                    for (int i = 0; i < valueCount; i++) {
                         double value = values.nextValue();
                         kahanSummation.add(value);
                     }
@@ -137,13 +148,17 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue implemen
             @Override
             public void collect(DocIdStream stream, long bucket) throws IOException {
                 setKahanSummation(bucket);
+                final int[] count = { 0 };
                 stream.forEach((doc) -> {
                     if (values.advanceExact(doc)) {
-                        for (int i = 0; i < values.docValueCount(); i++) {
+                        int valueCount = values.docValueCount();
+                        count[0] += valueCount;
+                        for (int i = 0; i < valueCount; i++) {
                             kahanSummation.add(values.nextValue());
                         }
                     }
                 });
+                counts.increment(bucket, count[0]);
                 compensations.set(bucket, kahanSummation.delta());
                 sums.set(bucket, kahanSummation.value());
             }
@@ -151,18 +166,23 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue implemen
             @Override
             public void collectRange(int min, int max) throws IOException {
                 setKahanSummation(0);
+                int count = 0;
                 for (int docId = min; docId < max; docId++) {
                     if (values.advanceExact(docId)) {
-                        for (int i = 0; i < values.docValueCount(); i++) {
+                        int valueCount = values.docValueCount();
+                        count += valueCount;
+                        for (int i = 0; i < valueCount; i++) {
                             kahanSummation.add(values.nextValue());
                         }
                     }
                 }
+                counts.increment(0, count);
                 sums.set(0, kahanSummation.value());
                 compensations.set(0, kahanSummation.delta());
             }
 
             private void setKahanSummation(long bucket) {
+                counts = bigArrays.grow(counts, bucket + 1);
                 sums = bigArrays.grow(sums, bucket + 1);
                 compensations = bigArrays.grow(compensations, bucket + 1);
                 // Compute the sum of double values with Kahan summation algorithm which is more
@@ -175,20 +195,49 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue implemen
     }
 
     private void precomputeLeafUsingStarTree(LeafReaderContext ctx, CompositeIndexFieldInfo starTree) throws IOException {
-        final CompensatedSum kahanSummation = new CompensatedSum(sums.get(0), compensations.get(0));
+        StarTreeValues starTreeValues = StarTreeQueryHelper.getStarTreeValues(ctx, starTree);
+        assert starTreeValues != null;
 
-        StarTreeQueryHelper.precomputeLeafUsingStarTree(
-            context,
-            valuesSource,
-            ctx,
-            starTree,
-            MetricStat.SUM.getTypeName(),
-            value -> kahanSummation.add(NumericUtils.sortableLongToDouble(value)),
-            () -> {
-                sums.set(0, kahanSummation.value());
-                compensations.set(0, kahanSummation.delta());
-            }
+        String fieldName = ((ValuesSource.Numeric.FieldData) valuesSource).getIndexFieldName();
+        String sumMetricName = StarTreeUtils.fullyQualifiedFieldNameForStarTreeMetricsDocValues(
+            starTree.getField(),
+            fieldName,
+            MetricStat.SUM.getTypeName()
         );
+        String countMetricName = StarTreeUtils.fullyQualifiedFieldNameForStarTreeMetricsDocValues(
+            starTree.getField(),
+            fieldName,
+            MetricStat.VALUE_COUNT.getTypeName()
+        );
+
+        final CompensatedSum kahanSummation = new CompensatedSum(sums.get(0), compensations.get(0));
+        SortedNumericStarTreeValuesIterator sumValuesIterator = (SortedNumericStarTreeValuesIterator) starTreeValues
+            .getMetricValuesIterator(sumMetricName);
+        SortedNumericStarTreeValuesIterator countValueIterator = (SortedNumericStarTreeValuesIterator) starTreeValues
+            .getMetricValuesIterator(countMetricName);
+        FixedBitSet matchedDocIds = getStarTreeFilteredValues(context, ctx, starTreeValues);
+        assert matchedDocIds != null;
+
+        int numBits = matchedDocIds.length();
+        if (numBits > 0) {
+            for (int bit = matchedDocIds.nextSetBit(0); bit != DocIdSetIterator.NO_MORE_DOCS; bit = bit + 1 < numBits
+                ? matchedDocIds.nextSetBit(bit + 1)
+                : DocIdSetIterator.NO_MORE_DOCS) {
+                if ((sumValuesIterator.advanceExact(bit) && countValueIterator.advanceExact(bit)) == false) {
+                    continue;
+                }
+
+                assert sumValuesIterator.entryValueCount() == countValueIterator.entryValueCount()
+                    : "StarTree sum and count iterators have mismatched entry value counts";
+                for (int i = 0; i < sumValuesIterator.entryValueCount(); i++) {
+                    kahanSummation.add(NumericUtils.sortableLongToDouble(sumValuesIterator.nextValue()));
+                    counts.increment(0, countValueIterator.nextValue());
+                }
+            }
+        }
+
+        sums.set(0, kahanSummation.value());
+        compensations.set(0, kahanSummation.delta());
     }
 
     /**
@@ -200,23 +249,42 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue implemen
         CompositeIndexFieldInfo starTree,
         StarTreeBucketCollector parentCollector
     ) throws IOException {
-        final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
-        return StarTreeQueryHelper.getStarTreeBucketMetricCollector(
-            starTree,
-            MetricStat.SUM.getTypeName(),
-            valuesSource,
-            parentCollector,
-            (bucket) -> {
+        assert parentCollector != null;
+        return new StarTreeBucketCollector(parentCollector) {
+            String sumMetricName = StarTreeUtils.fullyQualifiedFieldNameForStarTreeMetricsDocValues(
+                starTree.getField(),
+                ((ValuesSource.Numeric.FieldData) valuesSource).getIndexFieldName(),
+                MetricStat.SUM.getTypeName()
+            );
+            String valueCountMetricName = StarTreeUtils.fullyQualifiedFieldNameForStarTreeMetricsDocValues(
+                starTree.getField(),
+                ((ValuesSource.Numeric.FieldData) valuesSource).getIndexFieldName(),
+                MetricStat.VALUE_COUNT.getTypeName()
+            );
+            SortedNumericStarTreeValuesIterator sumMetricValuesIterator = (SortedNumericStarTreeValuesIterator) starTreeValues
+                .getMetricValuesIterator(sumMetricName);
+            SortedNumericStarTreeValuesIterator valueCountMetricValuesIterator = (SortedNumericStarTreeValuesIterator) starTreeValues
+                .getMetricValuesIterator(valueCountMetricName);
+
+            final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
+
+            @Override
+            public void collectStarTreeEntry(int starTreeEntryBit, long bucket) throws IOException {
+                counts = context.bigArrays().grow(counts, bucket + 1);
                 sums = context.bigArrays().grow(sums, bucket + 1);
                 compensations = context.bigArrays().grow(compensations, bucket + 1);
-            },
-            (bucket, metricValue) -> {
+                if (sumMetricValuesIterator.advanceExact(starTreeEntryBit) == false
+                    || valueCountMetricValuesIterator.advanceExact(starTreeEntryBit) == false) {
+                    return;
+                }
                 kahanSummation.reset(sums.get(bucket), compensations.get(bucket));
-                kahanSummation.add(NumericUtils.sortableLongToDouble(metricValue));
+                kahanSummation.add(NumericUtils.sortableLongToDouble(sumMetricValuesIterator.nextValue()));
+
                 sums.set(bucket, kahanSummation.value());
                 compensations.set(bucket, kahanSummation.delta());
+                counts.increment(bucket, valueCountMetricValuesIterator.nextValue());
             }
-        );
+        };
     }
 
     @Override
@@ -232,16 +300,19 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue implemen
         if (valuesSource == null || bucket >= sums.size()) {
             return buildEmptyAggregation();
         }
-        return new InternalSum(name, sums.get(bucket), format, metadata());
+        return new InternalSum(name, sums.get(bucket), counts.get(bucket), format, metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalSum(name, 0.0, format, metadata());
+        return new InternalSum(name, 0.0, 0L, format, metadata());
     }
 
     @Override
     public void doReset() {
+        if (counts != null) {
+            counts.fill(0, counts.size(), 0L);
+        }
         if (sums != null) {
             sums.fill(0, sums.size(), 0.0);
         }
@@ -252,6 +323,6 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue implemen
 
     @Override
     public void doClose() {
-        Releasables.close(sums, compensations);
+        Releasables.close(counts, sums, compensations);
     }
 }

--- a/server/src/main/java/org/opensearch/search/aggregations/support/AggregationInspectionHelper.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/support/AggregationInspectionHelper.java
@@ -173,8 +173,7 @@ public class AggregationInspectionHelper {
     }
 
     public static boolean hasValue(InternalSum agg) {
-        // TODO this could be incorrect... e.g. +1 + -1
-        return agg.getValue() != 0.0;
+        return agg.getCount() > 0;
     }
 
     public static boolean hasValue(InternalCardinality agg) {

--- a/server/src/test/java/org/opensearch/search/aggregations/AggregatorCancellationTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/AggregatorCancellationTests.java
@@ -188,13 +188,13 @@ public class AggregatorCancellationTests extends AggregatorTestCase {
 
         @Override
         public InternalAggregation[] buildAggregations(long[] owningBucketOrds) throws IOException {
-            InternalAggregation internalAggregation = new InternalSum(name(), 0.0, DocValueFormat.RAW, metadata());
+            InternalAggregation internalAggregation = new InternalSum(name(), 0.0, 0L, DocValueFormat.RAW, metadata());
             return new InternalAggregation[] { internalAggregation };
         }
 
         @Override
         public InternalAggregation buildEmptyAggregation() {
-            return new InternalSum(name(), 0.0, DocValueFormat.RAW, metadata());
+            return new InternalSum(name(), 0.0, 0L, DocValueFormat.RAW, metadata());
         }
     }
 }

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/InternalStatsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/InternalStatsTests.java
@@ -282,7 +282,7 @@ public class InternalStatsTests extends InternalAggregationTestCase<InternalStat
                 + "  \"min\" : null,\n"
                 + "  \"max\" : null,\n"
                 + "  \"avg\" : null,\n"
-                + "  \"sum\" : 0.0\n"
+                + "  \"sum\" : null\n"
                 + "}",
             builder.toString()
         );

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/InternalSumTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/InternalSumTests.java
@@ -31,29 +31,46 @@
 
 package org.opensearch.search.aggregations.metrics;
 
+import org.opensearch.Version;
+import org.opensearch.common.SetOnce;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.core.xcontent.XContentParserUtils;
 import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.ParsedAggregation;
 import org.opensearch.test.InternalAggregationTestCase;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static java.util.Collections.singletonMap;
+import static org.opensearch.core.xcontent.XContentHelper.toXContent;
+import static org.opensearch.rest.action.search.RestSearchAction.TYPED_KEYS_PARAM;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertToXContentEquivalent;
 
 public class InternalSumTests extends InternalAggregationTestCase<InternalSum> {
 
     @Override
     protected InternalSum createTestInstance(String name, Map<String, Object> metadata) {
         double value = frequently() ? randomDouble() : randomFrom(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN);
+        long count = frequently() ? randomNonNegativeLong() % 100000 : 0;
         DocValueFormat formatter = randomFrom(new DocValueFormat.Decimal("###.##"), DocValueFormat.RAW);
-        return new InternalSum(name, value, formatter, metadata);
+        return new InternalSum(name, value, count, formatter, metadata);
     }
 
     @Override
     protected void assertReduced(InternalSum reduced, List<InternalSum> inputs) {
         double expectedSum = inputs.stream().mapToDouble(InternalSum::getValue).sum();
+        long expectedCount = inputs.stream().mapToLong(InternalSum::getCount).sum();
         assertEquals(expectedSum, reduced.getValue(), 0.0001d);
+        assertEquals(expectedCount, reduced.getCount());
     }
 
     public void testSummationAccuracy() {
@@ -90,9 +107,9 @@ public class InternalSumTests extends InternalAggregationTestCase<InternalSum> {
     private void verifySummationOfDoubles(double[] values, double expected, double delta) {
         List<InternalAggregation> aggregations = new ArrayList<>(values.length);
         for (double value : values) {
-            aggregations.add(new InternalSum("dummy1", value, null, null));
+            aggregations.add(new InternalSum("dummy1", value, 1L, null, null));
         }
-        InternalSum internalSum = new InternalSum("dummy", 0, null, null);
+        InternalSum internalSum = new InternalSum("dummy", 0, 0L, null, null);
         InternalSum reduced = internalSum.reduce(aggregations, null);
         assertEquals(expected, reduced.value(), delta);
     }
@@ -100,17 +117,120 @@ public class InternalSumTests extends InternalAggregationTestCase<InternalSum> {
     @Override
     protected void assertFromXContent(InternalSum sum, ParsedAggregation parsedAggregation) {
         ParsedSum parsed = ((ParsedSum) parsedAggregation);
-        assertEquals(sum.getValue(), parsed.getValue(), Double.MIN_VALUE);
-        assertEquals(sum.getValueAsString(), parsed.getValueAsString());
+        if (sum.getCount() != 0) {
+            assertEquals(sum.getValue(), parsed.getValue(), Double.MIN_VALUE);
+            assertEquals(sum.getValueAsString(), parsed.getValueAsString());
+        } else {
+            // When count == 0, InternalSum renders "value": null.
+            // ParsedSum should parse null as the POSITIVE_INFINITY sentinel.
+            assertEquals(Double.POSITIVE_INFINITY, parsed.getValue(), 0d);
+        }
+    }
+
+    public void testVersionedSerializationPreV360() throws IOException {
+        InternalSum original = new InternalSum("test_sum", 42.0, 5L, DocValueFormat.RAW, null);
+        InternalSum deserialized = copyInstance(original, Version.V_3_5_0);
+
+        // Sum value is preserved across versions
+        assertEquals(original.getValue(), deserialized.getValue(), 0d);
+        // Pre-3.6 streams do not carry count; deserializer defaults to 1
+        assertEquals(1L, deserialized.getCount());
+    }
+
+    public void testVersionedSerializationPreV360ZeroCount() throws IOException {
+        // A new-format sum with count=0 (null semantics) sent to an old node and back
+        InternalSum original = new InternalSum("test_sum", 0.0, 0L, DocValueFormat.RAW, null);
+        InternalSum deserialized = copyInstance(original, Version.V_3_5_0);
+
+        assertEquals(original.getValue(), deserialized.getValue(), 0d);
+        // Legacy fallback: count becomes 1, so null semantics are lost on old nodes
+        assertEquals(1L, deserialized.getCount());
+    }
+
+    public void testVersionedSerializationCurrentVersion() throws IOException {
+        InternalSum original = new InternalSum("test_sum", 42.0, 5L, DocValueFormat.RAW, null);
+        InternalSum deserialized = copyInstance(original, Version.CURRENT);
+
+        assertEquals(original.getValue(), deserialized.getValue(), 0d);
+        assertEquals(original.getCount(), deserialized.getCount());
+    }
+
+    public void testVersionedSerializationCurrentVersionZeroCount() throws IOException {
+        InternalSum original = new InternalSum("test_sum", 0.0, 0L, DocValueFormat.RAW, null);
+        InternalSum deserialized = copyInstance(original, Version.CURRENT);
+
+        assertEquals(original.getValue(), deserialized.getValue(), 0d);
+        assertEquals(0L, deserialized.getCount());
+    }
+
+    public void testParsedSumNullValueXContentRoundTrip() throws IOException {
+        // InternalSum with count=0 should render "value": null in xcontent.
+        // ParsedSum should parse that null back as the POSITIVE_INFINITY sentinel
+        // and re-render it as null, completing a lossless round-trip.
+        InternalSum emptySum = new InternalSum("test_null", 0.0, 0L, DocValueFormat.RAW, null);
+
+        final ToXContent.Params params = new ToXContent.MapParams(singletonMap(TYPED_KEYS_PARAM, "true"));
+        final XContentType xContentType = randomFrom(XContentType.values());
+        final boolean humanReadable = randomBoolean();
+
+        // Serialize InternalSum to bytes
+        BytesReference originalBytes = toXContent(emptySum, xContentType, params, humanReadable);
+
+        // Parse bytes into ParsedSum
+        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+
+            SetOnce<Aggregation> parsedAgg = new SetOnce<>();
+            XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, parsedAgg::set);
+            ParsedSum parsed = (ParsedSum) parsedAgg.get();
+
+            // Verify the sentinel value is POSITIVE_INFINITY (not NEGATIVE_INFINITY)
+            assertEquals(Double.POSITIVE_INFINITY, parsed.getValue(), 0d);
+
+            // Re-serialize and verify round-trip consistency
+            BytesReference parsedBytes = toXContent(parsed, xContentType, params, humanReadable);
+            assertToXContentEquivalent(originalBytes, parsedBytes, xContentType);
+        }
+    }
+
+    public void testParsedSumPositiveInfinityRoundTrip() throws IOException {
+        // InternalSum with count > 0 and value = POSITIVE_INFINITY is a legitimate result
+        // (e.g. summing many Double.MAX_VALUE values). ParsedSum must not confuse it with
+        // the null sentinel and must round-trip it correctly as Infinity, not null.
+        InternalSum infSum = new InternalSum("test_inf", Double.POSITIVE_INFINITY, 5L, DocValueFormat.RAW, null);
+
+        final ToXContent.Params params = new ToXContent.MapParams(singletonMap(TYPED_KEYS_PARAM, "true"));
+        final XContentType xContentType = randomFrom(XContentType.values());
+        final boolean humanReadable = randomBoolean();
+
+        BytesReference originalBytes = toXContent(infSum, xContentType, params, humanReadable);
+
+        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+
+            SetOnce<Aggregation> parsedAgg = new SetOnce<>();
+            XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, parsedAgg::set);
+            ParsedSum parsed = (ParsedSum) parsedAgg.get();
+
+            assertEquals(Double.POSITIVE_INFINITY, parsed.getValue(), 0d);
+
+            BytesReference parsedBytes = toXContent(parsed, xContentType, params, humanReadable);
+            assertToXContentEquivalent(originalBytes, parsedBytes, xContentType);
+        }
     }
 
     @Override
     protected InternalSum mutateInstance(InternalSum instance) {
         String name = instance.getName();
         double value = instance.getValue();
+        long count = instance.getCount();
         DocValueFormat formatter = instance.format;
         Map<String, Object> metadata = instance.getMetadata();
-        switch (between(0, 2)) {
+        switch (between(0, 3)) {
             case 0:
                 name += randomAlphaOfLength(5);
                 break;
@@ -122,6 +242,9 @@ public class InternalSumTests extends InternalAggregationTestCase<InternalSum> {
                 }
                 break;
             case 2:
+                count += between(1, 100);
+                break;
+            case 3:
                 if (metadata == null) {
                     metadata = new HashMap<>(1);
                 } else {
@@ -132,6 +255,6 @@ public class InternalSumTests extends InternalAggregationTestCase<InternalSum> {
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
-        return new InternalSum(name, value, formatter, metadata);
+        return new InternalSum(name, value, count, formatter, metadata);
     }
 }

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/SumAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/SumAggregatorTests.java
@@ -110,6 +110,19 @@ public class SumAggregatorTests extends AggregatorTestCase {
         });
     }
 
+    public void testAllNullFieldValues() throws IOException {
+        testAggregation(new MatchAllDocsQuery(), iw -> {
+            // Documents exist but none have the aggregation field — equivalent to all-null values.
+            iw.addDocument(singleton(new NumericDocValuesField("unrelated", 10)));
+            iw.addDocument(singleton(new NumericDocValuesField("unrelated", 20)));
+            iw.addDocument(singleton(new NumericDocValuesField("unrelated", 30)));
+        }, sum -> {
+            assertEquals(0d, sum.getValue(), 0d);
+            assertEquals(0L, sum.getCount());
+            assertFalse(AggregationInspectionHelper.hasValue(sum));
+        });
+    }
+
     public void testNumericDocValues() throws IOException {
         testAggregation(new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 1)));


### PR DESCRIPTION
### Description

When all documents in a shard have null or missing values for the aggregated field, the `sum` aggregation currently returns `"value": 0.0`. This is misleading because it is indistinguishable from a genuine zero sum. This PR changes the behavior to return `"value": null` instead, aligning with how `avg`, `min`, and `max` aggregations already handle the all-null case.

**Key changes:**

- **SumAggregator** tracks the number of field values collected via a `count` field across all five collection paths (single doc, doc stream, range, StarTree precompute, StarTree bucket collector).
- **InternalSum** carries the count through serialization with version gating at `V_3_6_0` for mixed-cluster rolling upgrade compatibility. When `count == 0`, `doXContentBody` renders `"value": null`.
- **ParsedSum** uses an explicit `hasValue` boolean instead of a sentinel comparison to correctly round-trip both null values and legitimate `POSITIVE_INFINITY` sum results.
- **AggregationInspectionHelper** checks `count > 0` instead of `value != 0.0`, fixing false positives for genuine zero sums.
- **SumAggregator StarTree** path adds an assertion that sum and count iterator entry value counts match, and fixes negation style to use `== false` per OpenSearch convention.

**Behavior change:** REST API responses for `sum` aggregations will now return `"value": null` when no field values are present, instead of `"value": 0.0`. External clients that assume the sum is always numeric should handle the `null` case.

Resolves #17581

### Check List

- [x] Functionality includes testing.
- [N/A] API changes companion pull request created, if applicable.
- [N/A] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).