### PR TITLE
Add cluster.blocks.read.auto_release setting to control read block auto-release

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -494,19 +494,24 @@ public class DiskThresholdMonitor {
     }
 
     private void handleReadBlocks(ClusterState state, Set<String> indicesToBlockRead, ActionListener<Void> listener) {
-        final Set<String> indicesToReleaseReadBlock = StreamSupport.stream(
-            Spliterators.spliterator(state.routingTable().indicesRouting().entrySet(), 0),
-            false
-        )
-            .map(Map.Entry::getKey)
-            .filter(index -> indicesToBlockRead.contains(index) == false)
-            .filter(index -> state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_BLOCK))
-            .collect(Collectors.toSet());
+        if (diskThresholdSettings.isReadBlockAutoReleaseEnabled()) {
+            final Set<String> indicesToReleaseReadBlock = StreamSupport.stream(
+                Spliterators.spliterator(state.routingTable().indicesRouting().entrySet(), 0),
+                false
+            )
+                .map(Map.Entry::getKey)
+                .filter(index -> indicesToBlockRead.contains(index) == false)
+                .filter(index -> state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_BLOCK))
+                .collect(Collectors.toSet());
 
-        if (indicesToReleaseReadBlock.isEmpty() == false) {
-            updateIndicesReadBlock(indicesToReleaseReadBlock, listener, false);
+            if (indicesToReleaseReadBlock.isEmpty() == false) {
+                updateIndicesReadBlock(indicesToReleaseReadBlock, listener, false);
+            } else {
+                logger.trace("no auto-release required");
+                listener.onResponse(null);
+            }
         } else {
-            logger.trace("no auto-release required");
+            logger.trace("read block auto-release is disabled, skipping auto-release");
             listener.onResponse(null);
         }
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -494,6 +494,18 @@ public class DiskThresholdMonitor {
     }
 
     private void handleReadBlocks(ClusterState state, Set<String> indicesToBlockRead, ActionListener<Void> listener) {
+        final Runnable applyPhase = () -> {
+            final Set<String> indicesToApplyReadBlock = indicesToBlockRead.stream()
+                .filter(index -> !state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_BLOCK))
+                .collect(Collectors.toSet());
+            logger.trace("Applying read block on indices: [{}]", indicesToApplyReadBlock);
+            if (indicesToApplyReadBlock.isEmpty() == false) {
+                updateIndicesReadBlock(indicesToApplyReadBlock, listener, true);
+            } else {
+                listener.onResponse(null);
+            }
+        };
+
         if (diskThresholdSettings.isReadBlockAutoReleaseEnabled()) {
             final Set<String> indicesToReleaseReadBlock = StreamSupport.stream(
                 Spliterators.spliterator(state.routingTable().indicesRouting().entrySet(), 0),
@@ -505,24 +517,18 @@ public class DiskThresholdMonitor {
                 .collect(Collectors.toSet());
 
             if (indicesToReleaseReadBlock.isEmpty() == false) {
-                updateIndicesReadBlock(indicesToReleaseReadBlock, listener, false);
+                updateIndicesReadBlock(
+                    indicesToReleaseReadBlock,
+                    ActionListener.wrap(v -> applyPhase.run(), listener::onFailure),
+                    false
+                );
             } else {
                 logger.trace("no auto-release required");
-                listener.onResponse(null);
+                applyPhase.run();
             }
         } else {
             logger.trace("read block auto-release is disabled, skipping auto-release");
-            listener.onResponse(null);
-        }
-
-        final Set<String> indicesToApplyReadBlock = indicesToBlockRead.stream()
-            .filter(index -> !state.getBlocks().hasIndexBlock(index, IndexMetadata.INDEX_READ_BLOCK))
-            .collect(Collectors.toSet());
-        logger.trace("Applying read block on indices: [{}]", indicesToApplyReadBlock);
-        if (indicesToApplyReadBlock.isEmpty() == false) {
-            updateIndicesReadBlock(indicesToApplyReadBlock, listener, true);
-        } else {
-            listener.onResponse(null);
+            applyPhase.run();
         }
     }
 

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -114,6 +114,12 @@ public class DiskThresholdSettings {
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
+    public static final Setting<Boolean> CLUSTER_READ_BLOCK_AUTO_RELEASE = Setting.boolSetting(
+        "cluster.blocks.read.auto_release",
+        true,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
 
     private volatile String lowWatermarkRaw;
     private volatile String highWatermarkRaw;
@@ -123,6 +129,7 @@ public class DiskThresholdSettings {
     private volatile ByteSizeValue freeBytesThresholdHigh;
     private volatile boolean includeRelocations;
     private volatile boolean createIndexBlockAutoReleaseEnabled;
+    private volatile boolean readBlockAutoReleaseEnabled;
     private volatile boolean enabled;
     private volatile boolean warmThresholdEnabled;
     private volatile TimeValue rerouteInterval;
@@ -153,6 +160,7 @@ public class DiskThresholdSettings {
         this.enabled = CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.get(settings);
         this.warmThresholdEnabled = CLUSTER_ROUTING_ALLOCATION_WARM_DISK_THRESHOLD_ENABLED_SETTING.get(settings);
         this.createIndexBlockAutoReleaseEnabled = CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE.get(settings);
+        this.readBlockAutoReleaseEnabled = CLUSTER_READ_BLOCK_AUTO_RELEASE.get(settings);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING, this::setLowWatermark);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING, this::setHighWatermark);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING, this::setFloodStage);
@@ -164,6 +172,7 @@ public class DiskThresholdSettings {
             this::setWarmThresholdEnabled
         );
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE, this::setCreateIndexBlockAutoReleaseEnabled);
+        clusterSettings.addSettingsUpdateConsumer(CLUSTER_READ_BLOCK_AUTO_RELEASE, this::setReadBlockAutoReleaseEnabled);
     }
 
     /**
@@ -365,6 +374,10 @@ public class DiskThresholdSettings {
         this.createIndexBlockAutoReleaseEnabled = createIndexBlockAutoReleaseEnabled;
     }
 
+    private void setReadBlockAutoReleaseEnabled(boolean readBlockAutoReleaseEnabled) {
+        this.readBlockAutoReleaseEnabled = readBlockAutoReleaseEnabled;
+    }
+
     /**
      * Gets the raw (uninterpreted) low watermark value as found in the settings.
      */
@@ -421,6 +434,10 @@ public class DiskThresholdSettings {
 
     public boolean isCreateIndexBlockAutoReleaseEnabled() {
         return createIndexBlockAutoReleaseEnabled;
+    }
+
+    public boolean isReadBlockAutoReleaseEnabled() {
+        return readBlockAutoReleaseEnabled;
     }
 
     String describeLowThreshold() {

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -360,6 +360,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_WARM_DISK_THRESHOLD_ENABLED_SETTING,
                 DiskThresholdSettings.CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE,
+                DiskThresholdSettings.CLUSTER_READ_BLOCK_AUTO_RELEASE,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_INCLUDE_RELOCATIONS_SETTING,
                 DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING,
                 FileCacheThresholdSettings.CLUSTER_FILECACHE_ACTIVEUSAGE_THRESHOLD_ENABLED_SETTING,

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
@@ -74,6 +74,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
 
 import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_CREATE_INDEX_BLOCK_AUTO_RELEASE;
+import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_READ_BLOCK_AUTO_RELEASE;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -1170,6 +1171,101 @@ public class DiskThresholdMonitorTests extends OpenSearchAllocationTestCase {
         monitor.onNewInfo(clusterInfo(builder, Map.of(), shardSizes));
         assertFalse(indicesToMarkReadOnly.get().isEmpty());
         assertFalse(indicesToBlockRead.get().isEmpty());
+    }
+
+    public void testReadBlockAutoRelease() {
+        AllocationService allocation = createAllocationService(
+            Settings.builder().put("cluster.routing.allocation.node_concurrent_recoveries", 10).build()
+        );
+        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder("test_index")
+            .settings(
+                settings(Version.CURRENT).put(IndexMetadata.INDEX_BLOCKS_READ_SETTING.getKey(), true)
+                    .put("index.routing.allocation.require._id", "warm_node")
+            )
+            .numberOfShards(1)
+            .numberOfReplicas(0);
+        Metadata metadata = Metadata.builder().put(indexMetadataBuilder).build();
+        RoutingTable routingTable = RoutingTable.builder().addAsNew(metadata.index("test_index")).build();
+        DiscoveryNode warmNode = newNode("warm_node", Collections.singleton(DiscoveryNodeRole.WARM_ROLE));
+        final ClusterState clusterStateWithReadBlock = applyStartedShardsUntilNoChange(
+            ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+                .metadata(metadata)
+                .routingTable(routingTable)
+                .nodes(DiscoveryNodes.builder().add(warmNode))
+                .blocks(ClusterBlocks.builder().addBlocks(indexMetadataBuilder.build()).build())
+                .build(),
+            allocation
+        );
+        assertTrue(clusterStateWithReadBlock.blocks().hasIndexBlock("test_index", IndexMetadata.INDEX_READ_BLOCK));
+
+        // With auto-release enabled (default), the monitor should release the read block when disk usage is healthy
+        AtomicReference<Set<String>> releasedReadBlocks = new AtomicReference<>();
+        Settings autoReleaseEnabled = Settings.builder().put(CLUSTER_READ_BLOCK_AUTO_RELEASE.getKey(), true).build();
+        DiskThresholdMonitor monitorAutoReleaseEnabled = new DiskThresholdMonitor(
+            autoReleaseEnabled,
+            () -> clusterStateWithReadBlock,
+            new ClusterSettings(autoReleaseEnabled, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            null,
+            () -> 0L,
+            (reason, priority, listener) -> listener.onResponse(null),
+            () -> 2.0
+        ) {
+            @Override
+            protected void updateIndicesReadOnly(Set<String> indicesToUpdate, ActionListener<Void> listener, boolean readOnly) {
+                listener.onResponse(null);
+            }
+
+            @Override
+            protected void updateIndicesReadBlock(Set<String> indicesToUpdate, ActionListener<Void> listener, boolean readBlock) {
+                if (readBlock == false) {
+                    releasedReadBlocks.set(indicesToUpdate);
+                }
+                listener.onResponse(null);
+            }
+
+            @Override
+            protected void setIndexCreateBlock(ActionListener<Void> listener, boolean indexCreateBlock) {
+                listener.onResponse(null);
+            }
+        };
+        Map<String, DiskUsage> healthyUsage = new HashMap<>();
+        healthyUsage.put("warm_node", new DiskUsage("warm_node", "warm_node", "/foo/bar", 200, 100));
+        monitorAutoReleaseEnabled.onNewInfo(clusterInfo(healthyUsage, Map.of(), Map.of()));
+        assertNotNull(releasedReadBlocks.get());
+        assertTrue(releasedReadBlocks.get().contains("test_index"));
+
+        // With auto-release disabled, the monitor should NOT release the read block
+        releasedReadBlocks.set(null);
+        Settings autoReleaseDisabled = Settings.builder().put(CLUSTER_READ_BLOCK_AUTO_RELEASE.getKey(), false).build();
+        DiskThresholdMonitor monitorAutoReleaseDisabled = new DiskThresholdMonitor(
+            autoReleaseDisabled,
+            () -> clusterStateWithReadBlock,
+            new ClusterSettings(autoReleaseDisabled, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            null,
+            () -> 0L,
+            (reason, priority, listener) -> listener.onResponse(null),
+            () -> 2.0
+        ) {
+            @Override
+            protected void updateIndicesReadOnly(Set<String> indicesToUpdate, ActionListener<Void> listener, boolean readOnly) {
+                listener.onResponse(null);
+            }
+
+            @Override
+            protected void updateIndicesReadBlock(Set<String> indicesToUpdate, ActionListener<Void> listener, boolean readBlock) {
+                if (readBlock == false) {
+                    releasedReadBlocks.set(indicesToUpdate);
+                }
+                listener.onResponse(null);
+            }
+
+            @Override
+            protected void setIndexCreateBlock(ActionListener<Void> listener, boolean indexCreateBlock) {
+                listener.onResponse(null);
+            }
+        };
+        monitorAutoReleaseDisabled.onNewInfo(clusterInfo(healthyUsage, Map.of(), Map.of()));
+        assertNull(releasedReadBlocks.get());
     }
 
     public void testWarmNodeFileCacheIndexThresholdBreach() {


### PR DESCRIPTION
### Description

Introduces a new dynamic cluster setting `cluster.blocks.read.auto_release` (default: `true`) that controls whether `DiskThresholdMonitor` automatically releases index read blocks when disk usage returns to a healthy level.

Previously, the monitor unconditionally released read blocks whenever disk usage dropped below the high watermark threshold. This caused an issue for warm/cold node use cases where operators intentionally set `index.blocks.read` — the monitor would silently clear those blocks, causing unexpected write/read behavior.

With this change, operators can disable auto-release:

```
PUT _cluster/settings
{
  "persistent": {
    "cluster.blocks.read.auto_release": false
  }
}
```

When disabled, the monitor will not automatically release read blocks, leaving them in place until manually removed by the operator.

### Related Issues

Resolves #20539

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).