### PR TITLE
Fix flaky testOpenIndexOverLimit in ClusterShardLimitIT

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/shards/ClusterShardLimitIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/shards/ClusterShardLimitIT.java
@@ -40,7 +40,6 @@ import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
-import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
@@ -657,11 +656,15 @@ public class ClusterShardLimitIT extends ParameterizedStaticSettingsOpenSearchIn
                 .build()
         );
 
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        ClusterHealthResponse healthResponse = client.admin()
+            .cluster()
+            .prepareHealth("test-index-1")
+            .setWaitForGreenStatus()
+            .execute()
+            .actionGet();
         assertFalse(healthResponse.isTimedOut());
 
-        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test-index-1").execute().actionGet();
-        assertTrue(closeIndexResponse.isAcknowledged());
+        assertAcked(client.admin().indices().prepareClose("test-index-1"));
 
         // Fill up the cluster
         setMaxShardLimit(counts.getShardsPerNode(), getShardsPerNodeKey());
@@ -681,7 +684,7 @@ public class ClusterShardLimitIT extends ParameterizedStaticSettingsOpenSearchIn
             verifyException(dataNodes, counts, e);
         }
         ClusterState clusterState = client.admin().cluster().prepareState().get().getState();
-        assertFalse(clusterState.getMetadata().hasIndex("snapshot-index"));
+        assertEquals(IndexMetadata.State.CLOSE, clusterState.getMetadata().index("test-index-1").getState());
     }
 
     public void testIgnoreDotSettingOnMultipleNodes() throws IOException, InterruptedException {


### PR DESCRIPTION
Use assertAcked() for the close index operation instead of manually checking isAcknowledged(), which could return false when nodes fail to acknowledge within the default timeout on slow environments (e.g., Linux/Java 25 CI runners).

Also scope the pre-close health check to the specific index, and fix a copy-paste bug in the final assertion that was checking for 'snapshot-index' (from testRestoreSnapshotOverLimit) instead of verifying that 'test-index-1' remains in the CLOSE state.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
