### PR TITLE
[draft] Using ordinals in multi terms instead of byte values for bucket keys

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregationFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregationFactory.java
@@ -24,6 +24,7 @@ import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.aggregations.support.ValuesSourceConfig;
 import org.opensearch.search.aggregations.support.ValuesSourceRegistry;
 import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.startree.StarTreeQueryHelper;
 
 import java.io.IOException;
 import java.util.List;
@@ -142,11 +143,13 @@ public class MultiTermsAggregationFactory extends AggregatorFactory {
         }
         // TODO: Optimize passing too many value source config derived objects to aggregator
         bucketCountThresholds.ensureValidity();
+        List<ValuesSource> rawValuesSources = configs.stream().map(config -> config.v1().getValuesSource()).toList();
+        MultiTermsBucketOrds ordinalBucketOrds = selectOrdinalStrategy(rawValuesSources, searchContext, cardinality);
         return new MultiTermsAggregator(
             name,
             factories,
             showTermDocCountError,
-            configs.stream().map(config -> config.v1().getValuesSource()).toList(),
+            rawValuesSources,
             configs.stream()
                 .map(config -> queryShardContext.getValuesSourceRegistry().getAggregator(REGISTRY_KEY, config.v1()).build(config))
                 .collect(Collectors.toList()),
@@ -158,12 +161,46 @@ public class MultiTermsAggregationFactory extends AggregatorFactory {
             searchContext,
             parent,
             cardinality,
-            metadata
+            metadata,
+            ordinalBucketOrds
         );
     }
 
     public List<String> getRequestFields() {
         return requestFields;
+    }
+
+    /**
+     * Selects the optimal {@link MultiTermsBucketOrds} strategy based on field types.
+     * Returns {@code null} when the ordinal optimization cannot be applied (mixed types or overflow).
+     */
+    private static MultiTermsBucketOrds selectOrdinalStrategy(
+        List<ValuesSource> rawValuesSources,
+        SearchContext searchContext,
+        CardinalityUpperBound cardinality
+    ) throws IOException {
+        // Star-tree precomputation writes to the bytes-based bucketOrds, so the ordinal
+        // optimization must be disabled when a star-tree index is available to avoid
+        // splitting buckets across two different storage structures.
+        if (StarTreeQueryHelper.getSupportedStarTree(searchContext.getQueryShardContext()) != null) {
+            return null;
+        }
+        for (ValuesSource vs : rawValuesSources) {
+            if ((vs instanceof ValuesSource.Bytes.WithOrdinals) == false) {
+                return null;
+            }
+        }
+        int numFields = rawValuesSources.size();
+        if (numFields == 2) {
+            ValuesSource.Bytes.WithOrdinals vs0 = (ValuesSource.Bytes.WithOrdinals) rawValuesSources.get(0);
+            ValuesSource.Bytes.WithOrdinals vs1 = (ValuesSource.Bytes.WithOrdinals) rawValuesSources.get(1);
+            long maxOrd0 = vs0.globalMaxOrd(searchContext.searcher());
+            long maxOrd1 = vs1.globalMaxOrd(searchContext.searcher());
+            if (OrdinalPairBucketOrds.fitsInLong(maxOrd0, maxOrd1)) {
+                return new OrdinalPairBucketOrds(searchContext.bigArrays(), cardinality, maxOrd0, maxOrd1);
+            }
+        }
+        return new PackedOrdinalsBucketOrds(searchContext.bigArrays(), cardinality, numFields);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
@@ -10,6 +10,7 @@ package org.opensearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.PriorityQueue;
@@ -74,6 +75,8 @@ import static org.opensearch.search.startree.StarTreeQueryHelper.getSupportedSta
 public class MultiTermsAggregator extends DeferableBucketAggregator implements StarTreePreComputeCollector {
 
     private final BytesKeyedBucketOrds bucketOrds;
+    private final MultiTermsBucketOrds ordinalBucketOrds;
+    private final List<ValuesSource.Bytes.WithOrdinals> ordinalSources;
     private final MultiTermsValuesSource multiTermsValue;
     private final boolean showTermDocCountError;
     private final List<DocValueFormat> formats;
@@ -99,9 +102,20 @@ public class MultiTermsAggregator extends DeferableBucketAggregator implements S
         SearchContext context,
         Aggregator parent,
         CardinalityUpperBound cardinality,
-        Map<String, Object> metadata
+        Map<String, Object> metadata,
+        MultiTermsBucketOrds ordinalBucketOrds
     ) throws IOException {
         super(name, factories, context, parent, metadata);
+        this.ordinalBucketOrds = ordinalBucketOrds;
+        if (ordinalBucketOrds != null) {
+            List<ValuesSource.Bytes.WithOrdinals> ordSources = new ArrayList<>(rawValuesSources.size());
+            for (ValuesSource vs : rawValuesSources) {
+                ordSources.add((ValuesSource.Bytes.WithOrdinals) vs);
+            }
+            this.ordinalSources = ordSources;
+        } else {
+            this.ordinalSources = null;
+        }
         this.bucketOrds = BytesKeyedBucketOrds.build(context.bigArrays(), cardinality);
         this.multiTermsValue = new MultiTermsValuesSource(rawValuesSources, internalValuesSources);
         this.showTermDocCountError = showTermDocCountError;
@@ -140,45 +154,34 @@ public class MultiTermsAggregator extends DeferableBucketAggregator implements S
         LocalBucketCountThresholds localBucketCountThresholds = context.asLocalBucketCountThresholds(bucketCountThresholds);
         InternalMultiTerms.Bucket[][] topBucketsPerOrd = new InternalMultiTerms.Bucket[owningBucketOrds.length][];
         long[] otherDocCounts = new long[owningBucketOrds.length];
+
+        // Resolve SortedSetDocValues for ordinal lookup if using ordinal path
+        SortedSetDocValues[] globalOrdsForLookup = null;
+        if (ordinalBucketOrds != null) {
+            globalOrdsForLookup = new SortedSetDocValues[ordinalSources.size()];
+            List<LeafReaderContext> leaves = context.searcher().getTopReaderContext().leaves();
+            if (leaves.isEmpty() == false) {
+                LeafReaderContext leafCtx = leaves.get(0);
+                for (int i = 0; i < ordinalSources.size(); i++) {
+                    globalOrdsForLookup[i] = ordinalSources.get(i).globalOrdinalsValues(leafCtx);
+                }
+            }
+        }
+
         for (int ordIdx = 0; ordIdx < owningBucketOrds.length; ordIdx++) {
             checkCancelled();
             collectZeroDocEntriesIfNeeded(owningBucketOrds[ordIdx]);
-            long bucketsInOrd = bucketOrds.bucketsInOrd(owningBucketOrds[ordIdx]);
 
-            int size = (int) Math.min(bucketsInOrd, localBucketCountThresholds.getRequiredSize());
-            PriorityQueue<InternalMultiTerms.Bucket> ordered = new BucketPriorityQueue<>(size, partiallyBuiltBucketComparator);
-            InternalMultiTerms.Bucket spare = null;
-            BytesRef dest = null;
-            BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum = bucketOrds.ordsEnum(owningBucketOrds[ordIdx]);
-            CheckedSupplier<InternalMultiTerms.Bucket, IOException> emptyBucketBuilder = () -> InternalMultiTerms.Bucket.EMPTY(
-                showTermDocCountError,
-                formats
-            );
-            while (ordsEnum.next()) {
-                long docCount = bucketDocCount(ordsEnum.ord());
-                otherDocCounts[ordIdx] += docCount;
-                if (docCount < localBucketCountThresholds.getMinDocCount()) {
-                    continue;
-                }
-                if (spare == null) {
-                    spare = emptyBucketBuilder.get();
-                    dest = new BytesRef();
-                }
-
-                ordsEnum.readValue(dest);
-
-                spare.termValues = decode(dest);
-                spare.docCount = docCount;
-                spare.bucketOrd = ordsEnum.ord();
-                spare = ordered.insertWithOverflow(spare);
-            }
-
-            // Get the top buckets
-            InternalMultiTerms.Bucket[] bucketsForOrd = new InternalMultiTerms.Bucket[ordered.size()];
-            topBucketsPerOrd[ordIdx] = bucketsForOrd;
-            for (int b = ordered.size() - 1; b >= 0; --b) {
-                topBucketsPerOrd[ordIdx][b] = ordered.pop();
-                otherDocCounts[ordIdx] -= topBucketsPerOrd[ordIdx][b].getDocCount();
+            if (ordinalBucketOrds != null) {
+                topBucketsPerOrd[ordIdx] = buildOrdinalBuckets(
+                    owningBucketOrds[ordIdx],
+                    localBucketCountThresholds,
+                    otherDocCounts,
+                    ordIdx,
+                    globalOrdsForLookup
+                );
+            } else {
+                topBucketsPerOrd[ordIdx] = buildBytesBuckets(owningBucketOrds[ordIdx], localBucketCountThresholds, otherDocCounts, ordIdx);
             }
         }
 
@@ -189,6 +192,102 @@ public class MultiTermsAggregator extends DeferableBucketAggregator implements S
             result[ordIdx] = buildResult(owningBucketOrds[ordIdx], otherDocCounts[ordIdx], topBucketsPerOrd[ordIdx]);
         }
         return result;
+    }
+
+    /**
+     * Build top buckets from the ordinal-based path by resolving packed ordinals
+     * back to term values via {@code lookupOrd()}.
+     */
+    private InternalMultiTerms.Bucket[] buildOrdinalBuckets(
+        long owningBucketOrd,
+        LocalBucketCountThresholds localBucketCountThresholds,
+        long[] otherDocCounts,
+        int ordIdx,
+        SortedSetDocValues[] globalOrdsForLookup
+    ) throws IOException {
+        long bucketsInOrd = ordinalBucketOrds.bucketsInOrd(owningBucketOrd);
+        int size = (int) Math.min(bucketsInOrd, localBucketCountThresholds.getRequiredSize());
+        PriorityQueue<InternalMultiTerms.Bucket> ordered = new BucketPriorityQueue<>(size, partiallyBuiltBucketComparator);
+        InternalMultiTerms.Bucket spare = null;
+        CheckedSupplier<InternalMultiTerms.Bucket, IOException> emptyBucketBuilder = () -> InternalMultiTerms.Bucket.EMPTY(
+            showTermDocCountError,
+            formats
+        );
+        MultiTermsBucketOrds.BucketOrdsEnum ordsEnum = ordinalBucketOrds.ordsEnum(owningBucketOrd);
+        while (ordsEnum.next()) {
+            long docCount = bucketDocCount(ordsEnum.ord());
+            otherDocCounts[ordIdx] += docCount;
+            if (docCount < localBucketCountThresholds.getMinDocCount()) {
+                continue;
+            }
+            if (spare == null) {
+                spare = emptyBucketBuilder.get();
+            }
+
+            long[] ordinals = ordsEnum.ordinals();
+            List<Object> termValues = new ArrayList<>(ordinals.length);
+            for (int i = 0; i < ordinals.length; i++) {
+                termValues.add(BytesRef.deepCopyOf(globalOrdsForLookup[i].lookupOrd(ordinals[i])));
+            }
+
+            spare.termValues = termValues;
+            spare.docCount = docCount;
+            spare.bucketOrd = ordsEnum.ord();
+            spare = ordered.insertWithOverflow(spare);
+        }
+
+        InternalMultiTerms.Bucket[] bucketsForOrd = new InternalMultiTerms.Bucket[ordered.size()];
+        for (int b = ordered.size() - 1; b >= 0; --b) {
+            bucketsForOrd[b] = ordered.pop();
+            otherDocCounts[ordIdx] -= bucketsForOrd[b].getDocCount();
+        }
+        return bucketsForOrd;
+    }
+
+    /**
+     * Build top buckets from the existing bytes-based path.
+     */
+    private InternalMultiTerms.Bucket[] buildBytesBuckets(
+        long owningBucketOrd,
+        LocalBucketCountThresholds localBucketCountThresholds,
+        long[] otherDocCounts,
+        int ordIdx
+    ) throws IOException {
+        long bucketsInOrd = bucketOrds.bucketsInOrd(owningBucketOrd);
+        int size = (int) Math.min(bucketsInOrd, localBucketCountThresholds.getRequiredSize());
+        PriorityQueue<InternalMultiTerms.Bucket> ordered = new BucketPriorityQueue<>(size, partiallyBuiltBucketComparator);
+        InternalMultiTerms.Bucket spare = null;
+        BytesRef dest = null;
+        BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum = bucketOrds.ordsEnum(owningBucketOrd);
+        CheckedSupplier<InternalMultiTerms.Bucket, IOException> emptyBucketBuilder = () -> InternalMultiTerms.Bucket.EMPTY(
+            showTermDocCountError,
+            formats
+        );
+        while (ordsEnum.next()) {
+            long docCount = bucketDocCount(ordsEnum.ord());
+            otherDocCounts[ordIdx] += docCount;
+            if (docCount < localBucketCountThresholds.getMinDocCount()) {
+                continue;
+            }
+            if (spare == null) {
+                spare = emptyBucketBuilder.get();
+                dest = new BytesRef();
+            }
+
+            ordsEnum.readValue(dest);
+
+            spare.termValues = decode(dest);
+            spare.docCount = docCount;
+            spare.bucketOrd = ordsEnum.ord();
+            spare = ordered.insertWithOverflow(spare);
+        }
+
+        InternalMultiTerms.Bucket[] bucketsForOrd = new InternalMultiTerms.Bucket[ordered.size()];
+        for (int b = ordered.size() - 1; b >= 0; --b) {
+            bucketsForOrd[b] = ordered.pop();
+            otherDocCounts[ordIdx] -= bucketsForOrd[b].getDocCount();
+        }
+        return bucketsForOrd;
     }
 
     InternalMultiTerms buildResult(long owningBucketOrd, long otherDocCount, InternalMultiTerms.Bucket[] topBuckets) {
@@ -233,11 +332,69 @@ public class MultiTermsAggregator extends DeferableBucketAggregator implements S
 
     @Override
     protected LeafBucketCollector getLeafCollector(LeafReaderContext ctx, LeafBucketCollector sub) throws IOException {
+        if (ordinalBucketOrds != null) {
+            return getOrdinalLeafCollector(ctx, sub);
+        }
         MultiTermsValuesSourceCollector collector = multiTermsValue.getValues(ctx, bucketOrds, this, sub);
         return new LeafBucketCollector() {
             @Override
             public void collect(int doc, long owningBucketOrd) throws IOException {
                 collector.apply(doc, owningBucketOrd);
+            }
+        };
+    }
+
+    /**
+     * Creates a leaf collector that collects global ordinals directly instead of
+     * serialized term values. Generates the cartesian product of ordinal tuples
+     * across all fields for each document.
+     */
+    private LeafBucketCollector getOrdinalLeafCollector(LeafReaderContext ctx, LeafBucketCollector sub) throws IOException {
+        int numFields = ordinalSources.size();
+        SortedSetDocValues[] globalOrds = new SortedSetDocValues[numFields];
+        for (int i = 0; i < numFields; i++) {
+            globalOrds[i] = ordinalSources.get(i).globalOrdinalsValues(ctx);
+        }
+        return new LeafBucketCollector() {
+            private final long[] ordTuple = new long[numFields];
+
+            @Override
+            public void collect(int doc, long owningBucketOrd) throws IOException {
+                long[][] ordinalSets = new long[numFields][];
+                for (int i = 0; i < numFields; i++) {
+                    if (false == globalOrds[i].advanceExact(doc)) {
+                        return; // missing value in any field → skip doc
+                    }
+                    int count = globalOrds[i].docValueCount();
+                    ordinalSets[i] = new long[count];
+                    for (int j = 0; j < count; j++) {
+                        ordinalSets[i][j] = globalOrds[i].nextOrd();
+                    }
+                }
+                generateOrdinalCombinations(ordinalSets, 0, ordTuple, owningBucketOrd, doc, sub);
+            }
+
+            private void generateOrdinalCombinations(
+                long[][] ordinalSets,
+                int depth,
+                long[] current,
+                long owningBucketOrd,
+                int doc,
+                LeafBucketCollector sub
+            ) throws IOException {
+                if (depth == ordinalSets.length) {
+                    long bucketOrd = ordinalBucketOrds.add(owningBucketOrd, current);
+                    if (bucketOrd < 0) {
+                        collectExistingBucket(sub, doc, -1 - bucketOrd);
+                    } else {
+                        collectBucket(sub, doc, bucketOrd);
+                    }
+                    return;
+                }
+                for (long ord : ordinalSets[depth]) {
+                    current[depth] = ord;
+                    generateOrdinalCombinations(ordinalSets, depth + 1, current, owningBucketOrd, doc, sub);
+                }
             }
         };
     }
@@ -378,9 +535,17 @@ public class MultiTermsAggregator extends DeferableBucketAggregator implements S
         );
     }
 
+    /**
+     * Returns the ordinal-based bucket ords, or {@code null} if the bytes-based path is active.
+     * Package-private for testing.
+     */
+    MultiTermsBucketOrds getOrdinalBucketOrds() {
+        return ordinalBucketOrds;
+    }
+
     @Override
     protected void doClose() {
-        Releasables.close(bucketOrds, multiTermsValue);
+        Releasables.close(bucketOrds, ordinalBucketOrds, multiTermsValue);
     }
 
     private static List<Object> decode(BytesRef bytesRef) {
@@ -409,16 +574,70 @@ public class MultiTermsAggregator extends DeferableBucketAggregator implements S
         if (bucketCountThresholds.getMinDocCount() != 0) {
             return;
         }
-        if (InternalOrder.isCountDesc(order) && bucketOrds.bucketsInOrd(owningBucketOrd) >= bucketCountThresholds.getRequiredSize()) {
+        if (ordinalBucketOrds != null) {
+            if (InternalOrder.isCountDesc(order)
+                && ordinalBucketOrds.bucketsInOrd(owningBucketOrd) >= bucketCountThresholds.getRequiredSize()) {
+                return;
+            }
+            for (LeafReaderContext ctx : context.searcher().getTopReaderContext().leaves()) {
+                collectZeroDocOrdinals(ctx, owningBucketOrd);
+            }
+        } else {
+            if (InternalOrder.isCountDesc(order) && bucketOrds.bucketsInOrd(owningBucketOrd) >= bucketCountThresholds.getRequiredSize()) {
+                return;
+            }
+            // we need to fill-in the blanks
+            for (LeafReaderContext ctx : context.searcher().getTopReaderContext().leaves()) {
+                // brute force
+                MultiTermsValuesSourceCollector collector = multiTermsValue.getValues(ctx, bucketOrds, null, null);
+                for (int docId = 0; docId < ctx.reader().maxDoc(); ++docId) {
+                    collector.apply(docId, owningBucketOrd);
+                }
+            }
+        }
+    }
+
+    /**
+     * Adds all ordinal tuples from a leaf to the ordinal bucket ords without
+     * collecting sub-aggregators or incrementing doc counts. Used for zero-doc
+     * entry filling when minDocCount is 0.
+     */
+    private void collectZeroDocOrdinals(LeafReaderContext ctx, long owningBucketOrd) throws IOException {
+        int numFields = ordinalSources.size();
+        SortedSetDocValues[] globalOrds = new SortedSetDocValues[numFields];
+        for (int i = 0; i < numFields; i++) {
+            globalOrds[i] = ordinalSources.get(i).globalOrdinalsValues(ctx);
+        }
+        long[] ordTuple = new long[numFields];
+        for (int docId = 0; docId < ctx.reader().maxDoc(); ++docId) {
+            long[][] ordinalSets = new long[numFields][];
+            boolean skip = false;
+            for (int i = 0; i < numFields; i++) {
+                if (false == globalOrds[i].advanceExact(docId)) {
+                    skip = true;
+                    break;
+                }
+                int count = globalOrds[i].docValueCount();
+                ordinalSets[i] = new long[count];
+                for (int j = 0; j < count; j++) {
+                    ordinalSets[i][j] = globalOrds[i].nextOrd();
+                }
+            }
+            if (skip) {
+                continue;
+            }
+            addOrdinalCombinations(ordinalSets, 0, ordTuple, owningBucketOrd);
+        }
+    }
+
+    private void addOrdinalCombinations(long[][] ordinalSets, int depth, long[] current, long owningBucketOrd) {
+        if (depth == ordinalSets.length) {
+            ordinalBucketOrds.add(owningBucketOrd, current);
             return;
         }
-        // we need to fill-in the blanks
-        for (LeafReaderContext ctx : context.searcher().getTopReaderContext().leaves()) {
-            // brute force
-            MultiTermsValuesSourceCollector collector = multiTermsValue.getValues(ctx, bucketOrds, null, null);
-            for (int docId = 0; docId < ctx.reader().maxDoc(); ++docId) {
-                collector.apply(docId, owningBucketOrd);
-            }
+        for (long ord : ordinalSets[depth]) {
+            current[depth] = ord;
+            addOrdinalCombinations(ordinalSets, depth + 1, current, owningBucketOrd);
         }
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsBucketOrds.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsBucketOrds.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.terms;
+
+import org.opensearch.common.lease.Releasable;
+
+/**
+ * Maps composite ordinal tuples to bucket ordinals for multi-terms aggregation.
+ * Used when all fields in the aggregation support global ordinals, enabling
+ * packed ordinal storage instead of serialized BytesRef composite keys.
+ *
+ * @opensearch.internal
+ */
+public interface MultiTermsBucketOrds extends Releasable {
+
+    /**
+     * Add the {@code owningBucketOrd, ordinals} tuple. Return the ord for
+     * their bucket if they have yet to be added, or {@code -1-ord}
+     * if they were already present.
+     */
+    long add(long owningBucketOrd, long[] ordinals);
+
+    /**
+     * Count the buckets in {@code owningBucketOrd}.
+     */
+    long bucketsInOrd(long owningBucketOrd);
+
+    /**
+     * The number of collected buckets.
+     */
+    long size();
+
+    /**
+     * Build an iterator for buckets inside {@code owningBucketOrd} in order
+     * of increasing ord.
+     * <p>
+     * When first returned it is "unpositioned" and you must call
+     * {@link BucketOrdsEnum#next()} to move it to the first value.
+     */
+    BucketOrdsEnum ordsEnum(long owningBucketOrd);
+
+    /**
+     * An iterator for buckets inside a particular {@code owningBucketOrd}.
+     *
+     * @opensearch.internal
+     */
+    interface BucketOrdsEnum {
+        /**
+         * Advance to the next value.
+         * @return {@code true} if there *is* a next value,
+         *         {@code false} if there isn't
+         */
+        boolean next();
+
+        /**
+         * The ordinal of the current bucket.
+         */
+        long ord();
+
+        /**
+         * Read the ordinal tuple for the current bucket.
+         */
+        long[] ordinals();
+
+        /**
+         * An {@linkplain BucketOrdsEnum} that is empty.
+         */
+        BucketOrdsEnum EMPTY = new BucketOrdsEnum() {
+            @Override
+            public boolean next() {
+                return false;
+            }
+
+            @Override
+            public long ord() {
+                return 0;
+            }
+
+            @Override
+            public long[] ordinals() {
+                return new long[0];
+            }
+        };
+    }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/OrdinalPairBucketOrds.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/OrdinalPairBucketOrds.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.terms;
+
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.search.aggregations.CardinalityUpperBound;
+
+/**
+ * Optimized {@link MultiTermsBucketOrds} for exactly 2 keyword fields.
+ * Packs two global ordinals into a single {@code long} and delegates
+ * storage to {@link LongKeyedBucketOrds}.
+ *
+ * @opensearch.internal
+ */
+public class OrdinalPairBucketOrds implements MultiTermsBucketOrds {
+
+    private final LongKeyedBucketOrds delegate;
+    private final int bitsForOrd1;
+    private final long ord1Mask;
+
+    /**
+     * Create a new instance.
+     *
+     * @param bigArrays   for memory allocation
+     * @param cardinality upper bound on owning bucket cardinality
+     * @param maxOrd0     the value count (exclusive upper bound) for the first field's ordinals
+     * @param maxOrd1     the value count (exclusive upper bound) for the second field's ordinals
+     */
+    public OrdinalPairBucketOrds(BigArrays bigArrays, CardinalityUpperBound cardinality, long maxOrd0, long maxOrd1) {
+        this.bitsForOrd1 = bitsRequired(maxOrd1);
+        assert bitsRequired(maxOrd0) + bitsForOrd1 <= 63 : "ordinals do not fit in 63 bits";
+        this.ord1Mask = (1L << bitsForOrd1) - 1;
+        this.delegate = LongKeyedBucketOrds.build(bigArrays, cardinality);
+    }
+
+    /**
+     * Returns the minimum number of bits needed to represent values in {@code [0, maxOrd)}.
+     * Returns 0 when {@code maxOrd} is 0.
+     */
+    static int bitsRequired(long maxOrd) {
+        if (maxOrd <= 0) {
+            return 0;
+        }
+        return Long.SIZE - Long.numberOfLeadingZeros(maxOrd - 1);
+    }
+
+    /**
+     * Check whether two fields with the given max ordinal counts can be packed
+     * into a single long (63 usable bits, reserving the sign bit).
+     */
+    public static boolean fitsInLong(long maxOrd0, long maxOrd1) {
+        return bitsRequired(maxOrd0) + bitsRequired(maxOrd1) <= 63;
+    }
+
+    long packOrdinals(long ord0, long ord1) {
+        return (ord0 << bitsForOrd1) | ord1;
+    }
+
+    long unpackOrd0(long packed) {
+        return packed >>> bitsForOrd1;
+    }
+
+    long unpackOrd1(long packed) {
+        return packed & ord1Mask;
+    }
+
+    @Override
+    public long add(long owningBucketOrd, long[] ordinals) {
+        assert ordinals.length == 2;
+        return delegate.add(owningBucketOrd, packOrdinals(ordinals[0], ordinals[1]));
+    }
+
+    @Override
+    public long bucketsInOrd(long owningBucketOrd) {
+        return delegate.bucketsInOrd(owningBucketOrd);
+    }
+
+    @Override
+    public long size() {
+        return delegate.size();
+    }
+
+    @Override
+    public BucketOrdsEnum ordsEnum(long owningBucketOrd) {
+        LongKeyedBucketOrds.BucketOrdsEnum inner = delegate.ordsEnum(owningBucketOrd);
+        return new BucketOrdsEnum() {
+            @Override
+            public boolean next() {
+                return inner.next();
+            }
+
+            @Override
+            public long ord() {
+                return inner.ord();
+            }
+
+            @Override
+            public long[] ordinals() {
+                long packed = inner.value();
+                return new long[] { unpackOrd0(packed), unpackOrd1(packed) };
+            }
+        };
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/PackedOrdinalsBucketOrds.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/PackedOrdinalsBucketOrds.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.terms;
+
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.search.aggregations.CardinalityUpperBound;
+
+/**
+ * {@link MultiTermsBucketOrds} for 3 or more keyword fields.
+ * Serializes ordinals as fixed-width 8-byte longs into a {@link BytesRef}
+ * (no type tags or length prefixes) and delegates storage to
+ * {@link BytesKeyedBucketOrds}.
+ *
+ * @opensearch.internal
+ */
+public class PackedOrdinalsBucketOrds implements MultiTermsBucketOrds {
+
+    private final BytesKeyedBucketOrds delegate;
+    private final int numFields;
+    /** Reusable scratch buffer sized to exactly {@code numFields * 8} bytes. */
+    private final byte[] scratch;
+    /** Reusable BytesRef wrapping {@link #scratch}. */
+    private final BytesRef scratchRef;
+
+    /**
+     * Create a new instance.
+     *
+     * @param bigArrays   for memory allocation
+     * @param cardinality upper bound on owning bucket cardinality
+     * @param numFields   the number of fields (must be &ge; 2)
+     */
+    public PackedOrdinalsBucketOrds(BigArrays bigArrays, CardinalityUpperBound cardinality, int numFields) {
+        assert numFields >= 2 : "PackedOrdinalsBucketOrds requires at least 2 fields";
+        this.delegate = BytesKeyedBucketOrds.build(bigArrays, cardinality);
+        this.numFields = numFields;
+        this.scratch = new byte[numFields * Long.BYTES];
+        this.scratchRef = new BytesRef(scratch);
+    }
+
+    /**
+     * Pack ordinals into the scratch buffer and return the wrapping BytesRef.
+     */
+    private BytesRef packOrdinals(long[] ordinals) {
+        assert ordinals.length == numFields;
+        for (int i = 0; i < numFields; i++) {
+            long v = ordinals[i];
+            int off = i * Long.BYTES;
+            scratch[off] = (byte) (v >>> 56);
+            scratch[off + 1] = (byte) (v >>> 48);
+            scratch[off + 2] = (byte) (v >>> 40);
+            scratch[off + 3] = (byte) (v >>> 32);
+            scratch[off + 4] = (byte) (v >>> 24);
+            scratch[off + 5] = (byte) (v >>> 16);
+            scratch[off + 6] = (byte) (v >>> 8);
+            scratch[off + 7] = (byte) v;
+        }
+        return scratchRef;
+    }
+
+    /**
+     * Unpack ordinals from a BytesRef that was produced by {@link #packOrdinals}.
+     */
+    static long[] unpackOrdinals(BytesRef packed, int numFields) {
+        assert packed.length == numFields * Long.BYTES;
+        long[] ordinals = new long[numFields];
+        for (int i = 0; i < numFields; i++) {
+            int off = packed.offset + i * Long.BYTES;
+            ordinals[i] = ((long) (packed.bytes[off] & 0xFF) << 56) | ((long) (packed.bytes[off + 1] & 0xFF) << 48)
+                | ((long) (packed.bytes[off + 2] & 0xFF) << 40) | ((long) (packed.bytes[off + 3] & 0xFF) << 32) | ((long) (packed.bytes[off
+                    + 4] & 0xFF) << 24) | ((long) (packed.bytes[off + 5] & 0xFF) << 16) | ((long) (packed.bytes[off + 6] & 0xFF) << 8)
+                | ((long) (packed.bytes[off + 7] & 0xFF));
+        }
+        return ordinals;
+    }
+
+    @Override
+    public long add(long owningBucketOrd, long[] ordinals) {
+        return delegate.add(owningBucketOrd, packOrdinals(ordinals));
+    }
+
+    @Override
+    public long bucketsInOrd(long owningBucketOrd) {
+        return delegate.bucketsInOrd(owningBucketOrd);
+    }
+
+    @Override
+    public long size() {
+        return delegate.size();
+    }
+
+    @Override
+    public BucketOrdsEnum ordsEnum(long owningBucketOrd) {
+        BytesKeyedBucketOrds.BucketOrdsEnum inner = delegate.ordsEnum(owningBucketOrd);
+        int fields = this.numFields;
+        return new BucketOrdsEnum() {
+            private final BytesRef readBuffer = new BytesRef();
+
+            @Override
+            public boolean next() {
+                return inner.next();
+            }
+
+            @Override
+            public long ord() {
+                return inner.ord();
+            }
+
+            @Override
+            public long[] ordinals() {
+                inner.readValue(readBuffer);
+                return unpackOrdinals(readBuffer, fields);
+            }
+        };
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+}

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregatorTests.java
@@ -958,7 +958,8 @@ public class MultiTermsAggregatorTests extends AggregatorTestCase {
             context,
             parent,
             cardinality,
-            metadata
+            metadata,
+            null
         );
         InternalAggregation emptyAgg = mAgg.buildEmptyAggregation();
 

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsOrdinalOptimizationTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsOrdinalOptimizationTests.java
@@ -1,0 +1,558 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.terms;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.index.mapper.HllFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.search.aggregations.AggregatorTestCase;
+import org.opensearch.search.aggregations.support.CoreValuesSourceType;
+import org.opensearch.search.aggregations.support.MultiTermsValuesSourceConfig;
+import org.opensearch.search.aggregations.support.ValuesSourceType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+
+/**
+ * End-to-end equivalence tests verifying that the ordinal-based path and the
+ * bytes-based path produce identical aggregation results for the same data.
+ *
+ * <p><b>Property 7: Ordinal-bytes path equivalence</b></p>
+ * <p><b>Validates: Requirements 5.3, 6.1, 6.2, 6.3</b></p>
+ */
+public class MultiTermsOrdinalOptimizationTests extends AggregatorTestCase {
+
+    private static final String KW_FIELD_1 = "kw1";
+    private static final String KW_FIELD_2 = "kw2";
+    private static final String KW_FIELD_3 = "kw3";
+    private static final String INT_FIELD = "int_val";
+
+    private MappedFieldType[] allFieldTypes() {
+        return new MappedFieldType[] {
+            new KeywordFieldMapper.KeywordFieldType(KW_FIELD_1),
+            new KeywordFieldMapper.KeywordFieldType(KW_FIELD_2),
+            new KeywordFieldMapper.KeywordFieldType(KW_FIELD_3),
+            new NumberFieldMapper.NumberFieldType(INT_FIELD, NumberFieldMapper.NumberType.INTEGER) };
+    }
+
+    private MultiTermsValuesSourceConfig kwConfig(String field) {
+        return new MultiTermsValuesSourceConfig.Builder().setFieldName(field).build();
+    }
+
+    private MultiTermsValuesSourceConfig intConfig() {
+        return new MultiTermsValuesSourceConfig.Builder().setFieldName(INT_FIELD).build();
+    }
+
+    /**
+     * Test with 2 keyword fields — exercises the OrdinalPairBucketOrds (pair packing) path.
+     * Indexes random documents with 2 keyword fields, runs multi_terms aggregation,
+     * and verifies results match expected bucket keys and doc counts.
+     *
+     * Validates: Requirements 5.3, 6.1, 6.2
+     */
+    public void testTwoKeywordFieldsPairPackingPath() throws IOException {
+        int numDistinctValues = randomIntBetween(3, 15);
+        String[] values = new String[numDistinctValues];
+        for (int i = 0; i < numDistinctValues; i++) {
+            values[i] = randomAlphaOfLength(randomIntBetween(3, 10));
+        }
+
+        int numDocs = randomIntBetween(20, 100);
+        Map<String, Long> expectedCounts = new HashMap<>();
+
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int i = 0; i < numDocs; i++) {
+                String v1 = values[randomIntBetween(0, numDistinctValues - 1)];
+                String v2 = values[randomIntBetween(0, numDistinctValues - 1)];
+                Document doc = new Document();
+                doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef(v1)));
+                doc.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef(v2)));
+                iw.addDocument(doc);
+                expectedCounts.merge(v1 + "|" + v2, 1L, Long::sum);
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2))
+                ).size(numDistinctValues * numDistinctValues + 10);
+
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+
+                // Verify every bucket matches expected counts
+                Map<String, Long> actualCounts = new HashMap<>();
+                for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+                    List<Object> key = bucket.getKey();
+                    assertEquals("Each bucket key should have 2 elements", 2, key.size());
+                    String compositeKey = key.get(0) + "|" + key.get(1);
+                    actualCounts.put(compositeKey, bucket.getDocCount());
+                }
+
+                assertEquals("Bucket count mismatch", expectedCounts.size(), actualCounts.size());
+                for (Map.Entry<String, Long> entry : expectedCounts.entrySet()) {
+                    assertEquals("Doc count mismatch for key " + entry.getKey(), entry.getValue(), actualCounts.get(entry.getKey()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Test with 3 keyword fields — exercises the PackedOrdinalsBucketOrds path.
+     * Indexes random documents with 3 keyword fields, runs multi_terms aggregation,
+     * and verifies results match expected bucket keys and doc counts.
+     *
+     * Validates: Requirements 5.3, 6.1, 6.2
+     */
+    public void testThreeKeywordFieldsPackedOrdinalsPath() throws IOException {
+        int numDistinctValues = randomIntBetween(2, 8);
+        String[] values = new String[numDistinctValues];
+        for (int i = 0; i < numDistinctValues; i++) {
+            values[i] = randomAlphaOfLength(randomIntBetween(3, 10));
+        }
+
+        int numDocs = randomIntBetween(20, 80);
+        Map<String, Long> expectedCounts = new HashMap<>();
+
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int i = 0; i < numDocs; i++) {
+                String v1 = values[randomIntBetween(0, numDistinctValues - 1)];
+                String v2 = values[randomIntBetween(0, numDistinctValues - 1)];
+                String v3 = values[randomIntBetween(0, numDistinctValues - 1)];
+                Document doc = new Document();
+                doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef(v1)));
+                doc.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef(v2)));
+                doc.add(new SortedDocValuesField(KW_FIELD_3, new BytesRef(v3)));
+                iw.addDocument(doc);
+                expectedCounts.merge(v1 + "|" + v2 + "|" + v3, 1L, Long::sum);
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2), kwConfig(KW_FIELD_3))
+                ).size(numDistinctValues * numDistinctValues * numDistinctValues + 10);
+
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+
+                Map<String, Long> actualCounts = new HashMap<>();
+                for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+                    List<Object> key = bucket.getKey();
+                    assertEquals("Each bucket key should have 3 elements", 3, key.size());
+                    String compositeKey = key.get(0) + "|" + key.get(1) + "|" + key.get(2);
+                    actualCounts.put(compositeKey, bucket.getDocCount());
+                }
+
+                assertEquals("Bucket count mismatch", expectedCounts.size(), actualCounts.size());
+                for (Map.Entry<String, Long> entry : expectedCounts.entrySet()) {
+                    assertEquals("Doc count mismatch for key " + entry.getKey(), entry.getValue(), actualCounts.get(entry.getKey()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Test with mixed keyword + numeric fields — exercises the BytesKeyedBucketOrds fallback path.
+     * Verifies that when not all fields are WithOrdinals, the aggregation still produces correct results.
+     *
+     * Validates: Requirements 6.1, 6.2, 6.3
+     */
+    public void testMixedKeywordAndNumericFallbackPath() throws IOException {
+        int numDistinctKw = randomIntBetween(3, 10);
+        String[] kwValues = new String[numDistinctKw];
+        for (int i = 0; i < numDistinctKw; i++) {
+            kwValues[i] = randomAlphaOfLength(randomIntBetween(3, 8));
+        }
+
+        int numDocs = randomIntBetween(20, 80);
+        Map<String, Long> expectedCounts = new HashMap<>();
+
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int i = 0; i < numDocs; i++) {
+                String kw1 = kwValues[randomIntBetween(0, numDistinctKw - 1)];
+                int intVal = randomIntBetween(1, 5);
+                Document doc = new Document();
+                doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef(kw1)));
+                doc.add(new NumericDocValuesField(INT_FIELD, intVal));
+                iw.addDocument(doc);
+                expectedCounts.merge(kw1 + "|" + intVal, 1L, Long::sum);
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), intConfig())
+                ).size(numDistinctKw * 5 + 10);
+
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+
+                Map<String, Long> actualCounts = new HashMap<>();
+                for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+                    List<Object> key = bucket.getKey();
+                    assertEquals("Each bucket key should have 2 elements", 2, key.size());
+                    String compositeKey = key.get(0) + "|" + key.get(1);
+                    actualCounts.put(compositeKey, bucket.getDocCount());
+                }
+
+                assertEquals("Bucket count mismatch", expectedCounts.size(), actualCounts.size());
+                for (Map.Entry<String, Long> entry : expectedCounts.entrySet()) {
+                    assertEquals("Doc count mismatch for key " + entry.getKey(), entry.getValue(), actualCounts.get(entry.getKey()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Test equivalence between ordinal path (2 keyword fields) and fallback path (keyword + int)
+     * using the same underlying data. Indexes documents with both keyword and numeric representations,
+     * then compares the sorted bucket results from both paths.
+     *
+     * Validates: Requirements 5.3, 6.1, 6.2
+     */
+    public void testOrdinalPathEquivalentToFallbackPath() throws IOException {
+        // Use deterministic values so we can compare across paths
+        String[] kw1Values = { "alpha", "beta", "gamma" };
+        String[] kw2Values = { "one", "two", "three" };
+        // Map kw2 values to integers for the fallback path
+        Map<String, Integer> kw2ToInt = new HashMap<>();
+        kw2ToInt.put("one", 1);
+        kw2ToInt.put("two", 2);
+        kw2ToInt.put("three", 3);
+
+        int numDocs = randomIntBetween(30, 100);
+        List<int[]> docChoices = new ArrayList<>();
+        for (int i = 0; i < numDocs; i++) {
+            docChoices.add(new int[] { randomIntBetween(0, 2), randomIntBetween(0, 2) });
+        }
+
+        // Run ordinal path: 2 keyword fields
+        List<String> ordinalBuckets;
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int[] choice : docChoices) {
+                Document doc = new Document();
+                doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef(kw1Values[choice[0]])));
+                doc.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef(kw2Values[choice[1]])));
+                iw.addDocument(doc);
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2))
+                ).size(100);
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+                ordinalBuckets = bucketsToSortedStrings(result);
+            }
+        }
+
+        // Run fallback path: keyword + int (forces BytesKeyedBucketOrds)
+        List<String> fallbackBuckets;
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int[] choice : docChoices) {
+                Document doc = new Document();
+                doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef(kw1Values[choice[0]])));
+                doc.add(new NumericDocValuesField(INT_FIELD, kw2ToInt.get(kw2Values[choice[1]])));
+                iw.addDocument(doc);
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), intConfig())
+                ).size(100);
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+                // Convert int keys to the kw2 equivalent for comparison
+                fallbackBuckets = new ArrayList<>();
+                Map<Long, String> intToKw2 = new HashMap<>();
+                intToKw2.put(1L, "one");
+                intToKw2.put(2L, "two");
+                intToKw2.put(3L, "three");
+                for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+                    String kw = (String) bucket.getKey().get(0);
+                    String mapped = intToKw2.get(bucket.getKey().get(1));
+                    fallbackBuckets.add(kw + "|" + mapped + "=" + bucket.getDocCount());
+                }
+                fallbackBuckets.sort(Comparator.naturalOrder());
+            }
+        }
+
+        assertEquals("Ordinal and fallback paths should produce equivalent results", ordinalBuckets, fallbackBuckets);
+    }
+
+    /**
+     * Test with high-cardinality fields that could trigger pair-packing overflow.
+     * When the combined bit width of two keyword fields exceeds 63 bits, the strategy
+     * should fall back to PackedOrdinalsBucketOrds instead of OrdinalPairBucketOrds.
+     * We simulate this by indexing many distinct values and verifying correct results.
+     *
+     * Validates: Requirements 5.3, 6.2
+     */
+    public void testHighCardinalityKeywordFields() throws IOException {
+        // Generate enough distinct values to exercise the ordinal path with higher cardinality
+        int numDistinct = randomIntBetween(50, 200);
+        String[] values = new String[numDistinct];
+        for (int i = 0; i < numDistinct; i++) {
+            values[i] = String.format(Locale.ROOT, "%05d_%s", i, randomAlphaOfLength(5));
+        }
+
+        int numDocs = randomIntBetween(100, 300);
+        Map<String, Long> expectedCounts = new HashMap<>();
+
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int i = 0; i < numDocs; i++) {
+                String v1 = values[randomIntBetween(0, numDistinct - 1)];
+                String v2 = values[randomIntBetween(0, numDistinct - 1)];
+                Document doc = new Document();
+                doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef(v1)));
+                doc.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef(v2)));
+                iw.addDocument(doc);
+                expectedCounts.merge(v1 + "|" + v2, 1L, Long::sum);
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+
+                // Use a large size to capture all buckets
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2))
+                ).size(expectedCounts.size() + 10);
+
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+
+                Map<String, Long> actualCounts = new HashMap<>();
+                for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+                    List<Object> key = bucket.getKey();
+                    assertEquals(2, key.size());
+                    String compositeKey = key.get(0) + "|" + key.get(1);
+                    actualCounts.put(compositeKey, bucket.getDocCount());
+                }
+
+                assertEquals("Bucket count mismatch for high-cardinality test", expectedCounts.size(), actualCounts.size());
+                for (Map.Entry<String, Long> entry : expectedCounts.entrySet()) {
+                    assertEquals("Doc count mismatch for key " + entry.getKey(), entry.getValue(), actualCounts.get(entry.getKey()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Test with multi-valued keyword fields (SortedSetDocValuesField) to verify
+     * the cartesian product is correctly generated in the ordinal path.
+     *
+     * Validates: Requirements 5.3, 6.2
+     */
+    public void testMultiValuedKeywordFieldsOrdinalPath() throws IOException {
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+
+            // Doc 1: kw1=[a,b], kw2=[x] → buckets: (a,x), (b,x)
+            Document doc1 = new Document();
+            doc1.add(new SortedSetDocValuesField(KW_FIELD_1, new BytesRef("a")));
+            doc1.add(new SortedSetDocValuesField(KW_FIELD_1, new BytesRef("b")));
+            doc1.add(new SortedSetDocValuesField(KW_FIELD_2, new BytesRef("x")));
+            iw.addDocument(doc1);
+
+            // Doc 2: kw1=[a], kw2=[x,y] → buckets: (a,x), (a,y)
+            Document doc2 = new Document();
+            doc2.add(new SortedSetDocValuesField(KW_FIELD_1, new BytesRef("a")));
+            doc2.add(new SortedSetDocValuesField(KW_FIELD_2, new BytesRef("x")));
+            doc2.add(new SortedSetDocValuesField(KW_FIELD_2, new BytesRef("y")));
+            iw.addDocument(doc2);
+
+            // Doc 3: kw1=[b], kw2=[y] → buckets: (b,y)
+            Document doc3 = new Document();
+            doc3.add(new SortedSetDocValuesField(KW_FIELD_1, new BytesRef("b")));
+            doc3.add(new SortedSetDocValuesField(KW_FIELD_2, new BytesRef("y")));
+            iw.addDocument(doc3);
+
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2))
+                ).size(100);
+
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+
+                Map<String, Long> actualCounts = new HashMap<>();
+                for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+                    String compositeKey = bucket.getKey().get(0) + "|" + bucket.getKey().get(1);
+                    actualCounts.put(compositeKey, bucket.getDocCount());
+                }
+
+                // Expected: (a,x)=2, (a,y)=1, (b,x)=1, (b,y)=1
+                assertEquals(Long.valueOf(2), actualCounts.get("a|x"));
+                assertEquals(Long.valueOf(1), actualCounts.get("a|y"));
+                assertEquals(Long.valueOf(1), actualCounts.get("b|x"));
+                assertEquals(Long.valueOf(1), actualCounts.get("b|y"));
+                assertEquals(4, actualCounts.size());
+            }
+        }
+    }
+
+    /**
+     * Verify that 2 keyword fields select the OrdinalPairBucketOrds strategy.
+     */
+    public void testStrategySelectionTwoKeywordFields() throws IOException {
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            Document doc = new Document();
+            doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef("a")));
+            doc.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef("b")));
+            iw.addDocument(doc);
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2))
+                );
+                MultiTermsAggregator agg = createAggregator(builder, searcher, allFieldTypes());
+                assertNotNull("Expected ordinal strategy for 2 keyword fields", agg.getOrdinalBucketOrds());
+                assertTrue(
+                    "Expected OrdinalPairBucketOrds for 2 keyword fields",
+                    agg.getOrdinalBucketOrds() instanceof OrdinalPairBucketOrds
+                );
+                agg.close();
+            }
+        }
+    }
+
+    /**
+     * Verify that 3 keyword fields select the PackedOrdinalsBucketOrds strategy.
+     */
+    public void testStrategySelectionThreeKeywordFields() throws IOException {
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            Document doc = new Document();
+            doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef("a")));
+            doc.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef("b")));
+            doc.add(new SortedDocValuesField(KW_FIELD_3, new BytesRef("c")));
+            iw.addDocument(doc);
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2), kwConfig(KW_FIELD_3))
+                );
+                MultiTermsAggregator agg = createAggregator(builder, searcher, allFieldTypes());
+                assertNotNull("Expected ordinal strategy for 3 keyword fields", agg.getOrdinalBucketOrds());
+                assertTrue(
+                    "Expected PackedOrdinalsBucketOrds for 3 keyword fields",
+                    agg.getOrdinalBucketOrds() instanceof PackedOrdinalsBucketOrds
+                );
+                agg.close();
+            }
+        }
+    }
+
+    /**
+     * Verify that mixed keyword + numeric fields fall back to the bytes-based path (no ordinal strategy).
+     */
+    public void testStrategySelectionMixedFieldsFallback() throws IOException {
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            Document doc = new Document();
+            doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef("a")));
+            doc.add(new NumericDocValuesField(INT_FIELD, 42));
+            iw.addDocument(doc);
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), intConfig())
+                );
+                MultiTermsAggregator agg = createAggregator(builder, searcher, allFieldTypes());
+                assertNull("Expected null ordinal strategy for mixed fields (bytes fallback)", agg.getOrdinalBucketOrds());
+                agg.close();
+            }
+        }
+    }
+
+    /**
+     * Convert InternalMultiTerms buckets to a sorted list of "key=count" strings for comparison.
+     */
+    private List<String> bucketsToSortedStrings(InternalMultiTerms result) {
+        List<String> bucketStrings = new ArrayList<>();
+        for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < bucket.getKey().size(); i++) {
+                if (i > 0) {
+                    sb.append("|");
+                }
+                sb.append(bucket.getKey().get(i));
+            }
+            sb.append("=").append(bucket.getDocCount());
+            bucketStrings.add(sb.toString());
+        }
+        bucketStrings.sort(Comparator.naturalOrder());
+        return bucketStrings;
+    }
+
+    @Override
+    protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
+        return List.of(
+            CoreValuesSourceType.NUMERIC,
+            CoreValuesSourceType.BYTES,
+            CoreValuesSourceType.IP,
+            CoreValuesSourceType.DATE,
+            CoreValuesSourceType.BOOLEAN
+        );
+    }
+
+    @Override
+    protected List<String> unsupportedMappedFieldTypes() {
+        return List.of(HllFieldMapper.CONTENT_TYPE);
+    }
+
+    @Override
+    protected org.opensearch.search.aggregations.AggregationBuilder createAggBuilderForTypeTest(
+        MappedFieldType fieldType,
+        String fieldName
+    ) {
+        return new MultiTermsAggregationBuilder("_name").terms(asList(kwConfig(fieldName), kwConfig(fieldName)));
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Testing out if using ordinals instead of byte values for multi-bucket keys help in speeding up multi-terms aggregations.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
