### PR TITLE
[Backport 1.3] Avoid overflow when sorting missing last on epoch_millis datetime   field

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-15]
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-15]
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Avoid overflow when sorting missing last on epoch_millis datetime field ([#12676](https://github.com/opensearch-project/OpenSearch/pull/12676))
 ### Security
 
 [Unreleased 1.3.x]: https://github.com/opensearch-project/OpenSearch/compare/1.3.20...HEAD

--- a/server/src/main/java/org/opensearch/common/time/EpochTime.java
+++ b/server/src/main/java/org/opensearch/common/time/EpochTime.java
@@ -124,7 +124,12 @@ class EpochTime {
 
         @Override
         public long getFrom(TemporalAccessor temporal) {
-            long instantSecondsInMillis = temporal.getLong(ChronoField.INSTANT_SECONDS) * 1_000;
+            long instantSeconds = temporal.getLong(ChronoField.INSTANT_SECONDS);
+            if (instantSeconds < Long.MIN_VALUE / 1000L || instantSeconds > Long.MAX_VALUE / 1000L) {
+                // Multiplying would yield integer overflow
+                return Long.MAX_VALUE;
+            }
+            long instantSecondsInMillis = instantSeconds * 1_000;
             if (instantSecondsInMillis >= 0) {
                 if (temporal.isSupported(ChronoField.NANO_OF_SECOND)) {
                     return instantSecondsInMillis + (temporal.getLong(ChronoField.NANO_OF_SECOND) / 1_000_000);

--- a/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/opensearch/common/time/DateFormattersTests.java
@@ -217,6 +217,10 @@ public class DateFormattersTests extends OpenSearchTestCase {
             assertThat(formatter.format(instant), is("-0.12345"));
             assertThat(Instant.from(formatter.parse(formatter.format(instant))), is(instant));
         }
+        {
+            Instant instant = Instant.ofEpochMilli(Long.MIN_VALUE);
+            assertThat(formatter.format(instant), is("-" + Long.MAX_VALUE)); // We actually truncate to Long.MAX_VALUE to avoid overflow
+        }
     }
 
     public void testInvalidEpochMilliParser() {


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Backport of #12676 to 1.3 branch.

Fixes #10253 for 1.3 with understanding 1.3 is not updated unless for minor security patches / no new feature development.


 When sorting a datetime field with \`epoch_millis\` formatting and putting missing values last (with a descending sort), the datetime value is \`Long.MIN_VALUE\`. Multiplying by 1000 causes integer overflow. This fix adds a bounds check to truncate to \`Long.MAX_VALUE\`.

The original PR was backported to 2.x (#12681) but not to 1.3.x. We are impacted by this bug on our OpenSearch 1.3 clusters today and would like to have this bug fixed in any subsequent 1.3.x patch if possible.

### Testing

Reproduced locally against OpenSearch 1.3.13 in Docker (can includes script)  confirmed null docs get sort value `-9223372036854775808` (Long.MIN_VALUE) on DESC sort with `missing: _last`. ASC sort works  correctly.

Signed-off-by: Cameron Durham <camdurha@amazon.com>

### Related Issues

N/A previous issue already merged.

<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable. -> N/A: bugfix
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. -> N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
