### PR TITLE
Pin localstack to a community image

### DIFF
--- a/plugins/ingestion-kinesis/src/internalClusterTest/java/org/opensearch/plugin/kinesis/KinesisIngestionBaseIT.java
+++ b/plugins/ingestion-kinesis/src/internalClusterTest/java/org/opensearch/plugin/kinesis/KinesisIngestionBaseIT.java
@@ -69,7 +69,7 @@ public class KinesisIngestionBaseIT extends OpenSearchIntegTestCase {
     Supplier<String> passwordSupplier = () -> RandomStrings.randomAsciiLettersOfLengthBetween(getRandom(), 16, 24);
 
     private void setupKinesis() throws InterruptedException {
-        localstack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest")).withEnv(
+        localstack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:4.14.0")).withEnv(
             "AWS_ACCESS_KEY_ID",
             passwordSupplier.get()
         ).withEnv("AWS_SECRET_ACCESS_KEY", passwordSupplier.get()).withServices(LocalStackContainer.Service.KINESIS);


### PR DESCRIPTION
Localstack has changed to require authenticated access. See [this blog post][1] for details. In the short term this commit will pin our usage to the last community release that supported unauthenticated access.

[1]: https://blog.localstack.cloud/localstack-single-image-next-steps/

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
