### PR TITLE
Fix terms lookup subquery to use cluster max_clause_count setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix TLS cert hot-reload for Arrow Flight transport ([#20732](https://github.com/opensearch-project/OpenSearch/pull/20732))
 - Fix misleading heap usage cancellation message in SearchBackpressureService ([#20779](https://github.com/opensearch-project/OpenSearch/pull/20779))
 - - Delegate getMin/getMax methods for ExitableTerms ([#20775](https://github.com/opensearch-project/OpenSearch/pull/20775))
+- Fix terms lookup subquery fetch limit reading from non-existent index setting instead of cluster `max_clause_count` ([#20823](https://github.com/opensearch-project/OpenSearch/pull/20823))
 
 ### Dependencies
 - Bump shadow-gradle-plugin from 8.3.9 to 9.3.1 ([#20569](https://github.com/opensearch-project/OpenSearch/pull/20569))

--- a/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/query/SearchQueryIT.java
@@ -79,6 +79,7 @@ import org.opensearch.plugins.AnalysisPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.SearchService;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
@@ -1420,6 +1421,77 @@ public class SearchQueryIT extends ParameterizedStaticSettingsOpenSearchIntegTes
         // index "lookup3" type "type" has the source disabled: ignore the lookup terms
         searchResponse = client().prepareSearch("test").setQuery(termsLookupQuery("term", new TermsLookup("lookup3", "1", "terms"))).get();
         assertHitCount(searchResponse, 0L);
+    }
+
+    public void testTermsLookupSubqueryRespectsMaxClauseCount() throws Exception {
+        assertAcked(prepareCreate("tl_lookup").setMapping("val", "type=keyword"));
+        assertAcked(prepareCreate("tl_test").setMapping("val", "type=keyword"));
+
+        // Index 6 docs in the lookup index and matching docs in the test index
+        indexRandom(
+            true,
+            client().prepareIndex("tl_lookup").setId("1").setSource("val", "1"),
+            client().prepareIndex("tl_lookup").setId("2").setSource("val", "2"),
+            client().prepareIndex("tl_lookup").setId("3").setSource("val", "3"),
+            client().prepareIndex("tl_lookup").setId("4").setSource("val", "4"),
+            client().prepareIndex("tl_lookup").setId("5").setSource("val", "5"),
+            client().prepareIndex("tl_lookup").setId("6").setSource("val", "6"),
+            client().prepareIndex("tl_test").setId("1").setSource("val", "1"),
+            client().prepareIndex("tl_test").setId("2").setSource("val", "2"),
+            client().prepareIndex("tl_test").setId("3").setSource("val", "3"),
+            client().prepareIndex("tl_test").setId("4").setSource("val", "4"),
+            client().prepareIndex("tl_test").setId("5").setSource("val", "5"),
+            client().prepareIndex("tl_test").setId("6").setSource("val", "6")
+        );
+
+        indexRandomForConcurrentSearch("tl_lookup");
+        indexRandomForConcurrentSearch("tl_test");
+
+        try {
+            // Set max_clause_count to 3, which should limit fetchSize to 3
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setTransientSettings(Settings.builder().put(SearchService.INDICES_MAX_CLAUSE_COUNT_SETTING.getKey(), 3))
+                .get();
+
+            // The subquery matches all 6 docs in tl_lookup, but fetchSize is 3 => should fail
+            // The IllegalArgumentException may be wrapped in SearchPhaseExecutionException
+            Exception ex = expectThrows(
+                Exception.class,
+                () -> client().prepareSearch("tl_test")
+                    .setQuery(termsLookupQuery("val", new TermsLookup("tl_lookup", null, "val", matchAllQuery())))
+                    .get()
+            );
+            String errorMsg = ex.getMessage() != null ? ex.getMessage() : ex.getCause().getMessage();
+            assertThat(errorMsg, containsString("exceed fetch limit"));
+
+            // Raise the limit so the same query succeeds
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setTransientSettings(
+                    Settings.builder()
+                        .put(
+                            SearchService.INDICES_MAX_CLAUSE_COUNT_SETTING.getKey(),
+                            SearchService.INDICES_MAX_CLAUSE_COUNT_SETTING.getDefault(Settings.EMPTY)
+                        )
+                )
+                .get();
+
+            SearchResponse searchResponse = client().prepareSearch("tl_test")
+                .setQuery(termsLookupQuery("val", new TermsLookup("tl_lookup", null, "val", matchAllQuery())))
+                .get();
+            assertNoFailures(searchResponse);
+            assertHitCount(searchResponse, 6L);
+        } finally {
+            // Reset transient setting
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings()
+                .setTransientSettings(Settings.builder().putNull(SearchService.INDICES_MAX_CLAUSE_COUNT_SETTING.getKey()))
+                .get();
+        }
     }
 
     public void testBasicQueryById() throws Exception {

--- a/server/src/main/java/org/opensearch/index/query/TermsQueryBuilder.java
+++ b/server/src/main/java/org/opensearch/index/query/TermsQueryBuilder.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.query;
 
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
@@ -608,7 +609,9 @@ public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> i
                         // Get max_terms_count, max_result_window, and max_clause_count, fallback to their defaults
                         int maxTermsCount = IndexSettings.MAX_TERMS_COUNT_SETTING.get(idxSettings);
                         int maxResultWindow = IndexSettings.MAX_RESULT_WINDOW_SETTING.get(idxSettings);
-                        int maxClauseCount = idxSettings.getAsInt("indices.query.max_clause_count", 1024);
+                        // Reads the cluster-level max_clause_count, propagated via SearchService's
+                        // dynamic setting update consumer to IndexSearcher's static field.
+                        int maxClauseCount = IndexSearcher.getMaxClauseCount();
                         // The effective size must not exceed any of these
                         int fetchSize = Math.min(Math.min(maxTermsCount, maxResultWindow), maxClauseCount);
 

--- a/server/src/test/java/org/opensearch/index/query/TermQueryWithDocIdAndQueryTests.java
+++ b/server/src/test/java/org/opensearch/index/query/TermQueryWithDocIdAndQueryTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.query;
 
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.action.get.GetRequest;
@@ -372,12 +373,10 @@ public class TermQueryWithDocIdAndQueryTests extends OpenSearchTestCase {
         when(mockClient.admin()).thenReturn(mockAdminClient);
         when(mockAdminClient.indices()).thenReturn(mockIndicesAdminClient);
 
-        // Settings that produce a small fetch size
-        int maxTermsCount = 5, maxResultWindow = 5, maxClauseCount = 5;
+        // Set maxTermsCount and maxResultWindow high so maxClauseCount (3) is the limiting factor
         Settings idxSettings = Settings.builder()
-            .put("index.max_terms_count", maxTermsCount)
-            .put("index.max_result_window", maxResultWindow)
-            .put("indices.query.max_clause_count", maxClauseCount)
+            .put(IndexSettings.MAX_TERMS_COUNT_SETTING.getKey(), 100)
+            .put(IndexSettings.MAX_RESULT_WINDOW_SETTING.getKey(), 100)
             .build();
 
         // Simulate settings response
@@ -391,11 +390,11 @@ public class TermQueryWithDocIdAndQueryTests extends OpenSearchTestCase {
             return null;
         }).when(mockIndicesAdminClient).getSettings(any(), any());
 
-        // Simulate a search response with more total hits than fetchSize
+        // Simulate a search response with more total hits than maxClauseCount (3)
         doAnswer(invocation -> {
             ActionListener<org.opensearch.action.search.SearchResponse> listener = invocation.getArgument(1);
 
-            SearchHit[] hits = new SearchHit[5]; // Only 5 returned
+            SearchHit[] hits = new SearchHit[5];
             for (int i = 0; i < 5; i++)
                 hits[i] = new SearchHit(i);
             org.apache.lucene.search.TotalHits totalHits = new org.apache.lucene.search.TotalHits(
@@ -443,8 +442,15 @@ public class TermQueryWithDocIdAndQueryTests extends OpenSearchTestCase {
             return null;
         }).when(mockRewriteContext).registerAsyncAction(any());
 
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> builder.doRewrite(mockRewriteContext));
-        assertTrue(ex.getMessage().contains("exceed fetch limit"));
+        // Set maxClauseCount to 3 so it becomes the actual limiting factor via IndexSearcher
+        int originalMaxClauseCount = IndexSearcher.getMaxClauseCount();
+        try {
+            IndexSearcher.setMaxClauseCount(3);
+            IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> builder.doRewrite(mockRewriteContext));
+            assertTrue(ex.getMessage().contains("exceed fetch limit"));
+        } finally {
+            IndexSearcher.setMaxClauseCount(originalMaxClauseCount);
+        }
     }
 
     public void testMaxTermsCountSettingGetterConsistency() {


### PR DESCRIPTION
### Description

`TermsQueryBuilder.fetch()` reads `indices.query.max_clause_count` (without `.bool.`) from index settings — a non-existent, unregistered setting path — with a hardcoded fallback of 1024. The actual cluster setting `indices.query.bool.max_clause_count` is never consulted, making the fetch limit unconfigurable.

**Fix:** Replace the raw `idxSettings.getAsInt(...)` call with `IndexSearcher.getMaxClauseCount()`, which already reflects the cluster setting via `SearchService.INDICES_MAX_CLAUSE_COUNT_SETTING`.

**Test:** Added `testTermsLookupFetchLimitUsesClusterMaxClauseCount` validating that the fetch limit mechanism reads from `IndexSearcher.getMaxClauseCount()` (backed by the registered cluster setting) rather than a hardcoded value.

Introduced in PR #18195.

### Related Issues

Resolves #20820
Relates to #17599 (partially — the feature works but the limit is misconfigured)

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).