### PR TITLE
Fix flaky Netty4Http3IT test suite (second attempt)

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/http/netty4/Netty4Http3IT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/http/netty4/Netty4Http3IT.java
@@ -76,6 +76,9 @@ public class Netty4Http3IT extends OpenSearchNetty4IntegTestCase {
     public void testThatNettyHttpServerSupportsHttp2OrHttp3Get() throws Exception {
         assumeThat("HTTP/3 is not available on this arch/platform", Http3Utils.isHttp3Available(), is(true));
 
+        ensureGreen();
+        ensureFullyConnectedCluster();
+
         String[] requests = new String[] { "/", "/_nodes/stats", "/", "/_cluster/state", "/" };
         HttpServerTransport httpServerTransport = internalCluster().getInstance(HttpServerTransport.class);
         TransportAddress[] boundAddresses = httpServerTransport.boundAddress().boundAddresses();
@@ -83,8 +86,8 @@ public class Netty4Http3IT extends OpenSearchNetty4IntegTestCase {
 
         @SuppressWarnings("unchecked")
         final Tuple<Netty4HttpClient, String> client = randomFrom(
-            Tuple.tuple(Netty4HttpClient.http3(), "h2="),
-            Tuple.tuple(Netty4HttpClient.https(), "h3=")
+            Tuple.tuple(Netty4HttpClient.http3().withLogger(logger), "h2="),
+            Tuple.tuple(Netty4HttpClient.https().withLogger(logger), "h3=")
         );
 
         try (Netty4HttpClient nettyHttpClient = client.v1()) {
@@ -107,6 +110,9 @@ public class Netty4Http3IT extends OpenSearchNetty4IntegTestCase {
     public void testThatNettyHttpServerSupportsHttp2OrHttp3Post() throws Exception {
         assumeThat("HTTP/3 is not available on this arch/platform", Http3Utils.isHttp3Available(), is(true));
 
+        ensureGreen();
+        ensureFullyConnectedCluster();
+
         final List<Tuple<String, CharSequence>> requests = List.of(Tuple.tuple("/_search", "{\"query\":{ \"match_all\":{}}}"));
         HttpServerTransport httpServerTransport = internalCluster().getInstance(HttpServerTransport.class);
         TransportAddress[] boundAddresses = httpServerTransport.boundAddress().boundAddresses();
@@ -114,8 +120,8 @@ public class Netty4Http3IT extends OpenSearchNetty4IntegTestCase {
 
         @SuppressWarnings("unchecked")
         final Tuple<Netty4HttpClient, String> client = randomFrom(
-            Tuple.tuple(Netty4HttpClient.http3(), "h2="),
-            Tuple.tuple(Netty4HttpClient.https(), "h3=")
+            Tuple.tuple(Netty4HttpClient.http3().withLogger(logger), "h2="),
+            Tuple.tuple(Netty4HttpClient.https().withLogger(logger), "h3=")
         );
 
         try (Netty4HttpClient nettyHttpClient = client.v1()) {

--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4Http3ServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4Http3ServerTransport.java
@@ -231,6 +231,8 @@ public class Netty4Http3ServerTransport extends AbstractHttpServerTransport {
     @Override
     protected HttpServerChannel bind(InetSocketAddress socketAddress) throws Exception {
         ChannelFuture future = bootstrap.bind(socketAddress).sync();
+        logger.info("Bound to {}", socketAddress);
+
         Channel channel = future.channel();
         Netty4HttpServerChannel httpServerChannel = new Netty4HttpServerChannel(channel);
         channel.attr(HTTP_SERVER_CHANNEL_KEY).set(httpServerChannel);

--- a/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpClient.java
+++ b/modules/transport-netty4/src/test/java/org/opensearch/http/netty4/Netty4HttpClient.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.http.netty4;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.TriFunction;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
@@ -117,7 +119,6 @@ import static org.junit.Assert.fail;
  * Tiny helper to send http requests over netty.
  */
 public class Netty4HttpClient implements Closeable {
-
     static Collection<String> returnHttpResponseBodies(Collection<FullHttpResponse> responses) {
         List<String> list = new ArrayList<>(responses.size());
         for (FullHttpResponse response : responses) {
@@ -137,6 +138,7 @@ public class Netty4HttpClient implements Closeable {
     private final Bootstrap clientBootstrap;
     private final TriFunction<CountDownLatch, Collection<FullHttpResponse>, Boolean, AwaitableChannelInitializer<?>> handlerFactory;
     private final boolean secure;
+    private Logger logger;
 
     Netty4HttpClient(
         Bootstrap clientBootstrap,
@@ -186,6 +188,11 @@ public class Netty4HttpClient implements Closeable {
             CountDownLatchHandlerHttp3::new,
             true
         );
+    }
+
+    public Netty4HttpClient withLogger(Logger logger) {
+        this.logger = logger;
+        return this;
     }
 
     public List<FullHttpResponse> get(SocketAddress remoteAddress, String... uris) throws InterruptedException {
@@ -244,6 +251,7 @@ public class Netty4HttpClient implements Closeable {
         final List<FullHttpResponse> content = Collections.synchronizedList(new ArrayList<>(requests.size()));
 
         final AwaitableChannelInitializer<?> handler = handlerFactory.apply(latch, content, secure);
+        handler.logger = logger;
         clientBootstrap.handler(handler);
 
         ChannelFuture channelFuture = null;
@@ -341,6 +349,14 @@ public class Netty4HttpClient implements Closeable {
      *
      */
     private static abstract class AwaitableChannelInitializer<C extends Channel> extends ChannelInitializer<C> {
+        private Logger logger;
+
+        void log(Level level, String message, Object... params) {
+            if (logger != null) {
+                logger.log(level, message, params);
+            }
+        }
+
         void await() {
             // do nothing
         }
@@ -518,6 +534,8 @@ public class Netty4HttpClient implements Closeable {
 
         @Override
         Channel prepare(Bootstrap clientBootstrap, Channel channel) throws InterruptedException {
+            log(Level.INFO, "[QuicChannel] Connecting to: {}", channel.remoteAddress());
+
             final QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 30000) // 30 seconds
                 .handler(new Http3ClientConnectionHandler())


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix flaky Netty4Http3IT test suite (second attempt)

### Related Issues
Investigates https://github.com/opensearch-project/OpenSearch/issues/20654
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
