### PR TITLE
Fix ShardRoutingTests for SPLITTING state

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/routing/ShardRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/ShardRoutingTests.java
@@ -215,8 +215,8 @@ public class ShardRoutingTests extends OpenSearchTestCase {
                     }
                     break;
                 case 4:
-                    // change recovery source (only works for inactive primaries)
-                    if (otherRouting.active() || otherRouting.primary() == false) {
+                    // change recovery source (only works for unassigned/initializing primaries)
+                    if (otherRouting.active() || otherRouting.primary() == false || otherRouting.state() == ShardRoutingState.SPLITTING) {
                         unchanged = true;
                     } else {
                         otherRouting = new ShardRouting(


### PR DESCRIPTION
The testEqualsIgnoringVersion test could fail when a randomly generated shard was in SPLITTING state. Case 4 attempted to set a recovery source on the shard, but the ShardRouting constructor only allows recovery sources on UNASSIGNED or INITIALIZING shards. Add SPLITTING to the guard condition so the case is skipped.

Fixes test failures like https://build.ci.opensearch.org/job/gradle-check/73794/testReport/junit/org.opensearch.cluster.routing/ShardRoutingTests/testEqualsIgnoringVersion/

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
