### PR TITLE
Fix race condition in TransferManager async cache ref counting

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/TransferManager.java
@@ -243,13 +243,18 @@ public class TransferManager {
                         return createIndexInput(fileCache, streamReader, request);
                     } catch (Exception e) {
                         fileCache.remove(request.getFilePath());
-                        throw new CompletionException(e);
+                        throw (e instanceof RuntimeException) ? (RuntimeException) e : new CompletionException(e);
                     }
                 }, executor).handle((indexInput, throwable) -> {
-                    fileCache.decRef(request.getFilePath());
                     if (throwable != null) {
-                        result.completeExceptionally(throwable);
+                        // On failure, the entry was already removed from the cache in the
+                        // catch block above, so we must not decRef here.
+                        Throwable cause = (throwable instanceof CompletionException && throwable.getCause() != null)
+                            ? throwable.getCause()
+                            : throwable;
+                        result.completeExceptionally(cause);
                     } else {
+                        fileCache.decRef(request.getFilePath());
                         result.complete(indexInput);
                     }
                     return null;


### PR DESCRIPTION
The handle callback in asyncLoadIndexInput unconditionally called fileCache.decRef on both success and failure paths. On failure, the entry was already removed by fileCache.remove in the catch block. If a new entry was added with the same key between the remove and decRef, the decRef would decrement the new entry's ref count, causing premature eviction and a NullPointerException when the evicted entry's IndexInput was cloned.

Move decRef to the success-only branch of the handle callback. Also unwrap CompletionException in the handle callback and avoid re-wrapping RuntimeExceptions in the catch block to prevent double-wrapping that broke IOException extraction in getIndexInput().

Resolves #18872

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
