### PR TITLE
Preserve percolator unmapped-field behavior after mapping updates

### DIFF
--- a/modules/percolator/src/main/java/org/opensearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/opensearch/percolator/PercolatorFieldMapper.java
@@ -125,7 +125,10 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
 
     @Override
     public ParametrizedFieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), queryShardContext).init(this);
+        Builder builder = new Builder(simpleName(), queryShardContext);
+        builder.init(this);
+        builder.mapUnmappedFieldsAsText = mapUnmappedFieldsAsText;
+        return builder;
     }
 
     static class Builder extends ParametrizedFieldMapper.Builder {
@@ -133,6 +136,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
         private final Supplier<QueryShardContext> queryShardContext;
+        private boolean mapUnmappedFieldsAsText;
 
         Builder(String fieldName, Supplier<QueryShardContext> queryShardContext) {
             super(fieldName);
@@ -178,7 +182,10 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
             );
         }
 
-        private static boolean getMapUnmappedFieldAsText(Settings indexSettings) {
+        private boolean getMapUnmappedFieldAsText(Settings indexSettings) {
+            if (indexSettings.isEmpty()) {
+                return mapUnmappedFieldsAsText;
+            }
             return INDEX_MAP_UNMAPPED_FIELDS_AS_TEXT_SETTING.get(indexSettings);
         }
 

--- a/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorQuerySearchTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorQuerySearchTests.java
@@ -48,6 +48,7 @@ import org.opensearch.index.query.Operator;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.SimpleQueryStringBuilder;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.script.MockScriptPlugin;
 import org.opensearch.script.Script;
@@ -299,6 +300,53 @@ public class PercolatorQuerySearchTests extends OpenSearchSingleNodeTestCase {
             .get();
         assertHitCount(response, 1);
         assertSearchHits(response, "1");
+    }
+
+    public void testMapUnmappedFieldAsTextAfterDynamicMappingUpdate() throws IOException {
+        Settings.Builder settings = Settings.builder().put("index.percolator.map_unmapped_fields_as_text", true);
+        IndexService indexService = createIndexWithSimpleMappings("test", settings.build(), "query", "type=percolator");
+
+        client().prepareIndex("test")
+            .setId("q1")
+            .setSource(
+                jsonBuilder().startObject()
+                    .field("query", new SimpleQueryStringBuilder("test").field("unmapped_field_1").defaultOperator(Operator.AND))
+                    .endObject()
+            )
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .get();
+
+        client().prepareIndex("test")
+            .setId("doc1")
+            .setSource(jsonBuilder().startObject().field("new_dynamic_field", "triggers dynamic mapping").endObject())
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .get();
+
+        PercolatorFieldMapper.PercolatorFieldType fieldType = (PercolatorFieldMapper.PercolatorFieldType) indexService.mapperService()
+            .fieldType("query");
+        assertTrue(fieldType.mapUnmappedFieldsAsText);
+
+        client().prepareIndex("test")
+            .setId("q2")
+            .setSource(
+                jsonBuilder().startObject()
+                    .field("query", new SimpleQueryStringBuilder("test").field("unmapped_field_2").defaultOperator(Operator.AND))
+                    .endObject()
+            )
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .get();
+
+        SearchResponse response = client().prepareSearch("test")
+            .setQuery(
+                new PercolateQueryBuilder(
+                    "query",
+                    BytesReference.bytes(jsonBuilder().startObject().field("unmapped_field_2", "test").endObject()),
+                    MediaTypeRegistry.JSON
+                )
+            )
+            .get();
+        assertHitCount(response, 1);
+        assertSearchHits(response, "q2");
     }
 
     public void testRangeQueriesWithNow() throws Exception {


### PR DESCRIPTION
### Description
This change preserves `index.percolator.map_unmapped_fields_as_text` across dynamic mapping updates.

The percolator field mapper was rebuilding merged field state with empty builder settings during mapping updates, which reset the percolator field\s### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

Validation:
`./gradlew :modules:percolator:test --tests 'org.opensearch.percolator.PercolatorQuerySearchTests.testMapUnmappedFieldAsText' --tests 'org.opensearch.percolator.PercolatorQuerySearchTests.testMapUnmappedFieldAsTextAfterDynamicMappingUpdate' --tests 'org.opensearch.percolator.PercolatorFieldMapperTests.testPercolatorFieldMapperUnMappedField'`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
