### PR TITLE
Added support for search_after pagination using LogicalFilter

### DIFF
--- a/sandbox/plugins/dsl-query-executor/README.md
+++ b/sandbox/plugins/dsl-query-executor/README.md
@@ -9,9 +9,28 @@ _search request
   → SearchActionFilter (intercepts SearchAction)
     → TransportDslExecuteAction (resolves index, orchestrates pipeline)
       → SearchSourceConverter (DSL → Calcite RelNode)
+      → FilterConverter (converts query + search_after to LogicalFilter)
       → DslQueryPlanExecutor (delegates to analytics engine)
       → SearchResponseBuilder (builds SearchResponse)
 ```
+
+## Supported Features
+
+- **Query DSL**: `term`, `match_all` (via QueryTranslators)
+- **Pagination**: `search_after` with multi-field sorting (converted to filter conditions via FilterConverter)
+- **Sorting**: Field sorts with `from`/`size`
+- **Aggregations**: Metric and bucket aggregations
+
+## Key Components
+
+### FilterConverter
+
+Converts DSL `query` clauses and `search_after` pagination into Calcite `LogicalFilter` nodes:
+
+- Translates OpenSearch queries to RexNode conditions using QueryRegistry
+- Converts `search_after` values into equivalent filter predicates based on sort order
+- Supports multi-field sorting with proper precedence handling
+- Validates that `search_after` values match sort field count
 
 ## Dependencies
 

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslSearchAfterIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslSearchAfterIT.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl;
+
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.SortOrder;
+
+/**
+ * Integration tests for DSL search_after pagination.
+ */
+public class DslSearchAfterIT extends DslIntegTestBase {
+
+    public void testSearchAfterWithSingleSort() {
+        createTestIndex();
+        assertOk(search(
+            new SearchSourceBuilder()
+                .sort("price", SortOrder.ASC)
+                .searchAfter(new Object[]{1000})
+        ));
+    }
+
+    public void testSearchAfterWithMultipleSorts() {
+        createTestIndex();
+        assertOk(search(
+            new SearchSourceBuilder()
+                .sort("brand", SortOrder.ASC)
+                .sort("price", SortOrder.DESC)
+                .searchAfter(new Object[]{"brandX", 1200})
+        ));
+    }
+
+    public void testSearchAfterWithQuery() {
+        createTestIndex();
+        assertOk(search(
+            new SearchSourceBuilder()
+                .query(org.opensearch.index.query.QueryBuilders.matchAllQuery())
+                .sort("rating", SortOrder.DESC)
+                .searchAfter(new Object[]{4.0})
+        ));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/FilterConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/FilterConverter.java
@@ -10,15 +10,21 @@ package org.opensearch.dsl.converter;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.opensearch.dsl.query.QueryRegistry;
 import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.FieldSortBuilder;
+import org.opensearch.search.sort.SortOrder;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
- * Converts the DSL {@code query} clause to a {@link LogicalFilter}.
- * Skips match_all since a table scan already returns all rows.
+ * Converts the DSL {@code query} clause and {@code search_after} to a {@link LogicalFilter}.
  */
 public class FilterConverter extends AbstractDslConverter {
 
@@ -35,13 +41,83 @@ public class FilterConverter extends AbstractDslConverter {
 
     @Override
     protected boolean isApplicable(ConversionContext ctx) {
-        return ctx.getSearchSource().query() != null
-            && !(ctx.getSearchSource().query() instanceof MatchAllQueryBuilder);
+        return hasQuery(ctx) || hasSearchAfter(ctx);
     }
 
     @Override
     protected RelNode doConvert(RelNode input, ConversionContext ctx) throws ConversionException {
-        RexNode condition = queryRegistry.convert(ctx.getSearchSource().query(), ctx);
+        List<RexNode> conditions = new ArrayList<>();
+
+        if (hasQuery(ctx)) {
+            conditions.add(queryRegistry.convert(ctx.getSearchSource().query(), ctx));
+        }
+
+        if (hasSearchAfter(ctx)) {
+            conditions.add(buildSearchAfterCondition(input, ctx));
+        }
+
+        RexNode condition = conditions.size() == 1 ? conditions.get(0)
+            : ctx.getRexBuilder().makeCall(SqlStdOperatorTable.AND, conditions);
         return LogicalFilter.create(input, condition);
     }
+
+    private RexNode buildSearchAfterCondition(RelNode input, ConversionContext ctx) throws ConversionException {
+        SearchSourceBuilder ss = ctx.getSearchSource();
+        Object[] values = ss.searchAfter();
+
+        if (ss.sorts() == null || ss.sorts().isEmpty()) {
+            throw new ConversionException("search_after requires sort");
+        }
+        if (values.length != ss.sorts().size()) {
+            throw new ConversionException("search_after values must match sort fields");
+        }
+
+        List<RexNode> orConditions = new ArrayList<>();
+        for (int sortIdx = 0; sortIdx < ss.sorts().size(); sortIdx++) {
+            if (!(ss.sorts().get(sortIdx) instanceof FieldSortBuilder fieldSort)) {
+                throw new ConversionException("search_after only supports field sorts");
+            }
+
+            RelDataTypeField field = input.getRowType().getField(fieldSort.getFieldName(), false, false);
+            if (field == null) {
+                throw new ConversionException("Field not found: " + fieldSort.getFieldName());
+            }
+
+            RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
+            RexNode literal = ctx.getRexBuilder().makeLiteral(values[sortIdx], field.getType(), true);
+            RexNode comparison = fieldSort.order() == SortOrder.ASC
+                ? ctx.getRexBuilder().makeCall(SqlStdOperatorTable.GREATER_THAN, fieldRef, literal)
+                : ctx.getRexBuilder().makeCall(SqlStdOperatorTable.LESS_THAN, fieldRef, literal);
+
+            List<RexNode> equals = new ArrayList<>();
+            for (int j = 0; j < sortIdx; j++) {
+                FieldSortBuilder prev = (FieldSortBuilder) ss.sorts().get(j);
+                RelDataTypeField pf = input.getRowType().getField(prev.getFieldName(), false, false);
+                equals.add(ctx.getRexBuilder().makeCall(SqlStdOperatorTable.EQUALS,
+                    ctx.getRexBuilder().makeInputRef(pf.getType(), pf.getIndex()),
+                    ctx.getRexBuilder().makeLiteral(values[j], pf.getType(), true)));
+            }
+
+            if (equals.isEmpty()) {
+                orConditions.add(comparison);
+            } else {
+                RexNode allEquals = equals.size() == 1 ? equals.get(0)
+                    : ctx.getRexBuilder().makeCall(SqlStdOperatorTable.AND, equals);
+                orConditions.add(ctx.getRexBuilder().makeCall(SqlStdOperatorTable.AND, allEquals, comparison));
+            }
+        }
+
+        return orConditions.size() == 1 ? orConditions.get(0)
+            : ctx.getRexBuilder().makeCall(SqlStdOperatorTable.OR, orConditions);
+    }
+
+    private static boolean hasQuery(ConversionContext ctx) {
+        return ctx.getSearchSource().query() != null
+            && !(ctx.getSearchSource().query() instanceof MatchAllQueryBuilder);
+    }
+
+    private static boolean hasSearchAfter(ConversionContext ctx) {
+        return ctx.getSearchSource().searchAfter() != null && ctx.getSearchSource().searchAfter().length > 0;
+    }
 }
+

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/FilterConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/FilterConverterTests.java
@@ -18,6 +18,7 @@ import org.opensearch.dsl.TestUtils;
 import org.opensearch.dsl.query.QueryRegistryFactory;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class FilterConverterTests extends OpenSearchTestCase {
@@ -80,5 +81,110 @@ public class FilterConverterTests extends OpenSearchTestCase {
         assertTrue(result instanceof LogicalFilter);
         LogicalFilter filter = (LogicalFilter) result;
         assertTrue(filter.getCondition() instanceof org.opensearch.dsl.query.UnresolvedQueryCall);
+    }
+
+    public void testSearchAfterWithSingleSortAsc() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder()
+            .sort("price", SortOrder.ASC)
+            .searchAfter(new Object[]{100});
+        ConversionContext ctx = TestUtils.createContext(source);
+        RelNode result = converter.convert(scan, ctx);
+
+        assertTrue(result instanceof LogicalFilter);
+        RexCall condition = (RexCall) ((LogicalFilter) result).getCondition();
+        assertEquals(SqlKind.GREATER_THAN, condition.getKind());
+    }
+
+    public void testSearchAfterWithSingleSortDesc() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder()
+            .sort("price", SortOrder.DESC)
+            .searchAfter(new Object[]{100});
+        ConversionContext ctx = TestUtils.createContext(source);
+        RelNode result = converter.convert(scan, ctx);
+
+        assertTrue(result instanceof LogicalFilter);
+        RexCall condition = (RexCall) ((LogicalFilter) result).getCondition();
+        assertEquals(SqlKind.LESS_THAN, condition.getKind());
+    }
+
+    public void testSearchAfterWithMultipleSorts() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder()
+            .sort("brand", SortOrder.ASC)
+            .sort("price", SortOrder.DESC)
+            .searchAfter(new Object[]{"acme", 500});
+        ConversionContext ctx = TestUtils.createContext(source);
+        RelNode result = converter.convert(scan, ctx);
+
+        assertTrue(result instanceof LogicalFilter);
+        RexCall condition = (RexCall) ((LogicalFilter) result).getCondition();
+        assertEquals(SqlKind.OR, condition.getKind());
+    }
+
+    public void testSearchAfterWithQueryCombinesConditions() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder()
+            .query(QueryBuilders.termQuery("name", "laptop"))
+            .sort("price", SortOrder.ASC)
+            .searchAfter(new Object[]{100});
+        ConversionContext ctx = TestUtils.createContext(source);
+        RelNode result = converter.convert(scan, ctx);
+
+        assertTrue(result instanceof LogicalFilter);
+        RexCall condition = (RexCall) ((LogicalFilter) result).getCondition();
+        assertEquals(SqlKind.AND, condition.getKind());
+    }
+
+    public void testSearchAfterWithoutSortThrowsException() {
+        SearchSourceBuilder source = new SearchSourceBuilder().searchAfter(new Object[]{100});
+        ConversionContext ctx = TestUtils.createContext(source);
+
+        ConversionException ex = expectThrows(ConversionException.class, () -> converter.convert(scan, ctx));
+        assertTrue(ex.getMessage().contains("search_after requires sort"));
+    }
+
+    public void testSearchAfterValuesMismatchThrowsException() {
+        SearchSourceBuilder source = new SearchSourceBuilder()
+            .sort("price", SortOrder.ASC)
+            .searchAfter(new Object[]{100, 200});
+        ConversionContext ctx = TestUtils.createContext(source);
+
+        ConversionException ex = expectThrows(ConversionException.class, () -> converter.convert(scan, ctx));
+        assertTrue(ex.getMessage().contains("search_after values must match sort fields"));
+    }
+
+    public void testSearchAfterWithUnknownFieldThrowsException() {
+        SearchSourceBuilder source = new SearchSourceBuilder()
+            .sort("unknown", SortOrder.ASC)
+            .searchAfter(new Object[]{100});
+        ConversionContext ctx = TestUtils.createContext(source);
+
+        ConversionException ex = expectThrows(ConversionException.class, () -> converter.convert(scan, ctx));
+        assertTrue(ex.getMessage().contains("Field not found"));
+    }
+
+    public void testSearchAfterMatchesSortOrderNotSchemaOrder() throws ConversionException {
+        // Schema: name(0), price(1), brand(2), rating(3)
+        // Sort: price, name → search_after values must match this order
+        SearchSourceBuilder source = new SearchSourceBuilder()
+            .sort("price", SortOrder.ASC)
+            .sort("name", SortOrder.ASC)
+            .searchAfter(new Object[]{100, "laptop"});
+        ConversionContext ctx = TestUtils.createContext(source);
+        RelNode result = converter.convert(scan, ctx);
+
+        assertTrue(result instanceof LogicalFilter);
+        RexCall condition = (RexCall) ((LogicalFilter) result).getCondition();
+        assertEquals(SqlKind.OR, condition.getKind());
+        
+        // First OR branch: price > 100 (field index 1)
+        RexCall firstBranch = (RexCall) condition.getOperands().get(0);
+        assertEquals(SqlKind.GREATER_THAN, firstBranch.getKind());
+        assertEquals(1, ((RexInputRef) firstBranch.getOperands().get(0)).getIndex());
+        
+        // Second OR branch: price = 100 AND name > "laptop"
+        RexCall secondBranch = (RexCall) condition.getOperands().get(1);
+        assertEquals(SqlKind.AND, secondBranch.getKind());
+        RexCall nameComparison = (RexCall) secondBranch.getOperands().get(1);
+        assertEquals(SqlKind.GREATER_THAN, nameComparison.getKind());
+        assertEquals(0, ((RexInputRef) nameComparison.getOperands().get(0)).getIndex());
     }
 }


### PR DESCRIPTION
### Summary

This PR implements search_after pagination support in the DSL query executor plugin by converting pagination parameters into Calcite LogicalFilter predicates. This enables efficient
cursor-based pagination for large result sets without the performance overhead of deep pagination using from/size.
* In Lucene-based systems (like OpenSearch), search_after is applied during result collection, not after a full sort. Internally, it uses a Top-K selection algorithm backed by a priority queue (heap), which avoids sorting the entire dataset. This leads to a time complexity of approximately: O(N · log K), where N = total number of matching documents, K = page size (number of results requested).

* In contrast, a Apache Calcite-based implementation models search_after as a filter condition followed by sorting. The execution flow becomes: Filter → Sort → Limit. This reduces the dataset first (from N → M), but then performs a full sort on the filtered results. The resulting time complexity is approximately: O(N + M · log M) ≈ O(M log M), where: M = number of rows after filtering. Further optimizations may apply if indexes are available, but in general, this approach still requires sorting the reduced dataset.

Overall, we can expect some performance difference with the Calcite implementation, and there isn’t a direct alternative approach to implement it. However, the expected performance impact is likely to be minimal.

### Problem Statement

The DSL query executor previously lacked support for search_after pagination, limiting its ability to efficiently paginate through large datasets. The from/size approach becomes 
increasingly expensive for deep pagination as it requires skipping all previous results.

### Solution

Enhanced the FilterConverter to translate search_after values into equivalent filter conditions based on the sort order. The converter now:

1. Validates pagination requirements: Ensures search_after is used with sort fields and that value counts match
2. Generates filter predicates: Converts pagination values into comparison operators (>, <) based on sort direction
3. Handles multi-field sorting: Creates OR conditions with proper precedence for complex sort orders
4. Combines with existing queries: Merges search_after filters with existing query conditions using AND logic

### Technical Details

#### FilterConverter Logic

For a single sort field with ASC order:
search_after: [100]
sort: price ASC                                                                                                                                                                      
→ Filter: price > 100                                                                                                                                                                
                                                                                                                                                                                     

For multiple sort fields:
search_after: ["brandX", 1200]
sort: brand ASC, price DESC                                                                                                                                                          
→ Filter: (brand > "brandX") OR (brand = "brandX" AND price < 1200)                                                                                                                  
                                                                                                                                                                                     

This approach ensures correct pagination semantics where results continue from the last seen document according to the sort order.

#### Key Implementation Points

• **Operator selection**: ASC sorts use >, DESC sorts use <
• **Multi-field precedence**: Earlier sort fields take precedence with equality checks cascading to later fields
• **Type safety**: Uses Calcite's RexBuilder to ensure type-correct literal creation
• **Error handling**: Validates field existence, sort presence, and value count matching

### Changes

#### Core Logic (FilterConverter.java)

• Extended isApplicable() to check for both query and search_after presence
• Added buildSearchAfterCondition() to construct filter predicates from pagination values
• Implemented multi-field sort handling with proper OR/AND combinations
• Added validation for sort requirements and value count matching
• Combined query and search_after conditions using AND operator

#### Integration Tests (DslSearchAfterIT.java) - Not Working as of Now

• testSearchAfterWithSingleSort(): Validates basic single-field pagination
• testSearchAfterWithMultipleSorts(): Tests multi-field sort precedence
• testSearchAfterWithQuery(): Ensures search_after works with query filters

#### Unit Tests (FilterConverterTests.java)

• Tests for ASC/DESC sort direction handling
• Multi-field sort combination logic
• Query + search_after condition merging
• Error cases: missing sort, value count mismatch, unknown fields
• Sort order vs schema order validation

### Testing

Unit Tests: 7 new test cases covering:
• Single and multi-field sorting
• ASC/DESC direction handling
• Query combination logic
• Error conditions and validation


### Manual Testing:
Index creation:
```
% curl -k -X PUT "localhost:9200/test-index" \            
-H "Content-Type: application/json" -d'
{                        
  "settings": {               
    "number_of_shards": 1,
    "number_of_replicas": 0   
  },                     
  "mappings": {               
    "properties": {      
      "name": { "type": "keyword" },
      "age":  { "type": "integer" }
    }                         
  }
}'
{"acknowledged":true,"shards_acknowledged":true,"index":"test-index"}%                                                                                                               
```
Test data for index:
```
% curl -k -X POST "localhost:9200/test-index/_bulk" \
-H "Content-Type: application/json" -d'
{ "index": { "_id": 1 } }
{ "name": "alice", "age": 25 }
{ "index": { "_id": 2 } }
{ "name": "bob",   "age": 30 }
{ "index": { "_id": 3 } }
{ "name": "john",  "age": 30 }
{ "index": { "_id": 4 } }
{ "name": "david", "age": 35 }
{ "index": { "_id": 5 } }
{ "name": "zara",  "age": 40 }
'
{"took":787,"errors":false,"items":[{"index":{"_index":"test-index","_id":"1","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"test-index","_id":"2","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1,"status":201}},{"index":{"_index":"test-index","_id":"3","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":2,"_primary_term":1,"status":201}},{"index":{"_index":"test-index","_id":"4","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":3,"_primary_term":1,"status":201}},{"index":{"_index":"test-index","_id":"5","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":4,"_primary_term":1,"status":201}}]}%                                
% curl -k -X POST "localhost:9200/test-index/_refresh"
{"_shards":{"total":1,"successful":1,"failed":0}}%     
```
Search Query with search_after pagination:
```
% curl -k -X GET "localhost:9200/test-index/_search" \
-H "Content-Type: application/json" -d'
{
  "size": 2,
  "sort": [
    { "age": "asc" },
    { "name": "asc" }
  ],
  "search_after": [30, "bob"],
  "_source": ["name", "age"]
}' 
```

Verification of Calcite Rel node creation:
* Sort order is broken due to known issue in Sort, will be raising fix in another PR for that.
```
LogicalSort(sort0=[$1], sort1=[$0], dir0=[ASC], dir1=[ASC], fetch=[2])
  LogicalProject(name=[$1], age=[$0])
    LogicalFilter(condition=[OR(>($0, CAST(30):INTEGER), AND(=($0, CAST(30):INTEGER), >($1, CAST('bob':VARCHAR):VARCHAR)))])
      LogicalTableScan(table=[[test-index]])
```

### Check List
- [Yes] Functionality includes testing.
- [Yes ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [Yes ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
