### PR TITLE
Add protoc support in maven snapshots publishing

### DIFF
--- a/.github/workflows/publish-maven-snapshots.yml
+++ b/.github/workflows/publish-maven-snapshots.yml
@@ -26,7 +26,6 @@ jobs:
           java-version: 21
 
       - name: Install protoc (Linux)
-        if: ${{ runner.os == 'Linux' }}
         run: |
           if [ "$(uname -m)" = "x86_64" ]; then \
               curl -SfL https://github.com/protocolbuffers/protobuf/releases/download/v33.0/protoc-33.0-linux-x86_64.zip -o protoc.zip; \


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add protoc support in maven snapshots publishing

### Related Issues
```
Caused by:
  process didn't exit successfully: `/home/runner/work/OpenSearch/OpenSearch/sandbox/plugins/analytics-backend-datafusion/target/release/build/substrait-859e6d0cbc9375a9/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=FORCE_REBUILD
  cargo:rerun-if-changed=substrait
  cargo:rerun-if-changed=substrait/text/dialect_schema.yaml
  cargo:rerun-if-changed=substrait/text/simple_extensions_schema.yaml
  cargo:rerun-if-changed=substrait/proto/substrait/parameterized_types.proto
  cargo:rerun-if-changed=substrait/proto/substrait/extensions/extensions.proto
  cargo:rerun-if-changed=substrait/proto/substrait/type.proto
  cargo:rerun-if-changed=substrait/proto/substrait/capabilities.proto
  cargo:rerun-if-changed=substrait/proto/substrait/algebra.proto
  cargo:rerun-if-changed=substrait/proto/substrait/extended_expression.proto
  cargo:rerun-if-changed=substrait/proto/substrait/function.proto
  cargo:rerun-if-changed=substrait/proto/substrait/type_expressions.proto
  cargo:rerun-if-changed=substrait/proto/substrait/plan.proto

  --- stderr
  Error: Custom { kind: NotFound, error: "Could not find `protoc`. If `protoc` is installed, try setting the `PROTOC` environment variable to the path of the `protoc` binary. To install it on Debian, run `apt-get install protobuf-compiler`. It is also available at https://github.com/protocolbuffers/protobuf/releases  For more information: https://docs.rs/prost-build/#sourcing-protoc" }
warning: build failed, waiting for other jobs to finish...

> Task :sandbox:plugins:analytics-backend-datafusion:buildRustLibrary FAILED


[Incubating] Problems report is available at: file:///home/runner/work/OpenSearch/OpenSearch/build/reports/problems/problems-report.html
FAILURE: Build failed with an exception.
1187 actionable tasks: 1186 executed, 1 from cache

* What went wrong:
Execution failed for task ':sandbox:plugins:analytics-backend-datafusion:buildRustLibrary'.
```

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
