### PR TITLE
Fix field_caps returning empty results for disable_objects mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix terms lookup subquery fetch limit reading from non-existent index setting instead of cluster `max_clause_count` ([#20823](https://github.com/opensearch-project/OpenSearch/pull/20823))
 - Fix array_index_out_of_bounds_exception with wildcard and aggregations ([#20842](https://github.com/opensearch-project/OpenSearch/pull/20842))
 - Handle dependencies between analyzers ([#19248](https://github.com/opensearch-project/OpenSearch/pull/19248))
+- Fix `_field_caps` returning empty results and corrupted field names for `disable_objects: true` mappings ([#20800](https://github.com/opensearch-project/OpenSearch/pull/20800))
 
 ### Dependencies
 - Bump shadow-gradle-plugin from 8.3.9 to 9.3.1 ([#20569](https://github.com/opensearch-project/OpenSearch/pull/20569))

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/40_disable_objects.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/40_disable_objects.yml
@@ -1,0 +1,139 @@
+---
+"Field caps with disable_objects returns leaf fields":
+
+  - skip:
+      version: " - 3.4.99"
+      reason: "disable_objects was introduced in 3.5.0"
+
+  - do:
+      indices.create:
+        index: test_disable_objects
+        body:
+          mappings:
+            properties:
+              attributes:
+                type: object
+                disable_objects: true
+
+  - do:
+      index:
+        index: test_disable_objects
+        id: "1"
+        body:
+          attributes:
+            foo:
+              bar: baz
+
+  - do:
+      indices.refresh:
+        index: test_disable_objects
+
+  - do:
+      field_caps:
+        index: test_disable_objects
+        fields: "*"
+
+  # Leaf field must exist
+  - is_true: fields.attributes\.foo\.bar
+
+  # Parent object field must have type object
+  - match: { fields.attributes.object.type: object }
+
+  # Intermediate path must not exist (since disable_objects is set)
+  - is_false: fields.attributes\.foo
+
+---
+"Field caps with disable_objects does not corrupt field names after second document indexed":
+
+  - skip:
+      version: " - 3.4.99"
+      reason: "disable_objects was introduced in 3.5.0"
+
+  - do:
+      indices.create:
+        index: test_disable_objects_merge
+        body:
+          mappings:
+            properties:
+              attributes:
+                type: object
+                disable_objects: true
+
+  # doc 1: creates the disable_objects leaf field
+  - do:
+      index:
+        index: test_disable_objects_merge
+        id: "1"
+        body:
+          attributes:
+            foo:
+              bar: baz
+
+  # doc 2: unrelated - must not corrupt the existing mapping
+  - do:
+      index:
+        index: test_disable_objects_merge
+        id: "2"
+        body:
+          key: 1
+
+  - do:
+      indices.refresh:
+        index: test_disable_objects_merge
+
+  - do:
+      field_caps:
+        index: test_disable_objects_merge
+        fields: "*"
+
+  # Leaf field must exist
+  - is_true: fields.attributes\.foo\.bar
+
+  # Corrupted field name must not exist
+  - is_false: fields.attributes\.foo\.foo\.bar
+
+  # The unrelated field must also exist
+  - is_true: fields.key
+
+---
+"Field caps with normal nested object returns intermediate paths":
+
+  - do:
+      indices.create:
+        index: test_normal_nested
+        body:
+          mappings:
+            properties:
+              user:
+                type: object
+                properties:
+                  address:
+                    type: object
+                    properties:
+                      city:
+                        type: keyword
+
+  - do:
+      index:
+        index: test_normal_nested
+        id: "1"
+        body:
+          user:
+            address:
+              city: Chemnitz
+
+  - do:
+      indices.refresh:
+        index: test_normal_nested
+
+  - do:
+      field_caps:
+        index: test_normal_nested
+        fields: "*"
+
+  # Leaf field must exist
+  - is_true: fields.user\.address\.city
+
+  # Intermediate object paths must also exist
+  - match: { fields.user\.address.object.type: object }
+  - match: { fields.user.object.type: object }

--- a/server/src/main/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -180,6 +180,12 @@ public class TransportFieldCapabilitiesIndexAction extends HandledTransportActio
                     if (mapperService.fieldType(parentField) == null) {
                         // no field type, it must be an object field
                         ObjectMapper mapper = mapperService.getObjectMapper(parentField);
+                        if (mapper == null) {
+                            // parentField is part of a literal dotted field name under a disable_objects=true parent
+                            // No ObjectMapper exists for this intermediate path so skip it and continue up the chain
+                            dotIndex = parentField.lastIndexOf('.');
+                            continue;
+                        }
                         String type = mapper.nested().isNested() ? "nested" : "object";
                         IndexFieldCapabilities fieldCap = new IndexFieldCapabilities(
                             parentField,

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -127,12 +127,14 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
         Conflicts conflicts = new Conflicts(name());
         builder.merge((FieldMapper) mergeWith, conflicts);
         conflicts.check();
-        return builder.build(new BuilderContext(Settings.EMPTY, parentPath(name())));
+        return builder.build(new BuilderContext(Settings.EMPTY, parentPath(name(), simpleName())));
     }
 
-    private static ContentPath parentPath(String name) {
-        int endPos = name.lastIndexOf(".");
-        if (endPos == -1) {
+    private static ContentPath parentPath(String name, String simpleName) {
+        // Use simpleName to compute the parent path so that fields whose simpleName contains dots
+        // (because of disable_objects) get the correct parent path
+        int endPos = name.length() - simpleName.length() - 1;
+        if (endPos < 0) {
             return new ContentPath(0);
         }
         return new ContentPath(name.substring(0, endPos));
@@ -619,7 +621,7 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
                 param.merge(in, conflicts);
             }
             for (Mapper newSubField : in.multiFields) {
-                multiFieldsBuilder.update(newSubField, parentPath(newSubField.name()));
+                multiFieldsBuilder.update(newSubField, parentPath(newSubField.name(), newSubField.simpleName()));
             }
             this.copyTo.reset(in.copyTo);
             validate();

--- a/server/src/test/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesIndexActionTests.java
+++ b/server/src/test/java/org/opensearch/action/fieldcaps/TransportFieldCapabilitiesIndexActionTests.java
@@ -1,0 +1,156 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.fieldcaps;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.test.OpenSearchSingleNodeTestCase;
+
+import java.util.Map;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+
+public class TransportFieldCapabilitiesIndexActionTests extends OpenSearchSingleNodeTestCase {
+
+    // With disable_objects=true, {"attributes": {"foo": {"bar": "baz"}}} is flattened into the leaf
+    // field "attributes.foo.bar". The intermediate path "attributes.foo" has no ObjectMapper and
+    // _field_caps must not silently return empty results when walking the parent chain.
+    public void testFieldCapsDisableObjects() throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject("attributes")
+            .field("type", "object")
+            .field("disable_objects", true)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping(mapping));
+
+        client().prepareIndex("test")
+            .setId("1")
+            .setSource(
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("attributes")
+                    .startObject("foo")
+                    .field("bar", "baz")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+            )
+            .get();
+
+        client().admin().indices().prepareRefresh("test").get();
+
+        FieldCapabilitiesResponse response = client().fieldCaps(new FieldCapabilitiesRequest().fields("*").indices("test")).actionGet();
+
+        Map<String, Map<String, FieldCapabilities>> fields = response.get();
+
+        assertTrue("expected attributes.foo.bar in field caps", fields.containsKey("attributes.foo.bar"));
+        assertTrue("expected attributes in field caps", fields.containsKey("attributes"));
+        assertEquals("object", fields.get("attributes").values().iterator().next().getType());
+        // phantom intermediate path has no ObjectMapper and must not exist
+        assertFalse("attributes.foo should not exist in field caps", fields.containsKey("attributes.foo"));
+    }
+
+    // Indexing a second document after a disable_objects field must not corrupt the flattened field
+    // name. Previously "attributes.foo.bar" became "attributes.foo.foo.bar" after a mapping merge
+    // triggered by an unrelated document.
+    public void testFieldCapsDisableObjectsAfterUnrelatedDocument() throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject("attributes")
+            .field("type", "object")
+            .field("disable_objects", true)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping(mapping));
+
+        // doc 1: creates the disable_objects leaf field
+        client().prepareIndex("test")
+            .setId("1")
+            .setSource(
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("attributes")
+                    .startObject("foo")
+                    .field("bar", "baz")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+            )
+            .get();
+
+        // doc 2: unrelated - must not corrupt the existing mapping
+        client().prepareIndex("test").setId("2").setSource("{\"key\": 1}", MediaTypeRegistry.JSON).get();
+
+        client().admin().indices().prepareRefresh("test").get();
+
+        FieldCapabilitiesResponse response = client().fieldCaps(new FieldCapabilitiesRequest().fields("*").indices("test")).actionGet();
+
+        Map<String, Map<String, FieldCapabilities>> fields = response.get();
+
+        assertTrue("expected attributes.foo.bar in field caps", fields.containsKey("attributes.foo.bar"));
+        assertTrue("expected attributes.foo.bar.keyword in field caps", fields.containsKey("attributes.foo.bar.keyword"));
+        assertFalse("attributes.foo.foo.bar must not exist", fields.containsKey("attributes.foo.foo.bar"));
+        assertTrue("expected attributes in field caps", fields.containsKey("attributes"));
+        assertTrue("expected key in field caps", fields.containsKey("key"));
+    }
+
+    // Regression test: the parentPath fix in ParametrizedFieldMapper must not break normal object
+    // field handling. Regular nested object fields (without disable_objects) must still produce the
+    // correct parent entries in _field_caps.
+    public void testFieldCapsNormalNestedObjectUnaffected() throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject("user")
+            .field("type", "object")
+            .startObject("properties")
+            .startObject("address")
+            .field("type", "object")
+            .startObject("properties")
+            .startObject("city")
+            .field("type", "keyword")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping(mapping));
+
+        client().prepareIndex("test")
+            .setId("1")
+            .setSource("{\"user\":{\"address\":{\"city\":\"Chemnitz\"}}}", MediaTypeRegistry.JSON)
+            .get();
+
+        client().admin().indices().prepareRefresh("test").get();
+
+        FieldCapabilitiesResponse response = client().fieldCaps(new FieldCapabilitiesRequest().fields("*").indices("test")).actionGet();
+
+        Map<String, Map<String, FieldCapabilities>> fields = response.get();
+
+        assertTrue("expected user.address.city", fields.containsKey("user.address.city"));
+        assertTrue("expected user.address as object", fields.containsKey("user.address"));
+        assertEquals("object", fields.get("user.address").values().iterator().next().getType());
+        assertTrue("expected user as object", fields.containsKey("user"));
+        assertEquals("object", fields.get("user").values().iterator().next().getType());
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

`_field_caps` returns an empty response for indexes where a `disable_objects: true` object field has been populated with a child field. A second bug causes such child fields to be corrupted after any subsequent document is indexed into the same index - for example `attributes.foo.bar` becomes `attributes.foo.foo.bar`.

#### Root causes

When `_field_caps` walks the parent chain of a flattened leaf field (e.g. `attributes.foo.bar`), it looks up an `ObjectMapper` for each intermediate path. Under `disable_objects: true`, intermediate paths like `attributes.foo` have no `ObjectMapper` by design - the fix adds a null check to skip them and continue up the chain.

The field name corruption is caused by `ParametrizedFieldMapper.merge()` using `name().lastIndexOf('.')` to reconstruct the parent `ContentPath` when rebuilding a mapper. For a field with `simpleName` `foo.bar` and full name `attributes.foo.bar`, this returns the position of the dot before `bar` rather than the dot before `foo.bar`, so the parent path is computed as `attributes.foo` instead of `attributes`. The fix computes the boundary from `simpleName.length()` instead.

### Related Issues
Resolves #20811
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
