### PR TITLE
Add negative test for repository creation failure in RemoteStoreRepositoryRegistrationIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRepositoryRegistrationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/remotestore/RemoteStoreRepositoryRegistrationIT.java
@@ -280,4 +280,29 @@ public class RemoteStoreRepositoryRegistrationIT extends RemoteStoreBaseIntegTes
         ensureStableCluster(1);
     }
 
+    /**
+     * Test that node join fails when repository creation fails due to missing repository configuration.
+     * This verifies that a node referencing a repository name with no corresponding type or settings
+     * is rejected during the join process.
+     */
+    public void testNodeJoinFailureWithRepositoryCreationFailure() throws Exception {
+        internalCluster().startNode();
+        ensureStableCluster(1);
+
+        String nonExistentRepo = "non-existent-repo";
+
+        // Attempt to start a node that references a repository name with no type or settings configured.
+        // This should fail because the repository cannot be created without valid configuration.
+        expectThrows(Exception.class, () -> {
+            internalCluster().startNode(
+                Settings.builder()
+                    .put("node.attr.remote_store.segment.repository", nonExistentRepo)
+                    .put("node.attr.remote_store.translog.repository", nonExistentRepo)
+                    .build()
+            );
+        });
+
+        ensureStableCluster(1);
+    }
+
 }


### PR DESCRIPTION
### Description

Adds `testNodeJoinFailureWithRepositoryCreationFailure` to `RemoteStoreRepositoryRegistrationIT` — verifies that a node referencing a non-existent repository name (with no type or settings configured) is rejected during the join process.

### Related Issues

Resolves partially: https://github.com/opensearch-project/OpenSearch/issues/9675

Addresses the unchecked item: "Node join fails due to repository creation fails"

Note: The "remote store node joining non-remote store cluster" test case requires framework discussion (see comment on #9675).

### Check List
- [x] Functionality includes testing
- [ ] API changes companion PR created - N/A
- [ ] Public documentation issue/PR created - N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.