### PR TITLE
Mute flaky CompositeIndexWriterForAppendTests

### DIFF
--- a/server/src/test/java/org/opensearch/index/engine/CompositeIndexWriterForAppendTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/CompositeIndexWriterForAppendTests.java
@@ -18,6 +18,7 @@ import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.FilterIndexOutput;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.opensearch.common.CheckedBiFunction;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lucene.uid.Versions;
@@ -44,6 +45,7 @@ import java.util.function.Supplier;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.mockito.Mockito.mock;
 
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/20005")
 public class CompositeIndexWriterForAppendTests extends CriteriaBasedCompositeIndexWriterBaseTests {
 
     // For refresh


### PR DESCRIPTION
Muting the entire class because some of the failures are file leaks detected during teardown, so I'm not sure which test method is causing the problem.

```
CompositeIndexWriterForAppendTests > classMethod FAILED
    java.lang.RuntimeException: file handle leaks:
[FileChannel(/var/jenkins/workspace/gradle-check/search/server/build/testrun/test/temp/org.opensearch.index.engine.CompositeIndexWriterForAppendTests_5D4C13243992BC3C-001/index-MMapDirectory-001/write.lock)]
```

Related to https://github.com/opensearch-project/OpenSearch/issues/20005

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
