### PR TITLE
Fix flaky DerivedSourceLeafReaderTests

### DIFF
--- a/server/src/test/java/org/opensearch/common/lucene/index/DerivedSourceLeafReaderTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/index/DerivedSourceLeafReaderTests.java
@@ -18,7 +18,6 @@ import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.store.Directory;
@@ -146,8 +145,7 @@ public class DerivedSourceLeafReaderTests extends OpenSearchTestCase {
 
     public void testWithRandomDocuments() throws IOException {
         Directory randomDir = newDirectory();
-        IndexWriterConfig config = newIndexWriterConfig(random(), null).setCodec(new RandomCodec(random()))
-            .setMergePolicy(NoMergePolicy.INSTANCE); // Prevent automatic merges
+        IndexWriterConfig config = newIndexWriterConfig(random(), null).setCodec(new RandomCodec(random()));
 
         IndexWriter randomWriter = new IndexWriter(randomDir, config);
 
@@ -158,7 +156,7 @@ public class DerivedSourceLeafReaderTests extends OpenSearchTestCase {
             byte[] source = randomByteArrayOfLength(randomIntBetween(10, 50));
             docIdToSource.put(i, source);
             Document doc = new Document();
-            doc.add(new StoredField("_source", source));
+            doc.add(new StoredField("field", i));
             randomWriter.addDocument(doc);
         }
 


### PR DESCRIPTION
testWithRandomDocuments was flaky due to two issues:

1. NoMergePolicy blocked forceMerge(1), so randomized IndexWriterConfig settings that caused multiple flushes resulted in multiple segments instead of the expected one.

2. The test stored _source in the index, but DerivedSourceStoredFields injects _source via the source provider then delegates to the underlying stored fields. This caused the visitor to receive _source twice, with the second call using Lucene's internal buffer which could differ from the original bytes.

Fix by removing NoMergePolicy so forceMerge(1) works, and not storing _source in the index, which matches the production use case where derived source synthesizes _source from other data.

### Related Issues
Resolves #20812

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
