### PR TITLE
Fix array_index_out_of_bounds_exception with wildcard and aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix ShardSearchFailure in transport-grpc ([#20641](https://github.com/opensearch-project/OpenSearch/pull/20641))
 - Fix TLS cert hot-reload for Arrow Flight transport ([#20732](https://github.com/opensearch-project/OpenSearch/pull/20732))
 - Fix misleading heap usage cancellation message in SearchBackpressureService ([#20779](https://github.com/opensearch-project/OpenSearch/pull/20779))
-- - Delegate getMin/getMax methods for ExitableTerms ([#20775](https://github.com/opensearch-project/OpenSearch/pull/20775))
+- Delegate getMin/getMax methods for ExitableTerms ([#20775](https://github.com/opensearch-project/OpenSearch/pull/20775))
 - Fix terms lookup subquery fetch limit reading from non-existent index setting instead of cluster `max_clause_count` ([#20823](https://github.com/opensearch-project/OpenSearch/pull/20823))
+- Fix array_index_out_of_bounds_exception with wildcard and aggregations ([#20842](https://github.com/opensearch-project/OpenSearch/pull/20842))
 
 ### Dependencies
 - Bump shadow-gradle-plugin from 8.3.9 to 9.3.1 ([#20569](https://github.com/opensearch-project/OpenSearch/pull/20569))

--- a/server/src/main/java/org/opensearch/index/mapper/WildcardFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/WildcardFieldMapper.java
@@ -743,7 +743,7 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
         private final Query firstPhaseQuery;
         private final Predicate<String> secondPhaseMatcher;
         private final String patternString; // For toString
-        private final ValueFetcher valueFetcher;
+        private final Supplier<ValueFetcher> valueFetcherSupplier;
         private final SearchLookup searchLookup;
 
         WildcardMatchingQuery(String fieldName, Query firstPhaseQuery, String patternString) {
@@ -764,10 +764,10 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
             this.patternString = Objects.requireNonNull(patternString);
             if (context != null) {
                 this.searchLookup = context.lookup();
-                this.valueFetcher = fieldType.valueFetcher(context, context.lookup(), null);
+                this.valueFetcherSupplier = () -> fieldType.valueFetcher(context, context.lookup(), null);
             } else {
                 this.searchLookup = null;
-                this.valueFetcher = null;
+                this.valueFetcherSupplier = null;
             }
         }
 
@@ -776,14 +776,14 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
             Query firstPhaseQuery,
             Predicate<String> secondPhaseMatcher,
             String patternString,
-            ValueFetcher valueFetcher,
+            Supplier<ValueFetcher> valueFetcherSupplier,
             SearchLookup searchLookup
         ) {
             this.fieldName = fieldName;
             this.firstPhaseQuery = firstPhaseQuery;
             this.secondPhaseMatcher = secondPhaseMatcher;
             this.patternString = patternString;
-            this.valueFetcher = valueFetcher;
+            this.valueFetcherSupplier = valueFetcherSupplier;
             this.searchLookup = searchLookup;
         }
 
@@ -821,7 +821,7 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
                     rewriteFirstPhase,
                     secondPhaseMatcher,
                     patternString,
-                    valueFetcher,
+                    valueFetcherSupplier,
                     searchLookup
                 );
             }
@@ -844,6 +844,9 @@ public class WildcardFieldMapper extends ParametrizedFieldMapper {
                             Scorer approximateScorer = firstPhaseSupplier.get(leadCost);
                             DocIdSetIterator approximation = approximateScorer.iterator();
                             LeafSearchLookup leafSearchLookup = searchLookup.getLeafSearchLookup(context);
+                            // Create a new ValueFetcher per thread.
+                            // ValueFetcher.setNextReader is not thread safe.
+                            final ValueFetcher valueFetcher = valueFetcherSupplier.get();
                             valueFetcher.setNextReader(context);
 
                             TwoPhaseIterator twoPhaseIterator = new TwoPhaseIterator(approximation) {


### PR DESCRIPTION
### Description
under concurrent conditions, encountered a situation where multiple threads were simultaneously calling the valueFetcher object, causing the buffer to be read and written at the same time.

I was unable to reproduce the bug in the IT test cases; I only reproduced and fixed the issue locally using the method mentioned in the issue. I would be very grateful if anyone could help supplement the test cases.

##### This pr need to backport to 2.x

### Related Issues
[#20838](https://github.com/opensearch-project/OpenSearch/issues/20838)
[#18701](https://github.com/opensearch-project/OpenSearch/issues/18701)


### Check List
- [ ] Functionality includes testing.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
