### PR TITLE
Split gradle check into parallel check and bwc jobs

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -65,6 +65,14 @@ jobs:
       issues: write # To create an issue if check fails on push.
     runs-on: ubuntu-latest
     timeout-minutes: 130
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: check
+            gradle_check_command: 'check -Dtests.coverage=true'
+          - label: bwc
+            gradle_check_command: 'bwcTestSnapshots -Dbwc.buildUnreleasedFromSource=false'
     steps:
       - name: Checkout OpenSearch repo
         uses: actions/checkout@v6
@@ -128,7 +136,7 @@ jobs:
         run: |
           set -e
           set -o pipefail
-          bash opensearch-build/scripts/gradle/gradle-check.sh -t ${{ secrets.JENKINS_GRADLE_CHECK_GENERIC_WEBHOOK_TOKEN }} -u ${{ secrets.JENKINS_GITHUB_USER}} -p ${{ secrets.JENKINS_GITHUB_USER_TOKEN}} | tee -a gradle-check.log
+          bash opensearch-build/scripts/gradle/gradle-check.sh -t ${{ secrets.JENKINS_GRADLE_CHECK_GENERIC_WEBHOOK_TOKEN }} -u ${{ secrets.JENKINS_GITHUB_USER}} -p ${{ secrets.JENKINS_GITHUB_USER_TOKEN}} -c "${{ matrix.gradle_check_command }}" | tee -a gradle-check.log
 
       - name: Setup Result Status
         if: always()
@@ -139,7 +147,7 @@ jobs:
           echo "result=$RESULT" >> $GITHUB_ENV
 
       - name: Upload Coverage Report
-        if: success()
+        if: success() && matrix.label == 'check'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -151,7 +159,7 @@ jobs:
         with:
           issue-number: ${{ env.pr_number }}
           body: |
-            :white_check_mark: Gradle check result for ${{ env.pr_from_sha }}: [${{ env.result }}](${{ env.workflow_url }})
+            :white_check_mark: Build result for **${{ matrix.label }}** (${{ env.pr_from_sha }}): [${{ env.result }}](${{ env.workflow_url }})
 
       - name: Extract Test Failure
         if: ${{ github.event_name == 'pull_request_target' && env.result != 'SUCCESS' }}
@@ -174,7 +182,7 @@ jobs:
         with:
           issue-number: ${{ env.pr_number }}
           body: |
-            :grey_exclamation: Gradle check result for ${{ env.pr_from_sha }}: [${{ env.result }}](${{ env.workflow_url }}) ${{ env.test_failures }}
+            :grey_exclamation: Build result for **${{ matrix.label }}** (${{ env.pr_from_sha }}): [${{ env.result }}](${{ env.workflow_url }}) ${{ env.test_failures }}
 
             Please review all [flaky tests](https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md#flaky-tests) that succeeded after retry and create an issue if one does not already exist to track the flaky failure.
 
@@ -184,7 +192,7 @@ jobs:
         with:
           issue-number: ${{ env.pr_number }}
           body: |
-            :x: Gradle check result for ${{ env.pr_from_sha }}: [${{ env.result }}](${{ env.workflow_url }})
+            :x: Build result for **${{ matrix.label }}** (${{ env.pr_from_sha }}): [${{ env.result }}](${{ env.workflow_url }})
 
             Please examine the workflow log, locate, and copy-paste the failure(s) below, then iterate to green. Is the failure [a flaky test](https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md#flaky-tests) unrelated to your change?
 

--- a/gradle/bwc-test.gradle
+++ b/gradle/bwc-test.gradle
@@ -35,8 +35,4 @@ tasks.withType(Test).configureEach {
   onlyIf { project.bwc_tests_enabled }
 }
 
-tasks.named("check").configure {
-  dependsOn(bwcTestSnapshots)
-}
-
 tasks.findByName("test")?.enabled = false


### PR DESCRIPTION
Run `check` and `bwcTestSnapshots` as separate matrix entries in the gradle-check GitHub Actions workflow. Remove bwcTestSnapshots as a dependency of the check task.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
