### PR TITLE
Conditionally run assemble GitHub action

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -1,5 +1,14 @@
 name: Gradle Assemble
-on: [pull_request]
+on:
+  pull_request:
+    # Skip this check unless files that could plausibly impact a
+    # distribution have changed.
+    paths:
+      - 'distribution/**'
+      - 'buildSrc/**'
+      - '**/*.gradle'
+      - 'gradle/**'
+      - '.github/workflows/assemble.yml'
 
 jobs:
   assemble:


### PR DESCRIPTION
Only trigger the assemble GitHub action if files that could plausibly impact building the distributions have changed.

Part of #20899

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
