### PR TITLE
Add Liquid Cache runtime initialization and query execution metrics logging

### DIFF
--- a/gradle/run.gradle
+++ b/gradle/run.gradle
@@ -40,6 +40,11 @@ testClusters {
     testDistribution = 'archive'
     if (numZones > 1) numberOfZones = numZones
     if (numNodes > 1) numberOfNodes = numNodes
+    // Liquid Cache configuration for DataFusion engine
+    if (findProperty("enableLiquidCache")) {
+      setting 'datafusion.liquid_cache.enabled', 'true'
+      setting 'datafusion.liquid_cache.size', findProperty("liquidCacheSize") ?: '1gb'
+    }
     // S3 repository configuration
     if (findProperty("enableS3")) {
       plugin(':plugins:repository-s3')

--- a/plugins/engine-datafusion/jni/src/eviction_policy.rs
+++ b/plugins/engine-datafusion/jni/src/eviction_policy.rs
@@ -126,7 +126,7 @@ impl CachePolicy for LruPolicy {
     }
 
     fn select_for_eviction(&self, target_size: usize) -> Vec<String> {
-        println!("info seleectpon");
+        // println!("info seleectpon");
         if target_size == 0 {
             return Vec::new();
         }

--- a/plugins/engine-datafusion/jni/src/lib.rs
+++ b/plugins/engine-datafusion/jni/src/lib.rs
@@ -938,3 +938,11 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_streamClo
     // Log Liquid Cache stats after stream is fully consumed
     liquid_cache::LiquidOnlyRuntime::log_stats_if_initialized();
 }
+
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_clearLiquidCache(
+    _env: JNIEnv,
+    _class: JClass,
+) {
+    liquid_cache::LiquidOnlyRuntime::reset_cache_if_initialized();
+}

--- a/plugins/engine-datafusion/jni/src/lib.rs
+++ b/plugins/engine-datafusion/jni/src/lib.rs
@@ -80,11 +80,16 @@ use crate::runtime_manager::RuntimeManager;
 
 mod statistics_cache;
 mod eviction_policy;
+mod liquid_cache;
 
 struct DataFusionRuntime {
     runtime_env: RuntimeEnv,
     custom_cache_manager: Option<CustomCacheManager>,
     monitor: Arc<Monitor>,
+    /// Liquid Cache physical optimizer rule (if enabled)
+    liquid_cache_optimizer: Option<Arc<dyn datafusion::physical_optimizer::PhysicalOptimizerRule + Send + Sync>>,
+    /// Liquid Cache lineage optimizer rule (if enabled)
+    liquid_cache_lineage_optimizer: Option<Arc<dyn datafusion::optimizer::OptimizerRule + Send + Sync>>,
 }
 
 // TASK monitorint metrics
@@ -248,7 +253,9 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_createGlo
     memory_pool_limit: jlong,
     cache_manager_ptr: jlong,
     spill_dir: JString,
-    spill_limit: jlong
+    spill_limit: jlong,
+    liquid_cache_enabled: jboolean,
+    liquid_cache_size: jlong,
 ) -> jlong {
     let spill_dir: String = match env.get_string(&spill_dir) {
         Ok(path) => path.into(),
@@ -285,16 +292,44 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_createGlo
         }
     };
 
-    let runtime_env = RuntimeEnvBuilder::new()
-        .with_cache_manager(cache_manager_config)
-        .with_memory_pool(memory_pool.clone())
-        .with_disk_manager_builder(builder)
-        .build().unwrap();
+    // Initialize Liquid Cache if enabled, otherwise use standard RuntimeEnv
+    let liquid_cache_enabled = liquid_cache_enabled != 0;
+    let (runtime_env, liquid_optimizer, liquid_lineage_optimizer) = if liquid_cache_enabled {
+        match liquid_cache::LiquidOnlyRuntime::init(liquid_cache_size as u64) {
+            Ok(liquid_runtime) => {
+                log_info!("[LiquidCache] Initialized with size: {} bytes", liquid_cache_size);
+                let liquid_env = liquid_runtime.runtime_env();
+                (
+                    (*liquid_env).clone(),
+                    Some(liquid_runtime.optimizer()),
+                    Some(liquid_runtime.lineage_optimizer()),
+                )
+            }
+            Err(e) => {
+                log_error!("[LiquidCache] Initialization failed: {}", e);
+                let _ = env.throw_new(
+                    "java/lang/RuntimeException",
+                    format!("Failed to initialize liquid cache: {}", e),
+                );
+                return 0;
+            }
+        }
+    } else {
+        log_info!("[LiquidCache] Disabled");
+        let env = RuntimeEnvBuilder::new()
+            .with_cache_manager(cache_manager_config)
+            .with_memory_pool(memory_pool.clone())
+            .with_disk_manager_builder(builder)
+            .build().unwrap();
+        (env, None, None)
+    };
 
     let runtime = DataFusionRuntime {
         runtime_env,
         custom_cache_manager,
         monitor,
+        liquid_cache_optimizer: liquid_optimizer,
+        liquid_cache_lineage_optimizer: liquid_lineage_optimizer,
     };
 
     Box::into_raw(Box::new(runtime)) as jlong
@@ -900,4 +935,6 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_streamClo
     stream: jlong,
 ) {
     let _ = unsafe { Box::from_raw(stream as *mut RecordBatchStreamAdapter<CrossRtStream>) };
+    // Log Liquid Cache stats after stream is fully consumed
+    liquid_cache::LiquidOnlyRuntime::log_stats_if_initialized();
 }

--- a/plugins/engine-datafusion/jni/src/lib.rs
+++ b/plugins/engine-datafusion/jni/src/lib.rs
@@ -17,6 +17,7 @@ use jni::objects::JLongArray;
 use jni::sys::{jboolean, jbyteArray, jint, jlong, jstring};
 use jni::{JNIEnv, JavaVM};
 use std::sync::{Arc, OnceLock};
+use std::sync::atomic::{AtomicU64, Ordering};
 use arrow_array::{Array, RecordBatch, StructArray};
 use arrow_array::ffi::FFI_ArrowArray;
 use arrow_schema::ffi::FFI_ArrowSchema;
@@ -106,6 +107,9 @@ static TOKIO_RUNTIME_MANAGER: OnceLock<Arc<RuntimeManager>> = OnceLock::new();
 
 // Global JavaVM reference
 static JAVA_VM: OnceLock<JavaVM> = OnceLock::new();
+
+// Global query counter for correlating logs
+static QUERY_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 thread_local! {
     static THREAD_JNIENV: RefCell<Option<JNIEnv<'static>>> = RefCell::new(None);
@@ -657,7 +661,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeQu
         let result = query_executor::execute_query_with_cross_rt_stream(
             table_path,
             files_meta,
-            table_name,
+            table_name.clone(),
             plan_bytes_vec,
             is_query_plan_explain_enabled,
             target_partitions,
@@ -667,6 +671,8 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeQu
 
         match result {
             Ok(stream_ptr) => {
+                let query_id = QUERY_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
+                log_info!("[LiquidCache] query_id={} table={} stream started", query_id, table_name);
                 with_jni_env(|env| {
                     set_action_listener_ok_global(env, &listener_ref, stream_ptr);
                 });
@@ -936,6 +942,8 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_streamClo
 ) {
     let _ = unsafe { Box::from_raw(stream as *mut RecordBatchStreamAdapter<CrossRtStream>) };
     // Log Liquid Cache stats after stream is fully consumed
+    let query_id = QUERY_COUNTER.load(Ordering::Relaxed);
+    log_info!("[LiquidCache] query_id={} stream closed", query_id);
     liquid_cache::LiquidOnlyRuntime::log_stats_if_initialized();
 }
 

--- a/plugins/engine-datafusion/jni/src/lib.rs
+++ b/plugins/engine-datafusion/jni/src/lib.rs
@@ -20,6 +20,7 @@ use std::sync::{Arc, OnceLock};
 use arrow_array::{Array, RecordBatch, StructArray};
 use arrow_array::ffi::FFI_ArrowArray;
 use arrow_schema::ffi::FFI_ArrowSchema;
+use arrow_schema::SchemaRef;
 use datafusion::{
     common::DataFusionError,
     datasource::listing::ListingTableUrl,
@@ -483,7 +484,16 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_createDat
         }
     };
 
-    let shard_view = ShardView::new(table_url, files_metadata);
+    let mut shard_view = ShardView::new(table_url, files_metadata);
+
+    if let Some(first_meta) = shard_view.files_metadata().first() {
+        let file_path = format!("/{}", first_meta.object_meta.location.as_ref().trim_start_matches('/'));
+        if let Ok(file) = std::fs::File::open(&file_path) {
+            if let Ok(builder) = datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file) {
+                shard_view.set_cached_schema(builder.schema().clone());
+            }
+        }
+    }
 
     Box::into_raw(Box::new(shard_view)) as jlong
 }
@@ -511,6 +521,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_destroyTo
 pub struct ShardView {
     table_path: ListingTableUrl,
     files_metadata: Arc<Vec<CustomFileMeta>>,
+    cached_schema: Option<SchemaRef>,
 }
 
 impl ShardView {
@@ -519,6 +530,7 @@ impl ShardView {
         ShardView {
             table_path,
             files_metadata,
+            cached_schema: None,
         }
     }
 
@@ -528,6 +540,14 @@ impl ShardView {
 
     pub fn files_metadata(&self) -> Arc<Vec<CustomFileMeta>> {
         self.files_metadata.clone()
+    }
+
+    pub fn cached_schema(&self) -> Option<SchemaRef> {
+        self.cached_schema.clone()
+    }
+
+    pub fn set_cached_schema(&mut self, schema: SchemaRef) {
+        self.cached_schema = Some(schema);
     }
 }
 
@@ -651,6 +671,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeQu
 
     let table_path = shard_view.table_path();
     let files_meta = shard_view.files_metadata();
+    let cached_schema = shard_view.cached_schema();
 
     io_runtime.block_on(async move {
 
@@ -663,6 +684,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeQu
             target_partitions,
             runtime,
             cpu_executor,
+            cached_schema,
         ).await;
 
         match result {
@@ -852,6 +874,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeFe
 
     let table_path = shard_view.table_path();
     let files_metadata = shard_view.files_metadata();
+    let cached_schema = shard_view.cached_schema();
 
     let include_fields: Vec<String> =
         parse_string_arr(&mut env, include_fields).expect("Expected list of files");
@@ -915,6 +938,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeFe
             exclude_fields,
             runtime,
             cpu_executor,
+            cached_schema,
         ).await {
             Ok(stream_ptr) => stream_ptr,
             Err(e) => {

--- a/plugins/engine-datafusion/jni/src/lib.rs
+++ b/plugins/engine-datafusion/jni/src/lib.rs
@@ -17,7 +17,6 @@ use jni::objects::JLongArray;
 use jni::sys::{jboolean, jbyteArray, jint, jlong, jstring};
 use jni::{JNIEnv, JavaVM};
 use std::sync::{Arc, OnceLock};
-use std::sync::atomic::{AtomicU64, Ordering};
 use arrow_array::{Array, RecordBatch, StructArray};
 use arrow_array::ffi::FFI_ArrowArray;
 use arrow_schema::ffi::FFI_ArrowSchema;
@@ -107,9 +106,6 @@ static TOKIO_RUNTIME_MANAGER: OnceLock<Arc<RuntimeManager>> = OnceLock::new();
 
 // Global JavaVM reference
 static JAVA_VM: OnceLock<JavaVM> = OnceLock::new();
-
-// Global query counter for correlating logs
-static QUERY_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 thread_local! {
     static THREAD_JNIENV: RefCell<Option<JNIEnv<'static>>> = RefCell::new(None);
@@ -661,7 +657,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeQu
         let result = query_executor::execute_query_with_cross_rt_stream(
             table_path,
             files_meta,
-            table_name.clone(),
+            table_name,
             plan_bytes_vec,
             is_query_plan_explain_enabled,
             target_partitions,
@@ -671,8 +667,6 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeQu
 
         match result {
             Ok(stream_ptr) => {
-                let query_id = QUERY_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
-                log_info!("[LiquidCache] query_id={} table={} stream started", query_id, table_name);
                 with_jni_env(|env| {
                     set_action_listener_ok_global(env, &listener_ref, stream_ptr);
                 });
@@ -942,8 +936,6 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_streamClo
 ) {
     let _ = unsafe { Box::from_raw(stream as *mut RecordBatchStreamAdapter<CrossRtStream>) };
     // Log Liquid Cache stats after stream is fully consumed
-    let query_id = QUERY_COUNTER.load(Ordering::Relaxed);
-    log_info!("[LiquidCache] query_id={} stream closed", query_id);
     liquid_cache::LiquidOnlyRuntime::log_stats_if_initialized();
 }
 
@@ -951,6 +943,17 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_streamClo
 pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_clearLiquidCache(
     _env: JNIEnv,
     _class: JClass,
+    runtime_ptr: jlong,
 ) {
+    // Clear Liquid Cache if initialized
     liquid_cache::LiquidOnlyRuntime::reset_cache_if_initialized();
+
+    // Clear DataFusion's internal caches (file metadata, statistics)
+    if runtime_ptr != 0 {
+        let runtime = unsafe { &*(runtime_ptr as *const DataFusionRuntime) };
+        if let Some(ref cache_manager) = runtime.custom_cache_manager {
+            cache_manager.clear_all();
+            log_info!("[Cache] DataFusion caches cleared");
+        }
+    }
 }

--- a/plugins/engine-datafusion/jni/src/liquid_cache.rs
+++ b/plugins/engine-datafusion/jni/src/liquid_cache.rs
@@ -17,7 +17,7 @@ use datafusion::{
 use liquid_cache_datafusion_local::LiquidCacheLocalBuilder;
 use liquid_cache_datafusion_local::storage::cache::LiquidCache;
 use liquid_cache_datafusion_local::storage::cache_policies::LiquidPolicy;
-use vectorized_exec_spi::log_info;
+use vectorized_exec_spi::{log_info, log_error};
 
 pub const LIQUID_CACHE_DIR: &str = "/tmp/opensearch/liquid_cache";
 
@@ -132,6 +132,31 @@ impl LiquidOnlyRuntime {
     pub fn log_stats_if_initialized() {
         if let Some(Ok(runtime)) = LIQUID_ONLY.get() {
             runtime.log_stats();
+        }
+    }
+
+    /// Reset the cache, clearing all in-memory entries and disk files.
+    pub fn reset_cache(&self) {
+        self.cache_storage.reset();
+
+        let cache_dir = PathBuf::from(LIQUID_CACHE_DIR);
+        if cache_dir.exists() {
+            if let Err(e) = fs::remove_dir_all(&cache_dir) {
+                log_error!("[LiquidCache] Failed to clean cache dir: {}", e);
+            }
+        }
+        if let Err(e) = fs::create_dir_all(&cache_dir) {
+            log_error!("[LiquidCache] Failed to recreate cache dir: {}", e);
+        }
+
+        log_info!("[LiquidCache] Cache cleared");
+        self.log_stats();
+    }
+
+    /// Reset cache if Liquid Cache has been initialized.
+    pub fn reset_cache_if_initialized() {
+        if let Some(Ok(runtime)) = LIQUID_ONLY.get() {
+            runtime.reset_cache();
         }
     }
 }

--- a/plugins/engine-datafusion/jni/src/liquid_cache.rs
+++ b/plugins/engine-datafusion/jni/src/liquid_cache.rs
@@ -1,0 +1,137 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{Arc, OnceLock},
+};
+
+use datafusion::{
+    common::DataFusionError,
+    execution::runtime_env::RuntimeEnv,
+    optimizer::OptimizerRule,
+    physical_optimizer::PhysicalOptimizerRule,
+    prelude::SessionConfig,
+};
+
+use liquid_cache_datafusion_local::LiquidCacheLocalBuilder;
+use liquid_cache_datafusion_local::storage::cache::LiquidCache;
+use liquid_cache_datafusion_local::storage::cache_policies::LiquidPolicy;
+use vectorized_exec_spi::log_info;
+
+pub const LIQUID_CACHE_DIR: &str = "/tmp/opensearch/liquid_cache";
+
+/// Holds global Liquid Cache runtime and optimizer.
+/// `_cache_ref` MUST be kept alive for the lifetime of the process.
+pub struct LiquidOnlyRuntime {
+    runtime_env: Arc<RuntimeEnv>,
+    /// The physical optimizer rule that rewrites Parquet scans to use Liquid Cache.
+    optimizer: Arc<dyn PhysicalOptimizerRule + Send + Sync>,
+    /// The logical optimizer rule for lineage tracking.
+    lineage_optimizer: Arc<dyn OptimizerRule + Send + Sync>,
+    /// Keep the cache ref alive for the lifetime of the process.
+    _cache_ref: Box<dyn std::any::Any + Send + Sync>,
+    /// Direct handle to the underlying cache storage for stats.
+    cache_storage: Arc<LiquidCache>,
+}
+
+static LIQUID_ONLY: OnceLock<Result<LiquidOnlyRuntime, String>> = OnceLock::new();
+
+impl LiquidOnlyRuntime {
+    /// Initialize Liquid Cache once per process and return the global runtime.
+    pub fn init(
+        max_cache_bytes: u64,
+    ) -> Result<&'static LiquidOnlyRuntime, DataFusionError> {
+        let result = LIQUID_ONLY.get_or_init(|| {
+            let cache_dir = PathBuf::from(LIQUID_CACHE_DIR);
+            if let Err(e) = fs::create_dir_all(&cache_dir) {
+                return Err(format!(
+                    "Failed to create liquid cache dir {:?}: {}",
+                    cache_dir, e
+                ));
+            }
+
+            let bootstrap_cfg = SessionConfig::new();
+
+            let (liquid_ctx, liquid_cache_ref) = match LiquidCacheLocalBuilder::new()
+                .with_max_cache_bytes(max_cache_bytes as usize)
+                .with_cache_dir(cache_dir)
+                .with_cache_policy(Box::new(LiquidPolicy::new()))
+                .build(bootstrap_cfg)
+            {
+                Ok(result) => result,
+                Err(e) => return Err(format!("Liquid cache build failed: {}", e)),
+            };
+
+            // Grab a handle to the underlying cache storage for stats before boxing
+            let cache_storage = liquid_cache_ref.storage().clone();
+
+            // Extract the optimizer rules from the Liquid Cache SessionState
+            // so we can apply them to per-query SessionStates
+            let state = liquid_ctx.state();
+
+            let physical_rules = state.physical_optimizers();
+            let liquid_optimizer = physical_rules
+                .iter()
+                .find(|r| r.name() == "LocalModeLiquidCacheOptimizer")
+                .cloned()
+                .ok_or_else(|| "LocalModeLiquidCacheOptimizer not found in Liquid Cache session state".to_string())?;
+
+            let optimizer_rules = state.optimizers();
+            let lineage_optimizer = optimizer_rules
+                .iter()
+                .find(|r| r.name() == "LineageOptimizer")
+                .cloned()
+                .ok_or_else(|| "LineageOptimizer not found in Liquid Cache session state".to_string())?;
+
+            Ok(LiquidOnlyRuntime {
+                runtime_env: liquid_ctx.runtime_env(),
+                optimizer: liquid_optimizer,
+                lineage_optimizer,
+                _cache_ref: Box::new(liquid_cache_ref),
+                cache_storage,
+            })
+        });
+
+        result
+            .as_ref()
+            .map_err(|e| DataFusionError::Execution(e.clone()))
+    }
+
+    pub fn runtime_env(&self) -> Arc<RuntimeEnv> {
+        self.runtime_env.clone()
+    }
+
+    pub fn optimizer(&self) -> Arc<dyn PhysicalOptimizerRule + Send + Sync> {
+        self.optimizer.clone()
+    }
+
+    pub fn lineage_optimizer(&self) -> Arc<dyn OptimizerRule + Send + Sync> {
+        self.lineage_optimizer.clone()
+    }
+
+    /// Log current cache statistics.
+    pub fn log_stats(&self) {
+        let stats = self.cache_storage.stats();
+        log_info!(
+            "[LiquidCache] Stats: entries={}, memory={}/{} bytes, disk={} bytes, \
+             arrow_mem={}, liquid_mem={}, squeezed_mem={}, disk_liquid={}, disk_arrow={}",
+            stats.total_entries,
+            stats.memory_usage_bytes,
+            stats.max_cache_bytes,
+            stats.disk_usage_bytes,
+            stats.memory_arrow_entries,
+            stats.memory_liquid_entries,
+            stats.memory_squeezed_liquid_entries,
+            stats.disk_liquid_entries,
+            stats.disk_arrow_entries,
+        );
+    }
+
+    /// Log cache stats if Liquid Cache has been initialized.
+    pub fn log_stats_if_initialized() {
+        if let Some(Ok(runtime)) = LIQUID_ONLY.get() {
+            runtime.log_stats();
+        }
+    }
+}

--- a/plugins/engine-datafusion/jni/src/listing_table.rs
+++ b/plugins/engine-datafusion/jni/src/listing_table.rs
@@ -712,17 +712,31 @@ impl ListingOptions {
         state: &dyn Session,
         table_path: &'a ListingTableUrl,
     ) -> Result<SchemaRef> {
+        let t0 = std::time::Instant::now();
         let store = state.runtime_env().object_store(table_path)?;
 
         let files: Vec<_> = table_path
             .list_all_files(state, store.as_ref(), &self.file_extension)
             .await?
-            // Empty files cannot affect schema but may throw when trying to read for it
             .try_filter(|object_meta| future::ready(object_meta.size > 0))
             .try_collect()
             .await?;
 
+        let t1 = std::time::Instant::now();
         let schema = self.format.infer_schema(state, &store, &files).await?;
+
+        println!("╔══════════════════════════════════════════════════════════════");
+        println!("║ [InferSchema] path={}", table_path);
+        println!("║   list_files: {:?}, {} files found", t0.elapsed(), files.len());
+        for f in &files {
+            println!("║     file: {} ({}B)", f.location, f.size);
+        }
+        println!("║   format.infer_schema: {:?}", t1.elapsed());
+        println!("║   result schema ({} fields):", schema.fields().len());
+        for field in schema.fields() {
+            println!("║     - {} : {:?} (nullable={})", field.name(), field.data_type(), field.is_nullable());
+        }
+        println!("╚══════════════════════════════════════════════════════════════");
 
         Ok(schema)
     }
@@ -1223,6 +1237,14 @@ impl TableProvider for ListingTable {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        println!("╔══════════════════════════════════════════════════════════════");
+        println!("║ [Scan] collect_stat={}, files_metadata={}", self.options.collect_stat, self.options.files_metadata.len());
+        println!("║ [Scan] Stacktrace:");
+        let bt = std::backtrace::Backtrace::force_capture();
+        for line in bt.to_string().lines().take(40) {
+            println!("║   {}", line);
+        }
+        println!("╚══════════════════════════════════════════════════════════════");
         // extract types of partition columns
         let table_partition_cols = self
             .options
@@ -1470,7 +1492,7 @@ impl ListingTable {
         if let Some(factory) = &self.schema_adapter_factory {
             let schema_adapter = factory.create_with_projected_schema(self.schema());
             let (schema_mapper, _) = schema_adapter.map_schema(self.file_schema.as_ref())?;
-            
+
             stats.column_statistics = schema_mapper.map_column_statistics(&stats.column_statistics)?;
             file_groups.iter_mut().try_for_each(|file_group| {
                 if let Some(stat) = file_group.statistics_mut() {
@@ -1479,7 +1501,7 @@ impl ListingTable {
                 Ok::<_, DataFusionError>(())
             })?;
         }
-        
+
         Ok((file_groups, stats))
     }
 
@@ -1494,12 +1516,18 @@ impl ListingTable {
         store: &Arc<dyn ObjectStore>,
         part_file: &PartitionedFile,
     ) -> Result<Arc<Statistics>> {
+        let file_loc = part_file.object_meta.location.to_string();
+        let short_name = file_loc.rsplit('/').next().unwrap_or(&file_loc);
         match self
             .collected_statistics
             .get_with_extra(&part_file.object_meta.location, &part_file.object_meta)
         {
-            Some(statistics) => Ok(statistics),
+            Some(statistics) => {
+                println!("║ [StatsCache] HIT  {} | num_rows={:?} cols={}", short_name, statistics.num_rows, statistics.column_statistics.len());
+                Ok(statistics)
+            },
             None => {
+                let t_infer = std::time::Instant::now();
                 let statistics = self
                     .options
                     .format
@@ -1510,6 +1538,11 @@ impl ListingTable {
                         &part_file.object_meta,
                     )
                     .await?;
+                println!("[StatsCache] infer_stats took {:?}, num_rows={:?}, cols={}", t_infer.elapsed(), statistics.num_rows, statistics.column_statistics.len());
+                println!("║ [StatsCache] MISS {} | infer_stats {:?} | num_rows={:?} cols={}", short_name, t_infer.elapsed(), statistics.num_rows, statistics.column_statistics.len());
+                for (i, col_stat) in statistics.column_statistics.iter().enumerate() {
+                    println!("║   col[{}]: null_count={:?} min={:?} max={:?}", i, col_stat.null_count, col_stat.min_value, col_stat.max_value);
+                }
                 let statistics = Arc::new(statistics);
                 self.collected_statistics.put_with_extra(
                     &part_file.object_meta.location,

--- a/plugins/engine-datafusion/jni/src/listing_table.rs
+++ b/plugins/engine-datafusion/jni/src/listing_table.rs
@@ -1446,37 +1446,62 @@ impl ListingTable {
         } else {
             return Ok((vec![], Statistics::new_unknown(&self.file_schema)));
         };
-        // list files (with partitions)
-        let table_partition_cols: Vec<(String, DataType)> = vec![]; // Passing empty partition cols as current partition cols are not mapped to directory path
-        let file_list = future::try_join_all(self.table_paths.iter().map(|table_path| {
-            pruned_partition_list(
-                ctx,
-                store.as_ref(),
-                table_path,
-                filters,
-                &self.options.file_extension,
-                &table_partition_cols,
-            )
-        }))
-        .await?;
-        let meta_fetch_concurrency = ctx.config_options().execution.meta_fetch_concurrency;
-        let file_list = stream::iter(file_list).flatten_unordered(meta_fetch_concurrency);
-        // collect the statistics if required by the config
-        let files = file_list
-            .map(|part_file| async {
-                let part_file = part_file?;
-                let statistics = if self.options.collect_stat {
-                    self.do_collect_statistics(ctx, &store, &part_file).await?
-                } else {
-                    Arc::new(Statistics::new_unknown(&self.file_schema))
-                };
-                Ok(part_file.with_statistics(statistics))
-            })
-            .boxed()
-            .buffer_unordered(ctx.config_options().execution.meta_fetch_concurrency);
 
-        let (file_group, inexact_stats) =
-            get_files_with_limit(files, limit, self.options.collect_stat).await?;
+        // build PartitionedFiles directly from pre-cached files_metadata,
+        // avoiding expensive object store LIST calls via pruned_partition_list
+        let (file_group, inexact_stats) = if !self.options.files_metadata.is_empty() {
+            let mut files = Vec::with_capacity(self.options.files_metadata.len());
+            for meta in self.options.files_metadata.iter() {
+                let part_file = PartitionedFile {
+                    object_meta: (*meta.object_meta).clone(),
+                    partition_values: vec![],
+                    range: None,
+                    statistics: None,
+                    extensions: None,
+                    metadata_size_hint: None,
+                };
+                if self.options.collect_stat {
+                    let statistics = self.do_collect_statistics(ctx, &store, &part_file).await?;
+                    files.push(part_file.with_statistics(statistics));
+                } else {
+                    files.push(part_file);
+                }
+            }
+            get_files_with_limit(
+                stream::iter(files.into_iter().map(Ok)),
+                limit,
+                self.options.collect_stat,
+            ).await?
+        } else {
+            let table_partition_cols: Vec<(String, DataType)> = vec![];
+            let file_list = future::try_join_all(self.table_paths.iter().map(|table_path| {
+                pruned_partition_list(
+                    ctx,
+                    store.as_ref(),
+                    table_path,
+                    filters,
+                    &self.options.file_extension,
+                    &table_partition_cols,
+                )
+            }))
+            .await?;
+            let meta_fetch_concurrency = ctx.config_options().execution.meta_fetch_concurrency;
+            let file_list = stream::iter(file_list).flatten_unordered(meta_fetch_concurrency);
+            let files = file_list
+                .map(|part_file| async {
+                    let part_file = part_file?;
+                    let statistics = if self.options.collect_stat {
+                        self.do_collect_statistics(ctx, &store, &part_file).await?
+                    } else {
+                        Arc::new(Statistics::new_unknown(&self.file_schema))
+                    };
+                    Ok(part_file.with_statistics(statistics))
+                })
+                .boxed()
+                .buffer_unordered(ctx.config_options().execution.meta_fetch_concurrency);
+
+            get_files_with_limit(files, limit, self.options.collect_stat).await?
+        };
 
         let file_groups = file_group.split_files(self.options.target_partitions);
         let (mut file_groups, mut stats) = compute_all_files_statistics(

--- a/plugins/engine-datafusion/jni/src/query_executor.rs
+++ b/plugins/engine-datafusion/jni/src/query_executor.rs
@@ -201,7 +201,10 @@ pub async fn execute_query_with_cross_rt_stream(
         .with_schema(resolved_schema);
 
     let provider = match ListingTable::try_new(table_config) {
-        Ok(table) => Arc::new(table),
+        Ok(table) => {
+            let table = table.with_cache(runtimeEnv.cache_manager.get_file_statistic_cache());
+            Arc::new(table)
+        },
         Err(e) => {
             error!("Failed to create listing table: {}", e);
             return Err(e);

--- a/plugins/engine-datafusion/jni/src/query_executor.rs
+++ b/plugins/engine-datafusion/jni/src/query_executor.rs
@@ -113,6 +113,7 @@ pub async fn execute_query_with_cross_rt_stream(
     target_partitions: usize,
     runtime: &DataFusionRuntime,
     cpu_executor: DedicatedExecutor,
+    cached_schema: Option<SchemaRef>,
 ) -> Result<jlong, DataFusionError> {
     let object_meta: Arc<Vec<ObjectMeta>> = Arc::new(
         files_meta
@@ -137,7 +138,7 @@ pub async fn execute_query_with_cross_rt_stream(
                 .with_file_metadata_cache(Some(runtimeEnv.cache_manager.get_file_metadata_cache()))
                 .with_files_statistics_cache(runtimeEnv.cache_manager.get_file_statistic_cache()),
         )
-        .with_metadata_cache_limit(250 * 1024 * 1024) // 250 MB
+        .with_metadata_cache_limit(4 * 1024 * 1024 * 1024)
         .build() {
         Ok(env) => env,
         Err(e) => {
@@ -147,7 +148,8 @@ pub async fn execute_query_with_cross_rt_stream(
     };
 
     let mut config = SessionConfig::new();
-    config.options_mut().execution.parquet.pushdown_filters = false;
+    config.options_mut().execution.parquet.pushdown_filters = true;
+    config.options_mut().execution.parquet.reorder_filters = true;
     config.options_mut().execution.target_partitions = target_partitions;
     config.options_mut().execution.batch_size = 8192;
     // Liquid Cache requires these Parquet settings
@@ -186,13 +188,16 @@ pub async fn execute_query_with_cross_rt_stream(
         // the AbsoluteRowIdOptimizer to convert relative row IDs to absolute ones
         .with_table_partition_cols(vec![(ROW_BASE_FIELD_NAME.to_string(), DataType::Int64)]);
 
-    let resolved_schema = match listing_options
-        .infer_schema(&ctx.state(), &table_path)
-        .await {
-        Ok(schema) => schema,
-        Err(e) => {
-            error!("Failed to infer schema: {}", e);
-            return Err(e);
+    let resolved_schema = match cached_schema {
+        Some(schema) => schema,
+        None => {
+            match listing_options.infer_schema(&ctx.state(), &table_path).await {
+                Ok(schema) => schema,
+                Err(e) => {
+                    error!("Failed to infer schema: {}", e);
+                    return Err(e);
+                }
+            }
         }
     };
 
@@ -215,7 +220,7 @@ pub async fn execute_query_with_cross_rt_stream(
         error!("Failed to register table: {}", e);
         return Err(e);
     }
-
+    
     // Decode substrait
     let substrait_plan = match Plan::decode(plan_bytes_vec.as_slice()) {
         Ok(plan) => plan,
@@ -368,6 +373,7 @@ pub async fn execute_fetch_phase(
     exclude_fields: Vec<String>,
     runtime: &DataFusionRuntime,
     cpu_executor: DedicatedExecutor,
+    cached_schema: Option<SchemaRef>,
 ) -> Result<jlong, DataFusionError> {
     // Create optimized Parquet access plans for targeted row retrieval
     let access_plans = create_access_plans(row_ids, files_metadata.clone()).await?;
@@ -410,7 +416,10 @@ pub async fn execute_fetch_phase(
     let file_format = ParquetFormat::new();
     let listing_options = ListingOptions::new(Arc::new(file_format)).with_file_extension(".parquet").with_collect_stat(true);
 
-    let parquet_schema = listing_options.infer_schema(&ctx.state(), &table_path).await?;
+    let parquet_schema = match cached_schema {
+        Some(schema) => schema,
+        None => listing_options.infer_schema(&ctx.state(), &table_path).await?,
+    };
     let projections = create_projections(include_fields, exclude_fields, parquet_schema.clone());
 
     let partitioned_files: Vec<PartitionedFile> = files_metadata

--- a/plugins/engine-datafusion/jni/src/query_executor.rs
+++ b/plugins/engine-datafusion/jni/src/query_executor.rs
@@ -150,13 +150,26 @@ pub async fn execute_query_with_cross_rt_stream(
     config.options_mut().execution.parquet.pushdown_filters = false;
     config.options_mut().execution.target_partitions = target_partitions;
     config.options_mut().execution.batch_size = 8192;
+    // Liquid Cache requires these Parquet settings
+    config.options_mut().execution.parquet.schema_force_view_types = false;
+    config.options_mut().execution.parquet.skip_arrow_metadata = false;
+    config.options_mut().execution.parquet.skip_metadata = false;
 
-    let state = datafusion::execution::SessionStateBuilder::new()
+    let mut state_builder = datafusion::execution::SessionStateBuilder::new()
         .with_config(config.clone())
         .with_runtime_env(Arc::from(runtime_env))
         .with_default_features()
-        .with_physical_optimizer_rule(Arc::new(PartialAggregationOptimizer))
-        .build();
+        .with_physical_optimizer_rule(Arc::new(PartialAggregationOptimizer));
+
+    // Add Liquid Cache optimizer rules if enabled
+    if let Some(ref optimizer) = runtime.liquid_cache_optimizer {
+        state_builder = state_builder.with_physical_optimizer_rule(optimizer.clone());
+    }
+    if let Some(ref lineage_opt) = runtime.liquid_cache_lineage_optimizer {
+        state_builder = state_builder.with_optimizer_rule(lineage_opt.clone());
+    }
+
+    let state = state_builder.build();
 
     let ctx = SessionContext::new_with_state(state);
 
@@ -354,8 +367,6 @@ pub async fn execute_fetch_phase(
     cpu_executor: DedicatedExecutor,
 ) -> Result<jlong, DataFusionError> {
     // Create optimized Parquet access plans for targeted row retrieval
-    // This converts absolute row IDs back to file-relative positions and creates
-    // efficient access patterns for each file's row groups
     let access_plans = create_access_plans(row_ids, files_metadata.clone()).await?;
 
     let object_meta: Arc<Vec<ObjectMeta>> = Arc::new(
@@ -372,7 +383,7 @@ pub async fn execute_fetch_phase(
     };
     list_file_cache.put(&table_scoped_path, object_meta);
 
-    let runtime_env = RuntimeEnvBuilder::new()
+    let runtime_env = RuntimeEnvBuilder::from_runtime_env(&runtime.runtime_env)
         .with_cache_manager(
             CacheManagerConfig::default().with_list_files_cache(Some(list_file_cache))
                 .with_metadata_cache_limit(runtime.runtime_env.cache_manager.get_file_metadata_cache().cache_limit())

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DataFusionPlugin.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DataFusionPlugin.java
@@ -171,7 +171,7 @@ public class DataFusionPlugin extends Plugin implements ActionPlugin, SearchEngi
         if (!isDataFusionEnabled) {
             return Collections.emptyList();
         }
-        return List.of(new DataFusionAction(), new ClearCacheAction());
+        return List.of(new DataFusionAction(), new ClearCacheAction(dataFusionService));
     }
 
     @Override

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DataFusionPlugin.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DataFusionPlugin.java
@@ -26,6 +26,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.datafusion.action.ClearCacheAction;
 import org.opensearch.datafusion.action.DataFusionAction;
 import org.opensearch.datafusion.action.NodesDataFusionInfoAction;
 import org.opensearch.datafusion.action.TransportNodesDataFusionInfoAction;
@@ -170,7 +171,7 @@ public class DataFusionPlugin extends Plugin implements ActionPlugin, SearchEngi
         if (!isDataFusionEnabled) {
             return Collections.emptyList();
         }
-        return List.of(new DataFusionAction());
+        return List.of(new DataFusionAction(), new ClearCacheAction());
     }
 
     @Override

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DataFusionPlugin.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DataFusionPlugin.java
@@ -63,6 +63,8 @@ import java.util.function.Supplier;
 
 import static org.opensearch.datafusion.core.DataFusionRuntimeEnv.DATAFUSION_MEMORY_POOL_CONFIGURATION;
 import static org.opensearch.datafusion.core.DataFusionRuntimeEnv.DATAFUSION_SPILL_MEMORY_LIMIT_CONFIGURATION;
+import static org.opensearch.datafusion.core.DataFusionRuntimeEnv.DATAFUSION_LIQUID_CACHE_ENABLED;
+import static org.opensearch.datafusion.core.DataFusionRuntimeEnv.DATAFUSION_LIQUID_CACHE_SIZE;
 
 
 /**
@@ -177,6 +179,8 @@ public class DataFusionPlugin extends Plugin implements ActionPlugin, SearchEngi
 
         settingList.add(DATAFUSION_MEMORY_POOL_CONFIGURATION);
         settingList.add(DATAFUSION_SPILL_MEMORY_LIMIT_CONFIGURATION);
+        settingList.add(DATAFUSION_LIQUID_CACHE_ENABLED);
+        settingList.add(DATAFUSION_LIQUID_CACHE_SIZE);
         settingList.addAll(Stream.of(
                 CacheSettings.CACHE_SETTINGS,
                 CacheSettings.CACHE_ENABLED)

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/action/ClearCacheAction.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/action/ClearCacheAction.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.datafusion.action;
 
+import org.opensearch.datafusion.DataFusionService;
 import org.opensearch.datafusion.jni.NativeBridge;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
@@ -20,10 +21,16 @@ import java.util.List;
 import static org.opensearch.rest.RestRequest.Method.POST;
 
 /**
- * REST handler to clear the Liquid Cache.
+ * REST handler to clear all DataFusion caches (Liquid Cache + file metadata/statistics).
  * POST /_plugins/datafusion/clear_liquid_cache
  */
 public class ClearCacheAction extends BaseRestHandler {
+
+    private final DataFusionService dataFusionService;
+
+    public ClearCacheAction(DataFusionService dataFusionService) {
+        this.dataFusionService = dataFusionService;
+    }
 
     @Override
     public String getName() {
@@ -38,8 +45,8 @@ public class ClearCacheAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
         return channel -> {
-            NativeBridge.clearLiquidCache();
-            channel.sendResponse(new BytesRestResponse(RestStatus.OK, "{\"status\":\"ok\",\"message\":\"Liquid cache cleared\"}"));
+            NativeBridge.clearLiquidCache(dataFusionService.getRuntimePointer());
+            channel.sendResponse(new BytesRestResponse(RestStatus.OK, "{\"status\":\"ok\",\"message\":\"Cache cleared\"}"));
         };
     }
 }

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/action/ClearCacheAction.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/action/ClearCacheAction.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.datafusion.action;
+
+import org.opensearch.datafusion.jni.NativeBridge;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.util.List;
+
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+/**
+ * REST handler to clear the Liquid Cache.
+ * POST /_plugins/datafusion/clear_liquid_cache
+ */
+public class ClearCacheAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "clear_liquid_cache_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(POST, "/_plugins/datafusion/clear_liquid_cache"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        return channel -> {
+            NativeBridge.clearLiquidCache();
+            channel.sendResponse(new BytesRestResponse(RestStatus.OK, "{\"status\":\"ok\",\"message\":\"Liquid cache cleared\"}"));
+        };
+    }
+}

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/core/DataFusionRuntimeEnv.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/core/DataFusionRuntimeEnv.java
@@ -49,15 +49,38 @@ public final class DataFusionRuntimeEnv implements AutoCloseable {
     );
 
     /**
+     * Controls whether Liquid Cache is enabled for byte-level Parquet caching.
+     */
+    public static final Setting<Boolean> DATAFUSION_LIQUID_CACHE_ENABLED = Setting.boolSetting(
+        "datafusion.liquid_cache.enabled",
+        false,
+        Setting.Property.Final,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Controls the Liquid Cache size for byte-level Parquet caching.
+     * Only used when liquid cache is enabled.
+     */
+    public static final Setting<ByteSizeValue> DATAFUSION_LIQUID_CACHE_SIZE = Setting.byteSizeSetting(
+        "datafusion.liquid_cache.size",
+        new ByteSizeValue(1, ByteSizeUnit.GB),
+        Setting.Property.Final,
+        Setting.Property.NodeScope
+    );
+
+    /**
      * Creates a new DataFusion runtime environment.
      */
     public DataFusionRuntimeEnv(ClusterService clusterService, String spill_dir) {
         long memoryLimit = clusterService.getClusterSettings().get(DATAFUSION_MEMORY_POOL_CONFIGURATION).getBytes();
         long spillLimit = clusterService.getClusterSettings().get(DATAFUSION_SPILL_MEMORY_LIMIT_CONFIGURATION).getBytes();
+        boolean liquidCacheEnabled = clusterService.getClusterSettings().get(DATAFUSION_LIQUID_CACHE_ENABLED);
+        long liquidCacheSize = clusterService.getClusterSettings().get(DATAFUSION_LIQUID_CACHE_SIZE).getBytes();
         long cacheManagerConfigPtr = CacheUtils.createCacheConfig(clusterService.getClusterSettings());
         NativeBridge.initTokioRuntimeManager(Runtime.getRuntime().availableProcessors());
         NativeBridge.startTokioRuntimeMonitoring(); // TODO : do we need this control in java ?
-        this.runtimeHandle = new GlobalRuntimeHandle(memoryLimit, cacheManagerConfigPtr, spill_dir, spillLimit);
+        this.runtimeHandle = new GlobalRuntimeHandle(memoryLimit, cacheManagerConfigPtr, spill_dir, spillLimit, liquidCacheEnabled, liquidCacheSize);
         System.out.println("Runtime : " + this.runtimeHandle);
         this.cacheManager = new CacheManager(this.runtimeHandle);
     }

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/NativeBridge.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/NativeBridge.java
@@ -49,6 +49,9 @@ public final class NativeBridge {
     public static native void streamGetSchema(long stream, ActionListener<Long> listener);
     public static native void streamClose(long stream);
 
+    // Liquid Cache
+    public static native void clearLiquidCache();
+
     // Cache management
     public static native long createCustomCacheManager();
     public static native long createCache(long cacheManagerPointer, String cacheType, long sizeLimit, String evictionType);

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/NativeBridge.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/NativeBridge.java
@@ -27,7 +27,7 @@ public final class NativeBridge {
     private NativeBridge() {}
 
     // Runtime management
-    public static native long createGlobalRuntime(long limit, long cacheManagerPtr, String spillDir, long spillLimit);
+    public static native long createGlobalRuntime(long limit, long cacheManagerPtr, String spillDir, long spillLimit, boolean liquidCacheEnabled, long liquidCacheSize);
     public static native void closeGlobalRuntime(long ptr);
 
     // Tokio runtime

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/NativeBridge.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/NativeBridge.java
@@ -50,7 +50,7 @@ public final class NativeBridge {
     public static native void streamClose(long stream);
 
     // Liquid Cache
-    public static native void clearLiquidCache();
+    public static native void clearLiquidCache(long runtimePtr);
 
     // Cache management
     public static native long createCustomCacheManager();

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/handle/GlobalRuntimeHandle.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/handle/GlobalRuntimeHandle.java
@@ -16,8 +16,8 @@ import org.opensearch.vectorized.execution.jni.NativeHandle;
  */
 public final class GlobalRuntimeHandle extends NativeHandle {
 
-    public GlobalRuntimeHandle(long memoryLimit, long cacheManagerConfigPtr, String spillDir, long spillLimit) {
-        super(NativeBridge.createGlobalRuntime(memoryLimit,cacheManagerConfigPtr, spillDir, spillLimit));
+    public GlobalRuntimeHandle(long memoryLimit, long cacheManagerConfigPtr, String spillDir, long spillLimit, boolean liquidCacheEnabled, long liquidCacheSize) {
+        super(NativeBridge.createGlobalRuntime(memoryLimit, cacheManagerConfigPtr, spillDir, spillLimit, liquidCacheEnabled, liquidCacheSize));
     }
 
     /**

--- a/plugins/engine-datafusion/src/test/java/org/opensearch/datafusion/DataFusionReaderManagerTests.java
+++ b/plugins/engine-datafusion/src/test/java/org/opensearch/datafusion/DataFusionReaderManagerTests.java
@@ -76,6 +76,8 @@ public class DataFusionReaderManagerTests extends OpenSearchTestCase {
         clusterSettingsToAdd.add(STATISTICS_CACHE_EVICTION_TYPE);
         clusterSettingsToAdd.add(DataFusionRuntimeEnv.DATAFUSION_MEMORY_POOL_CONFIGURATION);
         clusterSettingsToAdd.add(DataFusionRuntimeEnv.DATAFUSION_SPILL_MEMORY_LIMIT_CONFIGURATION);
+        clusterSettingsToAdd.add(DataFusionRuntimeEnv.DATAFUSION_LIQUID_CACHE_ENABLED);
+        clusterSettingsToAdd.add(DataFusionRuntimeEnv.DATAFUSION_LIQUID_CACHE_SIZE);
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, clusterSettingsToAdd);
 
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);

--- a/plugins/engine-datafusion/src/test/java/org/opensearch/datafusion/DataFusionServiceTests.java
+++ b/plugins/engine-datafusion/src/test/java/org/opensearch/datafusion/DataFusionServiceTests.java
@@ -124,6 +124,8 @@ public class DataFusionServiceTests extends OpenSearchSingleNodeTestCase {
         clusterSettingsToAdd.add(CacheSettings.STATISTICS_CACHE_EVICTION_TYPE);
         clusterSettingsToAdd.add(DataFusionRuntimeEnv.DATAFUSION_MEMORY_POOL_CONFIGURATION);
         clusterSettingsToAdd.add(DataFusionRuntimeEnv.DATAFUSION_SPILL_MEMORY_LIMIT_CONFIGURATION);
+        clusterSettingsToAdd.add(DataFusionRuntimeEnv.DATAFUSION_LIQUID_CACHE_ENABLED);
+        clusterSettingsToAdd.add(DataFusionRuntimeEnv.DATAFUSION_LIQUID_CACHE_SIZE);
 
 
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, clusterSettingsToAdd);

--- a/plugins/engine-datafusion/src/test/java/org/opensearch/datafusion/DatafusionCacheManagerTests.java
+++ b/plugins/engine-datafusion/src/test/java/org/opensearch/datafusion/DatafusionCacheManagerTests.java
@@ -65,6 +65,8 @@ public class DatafusionCacheManagerTests extends OpenSearchSingleNodeTestCase {
         clusterSettingsToAdd.add(STATISTICS_CACHE_EVICTION_TYPE);
         clusterSettingsToAdd.add(DataFusionRuntimeEnv.DATAFUSION_MEMORY_POOL_CONFIGURATION);
         clusterSettingsToAdd.add(DataFusionRuntimeEnv.DATAFUSION_SPILL_MEMORY_LIMIT_CONFIGURATION);
+        clusterSettingsToAdd.add(DataFusionRuntimeEnv.DATAFUSION_LIQUID_CACHE_ENABLED);
+        clusterSettingsToAdd.add(DataFusionRuntimeEnv.DATAFUSION_LIQUID_CACHE_SIZE);
 
 
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, clusterSettingsToAdd);


### PR DESCRIPTION
### Description
This change integrates Liquid Cache as the underlying runtime environment for DataFusion query execution and introduces logging to verify cache usage and effectiveness.

The Liquid Cache runtime is initialized once per process and reused across queries. Query execution paths now emit cache usage and execution metrics to help validate that the cache is actively being utilized.

### Motivation

Liquid Cache provides byte-level caching for Parquet file reads, which can significantly reduce repeated I/O for frequently accessed data.

However, verifying whether the cache is actually being used during query execution is difficult without explicit instrumentation. This PR introduces runtime-level logging that surfaces cache usage and execution metrics to aid debugging and validation.

### Architecture Diagram

                                 +----------------------+
                                 |   Java / JNI Caller  |
                                 +----------+-----------+
                                            |
                                            v
                     +-----------------------------------------------+
                     |          query_executor.rs                    |
                     |-----------------------------------------------|
                     | execute_query_with_cross_rt_stream()          |
                     | execute_fetch_phase()                         |
                     +-------------------+---------------------------+
                                         |
                                         v
                     +-----------------------------------------------+
                     |         LiquidOnlyRuntime::init()             |
                     |-----------------------------------------------|
                     | OnceLock singleton                            |
                     | - initializes Liquid Cache once               |
                     | - stores RuntimeEnv                           |
                     | - stores LiquidCacheRef / keepalive handle    |
                     +-------------------+---------------------------+
                                         |
                                         v
                     +-----------------------------------------------+
                     |        Liquid Cache RuntimeEnv                |
                     |-----------------------------------------------|
                     | Byte-level Parquet cache                      |
                     | Cache dir: /var/lib/opensearch/liquid_cache   |
                     +-------------------+---------------------------+
                                         |
                                         v
                     +-----------------------------------------------+
                     |      DataFusion Session / Physical Plan       |
                     |-----------------------------------------------|
                     | SessionStateBuilder                           |
                     | ListingTable / ListingOptions                 |
                     | Projection / Optimizers                       |
                     | execute_stream()                              |
                     +-------------------+---------------------------+
                                         |
                                         v
                     +-----------------------------------------------+
                     |            Parquet / Object Store             |
                     |-----------------------------------------------|
                     | Local FS / storage layer                      |
                     | Reads go through Liquid Cache runtime         |
                     +-----------------------------------------------+