### PR TITLE
Cluster state and recovery constructs for in-place shard split

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/indices/split/InPlaceSplitShardClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/split/InPlaceSplitShardClusterStateUpdateRequest.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.split;
+
+import org.opensearch.cluster.ack.ClusterStateUpdateRequest;
+import org.opensearch.common.annotation.ExperimentalApi;
+
+/**
+ * Cluster state update request for in-place shard split.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class InPlaceSplitShardClusterStateUpdateRequest extends ClusterStateUpdateRequest<InPlaceSplitShardClusterStateUpdateRequest> {
+
+    private final String index;
+    private final int shardId;
+    private final int splitInto;
+    private final String cause;
+
+    public InPlaceSplitShardClusterStateUpdateRequest(String cause, String index, int shardId, int splitInto) {
+        this.index = index;
+        this.shardId = shardId;
+        this.splitInto = splitInto;
+        this.cause = cause;
+    }
+
+    public String getIndex() {
+        return index;
+    }
+
+    public int getSplitInto() {
+        return splitInto;
+    }
+
+    public String cause() {
+        return cause;
+    }
+
+    public int getShardId() {
+        return shardId;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/indices/split/package-info.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/split/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * This package contains actions and requests for splitting indices.
+ */
+package org.opensearch.action.admin.indices.split;

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataInPlaceSplitShardService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataInPlaceSplitShardService.java
@@ -1,0 +1,159 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.metadata;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.Version;
+import org.opensearch.action.admin.indices.split.InPlaceSplitShardClusterStateUpdateRequest;
+import org.opensearch.cluster.AckedClusterStateUpdateTask;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.ack.ClusterStateUpdateResponse;
+import org.opensearch.cluster.routing.RoutingTable;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.allocation.AllocationService;
+import org.opensearch.cluster.service.ClusterManagerTask;
+import org.opensearch.cluster.service.ClusterManagerTaskThrottler;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Priority;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.core.action.ActionListener;
+
+import java.util.function.BiFunction;
+
+/**
+ * Service responsible for applying in-place shard split requests to cluster state.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public class MetadataInPlaceSplitShardService {
+    private static final Logger logger = LogManager.getLogger(MetadataInPlaceSplitShardService.class);
+
+    private final ClusterService clusterService;
+    private final AllocationService allocationService;
+    private final ClusterManagerTaskThrottler.ThrottlingKey splitShardTaskKey;
+
+    public MetadataInPlaceSplitShardService(final ClusterService clusterService, final AllocationService allocationService) {
+        this.clusterService = clusterService;
+        this.allocationService = allocationService;
+        this.splitShardTaskKey = clusterService.registerClusterManagerTask(ClusterManagerTask.IN_PLACE_SPLIT_SHARD, true);
+    }
+
+    /**
+     * Submits a cluster state update task to split a shard in-place.
+     */
+    public void split(final InPlaceSplitShardClusterStateUpdateRequest request, final ActionListener<ClusterStateUpdateResponse> listener) {
+        clusterService.submitStateUpdateTask(
+            "in-place-split-shard [" + request.getShardId() + "] of index [" + request.getIndex() + "], cause [" + request.cause() + "]",
+            new AckedClusterStateUpdateTask<>(Priority.URGENT, request, listener) {
+                @Override
+                protected ClusterStateUpdateResponse newResponse(boolean acknowledged) {
+                    return new ClusterStateUpdateResponse(acknowledged);
+                }
+
+                @Override
+                public ClusterManagerTaskThrottler.ThrottlingKey getClusterManagerThrottlingKey() {
+                    return splitShardTaskKey;
+                }
+
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    return applySplitShardRequest(currentState, request, allocationService::reroute);
+                }
+
+                @Override
+                public void onFailure(String source, Exception e) {
+                    logger.trace(
+                        () -> new ParameterizedMessage(
+                            "[{}] of index [{}] failed to split online",
+                            request.getShardId(),
+                            request.getIndex()
+                        ),
+                        e
+                    );
+                    super.onFailure(source, e);
+                }
+            }
+        );
+    }
+
+    /**
+     * Applies a shard split request to the given cluster state. Updates the split metadata
+     * in the index metadata and triggers a reroute so that child shards get allocated.
+     */
+    static ClusterState applySplitShardRequest(
+        ClusterState currentState,
+        InPlaceSplitShardClusterStateUpdateRequest request,
+        BiFunction<ClusterState, String, ClusterState> rerouteRoutingTable
+    ) {
+        IndexMetadata curIndexMetadata = currentState.metadata().index(request.getIndex());
+        if (curIndexMetadata == null) {
+            throw new IllegalArgumentException("Index [" + request.getIndex() + "] not found");
+        }
+
+        if (curIndexMetadata.getNumberOfVirtualShards() != -1) {
+            throw new IllegalArgumentException(
+                "In-place shard split is not supported on index [" + request.getIndex() + "] with virtual shards enabled"
+            );
+        }
+
+        if (currentState.nodes().getMinNodeVersion().equals(currentState.nodes().getMaxNodeVersion()) == false
+            || currentState.nodes().getMinNodeVersion().before(Version.V_3_7_0)) {
+            throw new IllegalArgumentException(
+                "In-place shard split requires all nodes to be on the same version, at or above " + Version.V_3_7_0
+            );
+        }
+
+        int shardId = request.getShardId();
+        SplitShardsMetadata splitShardsMetadata = curIndexMetadata.getSplitShardsMetadata();
+
+        if (splitShardsMetadata.getInProgressSplitShardIds().contains(shardId)) {
+            throw new IllegalArgumentException("Splitting of shard [" + shardId + "] is already in progress");
+        }
+
+        if (splitShardsMetadata.isSplitParent(shardId)) {
+            throw new IllegalArgumentException("Shard [" + shardId + "] has already been split.");
+        }
+
+        ShardRouting primaryShard = currentState.routingTable()
+            .shardRoutingTable(curIndexMetadata.getIndex().getName(), shardId)
+            .primaryShard();
+        if (primaryShard.relocating()) {
+            throw new IllegalArgumentException(
+                "Cannot split shard [" + shardId + "] on index [" + request.getIndex() + "] because it is currently relocating"
+            );
+        }
+        if (primaryShard.started() == false) {
+            throw new IllegalArgumentException(
+                "Cannot split shard ["
+                    + shardId
+                    + "] on index ["
+                    + request.getIndex()
+                    + "] because the primary shard is not started, current state: "
+                    + primaryShard.state()
+            );
+        }
+
+        RoutingTable.Builder routingTableBuilder = RoutingTable.builder(currentState.routingTable());
+        Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
+        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(curIndexMetadata);
+
+        SplitShardsMetadata.Builder splitMetadataBuilder = new SplitShardsMetadata.Builder(splitShardsMetadata);
+        splitMetadataBuilder.splitShard(shardId, request.getSplitInto());
+        indexMetadataBuilder.splitShardsMetadata(splitMetadataBuilder.build());
+
+        RoutingTable routingTable = routingTableBuilder.build();
+        metadataBuilder.put(indexMetadataBuilder);
+
+        ClusterState updatedState = ClusterState.builder(currentState).metadata(metadataBuilder).routingTable(routingTable).build();
+        return rerouteRoutingTable.apply(updatedState, "shard [" + shardId + "] of index [" + request.getIndex() + "] split");
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/routing/AllocationId.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/AllocationId.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.cluster.routing;
 
+import org.opensearch.Version;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.annotation.PublicApi;
@@ -45,6 +46,9 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -62,17 +66,26 @@ import java.util.Objects;
 public class AllocationId implements ToXContentObject, Writeable {
     private static final String ID_KEY = "id";
     private static final String RELOCATION_ID_KEY = "relocation_id";
+    private static final String SPLIT_CHILD_ALLOCATION_IDS = "split_child_allocation_ids";
+    private static final String PARENT_ALLOCATION_ID = "parent_allocation_id";
 
     private static final ObjectParser<AllocationId.Builder, Void> ALLOCATION_ID_PARSER = new ObjectParser<>("allocationId");
 
     static {
         ALLOCATION_ID_PARSER.declareString(AllocationId.Builder::setId, new ParseField(ID_KEY));
         ALLOCATION_ID_PARSER.declareString(AllocationId.Builder::setRelocationId, new ParseField(RELOCATION_ID_KEY));
+        ALLOCATION_ID_PARSER.declareStringArray(
+            AllocationId.Builder::setSplitChildAllocationIds,
+            new ParseField(SPLIT_CHILD_ALLOCATION_IDS)
+        );
+        ALLOCATION_ID_PARSER.declareString(AllocationId.Builder::setParentAllocationId, new ParseField(PARENT_ALLOCATION_ID));
     }
 
     private static class Builder {
         private String id;
         private String relocationId;
+        private List<String> splitChildAllocationIds;
+        private String parentAllocationId;
 
         public void setId(String id) {
             this.id = id;
@@ -82,44 +95,70 @@ public class AllocationId implements ToXContentObject, Writeable {
             this.relocationId = relocationId;
         }
 
+        public void setSplitChildAllocationIds(List<String> splitChildAllocationIds) {
+            this.splitChildAllocationIds = splitChildAllocationIds;
+        }
+
+        public void setParentAllocationId(String parentAllocationId) {
+            this.parentAllocationId = parentAllocationId;
+        }
+
         public AllocationId build() {
-            return new AllocationId(id, relocationId);
+            return new AllocationId(id, relocationId, splitChildAllocationIds, parentAllocationId);
         }
     }
 
     private final String id;
     @Nullable
     private final String relocationId;
+    @Nullable
+    private final List<String> splitChildAllocationIds;
+    @Nullable
+    private final String parentAllocationId;
 
     AllocationId(StreamInput in) throws IOException {
         this.id = in.readString();
         this.relocationId = in.readOptionalString();
+        if (in.getVersion().onOrAfter(Version.V_3_7_0)) {
+            List<String> childIds = in.readOptionalStringList();
+            splitChildAllocationIds = childIds == null ? null : Collections.unmodifiableList(childIds);
+            parentAllocationId = in.readOptionalString();
+        } else {
+            splitChildAllocationIds = null;
+            parentAllocationId = null;
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(this.id);
         out.writeOptionalString(this.relocationId);
+        if (out.getVersion().onOrAfter(Version.V_3_7_0)) {
+            out.writeOptionalStringCollection(splitChildAllocationIds);
+            out.writeOptionalString(parentAllocationId);
+        }
     }
 
-    private AllocationId(String id, String relocationId) {
+    private AllocationId(String id, String relocationId, List<String> splitChildAllocationIds, String parentAllocationId) {
         Objects.requireNonNull(id, "Argument [id] must be non-null");
         this.id = id;
         this.relocationId = relocationId;
+        this.splitChildAllocationIds = splitChildAllocationIds == null ? null : Collections.unmodifiableList(splitChildAllocationIds);
+        this.parentAllocationId = parentAllocationId;
     }
 
     /**
      * Creates a new allocation id for initializing allocation.
      */
     public static AllocationId newInitializing() {
-        return new AllocationId(UUIDs.randomBase64UUID(), null);
+        return new AllocationId(UUIDs.randomBase64UUID(), null, null, null);
     }
 
     /**
      * Creates a new allocation id for initializing allocation based on an existing id.
      */
     public static AllocationId newInitializing(String existingAllocationId) {
-        return new AllocationId(existingAllocationId, null);
+        return new AllocationId(existingAllocationId, null, null, null);
     }
 
     /**
@@ -128,7 +167,7 @@ public class AllocationId implements ToXContentObject, Writeable {
      */
     public static AllocationId newTargetRelocation(AllocationId allocationId) {
         assert allocationId.getRelocationId() != null;
-        return new AllocationId(allocationId.getRelocationId(), allocationId.getId());
+        return new AllocationId(allocationId.getRelocationId(), allocationId.getId(), null, null);
     }
 
     /**
@@ -137,18 +176,18 @@ public class AllocationId implements ToXContentObject, Writeable {
      */
     public static AllocationId newRelocation(AllocationId allocationId) {
         assert allocationId.getRelocationId() == null;
-        return new AllocationId(allocationId.getId(), UUIDs.randomBase64UUID());
+        return new AllocationId(allocationId.getId(), UUIDs.randomBase64UUID(), null, null);
     }
 
     /**
      * Creates a new allocation id representing a cancelled relocation.
      * <p>
      * Note that this is expected to be called on the allocation id
-     * of the *source* shard
+     * of the *source* shard.
      */
     public static AllocationId cancelRelocation(AllocationId allocationId) {
         assert allocationId.getRelocationId() != null;
-        return new AllocationId(allocationId.getId(), null);
+        return new AllocationId(allocationId.getId(), null, null, null);
     }
 
     /**
@@ -159,7 +198,44 @@ public class AllocationId implements ToXContentObject, Writeable {
      */
     public static AllocationId finishRelocation(AllocationId allocationId) {
         assert allocationId.getRelocationId() != null;
-        return new AllocationId(allocationId.getId(), null);
+        return new AllocationId(allocationId.getId(), null, null, null);
+    }
+
+    /**
+     * Creates a new allocation id for a shard that is undergoing split, populating
+     * the transient holder for splitChildAllocationIds.
+     */
+    public static AllocationId newSplit(AllocationId allocationId, int numberOfChildShards) {
+        assert allocationId.getSplitChildAllocationIds() == null && allocationId.getParentAllocationId() == null;
+        List<String> childIds = new ArrayList<>();
+        for (int c = 0; c < numberOfChildShards; c++) {
+            childIds.add(UUIDs.randomBase64UUID());
+        }
+        return new AllocationId(allocationId.getId(), null, childIds, null);
+    }
+
+    /**
+     * Creates a new allocation id for a child shard that is the result of a split.
+     */
+    public static AllocationId newTargetSplit(AllocationId allocationId, String childAllocId) {
+        assert allocationId.getSplitChildAllocationIds() != null;
+        return new AllocationId(childAllocId, null, null, allocationId.getId());
+    }
+
+    /**
+     * Creates a new allocation id representing a cancelled split.
+     */
+    public static AllocationId cancelSplit(AllocationId allocationId) {
+        assert allocationId.getSplitChildAllocationIds() != null;
+        return new AllocationId(allocationId.getId(), null, null, null);
+    }
+
+    /**
+     * Creates a new allocation id finalizing a split on the target child shard.
+     */
+    public static AllocationId finishSplit(AllocationId allocationId) {
+        assert allocationId.getParentAllocationId() != null;
+        return new AllocationId(allocationId.getId(), null, null, null);
     }
 
     /**
@@ -177,32 +253,44 @@ public class AllocationId implements ToXContentObject, Writeable {
         return relocationId;
     }
 
+    /**
+     * The transient split child allocation ids holding the unique ids which are used for split.
+     */
+    public List<String> getSplitChildAllocationIds() {
+        return splitChildAllocationIds;
+    }
+
+    /**
+     * The transient split parent allocation id holding the unique id that is used for split.
+     */
+    public String getParentAllocationId() {
+        return parentAllocationId;
+    }
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (!(o instanceof AllocationId)) return false;
         AllocationId that = (AllocationId) o;
-        if (!id.equals(that.id)) {
-            return false;
-        }
-        return !(relocationId != null ? !relocationId.equals(that.relocationId) : that.relocationId != null);
-
+        return Objects.equals(id, that.id)
+            && Objects.equals(relocationId, that.relocationId)
+            && Objects.equals(splitChildAllocationIds, that.splitChildAllocationIds)
+            && Objects.equals(parentAllocationId, that.parentAllocationId);
     }
 
     @Override
     public int hashCode() {
-        int result = id.hashCode();
-        result = 31 * result + (relocationId != null ? relocationId.hashCode() : 0);
-        return result;
+        return Objects.hash(id, relocationId, splitChildAllocationIds, parentAllocationId);
     }
 
     @Override
     public String toString() {
-        return "[id=" + id + (relocationId == null ? "" : ", rId=" + relocationId) + "]";
+        return "[id="
+            + id
+            + (relocationId == null ? "" : ", rId=" + relocationId)
+            + (splitChildAllocationIds == null ? "" : ", splitChildIds=" + splitChildAllocationIds)
+            + (parentAllocationId == null ? "" : ", parentId=" + parentAllocationId)
+            + "]";
     }
 
     @Override
@@ -211,6 +299,16 @@ public class AllocationId implements ToXContentObject, Writeable {
         builder.field(ID_KEY, id);
         if (relocationId != null) {
             builder.field(RELOCATION_ID_KEY, relocationId);
+        }
+        if (splitChildAllocationIds != null) {
+            builder.startArray(SPLIT_CHILD_ALLOCATION_IDS);
+            for (String childId : splitChildAllocationIds) {
+                builder.value(childId);
+            }
+            builder.endArray();
+        }
+        if (parentAllocationId != null) {
+            builder.field(PARENT_ALLOCATION_ID, parentAllocationId);
         }
         builder.endObject();
         return builder;

--- a/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/RecoverySource.java
@@ -56,6 +56,7 @@ import java.util.Objects;
  * - {@link PeerRecoverySource} recovery from a primary on another node
  * - {@link SnapshotRecoverySource} recovery from a snapshot
  * - {@link LocalShardsRecoverySource} recovery from other shards of another index on the same node
+ * - {@link InPlaceSplitShardRecoverySource} recovery of child shards from a source shard on the same node
  *
  * @opensearch.api
  */
@@ -90,6 +91,8 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
                 return new SnapshotRecoverySource(in);
             case LOCAL_SHARDS:
                 return LocalShardsRecoverySource.INSTANCE;
+            case IN_PLACE_SPLIT_SHARD:
+                return InPlaceSplitShardRecoverySource.INSTANCE;
             case REMOTE_STORE:
                 return new RemoteStoreRecoverySource(in);
             default:
@@ -122,7 +125,8 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         PEER,
         SNAPSHOT,
         LOCAL_SHARDS,
-        REMOTE_STORE
+        REMOTE_STORE,
+        IN_PLACE_SPLIT_SHARD
     }
 
     public abstract Type getType();
@@ -245,6 +249,33 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
             return "local shards recovery";
         }
 
+    }
+
+    /**
+     * Recovery of child shards from a source shard on the same node during in-place shard split.
+     *
+     * @opensearch.experimental
+     */
+    public static class InPlaceSplitShardRecoverySource extends RecoverySource {
+
+        public static final InPlaceSplitShardRecoverySource INSTANCE = new InPlaceSplitShardRecoverySource();
+
+        private InPlaceSplitShardRecoverySource() {}
+
+        @Override
+        public Type getType() {
+            return Type.IN_PLACE_SPLIT_SHARD;
+        }
+
+        @Override
+        public String toString() {
+            return "in-place shard split";
+        }
+
+        @Override
+        public boolean expectEmptyRetentionLeases() {
+            return false;
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/ShardRouting.java
@@ -77,6 +77,10 @@ public class ShardRouting implements Writeable, ToXContentObject {
     private final long expectedShardSize;
     @Nullable
     private final ShardRouting targetRelocatingShard;
+    @Nullable
+    private final ShardRouting[] recoveringChildShards;
+    @Nullable
+    private final ShardId parentShardId;
 
     /**
      * A constructor to internally create shard routing instances, note, the internal flag should only be set to true
@@ -94,6 +98,36 @@ public class ShardRouting implements Writeable, ToXContentObject {
         AllocationId allocationId,
         long expectedShardSize
     ) {
+        this(
+            shardId,
+            currentNodeId,
+            relocatingNodeId,
+            primary,
+            searchOnly,
+            state,
+            recoverySource,
+            unassignedInfo,
+            allocationId,
+            expectedShardSize,
+            null,
+            null
+        );
+    }
+
+    protected ShardRouting(
+        ShardId shardId,
+        String currentNodeId,
+        String relocatingNodeId,
+        boolean primary,
+        boolean searchOnly,
+        ShardRoutingState state,
+        RecoverySource recoverySource,
+        UnassignedInfo unassignedInfo,
+        AllocationId allocationId,
+        long expectedShardSize,
+        ShardRouting[] recoveringChildShards,
+        ShardId parentShardId
+    ) {
         this.shardId = shardId;
         this.currentNodeId = currentNodeId;
         this.relocatingNodeId = relocatingNodeId;
@@ -105,17 +139,25 @@ public class ShardRouting implements Writeable, ToXContentObject {
         this.allocationId = allocationId;
         this.expectedShardSize = expectedShardSize;
         this.targetRelocatingShard = initializeTargetRelocatingShard();
+        this.recoveringChildShards = recoveringChildShards;
+        this.parentShardId = parentShardId;
         this.asList = Collections.singletonList(this);
         assert expectedShardSize == UNAVAILABLE_EXPECTED_SHARD_SIZE
             || state == ShardRoutingState.INITIALIZING
-            || state == ShardRoutingState.RELOCATING : expectedShardSize + " state: " + state;
-        assert expectedShardSize >= 0 || state != ShardRoutingState.INITIALIZING || state != ShardRoutingState.RELOCATING
-            : expectedShardSize + " state: " + state;
+            || state == ShardRoutingState.RELOCATING
+            || state == ShardRoutingState.SPLITTING : expectedShardSize + " state: " + state;
+        assert expectedShardSize >= 0
+            || state != ShardRoutingState.INITIALIZING
+            || state != ShardRoutingState.RELOCATING
+            || state != ShardRoutingState.SPLITTING : expectedShardSize + " state: " + state;
         assert !(state == ShardRoutingState.UNASSIGNED && unassignedInfo == null) : "unassigned shard must be created with meta";
         assert (state == ShardRoutingState.UNASSIGNED || state == ShardRoutingState.INITIALIZING) == (recoverySource != null)
             : "recovery source only available on unassigned or initializing shard but was " + state;
-        assert recoverySource == null || recoverySource == PeerRecoverySource.INSTANCE || primary || searchOnly
-            : "replica shards always recover from primary";
+        assert recoverySource == null
+            || recoverySource == PeerRecoverySource.INSTANCE
+            || primary
+            || searchOnly
+            || recoverySource == RecoverySource.InPlaceSplitShardRecoverySource.INSTANCE : "replica shards always recover from primary";
         assert (currentNodeId == null) == (state == ShardRoutingState.UNASSIGNED) : "unassigned shard must not be assigned to a node "
             + this;
     }
@@ -269,6 +311,35 @@ public class ShardRouting implements Writeable, ToXContentObject {
     }
 
     /**
+     * Returns <code>true</code> iff the shard is in splitting state.
+     */
+    public boolean splitting() {
+        return state == ShardRoutingState.SPLITTING;
+    }
+
+    /**
+     * Returns <code>true</code> if this shard is a child shard created by an in-place split.
+     */
+    public boolean isSplitTarget() {
+        return parentShardId != null;
+    }
+
+    /**
+     * Returns a copy of the recovering child shards of this splitting shard, or null if not splitting.
+     */
+    @Nullable
+    public ShardRouting[] getRecoveringChildShards() {
+        return recoveringChildShards == null ? null : recoveringChildShards.clone();
+    }
+
+    /**
+     * Returns the parent shard id if this is a child shard created by split, or null otherwise.
+     */
+    public ShardId getParentShardId() {
+        return parentShardId;
+    }
+
+    /**
      * Returns <code>true</code> iff this shard is assigned to a node ie. not
      * {@link ShardRoutingState#UNASSIGNED unassigned}. Otherwise <code>false</code>
      */
@@ -371,7 +442,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
         unassignedInfo = in.readOptionalWriteable(UnassignedInfo::new);
         allocationId = in.readOptionalWriteable(AllocationId::new);
         final long shardSize;
-        if (state == ShardRoutingState.RELOCATING || state == ShardRoutingState.INITIALIZING) {
+        if (state == ShardRoutingState.RELOCATING || state == ShardRoutingState.INITIALIZING || state == ShardRoutingState.SPLITTING) {
             shardSize = in.readLong();
         } else {
             shardSize = UNAVAILABLE_EXPECTED_SHARD_SIZE;
@@ -379,6 +450,9 @@ public class ShardRouting implements Writeable, ToXContentObject {
         expectedShardSize = shardSize;
         asList = Collections.singletonList(this);
         targetRelocatingShard = initializeTargetRelocatingShard();
+        // These fields are transient - populated by RoutingNodes constructor, not serialized on the wire.
+        recoveringChildShards = null;
+        parentShardId = null;
     }
 
     public ShardRouting(StreamInput in) throws IOException {
@@ -404,7 +478,7 @@ public class ShardRouting implements Writeable, ToXContentObject {
         }
         out.writeOptionalWriteable(unassignedInfo);
         out.writeOptionalWriteable(allocationId);
-        if (state == ShardRoutingState.RELOCATING || state == ShardRoutingState.INITIALIZING) {
+        if (state == ShardRoutingState.RELOCATING || state == ShardRoutingState.INITIALIZING || state == ShardRoutingState.SPLITTING) {
             out.writeLong(expectedShardSize);
         }
     }

--- a/server/src/main/java/org/opensearch/cluster/routing/ShardRoutingState.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/ShardRoutingState.java
@@ -58,7 +58,11 @@ public enum ShardRoutingState {
     /**
      * The shard is in the process being relocated.
      */
-    RELOCATING((byte) 4);
+    RELOCATING((byte) 4),
+    /**
+     * The shard is in the process of being split in-place.
+     */
+    SPLITTING((byte) 5);
 
     private byte value;
 
@@ -84,6 +88,8 @@ public enum ShardRoutingState {
                 return STARTED;
             case 4:
                 return RELOCATING;
+            case 5:
+                return SPLITTING;
             default:
                 throw new IllegalStateException("No routing state mapped for [" + value + "]");
         }

--- a/server/src/main/java/org/opensearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/UnassignedInfo.java
@@ -150,7 +150,11 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
         /**
          * Unassigned as a result of closing an index.
          */
-        INDEX_CLOSED
+        INDEX_CLOSED,
+        /**
+         * Unassigned as allocation of this child shard is pending.
+         */
+        CHILD_SHARD_CREATED
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/service/ClusterManagerTask.java
+++ b/server/src/main/java/org/opensearch/cluster/service/ClusterManagerTask.java
@@ -55,7 +55,8 @@ public enum ClusterManagerTask {
     ROLLOVER_INDEX("rollover-index", 200),
     INDEX_ALIASES("index-aliases", 200),
     PUT_MAPPING("put-mapping", 10000),
-    UPDATE_SNAPSHOT_STATE("update-snapshot-state", 5000);
+    UPDATE_SNAPSHOT_STATE("update-snapshot-state", 5000),
+    IN_PLACE_SPLIT_SHARD("in-place-split-shard", 50);
 
     private final String key;
     private final int threshold;

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataInPlaceSplitShardServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataInPlaceSplitShardServiceTests.java
@@ -1,0 +1,314 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.metadata;
+
+import org.opensearch.Version;
+import org.opensearch.action.admin.indices.split.InPlaceSplitShardClusterStateUpdateRequest;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.IndexRoutingTable;
+import org.opensearch.cluster.routing.IndexShardRoutingTable;
+import org.opensearch.cluster.routing.RoutingTable;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.ShardRoutingState;
+import org.opensearch.cluster.routing.TestShardRouting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class MetadataInPlaceSplitShardServiceTests extends OpenSearchTestCase {
+
+    // --- applySplitShardRequest: success cases ---
+
+    public void testApplySplitShardRequestUpdatesMetadata() {
+        ClusterState state = createClusterState("test-index", 3, 1);
+        InPlaceSplitShardClusterStateUpdateRequest request = newRequest("test-index", 0, 2);
+
+        ClusterState updatedState = applyRequest(state, request);
+
+        SplitShardsMetadata splitMetadata = updatedState.metadata().index("test-index").getSplitShardsMetadata();
+        assertTrue(splitMetadata.isSplitOfShardInProgress(0));
+        assertEquals(2, splitMetadata.getChildShardIdsOfParent(0).size());
+    }
+
+    public void testApplySplitShardRequestCallsReroute() {
+        ClusterState state = createClusterState("test-index", 3, 1);
+        InPlaceSplitShardClusterStateUpdateRequest request = newRequest("test-index", 1, 3);
+
+        boolean[] rerouteCalled = { false };
+        MetadataInPlaceSplitShardService.applySplitShardRequest(state, request, (cs, reason) -> {
+            rerouteCalled[0] = true;
+            assertTrue(reason.contains("shard [1]"));
+            assertTrue(reason.contains("test-index"));
+            return cs;
+        });
+
+        assertTrue(rerouteCalled[0]);
+    }
+
+    public void testApplySplitShardRequestBumpsVersion() {
+        ClusterState state = createClusterState("test-index", 3, 0);
+        long versionBefore = state.metadata().index("test-index").getVersion();
+
+        ClusterState updatedState = applyRequest(state, newRequest("test-index", 0, 2));
+
+        long versionAfter = updatedState.metadata().index("test-index").getVersion();
+        assertTrue(versionAfter > versionBefore);
+    }
+
+    public void testApplySplitShardRequestMultipleShardsIndependently() {
+        ClusterState state = createClusterState("test-index", 5, 0);
+
+        ClusterState afterSplit0 = applyRequest(state, newRequest("test-index", 0, 2));
+        ClusterState afterSplit2 = applyRequest(afterSplit0, newRequest("test-index", 2, 3));
+
+        SplitShardsMetadata splitMetadata = afterSplit2.metadata().index("test-index").getSplitShardsMetadata();
+        assertTrue(splitMetadata.isSplitOfShardInProgress(0));
+        assertTrue(splitMetadata.isSplitOfShardInProgress(2));
+        assertEquals(2, splitMetadata.getChildShardIdsOfParent(0).size());
+        assertEquals(3, splitMetadata.getChildShardIdsOfParent(2).size());
+        assertFalse(splitMetadata.isSplitOfShardInProgress(1));
+    }
+
+    public void testApplySplitShardRequestPreservesExistingMetadata() {
+        ClusterState state = createClusterState("test-index", 3, 1);
+        IndexMetadata originalMetadata = state.metadata().index("test-index");
+
+        ClusterState updatedState = applyRequest(state, newRequest("test-index", 0, 2));
+
+        IndexMetadata updatedMetadata = updatedState.metadata().index("test-index");
+        assertEquals(originalMetadata.getNumberOfShards(), updatedMetadata.getNumberOfShards());
+        assertEquals(originalMetadata.getNumberOfReplicas(), updatedMetadata.getNumberOfReplicas());
+        assertEquals(originalMetadata.getIndex(), updatedMetadata.getIndex());
+    }
+
+    public void testApplySplitShardRequestChildShardIdsAreUnique() {
+        ClusterState state = createClusterState("test-index", 5, 0);
+
+        ClusterState afterSplit0 = applyRequest(state, newRequest("test-index", 0, 3));
+        ClusterState afterSplit1 = applyRequest(afterSplit0, newRequest("test-index", 1, 2));
+
+        SplitShardsMetadata splitMetadata = afterSplit1.metadata().index("test-index").getSplitShardsMetadata();
+        Set<Integer> allChildIds = new HashSet<>();
+        allChildIds.addAll(splitMetadata.getChildShardIdsOfParent(0));
+        allChildIds.addAll(splitMetadata.getChildShardIdsOfParent(1));
+        assertEquals(5, allChildIds.size()); // 3 + 2, all unique
+    }
+
+    // --- applySplitShardRequest: error cases ---
+
+    public void testApplySplitShardRequestThrowsIfAlreadyInProgress() {
+        ClusterState state = createClusterState("test-index", 3, 1);
+        ClusterState afterFirstSplit = applyRequest(state, newRequest("test-index", 0, 2));
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> applyRequest(afterFirstSplit, newRequest("test-index", 0, 2))
+        );
+        assertTrue(e.getMessage().contains("already in progress"));
+    }
+
+    public void testApplySplitShardRequestThrowsIfAlreadySplit() {
+        ClusterState state = createClusterState("test-index", 3, 1);
+
+        IndexMetadata indexMetadata = state.metadata().index("test-index");
+        SplitShardsMetadata.Builder splitBuilder = new SplitShardsMetadata.Builder(indexMetadata.getSplitShardsMetadata());
+        var childShards = splitBuilder.splitShard(0, 2);
+        Set<Integer> childIds = new HashSet<>();
+        childShards.forEach(s -> childIds.add(s.shardId()));
+        splitBuilder.updateSplitMetadataForChildShards(0, childIds);
+
+        IndexMetadata.Builder imBuilder = IndexMetadata.builder(indexMetadata);
+        imBuilder.splitShardsMetadata(splitBuilder.build());
+        Metadata.Builder metaBuilder = Metadata.builder(state.metadata()).put(imBuilder);
+        ClusterState stateWithCompletedSplit = ClusterState.builder(state).metadata(metaBuilder).build();
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> applyRequest(stateWithCompletedSplit, newRequest("test-index", 0, 2))
+        );
+        assertTrue(e.getMessage().contains("already been split"));
+    }
+
+    public void testApplySplitShardRequestThrowsForNonExistentIndex() {
+        ClusterState state = createClusterState("test-index", 3, 1);
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> applyRequest(state, newRequest("non-existent-index", 0, 2))
+        );
+        assertTrue(e.getMessage().contains("not found"));
+    }
+
+    public void testApplySplitShardRequestThrowsForInvalidShardId() {
+        ClusterState state = createClusterState("test-index", 3, 0);
+
+        expectThrows(Exception.class, () -> applyRequest(state, newRequest("test-index", 99, 2)));
+    }
+
+    public void testApplySplitShardRequestThrowsForSplitIntoZero() {
+        ClusterState state = createClusterState("test-index", 3, 0);
+
+        expectThrows(ArithmeticException.class, () -> applyRequest(state, newRequest("test-index", 0, 0)));
+    }
+
+    public void testApplySplitShardRequestThrowsIfVirtualShardsEnabled() {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_NUMBER_OF_VIRTUAL_SHARDS, 6)
+            .build();
+        IndexMetadata indexMetadata = IndexMetadata.builder("test-index").settings(indexSettings).build();
+        ClusterState state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(Metadata.builder().put(indexMetadata, false))
+            .routingTable(RoutingTable.builder().addAsNew(indexMetadata).build())
+            .build();
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> applyRequest(state, newRequest("test-index", 0, 2))
+        );
+        assertTrue(e.getMessage().contains("virtual shards"));
+    }
+
+    public void testApplySplitShardRequestThrowsInMixedVersionCluster() {
+        ClusterState state = createClusterState("test-index", 3, 0);
+        DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
+        nodesBuilder.add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.V_3_6_0));
+        nodesBuilder.add(new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.V_3_5_0));
+        state = ClusterState.builder(state).nodes(nodesBuilder).build();
+
+        ClusterState finalState = state;
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> applyRequest(finalState, newRequest("test-index", 0, 2))
+        );
+        assertTrue(e.getMessage().contains("same version"));
+    }
+
+    public void testApplySplitShardRequestThrowsIfNodeBelowSplitVersion() {
+        ClusterState state = createClusterState("test-index", 3, 0);
+        DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
+        nodesBuilder.add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.V_3_5_0));
+        nodesBuilder.add(new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.V_3_5_0));
+        state = ClusterState.builder(state).nodes(nodesBuilder).build();
+
+        ClusterState finalState = state;
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> applyRequest(finalState, newRequest("test-index", 0, 2))
+        );
+        assertTrue(e.getMessage().contains(Version.V_3_7_0.toString()));
+    }
+
+    public void testApplySplitShardRequestThrowsIfShardIsRelocating() {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .build();
+        IndexMetadata indexMetadata = IndexMetadata.builder("test-index").settings(indexSettings).build();
+        Index index = indexMetadata.getIndex();
+
+        // Build a routing table where shard 0 is relocating
+        ShardRouting relocatingShard = TestShardRouting.newShardRouting(
+            new ShardId(index, 0),
+            "node1",
+            "node2",
+            true,
+            ShardRoutingState.RELOCATING
+        );
+        IndexShardRoutingTable.Builder shardTable0 = new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(relocatingShard);
+        IndexShardRoutingTable.Builder shardTable1 = new IndexShardRoutingTable.Builder(new ShardId(index, 1)).addShard(
+            TestShardRouting.newShardRouting(new ShardId(index, 1), "node1", true, ShardRoutingState.STARTED)
+        );
+        IndexShardRoutingTable.Builder shardTable2 = new IndexShardRoutingTable.Builder(new ShardId(index, 2)).addShard(
+            TestShardRouting.newShardRouting(new ShardId(index, 2), "node1", true, ShardRoutingState.STARTED)
+        );
+        IndexRoutingTable.Builder indexRoutingBuilder = new IndexRoutingTable.Builder(index).addIndexShard(shardTable0.build())
+            .addIndexShard(shardTable1.build())
+            .addIndexShard(shardTable2.build());
+
+        ClusterState state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(Metadata.builder().put(indexMetadata, false))
+            .routingTable(RoutingTable.builder().add(indexRoutingBuilder).build())
+            .build();
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> applyRequest(state, newRequest("test-index", 0, 2))
+        );
+        assertTrue(e.getMessage().contains("relocating"));
+    }
+
+    public void testApplySplitShardRequestThrowsIfPrimaryNotStarted() {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .build();
+        IndexMetadata indexMetadata = IndexMetadata.builder("test-index").settings(indexSettings).build();
+        // addAsNew creates UNASSIGNED shards
+        ClusterState state = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(Metadata.builder().put(indexMetadata, false))
+            .routingTable(RoutingTable.builder().addAsNew(indexMetadata).build())
+            .build();
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> applyRequest(state, newRequest("test-index", 0, 2))
+        );
+        assertTrue(e.getMessage().contains("primary shard is not started"));
+    }
+
+    // --- helpers ---
+
+    private static ClusterState applyRequest(ClusterState state, InPlaceSplitShardClusterStateUpdateRequest request) {
+        return MetadataInPlaceSplitShardService.applySplitShardRequest(state, request, (cs, reason) -> cs);
+    }
+
+    private static InPlaceSplitShardClusterStateUpdateRequest newRequest(String index, int shardId, int splitInto) {
+        return new InPlaceSplitShardClusterStateUpdateRequest("test", index, shardId, splitInto);
+    }
+
+    private ClusterState createClusterState(String indexName, int numShards, int numReplicas) {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numReplicas)
+            .build();
+
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName).settings(indexSettings).build();
+        Index index = indexMetadata.getIndex();
+
+        IndexRoutingTable.Builder indexRoutingBuilder = new IndexRoutingTable.Builder(index);
+        for (int i = 0; i < numShards; i++) {
+            IndexShardRoutingTable.Builder shardBuilder = new IndexShardRoutingTable.Builder(new ShardId(index, i));
+            shardBuilder.addShard(TestShardRouting.newShardRouting(new ShardId(index, i), "node1", true, ShardRoutingState.STARTED));
+            for (int r = 0; r < numReplicas; r++) {
+                shardBuilder.addShard(
+                    TestShardRouting.newShardRouting(new ShardId(index, i), "node" + (r + 2), false, ShardRoutingState.STARTED)
+                );
+            }
+            indexRoutingBuilder.addIndexShard(shardBuilder.build());
+        }
+
+        return ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(Metadata.builder().put(indexMetadata, false))
+            .routingTable(RoutingTable.builder().add(indexRoutingBuilder).build())
+            .build();
+    }
+}

--- a/server/src/test/java/org/opensearch/cluster/routing/AllocationIdSplitTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/AllocationIdSplitTests.java
@@ -1,0 +1,200 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.routing;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.List;
+
+public class AllocationIdSplitTests extends OpenSearchTestCase {
+
+    public void testNewSplitCreatesChildAllocationIds() {
+        AllocationId original = AllocationId.newInitializing();
+        AllocationId split = AllocationId.newSplit(original, 3);
+
+        assertEquals(original.getId(), split.getId());
+        assertNull(split.getRelocationId());
+        assertNotNull(split.getSplitChildAllocationIds());
+        assertEquals(3, split.getSplitChildAllocationIds().size());
+        assertNull(split.getParentAllocationId());
+    }
+
+    public void testNewSplitChildIdsAreUnique() {
+        AllocationId split = AllocationId.newSplit(AllocationId.newInitializing(), 5);
+        List<String> childIds = split.getSplitChildAllocationIds();
+        assertEquals(5, childIds.stream().distinct().count());
+    }
+
+    public void testNewTargetSplitSetsParentAllocationId() {
+        AllocationId parent = AllocationId.newSplit(AllocationId.newInitializing(), 2);
+        String childAllocId = parent.getSplitChildAllocationIds().get(0);
+
+        AllocationId child = AllocationId.newTargetSplit(parent, childAllocId);
+
+        assertEquals(childAllocId, child.getId());
+        assertNull(child.getRelocationId());
+        assertNull(child.getSplitChildAllocationIds());
+        assertEquals(parent.getId(), child.getParentAllocationId());
+    }
+
+    public void testCancelSplitClearsChildIds() {
+        AllocationId split = AllocationId.newSplit(AllocationId.newInitializing(), 2);
+        AllocationId cancelled = AllocationId.cancelSplit(split);
+
+        assertEquals(split.getId(), cancelled.getId());
+        assertNull(cancelled.getSplitChildAllocationIds());
+        assertNull(cancelled.getParentAllocationId());
+    }
+
+    public void testFinishSplitClearsParentId() {
+        AllocationId parent = AllocationId.newSplit(AllocationId.newInitializing(), 2);
+        AllocationId child = AllocationId.newTargetSplit(parent, parent.getSplitChildAllocationIds().get(0));
+        AllocationId finished = AllocationId.finishSplit(child);
+
+        assertEquals(child.getId(), finished.getId());
+        assertNull(finished.getParentAllocationId());
+        assertNull(finished.getSplitChildAllocationIds());
+    }
+
+    public void testEqualsWithSplitFields() {
+        AllocationId a = AllocationId.newSplit(AllocationId.newInitializing(), 2);
+        AllocationId b = AllocationId.newSplit(AllocationId.newInitializing(), 2);
+
+        // Different ids, so not equal
+        assertNotEquals(a, b);
+
+        // Same object
+        assertEquals(a, a);
+    }
+
+    public void testEqualsNullSplitFieldsMatchOriginal() {
+        AllocationId a = AllocationId.newInitializing();
+        AllocationId b = AllocationId.newInitializing();
+
+        // Different random ids
+        assertNotEquals(a, b);
+
+        // Initializing with same id
+        AllocationId c = AllocationId.newInitializing("fixed-id");
+        AllocationId d = AllocationId.newInitializing("fixed-id");
+        assertEquals(c, d);
+    }
+
+    public void testSerializationRoundTrip() throws IOException {
+        AllocationId original = AllocationId.newSplit(AllocationId.newInitializing(), 3);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        AllocationId deserialized = new AllocationId(in);
+
+        assertEquals(original, deserialized);
+        assertEquals(original.getSplitChildAllocationIds(), deserialized.getSplitChildAllocationIds());
+    }
+
+    public void testSerializationRoundTripWithParentId() throws IOException {
+        AllocationId parent = AllocationId.newSplit(AllocationId.newInitializing(), 2);
+        AllocationId child = AllocationId.newTargetSplit(parent, parent.getSplitChildAllocationIds().get(0));
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        child.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        AllocationId deserialized = new AllocationId(in);
+
+        assertEquals(child, deserialized);
+        assertEquals(child.getParentAllocationId(), deserialized.getParentAllocationId());
+    }
+
+    public void testSerializationRoundTripNoSplitFields() throws IOException {
+        AllocationId original = AllocationId.newInitializing();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        AllocationId deserialized = new AllocationId(in);
+
+        assertEquals(original, deserialized);
+        assertNull(deserialized.getSplitChildAllocationIds());
+        assertNull(deserialized.getParentAllocationId());
+    }
+
+    public void testRelocationFactoryMethodsPreserveNullSplitFields() {
+        AllocationId init = AllocationId.newInitializing();
+        AllocationId reloc = AllocationId.newRelocation(init);
+
+        assertNull(reloc.getSplitChildAllocationIds());
+        assertNull(reloc.getParentAllocationId());
+        assertNotNull(reloc.getRelocationId());
+
+        AllocationId target = AllocationId.newTargetRelocation(reloc);
+        assertNull(target.getSplitChildAllocationIds());
+        assertNull(target.getParentAllocationId());
+
+        AllocationId cancelled = AllocationId.cancelRelocation(reloc);
+        assertNull(cancelled.getSplitChildAllocationIds());
+
+        AllocationId finished = AllocationId.finishRelocation(reloc);
+        assertNull(finished.getSplitChildAllocationIds());
+    }
+
+    public void testToXContentWithSplitChildIds() throws IOException {
+        AllocationId split = AllocationId.newSplit(AllocationId.newInitializing(), 2);
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        split.toXContent(builder, null);
+        String json = builder.toString();
+        assertTrue(json.contains("split_child_allocation_ids"));
+        assertTrue(json.contains(split.getSplitChildAllocationIds().get(0)));
+        assertTrue(json.contains(split.getSplitChildAllocationIds().get(1)));
+    }
+
+    public void testToXContentWithParentAllocationId() throws IOException {
+        AllocationId parent = AllocationId.newSplit(AllocationId.newInitializing(), 1);
+        AllocationId child = AllocationId.newTargetSplit(parent, parent.getSplitChildAllocationIds().get(0));
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        child.toXContent(builder, null);
+        String json = builder.toString();
+        assertTrue(json.contains("parent_allocation_id"));
+        assertTrue(json.contains(parent.getId()));
+    }
+
+    public void testFromXContentRoundTripWithSplitFields() throws IOException {
+        AllocationId split = AllocationId.newSplit(AllocationId.newInitializing(), 2);
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        split.toXContent(builder, null);
+
+        XContentParser parser = createParser(JsonXContent.jsonXContent, builder.toString());
+        AllocationId parsed = AllocationId.fromXContent(parser);
+        assertEquals(split, parsed);
+    }
+
+    public void testHashCodeWithSplitFields() {
+        AllocationId split = AllocationId.newSplit(AllocationId.newInitializing(), 2);
+        AllocationId cancelled = AllocationId.cancelSplit(split);
+        // Different hashcodes because split fields differ
+        assertNotEquals(split.hashCode(), cancelled.hashCode());
+    }
+
+    public void testToStringWithSplitFields() {
+        AllocationId split = AllocationId.newSplit(AllocationId.newInitializing(), 2);
+        String str = split.toString();
+        assertTrue(str.contains(split.getId()));
+        assertTrue(str.contains("splitChildIds"));
+    }
+
+    public void testSplitChildAllocationIdsAreUnmodifiable() {
+        AllocationId split = AllocationId.newSplit(AllocationId.newInitializing(), 2);
+        expectThrows(UnsupportedOperationException.class, () -> split.getSplitChildAllocationIds().add("new-id"));
+    }
+}

--- a/server/src/test/java/org/opensearch/cluster/routing/RecoverySourceSplitTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RecoverySourceSplitTests.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.routing;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class RecoverySourceSplitTests extends OpenSearchTestCase {
+
+    public void testInPlaceSplitShardRecoverySourceType() {
+        RecoverySource.InPlaceSplitShardRecoverySource source = RecoverySource.InPlaceSplitShardRecoverySource.INSTANCE;
+        assertEquals(RecoverySource.Type.IN_PLACE_SPLIT_SHARD, source.getType());
+    }
+
+    public void testInPlaceSplitShardRecoverySourceIsSingleton() {
+        assertSame(RecoverySource.InPlaceSplitShardRecoverySource.INSTANCE, RecoverySource.InPlaceSplitShardRecoverySource.INSTANCE);
+    }
+
+    public void testInPlaceSplitShardRecoverySourceDoesNotExpectEmptyRetentionLeases() {
+        assertFalse(RecoverySource.InPlaceSplitShardRecoverySource.INSTANCE.expectEmptyRetentionLeases());
+    }
+
+    public void testInPlaceSplitShardRecoverySourceToString() {
+        assertEquals("in-place shard split", RecoverySource.InPlaceSplitShardRecoverySource.INSTANCE.toString());
+    }
+
+    public void testSerializationRoundTrip() throws IOException {
+        RecoverySource source = RecoverySource.InPlaceSplitShardRecoverySource.INSTANCE;
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        source.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        RecoverySource deserialized = RecoverySource.readFrom(in);
+
+        assertSame(RecoverySource.InPlaceSplitShardRecoverySource.INSTANCE, deserialized);
+    }
+
+    public void testTypeEnumOrdinalStability() {
+        // IN_PLACE_SPLIT_SHARD must be at the end to preserve ordinals of existing types
+        RecoverySource.Type[] types = RecoverySource.Type.values();
+        assertEquals(RecoverySource.Type.IN_PLACE_SPLIT_SHARD, types[types.length - 1]);
+    }
+}

--- a/server/src/test/java/org/opensearch/cluster/routing/RecoverySourceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RecoverySourceTests.java
@@ -85,10 +85,11 @@ public class RecoverySourceTests extends OpenSearchTestCase {
         assertEquals(RecoverySource.Type.SNAPSHOT.ordinal(), 3);
         assertEquals(RecoverySource.Type.LOCAL_SHARDS.ordinal(), 4);
         assertEquals(RecoverySource.Type.REMOTE_STORE.ordinal(), 5);
+        assertEquals(RecoverySource.Type.IN_PLACE_SPLIT_SHARD.ordinal(), 6);
         // check exhaustiveness
         for (RecoverySource.Type type : RecoverySource.Type.values()) {
             assertThat(type.ordinal(), greaterThanOrEqualTo(0));
-            assertThat(type.ordinal(), lessThanOrEqualTo(5));
+            assertThat(type.ordinal(), lessThanOrEqualTo(6));
         }
     }
 

--- a/server/src/test/java/org/opensearch/cluster/routing/ShardRoutingStateSplitTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/ShardRoutingStateSplitTests.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.routing;
+
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ShardRoutingStateSplitTests extends OpenSearchTestCase {
+
+    public void testSplittingStateValue() {
+        assertEquals((byte) 5, ShardRoutingState.SPLITTING.value());
+    }
+
+    public void testFromValueSplitting() {
+        assertEquals(ShardRoutingState.SPLITTING, ShardRoutingState.fromValue((byte) 5));
+    }
+
+    public void testFromValueInvalid() {
+        expectThrows(IllegalStateException.class, () -> ShardRoutingState.fromValue((byte) 6));
+    }
+
+    public void testAllStatesRoundTrip() {
+        for (ShardRoutingState state : ShardRoutingState.values()) {
+            assertEquals(state, ShardRoutingState.fromValue(state.value()));
+        }
+    }
+
+    public void testSplittingMethodReturnsTrueForSplittingState() {
+        ShardRouting shard = TestShardRouting.newShardRouting(
+            new ShardId(new Index("idx", "uuid"), 0),
+            "node1",
+            true,
+            ShardRoutingState.SPLITTING
+        );
+        assertTrue(shard.splitting());
+        assertFalse(shard.started());
+        assertFalse(shard.relocating());
+    }
+
+    public void testSplittingMethodReturnsFalseForOtherStates() {
+        ShardRouting started = TestShardRouting.newShardRouting(
+            new ShardId(new Index("idx", "uuid"), 0),
+            "node1",
+            true,
+            ShardRoutingState.STARTED
+        );
+        assertFalse(started.splitting());
+    }
+
+    public void testIsSplitTargetReturnsFalseForNormalShard() {
+        ShardRouting shard = TestShardRouting.newShardRouting(
+            new ShardId(new Index("idx", "uuid"), 0),
+            "node1",
+            true,
+            ShardRoutingState.STARTED
+        );
+        assertFalse(shard.isSplitTarget());
+        assertNull(shard.getParentShardId());
+    }
+
+    public void testGetRecoveringChildShardsReturnsNullForNonSplittingShard() {
+        ShardRouting shard = TestShardRouting.newShardRouting(
+            new ShardId(new Index("idx", "uuid"), 0),
+            "node1",
+            true,
+            ShardRoutingState.STARTED
+        );
+        assertNull(shard.getRecoveringChildShards());
+    }
+}

--- a/server/src/test/java/org/opensearch/cluster/routing/UnassignedInfoTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/UnassignedInfoTests.java
@@ -89,7 +89,8 @@ public class UnassignedInfoTests extends OpenSearchAllocationTestCase {
             UnassignedInfo.Reason.PRIMARY_FAILED,
             UnassignedInfo.Reason.FORCED_EMPTY_PRIMARY,
             UnassignedInfo.Reason.MANUAL_ALLOCATION,
-            UnassignedInfo.Reason.INDEX_CLOSED, };
+            UnassignedInfo.Reason.INDEX_CLOSED,
+            UnassignedInfo.Reason.CHILD_SHARD_CREATED, };
         for (int i = 0; i < order.length; i++) {
             assertThat(order[i].ordinal(), equalTo(i));
         }

--- a/test/framework/src/main/java/org/opensearch/cluster/routing/TestShardRouting.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/routing/TestShardRouting.java
@@ -271,6 +271,7 @@ public class TestShardRouting {
                 }
             case STARTED:
             case RELOCATING:
+            case SPLITTING:
                 return null;
             default:
                 throw new IllegalStateException("illegal state");
@@ -287,6 +288,9 @@ public class TestShardRouting {
             case RELOCATING:
                 AllocationId allocationId = AllocationId.newInitializing();
                 return AllocationId.newRelocation(allocationId);
+            case SPLITTING:
+                AllocationId splitAllocId = AllocationId.newInitializing();
+                return AllocationId.newSplit(splitAllocId, 2);
             default:
                 throw new IllegalStateException("illegal state");
         }
@@ -299,6 +303,7 @@ public class TestShardRouting {
                 return new UnassignedInfo(OpenSearchTestCase.randomFrom(UnassignedInfo.Reason.values()), "auto generated for test");
             case STARTED:
             case RELOCATING:
+            case SPLITTING:
                 return null;
             default:
                 throw new IllegalStateException("illegal state");


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add cluster state infrastructure for in-place shard split

This PR adds the cluster state update service and supporting POJO changes needed to trigger an in-place shard split. 

Changes:

Cluster state update service:
- MetadataInPlaceShardSplitService: Submits an acked cluster state update task that updates SplitShardsMetadata on the target index and triggers a reroute. Validates that the index exists, the shard is not already splitting or already split, and virtual shards are not enabled on the index.
- InPlaceShardSplitClusterStateUpdateRequest: Request POJO holding index name, shard ID, split-into count, and cause.
- ClusterManagerTask: Added IN_PLACE_SHARD_SPLIT task key for cluster manager task throttling.

Routing POJO changes to support shard split lifecycle:
- ShardRoutingState: Added SPLITTING state for parent shards undergoing an in-place split.
- RecoverySource: Added InPlaceShardSplitRecoverySource type for child shards recovering from a parent shard on the same node.
- UnassignedInfo: Added CHILD_SHARD_CREATED reason for child shards pending allocation after a split.
- AllocationId: Added splitChildAllocationIds and parentAllocationId fields with version-gated serialization (V_3_6_0), factory methods (newSplit, newTargetSplit, cancelSplit, finishSplit), and updated equals/hashCode/toXContent.
- ShardRouting: Added recoveringChildShards and parentShardId fields, new constructor accepting split fields, and query methods (splitting(), isSplitTarget(), getRecoveringChildShards(), getParentShardId()).

The REST API is not exposed in this PR. The routing allocation logic to actually assign child shards to nodes will follow in a subsequent PR.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
