### PR TITLE
Fix SegmentReplicationWithNodeToNodeIndexShardTests

### DIFF
--- a/server/src/main/java/org/opensearch/indices/recovery/RecoverySettings.java
+++ b/server/src/main/java/org/opensearch/indices/recovery/RecoverySettings.java
@@ -244,7 +244,7 @@ public class RecoverySettings {
     public static final Setting<Integer> INDICES_TRANSLOG_CONCURRENT_RECOVERY_BATCH_SIZE = Setting.intSetting(
         "indices.translog_concurrent_recovery.batch_size",
         500000,
-        10000,
+        1000,
         1000000,
         Property.Dynamic,
         Property.NodeScope

--- a/server/src/test/java/org/opensearch/index/shard/SegmentReplicationWithNodeToNodeIndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/SegmentReplicationWithNodeToNodeIndexShardTests.java
@@ -541,7 +541,7 @@ public class SegmentReplicationWithNodeToNodeIndexShardTests extends SegmentRepl
         final RecoverySettings recoverySettings = new RecoverySettings(
             Settings.builder()
                 .put(RecoverySettings.INDICES_TRANSLOG_CONCURRENT_RECOVERY_ENABLE.getKey(), true)
-                .put(RecoverySettings.INDICES_TRANSLOG_CONCURRENT_RECOVERY_BATCH_SIZE.getKey(), 11000)
+                .put(RecoverySettings.INDICES_TRANSLOG_CONCURRENT_RECOVERY_BATCH_SIZE.getKey(), 1000)
                 .build(),
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
         );
@@ -555,7 +555,7 @@ public class SegmentReplicationWithNodeToNodeIndexShardTests extends SegmentRepl
                 MergedSegmentPublisher.EMPTY
             )
         ) {
-            doPrimaryPromotion(shards, randomInt(10), randomIntBetween(30000, 40000));
+            doPrimaryPromotion(shards, randomInt(10), randomIntBetween(1100, 2000));
         }
     }
 

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -798,7 +798,7 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 false,
                 discoveryNodes,
                 mockReplicationStatsProvider,
-                new MergedSegmentWarmerFactory(null, new RecoverySettings(nodeSettings, clusterSettings), null),
+                new MergedSegmentWarmerFactory(null, new RecoverySettings(nodeSettings, clusterSettings), clusterService),
                 false,
                 () -> Boolean.FALSE,
                 indexSettings::getRefreshInterval,


### PR DESCRIPTION
Two fixes here:
- Wire in the cluster service to prevent an NPE
- Reduce random document count by 100x

The tests were previously indexing 30000-40000 documents. This would get the test into an fsync loop on the test machine and we were seeing frequent [test timeouts in CI][1].

[1]: https://build.ci.opensearch.org/job/gradle-check/73191/testReport/junit/org.opensearch.index.shard/SegmentReplicationWithNodeToNodeIndexShardTests/testPrimaryPromotionWithConcurrentTranslogRecovery/

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
