### PR TITLE
Add static method to expose STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED index option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add support for enabling pluggable data formats, starting with phase-1 of decoupling shard from engine, and introducing basic abstractions ([#20675](https://github.com/opensearch-project/OpenSearch/pull/20675))
 
 - Add warmup phase to wait for lag to catch up in pull-based ingestion before serving ([#20526](https://github.com/opensearch-project/OpenSearch/pull/20526))
+- Add a new static method to IndicesOptions API to expose `STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED` index option ([#20980](https://github.com/opensearch-project/OpenSearch/pull/20980))
+
 ### Changed
 - Make telemetry `Tags` immutable ([#20788](https://github.com/opensearch-project/OpenSearch/pull/20788))
 - Move Randomness from server to libs/common ([#20570](https://github.com/opensearch-project/OpenSearch/pull/20570))

--- a/server/src/main/java/org/opensearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/opensearch/action/support/IndicesOptions.java
@@ -590,6 +590,15 @@ public class IndicesOptions implements ToXContentFragment {
     }
 
     /**
+     * @return indices options that requires every specified index to exist, expand wildcards only to open indices,
+     *         includes hidden indices, allows that no indices are resolved from wildcard expressions (not returning an error)
+     *         and forbids the use of closed indices by throwing an error.
+     */
+    public static IndicesOptions strictExpandOpenHiddenAndForbidClosed() {
+        return STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED;
+    }
+
+    /**
      * @return indices options that requires every specified index to exist, expands wildcards only to open indices,
      *         allows that no indices are resolved from wildcard expressions (not returning an error),
      *         forbids the use of closed indices by throwing an error and ignores indices that are throttled.

--- a/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/test/OpenSearchIntegTestCase.java
@@ -1398,7 +1398,7 @@ public abstract class OpenSearchIntegTestCase extends OpenSearchTestCase {
         RefreshResponse actionGet = client().admin()
             .indices()
             .prepareRefresh(indices)
-            .setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED)
+            .setIndicesOptions(IndicesOptions.strictExpandOpenHiddenAndForbidClosed())
             .execute()
             .actionGet();
         assertNoFailures(actionGet);


### PR DESCRIPTION
### Description

IndicesOptions class provide static methods to access all index options but this one. It seems like it has been forgotten. This PR addresses this which makes it possible to document this option the same way other index options are documented.

Important question: Does this PR changes public API in any way that needs to be documented or annotated?

I also changed one test to use access method instead of directly access the constant instance. See https://github.com/opensearch-project/OpenSearch/issues/20981 for more general discussion about this.

### Related Issues

Closes: #20963

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
