### PR TITLE
Fix: resolve request-level derived fields during can_match phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix array_index_out_of_bounds_exception with wildcard and aggregations ([#20842](https://github.com/opensearch-project/OpenSearch/pull/20842))
 - Fix stale segment cleanup logic for remote store ([#20976](https://github.com/opensearch-project/OpenSearch/pull/20976))
 - Ensure that transient ThreadContext headers with propagators survive restore ([#169373](https://github.com/opensearch-project/OpenSearch/pull/20854))
+- Fix derived fields not resolved during `can_match` phase ([#21004](https://github.com/opensearch-project/OpenSearch/pull/21004))
 - Handle dependencies between analyzers ([#19248](https://github.com/opensearch-project/OpenSearch/pull/19248))
 - Restore default `shard_path_type` to FIXED for snapshot repositories ([#20643](https://github.com/opensearch-project/OpenSearch/issues/20643))
 - Fix `_field_caps` returning empty results and corrupted field names for `disable_objects: true` mappings ([#20800](https://github.com/opensearch-project/OpenSearch/pull/20800))

--- a/modules/lang-painless/src/internalClusterTest/java/org/opensearch/painless/DerivedFieldIndexAliasIT.java
+++ b/modules/lang-painless/src/internalClusterTest/java/org/opensearch/painless/DerivedFieldIndexAliasIT.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.painless;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.script.Script;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.bucket.terms.Terms;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
+
+/**
+ * Integration tests to verify that derived fields are correctly resolved
+ * during the can_match phase when querying across multiple indices via an alias.
+ */
+@OpenSearchIntegTestCase.SuiteScopeTestCase
+public class DerivedFieldIndexAliasIT extends OpenSearchIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(PainlessModulePlugin.class);
+    }
+
+    private void setupIndex(String indexName) {
+        assertAcked(
+            prepareCreate(indexName).setSettings(
+                Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            )
+        );
+
+        client().prepareIndex(indexName)
+            .setId("1")
+            .setSource("{\"field\":\"value1\", \"num\": 20}", MediaTypeRegistry.JSON)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .get();
+        client().prepareIndex(indexName)
+            .setId("2")
+            .setSource("{\"field\":\"value2\", \"num\": 30}", MediaTypeRegistry.JSON)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .get();
+        ensureSearchable(indexName);
+    }
+
+    @Override
+    public void setupSuiteScopeCluster() {
+        setupIndex("test-index-1");
+        setupIndex("test-index-2");
+        assertAcked(
+            client().admin().indices().prepareAliases().addAlias(new String[] { "test-index-1", "test-index-2" }, "alias-test").get()
+        );
+    }
+
+    public void testIndexAliasSearch() {
+        SearchRequest searchRequest = new SearchRequest("alias-test").source(
+            SearchSourceBuilder.searchSource()
+                .derivedField("derived_num", "long", new Script("emit(doc['num'].value)"))
+                .query(QueryBuilders.rangeQuery("derived_num").gte(15).lte(25))
+        );
+        // Setting pre_filter_shard_size to 1 forces the can_match phase.
+        searchRequest.setPreFilterShardSize(1);
+
+        SearchResponse response = client().search(searchRequest).actionGet();
+        assertSearchResponse(response);
+
+        // We expect 2 hits (doc 1 from each index has num=20).
+        assertEquals(2, response.getHits().getTotalHits().value());
+    }
+
+    public void testIndexAliasAggregation() {
+        SearchRequest searchRequest = new SearchRequest("alias-test").source(
+            SearchSourceBuilder.searchSource()
+                .derivedField("derived_num", "long", new Script("emit(doc['num'].value)"))
+                .query(QueryBuilders.matchAllQuery())
+                .aggregation(AggregationBuilders.terms("derived_terms").field("derived_num"))
+        );
+        // Setting pre_filter_shard_size to 1 forces the can_match phase.
+        searchRequest.setPreFilterShardSize(1);
+
+        SearchResponse response = client().search(searchRequest).actionGet();
+        assertSearchResponse(response);
+
+        Terms terms = response.getAggregations().get("derived_terms");
+        assertEquals(2, terms.getBuckets().size());
+
+        Terms.Bucket bucket1 = terms.getBuckets().get(0);
+        assertEquals(20L, bucket1.getKeyAsNumber().longValue());
+        assertEquals(2, bucket1.getDocCount());
+
+        Terms.Bucket bucket2 = terms.getBuckets().get(1);
+        assertEquals(30L, bucket2.getKeyAsNumber().longValue());
+        assertEquals(2, bucket2.getDocCount());
+    }
+}

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -1905,6 +1905,13 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     request::nowInMillis,
                     request.getClusterAlias()
                 );
+                DerivedFieldResolver derivedFieldResolver = DerivedFieldResolverFactory.createResolver(
+                    context,
+                    Optional.ofNullable(request.source()).map(SearchSourceBuilder::getDerivedFieldsObject).orElse(Collections.emptyMap()),
+                    Optional.ofNullable(request.source()).map(SearchSourceBuilder::getDerivedFields).orElse(Collections.emptyList()),
+                    context.getIndexSettings().isDerivedFieldAllowed() && allowDerivedField
+                );
+                context.setDerivedFieldResolver(derivedFieldResolver);
                 Rewriteable.rewrite(request.getRewriteable(), context, false);
                 final boolean aliasFilterCanMatch = request.getAliasFilter().getQueryBuilder() instanceof MatchNoneQueryBuilder == false;
                 FieldSortBuilder sortBuilder = FieldSortBuilder.getPrimaryFieldSortOrNull(request.source());


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The `QueryShardContext` built in `SearchService.canMatch()` did not include derived fields defined in the search request's source. This caused query rewriting to fail for derived field queries, leading to shards being incorrectly excluded (canMatch=false) when the can_match pre-filter phase was active.

### Related Issues
Resolves #20965
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
