### PR TITLE
added cross validation for CI and versions

### DIFF
--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -1,0 +1,40 @@
+##
+## Copyright OpenSearch Contributors. See
+## GitHub history for details.
+##
+
+## This workflow validates that Version.java, buildSrc/version.properties,
+## and .ci/bwcVersions are mutually consistent on every PR and push.
+## It runs offline (no Maven Central access required) and is intentionally
+## lightweight — a single Gradle task on a single runner.
+
+name: Version Consistency Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
+  push:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
+
+jobs:
+  version-consistency:
+    if: github.repository == 'opensearch-project/OpenSearch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: gradle
+      - name: Validate version consistency
+        shell: bash
+        run: |
+          ./gradlew validateVersionConsistency

--- a/build.gradle
+++ b/build.gradle
@@ -211,6 +211,54 @@ allprojects {
   }
 }
 
+tasks.register("validateVersionConsistency") {
+  description 'Validates offline that Version.java, buildSrc/version.properties, and .ci/bwcVersions are mutually consistent.'
+  group 'Verification'
+  doLast {
+    List<String> errors = []
+    String ciYml = file(".ci/bwcVersions").text
+
+    // Collect the versions listed in .ci/bwcVersions
+    List<String> ciVersions = []
+    ciYml.eachLine { line ->
+      def m = line =~ /^\s+-\s+"(\d+\.\d+\.\d+)"\s*$/
+      if (m) ciVersions << m[0][1]
+    }
+
+    // indexCompatible = all versions (prev major + current major) except CURRENT itself.
+    // These are exactly the versions that should be in .ci/bwcVersions.
+    List<String> expectedVersions = BuildParams.bwcVersions.indexCompatible.collect { it.toString() }
+
+    // Check 1: every version in indexCompatible must appear in .ci/bwcVersions
+    List<String> missingFromCi = expectedVersions.findAll { ciVersions.contains(it) == false }
+    if (missingFromCi.isEmpty() == false) {
+      errors << ".ci/bwcVersions is missing versions declared in Version.java:\n" +
+        missingFromCi.collect { "  - $it" }.join('\n') +
+        "\nRun: ./gradlew updateCIBwcVersions  then review and commit the result."
+    }
+
+    // Check 2: every version in .ci/bwcVersions must be in indexCompatible
+    List<String> unknownInCi = ciVersions.findAll { expectedVersions.contains(it) == false }
+    if (unknownInCi.isEmpty() == false) {
+      errors << ".ci/bwcVersions contains versions not present in Version.java's index-compatible list:\n" +
+        unknownInCi.collect { "  - $it" }.join('\n') +
+        "\nAdd the missing constant(s) to Version.java or remove the entry from .ci/bwcVersions."
+    }
+
+    // Check 3: the current dev version must NOT appear in .ci/bwcVersions (it is unreleased)
+    String currentVersion = VersionProperties.getOpenSearch().replace('-SNAPSHOT', '')
+    if (ciVersions.contains(currentVersion)) {
+      errors << ".ci/bwcVersions contains ${currentVersion}, which is the current development version in " +
+        "buildSrc/version.properties.\nOnly released versions should appear in .ci/bwcVersions. " +
+        "Remove ${currentVersion} from that file."
+    }
+
+    if (errors.isEmpty() == false) {
+      throw new GradleException("Version consistency check failed:\n\n" + errors.collect { "* $it" }.join('\n\n'))
+    }
+  }
+}
+
 tasks.register("verifyVersions") {
   doLast {
     if (gradle.startParameter.isOffline()) {
@@ -265,7 +313,7 @@ tasks.register("verifyBwcTestsEnabled") {
 tasks.register("branchConsistency") {
   description 'Ensures this branch is internally consistent. For example, that versions constants match released versions.'
   group 'Verification'
-  dependsOn ":verifyVersions", ":verifyBwcTestsEnabled"
+  dependsOn ":validateVersionConsistency", ":verifyVersions", ":verifyBwcTestsEnabled"
 }
 
 allprojects {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
When incrementing an OpenSearch version, three files (Version.java, buildSrc/version.properties, .ci/bwcVersions) must be kept in sync manually. There was no CI check to catch inconsistencies between them, making it easy to introduce drift through unrelated PRs as #2430 
- Fixed: adds cross validation CI check that validates the three version sources are mutually consistent on every PR and push.

### Related Issues
Resolves #2533 
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
