### PR TITLE
Bump `com.netflix.nebula:gradle-info-plugin` to 16.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `org.tukaani:xz` from 1.11 to 1.12 ([#20760](https://github.com/opensearch-project/OpenSearch/pull/20760))
 - Bump `org.jline:jline` from 3.30.6 to 4.0.0 ([#20800](https://github.com/opensearch-project/OpenSearch/pull/20800))
 - Bump `com.netflix.nebula.ospackage-base` from 12.2.0 to 12.3.0 ([#20799](https://github.com/opensearch-project/OpenSearch/pull/20799))
+- Bump `com.netflix.nebula:gradle-info-plugin` to 16.2.1 ([#20825](https://github.com/opensearch-project/OpenSearch/pull/20825))
 
 ### Removed
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -105,9 +105,9 @@ dependencies {
   api "commons-codec:commons-codec:${props.getProperty('commonscodec')}"
   api "org.apache.commons:commons-compress:${props.getProperty('commonscompress')}"
   api 'org.apache.ant:ant:1.10.15'
-  api 'com.netflix.nebula:gradle-extra-configurations-plugin:10.0.0'
+  api 'com.netflix.nebula:gradle-extra-configurations-plugin:10.0.1'
   api 'com.netflix.nebula:nebula-publishing-plugin:23.0.0'
-  api 'com.netflix.nebula:gradle-info-plugin:12.1.6'
+  api 'com.netflix.nebula:gradle-info-plugin:16.2.1'
   api 'org.apache.rat:apache-rat:0.15'
   api "commons-io:commons-io:${props.getProperty('commonsio')}"
   api "net.java.dev.jna:jna:5.16.0"


### PR DESCRIPTION
### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
