### PR TITLE
Enhance logging for gRPC transport extensions

### DIFF
--- a/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/GrpcPlugin.java
+++ b/modules/transport-grpc/src/main/java/org/opensearch/transport/grpc/GrpcPlugin.java
@@ -123,13 +123,21 @@ public final class GrpcPlugin extends Plugin implements NetworkPlugin, Extensibl
             // Note: ThreadContext will be provided during component creation
             // For now, we collect providers to be initialized later with ThreadContext
             this.interceptorProviders = providers;
-            logger.info("Found {} gRPC interceptor providers, will initialize during component creation", providers.size());
+            logger.info(
+                "Found {} gRPC interceptor providers [{}], will initialize during component creation",
+                providers.size(),
+                providers.stream().map(p -> p.getClass().getName()).collect(Collectors.joining(", "))
+            );
         }
         // Load discovered gRPC service factories
         List<GrpcServiceFactory> services = loader.loadExtensions(GrpcServiceFactory.class);
         if (services != null) {
             servicesFactory.addAll(services);
-            logger.info("Successfully loaded {} GrpcServiceFactory extensions", services.size());
+            logger.info(
+                "Successfully loaded {} GrpcServiceFactory extensions [{}]",
+                services.size(),
+                services.stream().map(GrpcServiceFactory::plugin).collect(Collectors.joining(", "))
+            );
         }
     }
 
@@ -385,7 +393,13 @@ public final class GrpcPlugin extends Plugin implements NetworkPlugin, Extensibl
                 // This ensures proper ordering and exception handling
                 serverInterceptor.addInterceptors(orderedList);
 
-                logger.info("Loaded {} gRPC interceptors into chain", orderedList.size());
+                logger.info(
+                    "Loaded {} gRPC interceptors into chain in order: [{}]",
+                    orderedList.size(),
+                    orderedList.stream()
+                        .map(i -> i.getInterceptor().getClass().getName() + "(order=" + i.order() + ")")
+                        .collect(Collectors.joining(", "))
+                );
             }
         }
 


### PR DESCRIPTION
### Description
Adds some additional logs to show the name and order of interceptors/services injected into the gRPC server.

Example logs from test output:
(class names are a little strange due to mocked interceptor provider)
```
[2026-03-27T16:37:16,712][INFO ][o.o.t.g.GrpcPlugin       ] [testGrpcInterceptorChainIntegrationWithPlugin] Found 1 gRPC interceptor providers [org.opensearch.transport.grpc.spi.GrpcInterceptorProvider$MockitoMock$noX7shHC], will initialize during component creation
[2026-03-27T16:37:16,712][INFO ][o.o.t.g.GrpcPlugin       ] [testGrpcInterceptorChainIntegrationWithPlugin] Loaded 3 gRPC interceptors into chain in order: [org.opensearch.transport.grpc.GrpcPluginTests$3$1(order=10), org.opensearch.transport.grpc.GrpcPluginTests$3$1(order=20), org.opensearch.transport.grpc.GrpcPluginTests$3$1(order=30)]
```

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).