### PR TITLE
Mute flaky WorkloadManagementIT tests

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/wlm/WorkloadManagementIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/wlm/WorkloadManagementIT.java
@@ -112,6 +112,7 @@ public class WorkloadManagementIT extends ParameterizedStaticSettingsOpenSearchI
         );
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/17154")
     public void testHighCPUInEnforcedMode() throws InterruptedException {
         Settings request = Settings.builder().put(WorkloadManagementSettings.WLM_MODE_SETTING.getKey(), ENABLED).build();
         assertAcked(client().admin().cluster().prepareUpdateSettings().setPersistentSettings(request).get());
@@ -129,6 +130,7 @@ public class WorkloadManagementIT extends ParameterizedStaticSettingsOpenSearchI
         updateWorkloadGroupInClusterState(DELETE, workloadGroup);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/17154")
     public void testHighCPUInMonitorMode() throws InterruptedException {
         WorkloadGroup workloadGroup = new WorkloadGroup(
             "name",
@@ -143,6 +145,7 @@ public class WorkloadManagementIT extends ParameterizedStaticSettingsOpenSearchI
         updateWorkloadGroupInClusterState(DELETE, workloadGroup);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/17154")
     public void testHighMemoryInEnforcedMode() throws InterruptedException {
         Settings request = Settings.builder().put(WorkloadManagementSettings.WLM_MODE_SETTING.getKey(), ENABLED).build();
         assertAcked(client().admin().cluster().prepareUpdateSettings().setPersistentSettings(request).get());
@@ -157,6 +160,7 @@ public class WorkloadManagementIT extends ParameterizedStaticSettingsOpenSearchI
         updateWorkloadGroupInClusterState(DELETE, workloadGroup);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/17154")
     public void testHighMemoryInMonitorMode() throws InterruptedException {
         WorkloadGroup workloadGroup = new WorkloadGroup(
             "name",


### PR DESCRIPTION
Recent failures:

Time                        | test_name                               | build_number
--------------------------- | --------------------------------------- | ------------
Mar 20, 2026 @ 11:23:14.479 | testHighCPUInEnforcedMode {css:false}   | 72965
Mar 16, 2026 @ 10:48:27.610 | testHighCPUInEnforcedMode {css:true}    | 72635
Feb 18, 2026 @ 20:55:00.772 | testHighCPUInEnforcedMode {css:true}    | 71503
Feb  3, 2026 @ 16:09:27.278 | testHighCPUInMonitorMode {css:true}     | 70913
Feb  3, 2026 @ 16:09:27.278 | testHighMemoryInMonitorMode {css:true}  | 70913
Feb  3, 2026 @ 16:09:27.278 | testHighCPUInMonitorMode {css:false}    | 70913
Feb  3, 2026 @ 16:09:27.278 | testHighMemoryInMonitorMode {css:false} | 70913
Dec 26, 2025 @ 16:55:00.390 | testHighCPUInEnforcedMode {css:true}    | 69312
Dec 15, 2025 @ 15:36:15.851 | testHighCPUInEnforcedMode {css:true}    | 68815
Dec  2, 2025 @ 19:00:07.265 | testHighCPUInEnforcedMode {css:false}   | 68207
Nov 27, 2025 @ 09:55:11.983 | testHighMemoryInEnforcedMode {css:true} | 67964
Nov 20, 2025 @ 14:36:39.346 | testHighCPUInEnforcedMode {css:true}    | 67665
Nov 19, 2025 @ 08:55:02.213 | testHighCPUInMonitorMode {css:true}     | 67608
Nov 18, 2025 @ 20:55:00.866 | testHighMemoryInEnforcedMode {css:false}| 67565
Nov 18, 2025 @ 00:44:05.665 | testHighMemoryInEnforcedMode {css:true} | 67513
Nov  2, 2025 @ 12:55:00.423 | testHighCPUInEnforcedMode {css:false}   | 66616
Nov  2, 2025 @ 06:55:00.161 | testHighCPUInEnforcedMode {css:true}    | 66605
Nov  2, 2025 @ 06:55:00.161 | testHighMemoryInMonitorMode {css:false} | 66605
Nov  2, 2025 @ 06:55:00.161 | testHighMemoryInEnforcedMode {css:false}| 66605
Nov  2, 2025 @ 06:55:00.161 | testHighCPUInMonitorMode {css:false}    | 66605
Nov  2, 2025 @ 06:55:00.161 | testNoCancellation {css:false}          | 66605
Oct 31, 2025 @ 09:47:40.830 | testHighCPUInEnforcedMode {css:false}   | 66532
Oct 30, 2025 @ 22:00:48.148 | testHighCPUInEnforcedMode {css:false}   | 66502
Oct 27, 2025 @ 16:25:21.579 | testHighCPUInEnforcedMode {css:true}    | 66317
Oct 24, 2025 @ 10:23:09.269 | testHighCPUInEnforcedMode {css:false}   | 66162
Oct 24, 2025 @ 01:55:00.887 | testHighMemoryInEnforcedMode {css:true} | 66129
Oct 16, 2025 @ 15:55:00.959 | testHighCPUInEnforcedMode {css:true}    | 65655
Oct 13, 2025 @ 17:58:16.185 | testHighMemoryInEnforcedMode {css:true} | 65458
Oct 13, 2025 @ 10:32:53.688 | testHighCPUInEnforcedMode {css:true}    | 65427
Oct  8, 2025 @ 11:27:12.471 | testHighCPUInEnforcedMode {css:false}   | 65191
Sep 30, 2025 @ 11:55:00.306 | testHighCPUInEnforcedMode {css:false}   | 64781
Sep 29, 2025 @ 18:48:51.923 | testHighCPUInEnforcedMode {css:false}   | 64691
Sep 28, 2025 @ 22:37:23.531 | testHighCPUInEnforcedMode {css:false}   | 64559
Sep 27, 2025 @ 11:26:15.151 | testHighMemoryInEnforcedMode {css:true} | 64496
Sep 25, 2025 @ 09:22:26.007 | testHighCPUInEnforcedMode {css:true}    | 64373
Sep 22, 2025 @ 19:21:26.437 | testHighMemoryInEnforcedMode {css:false}| 64108

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Related Issues
Related to #17154

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
