### PR TITLE
Upgrade Spotless Gradle plugin from 8.0.0 to 8.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ plugins {
   id 'lifecycle-base'
   id 'opensearch.docker-support'
   id 'opensearch.global-build-info'
-  id "com.diffplug.spotless" version "8.0.0" apply false
+  id "com.diffplug.spotless" version "8.4.0" apply false
   id "org.gradle.test-retry" version "1.6.2" apply false
   id "test-report-aggregation"
   id 'jacoco-report-aggregation'


### PR DESCRIPTION
### Description

Upgrades the Spotless Gradle plugin from 8.0.0 to 8.4.0. This picks up serialization and configuration cache fixes that address intermittent `Cannot fingerprint input property 'stepsInternalEquality'` build failures seen in CI (e.g. [build 73416](https://build.ci.opensearch.org/job/gradle-check/73416/)).

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).