### PR TITLE
[RW Separation] Search only shards in the scale down state do not pull data from the remote store.

### DIFF
--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -1572,7 +1572,9 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
 
         @Override
         protected void runInternal() {
-            indexService.maybeSyncSegments(false);
+            if (shouldRun()) {
+                indexService.maybeSyncSegments(false);
+            }
         }
 
         @Override
@@ -1588,6 +1590,13 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         @Override
         protected boolean mustReschedule() {
             return indexSettings.isSegRepEnabledOrRemoteNode() && super.mustReschedule();
+        }
+
+        // visible for tests
+        protected boolean shouldRun() {
+            return false == indexSettings.getIndexMetadata()
+                .getSettings()
+                .getAsBoolean(IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING.getKey(), false);
         }
     }
 

--- a/server/src/test/java/org/opensearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexServiceTests.java
@@ -600,6 +600,7 @@ public class IndexServiceTests extends OpenSearchSingleNodeTestCase {
         task = indexService.getReplicationTask();
         assertTrue(task.isScheduled());
         assertTrue(task.mustReschedule());
+        assertTrue(task.shouldRun());
         assertEquals(5000, task.getInterval().millis());
 
         // test we can update the interval
@@ -615,7 +616,30 @@ public class IndexServiceTests extends OpenSearchSingleNodeTestCase {
         assertTrue(task.isClosed());
         assertTrue(updatedTask.isScheduled());
         assertTrue(updatedTask.mustReschedule());
+        assertTrue(updatedTask.shouldRun());
         assertEquals(1000, updatedTask.getInterval().millis());
+
+        client().admin()
+            .indices()
+            .prepareUpdateSettings("segrep_index")
+            .setSettings(Settings.builder().put(IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING.getKey(), "true"))
+            .get();
+
+        updatedTask = indexService.getReplicationTask();
+        assertTrue(updatedTask.isScheduled());
+        assertTrue(updatedTask.mustReschedule());
+        assertFalse(updatedTask.shouldRun());
+
+        client().admin()
+            .indices()
+            .prepareUpdateSettings("segrep_index")
+            .setSettings(Settings.builder().put(IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING.getKey(), "false"))
+            .get();
+
+        updatedTask = indexService.getReplicationTask();
+        assertTrue(updatedTask.isScheduled());
+        assertTrue(updatedTask.mustReschedule());
+        assertTrue(updatedTask.shouldRun());
     }
 
     public void testPublishReferencedSegmentsTask() throws Exception {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
To avoid redundant operations of pulling metadata from the remote store, we can decide whether to perform the pull action based on `INDEX_BLOCKS_SEARCH_ONLY_SETTING`.

### Related Issues
Resolves #[[21069](https://github.com/opensearch-project/OpenSearch/issues/21069)]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
