### PR TITLE
Make IndexShard#getEngine method public for plugin access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added support of WarmerRefreshListener in NRTReplicationEngine to trigger warmer after replication on replica shards ([#20650](https://github.com/opensearch-project/OpenSearch/pull/20650))
 
 ### Changed
+- Make `IndexShard#getEngine` method public for plugin access ([#20817](https://github.com/opensearch-project/OpenSearch/pull/20817))
 - Make telemetry `Tags` immutable ([#20788](https://github.com/opensearch-project/OpenSearch/pull/20788))
 - Move Randomness from server to libs/common ([#20570](https://github.com/opensearch-project/OpenSearch/pull/20570))
 - Use env variable (OPENSEARCH_FIPS_MODE) to enable opensearch to run in FIPS enforced mode instead of checking for existence of bcFIPS jars ([#20625](https://github.com/opensearch-project/OpenSearch/pull/20625))

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -4017,7 +4017,12 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         recoveryState.getVerifyIndex().checkIndexTime(Math.max(0, TimeValue.nsecToMSec(System.nanoTime() - timeNS)));
     }
 
-    Engine getEngine() {
+    /**
+     * Returns the current engine of this shard.
+     *
+     * @throws AlreadyClosedException if the engine is closed
+     */
+    public Engine getEngine() {
         Engine engine = getEngineOrNull();
         if (engine == null) {
             throw new AlreadyClosedException("engine is closed");


### PR DESCRIPTION
## Summary
- Makes `IndexShard#getEngine()` public (was package-private) so plugins can access the engine without resorting to reflection.
- `getEngine()` is preferred over `getEngineOrNull()` because it throws `AlreadyClosedException` when the engine is closed, giving callers a clear signal rather than a null.

## Context
The [time-series-db plugin](https://github.com/opensearch-project/time-series-db) has a requirement to load a block in a shard, which requires the engine access for the shard, `getEngine` on `IndexShard` (see [time-series-db#39](https://github.com/opensearch-project/time-series-db/pull/39#discussion_r2785705308)). As noted by @msfroh in that review:

> Doing this via reflection definitely shouldn't be the way to go... I think I like the idea of exposing `getEngine` better than `getEngineOrNull`. In particular, the former will throw an exception if the engine is closed, which I think probably makes sense.

This PR exposes `getEngine` as public so plugins can use it directly.

## Changes
- `server/src/main/java/org/opensearch/index/shard/IndexShard.java`: Changed `getEngine()` from package-private to `public` and added Javadoc.
- `CHANGELOG.md`: Added entry under `[Unreleased 3.x] > Changed`.

## Test plan
- [ ] Existing unit tests pass (no behavioral change — only visibility widened)
- [ ] Verify no new test failures in `IndexShardTests`

Signed-off-by: Venketep Prasad <venketep.prasad@uber.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)