### PR TITLE
Fix camelCase fields in recovery API response

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
@@ -414,11 +414,11 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
                 .field("snapshot", snapshot.getSnapshotId().getName())
                 .field("version", version.toString())
                 .field("index", index.getName())
-                .field("restoreUUID", restoreUUID)
-                .field("isSearchableSnapshot", isSearchableSnapshot)
-                .field("remoteStoreIndexShallowCopy", remoteStoreIndexShallowCopy)
-                .field("sourceRemoteStoreRepository", sourceRemoteStoreRepository)
-                .field("sourceRemoteTranslogRepository", sourceRemoteTranslogRepository);
+                .field("restore_uuid", restoreUUID)
+                .field("is_searchable_snapshot", isSearchableSnapshot)
+                .field("remote_store_index_shallow_copy", remoteStoreIndexShallowCopy)
+                .field("source_remote_store_repository", sourceRemoteStoreRepository)
+                .field("source_remote_translog_repository", sourceRemoteTranslogRepository);
         }
 
         @Override
@@ -522,7 +522,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
 
         @Override
         public void addAdditionalFields(XContentBuilder builder, ToXContent.Params params) throws IOException {
-            builder.field("version", version.toString()).field("index", index.getName()).field("restoreUUID", restoreUUID);
+            builder.field("version", version.toString()).field("index", index.getName()).field("restore_uuid", restoreUUID);
         }
 
         @Override


### PR DESCRIPTION
## Description

Fixes #16334

The /{index}/_recovery API returns several fields in camelCase format instead of the standard snake_case format used by all other OpenSearch REST APIs.

### Changes

Renamed the following fields in the recovery API response:
- restoreUUID → restore_uuid
- isSearchableSnapshot → is_searchable_snapshot
- remoteStoreIndexShallowCopy → remote_store_index_shallow_copy
- sourceRemoteStoreRepository → source_remote_store_repository
- sourceRemoteTranslogRepository → source_remote_translog_repository

## Issues Resolved

Fixes #16334

## Check List

- [x] New functionality includes testing
- [x] Commits are signed (DCO)