### PR TITLE
[Feature] Coordinator-level shard pruning using @timestamp range metadata

### DIFF
--- a/server/src/main/java/org/opensearch/action/search/CoordinatorTimestampPruner.java
+++ b/server/src/main/java/org/opensearch/action/search/CoordinatorTimestampPruner.java
@@ -1,0 +1,180 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.search;
+
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexLongFieldRange;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.routing.GroupShardsIterator;
+import org.opensearch.common.time.DateFormatter;
+import org.opensearch.common.time.DateMathParser;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.LongSupplier;
+
+/**
+ * Coordinator-level utility that prunes shards based on per-index {@code @timestamp} range metadata
+ * stored in {@link IndexMetadata}. This avoids sending network {@code can_match} probes to shards
+ * whose index provably cannot contain data within the query's time range.
+ *
+ * @opensearch.experimental
+ */
+final class CoordinatorTimestampPruner {
+
+    static final String TIMESTAMP_FIELD = "@timestamp";
+
+    private CoordinatorTimestampPruner() {}
+
+    /**
+     * Examines the query for a {@code @timestamp} range filter and marks shards as skippable
+     * when their index's timestamp range metadata indicates the query cannot match.
+     *
+     * @param shardsIts    the shard iterators to potentially prune
+     * @param clusterState the current cluster state (provides IndexMetadata)
+     * @param request      the search request (provides the query)
+     */
+    static void pruneShards(
+        GroupShardsIterator<SearchShardIterator> shardsIts,
+        ClusterState clusterState,
+        SearchRequest request
+    ) {
+        SearchSourceBuilder source = request.source();
+        if (source == null || source.query() == null) {
+            return;
+        }
+
+        TimestampBounds bounds = extractTimestampBounds(source.query());
+        if (bounds == null) {
+            return;
+        }
+
+        LongSupplier nowSupplier = System::currentTimeMillis;
+        long queryMin = resolveToEpochMillis(bounds.from, bounds.format, nowSupplier, false);
+        long queryMax = resolveToEpochMillis(bounds.to, bounds.format, nowSupplier, true);
+
+        if (queryMin == Long.MIN_VALUE && queryMax == Long.MAX_VALUE) {
+            return;
+        }
+
+        for (SearchShardIterator shardIt : shardsIts) {
+            if (shardIt.skip()) {
+                continue;
+            }
+
+            IndexMetadata indexMetadata = clusterState.metadata().index(shardIt.shardId().getIndex());
+            if (indexMetadata == null) {
+                continue;
+            }
+
+            IndexLongFieldRange timestampRange = indexMetadata.getTimestampRange();
+            IndexLongFieldRange.Relation relation = timestampRange.relation(queryMin, queryMax);
+
+            if (relation == IndexLongFieldRange.Relation.DISJOINT) {
+                shardIt.resetAndSkip();
+            }
+        }
+    }
+
+    /**
+     * Extracts the tightest {@code @timestamp} range bounds from the query tree.
+     * Looks for {@link RangeQueryBuilder} targeting {@code @timestamp} at the top level
+     * or inside a {@link BoolQueryBuilder}'s {@code filter} or {@code must} clauses.
+     */
+    static TimestampBounds extractTimestampBounds(QueryBuilder query) {
+        List<RangeQueryBuilder> candidates = new ArrayList<>();
+        collectTimestampRanges(query, candidates);
+
+        if (candidates.isEmpty()) {
+            return null;
+        }
+
+        // If multiple ranges exist (e.g., in a bool filter), intersect them
+        Object from = null;
+        Object to = null;
+        String format = null;
+        for (RangeQueryBuilder range : candidates) {
+            if (range.from() != null) {
+                from = from == null ? range.from() : from; // take first non-null
+            }
+            if (range.to() != null) {
+                to = to == null ? range.to() : to;
+            }
+            if (range.format() != null && format == null) {
+                format = range.format();
+            }
+        }
+
+        if (from == null && to == null) {
+            return null;
+        }
+
+        return new TimestampBounds(from, to, format);
+    }
+
+    private static void collectTimestampRanges(QueryBuilder query, List<RangeQueryBuilder> candidates) {
+        if (query instanceof RangeQueryBuilder) {
+            RangeQueryBuilder range = (RangeQueryBuilder) query;
+            if (TIMESTAMP_FIELD.equals(range.fieldName())) {
+                candidates.add(range);
+            }
+        } else if (query instanceof BoolQueryBuilder) {
+            BoolQueryBuilder bool = (BoolQueryBuilder) query;
+            for (QueryBuilder clause : bool.filter()) {
+                collectTimestampRanges(clause, candidates);
+            }
+            for (QueryBuilder clause : bool.must()) {
+                collectTimestampRanges(clause, candidates);
+            }
+        }
+    }
+
+    /**
+     * Resolves a date value (which may be a date math expression like "now-7d" or a formatted date string)
+     * to epoch milliseconds.
+     */
+    static long resolveToEpochMillis(Object value, String format, LongSupplier nowSupplier, boolean roundUp) {
+        if (value == null) {
+            return roundUp ? Long.MAX_VALUE : Long.MIN_VALUE;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+
+        String dateStr = value.toString();
+        DateFormatter formatter = format != null
+            ? DateFormatter.forPattern(format)
+            : DateFormatter.forPattern("strict_date_optional_time||epoch_millis");
+        DateMathParser parser = formatter.toDateMathParser();
+
+        Instant instant = parser.parse(dateStr, nowSupplier, roundUp, ZoneOffset.UTC);
+        return instant.toEpochMilli();
+    }
+
+    /**
+     * Holds the extracted bounds from a {@code @timestamp} range query.
+     */
+    static class TimestampBounds {
+        final Object from;
+        final Object to;
+        final String format;
+
+        TimestampBounds(Object from, Object to, String format) {
+            this.from = from;
+            this.to = to;
+            this.format = format;
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/action/search/CoordinatorTimestampPruner.java
+++ b/server/src/main/java/org/opensearch/action/search/CoordinatorTimestampPruner.java
@@ -61,9 +61,18 @@ final class CoordinatorTimestampPruner {
             return;
         }
 
-        LongSupplier nowSupplier = System::currentTimeMillis;
-        long queryMin = resolveToEpochMillis(bounds.from, bounds.format, nowSupplier, false);
-        long queryMax = resolveToEpochMillis(bounds.to, bounds.format, nowSupplier, true);
+        final long now = System.currentTimeMillis();
+        LongSupplier nowSupplier = () -> now;
+
+        final long queryMin;
+        final long queryMax;
+        try {
+            queryMin = resolveToEpochMillis(bounds.from, bounds.format, nowSupplier, false);
+            queryMax = resolveToEpochMillis(bounds.to, bounds.format, nowSupplier, true);
+        } catch (Exception e) {
+            // If date parsing fails, fall through to shard-level can_match rather than failing the search
+            return;
+        }
 
         if (queryMin == Long.MIN_VALUE && queryMax == Long.MAX_VALUE) {
             return;
@@ -101,27 +110,49 @@ final class CoordinatorTimestampPruner {
             return null;
         }
 
-        // If multiple ranges exist (e.g., in a bool filter), intersect them
-        Object from = null;
-        Object to = null;
-        String format = null;
+        if (candidates.size() == 1) {
+            RangeQueryBuilder range = candidates.get(0);
+            if (range.from() == null && range.to() == null) {
+                return null;
+            }
+            return new TimestampBounds(range.from(), range.to(), range.format());
+        }
+
+        // Multiple @timestamp ranges exist (e.g., in a bool filter). Intersect them
+        // by resolving to epoch millis and taking the tightest bounds: max(from), min(to).
+        final long now = System.currentTimeMillis();
+        LongSupplier nowSupplier = () -> now;
+        long resolvedFrom = Long.MIN_VALUE;
+        long resolvedTo = Long.MAX_VALUE;
         for (RangeQueryBuilder range : candidates) {
             if (range.from() != null) {
-                from = from == null ? range.from() : from; // take first non-null
+                try {
+                    long candidateFrom = resolveToEpochMillis(range.from(), range.format(), nowSupplier, false);
+                    resolvedFrom = Math.max(resolvedFrom, candidateFrom);
+                } catch (Exception e) {
+                    // Cannot parse; skip this bound
+                }
             }
             if (range.to() != null) {
-                to = to == null ? range.to() : to;
-            }
-            if (range.format() != null && format == null) {
-                format = range.format();
+                try {
+                    long candidateTo = resolveToEpochMillis(range.to(), range.format(), nowSupplier, true);
+                    resolvedTo = Math.min(resolvedTo, candidateTo);
+                } catch (Exception e) {
+                    // Cannot parse; skip this bound
+                }
             }
         }
 
-        if (from == null && to == null) {
+        if (resolvedFrom == Long.MIN_VALUE && resolvedTo == Long.MAX_VALUE) {
             return null;
         }
 
-        return new TimestampBounds(from, to, format);
+        // Return pre-resolved millis values so they don't need re-parsing
+        return new TimestampBounds(
+            resolvedFrom != Long.MIN_VALUE ? resolvedFrom : null,
+            resolvedTo != Long.MAX_VALUE ? resolvedTo : null,
+            null // format not needed since values are already epoch millis
+        );
     }
 
     private static void collectTimestampRanges(QueryBuilder query, List<RangeQueryBuilder> candidates) {

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -1275,6 +1275,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         SearchRequestContext searchRequestContext
     ) {
         if (preFilter) {
+            CoordinatorTimestampPruner.pruneShards(shardIterators, clusterState, searchRequest);
             return new CanMatchPreFilterSearchPhase(
                 logger,
                 searchTransportService,

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexLongFieldRange.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexLongFieldRange.java
@@ -1,0 +1,292 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.metadata;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Represents the range of values for a long field (typically {@code @timestamp}) across an entire index.
+ * <p>
+ * This is stored in {@link IndexMetadata} as part of cluster state, enabling the coordinating node
+ * to skip indices whose timestamp range does not overlap a query's time range — without sending
+ * any network {@code can_match} probes to data nodes.
+ * <p>
+ * Three states are possible:
+ * <ul>
+ *   <li>{@link #UNKNOWN} — the range has not been computed yet. Queries must fall through to
+ *       shard-level {@code can_match}.</li>
+ *   <li>{@link #EMPTY} — the field does not exist in the index mapping or the index has no documents.
+ *       The index is guaranteed to not match any range query on this field.</li>
+ *   <li>A concrete range with known {@code min} and {@code max} values.</li>
+ * </ul>
+ *
+ * @opensearch.experimental
+ */
+public final class IndexLongFieldRange implements Writeable, ToXContentFragment {
+
+    private static final String KEY_MIN = "min";
+    private static final String KEY_MAX = "max";
+    private static final String KEY_UNKNOWN = "unknown";
+    private static final String KEY_EMPTY = "empty";
+
+    private static final byte SERIAL_UNKNOWN = 0;
+    private static final byte SERIAL_EMPTY = 1;
+    private static final byte SERIAL_RANGE = 2;
+
+    /**
+     * The range is not yet known. This is the default for all indices until the range is populated.
+     * Queries targeting this index must fall through to the existing shard-level {@code can_match} path.
+     */
+    public static final IndexLongFieldRange UNKNOWN = new IndexLongFieldRange(true, false, Long.MIN_VALUE, Long.MAX_VALUE);
+
+    /**
+     * The field does not exist in this index or the index contains no documents.
+     * Any range query on this field is guaranteed to not match.
+     */
+    public static final IndexLongFieldRange EMPTY = new IndexLongFieldRange(false, true, Long.MIN_VALUE, Long.MAX_VALUE);
+
+    private final boolean unknown;
+    private final boolean empty;
+    private final long min;
+    private final long max;
+
+    private IndexLongFieldRange(boolean unknown, boolean empty, long min, long max) {
+        this.unknown = unknown;
+        this.empty = empty;
+        this.min = min;
+        this.max = max;
+    }
+
+    /**
+     * Creates a range with known min and max values.
+     */
+    public static IndexLongFieldRange of(long min, long max) {
+        if (min > max) {
+            throw new IllegalArgumentException("min [" + min + "] must be <= max [" + max + "]");
+        }
+        return new IndexLongFieldRange(false, false, min, max);
+    }
+
+    /**
+     * Returns {@code true} if the range is not yet known.
+     */
+    public boolean isUnknown() {
+        return unknown;
+    }
+
+    /**
+     * Returns {@code true} if the field does not exist or the index has no documents.
+     */
+    public boolean isEmpty() {
+        return empty;
+    }
+
+    /**
+     * Returns the minimum value, only meaningful when neither {@link #isUnknown()} nor {@link #isEmpty()}.
+     */
+    public long getMin() {
+        return min;
+    }
+
+    /**
+     * Returns the maximum value, only meaningful when neither {@link #isUnknown()} nor {@link #isEmpty()}.
+     */
+    public long getMax() {
+        return max;
+    }
+
+    /**
+     * Determines the relation between this index's field range and the given query range.
+     *
+     * @param queryMin the lower bound of the query range (inclusive)
+     * @param queryMax the upper bound of the query range (inclusive)
+     * @return the relation
+     */
+    public Relation relation(long queryMin, long queryMax) {
+        if (unknown) {
+            return Relation.UNKNOWN;
+        }
+        if (empty) {
+            return Relation.DISJOINT;
+        }
+        if (max < queryMin || min > queryMax) {
+            return Relation.DISJOINT;
+        }
+        if (min >= queryMin && max <= queryMax) {
+            return Relation.WITHIN;
+        }
+        return Relation.INTERSECTS;
+    }
+
+    /**
+     * Returns a new range that extends this range to include the given value.
+     */
+    public IndexLongFieldRange extendWithValue(long value) {
+        if (unknown || empty) {
+            return IndexLongFieldRange.of(value, value);
+        }
+        return IndexLongFieldRange.of(Math.min(min, value), Math.max(max, value));
+    }
+
+    /**
+     * Returns a new range that is the union of this range and the given range.
+     */
+    public IndexLongFieldRange union(IndexLongFieldRange other) {
+        if (other.unknown || this.unknown) {
+            return UNKNOWN;
+        }
+        if (other.empty) {
+            return this;
+        }
+        if (this.empty) {
+            return other;
+        }
+        return IndexLongFieldRange.of(Math.min(this.min, other.min), Math.max(this.max, other.max));
+    }
+
+    // --- Serialization ---
+
+    public IndexLongFieldRange(StreamInput in) throws IOException {
+        byte type = in.readByte();
+        switch (type) {
+            case SERIAL_UNKNOWN:
+                this.unknown = true;
+                this.empty = false;
+                this.min = Long.MIN_VALUE;
+                this.max = Long.MAX_VALUE;
+                break;
+            case SERIAL_EMPTY:
+                this.unknown = false;
+                this.empty = true;
+                this.min = Long.MIN_VALUE;
+                this.max = Long.MAX_VALUE;
+                break;
+            case SERIAL_RANGE:
+                this.unknown = false;
+                this.empty = false;
+                this.min = in.readLong();
+                this.max = in.readLong();
+                break;
+            default:
+                throw new IOException("Unknown IndexLongFieldRange type: " + type);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        if (unknown) {
+            out.writeByte(SERIAL_UNKNOWN);
+        } else if (empty) {
+            out.writeByte(SERIAL_EMPTY);
+        } else {
+            out.writeByte(SERIAL_RANGE);
+            out.writeLong(min);
+            out.writeLong(max);
+        }
+    }
+
+    // --- XContent ---
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        if (unknown) {
+            builder.field(KEY_UNKNOWN, true);
+        } else if (empty) {
+            builder.field(KEY_EMPTY, true);
+        } else {
+            builder.field(KEY_MIN, min);
+            builder.field(KEY_MAX, max);
+        }
+        return builder;
+    }
+
+    public static IndexLongFieldRange fromXContent(XContentParser parser) throws IOException {
+        XContentParser.Token token;
+        String currentFieldName = null;
+        Long min = null;
+        Long max = null;
+        boolean isUnknown = false;
+        boolean isEmpty = false;
+
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token.isValue()) {
+                if (KEY_MIN.equals(currentFieldName)) {
+                    min = parser.longValue();
+                } else if (KEY_MAX.equals(currentFieldName)) {
+                    max = parser.longValue();
+                } else if (KEY_UNKNOWN.equals(currentFieldName)) {
+                    isUnknown = parser.booleanValue();
+                } else if (KEY_EMPTY.equals(currentFieldName)) {
+                    isEmpty = parser.booleanValue();
+                }
+            }
+        }
+
+        if (isUnknown) {
+            return UNKNOWN;
+        }
+        if (isEmpty) {
+            return EMPTY;
+        }
+        if (min != null && max != null) {
+            return IndexLongFieldRange.of(min, max);
+        }
+        return UNKNOWN;
+    }
+
+    // --- Object methods ---
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IndexLongFieldRange that = (IndexLongFieldRange) o;
+        return unknown == that.unknown && empty == that.empty && min == that.min && max == that.max;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(unknown, empty, min, max);
+    }
+
+    @Override
+    public String toString() {
+        if (unknown) {
+            return "IndexLongFieldRange[UNKNOWN]";
+        }
+        if (empty) {
+            return "IndexLongFieldRange[EMPTY]";
+        }
+        return "IndexLongFieldRange[" + min + "-" + max + "]";
+    }
+
+    /**
+     * The relation between an index's field range and a query range.
+     */
+    public enum Relation {
+        /** The range has not been computed; no pruning decision can be made. */
+        UNKNOWN,
+        /** The index's range does not overlap the query range at all. */
+        DISJOINT,
+        /** The index's range is entirely contained within the query range. */
+        WITHIN,
+        /** The index's range partially overlaps the query range. */
+        INTERSECTS
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexLongFieldRange.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexLongFieldRange.java
@@ -160,27 +160,19 @@ public final class IndexLongFieldRange implements Writeable, ToXContentFragment 
 
     // --- Serialization ---
 
-    public IndexLongFieldRange(StreamInput in) throws IOException {
+    /**
+     * Reads an {@link IndexLongFieldRange} from a stream. Returns singleton instances for
+     * {@link #UNKNOWN} and {@link #EMPTY} states.
+     */
+    public static IndexLongFieldRange readFrom(StreamInput in) throws IOException {
         byte type = in.readByte();
         switch (type) {
             case SERIAL_UNKNOWN:
-                this.unknown = true;
-                this.empty = false;
-                this.min = Long.MIN_VALUE;
-                this.max = Long.MAX_VALUE;
-                break;
+                return UNKNOWN;
             case SERIAL_EMPTY:
-                this.unknown = false;
-                this.empty = true;
-                this.min = Long.MIN_VALUE;
-                this.max = Long.MAX_VALUE;
-                break;
+                return EMPTY;
             case SERIAL_RANGE:
-                this.unknown = false;
-                this.empty = false;
-                this.min = in.readLong();
-                this.max = in.readLong();
-                break;
+                return IndexLongFieldRange.of(in.readLong(), in.readLong());
             default:
                 throw new IOException("Unknown IndexLongFieldRange type: " + type);
         }

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -1752,7 +1752,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             }
 
             if (in.getVersion().onOrAfter(Version.V_3_7_0)) {
-                timestampRange = new IndexLongFieldRange(in);
+                timestampRange = IndexLongFieldRange.readFrom(in);
             } else {
                 timestampRange = IndexLongFieldRange.UNKNOWN;
             }
@@ -1891,7 +1891,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         }
 
         if (in.getVersion().onOrAfter(Version.V_3_7_0)) {
-            builder.timestampRange(new IndexLongFieldRange(in));
+            builder.timestampRange(IndexLongFieldRange.readFrom(in));
         }
         return builder.build();
     }
@@ -2697,7 +2697,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 builder.endObject();
             }
 
-            if (indexMetadata.timestampRange != null && !indexMetadata.timestampRange.isUnknown()) {
+            if (indexMetadata.timestampRange != null) {
                 builder.startObject(KEY_TIMESTAMP_RANGE);
                 indexMetadata.timestampRange.toXContent(builder, params);
                 builder.endObject();

--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -1081,6 +1081,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     static final String KEY_ROLLOVER_INFOS = "rollover_info";
     static final String KEY_SYSTEM = "system";
     static final String KEY_SPLIT_SHARDS_METADATA = "split_shards_metadata";
+    static final String KEY_TIMESTAMP_RANGE = "timestamp_range";
     public static final String KEY_PRIMARY_TERMS = "primary_terms";
     public static final String KEY_PRIMARY_TERMS_MAP = "primary_terms_map";
     public static final String REMOTE_STORE_CUSTOM_KEY = "remote_store";
@@ -1150,6 +1151,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     private final SplitShardsMetadata splitShardsMetadata;
 
+    private final IndexLongFieldRange timestampRange;
+
     private IndexMetadata(
         final Index index,
         final long version,
@@ -1184,7 +1187,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         final Context context,
         final IngestionStatus ingestionStatus,
         final SplitShardsMetadata splitShardsMetadata,
-        final Map<Integer, Long> primaryTermsMap
+        final Map<Integer, Long> primaryTermsMap,
+        final IndexLongFieldRange timestampRange
     ) {
 
         this.index = index;
@@ -1238,6 +1242,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         this.context = context;
         this.ingestionStatus = ingestionStatus;
         this.splitShardsMetadata = splitShardsMetadata;
+        this.timestampRange = timestampRange;
         assert numberOfShards * routingFactor == routingNumShards : routingNumShards + " must be a multiple of " + numberOfShards;
     }
 
@@ -1477,6 +1482,14 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         return splitShardsMetadata;
     }
 
+    /**
+     * Returns the known range of {@code @timestamp} values in this index, or {@link IndexLongFieldRange#UNKNOWN}
+     * if not yet computed.
+     */
+    public IndexLongFieldRange getTimestampRange() {
+        return timestampRange;
+    }
+
     public int getIndexTotalShardsPerNodeLimit() {
         return this.indexTotalShardsPerNodeLimit;
     }
@@ -1581,6 +1594,9 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         if (!Objects.equals(splitShardsMetadata, that.splitShardsMetadata)) {
             return false;
         }
+        if (!Objects.equals(timestampRange, that.timestampRange)) {
+            return false;
+        }
         return true;
     }
 
@@ -1602,6 +1618,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         result = 31 * result + Objects.hashCode(context);
         result = 31 * result + Objects.hashCode(ingestionStatus);
         result = 31 * result + Objects.hashCode(splitShardsMetadata);
+        result = 31 * result + Objects.hashCode(timestampRange);
         return result;
     }
 
@@ -1649,6 +1666,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         private final IngestionStatus ingestionStatus;
         private final Diff<SplitShardsMetadata> splitMetadata;
         private final Map<Integer, Long> primaryTermsMap;
+        private final IndexLongFieldRange timestampRange;
 
         IndexMetadataDiff(IndexMetadata before, IndexMetadata after) {
             index = after.index.getName();
@@ -1674,6 +1692,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             ingestionStatus = after.ingestionStatus;
             splitMetadata = after.splitShardsMetadata.diff(before.splitShardsMetadata);
             primaryTermsMap = after.primaryTermsMap;
+            timestampRange = after.timestampRange;
         }
 
         private static final DiffableUtils.DiffableValueReader<String, AliasMetadata> ALIAS_METADATA_DIFF_VALUE_READER =
@@ -1731,6 +1750,12 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 }
                 this.primaryTermsMap = primaryTermsMap;
             }
+
+            if (in.getVersion().onOrAfter(Version.V_3_7_0)) {
+                timestampRange = new IndexLongFieldRange(in);
+            } else {
+                timestampRange = IndexLongFieldRange.UNKNOWN;
+            }
         }
 
         @Override
@@ -1770,6 +1795,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 splitMetadata.writeTo(out);
                 out.writeMap(primaryTermsMap, StreamOutput::writeInt, StreamOutput::writeLong);
             }
+
+            if (out.getVersion().onOrAfter(Version.V_3_7_0)) {
+                timestampRange.writeTo(out);
+            }
         }
 
         @Override
@@ -1794,6 +1823,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             if (splitMetadata != null) {
                 builder.splitShardsMetadata(splitMetadata.apply(part.splitShardsMetadata));
             }
+            builder.timestampRange(timestampRange);
             // TODO: support ingestion source
             return builder.build();
         }
@@ -1858,6 +1888,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 primaryTermsMapFromArray.put(shardId, primaryTerms[shardId]);
             }
             builder.primaryTermsMap(primaryTermsMapFromArray);
+        }
+
+        if (in.getVersion().onOrAfter(Version.V_3_7_0)) {
+            builder.timestampRange(new IndexLongFieldRange(in));
         }
         return builder.build();
     }
@@ -1925,6 +1959,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             splitShardsMetadata.writeTo(out);
             out.writeMap(primaryTermsMap, StreamOutput::writeInt, StreamOutput::writeLong);
         }
+
+        if (out.getVersion().onOrAfter(Version.V_3_7_0)) {
+            timestampRange.writeTo(out);
+        }
     }
 
     @Override
@@ -1957,6 +1995,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         if (out.getVersion().onOrAfter(Version.V_3_6_0)) {
             splitShardsMetadata.writeTo(out);
             out.writeMap(primaryTermsMap, StreamOutput::writeInt, StreamOutput::writeLong);
+        }
+
+        if (out.getVersion().onOrAfter(Version.V_3_7_0)) {
+            timestampRange.writeTo(out);
         }
     }
 
@@ -1998,6 +2040,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             .append(ingestionStatus)
             .append(", splitShardsMetadata=")
             .append(splitShardsMetadata)
+            .append(", timestampRange=")
+            .append(timestampRange)
             .append("}")
             .toString();
     }
@@ -2048,6 +2092,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         private Context context;
         private IngestionStatus ingestionStatus;
         private SplitShardsMetadata splitShardsMetadata;
+        private IndexLongFieldRange timestampRange = IndexLongFieldRange.UNKNOWN;
 
         public Builder(String index) {
             this.index = index;
@@ -2078,6 +2123,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.context = indexMetadata.context;
             this.ingestionStatus = indexMetadata.ingestionStatus;
             this.splitShardsMetadata = indexMetadata.splitShardsMetadata;
+            this.timestampRange = indexMetadata.timestampRange;
         }
 
         public Builder index(String index) {
@@ -2333,6 +2379,15 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             return splitShardsMetadata;
         }
 
+        public Builder timestampRange(IndexLongFieldRange timestampRange) {
+            this.timestampRange = timestampRange;
+            return this;
+        }
+
+        public IndexLongFieldRange getTimestampRange() {
+            return timestampRange;
+        }
+
         public IndexMetadata build() {
             final Map<String, AliasMetadata> tmpAliases = aliases;
             Settings tmpSettings = settings;
@@ -2514,7 +2569,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 context,
                 ingestionStatus,
                 splitShardsMetadata,
-                primaryTermsMap
+                primaryTermsMap,
+                timestampRange
             );
         }
 
@@ -2641,6 +2697,12 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 builder.endObject();
             }
 
+            if (indexMetadata.timestampRange != null && !indexMetadata.timestampRange.isUnknown()) {
+                builder.startObject(KEY_TIMESTAMP_RANGE);
+                indexMetadata.timestampRange.toXContent(builder, params);
+                builder.endObject();
+            }
+
             builder.endObject();
         }
 
@@ -2726,6 +2788,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                         builder.ingestionStatus(IngestionStatus.fromXContent(parser));
                     } else if (KEY_SPLIT_SHARDS_METADATA.equals(currentFieldName)) {
                         builder.splitShardsMetadata(SplitShardsMetadata.parse(parser));
+                    } else if (KEY_TIMESTAMP_RANGE.equals(currentFieldName)) {
+                        builder.timestampRange(IndexLongFieldRange.fromXContent(parser));
                     } else if (KEY_PRIMARY_TERMS_MAP.equals(currentFieldName)) {
                         Map<Integer, Long> primaryTermsMap = new HashMap<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {

--- a/server/src/test/java/org/opensearch/action/search/CoordinatorTimestampPrunerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/CoordinatorTimestampPrunerTests.java
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.search;
+
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class CoordinatorTimestampPrunerTests extends OpenSearchTestCase {
+
+    public void testExtractFromSimpleRange() {
+        RangeQueryBuilder range = new RangeQueryBuilder("@timestamp").gte("2026-01-01").lte("2026-01-31");
+        CoordinatorTimestampPruner.TimestampBounds bounds = CoordinatorTimestampPruner.extractTimestampBounds(range);
+        assertNotNull(bounds);
+        assertEquals("2026-01-01", bounds.from.toString());
+        assertEquals("2026-01-31", bounds.to.toString());
+    }
+
+    public void testExtractFromBoolFilter() {
+        BoolQueryBuilder bool = new BoolQueryBuilder()
+            .filter(new RangeQueryBuilder("@timestamp").gte("2026-01-01").lte("2026-01-31"))
+            .filter(new MatchAllQueryBuilder());
+        CoordinatorTimestampPruner.TimestampBounds bounds = CoordinatorTimestampPruner.extractTimestampBounds(bool);
+        assertNotNull(bounds);
+        assertEquals("2026-01-01", bounds.from.toString());
+        assertEquals("2026-01-31", bounds.to.toString());
+    }
+
+    public void testExtractFromBoolMust() {
+        BoolQueryBuilder bool = new BoolQueryBuilder()
+            .must(new RangeQueryBuilder("@timestamp").gte("2026-01-01").lte("2026-01-31"));
+        CoordinatorTimestampPruner.TimestampBounds bounds = CoordinatorTimestampPruner.extractTimestampBounds(bool);
+        assertNotNull(bounds);
+    }
+
+    public void testExtractIgnoresNonTimestampRange() {
+        RangeQueryBuilder range = new RangeQueryBuilder("other_field").gte(0).lte(100);
+        CoordinatorTimestampPruner.TimestampBounds bounds = CoordinatorTimestampPruner.extractTimestampBounds(range);
+        assertNull(bounds);
+    }
+
+    public void testExtractFromMatchAll() {
+        CoordinatorTimestampPruner.TimestampBounds bounds = CoordinatorTimestampPruner.extractTimestampBounds(
+            new MatchAllQueryBuilder()
+        );
+        assertNull(bounds);
+    }
+
+    public void testExtractFromNestedBool() {
+        BoolQueryBuilder inner = new BoolQueryBuilder()
+            .filter(new RangeQueryBuilder("@timestamp").gte("2026-01-01"));
+        BoolQueryBuilder outer = new BoolQueryBuilder().must(inner);
+        CoordinatorTimestampPruner.TimestampBounds bounds = CoordinatorTimestampPruner.extractTimestampBounds(outer);
+        assertNotNull(bounds);
+        assertEquals("2026-01-01", bounds.from.toString());
+        assertNull(bounds.to);
+    }
+
+    public void testResolveEpochMillis() {
+        long result = CoordinatorTimestampPruner.resolveToEpochMillis(1000L, null, System::currentTimeMillis, false);
+        assertEquals(1000L, result);
+    }
+
+    public void testResolveNull() {
+        long resultMin = CoordinatorTimestampPruner.resolveToEpochMillis(null, null, System::currentTimeMillis, false);
+        assertEquals(Long.MIN_VALUE, resultMin);
+
+        long resultMax = CoordinatorTimestampPruner.resolveToEpochMillis(null, null, System::currentTimeMillis, true);
+        assertEquals(Long.MAX_VALUE, resultMax);
+    }
+
+    public void testResolveDateString() {
+        long result = CoordinatorTimestampPruner.resolveToEpochMillis(
+            "2026-01-01T00:00:00.000Z",
+            null,
+            System::currentTimeMillis,
+            false
+        );
+        assertTrue(result > 0);
+        // 2026-01-01 epoch millis = 1767225600000
+        assertEquals(1767225600000L, result);
+    }
+
+    public void testResolveWithFormat() {
+        long result = CoordinatorTimestampPruner.resolveToEpochMillis(
+            "2026-01-01",
+            "yyyy-MM-dd",
+            System::currentTimeMillis,
+            false
+        );
+        assertEquals(1767225600000L, result);
+    }
+
+    public void testExtractFromBoolShould() {
+        // should clauses are not extracted because they are OR conditions
+        BoolQueryBuilder bool = new BoolQueryBuilder()
+            .should(new RangeQueryBuilder("@timestamp").gte("2026-01-01").lte("2026-01-31"));
+        CoordinatorTimestampPruner.TimestampBounds bounds = CoordinatorTimestampPruner.extractTimestampBounds(bool);
+        assertNull(bounds);
+    }
+
+    public void testExtractWithOnlyFrom() {
+        RangeQueryBuilder range = new RangeQueryBuilder("@timestamp").gte("2026-01-01");
+        CoordinatorTimestampPruner.TimestampBounds bounds = CoordinatorTimestampPruner.extractTimestampBounds(range);
+        assertNotNull(bounds);
+        assertEquals("2026-01-01", bounds.from.toString());
+        assertNull(bounds.to);
+    }
+
+    public void testExtractWithOnlyTo() {
+        RangeQueryBuilder range = new RangeQueryBuilder("@timestamp").lte("2026-01-31");
+        CoordinatorTimestampPruner.TimestampBounds bounds = CoordinatorTimestampPruner.extractTimestampBounds(range);
+        assertNotNull(bounds);
+        assertNull(bounds.from);
+        assertEquals("2026-01-31", bounds.to.toString());
+    }
+}

--- a/server/src/test/java/org/opensearch/action/search/CoordinatorTimestampPrunerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/CoordinatorTimestampPrunerTests.java
@@ -115,6 +115,22 @@ public class CoordinatorTimestampPrunerTests extends OpenSearchTestCase {
         assertNull(bounds.to);
     }
 
+    public void testExtractIntersectsMultipleRanges() {
+        // Two range filters: from Jan 1 to Jan 31 AND from Jan 15 to Feb 15
+        // Intersection should be Jan 15 to Jan 31
+        BoolQueryBuilder bool = new BoolQueryBuilder()
+            .filter(new RangeQueryBuilder("@timestamp").gte("2026-01-01T00:00:00.000Z").lte("2026-01-31T23:59:59.999Z"))
+            .filter(new RangeQueryBuilder("@timestamp").gte("2026-01-15T00:00:00.000Z").lte("2026-02-15T23:59:59.999Z"));
+        CoordinatorTimestampPruner.TimestampBounds bounds = CoordinatorTimestampPruner.extractTimestampBounds(bool);
+        assertNotNull(bounds);
+        // from should be Jan 15 (the later/tighter lower bound)
+        // 2026-01-15T00:00:00.000Z = 1736899200000
+        assertEquals(1736899200000L, ((Number) bounds.from).longValue());
+        // to should be Jan 31 23:59:59.999 (the earlier/tighter upper bound)
+        // 2026-01-31T23:59:59.999Z = 1738367999999
+        assertEquals(1738367999999L, ((Number) bounds.to).longValue());
+    }
+
     public void testExtractWithOnlyTo() {
         RangeQueryBuilder range = new RangeQueryBuilder("@timestamp").lte("2026-01-31");
         CoordinatorTimestampPruner.TimestampBounds bounds = CoordinatorTimestampPruner.extractTimestampBounds(range);

--- a/server/src/test/java/org/opensearch/cluster/metadata/IndexLongFieldRangeTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IndexLongFieldRangeTests.java
@@ -154,7 +154,7 @@ public class IndexLongFieldRangeTests extends OpenSearchTestCase {
         BytesStreamOutput out = new BytesStreamOutput();
         original.writeTo(out);
         StreamInput in = out.bytes().streamInput();
-        IndexLongFieldRange deserialized = new IndexLongFieldRange(in);
+        IndexLongFieldRange deserialized = IndexLongFieldRange.readFrom(in);
         assertEquals(original, deserialized);
     }
 }

--- a/server/src/test/java/org/opensearch/cluster/metadata/IndexLongFieldRangeTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/IndexLongFieldRangeTests.java
@@ -1,0 +1,160 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.metadata;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class IndexLongFieldRangeTests extends OpenSearchTestCase {
+
+    public void testUnknownState() {
+        IndexLongFieldRange range = IndexLongFieldRange.UNKNOWN;
+        assertTrue(range.isUnknown());
+        assertFalse(range.isEmpty());
+        assertEquals(IndexLongFieldRange.Relation.UNKNOWN, range.relation(0, 100));
+    }
+
+    public void testEmptyState() {
+        IndexLongFieldRange range = IndexLongFieldRange.EMPTY;
+        assertFalse(range.isUnknown());
+        assertTrue(range.isEmpty());
+        assertEquals(IndexLongFieldRange.Relation.DISJOINT, range.relation(0, 100));
+    }
+
+    public void testConcreteRange() {
+        IndexLongFieldRange range = IndexLongFieldRange.of(100, 200);
+        assertFalse(range.isUnknown());
+        assertFalse(range.isEmpty());
+        assertEquals(100, range.getMin());
+        assertEquals(200, range.getMax());
+    }
+
+    public void testInvalidRange() {
+        expectThrows(IllegalArgumentException.class, () -> IndexLongFieldRange.of(200, 100));
+    }
+
+    public void testRelationDisjointBefore() {
+        IndexLongFieldRange range = IndexLongFieldRange.of(100, 200);
+        assertEquals(IndexLongFieldRange.Relation.DISJOINT, range.relation(0, 99));
+    }
+
+    public void testRelationDisjointAfter() {
+        IndexLongFieldRange range = IndexLongFieldRange.of(100, 200);
+        assertEquals(IndexLongFieldRange.Relation.DISJOINT, range.relation(201, 300));
+    }
+
+    public void testRelationWithin() {
+        IndexLongFieldRange range = IndexLongFieldRange.of(100, 200);
+        assertEquals(IndexLongFieldRange.Relation.WITHIN, range.relation(50, 250));
+    }
+
+    public void testRelationWithinExact() {
+        IndexLongFieldRange range = IndexLongFieldRange.of(100, 200);
+        assertEquals(IndexLongFieldRange.Relation.WITHIN, range.relation(100, 200));
+    }
+
+    public void testRelationIntersectsLeft() {
+        IndexLongFieldRange range = IndexLongFieldRange.of(100, 200);
+        assertEquals(IndexLongFieldRange.Relation.INTERSECTS, range.relation(50, 150));
+    }
+
+    public void testRelationIntersectsRight() {
+        IndexLongFieldRange range = IndexLongFieldRange.of(100, 200);
+        assertEquals(IndexLongFieldRange.Relation.INTERSECTS, range.relation(150, 250));
+    }
+
+    public void testRelationIntersectsContains() {
+        IndexLongFieldRange range = IndexLongFieldRange.of(100, 200);
+        assertEquals(IndexLongFieldRange.Relation.INTERSECTS, range.relation(120, 180));
+    }
+
+    public void testExtendWithValueFromUnknown() {
+        IndexLongFieldRange result = IndexLongFieldRange.UNKNOWN.extendWithValue(150);
+        assertFalse(result.isUnknown());
+        assertEquals(150, result.getMin());
+        assertEquals(150, result.getMax());
+    }
+
+    public void testExtendWithValueFromEmpty() {
+        IndexLongFieldRange result = IndexLongFieldRange.EMPTY.extendWithValue(150);
+        assertFalse(result.isEmpty());
+        assertEquals(150, result.getMin());
+        assertEquals(150, result.getMax());
+    }
+
+    public void testExtendWithValueExpands() {
+        IndexLongFieldRange range = IndexLongFieldRange.of(100, 200);
+        IndexLongFieldRange result = range.extendWithValue(50);
+        assertEquals(50, result.getMin());
+        assertEquals(200, result.getMax());
+
+        result = range.extendWithValue(250);
+        assertEquals(100, result.getMin());
+        assertEquals(250, result.getMax());
+    }
+
+    public void testUnionBothKnown() {
+        IndexLongFieldRange a = IndexLongFieldRange.of(100, 200);
+        IndexLongFieldRange b = IndexLongFieldRange.of(150, 300);
+        IndexLongFieldRange result = a.union(b);
+        assertEquals(100, result.getMin());
+        assertEquals(300, result.getMax());
+    }
+
+    public void testUnionWithUnknown() {
+        IndexLongFieldRange a = IndexLongFieldRange.of(100, 200);
+        IndexLongFieldRange result = a.union(IndexLongFieldRange.UNKNOWN);
+        assertTrue(result.isUnknown());
+
+        result = IndexLongFieldRange.UNKNOWN.union(a);
+        assertTrue(result.isUnknown());
+    }
+
+    public void testUnionWithEmpty() {
+        IndexLongFieldRange a = IndexLongFieldRange.of(100, 200);
+        IndexLongFieldRange result = a.union(IndexLongFieldRange.EMPTY);
+        assertEquals(100, result.getMin());
+        assertEquals(200, result.getMax());
+
+        result = IndexLongFieldRange.EMPTY.union(a);
+        assertEquals(100, result.getMin());
+        assertEquals(200, result.getMax());
+    }
+
+    public void testSerializationRoundTripUnknown() throws IOException {
+        assertSerializationRoundTrip(IndexLongFieldRange.UNKNOWN);
+    }
+
+    public void testSerializationRoundTripEmpty() throws IOException {
+        assertSerializationRoundTrip(IndexLongFieldRange.EMPTY);
+    }
+
+    public void testSerializationRoundTripRange() throws IOException {
+        assertSerializationRoundTrip(IndexLongFieldRange.of(1000, 2000));
+    }
+
+    public void testEquality() {
+        assertEquals(IndexLongFieldRange.UNKNOWN, IndexLongFieldRange.UNKNOWN);
+        assertEquals(IndexLongFieldRange.EMPTY, IndexLongFieldRange.EMPTY);
+        assertEquals(IndexLongFieldRange.of(100, 200), IndexLongFieldRange.of(100, 200));
+        assertNotEquals(IndexLongFieldRange.of(100, 200), IndexLongFieldRange.of(100, 300));
+        assertNotEquals(IndexLongFieldRange.UNKNOWN, IndexLongFieldRange.EMPTY);
+    }
+
+    private void assertSerializationRoundTrip(IndexLongFieldRange original) throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        IndexLongFieldRange deserialized = new IndexLongFieldRange(in);
+        assertEquals(original, deserialized);
+    }
+}


### PR DESCRIPTION
## Summary

Adds per-index `@timestamp` min/max bounds to `IndexMetadata` in cluster state, enabling the coordinating node to skip shards whose index provably falls outside a query's time range — without sending any `can_match` network probes to data nodes.

### Problem

When a search request targets multiple indices (via wildcard patterns, aliases, or data streams), the coordinating node sends a `can_match` probe to **every** shard across all matching indices, even when the query contains a narrow `@timestamp` range filter. For time-series workloads with hundreds of daily indices, this means hundreds of unnecessary network round-trips.

### Solution

- **`IndexLongFieldRange`**: immutable value class with three states — `UNKNOWN` (no data yet, fall through to existing `can_match`), `EMPTY` (no docs/field), or a concrete `min/max` range
- **`IndexMetadata.timestampRange`**: new field stored in cluster state with `V_3_7_0` version guard. Mixed-version clusters degrade gracefully — pre-3.7 nodes see `UNKNOWN` and fall through to shard-level `can_match`
- **`CoordinatorTimestampPruner`**: extracts `@timestamp` range bounds from the query tree (including inside `BoolQueryBuilder` filter/must clauses), resolves date math, and marks disjoint shards as skipped via `SearchShardIterator.resetAndSkip()`
- Integration in `TransportSearchAction.searchAsyncAction()` — one-line call before `CanMatchPreFilterSearchPhase` construction

### Scope

This draft implements the **coordinator-level pruning path**. Automatic population of timestamp ranges during indexing (cluster-manager-side service that reads `PointValues` min/max from shards and updates `IndexMetadata`) is a follow-up.

Closes https://github.com/opensearch-project/OpenSearch/issues/21148

## Test plan

- [ ] `IndexLongFieldRangeTests` — UNKNOWN/EMPTY/Range states, relation() for DISJOINT/WITHIN/INTERSECTS, union, serialization round-trip
- [ ] `CoordinatorTimestampPrunerTests` — query extraction from simple range, bool filter, bool must, nested bool; date math resolution; non-timestamp fields ignored
- [ ] `IndexMetadata` serialization round-trip with new field
- [ ] Integration test: shards with DISJOINT ranges are skipped, UNKNOWN ranges fall through to existing `can_match`
- [ ] Verify backward compatibility: pre-3.7 nodes ignore the new field gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)