### PR TITLE
Fix nightly-precommit.yml workflow

### DIFF
--- a/.github/workflows/nightly-precommit.yml
+++ b/.github/workflows/nightly-precommit.yml
@@ -35,7 +35,7 @@ jobs:
 
   open-issue-on-failure:
     if: failure() && github.event_name == 'schedule'
-    needs: precommit
+    needs: nightly-precommit
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fix `nightly-precommit.yml` workflow, as reported by Github:

```

Invalid workflow file: .github/workflows/nightly-precommit.yml#L1
(Line: 38, Col: 12): Job 'open-issue-on-failure' depends on unknown job 'precommit'.

```

### Related Issues
See please https://github.com/opensearch-project/OpenSearch/actions/runs/23740638771

<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
