### PR TITLE
Support downloading pre-built SNAPSHOT artifacts for BWC tests

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/DistributionDownloadPlugin.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.gradle;
 
-import org.opensearch.gradle.OpenSearchDistribution.Platform;
 import org.opensearch.gradle.OpenSearchDistribution.Type;
 import org.opensearch.gradle.docker.DockerSupportPlugin;
 import org.opensearch.gradle.docker.DockerSupportService;
@@ -221,40 +220,11 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
      * coordinates that resolve to the OpenSearch download service through an ivy repository.
      */
     private String dependencyNotation(OpenSearchDistribution distribution) {
-        Version distroVersion = Version.fromString(distribution.getVersion());
         if (distribution.getType() == Type.INTEG_TEST_ZIP) {
             return "org.opensearch.distribution.integ-test-zip:opensearch:" + distribution.getVersion() + "@zip";
         }
 
-        String extension = distribution.getType().toString();
-        String classifier = distroVersion.onOrAfter("1.0.0") ? ":x64" : ":x86_64";
-        if (distribution.getType() == Type.ARCHIVE) {
-            extension = distribution.getPlatform() == Platform.WINDOWS ? "zip" : "tar.gz";
-
-            switch (distribution.getArchitecture()) {
-                case ARM64:
-                    classifier = ":" + distribution.getPlatform() + "-arm64";
-                    break;
-                case X64:
-                    classifier = ":" + distribution.getPlatform() + "-x64";
-                    break;
-                case S390X:
-                    classifier = ":" + distribution.getPlatform() + "-s390x";
-                    break;
-                case PPC64LE:
-                    classifier = ":" + distribution.getPlatform() + "-ppc64le";
-                    break;
-                case RISCV64:
-                    classifier = ":" + distribution.getPlatform() + "-riscv64";
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unsupported architecture: " + distribution.getArchitecture());
-            }
-        } else if (distribution.getType() == Type.DEB) {
-            classifier = ":amd64";
-        }
-
         String group = distribution.getVersion().endsWith("-SNAPSHOT") ? FAKE_SNAPSHOT_IVY_GROUP : FAKE_IVY_GROUP;
-        return group + ":opensearch" + ":" + distribution.getVersion() + classifier + "@" + extension;
+        return group + ":opensearch:" + distribution.getVersion() + distribution.classifierAndExtension();
     }
 }

--- a/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchDistribution.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/OpenSearchDistribution.java
@@ -216,6 +216,39 @@ public class OpenSearchDistribution implements Buildable, Iterable<File> {
         return configuration.getBuildDependencies();
     }
 
+    /**
+     * Returns the classifier and extension portion of a dependency notation, e.g. {@code ":linux-x64@tar.gz"}.
+     */
+    public String classifierAndExtension() {
+        String extension = getType().toString();
+        String classifier = ":x64";
+        if (getType() == Type.ARCHIVE) {
+            extension = getPlatform() == Platform.WINDOWS ? "zip" : "tar.gz";
+            switch (getArchitecture()) {
+                case ARM64:
+                    classifier = ":" + getPlatform() + "-arm64";
+                    break;
+                case X64:
+                    classifier = ":" + getPlatform() + "-x64";
+                    break;
+                case S390X:
+                    classifier = ":" + getPlatform() + "-s390x";
+                    break;
+                case PPC64LE:
+                    classifier = ":" + getPlatform() + "-ppc64le";
+                    break;
+                case RISCV64:
+                    classifier = ":" + getPlatform() + "-riscv64";
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unsupported architecture: " + getArchitecture());
+            }
+        } else if (getType() == Type.DEB) {
+            classifier = ":amd64";
+        }
+        return classifier + "@" + extension;
+    }
+
     @Override
     public Iterator<File> iterator() {
         return configuration.iterator();

--- a/buildSrc/src/main/java/org/opensearch/gradle/info/BuildParams.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/info/BuildParams.java
@@ -61,6 +61,7 @@ public class BuildParams {
     private static Boolean isInternal;
     private static Integer defaultParallel;
     private static Boolean isSnapshotBuild;
+    private static Boolean buildUnreleasedFromSource;
     private static BwcVersions bwcVersions;
 
     /**
@@ -145,6 +146,10 @@ public class BuildParams {
 
     public static boolean isSnapshotBuild() {
         return value(BuildParams.isSnapshotBuild);
+    }
+
+    public static boolean buildUnreleasedFromSource() {
+        return value(BuildParams.buildUnreleasedFromSource);
     }
 
     private static <T> T value(T object) {
@@ -254,6 +259,10 @@ public class BuildParams {
 
         public void setIsSnapshotBuild(final boolean isSnapshotBuild) {
             BuildParams.isSnapshotBuild = isSnapshotBuild;
+        }
+
+        public void setBuildUnreleasedFromSource(final boolean buildUnreleasedFromSource) {
+            BuildParams.buildUnreleasedFromSource = buildUnreleasedFromSource;
         }
 
         public void setBwcVersions(BwcVersions bwcVersions) {

--- a/buildSrc/src/main/java/org/opensearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -133,6 +133,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             params.setDefaultParallel(findDefaultParallel(project));
             params.setInFipsJvm(FipsBuildParams.isInFipsMode());
             params.setIsSnapshotBuild(Util.getBooleanProperty("build.snapshot", true));
+            params.setBuildUnreleasedFromSource(Util.getBooleanProperty("bwc.buildUnreleasedFromSource", true));
             if (isInternal) {
                 params.setBwcVersions(resolveBwcVersions(rootDir));
             }

--- a/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/internal/InternalDistributionDownloadPlugin.java
@@ -100,6 +100,10 @@ public class InternalDistributionDownloadPlugin implements Plugin<Project> {
         resolutions.register("bwc", distributionResolution -> distributionResolution.setResolver((project, distribution) -> {
             BwcVersions.UnreleasedVersionInfo unreleasedInfo = bwcVersions.unreleasedInfo(Version.fromString(distribution.getVersion()));
             if (unreleasedInfo != null) {
+                if (BuildParams.buildUnreleasedFromSource() == false) {
+                    // Download pre-built SNAPSHOT artifacts instead of building from source
+                    return DistributionDependency.of(snapshotDependencyNotation(distribution));
+                }
                 if (distribution.getBundledJdk() == JavaPackageType.NONE) {
                     throw new GradleException(
                         "Configuring a snapshot bwc distribution ('"
@@ -193,6 +197,16 @@ public class InternalDistributionDownloadPlugin implements Plugin<Project> {
                 break;
         }
         return projectName;
+    }
+
+    /**
+     * Constructs a dependency notation that resolves an unreleased version from the snapshot artifact repository.
+     */
+    private static String snapshotDependencyNotation(OpenSearchDistribution distribution) {
+        return "opensearch-distribution-snapshot:opensearch:"
+            + distribution.getVersion()
+            + "-SNAPSHOT"
+            + distribution.classifierAndExtension();
     }
 
     private static class ProjectBasedDistributionDependency implements DistributionDependency {

--- a/buildSrc/src/test/java/org/opensearch/gradle/OpenSearchDistributionTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/OpenSearchDistributionTests.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gradle;
+
+import org.opensearch.gradle.OpenSearchDistribution.Platform;
+import org.opensearch.gradle.OpenSearchDistribution.Type;
+import org.opensearch.gradle.test.GradleUnitTestCase;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+
+public class OpenSearchDistributionTests extends GradleUnitTestCase {
+
+    private Project project;
+
+    private void initProject() {
+        project = ProjectBuilder.builder().build();
+        project.getPlugins().apply("opensearch.distribution-download");
+    }
+
+    private OpenSearchDistribution createDistro(String name, Type type, Platform platform, Architecture arch) {
+        if (project == null) {
+            initProject();
+        }
+        NamedDomainObjectContainer<OpenSearchDistribution> distros = DistributionDownloadPlugin.getContainer(project);
+        return distros.create(name, distro -> {
+            distro.setVersion("3.5.1");
+            distro.setType(type);
+            if (platform != null) {
+                distro.setPlatform(platform);
+            }
+            distro.setArchitecture(arch);
+        });
+    }
+
+    public void testClassifierAndExtensionLinuxX64() {
+        OpenSearchDistribution distro = createDistro("linux-x64", Type.ARCHIVE, Platform.LINUX, Architecture.X64);
+        distro.finalizeValues();
+        assertEquals(":linux-x64@tar.gz", distro.classifierAndExtension());
+    }
+
+    public void testClassifierAndExtensionLinuxArm64() {
+        OpenSearchDistribution distro = createDistro("linux-arm64", Type.ARCHIVE, Platform.LINUX, Architecture.ARM64);
+        distro.finalizeValues();
+        assertEquals(":linux-arm64@tar.gz", distro.classifierAndExtension());
+    }
+
+    public void testClassifierAndExtensionWindowsX64() {
+        OpenSearchDistribution distro = createDistro("windows-x64", Type.ARCHIVE, Platform.WINDOWS, Architecture.X64);
+        distro.finalizeValues();
+        assertEquals(":windows-x64@zip", distro.classifierAndExtension());
+    }
+
+    public void testClassifierAndExtensionRpm() {
+        OpenSearchDistribution distro = createDistro("rpm", Type.RPM, null, Architecture.X64);
+        distro.finalizeValues();
+        assertEquals(":x64@rpm", distro.classifierAndExtension());
+    }
+
+    public void testClassifierAndExtensionDeb() {
+        OpenSearchDistribution distro = createDistro("deb", Type.DEB, null, Architecture.X64);
+        distro.finalizeValues();
+        assertEquals(":amd64@deb", distro.classifierAndExtension());
+    }
+
+    public void testClassifierAndExtensionLinuxS390x() {
+        OpenSearchDistribution distro = createDistro("linux-s390x", Type.ARCHIVE, Platform.LINUX, Architecture.S390X);
+        distro.finalizeValues();
+        assertEquals(":linux-s390x@tar.gz", distro.classifierAndExtension());
+    }
+
+    public void testClassifierAndExtensionLinuxPpc64le() {
+        OpenSearchDistribution distro = createDistro("linux-ppc64le", Type.ARCHIVE, Platform.LINUX, Architecture.PPC64LE);
+        distro.finalizeValues();
+        assertEquals(":linux-ppc64le@tar.gz", distro.classifierAndExtension());
+    }
+
+    public void testClassifierAndExtensionLinuxRiscv64() {
+        OpenSearchDistribution distro = createDistro("linux-riscv64", Type.ARCHIVE, Platform.LINUX, Architecture.RISCV64);
+        distro.finalizeValues();
+        assertEquals(":linux-riscv64@tar.gz", distro.classifierAndExtension());
+    }
+}


### PR DESCRIPTION
Add a `-Dbwc.buildUnreleasedFromSource=false` flag that downloads pre-built SNAPSHOT artifacts from artifacts.opensearch.org for unreleased versions instead of checking out git branches and compiling from source. The default behavior (building from source) is unchanged.

This is the first step towards #20988. This PR adds the option to run the following:

```
./gradlew :qa:full-cluster-restart:v2.19.6#bwcTest -Dbwc.buildUnreleasedFromSource=false
```

and as the parameter suggests this will not build 2.19.6 from source but instead fetch the SNAPSHOT artifact. Currently this does not work with 3.5.1 due to a FIPS issue with that distribution, but I'm still working on that. I believe the code here is correct.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
