### PR TITLE
Add debug logging to RemoteSegmentStoreDirectory for stale segment cl…

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
+++ b/server/src/main/java/org/opensearch/index/shard/RemoteStoreRefreshListener.java
@@ -243,6 +243,7 @@ public final class RemoteStoreRefreshListener extends ReleasableRetryableRefresh
                 // is considered as a first refresh post commit. A cleanup of stale commit files is triggered.
                 // This is done to avoid delete post each refresh.
                 if (isRefreshAfterCommit()) {
+                    logger.debug("isRefreshAfterCommit=true, triggering deleteStaleSegmentsAsync");
                     remoteDirectory.deleteStaleSegmentsAsync(indexShard.getRemoteStoreSettings().getMinRemoteSegmentMetadataFiles());
                 }
 

--- a/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
+++ b/server/src/main/java/org/opensearch/index/store/RemoteSegmentStoreDirectory.java
@@ -724,6 +724,7 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
     private void postUpload(Directory from, String src, String remoteFilename, String checksum) throws IOException {
         UploadedSegmentMetadata segmentMetadata = new UploadedSegmentMetadata(src, remoteFilename, checksum, from.fileLength(src));
         segmentsUploadedToRemoteStore.put(src, segmentMetadata);
+        logger.debug("postUpload: added={}, mapSize={}", src, segmentsUploadedToRemoteStore.size());
     }
 
     /**
@@ -948,9 +949,18 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             return;
         }
 
+        long startNanos = System.nanoTime();
+        logger.debug("deleteStaleSegments: entering, mapSize={}", segmentsUploadedToRemoteStore.size());
         List<String> sortedMetadataFileList = remoteMetadataDirectory.listFilesByPrefixInLexicographicOrder(
             MetadataFilenameUtils.METADATA_PREFIX,
             Integer.MAX_VALUE
+        );
+        long listingTimeMs = (System.nanoTime() - startNanos) / 1_000_000;
+        logger.debug(
+            "deleteStaleSegments: metadataFileCount={}, listingTimeMs={}, mapSize={}",
+            sortedMetadataFileList.size(),
+            listingTimeMs,
+            segmentsUploadedToRemoteStore.size()
         );
         if (sortedMetadataFileList.size() <= lastNMetadataFilesToKeep) {
             logger.debug(
@@ -989,6 +999,8 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             return;
         }
 
+        logger.debug("deleteStaleSegments: lockFiles={}, implicitLockedFiles={}", allLockFiles.size(), implicitLockedFiles.size());
+
         List<String> metadataFilesEligibleToDelete = new ArrayList<>(
             sortedMetadataFileList.subList(lastNMetadataFilesToKeep, sortedMetadataFileList.size())
         );
@@ -1002,7 +1014,8 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
         );
 
         if (metadataFilesEligibleToDelete.isEmpty()) {
-            logger.debug("No metadata files are eligible to be deleted based on lastNMetadataFilesToKeep and age");
+            long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
+            logger.debug("No metadata files are eligible to be deleted based on lastNMetadataFilesToKeep and age, elapsedMs={}", elapsedMs);
             return;
         }
 
@@ -1011,9 +1024,10 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
             .collect(Collectors.toList());
 
         logger.debug(
-            "metadataFilesEligibleToDelete={} metadataFilesToBeDeleted={}",
-            metadataFilesEligibleToDelete,
-            metadataFilesToBeDeleted
+            "deleteStaleSegments: eligible={}, toBeDeleted={}, elapsedMs={}",
+            metadataFilesEligibleToDelete.size(),
+            metadataFilesToBeDeleted.size(),
+            (System.nanoTime() - startNanos) / 1_000_000
         );
 
         Map<String, UploadedSegmentMetadata> activeSegmentFilesMetadataMap = new HashMap<>();
@@ -1032,6 +1046,12 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
                 segmentMetadataMap.values().stream().map(metadata -> metadata.uploadedFilename).collect(Collectors.toSet())
             );
         }
+        logger.debug(
+            "deleteStaleSegments: metadataFilesToFilterActive={}, activeSegments={}, elapsedMs={}",
+            metadataFilesToFilterActiveSegments.size(),
+            activeSegmentRemoteFilenames.size(),
+            (System.nanoTime() - startNanos) / 1_000_000
+        );
         Set<String> deletedSegmentFiles = new HashSet<>();
         for (String metadataFile : metadataFilesToBeDeleted) {
             Map<String, UploadedSegmentMetadata> staleSegmentFilesMetadataMap = readMetadataFile(metadataFile).getMetadata();
@@ -1045,6 +1065,12 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
                 .filter(file -> activeSegmentRemoteFilenames.contains(file) == false)
                 .filter(file -> deletedSegmentFiles.contains(file) == false)
                 .collect(Collectors.toList());
+            logger.debug(
+                "deleteStaleSegments: metadataFile={}, staleSegments={}, filesToDelete={}",
+                metadataFile,
+                staleSegmentRemoteFilenames.size(),
+                filesToDelete.size()
+            );
 
             AtomicBoolean deletionSuccessful = new AtomicBoolean(true);
             try {
@@ -1073,7 +1099,12 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
                 remoteMetadataDirectory.deleteFile(metadataFile);
             }
         }
-        logger.debug("deletedSegmentFiles={}", deletedSegmentFiles);
+        logger.debug(
+            "deletedSegmentFiles={}, mapSize={}, totalTimeMs={}",
+            deletedSegmentFiles,
+            segmentsUploadedToRemoteStore.size(),
+            (System.nanoTime() - startNanos) / 1_000_000
+        );
     }
 
     public void deleteStaleSegmentsAsync(int lastNMetadataFilesToKeep) {
@@ -1108,6 +1139,8 @@ public final class RemoteSegmentStoreDirectory extends FilterDirectory implement
                 canDeleteStaleCommits.set(true);
                 listener.onFailure(e);
             }
+        } else {
+            logger.debug("deleteStaleSegmentsAsync: skipped, gate held by another run, mapSize={}", segmentsUploadedToRemoteStore.size());
         }
     }
 


### PR DESCRIPTION
### Description

Add debug logging to RemoteSegmentStoreDirectory to diagnose why deleteStaleSegments does not complete for certain indices, leading to unbounded growth of segmentsUploadedToRemoteStore ConcurrentHashMap and JVM heap pressure.

Logs added:
- postUpload: map size after each entry added — tracks growth rate
- deleteStaleSegments entering: confirms method entry
- deleteStaleSegments metadataFileCount, listingTimeMs: S3 metadata listing duration and file count
- deleteStaleSegments lockFiles: lock file counts after fetch
- deleteStaleSegments eligible, toBeDeleted: metadata files eligible for deletion after filtering
- deleteStaleSegments metadataFilesToFilterActive, activeSegments: active segment computation
- deleteStaleSegments metadataFile, staleSegments, filesToDelete: per-iteration deletion counts
- deletedSegmentFiles, mapSize, totalTimeMs: completion with total elapsed time
- deleteStaleSegmentsAsync skipped, gate held: when canDeleteStaleCommits gate blocks entry
- isRefreshAfterCommit=true: in RemoteStoreRefreshListener to confirm call frequency

All logs are at DEBUG level — no production impact unless debug logging is enabled.

### Related Issues
<!-- If there's no public GitHub issue yet, you can leave this blank or create one -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

