### PR TITLE
Add configurable index.max_doc_id_length setting (#19075)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add intra segment support for single-value metric aggregations ([#20503](https://github.com/opensearch-project/OpenSearch/pull/20503))
 - Add ref_path support for package-based hunspell dictionary loading ([#20840](https://github.com/opensearch-project/OpenSearch/pull/20840))
 - Add support for enabling pluggable data formats, starting with phase-1 of decoupling shard from engine, and introducing basic abstractions ([#20675](https://github.com/opensearch-project/OpenSearch/pull/20675))
+- Add configurable `index.max_doc_id_length` setting to allow raising the `_id` length limit beyond 512 bytes up to 32766 ([#20919](https://github.com/opensearch-project/OpenSearch/pull/20919))
 
 ### Changed
 - Make telemetry `Tags` immutable ([#20788](https://github.com/opensearch-project/OpenSearch/pull/20788))

--- a/server/src/internalClusterTest/java/org/opensearch/action/bulk/BulkIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/bulk/BulkIntegrationIT.java
@@ -44,6 +44,7 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.action.support.replication.ReplicationRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
@@ -218,38 +219,44 @@ public class BulkIntegrationIT extends OpenSearchIntegTestCase {
         assertFalse(thread.isAlive());
     }
 
-    public void testDocIdTooLong() {
+    public void testDocIdTooLongDefaultSetting() {
         String index = "testing";
         createIndex(index);
         String validId = String.join("", Collections.nCopies(512, "a"));
         String invalidId = String.join("", Collections.nCopies(513, "a"));
 
-        // Index Request
+        // Index Request - valid id should succeed
         IndexRequest indexRequest = new IndexRequest(index).source(Collections.singletonMap("foo", "baz"));
-        // Valid id shouldn't throw any exception
         assertFalse(client().prepareBulk().add(indexRequest.id(validId)).get().hasFailures());
-        // Invalid id should throw the ActionRequestValidationException
-        validateDocIdLimit(() -> client().prepareBulk().add(indexRequest.id(invalidId)).get());
 
-        // Update Request
+        // Index Request - id exceeding default limit (512) is rejected at shard level
+        BulkResponse bulkResponse = client().prepareBulk().add(indexRequest.id(invalidId)).get();
+        assertTrue(bulkResponse.hasFailures());
+        assertThat(bulkResponse.getItems()[0].getFailureMessage(), containsString("is too long, must be no longer than 512 bytes"));
+
+        // Update Request - valid id should succeed
         UpdateRequest updateRequest = new UpdateRequest(index, validId).doc("reason", "no source");
-        // Valid id shouldn't throw any exception
         assertFalse(client().prepareBulk().add(updateRequest).get().hasFailures());
-        // Invalid id should throw the ActionRequestValidationException
-        validateDocIdLimit(() -> client().prepareBulk().add(updateRequest.id(invalidId)).get());
+
+        // Update Request - id exceeding default limit is rejected at shard level
+        bulkResponse = client().prepareBulk().add(updateRequest.id(invalidId)).get();
+        assertTrue(bulkResponse.hasFailures());
+        assertThat(bulkResponse.getItems()[0].getFailureMessage(), containsString("is too long, must be no longer than 512 bytes"));
     }
 
-    private void validateDocIdLimit(Runnable runner) {
-        try {
-            runner.run();
-            fail("Request validation for docId didn't fail");
-        } catch (ActionRequestValidationException e) {
-            assertEquals(
-                1,
-                e.validationErrors().stream().filter(msg -> msg.contains("is too long, must be no longer than 512 bytes but was")).count()
-            );
-        } catch (Exception e) {
-            fail("Request validation for docId failed with different exception: " + e);
-        }
+    public void testDocIdWithCustomMaxLength() {
+        String index = "testing_custom_id_length";
+        createIndex(index, Settings.builder().put("index.max_doc_id_length", 2048).build());
+        String longId = String.join("", Collections.nCopies(1024, "a"));
+        String tooLongId = String.join("", Collections.nCopies(2049, "a"));
+
+        // 1024-byte ID should succeed with custom limit of 2048
+        IndexRequest indexRequest = new IndexRequest(index).source(Collections.singletonMap("foo", "baz"));
+        assertFalse(client().prepareBulk().add(indexRequest.id(longId)).get().hasFailures());
+
+        // 2049-byte ID should be rejected
+        BulkResponse bulkResponse = client().prepareBulk().add(indexRequest.id(tooLongId)).get();
+        assertTrue(bulkResponse.hasFailures());
+        assertThat(bulkResponse.getItems()[0].getFailureMessage(), containsString("is too long, must be no longer than 2048 bytes"));
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/action/bulk/BulkIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/bulk/BulkIntegrationIT.java
@@ -37,6 +37,7 @@ import org.opensearch.Version;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.action.admin.indices.mapping.get.GetMappingsResponse;
+import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.ingest.PutPipelineRequest;
@@ -258,5 +259,41 @@ public class BulkIntegrationIT extends OpenSearchIntegTestCase {
         BulkResponse bulkResponse = client().prepareBulk().add(indexRequest.id(tooLongId)).get();
         assertTrue(bulkResponse.hasFailures());
         assertThat(bulkResponse.getItems()[0].getFailureMessage(), containsString("is too long, must be no longer than 2048 bytes"));
+    }
+
+    public void testDocIdMaxLengthDynamicUpdate() {
+        String index = "testing_dynamic_id_length";
+        createIndex(index);
+        String longId = String.join("", Collections.nCopies(1024, "a"));
+
+        // 1024-byte ID should be rejected with the default limit of 512
+        IndexRequest indexRequest = new IndexRequest(index).source(Collections.singletonMap("foo", "baz"));
+        BulkResponse bulkResponse = client().prepareBulk().add(indexRequest.id(longId)).get();
+        assertTrue(bulkResponse.hasFailures());
+        assertThat(bulkResponse.getItems()[0].getFailureMessage(), containsString("is too long, must be no longer than 512 bytes"));
+
+        // Dynamically raise the limit
+        client().admin().indices().prepareUpdateSettings(index).setSettings(Settings.builder().put("index.max_doc_id_length", 2048)).get();
+
+        // Same 1024-byte ID should now succeed
+        assertFalse(client().prepareBulk().add(indexRequest.id(longId)).get().hasFailures());
+    }
+
+    public void testDeleteWithLongDocIdAllowed() {
+        String index = "testing_delete_long_id";
+        createIndex(index, Settings.builder().put("index.max_doc_id_length", 2048).build());
+        String longId = String.join("", Collections.nCopies(1024, "a"));
+
+        // Index a document with a long ID
+        IndexRequest indexRequest = new IndexRequest(index).id(longId).source(Collections.singletonMap("foo", "baz"));
+        assertFalse(client().prepareBulk().add(indexRequest).get().hasFailures());
+
+        // Lower the limit below the existing doc's ID length
+        client().admin().indices().prepareUpdateSettings(index).setSettings(Settings.builder().put("index.max_doc_id_length", 512)).get();
+
+        // DELETE should still succeed even though the ID exceeds the current limit
+        DeleteRequest deleteRequest = new DeleteRequest(index, longId);
+        BulkResponse bulkResponse = client().prepareBulk().add(deleteRequest).get();
+        assertFalse(bulkResponse.hasFailures());
     }
 }

--- a/server/src/main/java/org/opensearch/action/DocWriteRequest.java
+++ b/server/src/main/java/org/opensearch/action/DocWriteRequest.java
@@ -243,17 +243,35 @@ public interface DocWriteRequest<T> extends IndicesRequest, DocRequest, Accounta
     }
 
     /**
-     * Validates whether the doc id length is under the limit.
+     * The default maximum length of the {@code _id} field in bytes, used by
+     * {@link org.opensearch.index.IndexSettings#MAX_DOC_ID_LENGTH_SETTING}.
+     */
+    static final int DEFAULT_MAX_DOC_ID_LENGTH = 512;
+
+    /**
+     * Absolute upper bound for the {@code _id} field length, equal to Lucene's
+     * maximum term length. Used for early request validation before index settings
+     * are available.
+     */
+    static final int MAX_DOC_ID_LENGTH_HARD_LIMIT = 32766;
+
+    /**
+     * Validates whether the doc id length is under the given limit.
      * @param id DocId to verify
+     * @param maxLength maximum allowed length in UTF-8 bytes
      * @param validationException containing all the validation errors.
      * @return validationException
      */
-    static ActionRequestValidationException validateDocIdLength(String id, ActionRequestValidationException validationException) {
+    static ActionRequestValidationException validateDocIdLength(
+        String id,
+        int maxLength,
+        ActionRequestValidationException validationException
+    ) {
         if (id != null) {
             int docIdLength = UnicodeUtil.calcUTF16toUTF8Length(id, 0, id.length());
-            if (docIdLength > 512) {
+            if (docIdLength > maxLength) {
                 return addValidationError(
-                    "id [" + id + "] is too long, must be no longer than 512 bytes but was: " + docIdLength,
+                    "id [" + id + "] is too long, must be no longer than " + maxLength + " bytes but was: " + docIdLength,
                     validationException
                 );
             }

--- a/server/src/main/java/org/opensearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportShardBulkAction.java
@@ -601,21 +601,23 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
         ActionListener<Void> itemDoneListener
     ) throws Exception {
         final DocWriteRequest<?> currentRequest = context.getCurrent();
-        final int maxDocIdLength = context.getPrimary().indexSettings().getMaxDocIdLength();
-        final String docId = currentRequest.id();
-        if (docId != null) {
-            final int docIdLength = org.apache.lucene.util.UnicodeUtil.calcUTF16toUTF8Length(docId, 0, docId.length());
-            if (docIdLength > maxDocIdLength) {
-                final Engine.Result result = new Engine.IndexResult(
-                    new IllegalArgumentException(
-                        "id [" + docId + "] is too long, must be no longer than " + maxDocIdLength + " bytes but was: " + docIdLength
-                    ),
-                    0
-                );
-                context.setRequestToExecute(currentRequest);
-                context.markOperationAsExecuted(result);
-                context.markAsCompleted(context.getExecutionResult());
-                return true;
+        if (currentRequest.opType() != DocWriteRequest.OpType.DELETE) {
+            final int maxDocIdLength = context.getPrimary().indexSettings().getMaxDocIdLength();
+            final String docId = currentRequest.id();
+            if (docId != null) {
+                final int docIdLength = org.apache.lucene.util.UnicodeUtil.calcUTF16toUTF8Length(docId, 0, docId.length());
+                if (docIdLength > maxDocIdLength) {
+                    final Engine.Result result = new Engine.IndexResult(
+                        new IllegalArgumentException(
+                            "id [" + docId + "] is too long, must be no longer than " + maxDocIdLength + " bytes but was: " + docIdLength
+                        ),
+                        currentRequest.version()
+                    );
+                    context.setRequestToExecute(currentRequest);
+                    context.markOperationAsExecuted(result);
+                    context.markAsCompleted(context.getExecutionResult());
+                    return true;
+                }
             }
         }
 

--- a/server/src/main/java/org/opensearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/opensearch/action/bulk/TransportShardBulkAction.java
@@ -600,7 +600,26 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
         Consumer<ActionListener<Void>> waitForMappingUpdate,
         ActionListener<Void> itemDoneListener
     ) throws Exception {
-        final DocWriteRequest.OpType opType = context.getCurrent().opType();
+        final DocWriteRequest<?> currentRequest = context.getCurrent();
+        final int maxDocIdLength = context.getPrimary().indexSettings().getMaxDocIdLength();
+        final String docId = currentRequest.id();
+        if (docId != null) {
+            final int docIdLength = org.apache.lucene.util.UnicodeUtil.calcUTF16toUTF8Length(docId, 0, docId.length());
+            if (docIdLength > maxDocIdLength) {
+                final Engine.Result result = new Engine.IndexResult(
+                    new IllegalArgumentException(
+                        "id [" + docId + "] is too long, must be no longer than " + maxDocIdLength + " bytes but was: " + docIdLength
+                    ),
+                    0
+                );
+                context.setRequestToExecute(currentRequest);
+                context.markOperationAsExecuted(result);
+                context.markAsCompleted(context.getExecutionResult());
+                return true;
+            }
+        }
+
+        final DocWriteRequest.OpType opType = currentRequest.opType();
 
         final UpdateHelper.Result updateResult;
         if (opType == DocWriteRequest.OpType.UPDATE) {

--- a/server/src/main/java/org/opensearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/opensearch/action/index/IndexRequest.java
@@ -237,7 +237,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
 
         validationException = DocWriteRequest.validateSeqNoBasedCASParams(this, validationException);
 
-        validationException = DocWriteRequest.validateDocIdLength(id, validationException);
+        validationException = DocWriteRequest.validateDocIdLength(id, DocWriteRequest.MAX_DOC_ID_LENGTH_HARD_LIMIT, validationException);
 
         if (pipeline != null && pipeline.isEmpty()) {
             validationException = addValidationError("pipeline cannot be an empty string", validationException);

--- a/server/src/main/java/org/opensearch/action/update/UpdateRequest.java
+++ b/server/src/main/java/org/opensearch/action/update/UpdateRequest.java
@@ -236,7 +236,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
             validationException = addValidationError("doc must be specified if doc_as_upsert is enabled", validationException);
         }
 
-        validationException = DocWriteRequest.validateDocIdLength(id, validationException);
+        validationException = DocWriteRequest.validateDocIdLength(id, DocWriteRequest.MAX_DOC_ID_LENGTH_HARD_LIMIT, validationException);
 
         return validationException;
     }

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -175,6 +175,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.MAX_SLICES_PER_PIT,
                 IndexSettings.MAX_REGEX_LENGTH_SETTING,
                 FlushModeResolver.STREAMING_AGGREGATION_MIN_SEGMENT_SIZE_SETTING,
+                IndexSettings.MAX_DOC_ID_LENGTH_SETTING,
                 ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING,
                 ShardsLimitAllocationDecider.INDEX_TOTAL_PRIMARY_SHARDS_PER_NODE_SETTING,
                 ShardsLimitAllocationDecider.INDEX_TOTAL_REMOTE_CAPABLE_SHARDS_PER_NODE_SETTING,

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -361,15 +361,16 @@ public final class IndexSettings {
 
     /**
      * Index setting describing the maximum length of the {@code _id} field in bytes.
-     * The default of 512 preserves backward compatibility. Lucene's maximum term length
-     * of 32766 bytes is the upper bound. Raising this allows workloads with naturally
-     * long identifiers (metric paths, URLs, composite keys) to use them as {@code _id}
-     * directly, avoiding the need to hash and store the original in a separate field.
+     * The default and minimum of 512 preserves backward compatibility. Lucene's maximum
+     * term length of 32766 bytes is the upper bound. Raising this allows workloads with
+     * naturally long identifiers (metric paths, URLs, composite keys) to use them as
+     * {@code _id} directly, avoiding the need to hash and store the original in a
+     * separate field.
      */
     public static final Setting<Integer> MAX_DOC_ID_LENGTH_SETTING = Setting.intSetting(
         "index.max_doc_id_length",
         512,
-        1,
+        512,
         32766,
         Property.Dynamic,
         Property.IndexScope

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -360,6 +360,22 @@ public final class IndexSettings {
     );
 
     /**
+     * Index setting describing the maximum length of the {@code _id} field in bytes.
+     * The default of 512 preserves backward compatibility. Lucene's maximum term length
+     * of 32766 bytes is the upper bound. Raising this allows workloads with naturally
+     * long identifiers (metric paths, URLs, composite keys) to use them as {@code _id}
+     * directly, avoiding the need to hash and store the original in a separate field.
+     */
+    public static final Setting<Integer> MAX_DOC_ID_LENGTH_SETTING = Setting.intSetting(
+        "index.max_doc_id_length",
+        512,
+        1,
+        32766,
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /**
      * Index setting describing the maximum value of allowed `docvalue_fields`that can be retrieved
      * per search request. The default maximum of 100 is defensive for the reason that retrieving
      * doc values might incur a per-field per-document seek.
@@ -1003,6 +1019,7 @@ public final class IndexSettings {
     private volatile int maxTermsCount;
 
     private volatile int maxNestedQueryDepth;
+    private volatile int maxDocIdLength;
     private volatile String defaultPipeline;
     private volatile String requiredPipeline;
     private volatile boolean searchThrottled;
@@ -1203,6 +1220,7 @@ public final class IndexSettings {
         maxNestedQueryDepth = scopedSettings.get(MAX_NESTED_QUERY_DEPTH_SETTING);
         maxRegexLength = scopedSettings.get(MAX_REGEX_LENGTH_SETTING);
         streamingAggregationMinSegmentSize = scopedSettings.get(FlushModeResolver.STREAMING_AGGREGATION_MIN_SEGMENT_SIZE_SETTING);
+        maxDocIdLength = scopedSettings.get(MAX_DOC_ID_LENGTH_SETTING);
         this.tieredMergePolicyProvider = new TieredMergePolicyProvider(logger, this);
         this.logByteSizeMergePolicyProvider = new LogByteSizeMergePolicyProvider(logger, this);
         this.indexSortConfig = new IndexSortConfig(this);
@@ -1308,6 +1326,7 @@ public final class IndexSettings {
             INDEX_PUBLISH_REFERENCED_SEGMENTS_INTERVAL_SETTING,
             this::setPublishReferencedSegmentsInterval
         );
+        scopedSettings.addSettingsUpdateConsumer(MAX_DOC_ID_LENGTH_SETTING, this::setMaxDocIdLength);
         scopedSettings.addSettingsUpdateConsumer(MAX_RESULT_WINDOW_SETTING, this::setMaxResultWindow);
         scopedSettings.addSettingsUpdateConsumer(MAX_INNER_RESULT_WINDOW_SETTING, this::setMaxInnerResultWindow);
         scopedSettings.addSettingsUpdateConsumer(MAX_ADJACENCY_MATRIX_FILTERS_SETTING, this::setMaxAdjacencyMatrixFilters);
@@ -1856,6 +1875,17 @@ public final class IndexSettings {
 
     private void setMaxResultWindow(int maxResultWindow) {
         this.maxResultWindow = maxResultWindow;
+    }
+
+    /**
+     * Returns the maximum allowed length of the {@code _id} field in bytes for this index.
+     */
+    public int getMaxDocIdLength() {
+        return maxDocIdLength;
+    }
+
+    private void setMaxDocIdLength(int maxDocIdLength) {
+        this.maxDocIdLength = maxDocIdLength;
     }
 
     /**

--- a/server/src/test/java/org/opensearch/action/bulk/BulkRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/BulkRequestTests.java
@@ -273,48 +273,51 @@ public class BulkRequestTests extends OpenSearchTestCase {
         );
     }
 
-    public void testBulkRequestInvalidDocIDDuringCreate() {
+    public void testBulkRequestDocIDAtLuceneLimitDuringCreate() {
+        // IDs up to Lucene's max term length pass request-level validation.
+        // The index-level setting (default 512) is enforced at the shard.
         String validDocID = String.join("", Collections.nCopies(512, "a"));
-        String invalidDocID = String.join("", Collections.nCopies(513, "a"));
-
-        // doc id length under limit
         IndexRequest indexRequest = new IndexRequest("index").id(validDocID).source(Requests.INDEX_CONTENT_TYPE, "field", "value");
         BulkRequest bulkRequest = new BulkRequest();
         bulkRequest.add(indexRequest);
         assertNull(bulkRequest.validate());
 
-        // doc id length over limit
-        indexRequest.id(invalidDocID);
+        // 1024-byte ID passes request validation (within Lucene limit)
+        String longerDocID = String.join("", Collections.nCopies(1024, "a"));
+        indexRequest.id(longerDocID);
+        assertNull(bulkRequest.validate());
+
+        // ID exceeding Lucene's max term length is rejected at request level
+        String tooLongDocID = String.join("", Collections.nCopies(32767, "a"));
+        indexRequest.id(tooLongDocID);
         ActionRequestValidationException validate = bulkRequest.validate();
         assertThat(validate, notNullValue());
         assertEquals(
             1,
-            validate.validationErrors()
-                .stream()
-                .filter(msg -> msg.contains("is too long, must be no longer than 512 bytes but was: "))
-                .count()
+            validate.validationErrors().stream().filter(msg -> msg.contains("is too long, must be no longer than 32766 bytes")).count()
         );
     }
 
-    public void testBulkRequestInvalidDocIDDuringUpdate() {
+    public void testBulkRequestDocIDAtLuceneLimitDuringUpdate() {
         String validDocID = String.join("", Collections.nCopies(512, "a"));
-        String invalidDocID = String.join("", Collections.nCopies(513, "a"));
-        // doc id length under limit
         UpdateRequest updateRequest = new UpdateRequest("index", validDocID).doc("reason", "no source");
         BulkRequest bulkRequest = new BulkRequest();
         bulkRequest.add(updateRequest);
         assertNull(bulkRequest.validate());
 
-        // doc id length over limit
-        updateRequest.id(invalidDocID);
+        // 1024-byte ID passes request validation (within Lucene limit)
+        String longerDocID = String.join("", Collections.nCopies(1024, "a"));
+        updateRequest.id(longerDocID);
+        assertNull(bulkRequest.validate());
+
+        // ID exceeding Lucene's max term length is rejected at request level
+        String tooLongDocID = String.join("", Collections.nCopies(32767, "a"));
+        updateRequest.id(tooLongDocID);
         ActionRequestValidationException validate = bulkRequest.validate();
         assertThat(validate, notNullValue());
         assertEquals(
             1,
-            validate.validationErrors()
-                .stream()
-                .filter(msg -> msg.contains("is too long, must be no longer than 512 bytes but was: "))
-                .count()
+            validate.validationErrors().stream().filter(msg -> msg.contains("is too long, must be no longer than 32766 bytes")).count()
         );
     }
 

--- a/server/src/test/java/org/opensearch/action/index/IndexRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/index/IndexRequestTests.java
@@ -96,7 +96,7 @@ public class IndexRequestTests extends OpenSearchTestCase {
         assertThat(request.validate().validationErrors(), not(empty()));
     }
 
-    public void testIndexingRejectsLongIds() {
+    public void testIndexingRejectsIdsExceedingLuceneLimit() {
         String id = randomAlphaOfLength(511);
         IndexRequest request = new IndexRequest("index").id(id);
         request.source("{}", MediaTypeRegistry.JSON);
@@ -109,12 +109,21 @@ public class IndexRequestTests extends OpenSearchTestCase {
         validate = request.validate();
         assertNull(validate);
 
-        id = randomAlphaOfLength(513);
+        // IDs between 513 and 32766 are now allowed at the request level;
+        // the index-level setting (default 512) is enforced at the shard.
+        id = randomAlphaOfLength(1024);
+        request = new IndexRequest("index").id(id);
+        request.source("{}", MediaTypeRegistry.JSON);
+        validate = request.validate();
+        assertNull(validate);
+
+        // IDs exceeding Lucene's max term length are always rejected
+        id = randomAlphaOfLength(32767);
         request = new IndexRequest("index").id(id);
         request.source("{}", MediaTypeRegistry.JSON);
         validate = request.validate();
         assertThat(validate, notNullValue());
-        assertThat(validate.getMessage(), containsString("id [" + id + "] is too long, must be no longer than 512 bytes but was: 513"));
+        assertThat(validate.getMessage(), containsString("is too long, must be no longer than 32766 bytes"));
     }
 
     public void testWaitForActiveShards() {


### PR DESCRIPTION
### Description

Introduces a new per-index setting `index.max_doc_id_length` that allows operators to raise the maximum allowed `_id` field length beyond the current hard-coded 512-byte default, up to Lucene's `MAX_TERM_LENGTH` (32766 bytes).

**Motivation:** The existing 512-byte `_id` limit was [inherited from Elasticsearch](https://github.com/elastic/elasticsearch/issues/16034) for HTTP GET URL ergonomics — not for any technical or performance reason. Workloads with naturally long identifiers (metric paths, URLs, composite keys) are forced to hash these identifiers and store the originals in a separate field, adding storage overhead, query complexity, and write-path logic. Making the limit configurable removes this workaround entirely.

**Implementation — two-tier validation:**

| Tier | Where | Limit | Purpose |
|------|-------|-------|---------|
| Request level | `IndexRequest` / `UpdateRequest` | 32766 (Lucene hard limit) | Early rejection before routing — prevents IDs that would always fail |
| Shard level | `TransportShardBulkAction` | `index.max_doc_id_length` (default 512) | Per-index configurable enforcement where index settings are available |

**Key design decisions:**
- DELETE operations are **exempt** from the length check — you must always be able to delete a document regardless of the current setting
- The setting is `Dynamic` and `IndexScope` — can be changed on existing indices without a restart
- Minimum is 512 (the current default) to prevent accidentally breaking backward compatibility
- Maximum is 32766 (Lucene's `MAX_TERM_LENGTH`) — the absolute physical limit

**Files changed:**

| File | Change |
|------|--------|
| `IndexSettings.java` | New `MAX_DOC_ID_LENGTH_SETTING` with default 512, min 512, max 32766 |
| `IndexScopedSettings.java` | Register the new setting |
| `DocWriteRequest.java` | Parameterize `validateDocIdLength(id, maxLength, ...)` + add constants |
| `IndexRequest.java` / `UpdateRequest.java` | Use Lucene hard limit (32766) for early validation |
| `TransportShardBulkAction.java` | Shard-level enforcement using per-index setting, skipping DELETEs |
| `BulkIntegrationIT.java` | Integration tests: default limit, custom limit, dynamic update, delete-with-long-id |
| `IndexRequestTests.java` / `BulkRequestTests.java` | Updated unit tests for two-tier validation |
| `CHANGELOG.md` | Entry under `[Unreleased 3.x] > Added` |

### Related Issues

Resolves #19075

### Check List

- [x] Functionality includes testing.
- [ ] API changes companion pull request created, if applicable.
- [ ] Public documentation issue/PR created, if applicable.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
