### PR TITLE
Refactor WLM settings to use Setting objects and rename field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ As of the 3.6 release [the CHANGELOG is no longer used][1] to generate release n
 - Restore default `shard_path_type` to FIXED for snapshot repositories ([#20643](https://github.com/opensearch-project/OpenSearch/issues/20643))
 - Fix `_field_caps` returning empty results and corrupted field names for `disable_objects: true` mappings ([#20800](https://github.com/opensearch-project/OpenSearch/pull/20800))
 - Fix race condition in PeerFinder where concurrent connection attempts could fail ([#21055](https://github.com/opensearch-project/OpenSearch/pull/21055))
+- Refactor WLM settings to use Setting objects and rename field ([#21143](https://github.com/opensearch-project/OpenSearch/pull/21143))
+
 
 
 ### Dependencies

--- a/plugins/workload-management/src/javaRestTest/java/org/opensearch/rest/WorkloadManagementRestIT.java
+++ b/plugins/workload-management/src/javaRestTest/java/org/opensearch/rest/WorkloadManagementRestIT.java
@@ -148,39 +148,39 @@ public class WorkloadManagementRestIT extends OpenSearchRestTestCase {
     }
 
     public void testSearchSettings() throws Exception {
-        // Create with search_settings
+        // Create with settings
         String createJson = """
             {
                 "name": "search_test",
                 "resiliency_mode": "enforced",
                 "resource_limits": {"cpu": 0.3, "memory": 0.3},
-                "search_settings": {
-                    "timeout": "30s"
+                "settings": {
+                    "search.default_search_timeout": "30s"
                 }
             }""";
         Response response = performOperation("PUT", "_wlm/workload_group", createJson);
         assertEquals(200, response.getStatusLine().getStatusCode());
 
-        // Verify search_settings in GET response
+        // Verify settings in GET response
         Response getResponse = performOperation("GET", "_wlm/workload_group/search_test", null);
         String responseBody = EntityUtils.toString(getResponse.getEntity());
-        assertTrue(responseBody.contains("\"search_settings\""));
-        assertTrue(responseBody.contains("\"timeout\":\"30s\""));
+        assertTrue(responseBody.contains("\"settings\""));
+        assertTrue(responseBody.contains("\"search.default_search_timeout\":\"30s\""));
 
-        // Update search_settings
+        // Update settings
         String updateJson = """
             {
-                "search_settings": {
-                    "timeout": "1m"
+                "settings": {
+                    "search.default_search_timeout": "1m"
                 }
             }""";
         Response updateResponse = performOperation("PUT", "_wlm/workload_group/search_test", updateJson);
         assertEquals(200, updateResponse.getStatusLine().getStatusCode());
 
-        // Verify updated search_settings
+        // Verify updated settings
         Response getResponse2 = performOperation("GET", "_wlm/workload_group/search_test", null);
         String responseBody2 = EntityUtils.toString(getResponse2.getEntity());
-        assertTrue(responseBody2.contains("\"timeout\":\"1m\""));
+        assertTrue(responseBody2.contains("\"search.default_search_timeout\":\"1m\""));
 
         performOperation("DELETE", "_wlm/workload_group/search_test", null);
     }
@@ -201,7 +201,7 @@ public class WorkloadManagementRestIT extends OpenSearchRestTestCase {
             + memory
             + "\n"
             + "    },\n"
-            + "    \"search_settings\": {}\n"
+            + "    \"settings\": {}\n"
             + "}";
     }
 

--- a/plugins/workload-management/src/javaRestTest/java/org/opensearch/rest/WorkloadManagementRestIT.java
+++ b/plugins/workload-management/src/javaRestTest/java/org/opensearch/rest/WorkloadManagementRestIT.java
@@ -148,77 +148,65 @@ public class WorkloadManagementRestIT extends OpenSearchRestTestCase {
     }
 
     public void testSearchSettings() throws Exception {
-        // Create with search_settings
+        // Create with settings
         String createJson = """
             {
                 "name": "search_test",
                 "resiliency_mode": "enforced",
                 "resource_limits": {"cpu": 0.3, "memory": 0.3},
-                "search_settings": {
-                    "timeout": "30s"
+                "settings": {
+                    "search.default_search_timeout": "30s"
                 }
             }""";
         Response response = performOperation("PUT", "_wlm/workload_group", createJson);
         assertEquals(200, response.getStatusLine().getStatusCode());
 
-        // Verify search_settings in GET response
+        // Verify settings in GET response
         Response getResponse = performOperation("GET", "_wlm/workload_group/search_test", null);
         String responseBody = EntityUtils.toString(getResponse.getEntity());
-        assertTrue(responseBody.contains("\"search_settings\""));
-        assertTrue(responseBody.contains("\"timeout\":\"30s\""));
+        assertTrue(responseBody.contains("\"settings\""));
+        assertTrue(responseBody.contains("\"search.default_search_timeout\":\"30s\""));
 
-        // Update search_settings
+        // Update settings
         String updateJson = """
             {
-                "search_settings": {
-                    "timeout": "1m"
+                "settings": {
+                    "search.default_search_timeout": "1m"
                 }
             }""";
         Response updateResponse = performOperation("PUT", "_wlm/workload_group/search_test", updateJson);
         assertEquals(200, updateResponse.getStatusLine().getStatusCode());
 
-        // Verify updated search_settings
+        // Verify updated settings
         Response getResponse2 = performOperation("GET", "_wlm/workload_group/search_test", null);
         String responseBody2 = EntityUtils.toString(getResponse2.getEntity());
-        assertTrue(responseBody2.contains("\"timeout\":\"1m\""));
+        assertTrue(responseBody2.contains("\"search.default_search_timeout\":\"1m\""));
 
         performOperation("DELETE", "_wlm/workload_group/search_test", null);
     }
 
     static String getCreateJson(String name, String resiliencyMode, double cpu, double memory) {
-        return "{\n"
-            + "    \"name\": \""
-            + name
-            + "\",\n"
-            + "    \"resiliency_mode\": \""
-            + resiliencyMode
-            + "\",\n"
-            + "    \"resource_limits\": {\n"
-            + "        \"cpu\" : "
-            + cpu
-            + ",\n"
-            + "        \"memory\" : "
-            + memory
-            + "\n"
-            + "    },\n"
-            + "    \"search_settings\": {}\n"
-            + "}";
+        return String.format(Locale.ROOT, """
+            {
+                "name": "%s",
+                "resiliency_mode": "%s",
+                "resource_limits": {
+                    "cpu" : %s,
+                    "memory" : %s
+                },
+                "settings": {}
+            }""", name, resiliencyMode, cpu, memory);
     }
 
     static String getUpdateJson(String resiliencyMode, double cpu, double memory) {
-        return "{\n"
-            + "    \"resiliency_mode\": \""
-            + resiliencyMode
-            + "\",\n"
-            + "    \"resource_limits\": {\n"
-            + "        \"cpu\" : "
-            + cpu
-            + ",\n"
-            + "        \"memory\" : "
-            + memory
-            + "\n"
-            + "    }\n"
-            + "}";
+        return String.format(Locale.ROOT, """
+            {
+                "resiliency_mode": "%s",
+                "resource_limits": {
+                    "cpu" : %s,
+                    "memory" : %s
+                }
+            }""", resiliencyMode, cpu, memory);
     }
 
     Response performOperation(String method, String uriPath, String json) throws IOException {

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/WorkloadManagementTestUtils.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/WorkloadManagementTestUtils.java
@@ -51,7 +51,7 @@ public class WorkloadManagementTestUtils {
     public static final long TIMESTAMP_ONE = 4513232413L;
     public static final long TIMESTAMP_TWO = 4513232415L;
     public static final long TIMESTAMP_THREE = 4513232417L;
-    public static final Map<String, String> TEST_SEARCH_SETTINGS = Map.of("timeout", "30s");
+    public static final Settings TEST_SEARCH_SETTINGS = Settings.builder().put("search.default_search_timeout", "30s").build();
     public static final WorkloadGroup workloadGroupOne = builder().name(NAME_ONE)
         ._id(_ID_ONE)
         .mutableWorkloadGroupFragment(

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/CreateWorkloadGroupResponseTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/CreateWorkloadGroupResponseTests.java
@@ -52,16 +52,17 @@ public class CreateWorkloadGroupResponseTests extends OpenSearchTestCase {
         XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
         CreateWorkloadGroupResponse response = new CreateWorkloadGroupResponse(WorkloadManagementTestUtils.workloadGroupOne, RestStatus.OK);
         String actual = response.toXContent(builder, mock(ToXContent.Params.class)).toString();
-        String expected = "{\n"
-            + "  \"_id\" : \"AgfUO5Ja9yfsYlONlYi3TQ==\",\n"
-            + "  \"name\" : \"workload_group_one\",\n"
-            + "  \"resiliency_mode\" : \"monitor\",\n"
-            + "  \"resource_limits\" : {\n"
-            + "    \"memory\" : 0.3\n"
-            + "  },\n"
-            + "  \"search_settings\" : { },\n"
-            + "  \"updated_at\" : 4513232413\n"
-            + "}";
+        String expected = """
+            {
+              "_id" : "AgfUO5Ja9yfsYlONlYi3TQ==",
+              "name" : "workload_group_one",
+              "resiliency_mode" : "monitor",
+              "resource_limits" : {
+                "memory" : 0.3
+              },
+              "settings" : { },
+              "updated_at" : 4513232413
+            }""";
         assertEquals(expected, actual);
     }
 
@@ -75,18 +76,19 @@ public class CreateWorkloadGroupResponseTests extends OpenSearchTestCase {
             RestStatus.OK
         );
         String actual = response.toXContent(builder, mock(ToXContent.Params.class)).toString();
-        String expected = "{\n"
-            + "  \"_id\" : \"H6jVP6Kb0zgtZmPOmZj4UQ==\",\n"
-            + "  \"name\" : \"workload_group_three\",\n"
-            + "  \"resiliency_mode\" : \"enforced\",\n"
-            + "  \"resource_limits\" : {\n"
-            + "    \"memory\" : 0.5\n"
-            + "  },\n"
-            + "  \"search_settings\" : {\n"
-            + "    \"timeout\" : \"30s\"\n"
-            + "  },\n"
-            + "  \"updated_at\" : 4513232417\n"
-            + "}";
+        String expected = """
+            {
+              "_id" : "H6jVP6Kb0zgtZmPOmZj4UQ==",
+              "name" : "workload_group_three",
+              "resiliency_mode" : "enforced",
+              "resource_limits" : {
+                "memory" : 0.5
+              },
+              "settings" : {
+                "search.default_search_timeout" : "30s"
+              },
+              "updated_at" : 4513232417
+            }""";
         assertEquals(expected, actual);
     }
 }

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/CreateWorkloadGroupResponseTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/CreateWorkloadGroupResponseTests.java
@@ -59,7 +59,7 @@ public class CreateWorkloadGroupResponseTests extends OpenSearchTestCase {
             + "  \"resource_limits\" : {\n"
             + "    \"memory\" : 0.3\n"
             + "  },\n"
-            + "  \"search_settings\" : { },\n"
+            + "  \"settings\" : { },\n"
             + "  \"updated_at\" : 4513232413\n"
             + "}";
         assertEquals(expected, actual);
@@ -82,8 +82,8 @@ public class CreateWorkloadGroupResponseTests extends OpenSearchTestCase {
             + "  \"resource_limits\" : {\n"
             + "    \"memory\" : 0.5\n"
             + "  },\n"
-            + "  \"search_settings\" : {\n"
-            + "    \"timeout\" : \"30s\"\n"
+            + "  \"settings\" : {\n"
+            + "    \"search.default_search_timeout\" : \"30s\"\n"
             + "  },\n"
             + "  \"updated_at\" : 4513232417\n"
             + "}";

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/GetWorkloadGroupResponseTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/GetWorkloadGroupResponseTests.java
@@ -97,7 +97,7 @@ public class GetWorkloadGroupResponseTests extends OpenSearchTestCase {
                   "resource_limits" : {
                     "memory" : 0.3
                   },
-                  "search_settings" : { },
+                  "settings" : { },
                   "updated_at" : 4513232413
                 }
               ]
@@ -125,7 +125,7 @@ public class GetWorkloadGroupResponseTests extends OpenSearchTestCase {
                   "resource_limits" : {
                     "memory" : 0.3
                   },
-                  "search_settings" : { },
+                  "settings" : { },
                   "updated_at" : 4513232413
                 },
                 {
@@ -135,7 +135,7 @@ public class GetWorkloadGroupResponseTests extends OpenSearchTestCase {
                   "resource_limits" : {
                     "memory" : 0.6
                   },
-                  "search_settings" : { },
+                  "settings" : { },
                   "updated_at" : 4513232415
                 }
               ]
@@ -176,8 +176,8 @@ public class GetWorkloadGroupResponseTests extends OpenSearchTestCase {
                   "resource_limits" : {
                     "memory" : 0.5
                   },
-                  "search_settings" : {
-                    "timeout" : "30s"
+                  "settings" : {
+                    "search.default_search_timeout" : "30s"
                   },
                   "updated_at" : 4513232417
                 }

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/UpdateWorkloadGroupResponseTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/UpdateWorkloadGroupResponseTests.java
@@ -60,7 +60,7 @@ public class UpdateWorkloadGroupResponseTests extends OpenSearchTestCase {
             + "  \"resource_limits\" : {\n"
             + "    \"memory\" : 0.3\n"
             + "  },\n"
-            + "  \"search_settings\" : { },\n"
+            + "  \"settings\" : { },\n"
             + "  \"updated_at\" : 4513232413\n"
             + "}";
         assertEquals(expected, actual);
@@ -83,8 +83,8 @@ public class UpdateWorkloadGroupResponseTests extends OpenSearchTestCase {
             + "  \"resource_limits\" : {\n"
             + "    \"memory\" : 0.5\n"
             + "  },\n"
-            + "  \"search_settings\" : {\n"
-            + "    \"timeout\" : \"30s\"\n"
+            + "  \"settings\" : {\n"
+            + "    \"search.default_search_timeout\" : \"30s\"\n"
             + "  },\n"
             + "  \"updated_at\" : 4513232417\n"
             + "}";

--- a/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/UpdateWorkloadGroupResponseTests.java
+++ b/plugins/workload-management/src/test/java/org/opensearch/plugin/wlm/action/UpdateWorkloadGroupResponseTests.java
@@ -53,16 +53,17 @@ public class UpdateWorkloadGroupResponseTests extends OpenSearchTestCase {
         XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
         UpdateWorkloadGroupResponse otherResponse = new UpdateWorkloadGroupResponse(workloadGroupOne, RestStatus.OK);
         String actual = otherResponse.toXContent(builder, mock(ToXContent.Params.class)).toString();
-        String expected = "{\n"
-            + "  \"_id\" : \"AgfUO5Ja9yfsYlONlYi3TQ==\",\n"
-            + "  \"name\" : \"workload_group_one\",\n"
-            + "  \"resiliency_mode\" : \"monitor\",\n"
-            + "  \"resource_limits\" : {\n"
-            + "    \"memory\" : 0.3\n"
-            + "  },\n"
-            + "  \"search_settings\" : { },\n"
-            + "  \"updated_at\" : 4513232413\n"
-            + "}";
+        String expected = """
+            {
+              "_id" : "AgfUO5Ja9yfsYlONlYi3TQ==",
+              "name" : "workload_group_one",
+              "resiliency_mode" : "monitor",
+              "resource_limits" : {
+                "memory" : 0.3
+              },
+              "settings" : { },
+              "updated_at" : 4513232413
+            }""";
         assertEquals(expected, actual);
     }
 
@@ -76,18 +77,19 @@ public class UpdateWorkloadGroupResponseTests extends OpenSearchTestCase {
             RestStatus.OK
         );
         String actual = response.toXContent(builder, mock(ToXContent.Params.class)).toString();
-        String expected = "{\n"
-            + "  \"_id\" : \"H6jVP6Kb0zgtZmPOmZj4UQ==\",\n"
-            + "  \"name\" : \"workload_group_three\",\n"
-            + "  \"resiliency_mode\" : \"enforced\",\n"
-            + "  \"resource_limits\" : {\n"
-            + "    \"memory\" : 0.5\n"
-            + "  },\n"
-            + "  \"search_settings\" : {\n"
-            + "    \"timeout\" : \"30s\"\n"
-            + "  },\n"
-            + "  \"updated_at\" : 4513232417\n"
-            + "}";
+        String expected = """
+            {
+              "_id" : "H6jVP6Kb0zgtZmPOmZj4UQ==",
+              "name" : "workload_group_three",
+              "resiliency_mode" : "enforced",
+              "resource_limits" : {
+                "memory" : 0.5
+              },
+              "settings" : {
+                "search.default_search_timeout" : "30s"
+              },
+              "updated_at" : 4513232417
+            }""";
         assertEquals(expected, actual);
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/metadata/WorkloadGroup.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/WorkloadGroup.java
@@ -13,6 +13,7 @@ import org.opensearch.cluster.Diff;
 import org.opensearch.common.UUIDs;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ToXContentObject;
@@ -73,12 +74,12 @@ public class WorkloadGroup extends AbstractDiffable<WorkloadGroup> implements To
             throw new IllegalArgumentException("WorkloadGroup.updatedAtInMillis is not a valid epoch");
         }
 
-        // Normalize null searchSettings to empty map for storage
-        if (mutableWorkloadGroupFragment.getSearchSettings() == null) {
+        // Normalize null settings to empty Settings for storage
+        if (mutableWorkloadGroupFragment.getSettings() == null) {
             mutableWorkloadGroupFragment = new MutableWorkloadGroupFragment(
                 mutableWorkloadGroupFragment.getResiliencyMode(),
                 mutableWorkloadGroupFragment.getResourceLimits(),
-                new HashMap<>()
+                Settings.EMPTY
             );
         }
 
@@ -113,23 +114,23 @@ public class WorkloadGroup extends AbstractDiffable<WorkloadGroup> implements To
         }
         final ResiliencyMode mode = Optional.ofNullable(mutableWorkloadGroupFragment.getResiliencyMode())
             .orElse(existingGroup.getResiliencyMode());
-        // Handle search_settings update:
+        // Handle settings update:
         // null = not specified (keep existing)
-        // empty map = explicitly clear (set to empty)
-        // non-empty map = replace with new values
-        final Map<String, String> mutableFragmentSearchSettings = mutableWorkloadGroupFragment.getSearchSettings();
-        final Map<String, String> updatedSearchSettings;
-        if (mutableFragmentSearchSettings == null) {
+        // empty Settings = explicitly clear (set to empty)
+        // non-empty Settings = replace with new values
+        final Settings mutableFragmentSettings = mutableWorkloadGroupFragment.getSettings();
+        final Settings updatedSettings;
+        if (mutableFragmentSettings == null) {
             // Not specified - keep existing
-            updatedSearchSettings = new HashMap<>(existingGroup.getSearchSettings());
+            updatedSettings = Settings.builder().put(existingGroup.getSettings()).build();
         } else {
             // Specified (empty or non-empty) - use the new value
-            updatedSearchSettings = new HashMap<>(mutableFragmentSearchSettings);
+            updatedSettings = Settings.builder().put(mutableFragmentSettings).build();
         }
         return new WorkloadGroup(
             existingGroup.getName(),
             existingGroup.get_id(),
-            new MutableWorkloadGroupFragment(mode, updatedResourceLimits, updatedSearchSettings),
+            new MutableWorkloadGroupFragment(mode, updatedResourceLimits, updatedSettings),
             Instant.now().getMillis()
         );
     }
@@ -201,8 +202,9 @@ public class WorkloadGroup extends AbstractDiffable<WorkloadGroup> implements To
         return getMutableWorkloadGroupFragment().getResourceLimits();
     }
 
-    public Map<String, String> getSearchSettings() {
-        return getMutableWorkloadGroupFragment().getSearchSettings();
+    @ExperimentalApi
+    public Settings getSettings() {
+        return getMutableWorkloadGroupFragment().getSettings();
     }
 
     public String get_id() {

--- a/server/src/main/java/org/opensearch/common/settings/Settings.java
+++ b/server/src/main/java/org/opensearch/common/settings/Settings.java
@@ -590,6 +590,30 @@ public final class Settings implements ToXContentFragment {
     }
 
     /**
+     * Reads an optional {@link Settings} from the stream. Returns {@code null} if no settings were written.
+     * Counterpart to {@link #writeOptionalSettingsToStream(Settings, StreamOutput)}.
+     */
+    public static Settings readOptionalSettingsFromStream(StreamInput in) throws IOException {
+        if (in.readBoolean()) {
+            return readSettingsFromStream(in);
+        }
+        return null;
+    }
+
+    /**
+     * Writes an optional {@link Settings} to the stream. A {@code null} value is permitted.
+     * Counterpart to {@link #readOptionalSettingsFromStream(StreamInput)}.
+     */
+    public static void writeOptionalSettingsToStream(Settings settings, StreamOutput out) throws IOException {
+        if (settings != null) {
+            out.writeBoolean(true);
+            writeSettingsToStream(settings, out);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+
+    /**
      * Returns a builder to be used in order to build settings.
      */
     public static Builder builder() {

--- a/server/src/main/java/org/opensearch/wlm/MutableWorkloadGroupFragment.java
+++ b/server/src/main/java/org/opensearch/wlm/MutableWorkloadGroupFragment.java
@@ -11,6 +11,7 @@ package org.opensearch.wlm;
 import org.opensearch.Version;
 import org.opensearch.cluster.AbstractDiffable;
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -34,12 +35,12 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
 
     public static final String RESILIENCY_MODE_STRING = "resiliency_mode";
     public static final String RESOURCE_LIMITS_STRING = "resource_limits";
-    public static final String SEARCH_SETTINGS_STRING = "search_settings";
+    public static final String SETTINGS_STRING = "settings";
     private ResiliencyMode resiliencyMode;
     private Map<ResourceType, Double> resourceLimits;
-    private Map<String, String> searchSettings;
+    private Settings settings;
 
-    public static final List<String> acceptedFieldNames = List.of(RESILIENCY_MODE_STRING, RESOURCE_LIMITS_STRING, SEARCH_SETTINGS_STRING);
+    public static final List<String> acceptedFieldNames = List.of(RESILIENCY_MODE_STRING, RESOURCE_LIMITS_STRING, SETTINGS_STRING);
 
     public MutableWorkloadGroupFragment() {}
 
@@ -47,19 +48,15 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
      * Constructor for tests only. Production code should use the full constructor below.
      */
     public MutableWorkloadGroupFragment(ResiliencyMode resiliencyMode, Map<ResourceType, Double> resourceLimits) {
-        this(resiliencyMode, resourceLimits, new HashMap<>());
+        this(resiliencyMode, resourceLimits, Settings.EMPTY);
     }
 
-    public MutableWorkloadGroupFragment(
-        ResiliencyMode resiliencyMode,
-        Map<ResourceType, Double> resourceLimits,
-        Map<String, String> searchSettings
-    ) {
+    public MutableWorkloadGroupFragment(ResiliencyMode resiliencyMode, Map<ResourceType, Double> resourceLimits, Settings settings) {
         validateResourceLimits(resourceLimits);
-        WorkloadGroupSearchSettings.validateSearchSettings(searchSettings);
+        WorkloadGroupSearchSettings.validate(settings);
         this.resiliencyMode = resiliencyMode;
         this.resourceLimits = resourceLimits;
-        this.searchSettings = searchSettings;
+        this.settings = settings;
     }
 
     public MutableWorkloadGroupFragment(StreamInput in) throws IOException {
@@ -70,12 +67,19 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         }
         String updatedResiliencyMode = in.readOptionalString();
         resiliencyMode = updatedResiliencyMode == null ? null : ResiliencyMode.fromName(updatedResiliencyMode);
-        if (in.getVersion().onOrAfter(Version.V_3_6_0)) {
-            // Read null marker: true means searchSettings is null (not specified)
+        if (in.getVersion().onOrAfter(Version.V_3_7_0)) {
+            // New 3.7 format: null marker boolean then Settings object
             boolean isNull = in.readBoolean();
-            searchSettings = isNull ? null : in.readMap(StreamInput::readString, StreamInput::readString);
+            settings = isNull ? null : Settings.readSettingsFromStream(in);
+        } else if (in.getVersion().onOrAfter(Version.V_3_6_0)) {
+            // Legacy 3.6 format: read and discard (experimental API, no backward compat guarantee)
+            boolean isNull = in.readBoolean();
+            if (isNull == false) {
+                in.readMap(StreamInput::readString, StreamInput::readString);
+            }
+            settings = Settings.EMPTY;
         } else {
-            searchSettings = new HashMap<>();
+            settings = Settings.EMPTY;
         }
     }
 
@@ -105,9 +109,16 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         }
     }
 
-    static class SearchSettingsParser implements FieldParser<Map<String, String>> {
-        public Map<String, String> parseField(XContentParser parser) throws IOException {
-            return parser.mapStrings();
+    static class SearchSettingsParser implements FieldParser<Settings> {
+        public Settings parseField(XContentParser parser) throws IOException {
+            Map<String, String> rawMap = parser.mapStrings();
+            Settings.Builder builder = Settings.builder();
+            for (Map.Entry<String, String> entry : rawMap.entrySet()) {
+                builder.put(entry.getKey(), entry.getValue());
+            }
+            Settings settings = builder.build();
+            WorkloadGroupSearchSettings.validate(settings);
+            return settings;
         }
     }
 
@@ -116,7 +127,7 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
             return switch (fieldName) {
                 case RESILIENCY_MODE_STRING -> Optional.of(new ResiliencyModeParser());
                 case RESOURCE_LIMITS_STRING -> Optional.of(new ResourceLimitsParser());
-                case SEARCH_SETTINGS_STRING -> Optional.of(new SearchSettingsParser());
+                case SETTINGS_STRING -> Optional.of(new SearchSettingsParser());
                 default -> Optional.empty();
             };
         }
@@ -142,18 +153,21 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         } catch (IOException e) {
             throw new IllegalStateException("writing error encountered for the field " + RESOURCE_LIMITS_STRING);
         }
-    }, SEARCH_SETTINGS_STRING, (builder) -> {
+    }, SETTINGS_STRING, (builder) -> {
         try {
-            builder.startObject(SEARCH_SETTINGS_STRING);
-            Map<String, String> settings = searchSettings != null ? searchSettings : Map.of();
-            Map<String, String> sortedSettingsMap = new TreeMap<>(settings);
-            for (Map.Entry<String, ?> e : sortedSettingsMap.entrySet()) {
+            builder.startObject(SETTINGS_STRING);
+            Settings s = settings != null ? settings : Settings.EMPTY;
+            Map<String, String> sortedSettingsMap = new TreeMap<>();
+            for (String key : s.keySet()) {
+                sortedSettingsMap.put(key, s.get(key));
+            }
+            for (Map.Entry<String, String> e : sortedSettingsMap.entrySet()) {
                 builder.field(e.getKey(), e.getValue());
             }
             builder.endObject();
             return null;
         } catch (IOException e) {
-            throw new IllegalStateException("writing error encountered for the field " + SEARCH_SETTINGS_STRING);
+            throw new IllegalStateException("writing error encountered for the field " + SETTINGS_STRING);
         }
     });
 
@@ -169,8 +183,10 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
                 switch (field) {
                     case RESILIENCY_MODE_STRING -> setResiliencyMode((ResiliencyMode) value);
                     case RESOURCE_LIMITS_STRING -> setResourceLimits((Map<ResourceType, Double>) value);
-                    case SEARCH_SETTINGS_STRING -> setSearchSettings((Map<String, String>) value);
+                    case SETTINGS_STRING -> setSettings((Settings) value);
                 }
+            } catch (IllegalArgumentException e) {
+                throw e;
             } catch (IOException e) {
                 throw new IllegalArgumentException(String.format(Locale.ROOT, "parsing error encountered for the field '%s'", field));
             }
@@ -190,11 +206,16 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
             out.writeMap(resourceLimits, ResourceType::writeTo, StreamOutput::writeDouble);
         }
         out.writeOptionalString(resiliencyMode == null ? null : resiliencyMode.getName());
-        if (out.getVersion().onOrAfter(Version.V_3_6_0)) {
-            out.writeBoolean(searchSettings == null);
-            if (searchSettings != null) {
-                out.writeMap(searchSettings, StreamOutput::writeString, StreamOutput::writeString);
+        if (out.getVersion().onOrAfter(Version.V_3_7_0)) {
+            // New 3.7 format: null marker boolean then Settings object
+            out.writeBoolean(settings == null);
+            if (settings != null) {
+                Settings.writeSettingsToStream(settings, out);
             }
+        } else if (out.getVersion().onOrAfter(Version.V_3_6_0)) {
+            // Legacy 3.6 format: write empty map (experimental API, settings not preserved across versions)
+            out.writeBoolean(false);
+            out.writeMap(Map.of(), StreamOutput::writeString, StreamOutput::writeString);
         }
     }
 
@@ -220,12 +241,12 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         MutableWorkloadGroupFragment that = (MutableWorkloadGroupFragment) o;
         return Objects.equals(resiliencyMode, that.resiliencyMode)
             && Objects.equals(resourceLimits, that.resourceLimits)
-            && Objects.equals(searchSettings, that.searchSettings);
+            && Objects.equals(settings, that.settings);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(resiliencyMode, resourceLimits, searchSettings);
+        return Objects.hash(resiliencyMode, resourceLimits, settings);
     }
 
     public ResiliencyMode getResiliencyMode() {
@@ -236,8 +257,8 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         return resourceLimits;
     }
 
-    public Map<String, String> getSearchSettings() {
-        return searchSettings;
+    public Settings getSettings() {
+        return settings;
     }
 
     /**
@@ -280,8 +301,8 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         this.resourceLimits = resourceLimits;
     }
 
-    void setSearchSettings(Map<String, String> searchSettings) {
-        WorkloadGroupSearchSettings.validateSearchSettings(searchSettings);
-        this.searchSettings = searchSettings;
+    void setSettings(Settings settings) {
+        WorkloadGroupSearchSettings.validate(settings);
+        this.settings = settings;
     }
 }

--- a/server/src/main/java/org/opensearch/wlm/MutableWorkloadGroupFragment.java
+++ b/server/src/main/java/org/opensearch/wlm/MutableWorkloadGroupFragment.java
@@ -11,6 +11,7 @@ package org.opensearch.wlm;
 import org.opensearch.Version;
 import org.opensearch.cluster.AbstractDiffable;
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -34,12 +35,12 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
 
     public static final String RESILIENCY_MODE_STRING = "resiliency_mode";
     public static final String RESOURCE_LIMITS_STRING = "resource_limits";
-    public static final String SEARCH_SETTINGS_STRING = "search_settings";
+    public static final String SETTINGS_STRING = "settings";
     private ResiliencyMode resiliencyMode;
     private Map<ResourceType, Double> resourceLimits;
-    private Map<String, String> searchSettings;
+    private Settings settings;
 
-    public static final List<String> acceptedFieldNames = List.of(RESILIENCY_MODE_STRING, RESOURCE_LIMITS_STRING, SEARCH_SETTINGS_STRING);
+    public static final List<String> acceptedFieldNames = List.of(RESILIENCY_MODE_STRING, RESOURCE_LIMITS_STRING, SETTINGS_STRING);
 
     public MutableWorkloadGroupFragment() {}
 
@@ -47,19 +48,15 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
      * Constructor for tests only. Production code should use the full constructor below.
      */
     public MutableWorkloadGroupFragment(ResiliencyMode resiliencyMode, Map<ResourceType, Double> resourceLimits) {
-        this(resiliencyMode, resourceLimits, new HashMap<>());
+        this(resiliencyMode, resourceLimits, Settings.EMPTY);
     }
 
-    public MutableWorkloadGroupFragment(
-        ResiliencyMode resiliencyMode,
-        Map<ResourceType, Double> resourceLimits,
-        Map<String, String> searchSettings
-    ) {
+    public MutableWorkloadGroupFragment(ResiliencyMode resiliencyMode, Map<ResourceType, Double> resourceLimits, Settings settings) {
         validateResourceLimits(resourceLimits);
-        WorkloadGroupSearchSettings.validateSearchSettings(searchSettings);
+        WorkloadGroupSearchSettings.validate(settings);
         this.resiliencyMode = resiliencyMode;
         this.resourceLimits = resourceLimits;
-        this.searchSettings = searchSettings;
+        this.settings = settings;
     }
 
     public MutableWorkloadGroupFragment(StreamInput in) throws IOException {
@@ -70,12 +67,17 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         }
         String updatedResiliencyMode = in.readOptionalString();
         resiliencyMode = updatedResiliencyMode == null ? null : ResiliencyMode.fromName(updatedResiliencyMode);
-        if (in.getVersion().onOrAfter(Version.V_3_6_0)) {
-            // Read null marker: true means searchSettings is null (not specified)
+        if (in.getVersion().onOrAfter(Version.V_3_7_0)) {
+            settings = Settings.readOptionalSettingsFromStream(in);
+        } else if (in.getVersion().onOrAfter(Version.V_3_6_0)) {
+            // Legacy 3.6 format: read and discard (experimental API, no backward compat guarantee)
             boolean isNull = in.readBoolean();
-            searchSettings = isNull ? null : in.readMap(StreamInput::readString, StreamInput::readString);
+            if (isNull == false) {
+                in.readMap(StreamInput::readString, StreamInput::readString);
+            }
+            settings = Settings.EMPTY;
         } else {
-            searchSettings = new HashMap<>();
+            settings = Settings.EMPTY;
         }
     }
 
@@ -105,9 +107,11 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         }
     }
 
-    static class SearchSettingsParser implements FieldParser<Map<String, String>> {
-        public Map<String, String> parseField(XContentParser parser) throws IOException {
-            return parser.mapStrings();
+    static class SearchSettingsParser implements FieldParser<Settings> {
+        public Settings parseField(XContentParser parser) throws IOException {
+            Settings settings = Settings.fromXContent(parser);
+            WorkloadGroupSearchSettings.validate(settings);
+            return settings;
         }
     }
 
@@ -116,7 +120,7 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
             return switch (fieldName) {
                 case RESILIENCY_MODE_STRING -> Optional.of(new ResiliencyModeParser());
                 case RESOURCE_LIMITS_STRING -> Optional.of(new ResourceLimitsParser());
-                case SEARCH_SETTINGS_STRING -> Optional.of(new SearchSettingsParser());
+                case SETTINGS_STRING -> Optional.of(new SearchSettingsParser());
                 default -> Optional.empty();
             };
         }
@@ -142,18 +146,21 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         } catch (IOException e) {
             throw new IllegalStateException("writing error encountered for the field " + RESOURCE_LIMITS_STRING);
         }
-    }, SEARCH_SETTINGS_STRING, (builder) -> {
+    }, SETTINGS_STRING, (builder) -> {
         try {
-            builder.startObject(SEARCH_SETTINGS_STRING);
-            Map<String, String> settings = searchSettings != null ? searchSettings : Map.of();
-            Map<String, String> sortedSettingsMap = new TreeMap<>(settings);
-            for (Map.Entry<String, ?> e : sortedSettingsMap.entrySet()) {
+            builder.startObject(SETTINGS_STRING);
+            Settings s = settings != null ? settings : Settings.EMPTY;
+            Map<String, String> sortedSettingsMap = new TreeMap<>();
+            for (String key : s.keySet()) {
+                sortedSettingsMap.put(key, s.get(key));
+            }
+            for (Map.Entry<String, String> e : sortedSettingsMap.entrySet()) {
                 builder.field(e.getKey(), e.getValue());
             }
             builder.endObject();
             return null;
         } catch (IOException e) {
-            throw new IllegalStateException("writing error encountered for the field " + SEARCH_SETTINGS_STRING);
+            throw new IllegalStateException("writing error encountered for the field " + SETTINGS_STRING);
         }
     });
 
@@ -169,8 +176,10 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
                 switch (field) {
                     case RESILIENCY_MODE_STRING -> setResiliencyMode((ResiliencyMode) value);
                     case RESOURCE_LIMITS_STRING -> setResourceLimits((Map<ResourceType, Double>) value);
-                    case SEARCH_SETTINGS_STRING -> setSearchSettings((Map<String, String>) value);
+                    case SETTINGS_STRING -> setSettings((Settings) value);
                 }
+            } catch (IllegalArgumentException e) {
+                throw e;
             } catch (IOException e) {
                 throw new IllegalArgumentException(String.format(Locale.ROOT, "parsing error encountered for the field '%s'", field));
             }
@@ -190,11 +199,12 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
             out.writeMap(resourceLimits, ResourceType::writeTo, StreamOutput::writeDouble);
         }
         out.writeOptionalString(resiliencyMode == null ? null : resiliencyMode.getName());
-        if (out.getVersion().onOrAfter(Version.V_3_6_0)) {
-            out.writeBoolean(searchSettings == null);
-            if (searchSettings != null) {
-                out.writeMap(searchSettings, StreamOutput::writeString, StreamOutput::writeString);
-            }
+        if (out.getVersion().onOrAfter(Version.V_3_7_0)) {
+            Settings.writeOptionalSettingsToStream(settings, out);
+        } else if (out.getVersion().onOrAfter(Version.V_3_6_0)) {
+            // Legacy 3.6 format: write empty map (experimental API, settings not preserved across versions)
+            out.writeBoolean(false);
+            out.writeMap(Map.of(), StreamOutput::writeString, StreamOutput::writeString);
         }
     }
 
@@ -220,12 +230,12 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         MutableWorkloadGroupFragment that = (MutableWorkloadGroupFragment) o;
         return Objects.equals(resiliencyMode, that.resiliencyMode)
             && Objects.equals(resourceLimits, that.resourceLimits)
-            && Objects.equals(searchSettings, that.searchSettings);
+            && Objects.equals(settings, that.settings);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(resiliencyMode, resourceLimits, searchSettings);
+        return Objects.hash(resiliencyMode, resourceLimits, settings);
     }
 
     public ResiliencyMode getResiliencyMode() {
@@ -236,8 +246,8 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         return resourceLimits;
     }
 
-    public Map<String, String> getSearchSettings() {
-        return searchSettings;
+    public Settings getSettings() {
+        return settings;
     }
 
     /**
@@ -280,8 +290,8 @@ public class MutableWorkloadGroupFragment extends AbstractDiffable<MutableWorklo
         this.resourceLimits = resourceLimits;
     }
 
-    void setSearchSettings(Map<String, String> searchSettings) {
-        WorkloadGroupSearchSettings.validateSearchSettings(searchSettings);
-        this.searchSettings = searchSettings;
+    void setSettings(Settings settings) {
+        WorkloadGroupSearchSettings.validate(settings);
+        this.settings = settings;
     }
 }

--- a/server/src/main/java/org/opensearch/wlm/WorkloadGroupSearchSettings.java
+++ b/server/src/main/java/org/opensearch/wlm/WorkloadGroupSearchSettings.java
@@ -8,14 +8,20 @@
 
 package org.opensearch.wlm;
 
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 
 import java.util.Map;
-import java.util.function.Function;
 
 /**
- * Registry of valid workload group search settings with their validators
+ * Registry of valid workload group settings with their validators.
+ * <p>
+ * Each WLM setting is defined as a {@link Setting} object with proper type validation,
+ * default values, and documentation.
  */
+@ExperimentalApi
 public class WorkloadGroupSearchSettings {
 
     /**
@@ -26,92 +32,48 @@ public class WorkloadGroupSearchSettings {
     }
 
     /**
-     * Enum defining valid workload group search settings with their validation logic.
-     * Settings are categorized as either query parameters or cluster settings.
+     * The WLM search timeout setting. Uses the same key as the cluster-level setting
+     * {@code search.default_search_timeout}. A value of -1 (MINUS_ONE) means no timeout.
      */
-    public enum WlmSearchSetting {
-        // Query parameters (applied to SearchRequest)
-        /** Setting for search request timeout */
-        TIMEOUT("timeout", WorkloadGroupSearchSettings::validateTimeValue);
-
-        private final String settingName;
-        private final Function<String, String> validator;
-
-        WlmSearchSetting(String settingName, Function<String, String> validator) {
-            this.settingName = settingName;
-            this.validator = validator;
-        }
-
-        /**
-         * Returns the setting name.
-         * @return the setting name
-         */
-        public String getSettingName() {
-            return settingName;
-        }
-
-        /**
-         * Validates the given value for this setting.
-         * @param value the value to validate
-         * @throws IllegalArgumentException if the value is invalid
-         */
-        void validate(String value) {
-            String error = validator.apply(value);
-            if (error != null) {
-                throw new IllegalArgumentException("Invalid value '" + value + "' for " + settingName + ": " + error);
-            }
-        }
-
-        /**
-         * Finds a setting by its name.
-         * @param settingName the setting name
-         * @return the setting or null if not found
-         */
-        public static WlmSearchSetting fromKey(String settingName) {
-            for (WlmSearchSetting setting : values()) {
-                if (setting.settingName.equals(settingName)) {
-                    return setting;
-                }
-            }
-            return null;
-        }
-    }
+    public static final Setting<TimeValue> WLM_SEARCH_TIMEOUT = Setting.timeSetting("search.default_search_timeout", TimeValue.MINUS_ONE);
 
     /**
-     * Validates all search settings in the provided map.
-     * @param searchSettings map of setting names to values
-     * @throws IllegalArgumentException if any setting is unknown or invalid
+     * All registered WLM settings, keyed by their canonical key name.
      */
-    public static void validateSearchSettings(Map<String, String> searchSettings) {
-        if (searchSettings == null) {
+    private static final Map<String, Setting<?>> REGISTERED_SETTINGS = Map.of("search.default_search_timeout", WLM_SEARCH_TIMEOUT);
+
+    /**
+     * Validates a {@link Settings} object against registered WLM settings.
+     * All keys in the settings must be registered, and all values must pass type validation.
+     *
+     * @param settings the settings to validate
+     * @throws IllegalArgumentException if any key is unknown or any value is invalid
+     */
+    public static void validate(Settings settings) {
+        if (settings == null) {
             return;
         }
-        for (Map.Entry<String, String> entry : searchSettings.entrySet()) {
-            if (entry.getKey() == null) {
-                throw new IllegalArgumentException("Search setting key cannot be null");
-            }
-            if (entry.getValue() == null) {
-                throw new IllegalArgumentException("Search setting value cannot be null for key: " + entry.getKey());
-            }
-            WlmSearchSetting setting = WlmSearchSetting.fromKey(entry.getKey());
+        for (String key : settings.keySet()) {
+            String value = settings.get(key);
+            Setting<?> setting = REGISTERED_SETTINGS.get(key);
             if (setting == null) {
-                throw new IllegalArgumentException("Unknown search setting: " + entry.getKey());
+                throw new IllegalArgumentException("Unknown WLM setting: " + key);
             }
-            setting.validate(entry.getValue());
+            try {
+                Settings testSettings = Settings.builder().put(key, value).build();
+                setting.get(testSettings);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Invalid value '" + value + "' for " + key + ": " + e.getMessage());
+            }
         }
     }
 
     /**
-     * Validates a time value string.
-     * @param value the string to validate
-     * @return null if valid, error message if invalid
+     * Returns an unmodifiable view of the registered settings.
+     *
+     * @return map of canonical key names to their {@link Setting} objects
      */
-    private static String validateTimeValue(String value) {
-        try {
-            TimeValue.parseTimeValue(value, "validation");
-            return null;
-        } catch (Exception e) {
-            return e.getMessage();
-        }
+    public static Map<String, Setting<?>> getRegisteredSettings() {
+        return REGISTERED_SETTINGS;
     }
 }

--- a/server/src/main/java/org/opensearch/wlm/listeners/WorkloadGroupRequestOperationListener.java
+++ b/server/src/main/java/org/opensearch/wlm/listeners/WorkloadGroupRequestOperationListener.java
@@ -15,13 +15,12 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchRequestContext;
 import org.opensearch.action.search.SearchRequestOperationsListener;
 import org.opensearch.cluster.metadata.WorkloadGroup;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.wlm.WorkloadGroupSearchSettings;
 import org.opensearch.wlm.WorkloadGroupService;
 import org.opensearch.wlm.WorkloadGroupTask;
-
-import java.util.Map;
 
 /**
  * This listener is used to listen for request lifecycle events for a workloadGroup
@@ -73,30 +72,15 @@ public class WorkloadGroupRequestOperationListener extends SearchRequestOperatio
             return;
         }
 
-        // Loop through WLM group search settings and apply them as needed
-        for (Map.Entry<String, String> entry : workloadGroup.getSearchSettings().entrySet()) {
+        Settings wlmSettings = workloadGroup.getSettings();
+        if (wlmSettings != null && wlmSettings.hasValue(WorkloadGroupSearchSettings.WLM_SEARCH_TIMEOUT.getKey())) {
             try {
-                WorkloadGroupSearchSettings.WlmSearchSetting settingKey = WorkloadGroupSearchSettings.WlmSearchSetting.fromKey(
-                    entry.getKey()
-                );
-                if (settingKey == null) continue;
-
-                switch (settingKey) {
-                    case TIMEOUT:
-                        // Only apply WLM timeout when the request has no explicit timeout
-                        if (searchRequest.source() != null && searchRequest.source().timeout() == null) {
-                            searchRequest.source()
-                                .timeout(
-                                    TimeValue.parseTimeValue(
-                                        entry.getValue(),
-                                        WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT.getSettingName()
-                                    )
-                                );
-                        }
-                        break;
+                TimeValue timeout = WorkloadGroupSearchSettings.WLM_SEARCH_TIMEOUT.get(wlmSettings);
+                if (searchRequest.source() != null && searchRequest.source().timeout() == null) {
+                    searchRequest.source().timeout(timeout);
                 }
             } catch (Exception e) {
-                logger.error("Failed to apply workload group setting [{}={}]: {}", entry.getKey(), entry.getValue(), e);
+                logger.error("Failed to apply workload group settings", e);
             }
         }
     }

--- a/server/src/test/java/org/opensearch/cluster/metadata/WorkloadGroupMetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/WorkloadGroupMetadataTests.java
@@ -50,7 +50,7 @@ public class WorkloadGroupMetadataTests extends AbstractDiffableSerializationTes
         builder.endObject();
         String expected = "{\"ajakgakg983r92_4242\":{\"_id\":\"ajakgakg983r92_4242\",\"name\":\"test\","
             + "\"resiliency_mode\":\"enforced\",\"resource_limits\":{\"memory\":0.5},"
-            + "\"search_settings\":{\"timeout\":\"30s\"},"
+            + "\"settings\":{\"search.default_search_timeout\":\"30s\"},"
             + "\"updated_at\":1720047207}}";
         assertEquals(expected, builder.toString());
     }

--- a/server/src/test/java/org/opensearch/cluster/metadata/WorkloadGroupMetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/WorkloadGroupMetadataTests.java
@@ -48,10 +48,14 @@ public class WorkloadGroupMetadataTests extends AbstractDiffableSerializationTes
         builder.startObject();
         workloadGroupMetadata.toXContent(builder, null);
         builder.endObject();
-        String expected = "{\"ajakgakg983r92_4242\":{\"_id\":\"ajakgakg983r92_4242\",\"name\":\"test\","
-            + "\"resiliency_mode\":\"enforced\",\"resource_limits\":{\"memory\":0.5},"
-            + "\"search_settings\":{\"timeout\":\"30s\"},"
-            + "\"updated_at\":1720047207}}";
+        String expected = """
+            {"ajakgakg983r92_4242":{\
+            "_id":"ajakgakg983r92_4242",\
+            "name":"test",\
+            "resiliency_mode":"enforced",\
+            "resource_limits":{"memory":0.5},\
+            "settings":{"search.default_search_timeout":"30s"},\
+            "updated_at":1720047207}}""";
         assertEquals(expected, builder.toString());
     }
 

--- a/server/src/test/java/org/opensearch/cluster/metadata/WorkloadGroupTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/WorkloadGroupTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.cluster.metadata;
 
 import org.opensearch.common.UUIDs;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.xcontent.ToXContent;
@@ -18,7 +19,6 @@ import org.opensearch.test.AbstractSerializingTestCase;
 import org.opensearch.wlm.MutableWorkloadGroupFragment;
 import org.opensearch.wlm.MutableWorkloadGroupFragment.ResiliencyMode;
 import org.opensearch.wlm.ResourceType;
-import org.opensearch.wlm.WorkloadGroupSearchSettings.WlmSearchSetting;
 import org.joda.time.Instant;
 
 import java.io.IOException;
@@ -31,7 +31,7 @@ import java.util.Map;
 public class WorkloadGroupTests extends AbstractSerializingTestCase<WorkloadGroup> {
 
     private static final List<ResiliencyMode> allowedModes = List.of(ResiliencyMode.SOFT, ResiliencyMode.ENFORCED, ResiliencyMode.MONITOR);
-    public static final Map<String, String> TEST_WLM_SEARCH_SETTINGS = Map.of(WlmSearchSetting.TIMEOUT.getSettingName(), "30s");
+    public static final Settings TEST_WLM_SEARCH_SETTINGS = Settings.builder().put("search.default_search_timeout", "30s").build();
 
     static WorkloadGroup createRandomWorkloadGroup(String _id) {
         String name = randomAlphaOfLength(10);
@@ -139,8 +139,8 @@ public class WorkloadGroupTests extends AbstractSerializingTestCase<WorkloadGrou
         assertEquals(1, workloadGroup.getResourceLimits().size());
         assertTrue(allowedModes.contains(workloadGroup.getResiliencyMode()));
         assertTrue(workloadGroup.getUpdatedAtInMillis() != 0);
-        assertNotNull(workloadGroup.getSearchSettings());
-        assertEquals(TEST_WLM_SEARCH_SETTINGS, workloadGroup.getSearchSettings());
+        assertNotNull(workloadGroup.getSettings());
+        assertEquals(TEST_WLM_SEARCH_SETTINGS, workloadGroup.getSettings());
     }
 
     public void testIllegalWorkloadGroupName() {
@@ -242,11 +242,21 @@ public class WorkloadGroupTests extends AbstractSerializingTestCase<WorkloadGrou
             Locale.ROOT,
             "{\"_id\":\"%s\",\"name\":\"TestWorkloadGroup\",\"resiliency_mode\":\"enforced\","
                 + "\"resource_limits\":{\"cpu\":0.3,\"memory\":0.4},"
-                + "\"search_settings\":{\"timeout\":\"30s\"},"
+                + "\"settings\":{\"search.default_search_timeout\":\"30s\"},"
                 + "\"updated_at\":%d}",
             workloadGroupId,
             currentTimeInMillis
         );
         assertEquals(expected, builder.toString());
+    }
+
+    public void testLegacySearchSettingsFieldRejected() throws IOException {
+        String json = "{\"_id\":\"test_id\",\"name\":\"test\",\"resiliency_mode\":\"enforced\","
+            + "\"resource_limits\":{\"memory\":0.5},"
+            + "\"search_settings\":{\"timeout\":\"30s\"},"
+            + "\"updated_at\":1720047207}";
+        XContentParser parser = createParser(JsonXContent.jsonXContent, json);
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> WorkloadGroup.fromXContent(parser));
+        assertTrue(exception.getMessage().contains("search_settings"));
     }
 }

--- a/server/src/test/java/org/opensearch/wlm/WorkloadGroupSearchSettingsTests.java
+++ b/server/src/test/java/org/opensearch/wlm/WorkloadGroupSearchSettingsTests.java
@@ -8,102 +8,66 @@
 
 package org.opensearch.wlm;
 
+import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class WorkloadGroupSearchSettingsTests extends OpenSearchTestCase {
 
-    public void testEnumSettingNames() {
-        assertEquals("timeout", WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT.getSettingName());
+    public void testWlmSearchTimeoutSettingExists() {
+        assertNotNull(WorkloadGroupSearchSettings.WLM_SEARCH_TIMEOUT);
+        assertEquals("search.default_search_timeout", WorkloadGroupSearchSettings.WLM_SEARCH_TIMEOUT.getKey());
     }
 
-    public void testFromKeyValidSettings() {
-        assertEquals(WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT, WorkloadGroupSearchSettings.WlmSearchSetting.fromKey("timeout"));
+    public void testValidateSettingsValid() {
+        Settings settings = Settings.builder().put("search.default_search_timeout", "30s").build();
+        WorkloadGroupSearchSettings.validate(settings);
     }
 
-    public void testFromKeyInvalidSetting() {
-        assertNull(WorkloadGroupSearchSettings.WlmSearchSetting.fromKey("invalid_setting"));
-        assertNull(WorkloadGroupSearchSettings.WlmSearchSetting.fromKey(""));
-        assertNull(WorkloadGroupSearchSettings.WlmSearchSetting.fromKey(null));
+    public void testValidateSettingsValidTimeValues() {
+        for (String timeVal : new String[] { "30s", "5m", "1h", "500ms" }) {
+            Settings settings = Settings.builder().put("search.default_search_timeout", timeVal).build();
+            WorkloadGroupSearchSettings.validate(settings);
+        }
     }
 
-    public void testValidateTimeValue() {
-        WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT.validate("30s");
-        WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT.validate("5m");
-        WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT.validate("1h");
-    }
-
-    public void testValidateInvalidTimeValue() {
+    public void testValidateSettingsUnknownKey() {
+        Settings settings = Settings.builder().put("unknown_key", "value").build();
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> WorkloadGroupSearchSettings.WlmSearchSetting.TIMEOUT.validate("invalid")
+            () -> WorkloadGroupSearchSettings.validate(settings)
+        );
+        assertTrue(exception.getMessage().contains("Unknown WLM setting: unknown_key"));
+    }
+
+    public void testValidateSettingsInvalidValue() {
+        Settings settings = Settings.builder().put("search.default_search_timeout", "not_a_time").build();
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> WorkloadGroupSearchSettings.validate(settings)
         );
         assertTrue(exception.getMessage().contains("Invalid value"));
+        assertTrue(exception.getMessage().contains("search.default_search_timeout"));
     }
 
-    public void testValidateSearchSettingsValid() {
-        Map<String, String> settings = new HashMap<>();
-        settings.put("timeout", "30s");
-
-        // Should not throw exception
-        WorkloadGroupSearchSettings.validateSearchSettings(settings);
+    public void testValidateSettingsNull() {
+        WorkloadGroupSearchSettings.validate(null);
     }
 
-    public void testValidateSearchSettingsUnknownSetting() {
-        Map<String, String> settings = new HashMap<>();
-        settings.put("unknown_setting", "true");
+    public void testValidateSettingsEmpty() {
+        WorkloadGroupSearchSettings.validate(Settings.EMPTY);
+    }
 
+    public void testGetRegisteredSettings() {
+        assertNotNull(WorkloadGroupSearchSettings.getRegisteredSettings());
+        assertTrue(WorkloadGroupSearchSettings.getRegisteredSettings().containsKey("search.default_search_timeout"));
+    }
+
+    public void testLegacyTimeoutKeyRejected() {
+        Settings settings = Settings.builder().put("timeout", "30s").build();
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> WorkloadGroupSearchSettings.validateSearchSettings(settings)
+            () -> WorkloadGroupSearchSettings.validate(settings)
         );
-        assertTrue(exception.getMessage().contains("Unknown search setting: unknown_setting"));
-    }
-
-    public void testValidateSearchSettingsInvalidValue() {
-        Map<String, String> settings = new HashMap<>();
-        settings.put("timeout", "invalid_time");
-
-        IllegalArgumentException exception = expectThrows(
-            IllegalArgumentException.class,
-            () -> WorkloadGroupSearchSettings.validateSearchSettings(settings)
-        );
-        assertTrue(exception.getMessage().contains("Invalid value"));
-    }
-
-    public void testValidateSearchSettingsNull() {
-        // Should not throw exception for null map
-        WorkloadGroupSearchSettings.validateSearchSettings(null);
-    }
-
-    public void testValidateSearchSettingsNullKey() {
-        Map<String, String> settings = new HashMap<>();
-        settings.put(null, "30s");
-
-        IllegalArgumentException exception = expectThrows(
-            IllegalArgumentException.class,
-            () -> WorkloadGroupSearchSettings.validateSearchSettings(settings)
-        );
-        assertTrue(exception.getMessage().contains("Search setting key cannot be null"));
-    }
-
-    public void testValidateSearchSettingsNullValue() {
-        Map<String, String> settings = new HashMap<>();
-        settings.put("timeout", null);
-
-        IllegalArgumentException exception = expectThrows(
-            IllegalArgumentException.class,
-            () -> WorkloadGroupSearchSettings.validateSearchSettings(settings)
-        );
-        assertTrue(exception.getMessage().contains("Search setting value cannot be null"));
-    }
-
-    public void testValidateSearchSettingsEmpty() {
-        Map<String, String> settings = new HashMap<>();
-
-        // Should not throw exception for empty map
-        WorkloadGroupSearchSettings.validateSearchSettings(settings);
+        assertTrue(exception.getMessage().contains("Unknown WLM setting: timeout"));
     }
 }

--- a/server/src/test/java/org/opensearch/wlm/listeners/WorkloadGroupRequestOperationListenerTests.java
+++ b/server/src/test/java/org/opensearch/wlm/listeners/WorkloadGroupRequestOperationListenerTests.java
@@ -14,6 +14,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.WorkloadGroup;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
@@ -308,7 +309,7 @@ public class WorkloadGroupRequestOperationListenerTests extends OpenSearchTestCa
         mockSearchRequest.source(new SearchSourceBuilder());
 
         String wgId = "test-wg";
-        WorkloadGroup wg = createWorkloadGroup(wgId, Map.of());
+        WorkloadGroup wg = createWorkloadGroup(wgId, Settings.EMPTY);
         when(workloadGroupService.getWorkloadGroupById(wgId)).thenReturn(wg);
         testThreadPool.getThreadContext().putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, wgId);
 
@@ -322,7 +323,7 @@ public class WorkloadGroupRequestOperationListenerTests extends OpenSearchTestCa
         assertNull(mockSearchRequest.source().timeout());
 
         String wgId = "test-wg";
-        WorkloadGroup wg = createWorkloadGroup(wgId, Map.of("timeout", "1m"));
+        WorkloadGroup wg = createWorkloadGroup(wgId, Settings.builder().put("search.default_search_timeout", "1m").build());
         when(workloadGroupService.getWorkloadGroupById(wgId)).thenReturn(wg);
         testThreadPool.getThreadContext().putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, wgId);
 
@@ -335,7 +336,7 @@ public class WorkloadGroupRequestOperationListenerTests extends OpenSearchTestCa
         mockSearchRequest.source(new SearchSourceBuilder().timeout(TimeValue.timeValueSeconds(30)));
 
         String wgId = "test-wg";
-        WorkloadGroup wg = createWorkloadGroup(wgId, Map.of("timeout", "10s"));
+        WorkloadGroup wg = createWorkloadGroup(wgId, Settings.builder().put("search.default_search_timeout", "10s").build());
         when(workloadGroupService.getWorkloadGroupById(wgId)).thenReturn(wg);
         testThreadPool.getThreadContext().putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, wgId);
 
@@ -348,7 +349,7 @@ public class WorkloadGroupRequestOperationListenerTests extends OpenSearchTestCa
         assertNull(mockSearchRequest.source());
 
         String wgId = "test-wg";
-        WorkloadGroup wg = createWorkloadGroup(wgId, Map.of("timeout", "30s"));
+        WorkloadGroup wg = createWorkloadGroup(wgId, Settings.builder().put("search.default_search_timeout", "30s").build());
         when(workloadGroupService.getWorkloadGroupById(wgId)).thenReturn(wg);
         testThreadPool.getThreadContext().putHeader(WorkloadGroupTask.WORKLOAD_GROUP_ID_HEADER, wgId);
 
@@ -357,7 +358,7 @@ public class WorkloadGroupRequestOperationListenerTests extends OpenSearchTestCa
         assertNull(mockSearchRequest.source()); // Should not throw, source remains null
     }
 
-    private WorkloadGroup createWorkloadGroup(String id, Map<String, String> searchSettings) {
+    private WorkloadGroup createWorkloadGroup(String id, Settings searchSettings) {
         return new WorkloadGroup(
             "test-name",
             id,


### PR DESCRIPTION
**Description**

This PR refactors the workload group settings introduced in #20536. The `search_settings` field (added in 3.6 as `@ExperimentalApi`) is replaced with a `settings` field backed by the OpenSearch `Settings` framework instead of a raw `Map<String, String>`.

Changes:
- Rename the JSON field from `"search_settings"` to `"settings"`
- Rename the timeout key from `"timeout"` to `"search.default_search_timeout"` to match the cluster setting name
- Replace `Map<String, String>` with `Settings` objects internally
- Mark `WorkloadGroupSearchSettings` and `WorkloadGroup.getSettings()` as `@ExperimentalApi`

**Backward compatibility (3.6 → 3.7 rolling upgrade)**

- Settings configured on 3.6 workload groups do not carry forward to 3.7. Users must re-apply settings using the new `"settings"` field and `"search.default_search_timeout"` key after upgrade. This is permitted because `search_settings` was marked `@ExperimentalApi`.
- Serialization is not broken during rolling upgrade. A 3.7 node sends and receives empty/dummy values when communicating with 3.6 nodes to prevent deserialization errors. The wire format remains structurally valid in both directions.

**Testing**

**Create group with settings**
```bash
curl -s -X PUT localhost:9200/_wlm/workload_group -H 'Content-Type: application/json' -d '{
  "name": "test_group",
  "resiliency_mode": "enforced",
  "resource_limits": {"cpu": 0.3, "memory": 0.3},
  "settings": {"search.default_search_timeout": "30s"}
}'

{
    "_id": "Tt2a5BZhR7yvEyLmkBiLOg",
    "name": "test_group",
    "resiliency_mode": "enforced",
    "resource_limits": { "cpu": 0.3, "memory": 0.3 },
    "settings": { "search.default_search_timeout": "30s" },
    "updated_at": 1775177784440
}
```

**Update settings**
```bash
curl -s -X PUT localhost:9200/_wlm/workload_group/test_group -H 'Content-Type: application/json' -d '{
  "settings": {"search.default_search_timeout": "1m"}
}'

{
    "_id": "Tt2a5BZhR7yvEyLmkBiLOg",
    "name": "test_group",
    "resiliency_mode": "enforced",
    "resource_limits": { "cpu": 0.3, "memory": 0.3 },
    "settings": { "search.default_search_timeout": "1m" },
    "updated_at": 1775177797926
}
```

**Create group without settings**
```bash
curl -s -X PUT localhost:9200/_wlm/workload_group -H 'Content-Type: application/json' -d '{
  "name": "no_settings_group",
  "resiliency_mode": "soft",
  "resource_limits": {"cpu": 0.2, "memory": 0.2}
}'

{
    "_id": "dXoLfTh3QzmA54o5OHEMNA",
    "name": "no_settings_group",
    "resiliency_mode": "soft",
    "resource_limits": { "cpu": 0.2, "memory": 0.2 },
    "settings": {},
    "updated_at": 1775177804834
}
```

**Old field name "search_settings" rejected**
```bash
curl -s -X PUT localhost:9200/_wlm/workload_group -H 'Content-Type: application/json' -d '{
  "name": "bad_group",
  "resiliency_mode": "soft",
  "resource_limits": {"cpu": 0.1, "memory": 0.1},
  "search_settings": {"timeout": "30s"}
}'

{
    "error": {
        "root_cause": [{
            "type": "illegal_argument_exception",
            "reason": "search_settings is not a valid object in WorkloadGroup"
        }],
        "type": "illegal_argument_exception",
        "reason": "search_settings is not a valid object in WorkloadGroup"
    },
    "status": 400
}
```

**Old key name "timeout" rejected**
```bash
curl -s -X PUT localhost:9200/_wlm/workload_group -H 'Content-Type: application/json' -d '{
  "name": "bad_group2",
  "resiliency_mode": "soft",
  "resource_limits": {"cpu": 0.1, "memory": 0.1},
  "settings": {"timeout": "30s"}
}'

{
    "error": {
        "root_cause": [{
            "type": "illegal_argument_exception",
            "reason": "Unknown WLM setting: timeout"
        }],
        "type": "illegal_argument_exception",
        "reason": "Unknown WLM setting: timeout"
    },
    "status": 400
}
```

**Invalid time value rejected**
```bash
curl -s -X PUT localhost:9200/_wlm/workload_group -H 'Content-Type: application/json' -d '{
  "name": "bad_group3",
  "resiliency_mode": "soft",
  "resource_limits": {"cpu": 0.1, "memory": 0.1},
  "settings": {"search.default_search_timeout": "not_a_time"}
}'

{
    "error": {
        "root_cause": [{
            "type": "illegal_argument_exception",
            "reason": "Invalid value 'not_a_time' for search.default_search_timeout: failed to parse setting [search.default_search_timeout] with value [not_a_time] as a time value: unit is missing or unrecognized"
        }],
        "type": "illegal_argument_exception",
        "reason": "Invalid value 'not_a_time' for search.default_search_timeout: failed to parse setting [search.default_search_timeout] with value [not_a_time] as a time value: unit is missing or unrecognized"
    },
    "status": 400
}
```

**Update resource_limits only — settings preserved**
```bash
curl -s -X PUT localhost:9200/_wlm/workload_group/test_group -H 'Content-Type: application/json' -d '{
  "resource_limits": {"cpu": 0.4, "memory": 0.4}
}'

{
    "_id": "Tt2a5BZhR7yvEyLmkBiLOg",
    "name": "test_group",
    "resiliency_mode": "enforced",
    "resource_limits": { "cpu": 0.4, "memory": 0.4 },
    "settings": { "search.default_search_timeout": "1m" },
    "updated_at": 1775244892902
}
```

**Clear settings with empty object**
```bash
curl -s -X PUT localhost:9200/_wlm/workload_group/test_group -H 'Content-Type: application/json' -d '{
  "settings": {}
}'

{
    "_id": "Tt2a5BZhR7yvEyLmkBiLOg",
    "name": "test_group",
    "resiliency_mode": "enforced",
    "resource_limits": { "cpu": 0.4, "memory": 0.4 },
    "settings": {},
    "updated_at": 1775177841951
}
```

### Related Issues
Part of https://github.com/opensearch-project/OpenSearch/issues/20555

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
