### PR TITLE
Remove relative date in IndicesRequestCacheIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -552,7 +552,7 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
             .setSize(0)
             .setRequestCache(true)
             .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-20").lte("2016-03-26"))
-            .addAggregation(dateRange("foo").field("s").addRange("now-10y", "now"))
+            .addAggregation(dateRange("foo").field("s").addRange("2016-01-01", "now"))
             .get();
         OpenSearchAssertions.assertAllSuccessful(r5);
         assertThat(r5.getHits().getTotalHits().value(), equalTo(7L));
@@ -575,7 +575,7 @@ public class IndicesRequestCacheIT extends ParameterizedStaticSettingsOpenSearch
             .setSize(0)
             .setRequestCache(true)
             .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-20").lte("2016-03-26"))
-            .addAggregation(filter("foo", QueryBuilders.rangeQuery("s").from("now-10y").to("now")))
+            .addAggregation(filter("foo", QueryBuilders.rangeQuery("s").from("2016-01-01").to("now")))
             .get();
         OpenSearchAssertions.assertAllSuccessful(r4);
         assertThat(r4.getHits().getTotalHits().value(), equalTo(7L));


### PR DESCRIPTION
The dates in the test are starting to fall out of the now-10y window. It should be fine to use a fixed date for the 'from' since the 'to' uses now.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
