### PR TITLE
Fix index blocks creating unrecoverable state when combined

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/blocks/SimpleBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/blocks/SimpleBlocksIT.java
@@ -142,6 +142,50 @@ public class SimpleBlocksIT extends OpenSearchIntegTestCase {
         canIndexDocument("test1");
     }
 
+    /**
+     * Test for bug #20293: Setting both index.blocks.read_only and index.blocks.write
+     * creates an unrecoverable state where settings cannot be changed.
+     */
+    public void testCombinedReadOnlyAndWriteBlocksCanBeRemoved() {
+        canCreateIndex("test");
+        canIndexDocument("test");
+
+        // Set both read_only and write blocks
+        client().admin()
+            .indices()
+            .prepareUpdateSettings("test")
+            .setSettings(Settings.builder()
+                .put(SETTING_READ_ONLY, true)
+                .put(SETTING_BLOCKS_WRITE, true))
+            .execute()
+            .actionGet();
+
+        // Verify both blocks are active
+        canNotIndexDocument("test");
+        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        assertTrue(state.blocks().hasIndexBlock("test", IndexMetadata.INDEX_READ_ONLY_BLOCK));
+        assertTrue(state.blocks().hasIndexBlock("test", IndexMetadata.INDEX_WRITE_BLOCK));
+
+        // Try to remove read_only block - this should work
+        client().admin()
+            .indices()
+            .prepareUpdateSettings("test")
+            .setSettings(Settings.builder().put(SETTING_READ_ONLY, false))
+            .execute()
+            .actionGet();
+
+        // Try to remove write block - this should also work
+        client().admin()
+            .indices()
+            .prepareUpdateSettings("test")
+            .setSettings(Settings.builder().put(SETTING_BLOCKS_WRITE, false))
+            .execute()
+            .actionGet();
+
+        // Verify index is now unblocked and can be written to
+        canIndexDocument("test");
+    }
+
     private void canCreateIndex(String index) {
         try {
             CreateIndexResponse r = client().admin().indices().prepareCreate(index).execute().actionGet();

--- a/server/src/main/java/org/opensearch/cluster/block/ClusterBlocks.java
+++ b/server/src/main/java/org/opensearch/cluster/block/ClusterBlocks.java
@@ -74,7 +74,10 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> implements Ve
     public static final Set<Setting<Boolean>> INDEX_DATA_READ_ONLY_BLOCK_SETTINGS = Set.of(
         IndexMetadata.INDEX_READ_ONLY_SETTING,
         IndexMetadata.INDEX_BLOCKS_METADATA_SETTING,
-        IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING
+        IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING,
+        IndexMetadata.INDEX_BLOCKS_WRITE_SETTING,
+        IndexMetadata.INDEX_BLOCKS_READ_SETTING,
+        IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING
     );
     private final Set<ClusterBlock> global;
 

--- a/server/src/test/java/org/opensearch/cluster/block/ClusterBlocksTests.java
+++ b/server/src/test/java/org/opensearch/cluster/block/ClusterBlocksTests.java
@@ -201,6 +201,21 @@ public class ClusterBlocksTests extends OpenSearchTestCase {
         }
     }
 
+    public void testAllBlockSettingsAreInExemptionList() {
+        // Verify that all block settings are in the exemption list to allow unblocking
+        // This is critical for bug #20293: combined blocks should not create unrecoverable state
+        assertTrue(ClusterBlocks.INDEX_DATA_READ_ONLY_BLOCK_SETTINGS.contains(IndexMetadata.INDEX_READ_ONLY_SETTING));
+        assertTrue(ClusterBlocks.INDEX_DATA_READ_ONLY_BLOCK_SETTINGS.contains(IndexMetadata.INDEX_BLOCKS_READ_SETTING));
+        assertTrue(ClusterBlocks.INDEX_DATA_READ_ONLY_BLOCK_SETTINGS.contains(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING));
+        assertTrue(ClusterBlocks.INDEX_DATA_READ_ONLY_BLOCK_SETTINGS.contains(IndexMetadata.INDEX_BLOCKS_METADATA_SETTING));
+        assertTrue(
+            ClusterBlocks.INDEX_DATA_READ_ONLY_BLOCK_SETTINGS.contains(IndexMetadata.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING)
+        );
+        assertTrue(ClusterBlocks.INDEX_DATA_READ_ONLY_BLOCK_SETTINGS.contains(IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING));
+        // Should have exactly 6 block settings
+        assertEquals(6, ClusterBlocks.INDEX_DATA_READ_ONLY_BLOCK_SETTINGS.size());
+    }
+
     private IndexMetadata createIndexMetadata(String index, boolean isRemoteIndex, String alias, Setting<Boolean> blockSetting) {
         IndexMetadata.Builder builder = IndexMetadata.builder(index).settings(createIndexSettingBuilder(isRemoteIndex, blockSetting));
         if (alias != null) {


### PR DESCRIPTION
## Summary
- Fixes #20293: Setting multiple index block settings simultaneously (e.g., `index.blocks.read_only` + `index.blocks.write`) creates a permanently locked index that cannot be recovered through the settings API.
- Root cause: `INDEX_DATA_READ_ONLY_BLOCK_SETTINGS` (the exemption set that allows block-setting updates even when blocks are active) was missing 3 of the 6 block settings: `INDEX_BLOCKS_WRITE_SETTING`, `INDEX_BLOCKS_READ_SETTING`, and `INDEX_BLOCKS_SEARCH_ONLY_SETTING`.
- This 3-line fix adds the missing settings to the exemption set, ensuring all block combinations remain removable.

## Test plan
- [x] Unit test: `ClusterBlocksTests.testAllBlockSettingsAreInExemptionList` — verifies all 6 block settings are in the exemption set
- [x] Integration test: `SimpleBlocksIT.testCombinedReadOnlyAndWriteBlocksCanBeRemoved` — applies both `read_only` and `write` blocks, then removes them sequentially, verifying the index is writable again
- [ ] Manual test: apply `index.blocks.read_only=true` and `index.blocks.write=true` to an index, then remove both settings