### PR TITLE
Adding lockable concurrent queue utils to be used for managing composite writers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix ShardSearchFailure in transport-grpc ([#20641](https://github.com/opensearch-project/OpenSearch/pull/20641))
 - Fix TLS cert hot-reload for Arrow Flight transport ([#20732](https://github.com/opensearch-project/OpenSearch/pull/20732))
 - Fix misleading heap usage cancellation message in SearchBackpressureService ([#20779](https://github.com/opensearch-project/OpenSearch/pull/20779))
+- Adding lockable concurrent queue utilities ([#20791](https://github.com/opensearch-project/OpenSearch/pull/20791))
 
 ### Dependencies
 - Bump shadow-gradle-plugin from 8.3.9 to 9.3.1 ([#20569](https://github.com/opensearch-project/OpenSearch/pull/20569))

--- a/server/src/main/java/org/opensearch/common/pool/ConcurrentQueue.java
+++ b/server/src/main/java/org/opensearch/common/pool/ConcurrentQueue.java
@@ -1,0 +1,173 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.pool;
+
+import java.util.Iterator;
+import java.util.Queue;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * A thread-safe queue implementation that distributes entries across multiple internal queues
+ * to reduce lock contention.
+ * <p>
+ * This queue uses a striping pattern where entries are distributed across a configurable number
+ * of internal queues, each protected by its own lock. This design allows multiple threads to
+ * operate on the queue concurrently with minimal contention.
+ * </p>
+ * <p>
+ * Thread affinity is achieved by using the current thread's hash code to determine which
+ * internal queue to access first, improving cache locality and reducing contention.
+ * </p>
+ *
+ * @param <T> the type of elements held in this queue
+ * @opensearch.internal
+ */
+final class ConcurrentQueue<T> {
+
+    /** Minimum allowed concurrency level. */
+    static final int MIN_CONCURRENCY = 1;
+
+    /** Maximum allowed concurrency level. */
+    static final int MAX_CONCURRENCY = 256;
+
+    private final int concurrency;
+    private final Lock[] locks;
+    private final Queue<T>[] queues;
+    private final Supplier<Queue<T>> queueSupplier;
+
+    /**
+     * Constructs a concurrent queue with the specified concurrency level.
+     *
+     * @param queueSupplier supplier that creates the underlying queue instances
+     * @param concurrency the number of internal queues to use, must be between
+     *                    {@link #MIN_CONCURRENCY} and {@link #MAX_CONCURRENCY}
+     * @throws IllegalArgumentException if concurrency is out of valid range
+     */
+    ConcurrentQueue(Supplier<Queue<T>> queueSupplier, int concurrency) {
+        if (concurrency < MIN_CONCURRENCY || concurrency > MAX_CONCURRENCY) {
+            throw new IllegalArgumentException(
+                "concurrency must be in [" + MIN_CONCURRENCY + ", " + MAX_CONCURRENCY + "], got " + concurrency
+            );
+        }
+        this.concurrency = concurrency;
+        this.queueSupplier = queueSupplier;
+        locks = new Lock[concurrency];
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        Queue<T>[] queues = new Queue[concurrency];
+        this.queues = queues;
+        for (int i = 0; i < concurrency; ++i) {
+            locks[i] = new ReentrantLock();
+            queues[i] = queueSupplier.get();
+        }
+    }
+
+    /**
+     * Adds an entry to the queue.
+     *
+     * @param entry the entry to add to the queue
+     */
+    void add(T entry) {
+        final int threadHash = Thread.currentThread().hashCode() & 0xFFFF;
+        for (int i = 0; i < concurrency; ++i) {
+            final int index = (threadHash + i) % concurrency;
+            final Lock lock = locks[index];
+            final Queue<T> queue = queues[index];
+            if (lock.tryLock()) {
+                try {
+                    queue.add(entry);
+                    return;
+                } finally {
+                    lock.unlock();
+                }
+            }
+        }
+        final int index = threadHash % concurrency;
+        final Lock lock = locks[index];
+        final Queue<T> queue = queues[index];
+        lock.lock();
+        try {
+            queue.add(entry);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Polls an entry from the queue that matches the given predicate.
+     *
+     * @param predicate the condition that the entry must satisfy
+     * @return the first entry that matches the predicate, or {@code null} if none found
+     */
+    T poll(Predicate<T> predicate) {
+        final int threadHash = Thread.currentThread().hashCode() & 0xFFFF;
+        for (int i = 0; i < concurrency; ++i) {
+            final int index = (threadHash + i) % concurrency;
+            final Lock lock = locks[index];
+            final Queue<T> queue = queues[index];
+            if (lock.tryLock()) {
+                try {
+                    Iterator<T> it = queue.iterator();
+                    while (it.hasNext()) {
+                        T entry = it.next();
+                        if (predicate.test(entry)) {
+                            it.remove();
+                            return entry;
+                        }
+                    }
+                } finally {
+                    lock.unlock();
+                }
+            }
+        }
+        for (int i = 0; i < concurrency; ++i) {
+            final int index = (threadHash + i) % concurrency;
+            final Lock lock = locks[index];
+            final Queue<T> queue = queues[index];
+            lock.lock();
+            try {
+                Iterator<T> it = queue.iterator();
+                while (it.hasNext()) {
+                    T entry = it.next();
+                    if (predicate.test(entry)) {
+                        it.remove();
+                        return entry;
+                    }
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Removes the specified entry from the queue.
+     *
+     * @param entry the entry to remove
+     * @return {@code true} if the entry was found and removed, {@code false} otherwise
+     */
+    boolean remove(T entry) {
+        for (int i = 0; i < concurrency; ++i) {
+            final Lock lock = locks[i];
+            final Queue<T> queue = queues[i];
+            lock.lock();
+            try {
+                if (queue.remove(entry)) {
+                    return true;
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+        return false;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/pool/LockableConcurrentQueue.java
+++ b/server/src/main/java/org/opensearch/common/pool/LockableConcurrentQueue.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.pool;
+
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.function.Supplier;
+
+/**
+ * A thread-safe queue for managing lockable entries.
+ *
+ * @param <T> the type of lockable entries, must extend {@link Lock}
+ * @opensearch.internal
+ */
+final class LockableConcurrentQueue<T extends Lock> {
+
+    private final ConcurrentQueue<T> queue;
+    private final AtomicInteger addAndUnlockCounter = new AtomicInteger();
+
+    /**
+     * Constructs a lockable concurrent queue with the specified concurrency level.
+     *
+     * @param queueSupplier supplier that creates the underlying queue instances
+     * @param concurrency the number of internal queues to use for distributing entries
+     */
+    LockableConcurrentQueue(Supplier<Queue<T>> queueSupplier, int concurrency) {
+        this.queue = new ConcurrentQueue<>(queueSupplier, concurrency);
+    }
+
+    /**
+     * Locks an entry and polls it from the queue, in that order.
+     *
+     * @return a locked entry from the queue, or {@code null} if no entry could be locked
+     */
+    T lockAndPoll() {
+        int addAndUnlockCount;
+        do {
+            addAndUnlockCount = addAndUnlockCounter.get();
+            T entry = queue.poll(Lock::tryLock);
+            if (entry != null) {
+                return entry;
+            }
+            // If an entry has been added to the queue in the meantime, try again.
+        } while (addAndUnlockCount != addAndUnlockCounter.get());
+
+        return null;
+    }
+
+    /**
+     * Removes an entry from the queue.
+     *
+     * @param entry the entry to remove
+     * @return {@code true} if the entry was found and removed, {@code false} otherwise
+     */
+    boolean remove(T entry) {
+        return queue.remove(entry);
+    }
+
+    /**
+     * Adds an entry to the queue and unlocks it, in that order.
+     *
+     * @param entry the locked entry to add and unlock
+     */
+    void addAndUnlock(T entry) {
+        queue.add(entry);
+        entry.unlock();
+        addAndUnlockCounter.incrementAndGet();
+    }
+}

--- a/server/src/main/java/org/opensearch/common/pool/LockableResourcePool.java
+++ b/server/src/main/java/org/opensearch/common/pool/LockableResourcePool.java
@@ -1,0 +1,171 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.pool;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.function.Supplier;
+
+/**
+ * A thread-safe pool for managing lockable resources.
+ * <p>
+ * This pool manages a collection of resources that extend {@link Lock}, providing
+ * thread-safe acquisition and release mechanisms. Resources are locked when acquired
+ * and unlocked when released back to the pool.
+ * </p>
+ *
+ * @param <T> the type of lockable resources managed by this pool, must extend {@link Lock}
+ * @opensearch.internal
+ */
+public class LockableResourcePool<T extends Lock> implements Iterable<T>, Closeable {
+
+    private final Set<T> entries;
+    private final LockableConcurrentQueue<T> availableEntries;
+    private final Supplier<T> entrySupplier;
+    private volatile boolean closed;
+
+    /**
+     * Constructs a lockable resource pool.
+     *
+     * @param entrySupplier supplier that creates new resource instances when needed
+     * @param queueSupplier supplier that creates queue instances for managing available resources
+     * @param concurrency the concurrency level for the underlying queue
+     */
+    public LockableResourcePool(Supplier<T> entrySupplier, Supplier<Queue<T>> queueSupplier, int concurrency) {
+        this.entries = Collections.newSetFromMap(new IdentityHashMap<>());
+        this.entrySupplier = entrySupplier;
+        this.availableEntries = new LockableConcurrentQueue<>(queueSupplier, concurrency);
+    }
+
+    /**
+     * Acquires and locks a resource from the pool.
+     *
+     * @return a locked resource from the pool
+     * @throws IllegalStateException if the pool has been closed
+     */
+    public T getAndLock() {
+        ensureOpen();
+        T entry = availableEntries.lockAndPoll();
+        return Objects.requireNonNullElseGet(entry, this::fetchEntry);
+    }
+
+    /**
+     * Creates a new resource and adds it to the pool.
+     *
+     * @return a new locked resource instance
+     * @throws IllegalStateException if the pool has been closed
+     */
+    private synchronized T fetchEntry() {
+        ensureOpen();
+        T entry = entrySupplier.get();
+        entry.lock();
+        entries.add(entry);
+        return entry;
+    }
+
+    /**
+     * Releases a resource back to the pool and unlocks it. After release, the resource becomes available for other threads to acquire.
+     *
+     * @param entry the resource to release and unlock
+     * @throws AssertionError if assertions are enabled and the entry is not registered with this pool
+     */
+    public void releaseAndUnlock(T entry) {
+        assert isRegistered(entry) : "Resource pool doesn't know about this resource";
+        availableEntries.addAndUnlock(entry);
+    }
+
+    /**
+     * Checks out all resources from the pool.
+     * <p>
+     * This method locks and removes all resources currently managed by the pool.
+     * The returned resources are no longer tracked by the pool and will not be
+     * returned by subsequent {@link #getAndLock()} calls unless explicitly added back.
+     * </p>
+     * <p>
+     * This is typically used for operations that require exclusive access to all resources,
+     * such as flushing or closing operations.
+     * </p>
+     *
+     * @return an unmodifiable list of all resources that were checked out
+     * @throws IllegalStateException if the pool has been closed
+     */
+    public List<T> checkoutAll() {
+        ensureOpen();
+        List<T> lockedEntries = new ArrayList<>();
+        List<T> checkedOutEntries = new ArrayList<>();
+        for (T entry : this) {
+            entry.lock();
+            lockedEntries.add(entry);
+        }
+        synchronized (this) {
+            for (T entry : lockedEntries) {
+                try {
+                    // Release this resource if it’s no longer managed by this pool; otherwise, check it out.
+                    if (isRegistered(entry) && entries.remove(entry)) {
+                        availableEntries.remove(entry);
+                        checkedOutEntries.add(entry);
+                    }
+                } finally {
+                    entry.unlock();
+                }
+            }
+        }
+        return Collections.unmodifiableList(checkedOutEntries);
+    }
+
+    /**
+     * Checks if a resource is registered with this pool.
+     *
+     * @param entry the resource to check
+     * @return {@code true} if the resource is managed by this pool, {@code false} otherwise
+     */
+    synchronized boolean isRegistered(T entry) {
+        return entries.contains(entry);
+    }
+
+    /**
+     * Ensures the pool is open and throws an exception if it has been closed.
+     *
+     * @throws IllegalStateException if the pool has been closed
+     */
+    private void ensureOpen() {
+        if (closed) {
+            throw new IllegalStateException("resource pool is already closed");
+        }
+    }
+
+    /**
+     * Returns an iterator over all resources currently managed by this pool.
+     *
+     * @return an iterator over the pool's resources
+     */
+    @Override
+    public synchronized Iterator<T> iterator() {
+        return List.copyOf(entries).iterator();
+    }
+
+    /**
+     * Closes this pool and prevents further resource acquisition.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        this.closed = true;
+    }
+}

--- a/server/src/test/java/org/opensearch/common/pool/ConcurrentQueueTests.java
+++ b/server/src/test/java/org/opensearch/common/pool/ConcurrentQueueTests.java
@@ -1,0 +1,219 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.pool;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.LinkedList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ConcurrentQueueTests extends OpenSearchTestCase {
+
+    public void testConstructorValidConcurrency() {
+        ConcurrentQueue<String> queue = new ConcurrentQueue<>(LinkedList::new, 1);
+        assertNotNull(queue);
+
+        queue = new ConcurrentQueue<>(LinkedList::new, 128);
+        assertNotNull(queue);
+
+        queue = new ConcurrentQueue<>(LinkedList::new, 256);
+        assertNotNull(queue);
+    }
+
+    public void testConstructorInvalidConcurrencyTooLow() {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new ConcurrentQueue<>(LinkedList::new, 0));
+        assertTrue(e.getMessage().contains("concurrency must be in"));
+    }
+
+    public void testConstructorInvalidConcurrencyTooHigh() {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new ConcurrentQueue<>(LinkedList::new, 257));
+        assertTrue(e.getMessage().contains("concurrency must be in"));
+    }
+
+    public void testAddAndPollSingleThread() {
+        ConcurrentQueue<Integer> queue = new ConcurrentQueue<>(LinkedList::new, 4);
+
+        queue.add(1);
+        queue.add(2);
+        queue.add(3);
+
+        Integer result = queue.poll(i -> i == 2);
+        assertEquals(Integer.valueOf(2), result);
+
+        result = queue.poll(i -> i == 1);
+        assertEquals(Integer.valueOf(1), result);
+
+        result = queue.poll(i -> i == 3);
+        assertEquals(Integer.valueOf(3), result);
+    }
+
+    public void testPollReturnsNullWhenEmpty() {
+        ConcurrentQueue<String> queue = new ConcurrentQueue<>(LinkedList::new, 4);
+
+        String result = queue.poll(s -> true);
+        assertNull(result);
+    }
+
+    public void testPollWithPredicateNoMatch() {
+        ConcurrentQueue<Integer> queue = new ConcurrentQueue<>(LinkedList::new, 4);
+
+        queue.add(1);
+        queue.add(2);
+        queue.add(3);
+
+        Integer result = queue.poll(i -> i == 10);
+        assertNull(result);
+    }
+
+    public void testRemoveExistingEntry() {
+        ConcurrentQueue<String> queue = new ConcurrentQueue<>(LinkedList::new, 4);
+
+        queue.add("a");
+        queue.add("b");
+        queue.add("c");
+
+        assertTrue(queue.remove("b"));
+
+        String result = queue.poll(s -> s.equals("b"));
+        assertNull(result);
+    }
+
+    public void testRemoveNonExistingEntry() {
+        ConcurrentQueue<String> queue = new ConcurrentQueue<>(LinkedList::new, 4);
+
+        queue.add("a");
+        queue.add("b");
+
+        assertFalse(queue.remove("c"));
+    }
+
+    public void testConcurrentAddAndPoll() throws Exception {
+        ConcurrentQueue<Integer> queue = new ConcurrentQueue<>(LinkedList::new, 8);
+        int numThreads = 10;
+        int itemsPerThread = 100;
+        CountDownLatch latch = new CountDownLatch(numThreads * 2);
+        AtomicInteger addedCount = new AtomicInteger();
+        AtomicInteger polledCount = new AtomicInteger();
+
+        for (int t = 0; t < numThreads; t++) {
+            final int threadId = t;
+            Thread producer = new Thread(() -> {
+                for (int i = 0; i < itemsPerThread; i++) {
+                    queue.add(threadId * itemsPerThread + i);
+                    addedCount.incrementAndGet();
+                }
+                latch.countDown();
+            });
+            producer.start();
+        }
+
+        for (int t = 0; t < numThreads; t++) {
+            Thread consumer = new Thread(() -> {
+                for (int i = 0; i < itemsPerThread; i++) {
+                    Integer value = queue.poll(v -> true);
+                    if (value != null) {
+                        polledCount.incrementAndGet();
+                    }
+                }
+                latch.countDown();
+            });
+            consumer.start();
+        }
+
+        latch.await();
+        assertEquals(numThreads * itemsPerThread, addedCount.get());
+        assertTrue(polledCount.get() > 0);
+    }
+
+    public void testConcurrentRemove() throws Exception {
+        ConcurrentQueue<Integer> queue = new ConcurrentQueue<>(LinkedList::new, 8);
+        int numItems = 100;
+
+        for (int i = 0; i < numItems; i++) {
+            queue.add(i);
+        }
+
+        int numThreads = 10;
+        CountDownLatch latch = new CountDownLatch(numThreads);
+        AtomicInteger removedCount = new AtomicInteger();
+
+        for (int t = 0; t < numThreads; t++) {
+            final int threadId = t;
+            Thread remover = new Thread(() -> {
+                for (int i = threadId; i < numItems; i += numThreads) {
+                    if (queue.remove(i)) {
+                        removedCount.incrementAndGet();
+                    }
+                }
+                latch.countDown();
+            });
+            remover.start();
+        }
+
+        latch.await();
+        assertEquals(numItems, removedCount.get());
+    }
+
+    public void testPollWithComplexPredicate() {
+        ConcurrentQueue<Integer> queue = new ConcurrentQueue<>(LinkedList::new, 4);
+
+        for (int i = 1; i <= 10; i++) {
+            queue.add(i);
+        }
+
+        Integer result = queue.poll(i -> i % 2 == 0 && i > 5);
+        assertNotNull(result);
+        assertTrue(result % 2 == 0);
+        assertTrue(result > 5);
+    }
+
+    public void testAddWithHighContention() throws Exception {
+        ConcurrentQueue<Integer> queue = new ConcurrentQueue<>(LinkedList::new, 2);
+        int numThreads = 20;
+        int itemsPerThread = 50;
+        CountDownLatch latch = new CountDownLatch(numThreads);
+
+        for (int t = 0; t < numThreads; t++) {
+            final int threadId = t;
+            Thread thread = new Thread(() -> {
+                for (int i = 0; i < itemsPerThread; i++) {
+                    queue.add(threadId * itemsPerThread + i);
+                }
+                latch.countDown();
+            });
+            thread.start();
+        }
+
+        latch.await();
+
+        int count = 0;
+        while (queue.poll(v -> true) != null) {
+            count++;
+        }
+        assertEquals(numThreads * itemsPerThread, count);
+    }
+
+    public void testMultipleAddsAndRemoves() {
+        ConcurrentQueue<String> queue = new ConcurrentQueue<>(LinkedList::new, 4);
+
+        queue.add("item1");
+        queue.add("item2");
+        queue.add("item3");
+
+        assertTrue(queue.remove("item2"));
+
+        queue.add("item4");
+
+        assertNotNull(queue.poll(s -> s.equals("item1")));
+        assertNotNull(queue.poll(s -> s.equals("item3")));
+        assertNotNull(queue.poll(s -> s.equals("item4")));
+        assertNull(queue.poll(s -> true));
+    }
+}

--- a/server/src/test/java/org/opensearch/common/pool/LockableConcurrentQueueTests.java
+++ b/server/src/test/java/org/opensearch/common/pool/LockableConcurrentQueueTests.java
@@ -1,0 +1,277 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.pool;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class LockableConcurrentQueueTests extends OpenSearchTestCase {
+
+    public void testConstructor() {
+        LockableConcurrentQueue<ReentrantLock> queue = new LockableConcurrentQueue<>(LinkedList::new, 4);
+        assertNotNull(queue);
+    }
+
+    public void testLockAndPollReturnsNullWhenEmpty() {
+        LockableConcurrentQueue<ReentrantLock> queue = new LockableConcurrentQueue<>(LinkedList::new, 4);
+
+        ReentrantLock lock = queue.lockAndPoll();
+        assertNull(lock);
+    }
+
+    public void testAddAndUnlockThenLockAndPoll() {
+        LockableConcurrentQueue<ReentrantLock> queue = new LockableConcurrentQueue<>(LinkedList::new, 4);
+
+        ReentrantLock lock1 = new ReentrantLock();
+        ReentrantLock lock2 = new ReentrantLock();
+
+        lock1.lock();
+        lock2.lock();
+
+        queue.addAndUnlock(lock1);
+        queue.addAndUnlock(lock2);
+
+        ReentrantLock polled1 = queue.lockAndPoll();
+        assertNotNull(polled1);
+        assertTrue(polled1.isHeldByCurrentThread());
+
+        ReentrantLock polled2 = queue.lockAndPoll();
+        assertNotNull(polled2);
+        assertTrue(polled2.isHeldByCurrentThread());
+
+        polled1.unlock();
+        polled2.unlock();
+    }
+
+    public void testLockAndPollSkipsLockedEntries() {
+        LockableConcurrentQueue<ReentrantLock> queue = new LockableConcurrentQueue<>(LinkedList::new, 4);
+
+        ReentrantLock lock1 = new ReentrantLock();
+        ReentrantLock lock2 = new ReentrantLock();
+
+        lock1.lock();
+        queue.addAndUnlock(lock1);
+
+        lock2.lock();
+        queue.addAndUnlock(lock2);
+
+        lock1.lock();
+
+        ReentrantLock polled = queue.lockAndPoll();
+        assertNotNull(polled);
+        assertEquals(lock2, polled);
+        assertTrue(polled.isHeldByCurrentThread());
+
+        polled.unlock();
+        lock1.unlock();
+    }
+
+    public void testRemove() {
+        LockableConcurrentQueue<ReentrantLock> queue = new LockableConcurrentQueue<>(LinkedList::new, 4);
+
+        ReentrantLock lock1 = new ReentrantLock();
+        ReentrantLock lock2 = new ReentrantLock();
+
+        lock1.lock();
+        lock2.lock();
+
+        queue.addAndUnlock(lock1);
+        queue.addAndUnlock(lock2);
+
+        assertTrue(queue.remove(lock1));
+        assertFalse(queue.remove(lock1));
+
+        ReentrantLock polled = queue.lockAndPoll();
+        assertEquals(lock2, polled);
+        polled.unlock();
+    }
+
+    public void testRemoveNonExistingEntry() {
+        LockableConcurrentQueue<ReentrantLock> queue = new LockableConcurrentQueue<>(LinkedList::new, 4);
+
+        ReentrantLock lock = new ReentrantLock();
+        assertFalse(queue.remove(lock));
+    }
+
+    public void testConcurrentAddAndLockAndPoll() throws Exception {
+        LockableConcurrentQueue<ReentrantLock> queue = new LockableConcurrentQueue<>(LinkedList::new, 8);
+        int numProducers = 5;
+        int numConsumers = 5;
+        int itemsPerProducer = 20;
+        CountDownLatch latch = new CountDownLatch(numProducers + numConsumers);
+        AtomicInteger addedCount = new AtomicInteger();
+        AtomicInteger polledCount = new AtomicInteger();
+
+        for (int t = 0; t < numProducers; t++) {
+            Thread producer = new Thread(() -> {
+                for (int i = 0; i < itemsPerProducer; i++) {
+                    ReentrantLock lock = new ReentrantLock();
+                    lock.lock();
+                    queue.addAndUnlock(lock);
+                    addedCount.incrementAndGet();
+                }
+                latch.countDown();
+            });
+            producer.start();
+        }
+
+        for (int t = 0; t < numConsumers; t++) {
+            Thread consumer = new Thread(() -> {
+                for (int i = 0; i < itemsPerProducer; i++) {
+                    ReentrantLock lock = queue.lockAndPoll();
+                    if (lock != null) {
+                        assertTrue(lock.isHeldByCurrentThread());
+                        polledCount.incrementAndGet();
+                        lock.unlock();
+                    }
+                }
+                latch.countDown();
+            });
+            consumer.start();
+        }
+
+        latch.await();
+        assertEquals(numProducers * itemsPerProducer, addedCount.get());
+        assertTrue(polledCount.get() > 0);
+    }
+
+    public void testLockAndPollRetriesOnConcurrentAdd() throws Exception {
+        LockableConcurrentQueue<ReentrantLock> queue = new LockableConcurrentQueue<>(LinkedList::new, 4);
+        CountDownLatch consumerStarted = new CountDownLatch(1);
+        CountDownLatch producerDone = new CountDownLatch(1);
+        AtomicInteger pollAttempts = new AtomicInteger();
+
+        Thread consumer = new Thread(() -> {
+            consumerStarted.countDown();
+            ReentrantLock lock = queue.lockAndPoll();
+            pollAttempts.incrementAndGet();
+            if (lock != null) {
+                lock.unlock();
+            }
+        });
+        consumer.start();
+
+        consumerStarted.await();
+        Thread.sleep(10);
+
+        ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        queue.addAndUnlock(lock);
+        producerDone.countDown();
+
+        consumer.join();
+        assertTrue(pollAttempts.get() > 0);
+    }
+
+    public void testConcurrentRemove() throws Exception {
+        LockableConcurrentQueue<ReentrantLock> queue = new LockableConcurrentQueue<>(LinkedList::new, 8);
+        int numLocks = 50;
+        List<ReentrantLock> locks = new ArrayList<>();
+
+        for (int i = 0; i < numLocks; i++) {
+            ReentrantLock lock = new ReentrantLock();
+            lock.lock();
+            queue.addAndUnlock(lock);
+            locks.add(lock);
+        }
+
+        int numThreads = 10;
+        CountDownLatch latch = new CountDownLatch(numThreads);
+        AtomicInteger removedCount = new AtomicInteger();
+
+        for (int t = 0; t < numThreads; t++) {
+            final int threadId = t;
+            Thread remover = new Thread(() -> {
+                for (int i = threadId; i < numLocks; i += numThreads) {
+                    if (queue.remove(locks.get(i))) {
+                        removedCount.incrementAndGet();
+                    }
+                }
+                latch.countDown();
+            });
+            remover.start();
+        }
+
+        latch.await();
+        assertEquals(numLocks, removedCount.get());
+    }
+
+    public void testAddAndUnlockUnlocksEntry() {
+        LockableConcurrentQueue<ReentrantLock> queue = new LockableConcurrentQueue<>(LinkedList::new, 4);
+
+        ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        assertTrue(lock.isHeldByCurrentThread());
+
+        queue.addAndUnlock(lock);
+        assertFalse(lock.isHeldByCurrentThread());
+    }
+
+    public void testMultipleAddAndPollCycles() {
+        LockableConcurrentQueue<ReentrantLock> queue = new LockableConcurrentQueue<>(LinkedList::new, 4);
+
+        for (int cycle = 0; cycle < 3; cycle++) {
+            ReentrantLock lock = new ReentrantLock();
+            lock.lock();
+            queue.addAndUnlock(lock);
+
+            ReentrantLock polled = queue.lockAndPoll();
+            assertNotNull(polled);
+            assertEquals(lock, polled);
+            assertTrue(polled.isHeldByCurrentThread());
+            polled.unlock();
+        }
+    }
+
+    public void testLockAndPollWithHighContention() throws Exception {
+        LockableConcurrentQueue<ReentrantLock> queue = new LockableConcurrentQueue<>(LinkedList::new, 2);
+        int numThreads = 20;
+        int itemsPerThread = 10;
+        CountDownLatch producerLatch = new CountDownLatch(numThreads);
+        CountDownLatch consumerLatch = new CountDownLatch(numThreads);
+        AtomicInteger successfulPolls = new AtomicInteger();
+
+        for (int t = 0; t < numThreads; t++) {
+            Thread producer = new Thread(() -> {
+                for (int i = 0; i < itemsPerThread; i++) {
+                    ReentrantLock lock = new ReentrantLock();
+                    lock.lock();
+                    queue.addAndUnlock(lock);
+                }
+                producerLatch.countDown();
+            });
+            producer.start();
+        }
+
+        producerLatch.await();
+
+        for (int t = 0; t < numThreads; t++) {
+            Thread consumer = new Thread(() -> {
+                for (int i = 0; i < itemsPerThread; i++) {
+                    ReentrantLock lock = queue.lockAndPoll();
+                    if (lock != null) {
+                        successfulPolls.incrementAndGet();
+                        lock.unlock();
+                    }
+                }
+                consumerLatch.countDown();
+            });
+            consumer.start();
+        }
+
+        consumerLatch.await();
+        assertEquals(numThreads * itemsPerThread, successfulPolls.get());
+    }
+}


### PR DESCRIPTION
### Description
- Adding lockable concurrent queue utilities to be used in CompositeEngine for managing pool of composite writers. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
