### PR TITLE
Fix flaky ResourceAwareTasksTests

### DIFF
--- a/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/ResourceAwareTasksTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/cluster/node/tasks/ResourceAwareTasksTests.java
@@ -410,7 +410,9 @@ public class ResourceAwareTasksTests extends TaskManagerTestCase {
         // Waiting for whole request to complete and return successfully till client
         taskTestContext.requestCompleteLatch.await();
 
-        assertEquals(0, resourceTasks.size());
+        // The task may not be removed from resourceAwareTasks immediately after the request completes
+        // because stopTracking is called asynchronously via the task's resource tracking completion listener.
+        assertBusy(() -> assertEquals(0, resourceTasks.size()));
         assertNull(throwableReference.get());
         assertNotNull(responseReference.get());
         assertEquals(1, responseReference.get().failureCount());


### PR DESCRIPTION
Race condition between request completion and task resource tracking cleanup.

The sequence of events:
1. Task is cancelled via `CancelTasksRequest`
2. The node operation throws `TaskCancelledException`
3. The response is sent back to the caller, which counts down `requestCompleteLatch`
4. The test's main thread wakes up from `requestCompleteLatch.await()` and asserts `resourceTasks.size() == 0`
5. Meanwhile, `TaskResourceTrackingService.stopTracking()` (which calls `resourceAwareTasks.remove()`) is invoked asynchronously via a `resourceTrackingCompletionListener` registered in `TaskManager.register()`

Steps 4 and 5 race. I was able to reproduce the failure locally using `stess-ng` and verify this fix.

### Related Issues
Resolves #14293

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
