### PR TITLE
Scale test suite timeout with test iterations

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchTestBasePlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchTestBasePlugin.java
@@ -200,9 +200,26 @@ public class OpenSearchTestBasePlugin implements Plugin<Project> {
                 logging.setShowStandardStreams(Util.getBooleanProperty("tests.output", false));
             });
 
-            if (OS.current().equals(OS.WINDOWS) && System.getProperty("tests.timeoutSuite") == null) {
-                // override the suite timeout to 30 mins for windows, because it has the most inefficient filesystem known to man
-                test.systemProperty("tests.timeoutSuite", "1800000!");
+            if (System.getProperty("tests.timeoutSuite") == null) {
+                // Default suite timeout is 20 minutes (1200000ms) as set by @TimeoutSuite annotation.
+                long baseTimeout = 20L * 60 * 1000;
+
+                if (OS.current().equals(OS.WINDOWS)) {
+                    // Override the suite timeout to 30 mins for windows, because it has the most
+                    // inefficient filesystem known to man.
+                    baseTimeout = 30L * 60 * 1000;
+                }
+
+                // Scale suite timeout based on test iterations to prevent false timeouts
+                // when using -Dtests.iters=N (see https://github.com/opensearch-project/OpenSearch/issues/5630)
+                String itersStr = System.getProperty("tests.iters");
+                int iters = (itersStr != null) ? Integer.parseInt(itersStr) : 1;
+                iters = Math.max(1, iters);
+
+                if (OS.current().equals(OS.WINDOWS) || iters > 1) {
+                    long timeout = baseTimeout * iters;
+                    test.systemProperty("tests.timeoutSuite", timeout + "!");
+                }
             }
 
             /*


### PR DESCRIPTION
## Summary
- Fixes #5630
- When running tests with `-Dtests.iters=N`, the suite timeout (default 20 minutes) now scales by multiplying the base timeout by the number of iterations
- The fix is in the Gradle test setup plugin (`OpenSearchTestBasePlugin`), using the `tests.timeoutSuite` system property that randomizedtesting supports for overriding `@TimeoutSuite` annotations
- Preserves existing Windows behavior (30 min base timeout) and also scales it when iterations are specified
- If the user explicitly sets `-Dtests.timeoutSuite`, it is respected and no automatic scaling is applied

## Test plan
- [ ] Run `./gradlew test -Dtests.iters=10 -Dtests.class=*.SomeTest` and verify the suite does not time out prematurely
- [ ] Verify that without `-Dtests.iters`, behavior is unchanged (20 min default from annotation)
- [ ] Verify that explicit `-Dtests.timeoutSuite` still overrides the automatic scaling