### PR TITLE
Remove @ExperimentalApi annotations from star-tree code

### DIFF
--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/StarTreeDocument.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/StarTreeDocument.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class StarTreeDocument {
     public final Long[] dimensions;
     public final Object[] metrics;

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/StarTreeField.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/StarTreeField.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class StarTreeField implements ToXContent {
     private final String name;
     private final List<Dimension> dimensionsOrder;

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/StarTreeFieldConfiguration.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/StarTreeFieldConfiguration.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class StarTreeFieldConfiguration implements ToXContent {
 
     private final AtomicInteger maxLeafDocs = new AtomicInteger();
@@ -53,7 +53,7 @@ public class StarTreeFieldConfiguration implements ToXContent {
      *
      * @opensearch.experimental
      */
-    @ExperimentalApi
+    @PublicApi(since = "3.6.0")
     public enum StarTreeBuildMode {
         // TODO : remove onheap support unless this proves useful
         ON_HEAP("onheap", (byte) 0),

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/StarTreeValidator.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/StarTreeValidator.java
@@ -27,7 +27,7 @@ import java.util.Set;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class StarTreeValidator {
     public static void validate(MapperService mapperService, CompositeIndexSettings compositeIndexSettings, IndexSettings indexSettings) {
         Set<CompositeMappedFieldType> compositeFieldTypes = mapperService.getCompositeFieldTypes();

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/AbstractDocumentsFileManager.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/AbstractDocumentsFileManager.java
@@ -40,7 +40,7 @@ import static org.opensearch.index.mapper.NumberFieldMapper.NumberType.LONG;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public abstract class AbstractDocumentsFileManager implements Closeable {
     private static final Logger logger = LogManager.getLogger(AbstractDocumentsFileManager.class);
     protected final StarTreeField starTreeField;

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/OffHeapStarTreeBuilder.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/OffHeapStarTreeBuilder.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class OffHeapStarTreeBuilder extends BaseStarTreeBuilder {
     private static final Logger logger = LogManager.getLogger(OffHeapStarTreeBuilder.class);
     private final StarTreeDocsFileManager starTreeDocumentFileManager;

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/OnHeapStarTreeBuilder.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/OnHeapStarTreeBuilder.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class OnHeapStarTreeBuilder extends BaseStarTreeBuilder {
 
     private final List<StarTreeDocument> starTreeDocuments = new ArrayList<>();

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/SegmentDocsFileManager.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/SegmentDocsFileManager.java
@@ -31,7 +31,7 @@ import java.util.List;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class SegmentDocsFileManager extends AbstractDocumentsFileManager implements Closeable {
 
     private static final Logger logger = LogManager.getLogger(SegmentDocsFileManager.class);

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeBuilder.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeBuilder.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public interface StarTreeBuilder extends Closeable {
     /**
      * Builds the star tree from the original segment documents

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeDocsFileManager.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreeDocsFileManager.java
@@ -48,7 +48,7 @@ import java.util.Map;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class StarTreeDocsFileManager extends AbstractDocumentsFileManager implements Closeable {
     private static final Logger logger = LogManager.getLogger(StarTreeDocsFileManager.class);
     private static final String STAR_TREE_DOC_FILE_NAME = "star-tree.documents";

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreesBuilder.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/builder/StarTreesBuilder.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class StarTreesBuilder implements Closeable {
 
     private static final Logger logger = LogManager.getLogger(StarTreesBuilder.class);

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/fileformats/meta/DimensionConfig.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/fileformats/meta/DimensionConfig.java
@@ -17,7 +17,7 @@ import org.opensearch.index.compositeindex.datacube.DimensionDataType;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class DimensionConfig {
 
     private final DocValuesType docValuesType;

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/fileformats/meta/StarTreeMetadata.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/fileformats/meta/StarTreeMetadata.java
@@ -34,7 +34,7 @@ import java.util.Set;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class StarTreeMetadata extends CompositeIndexMetadata {
     private static final Logger logger = LogManager.getLogger(StarTreeMetadata.class);
 

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/index/CompositeIndexValues.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/index/CompositeIndexValues.java
@@ -15,7 +15,7 @@ import org.opensearch.common.annotation.ExperimentalApi;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public interface CompositeIndexValues {
     CompositeIndexValues getValues();
 }

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/index/StarTreeValues.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/index/StarTreeValues.java
@@ -50,7 +50,7 @@ import static org.opensearch.index.compositeindex.datacube.startree.utils.StarTr
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class StarTreeValues implements CompositeIndexValues {
 
     /**

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/node/InMemoryTreeNode.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/node/InMemoryTreeNode.java
@@ -21,7 +21,7 @@ import static org.opensearch.index.compositeindex.datacube.startree.utils.StarTr
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class InMemoryTreeNode {
 
     public InMemoryTreeNode() {

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/node/StarTreeNode.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/node/StarTreeNode.java
@@ -20,7 +20,7 @@ import java.util.Iterator;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public interface StarTreeNode {
 
     /**

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/SequentialDocValuesIterator.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/SequentialDocValuesIterator.java
@@ -26,7 +26,7 @@ import java.io.IOException;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class SequentialDocValuesIterator {
 
     /**

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/date/DateTimeUnitRounding.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/date/DateTimeUnitRounding.java
@@ -15,7 +15,7 @@ import org.opensearch.common.annotation.ExperimentalApi;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public interface DateTimeUnitRounding {
     /**
      * Returns the short name of the time unit

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/iterator/SortedNumericStarTreeValuesIterator.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/iterator/SortedNumericStarTreeValuesIterator.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class SortedNumericStarTreeValuesIterator extends StarTreeValuesIterator {
 
     public SortedNumericStarTreeValuesIterator(DocIdSetIterator docIdSetIterator) {

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/iterator/SortedSetStarTreeValuesIterator.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/iterator/SortedSetStarTreeValuesIterator.java
@@ -22,7 +22,7 @@ import java.io.IOException;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class SortedSetStarTreeValuesIterator extends StarTreeValuesIterator {
 
     public SortedSetStarTreeValuesIterator(DocIdSetIterator docIdSetIterator) {

--- a/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/iterator/StarTreeValuesIterator.java
+++ b/server/src/main/java/org/opensearch/index/compositeindex/datacube/startree/utils/iterator/StarTreeValuesIterator.java
@@ -20,7 +20,7 @@ import java.io.IOException;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public abstract class StarTreeValuesIterator {
 
     public static final int NO_MORE_ENTRIES = Integer.MAX_VALUE;

--- a/server/src/main/java/org/opensearch/index/mapper/StarTreeMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/StarTreeMapper.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
  *
  * @opensearch.experimental
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class StarTreeMapper extends ParametrizedFieldMapper {
     public static final String CONTENT_TYPE = "star_tree";
     public static final String CONFIG = "config";
@@ -574,7 +574,7 @@ public class StarTreeMapper extends ParametrizedFieldMapper {
      *
      * @opensearch.experimental
      */
-    @ExperimentalApi
+    @PublicApi(since = "3.6.0")
     public static final class StarTreeFieldType extends CompositeDataCubeFieldType {
 
         private final StarTreeFieldConfiguration starTreeConfig;

--- a/server/src/main/java/org/opensearch/search/aggregations/StarTreeBucketCollector.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/StarTreeBucketCollector.java
@@ -22,7 +22,7 @@ import java.util.List;
  * collect relevant metrics across nested aggregations in a single traversal
  * @opensearch.internal
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public abstract class StarTreeBucketCollector {
 
     protected final StarTreeValues starTreeValues;

--- a/server/src/main/java/org/opensearch/search/startree/StarTreeNodeCollector.java
+++ b/server/src/main/java/org/opensearch/search/startree/StarTreeNodeCollector.java
@@ -14,7 +14,7 @@ import org.opensearch.index.compositeindex.datacube.startree.node.StarTreeNode;
 /**
  * Collects one or more @{@link StarTreeNode}'s
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public interface StarTreeNodeCollector {
     /**
      * Called to collect a @{@link StarTreeNode}

--- a/server/src/main/java/org/opensearch/search/startree/StarTreeQueryContext.java
+++ b/server/src/main/java/org/opensearch/search/startree/StarTreeQueryContext.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 /**
  * Stores the star tree related context of a search request.
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class StarTreeQueryContext {
 
     private final CompositeDataCubeFieldType compositeMappedFieldType;

--- a/server/src/main/java/org/opensearch/search/startree/filter/DimensionFilter.java
+++ b/server/src/main/java/org/opensearch/search/startree/filter/DimensionFilter.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 /**
  * Contains the logic to filter over a dimension either in StarTree Index or it's Dimension DocValues
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public interface DimensionFilter {
     /**
      * Converts parsed user values to ordinals based on segment and other init actions can be performed.
@@ -59,7 +59,7 @@ public interface DimensionFilter {
     /**
      * Represents how to match a value when comparing during StarTreeTraversal
      */
-    @ExperimentalApi
+    @PublicApi(since = "3.6.0")
     enum MatchType {
         GT,
         LT,

--- a/server/src/main/java/org/opensearch/search/startree/filter/ExactMatchDimFilter.java
+++ b/server/src/main/java/org/opensearch/search/startree/filter/ExactMatchDimFilter.java
@@ -25,7 +25,7 @@ import java.util.TreeSet;
 /**
  * Handles Term and Terms query like search in StarTree Dimension filtering.
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class ExactMatchDimFilter implements DimensionFilter {
 
     private final String dimensionName;

--- a/server/src/main/java/org/opensearch/search/startree/filter/MatchAllFilter.java
+++ b/server/src/main/java/org/opensearch/search/startree/filter/MatchAllFilter.java
@@ -21,7 +21,7 @@ import java.util.Iterator;
 /**
  * Matches all StarTreeNodes
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class MatchAllFilter implements DimensionFilter {
 
     public final String dimensionName;

--- a/server/src/main/java/org/opensearch/search/startree/filter/MatchNoneFilter.java
+++ b/server/src/main/java/org/opensearch/search/startree/filter/MatchNoneFilter.java
@@ -17,7 +17,7 @@ import org.opensearch.search.startree.StarTreeNodeCollector;
 /**
  * Filter which matches no StarTreeNodes.
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class MatchNoneFilter implements DimensionFilter {
 
     @Override

--- a/server/src/main/java/org/opensearch/search/startree/filter/RangeMatchDimFilter.java
+++ b/server/src/main/java/org/opensearch/search/startree/filter/RangeMatchDimFilter.java
@@ -22,7 +22,7 @@ import java.util.Optional;
  * Performs range match based on the params of @{@link org.opensearch.index.query.RangeQueryBuilder}
  * Also, contains logic to skip performing range search if it's sure that it won't be found in Star Tree.
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class RangeMatchDimFilter implements DimensionFilter {
 
     private final String dimensionName;

--- a/server/src/main/java/org/opensearch/search/startree/filter/StarTreeFilter.java
+++ b/server/src/main/java/org/opensearch/search/startree/filter/StarTreeFilter.java
@@ -18,7 +18,7 @@ import java.util.Set;
 /**
  * Container for intermediate/consolidated dimension filters that will be applied for a query in star tree traversal.
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public class StarTreeFilter {
 
     private final Map<String, List<DimensionFilter>> dimensionFilterMap;

--- a/server/src/main/java/org/opensearch/search/startree/filter/provider/DimensionFilterMapper.java
+++ b/server/src/main/java/org/opensearch/search/startree/filter/provider/DimensionFilterMapper.java
@@ -54,7 +54,7 @@ import static org.opensearch.index.mapper.NumberFieldMapper.NumberType.signum;
 /**
  * Generates the @{@link DimensionFilter} raw values and the @{@link MappedFieldType} of the dimension.
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public interface DimensionFilterMapper {
     /**
      * Generates @{@link ExactMatchDimFilter} from Term/Terms query input.

--- a/server/src/main/java/org/opensearch/search/startree/filter/provider/StarTreeFilterProvider.java
+++ b/server/src/main/java/org/opensearch/search/startree/filter/provider/StarTreeFilterProvider.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * Converts a {@link QueryBuilder} into a {@link StarTreeFilter} by generating the appropriate @{@link DimensionFilter}
  * for the fields provided in the user query.
  */
-@ExperimentalApi
+@PublicApi(since = "3.6.0")
 public interface StarTreeFilterProvider {
 
     /**


### PR DESCRIPTION
## Problem

The star-tree code files contained `@ExperimentalApi` annotations that needed to be updated to align with the project's API versioning strategy.

## Solution

Removed `@ExperimentalApi` annotations from all star-tree code files and replaced them with `@PublicApi(since = "3.6.0")` annotations, following the pattern established in related PR #18070.

## Validation

- All existing tests pass
- Code compiles without errors
- Follows the same annotation pattern as PR #18070

Fixes #20925