### PR TITLE
Add protoc 33.0 in assemble to support datafusion branch

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -21,6 +21,25 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+      - name: Install protoc (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          if [ "$(uname -m)" = "x86_64" ]; then \
+              curl -SfL https://github.com/protocolbuffers/protobuf/releases/download/v33.0/protoc-33.0-linux-x86_64.zip -o protoc.zip; \
+          else \
+              curl -SfL https://github.com/protocolbuffers/protobuf/releases/download/v33.0/protoc-33.0-linux-aarch_64.zip -o protoc.zip; \
+          fi; \
+          unzip protoc.zip -d $HOME/.local && rm -v protoc.zip && protoc --version
+      - name: Install protoc (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        uses: MinoruSekine/setup-scoop@v4.0.2
+        with:
+          scoop_update: false
+          buckets: extras
+          apps: protobuf
+      - name: Install protoc (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        run: brew install protobuf
       - name: Remove unnecessary files Linux
         if: ${{ runner.os == 'Linux' }}
         run: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add protoc 33.0 in assemble to support datafusion branch

### Related Issues
https://github.com/opensearch-project/opensearch-build/issues/5810

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
