### PR TITLE
Adding SPLITTING state to list of active states

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/ShardRouting.java
@@ -286,11 +286,12 @@ public class ShardRouting implements Writeable, ToXContentObject {
     /**
      * Returns <code>true</code> iff the this shard is currently
      * {@link ShardRoutingState#STARTED started} or
+     * {@link ShardRoutingState#SPLITTING splitting} or
      * {@link ShardRoutingState#RELOCATING relocating} to another node.
      * Otherwise <code>false</code>
      */
     public boolean active() {
-        return started() || relocating();
+        return started() || relocating() || splitting();
     }
 
     /**

--- a/server/src/test/java/org/opensearch/cluster/routing/ShardRoutingStateSplitTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/ShardRoutingStateSplitTests.java
@@ -74,4 +74,25 @@ public class ShardRoutingStateSplitTests extends OpenSearchTestCase {
         );
         assertNull(shard.getRecoveringChildShards());
     }
+
+    public void testSplittingShardIsActive() {
+        ShardRouting splitting = new ShardRouting(
+            new ShardId("index", "uuid", 0),
+            "node1",
+            null,
+            true,
+            false,
+            ShardRoutingState.SPLITTING,
+            null,
+            null,
+            AllocationId.newInitializing(),
+            0,
+            null,
+            null
+        );
+        assertTrue(splitting.active());
+        assertTrue(splitting.splitting());
+        assertFalse(splitting.started());
+        assertFalse(splitting.relocating());
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add SPLITTING state to ShardRouting.active()

A shard in SPLITTING state is an active primary that is undergoing an in-place split. It should be considered active, similar to STARTED and RELOCATING shards.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/OpenSearch/pull/21111
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
