### PR TITLE
Revert "Disable concurrent search for filter duplicates"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use env variable (OPENSEARCH_FIPS_MODE) to enable opensearch to run in FIPS enforced mode instead of checking for existence of bcFIPS jars ([#20625](https://github.com/opensearch-project/OpenSearch/pull/20625))
 - Update streaming flag to use search request context ([#20530](https://github.com/opensearch-project/OpenSearch/pull/20530))
 - Move pull-based ingestion classes from experimental to publicAPI ([#20704](https://github.com/opensearch-project/OpenSearch/pull/20704))
-- Disable concurrent search for filter duplicates in significant_text ([#20857](https://github.com/opensearch-project/OpenSearch/pull/20857))
 
 ### Fixed
 - Relax index template pattern overlap check to use minimum-string heuristic, allowing distinguishable multi-wildcard patterns at the same priority ([#20702](https://github.com/opensearch-project/OpenSearch/pull/20702))

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
@@ -315,9 +315,6 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory {
 
     @Override
     protected boolean supportsConcurrentSegmentSearch() {
-        // The underlying structured used to find duplicate byte sequences (DuplicateByteSequenceSpotter)
-        // is stateful and not thread-safe, so disable concurrent search if this particular feature is
-        // being used.
-        return filterDuplicateText == false;
+        return true;
     }
 }


### PR DESCRIPTION
Concurrent search creates a new aggregator per slice, so there is no concurrency problem here. The dedup logic is currently per-shard with no reduce logic at the coordinator, so concurrent search does change that to be per-slice, but does not fundamentally change the behavior. I'm reverting this and will deal with test flakiness if it continues.

This reverts commit f46ce23c24b53fd98dcfd9c4fce0a41cb565cda3.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
