### PR TITLE
Fix JVM deoptimization loop due to lambda misprediction

### DIFF
--- a/server/src/main/java/org/opensearch/action/bulk/BulkItemRequest.java
+++ b/server/src/main/java/org/opensearch/action/bulk/BulkItemRequest.java
@@ -140,15 +140,8 @@ public class BulkItemRequest implements Writeable, Accountable {
         out.writeVInt(id);
         DocWriteRequest.writeDocumentRequestThin(out, request);
 
-        BulkItemResponse primaryResponse = this.primaryResponse;
-
-        // Explicitly check if primaryResponse is null to avoid branching/mispredictions in a lambda
-        if (primaryResponse != null) {
-            out.writeBoolean(true);
-            primaryResponse.writeThin(out);
-        } else {
-            out.writeBoolean(false);
-        }
+        BulkItemResponse primaryResponse = this.primaryResponse; // Read volatile once
+        out.writeOptionalWriteable((o, resp) -> resp.writeThin(o), primaryResponse);
     }
 
     @Override


### PR DESCRIPTION
### Description
This change resolves a JVM deoptimization loop by refactoring how primaryResponse is written to the stream. 

To do this, we explicitly check if `primaryResponse == null`, avoiding the check within the lambda. This prevents the C2 compiler from generating an `invokedynamic` instruction, which is prone to permanent deoptimization when branch traffic flip-flops. The explicit if/else allows the JVM to compile both paths, relying on CPU branch prediction instead of a JVM trap.

It also fixes a potential race condition where the volatile `primaryResponse` is read once to check, and read again for use, though it may be modified in between. 

This pulls the `writeOptionalWriteable` logic outside, but this follows the convention of other places in the repo.

### Background
We recently found elevated CPU despite no change in load. 
<img width="1261" height="291" alt="image" src="https://github.com/user-attachments/assets/c42415d1-2f75-4c35-aef3-307e245a1456" />

Profiling revealed it was due to a deopt/uncommon trap hit at `BulkItemRequest#writeThin`
<img width="1205" height="302" alt="image" src="https://github.com/user-attachments/assets/33c2746f-6b69-4535-9f16-68b1e841c0cd" />

This is an example deopt event from the profile:
```
jdk.Deoptimization {
  startTime = 19:11:35.451 (2026-03-10)
  compileId = 26645
  compiler = "c2"
  method = org.opensearch.action.bulk.BulkItemRequest.writeThin(StreamOutput)
  lineNumber = 142
  bci = 21
  instruction = "ifnonnull"
  reason = "unstable_if"
  action = "none"
  eventThread = "opensearch[esdock-opensearch-metric-mvp-production-cluster-phx-ginuz-sukam][write][T#15]" (javaThreadId = 267)
  stackTrace = [
    org.opensearch.action.bulk.BulkItemRequest.writeThin(StreamOutput) line: 142
    org.opensearch.action.bulk.BulkShardRequest.lambda$writeTo$3(StreamOutput, BulkItemRequest) line: 102
    org.opensearch.core.common.io.stream.StreamOutput.writeArray(Writeable$Writer, Object[]) line: 939
    org.opensearch.action.bulk.BulkShardRequest.writeTo(StreamOutput) line: 99
    org.opensearch.action.support.replication.TransportReplicationAction$ConcreteShardRequest.writeTo(StreamOutput) line: 1589
  ]
}
```

`action = "none"` implies that we've hit the recompilation cutoff for the method. Since lambdas use `invokedynamic`, my understanding is that it's possible to flip-flop between predictions, eventually hitting the cutoff. In this case, the cutoff was hit while the wrong branch was compiled, and each invocation hits the trap. 

### Related Issues
n/a

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
