### PR TITLE
Fix flaky testConsumerReinitializationWithNoInitialMessages test

### DIFF
--- a/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
+++ b/server/src/test/java/org/opensearch/indices/pollingingest/DefaultStreamPollerTests.java
@@ -695,11 +695,18 @@ public class DefaultStreamPollerTests extends OpenSearchTestCase {
         // Verify no messages processed
         verify(processor, never()).process(any(), any());
 
-        // Request consumer reinitialization
+        // Request consumer reinitialization and wait for it to complete before adding messages
+        IngestionShardConsumer oldConsumer = poller.getConsumer();
         IngestionSource mockIngestionSource = new IngestionSource.Builder("test").build();
         poller.requestConsumerReinitialization(mockIngestionSource);
 
-        // Add a message
+        assertBusy(() -> {
+            IngestionShardConsumer currentConsumer = poller.getConsumer();
+            assertNotNull(currentConsumer);
+            assertNotSame(oldConsumer, currentConsumer);
+        }, 30, TimeUnit.SECONDS);
+
+        // Add a message after reinitialization is complete
         messages.add("{\"_id\":\"1\",\"_source\":{\"name\":\"bob\", \"age\": 24}}".getBytes(StandardCharsets.UTF_8));
 
         // Wait for the message to be processed


### PR DESCRIPTION
### Description
DefaultStreamPollerTests.testConsumerReinitializationWithNoInitialMessages test needs to wait for the consumer to be reinitialized before publishing the message, otherwise it'll read the message before and after reinitialization resulting in processing the message twice. This is not an issue, but results in flaky test. We update the test for deterministic result.

### Related Issues
Resolves #20069


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
