### PR TITLE
Add metrics for remote cluster state metadata transfer timeouts

### DIFF
--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -835,7 +835,24 @@ public class RemoteClusterStateService implements Closeable {
 
         try {
             if (latch.await(remoteGlobalMetadataManager.getGlobalMetadataUploadTimeout().millis(), TimeUnit.MILLISECONDS) == false) {
-                // TODO: We should add metrics where transfer is timing out. [Issue: #10687]
+                // Emit metrics for metadata upload timeout
+                int timedOutIndexCount = 0;
+                int timedOutGlobalCount = 0;
+                for (String uploadTask : uploadTasks) {
+                    if (results.containsKey(uploadTask) == false) {
+                        if (indexToUpload.stream().anyMatch(idx -> idx.getIndex().getName().equals(uploadTask))) {
+                            timedOutIndexCount++;
+                        } else {
+                            timedOutGlobalCount++;
+                        }
+                    }
+                }
+                if (timedOutIndexCount > 0) {
+                    remoteStateStats.indexMetadataUploadTimedOut();
+                }
+                if (timedOutGlobalCount > 0) {
+                    remoteStateStats.metadataUploadTimedOut();
+                }
                 RemoteStateTransferException ex = new RemoteStateTransferException(
                     String.format(
                         Locale.ROOT,

--- a/server/src/main/java/org/opensearch/gateway/remote/RemotePersistenceStats.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemotePersistenceStats.java
@@ -114,6 +114,22 @@ public class RemotePersistenceStats {
         remoteFullDownloadStats.incomingPublicationFailedCount();
     }
 
+    public void indexMetadataUploadTimedOut() {
+        remoteUploadStats.indexMetadataUploadTimedOut();
+    }
+
+    public long getIndexMetadataUploadTimeoutCount() {
+        return remoteUploadStats.getIndexMetadataUploadTimeoutCount();
+    }
+
+    public void metadataUploadTimedOut() {
+        remoteUploadStats.metadataUploadTimedOut();
+    }
+
+    public long getMetadataUploadTimeoutCount() {
+        return remoteUploadStats.getMetadataUploadTimeoutCount();
+    }
+
     public PersistedStateStats getUploadStats() {
         return remoteUploadStats;
     }

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteUploadStats.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteUploadStats.java
@@ -21,16 +21,22 @@ public class RemoteUploadStats extends PersistedStateStats {
     static final String CLEANUP_ATTEMPT_FAILED_COUNT = "cleanup_attempt_failed_count";
     static final String INDEX_ROUTING_FILES_CLEANUP_ATTEMPT_FAILED_COUNT = "index_routing_files_cleanup_attempt_failed_count";
     static final String INDICES_ROUTING_DIFF_FILES_CLEANUP_ATTEMPT_FAILED_COUNT = "indices_routing_diff_files_cleanup_attempt_failed_count";
+    static final String INDEX_METADATA_UPLOAD_TIMEOUT_COUNT = "index_metadata_upload_timeout_count";
+    static final String METADATA_UPLOAD_TIMEOUT_COUNT = "metadata_upload_timeout_count";
     static final String REMOTE_UPLOAD = "remote_upload";
     private AtomicLong cleanupAttemptFailedCount = new AtomicLong(0);
     private AtomicLong indexRoutingFilesCleanupAttemptFailedCount = new AtomicLong(0);
     private AtomicLong indicesRoutingDiffFilesCleanupAttemptFailedCount = new AtomicLong(0);
+    private AtomicLong indexMetadataUploadTimeoutCount = new AtomicLong(0);
+    private AtomicLong metadataUploadTimeoutCount = new AtomicLong(0);
 
     public RemoteUploadStats() {
         super(REMOTE_UPLOAD);
         addToExtendedFields(CLEANUP_ATTEMPT_FAILED_COUNT, cleanupAttemptFailedCount);
         addToExtendedFields(INDEX_ROUTING_FILES_CLEANUP_ATTEMPT_FAILED_COUNT, indexRoutingFilesCleanupAttemptFailedCount);
         addToExtendedFields(INDICES_ROUTING_DIFF_FILES_CLEANUP_ATTEMPT_FAILED_COUNT, indicesRoutingDiffFilesCleanupAttemptFailedCount);
+        addToExtendedFields(INDEX_METADATA_UPLOAD_TIMEOUT_COUNT, indexMetadataUploadTimeoutCount);
+        addToExtendedFields(METADATA_UPLOAD_TIMEOUT_COUNT, metadataUploadTimeoutCount);
     }
 
     public void cleanUpAttemptFailed() {
@@ -55,5 +61,21 @@ public class RemoteUploadStats extends PersistedStateStats {
 
     public long getIndicesRoutingDiffFileCleanupAttemptFailedCount() {
         return indicesRoutingDiffFilesCleanupAttemptFailedCount.get();
+    }
+
+    public void indexMetadataUploadTimedOut() {
+        indexMetadataUploadTimeoutCount.incrementAndGet();
+    }
+
+    public long getIndexMetadataUploadTimeoutCount() {
+        return indexMetadataUploadTimeoutCount.get();
+    }
+
+    public void metadataUploadTimedOut() {
+        metadataUploadTimeoutCount.incrementAndGet();
+    }
+
+    public long getMetadataUploadTimeoutCount() {
+        return metadataUploadTimeoutCount.get();
     }
 }

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -856,6 +856,8 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
             )
         );
         assertTrue(exception.getMessage().startsWith("Timed out waiting for transfer of following metadata to complete"));
+        assertEquals(0, remoteClusterStateService.getRemoteStateStats().getIndexMetadataUploadTimeoutCount());
+        assertEquals(1, remoteClusterStateService.getRemoteStateStats().getMetadataUploadTimeoutCount());
     }
 
     public void testGetClusterStateForManifest_IncludeEphemeral() throws IOException {


### PR DESCRIPTION
## Summary
- Adds `index_metadata_upload_timeout_count` and `metadata_upload_timeout_count` counters to `RemoteUploadStats` to emit metrics when metadata uploads to the remote store time out
- When the latch timeout fires in `writeMetadataInParallel`, the code now inspects which upload tasks did not complete and increments the appropriate counter (index metadata vs global metadata)
- Resolves #10687

## Test plan
- [x] Existing `testTimeoutWhileWritingMetadata` test updated with assertions verifying the new metric counters are incremented correctly on timeout
- [ ] Manual verification that metrics appear in node stats API output under `remote_upload` extended fields