### PR TITLE
5990: Fix security plugin issue

### DIFF
--- a/server/src/main/java/org/opensearch/action/ActionModule.java
+++ b/server/src/main/java/org/opensearch/action/ActionModule.java
@@ -595,13 +595,10 @@ public class ActionModule extends AbstractModule {
                 new RestHeaderDefinition(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, false)
             )
         ).collect(Collectors.toSet());
-        Set<String> transients =
-            Stream.concat(
-                actionPlugins.stream().flatMap(p -> p.getTransients().stream()),
-                Stream.of(
-                    TracerContextStorage.CURRENT_SPAN
-                )
-            ).collect(Collectors.toSet());
+        Set<String> transients = Stream.concat(
+            actionPlugins.stream().flatMap(p -> p.getTransients().stream()),
+            Stream.of(TracerContextStorage.CURRENT_SPAN)
+        ).collect(Collectors.toSet());
         UnaryOperator<RestHandler> restWrapper = null;
         for (ActionPlugin plugin : actionPlugins) {
             UnaryOperator<RestHandler> newRestWrapper = plugin.getRestHandlerWrapper(threadPool.getThreadContext(), headers, transients);

--- a/server/src/main/java/org/opensearch/action/ActionModule.java
+++ b/server/src/main/java/org/opensearch/action/ActionModule.java
@@ -500,6 +500,7 @@ import org.opensearch.rest.action.search.RestPutSearchPipelineAction;
 import org.opensearch.rest.action.search.RestSearchAction;
 import org.opensearch.rest.action.search.RestSearchScrollAction;
 import org.opensearch.tasks.Task;
+import org.opensearch.telemetry.tracing.TracerContextStorage;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.node.NodeClient;
 import org.opensearch.usage.UsageService;
@@ -594,9 +595,16 @@ public class ActionModule extends AbstractModule {
                 new RestHeaderDefinition(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, false)
             )
         ).collect(Collectors.toSet());
+        Set<String> transients =
+            Stream.concat(
+                actionPlugins.stream().flatMap(p -> p.getTransients().stream()),
+                Stream.of(
+                    TracerContextStorage.CURRENT_SPAN
+                )
+            ).collect(Collectors.toSet());
         UnaryOperator<RestHandler> restWrapper = null;
         for (ActionPlugin plugin : actionPlugins) {
-            UnaryOperator<RestHandler> newRestWrapper = plugin.getRestHandlerWrapper(threadPool.getThreadContext(), headers);
+            UnaryOperator<RestHandler> newRestWrapper = plugin.getRestHandlerWrapper(threadPool.getThreadContext(), headers, transients);
             if (newRestWrapper != null) {
                 logger.debug("Using REST wrapper from plugin " + plugin.getClass().getName());
                 if (restWrapper != null) {

--- a/server/src/main/java/org/opensearch/plugins/ActionPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/ActionPlugin.java
@@ -156,7 +156,11 @@ public interface ActionPlugin {
      *
      * Note: Only one installed plugin may implement a rest wrapper.
      */
-    default UnaryOperator<RestHandler> getRestHandlerWrapper(ThreadContext threadContext, Set<RestHeaderDefinition> headersToCopy, Set<String> transients) {
+    default UnaryOperator<RestHandler> getRestHandlerWrapper(
+        ThreadContext threadContext,
+        Set<RestHeaderDefinition> headersToCopy,
+        Set<String> transients
+    ) {
         return this.getRestHandlerWrapper(threadContext);
     }
 

--- a/server/src/main/java/org/opensearch/plugins/ActionPlugin.java
+++ b/server/src/main/java/org/opensearch/plugins/ActionPlugin.java
@@ -122,6 +122,13 @@ public interface ActionPlugin {
     }
 
     /**
+     * Returns transients which should be copied through context propagation
+     */
+    default Collection<String> getTransients() {
+        return Collections.emptyList();
+    }
+
+    /**
      * Returns headers which should be copied from internal requests into tasks.
      */
     default Collection<String> getTaskHeaders() {
@@ -149,6 +156,11 @@ public interface ActionPlugin {
      *
      * Note: Only one installed plugin may implement a rest wrapper.
      */
+    default UnaryOperator<RestHandler> getRestHandlerWrapper(ThreadContext threadContext, Set<RestHeaderDefinition> headersToCopy, Set<String> transients) {
+        return this.getRestHandlerWrapper(threadContext);
+    }
+
+    @Deprecated(forRemoval = true)
     default UnaryOperator<RestHandler> getRestHandlerWrapper(ThreadContext threadContext, Set<RestHeaderDefinition> headersToCopy) {
         return this.getRestHandlerWrapper(threadContext);
     }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/ThreadContextBasedTracerContextStorage.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/ThreadContextBasedTracerContextStorage.java
@@ -56,7 +56,7 @@ public class ThreadContextBasedTracerContextStorage implements TracerContextStor
         final Map<String, Object> transients = new HashMap<>();
         if (source.containsKey(CURRENT_SPAN)) {
             final SpanReference current = (SpanReference) source.get(CURRENT_SPAN);
-            if (current != null) {
+            if (current != null && current.getSpan() != null) {
                 transients.put(CURRENT_SPAN, new SpanReference(current.getSpan()));
             }
         }

--- a/server/src/test/java/org/opensearch/action/ActionModuleTests.java
+++ b/server/src/test/java/org/opensearch/action/ActionModuleTests.java
@@ -54,10 +54,12 @@ import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.RestHeaderDefinition;
 import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.rest.action.RestMainAction;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
+import org.opensearch.telemetry.tracing.TracerContextStorage;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -68,7 +70,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.Collection;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -274,4 +278,62 @@ public class ActionModuleTests extends OpenSearchTestCase {
             threadPool.shutdown();
         }
     }
-}
+
+    public void testTransientsCollectedFromPluginsAndCore() {
+
+        ThreadPool threadPool = new TestThreadPool("test");
+        try {
+            // Create a plugin that tracks what transients it receives
+            final Set<String>[] receivedTransients = new Set[1];
+            ActionPlugin testPlugin = new ActionPlugin() {
+                @Override
+                public Collection<String> getTransients() {
+                    return List.of("custom_transient");
+                }
+
+                @Override
+                public UnaryOperator<RestHandler> getRestHandlerWrapper(
+                    ThreadContext threadContext,
+                    Set<RestHeaderDefinition> headersToCopy,
+                    Set<String> transients
+                ) {
+                    // Capture the transients passed to this method
+                    receivedTransients[0] = transients;
+                    return handler -> handler;
+                }
+            };
+            List<ActionPlugin> plugins = List.of(testPlugin);
+
+            SettingsModule settings = new SettingsModule(Settings.EMPTY);
+            UsageService usageService = new UsageService();
+            ActionModule actionModule = new ActionModule(
+                settings.getSettings(),
+                new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY)),
+                settings.getIndexScopedSettings(),
+                settings.getClusterSettings(),
+                settings.getSettingsFilter(),
+                threadPool,
+                plugins,
+                null,
+                null,
+                usageService,
+                null,
+                new IdentityService(Settings.EMPTY, mock(ThreadPool.class), new ArrayList<>()),
+                new ExtensionsManager(Set.of(), new IdentityService(Settings.EMPTY, mock(ThreadPool.class), List.of()))
+            );
+
+            // Verify transients were passed to the plugin
+            assertNotNull("Plugin should have received transients", receivedTransients[0]);
+            assertTrue("Should contain custom transient from plugin",
+                receivedTransients[0].contains("custom_transient"));
+            assertTrue("Should contain core CURRENT_SPAN",
+                receivedTransients[0].contains(TracerContextStorage.CURRENT_SPAN));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        finally {
+            threadPool.shutdown();
+        }
+    }
+
+    }

--- a/server/src/test/java/org/opensearch/action/ActionModuleTests.java
+++ b/server/src/test/java/org/opensearch/action/ActionModuleTests.java
@@ -53,8 +53,8 @@ import org.opensearch.plugins.ActionPlugin.ActionHandler;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
-import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestHeaderDefinition;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.rest.action.RestMainAction;
 import org.opensearch.tasks.Task;
@@ -68,9 +68,9 @@ import org.opensearch.usage.UsageService;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.Collection;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
@@ -324,16 +324,13 @@ public class ActionModuleTests extends OpenSearchTestCase {
 
             // Verify transients were passed to the plugin
             assertNotNull("Plugin should have received transients", receivedTransients[0]);
-            assertTrue("Should contain custom transient from plugin",
-                receivedTransients[0].contains("custom_transient"));
-            assertTrue("Should contain core CURRENT_SPAN",
-                receivedTransients[0].contains(TracerContextStorage.CURRENT_SPAN));
+            assertTrue("Should contain custom transient from plugin", receivedTransients[0].contains("custom_transient"));
+            assertTrue("Should contain core CURRENT_SPAN", receivedTransients[0].contains(TracerContextStorage.CURRENT_SPAN));
         } catch (IOException e) {
             throw new RuntimeException(e);
-        }
-        finally {
+        } finally {
             threadPool.shutdown();
         }
     }
 
-    }
+}

--- a/server/src/test/java/org/opensearch/telemetry/tracing/ThreadContextBasedTracerContextStorageTests.java
+++ b/server/src/test/java/org/opensearch/telemetry/tracing/ThreadContextBasedTracerContextStorageTests.java
@@ -276,7 +276,7 @@ public class ThreadContextBasedTracerContextStorageTests extends OpenSearchTestC
         SpanReference spanReference = new SpanReference(null);
         Map<String, Object> source = new HashMap<>();
         source.put(ThreadContextBasedTracerContextStorage.CURRENT_SPAN, spanReference);
-        ThreadContextBasedTracerContextStorage context = (ThreadContextBasedTracerContextStorage)threadContextStorage;
+        ThreadContextBasedTracerContextStorage context = (ThreadContextBasedTracerContextStorage) threadContextStorage;
         assertTrue(context.transients(source).isEmpty());
     }
 }

--- a/server/src/test/java/org/opensearch/telemetry/tracing/ThreadContextBasedTracerContextStorageTests.java
+++ b/server/src/test/java/org/opensearch/telemetry/tracing/ThreadContextBasedTracerContextStorageTests.java
@@ -22,6 +22,8 @@ import org.opensearch.test.telemetry.tracing.MockTracingTelemetry;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -268,5 +270,13 @@ public class ThreadContextBasedTracerContextStorageTests extends OpenSearchTestC
 
         assertThat(threadContext.getTransient(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(not(nullValue())));
         assertThat(threadContextStorage.get(ThreadContextBasedTracerContextStorage.CURRENT_SPAN), is(nullValue()));
+    }
+
+    public void testNullSpanWithinSpanReference() {
+        SpanReference spanReference = new SpanReference(null);
+        Map<String, Object> source = new HashMap<>();
+        source.put(ThreadContextBasedTracerContextStorage.CURRENT_SPAN, spanReference);
+        ThreadContextBasedTracerContextStorage context = (ThreadContextBasedTracerContextStorage)threadContextStorage;
+        assertTrue(context.transients(source).isEmpty());
     }
 }


### PR DESCRIPTION

### Description
We are trying to fix: https://github.com/opensearch-project/security/issues/5990
We need to pass transients that should be copied. This change addresses that

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/security/issues/5990
Testing was done as follows:
* Open search was built with these changes using ./gradlew :distribution:archives:linux-arm64-tar:assemble -x test
* Security plugin was build such that is uses changes published by above ./gradlew assemble -Dopensearch.version=3.5.0-SNAPSHOT -Dbuild.snapshot=true -x test
* Then it was run and traces were validated. 

A couple of points in PR:
* A new method getTransients is added to ActionPlugin class. We could have reused headers but felt like it would be unclear which fields are transients to recover in security plugin within headers map. Also, responsibility wise both looked different. Do let me know if my understanding is incorrect
* Ideally OTelTelemetryPlugin should implements getTransients method but it does not extend ActionPlugin currently. Do let me know if modification should be made there appropriately
* Change to ThreadContextBasedTracerContextStorage.java was made as a bug was identified in it where SpanReference was not null but span within it was null. Due to this, security plugin would propagate incorrect empty span reference. Hence, added this check to avoid that. Will add screenshot of same in this PR to highlight where we observed this

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
<img width="3386" height="2018" alt="image" src="https://github.com/user-attachments/assets/776554b9-e15b-4898-9f75-f45265a2dc14" />
