### PR TITLE
Move OpenSearch-specific Jenkins file from opensearch-build

### DIFF
--- a/.ci/jenkins/gradle-check.jenkinsfile
+++ b/.ci/jenkins/gradle-check.jenkinsfile
@@ -1,0 +1,232 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+// @job-name: gradle-check
+// @description: Runs Gradle check on OpenSearch core repository for a given branch or commit.
+
+def secret_dockerhub_readonly = [
+    [envVar: 'DOCKER_USERNAME', secretRef: 'op://opensearch-infra-secrets/dockerhub-production-readonly-credentials/username'],
+    [envVar: 'DOCKER_PASSWORD', secretRef: 'op://opensearch-infra-secrets/dockerhub-production-readonly-credentials/password']
+]
+
+lib = library(identifier: 'jenkins@11.6.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
+
+pipeline {
+    agent { label AGENT_LABEL }
+    options {
+        timeout(time: 2, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '90'))
+        throttleJobProperty(
+            categories: [],
+            limitOneJobWithMatchingParams: false,
+            maxConcurrentPerNode: 0,
+            maxConcurrentTotal: 45,
+            paramsToUseForLimit: '',
+            throttleEnabled: true,
+            throttleOption: 'project',
+        )
+    }
+    parameters {
+        string(
+            name: 'GIT_REPO_URL',
+            description: 'OpenSearch core repository url on git, can be either the official upstream url or your fork url.',
+            defaultValue: 'https://github.com/opensearch-project/OpenSearch.git',
+            trim: true
+        )
+        string(
+            name: 'GIT_REFERENCE',
+            description: 'Git branch, tag, commitid for reference to checkout commit of OpenSearch core before running the gradle check.',
+            defaultValue: 'main',
+            trim: true
+        )
+        string(
+            name: 'GRADLE_CHECK_COMMAND',
+            description: '<Optional> Custom command to pass to runGradleCheck.',
+            defaultValue: 'check -Dtests.coverage=true',
+            trim: true
+        )
+        // Must use agent with 1 executor or gradle check will show a lot of java-related errors
+        // The c524xlarge is the instance type that has the least amount of errors during gradle check
+        // https://github.com/opensearch-project/OpenSearch/issues/1975
+        //
+        // Update 20230724: Recent investigation shows gradle check is memory-bound thus switch to a new
+        //                  runner of M58xlarge for more stable runs
+        //                  https://github.com/opensearch-project/opensearch-ci/issues/321
+        choice(
+            name: 'AGENT_LABEL',
+            description: '<Optional> Choose which jenkins agent to run gradle check on. Defaults to Jenkins-Agent-Ubuntu2404-X64-M58xlarge-Single-Host.',
+            choices: ['Jenkins-Agent-Ubuntu2404-X64-M7a8xlarge-Single-Host', 'Jenkins-Agent-Windows2019-X64-C524xlarge-Single-Host'],
+        )
+    }
+    triggers {
+        GenericTrigger(
+            genericVariables: [
+                [key: 'pr_from_sha', value: '$.pr_from_sha'],
+                [key: 'pr_from_clone_url', value: '$.pr_from_clone_url'],
+                [key: 'pr_to_clone_url', value: '$.pr_to_clone_url'],
+                [key: 'pr_title', value: '$.pr_title'],
+                [key: 'pr_number', value: '$.pr_number'],
+                [key: 'post_merge_action', value: '$.post_merge_action'],
+                [key: 'pr_owner', value: '$.pr_owner'],
+                [key: 'gradle_check_command', value: '$.gradle_check_command']
+            ],
+            tokenCredentialId: 'jenkins-gradle-check-generic-webhook-token',
+            causeString: 'Triggered by PR on OpenSearch core repository',
+            printContributedVariables: false,
+            printPostContent: false
+        )
+        parameterizedCron '''
+            H */2 * * * %GIT_REFERENCE=main;AGENT_LABEL=Jenkins-Agent-Ubuntu2404-X64-M58xlarge-Single-Host
+            H 6 * * * %GIT_REFERENCE=2.19;AGENT_LABEL=Jenkins-Agent-Ubuntu2404-X64-M58xlarge-Single-Host
+        '''
+    }
+    environment {
+        BUILD_CAUSE = currentBuild.getBuildCauses()
+    }
+    stages {
+        stage('Run Gradle Check') {
+            steps {
+                script {
+
+                    // Use webhook value if provided, otherwise fall back to pipeline parameter default
+                    if (binding.hasVariable('gradle_check_command') && gradle_check_command?.trim()) {
+                        env.GRADLE_CHECK_COMMAND = gradle_check_command
+                    }
+
+                    if (!(env.GRADLE_CHECK_COMMAND ==~ /^[a-zA-Z0-9\-._=: \/*#]+$/)) {
+                        error("Invalid GRADLE_CHECK_COMMAND '${env.GRADLE_CHECK_COMMAND}': contains disallowed characters")
+                    }
+
+                    sh """
+                        set +x
+                        set -e
+                        JAVA_HOME_LIST=`env | grep JAVA | grep HOME`
+                        echo "JAVA_HOME_LIST \$JAVA_HOME_LIST"
+
+                        if [ -n "\$JAVA_HOME_LIST" ] && [ "\$JAVA_HOME_LIST" != "" ]; then
+                            for java_version in \$JAVA_HOME_LIST; do
+                                echo \$java_version
+                                java_path="`echo \$java_version | cut -d= -f2`/bin/java -version"
+                                eval \$java_path
+                            done
+                        else
+                            echo "Missing JAVA_HOME information in env vars, exit 1"
+                            exit 1
+                        fi
+                    """
+
+                    def agent_name_array = params.AGENT_LABEL.tokenize('-')
+                    def agent_name = agent_name_array[2] + " " + agent_name_array[4]
+
+                    echo("Build Cause: ${BUILD_CAUSE}")
+                    withSecrets(secrets: secret_dockerhub_readonly){
+                        def bwc_checkout_align = "false"
+
+                        def dockerLogin = sh(returnStdout: true, script: "set +x && (echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin) || echo docker error").trim()
+
+                        if (!env.BUILD_CAUSE.contains('Started by user') && !env.BUILD_CAUSE.contains('Started by timer')) {
+                            def pr_url = "${pr_to_clone_url}".replace(".git", "/pull/${pr_number}")
+                            println("Triggered by GitHub: ${pr_to_clone_url}")
+                            if ("$post_merge_action" == "true") {
+                                currentBuild.description = """runner: ${agent_name}<br><a href="${pr_to_clone_url}">Others</a>: ${pr_title}"""
+                            }
+                            else {
+                                currentBuild.description = """runner: ${agent_name}<br><a href="${pr_url}">PR #${pr_number}</a>: ${pr_title} with bwc.checkout.align=true"""
+                                bwc_checkout_align = "true"
+                            }
+
+                            abortStaleJenkinsJobs(jobName: 'gradle-check', lookupTime: 3)
+
+                            runGradleCheck(
+                                gitRepoUrl: "${pr_from_clone_url}",
+                                gitReference: "${pr_from_sha}",
+                                bwcCheckoutAlign: "${bwc_checkout_align}",
+                                command: "${GRADLE_CHECK_COMMAND}"
+                            )
+                        }
+                        else {
+                            println("Triggered by User or Triggered by Timer")
+                            def repo_url = "${GIT_REPO_URL}".replace(".git", "/commit")
+                            currentBuild.description = """runner: ${agent_name}<br>git: <a href="${GIT_REPO_URL}">${GIT_REPO_URL}</a><br>ref: <a href="${repo_url}/${GIT_REFERENCE}">${GIT_REFERENCE}</a>"""
+
+                            runGradleCheck(
+                                gitRepoUrl: "${GIT_REPO_URL}",
+                                gitReference: "${GIT_REFERENCE}",
+                                bwcCheckoutAlign: "${bwc_checkout_align}",
+                                command: "${GRADLE_CHECK_COMMAND}"
+                            )
+                        }
+
+                        sh("docker logout || echo docker error")
+                    }
+                }
+            }
+            post() {
+                failure {
+                    archiveArtifacts artifacts: '**/build/heapdump/*.hprof', allowEmptyArchive: true
+                }
+                always {
+                    sh ("cp -v `find search/build/reports/jacoco/ -name '*.xml' | head -n 1` codeCoverage.xml || echo")
+                    junit allowEmptyResults: true, testResults: '**/build/test-results/**/*.xml'
+                    archiveArtifacts artifacts: 'codeCoverage.xml', onlyIfSuccessful: true
+                    script {
+                        def invokedBy
+                        def pullRequest
+                        def pullRequestTitle
+                        def gitReference
+                        def pullRequestOwner
+                        switch (true) {
+                            case env.BUILD_CAUSE.contains('Started by user'):
+                                invokedBy = 'User'
+                                pullRequest = "null"
+                                pullRequestTitle = "null"
+                                gitReference = "${GIT_REFERENCE}"
+                                pullRequestOwner = "null"
+                                break
+                            case env.BUILD_CAUSE.contains('Started by timer'):
+                                invokedBy = 'Timer'
+                                pullRequest = "null"
+                                pullRequestTitle = "null"
+                                gitReference = "${GIT_REFERENCE}"
+                                pullRequestOwner = "null"
+                                break
+                            case "${post_merge_action}" == "true":
+                                invokedBy = 'Post Merge Action'
+                                pullRequest = "${pr_number}"
+                                pullRequestTitle = "${pr_title}"
+                                gitReference = "${pr_from_sha}"
+                                pullRequestOwner = "${pr_owner}"
+                                break
+                            default:
+                                invokedBy = 'Pull Request'
+                                pullRequest = "${pr_number}"
+                                pullRequestTitle = "${pr_title}"
+                                gitReference = "${pr_from_sha}"
+                                pullRequestOwner = "${pr_owner}"
+                        }
+                        publishGradleCheckTestResults(prNumber: "${pullRequest}" , prTitle: "${pullRequestTitle}", prOwner: "${pullRequestOwner}", invokeType: "${invokedBy}", gitReference: "${gitReference}", command: "${GRADLE_CHECK_COMMAND}")
+                        sh("rm -rf *")
+                        postCleanup()
+                    }
+                }
+            }
+        }
+    }
+    post() {
+        always {
+            script {
+                postCleanup()
+                sh "(docker logout && docker image prune -f --all) || echo docker error"
+            }
+        }
+    }
+}

--- a/.ci/jenkins/scripts/gradle-check.sh
+++ b/.ci/jenkins/scripts/gradle-check.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This script is used in OpenSearch Core repo github actions
+# To trigger Jenkins Gradle Check from a PR
+
+
+JENKINS_URL="https://build.ci.opensearch.org"
+TRIGGER_TOKEN=""
+GITHUB_USER=""
+GITHUB_TOKEN=""
+
+GRADLE_CHECK_COMMAND=""
+
+while getopts "u:t:p:c:" opt; do
+  case $opt in
+    t)
+      TRIGGER_TOKEN="$OPTARG"
+      ;;
+    u)
+      GITHUB_USER="$OPTARG"
+      ;;
+    p)
+      GITHUB_TOKEN="$OPTARG"
+      ;;
+    c)
+      GRADLE_CHECK_COMMAND="$OPTARG"
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$TRIGGER_TOKEN" ]; then
+  echo "Error: TRIGGER_TOKEN is required. Use -t option to provide it."
+  exit 1
+fi
+
+if [ -z "$GITHUB_USER" ]; then
+  echo "Error: GITHUB_USER is required. Use -u option to provide it."
+  exit 1
+fi
+
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "Error: GITHUB_TOKEN is required. Use -p option to provide it."
+  exit 1
+fi
+
+
+TIMEPASS=0
+TIMEOUT=7200
+RESULT="null"
+PR_TITLE_NEW=`echo $pr_title | tr -dc '[:alnum:] ' | tr '[:upper:]' '[:lower:]'`
+PAYLOAD_JSON="{\"pr_from_sha\": \"$pr_from_sha\", \"pr_from_clone_url\": \"$pr_from_clone_url\", \"pr_to_clone_url\": \"$pr_to_clone_url\", \"pr_title\": \"$PR_TITLE_NEW\", \"pr_number\": \"$pr_number\", \"post_merge_action\": \"$post_merge_action\", \"pr_owner\": \"$pr_owner\", \"gradle_check_command\": \"$GRADLE_CHECK_COMMAND\"}"
+
+perform_curl_and_process_with_jq() {
+    local url=$1
+    local jq_filter=$2
+    local max_retries=$3
+    local count=0
+    local success=false
+
+    while [ "$count" -lt "$max_retries" ]; do
+        response=$(curl -s -XGET "${url}api/json" --user ${GITHUB_USER}:${GITHUB_TOKEN})
+        processed_response=$(echo "$response" | jq --raw-output "$jq_filter")
+        jq_exit_code=$?
+
+        if [ "$jq_exit_code" -eq "0" ]; then
+            success=true
+            echo "$processed_response"
+            break
+        else
+            echo "Attempt $((count+1))/$max_retries failed. The jq processing failed with exit code: $jq_exit_code. Retrying..."
+        fi
+
+        count=$((count+1))
+        sleep 10
+    done
+
+    if [ "$success" != "true" ]; then
+        echo "Failed to retrieve and process data after $max_retries attempts."
+        exit 1
+    fi
+}
+
+echo "Trigger Jenkins workflows"
+JENKINS_REQ=`curl -s -XPOST \
+     -H "Authorization: Bearer $TRIGGER_TOKEN" \
+     -H "Content-Type: application/json" \
+     "$JENKINS_URL/generic-webhook-trigger/invoke" \
+     --data "$(echo $PAYLOAD_JSON)"`
+
+echo $PAYLOAD_JSON
+echo $JENKINS_REQ
+
+QUEUE_URL=$(echo $JENKINS_REQ | jq --raw-output '.jobs."gradle-check".url')
+echo QUEUE_URL $QUEUE_URL
+echo "wait for jenkins to start workflow" && sleep 15
+
+echo "Check if queue exist in Jenkins after triggering"
+if [ -z "$QUEUE_URL" ] || [ "$QUEUE_URL" != "null" ]; then
+    while [ "$RESULT" = "null" ] && [ "$TIMEPASS" -le "$TIMEOUT" ]; do
+        echo "Use queue information to find build number in Jenkins if available"
+        WORKFLOW_URL=$(curl -s -XGET ${JENKINS_URL}/${QUEUE_URL}api/json --user ${GITHUB_USER}:${GITHUB_TOKEN} | jq --raw-output .executable.url)
+        echo WORKFLOW_URL $WORKFLOW_URL
+    
+        if [ -n "$WORKFLOW_URL" ] && [ "$WORKFLOW_URL" != "null" ]; then
+    
+            RUNNING="true"
+    
+            echo "Waiting for Jenkins to complete the run"
+            while [ "$RUNNING" = "true" ] && [ "$TIMEPASS" -le "$TIMEOUT" ]; do
+                echo "Still running, wait for another 30 seconds before checking again, max timeout $TIMEOUT"
+                echo "Jenkins Workflow Url: $WORKFLOW_URL"
+                TIMEPASS=$(( TIMEPASS + 30 )) && echo time passed: $TIMEPASS
+                sleep 30
+                RUNNING=$(perform_curl_and_process_with_jq "$WORKFLOW_URL" ".building" 10)
+                echo "Workflow running status :$RUNNING"
+            done
+    
+            if [ "$RUNNING" = "true" ]; then
+                echo "Timed out"
+                RESULT="TIMEOUT"
+            else
+                echo "Complete the run, checking results now......"
+                RESULT=$(curl -s -XGET ${WORKFLOW_URL}api/json --user ${GITHUB_USER}:${GITHUB_TOKEN} | jq --raw-output .result)
+            fi
+    
+        else
+            echo "Job not started yet. Waiting for 60 seconds before next attempt."
+            TIMEPASS=$(( TIMEPASS + 60 )) && echo time passed: $TIMEPASS
+            sleep 60
+        fi
+    done
+fi
+
+echo "Please check jenkins url for logs: $WORKFLOW_URL"
+echo "Result: $RESULT"
+if [ "$RESULT" == "SUCCESS" ] || [ "$RESULT" == "UNSTABLE" ]; then
+    echo "Get codeCoverage.xml" && curl -SLO ${WORKFLOW_URL}artifact/codeCoverage.xml --user ${GITHUB_USER}:${GITHUB_TOKEN}
+else
+    exit 1
+fi

--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Checkout OpenSearch repo
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: 'main'
 
       - name: Setup environment variables (PR)
         if: github.event_name == 'pull_request_target'
@@ -117,18 +117,11 @@ jobs:
           echo "pr_or_commit_description=$(jq --ascii-output .head_commit.message $GITHUB_EVENT_PATH)" >> $GITHUB_ENV
           echo "post_merge_action=true" >> $GITHUB_ENV
 
-      - name: Checkout opensearch-build repo
-        uses: actions/checkout@v6
-        with:
-          repository: opensearch-project/opensearch-build
-          ref: main
-          path: opensearch-build
-
       - name: Trigger jenkins workflow to run gradle check
         run: |
           set -e
           set -o pipefail
-          bash opensearch-build/scripts/gradle/gradle-check.sh -t ${{ secrets.JENKINS_GRADLE_CHECK_GENERIC_WEBHOOK_TOKEN }} -u ${{ secrets.JENKINS_GITHUB_USER}} -p ${{ secrets.JENKINS_GITHUB_USER_TOKEN}} | tee -a gradle-check.log
+          bash .ci/jenkins/scripts/gradle-check.sh -t ${{ secrets.JENKINS_GRADLE_CHECK_GENERIC_WEBHOOK_TOKEN }} -u ${{ secrets.JENKINS_GITHUB_USER }} -p ${{ secrets.JENKINS_GITHUB_USER_TOKEN }} | tee -a gradle-check.log
 
       - name: Setup Result Status
         if: always()


### PR DESCRIPTION
These files are entirely related to running CI workflows against this repository. They share nothing else in opensearch-build. They belong in this repository.

### Related Issues
Resolves https://github.com/opensearch-project/opensearch-build/issues/6094

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
