### PR TITLE
Fix flaky Netty4Http3IT test suite

### DIFF
--- a/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpClient.java
+++ b/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpClient.java
@@ -506,6 +506,7 @@ public class Netty4HttpClient implements Closeable {
 
             final ChannelHandler quicClientCodec = Http3.newQuicClientCodecBuilder()
                 .sslContext(context)
+                .maxIdleTimeout(60, TimeUnit.SECONDS)
                 .initialMaxData(SETTING_HTTP_MAX_CONTENT_LENGTH.get(Settings.EMPTY).getBytes())
                 .initialMaxStreamDataBidirectionalLocal(SETTING_H3_MAX_STREAM_LOCAL_LENGTH.get(Settings.EMPTY).getBytes())
                 .initialMaxStreamDataBidirectionalRemote(SETTING_H3_MAX_STREAM_REMOTE_LENGTH.get(Settings.EMPTY).getBytes())
@@ -518,6 +519,7 @@ public class Netty4HttpClient implements Closeable {
         @Override
         Channel prepare(Bootstrap clientBootstrap, Channel channel) throws InterruptedException {
             final QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 30000) // 30 seconds
                 .handler(new Http3ClientConnectionHandler())
                 .remoteAddress(channel.remoteAddress())
                 .connect()


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixing flaky Netty4Http3IT test suite

### Related Issues
Closes https://github.com/opensearch-project/OpenSearch/issues/20654

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
