### PR TITLE
Resolve actual BWC version from build output

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -50,6 +50,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import javax.inject.Inject;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -270,6 +271,17 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                                     + " or fallback "
                                     + distributionProject.getFallbackDistFile()
                             );
+                        }
+                        Version actualVersion = distributionProject.getExpectedDistFile().exists()
+                            ? bwcVersion.get()
+                            : distributionProject.getFallbackVersion();
+                        try {
+                            Files.writeString(
+                                new File(project.getBuildDir(), "actual-bwc-version-" + bwcVersion.get()).toPath(),
+                                actualVersion.toString()
+                            );
+                        } catch (java.io.IOException e) {
+                            throw new java.io.UncheckedIOException(e);
                         }
                     }
                 });

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -33,6 +33,8 @@ import org.opensearch.gradle.Version
 import org.opensearch.gradle.info.BuildParams
 import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 
+import java.util.function.Supplier
+
 apply plugin: 'opensearch.testclusters'
 apply plugin: 'opensearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
@@ -70,9 +72,18 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
     systemProperty 'tests.is_old_cluster', 'false'
   }
 
-  String oldVersion = bwcVersion.toString().minus("-SNAPSHOT")
+  def localBwcVersion = bwcVersion
+  def unreleasedInfo = BuildParams.bwcVersions.unreleasedInfo(localBwcVersion)
+  def versionFile = unreleasedInfo != null
+    ? project.file("${project.project(unreleasedInfo.gradleProjectPath).buildDir}/actual-bwc-version-${localBwcVersion}")
+    : null
   tasks.matching { it.name.startsWith(baseName) && it.name.endsWith("ClusterTest") }.configureEach {
-    it.systemProperty 'tests.old_cluster_version', oldVersion
+    it.nonInputProperties.systemProperty('tests.old_cluster_version', {
+      if (versionFile != null && versionFile.exists()) {
+        return versionFile.text.trim()
+      }
+      return localBwcVersion.toString().minus('-SNAPSHOT')
+    } as Supplier<String>)
     it.systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
     it.nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     it.nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")


### PR DESCRIPTION
When a BWC branch bumps its patch version before Version.java on main is updated, the tests.old_cluster_version system property passed to BWC tests is wrong. This causes test failures in assertions that compare the expected version against values reported by the running cluster or stored in index metadata.

InternalDistributionBwcSetupPlugin already detects when the BWC branch produces a fallback artifact with a different patch version.  Write the actual version to a file so that downstream test tasks can read it at execution time instead of relying on the version inferred from Version.java on main.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
