### PR TITLE
Fix flaky testOverflowDisabledAsynchronous by throwing AlreadyClosedException

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
@@ -10,6 +10,7 @@ package org.opensearch.index.store.remote.utils;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.common.annotation.ExperimentalApi;
@@ -206,7 +207,7 @@ public class TransferManager {
         @Override
         public IndexInput getIndexInput() throws IOException {
             if (isClosed.get()) {
-                throw new IllegalStateException("Already closed");
+                throw new AlreadyClosedException("Already closed");
             }
             if (isStarted.getAndSet(true) == false) {
                 // We're the first one here, need to download the block
@@ -233,7 +234,7 @@ public class TransferManager {
         public CompletableFuture<IndexInput> asyncLoadIndexInput(Executor executor) {
             if (isClosed.get()) {
                 fileCache.decRef(request.getFilePath());
-                return CompletableFuture.failedFuture(new IllegalStateException("Already closed"));
+                return CompletableFuture.failedFuture(new AlreadyClosedException("Already closed"));
             }
             if (isStarted.getAndSet(true) == false) {
                 // Create new future and set it as the result


### PR DESCRIPTION
When the file cache is full and a blob fetch races with cache eviction, DelayedCreationCachedIndexInput.getIndexInput() throws an IllegalStateException, so this surfaces as an IllegalStateException instead of the IOException callers expect. Replace IllegalStateException with Lucene's AlreadyClosedException (which extends IOException) in both getIndexInput() and asyncLoadIndexInput().

Resolves #18850
Resolves #16676
Resolves #18872


### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
