### PR TITLE
Adding DynamicMemoryPool to track the memory allocation with configurable setting

### DIFF
--- a/plugins/engine-datafusion/jni/src/lib.rs
+++ b/plugins/engine-datafusion/jni/src/lib.rs
@@ -61,7 +61,7 @@ use vectorized_exec_spi::{log_info, log_error, log_debug};
 
 use crate::custom_cache_manager::CustomCacheManager;
 use crate::util::{create_file_meta_from_filenames, parse_string_arr, set_action_listener_error, set_action_listener_error_global, set_action_listener_ok, set_action_listener_ok_global, set_action_listener_ok_global_with_map};
-use datafusion::execution::memory_pool::{GreedyMemoryPool, TrackConsumersPool};
+use datafusion::execution::memory_pool::TrackConsumersPool;
 
 use crate::statistics_cache::CustomStatisticsCache;
 use datafusion::execution::cache::cache_manager::CacheManagerConfig;
@@ -80,7 +80,7 @@ use log::error;
 use once_cell::sync::Lazy;
 use tokio_metrics::TaskMonitor;
 use crate::cross_rt_stream::CrossRtStream;
-use crate::memory::{Monitor, MonitoredMemoryPool};
+use crate::memory::{DynamicLimitHandle, DynamicLimitPool, Monitor, MonitoredMemoryPool};
 use crate::runtime_manager::RuntimeManager;
 
 mod statistics_cache;
@@ -90,6 +90,7 @@ struct DataFusionRuntime {
     runtime_env: RuntimeEnv,
     custom_cache_manager: Option<CustomCacheManager>,
     monitor: Arc<Monitor>,
+    dynamic_limit_handle: DynamicLimitHandle,
 }
 
 // TASK monitorint metrics
@@ -363,9 +364,10 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_createGlo
     let builder = builder.with_mode(DiskManagerMode::Directories(vec![PathBuf::from(spill_dir)]));
 
     let monitor = Arc::new(Monitor::default());
+    let (dynamic_pool, dynamic_limit_handle) = DynamicLimitPool::new(memory_pool_limit as usize);
     let memory_pool = Arc::new(MonitoredMemoryPool::new(
         Arc::new(TrackConsumersPool::new(
-            GreedyMemoryPool::new(memory_pool_limit as usize),
+            dynamic_pool,
             NonZeroUsize::new(5).unwrap(),
         )),
         monitor.clone(),
@@ -391,6 +393,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_createGlo
         runtime_env,
         custom_cache_manager,
         monitor,
+        dynamic_limit_handle,
     };
 
     Box::into_raw(Box::new(runtime)) as jlong
@@ -405,6 +408,61 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_closeGlob
     if ptr != 0 {
         let _ = unsafe { Box::from_raw(ptr as *mut DataFusionRuntime) };
     }
+}
+
+/// Get current memory pool usage in bytes.
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_getMemoryPoolCurrentUsage(
+    _env: JNIEnv,
+    _class: JClass,
+    runtime_ptr: jlong,
+) -> jlong {
+    if runtime_ptr == 0 { return 0; }
+    let runtime = unsafe { &*(runtime_ptr as *const DataFusionRuntime) };
+    runtime.monitor.get_current_val() as jlong
+}
+
+/// Get peak memory pool usage in bytes.
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_getMemoryPoolPeakUsage(
+    _env: JNIEnv,
+    _class: JClass,
+    runtime_ptr: jlong,
+) -> jlong {
+    if runtime_ptr == 0 { return 0; }
+    let runtime = unsafe { &*(runtime_ptr as *const DataFusionRuntime) };
+    runtime.monitor.max() as jlong
+}
+
+/// Get current memory pool limit in bytes.
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_getMemoryPoolLimit(
+    _env: JNIEnv,
+    _class: JClass,
+    runtime_ptr: jlong,
+) -> jlong {
+    if runtime_ptr == 0 { return 0; }
+    let runtime = unsafe { &*(runtime_ptr as *const DataFusionRuntime) };
+    runtime.dynamic_limit_handle.limit() as jlong
+}
+
+/// Set memory pool limit at runtime. Takes effect for new allocations only.
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_setMemoryPoolLimit(
+    _env: JNIEnv,
+    _class: JClass,
+    runtime_ptr: jlong,
+    new_limit_bytes: jlong,
+) {
+    if runtime_ptr == 0 { return; }
+    let runtime = unsafe { &*(runtime_ptr as *const DataFusionRuntime) };
+    let old_limit = runtime.dynamic_limit_handle.limit();
+    runtime.dynamic_limit_handle.set_limit(new_limit_bytes as usize);
+    log_info!(
+        "Memory pool limit changed from {}MB to {}MB",
+        old_limit / (1024 * 1024),
+        new_limit_bytes as usize / (1024 * 1024)
+    );
 }
 
 #[no_mangle]

--- a/plugins/engine-datafusion/jni/src/memory.rs
+++ b/plugins/engine-datafusion/jni/src/memory.rs
@@ -55,8 +55,93 @@ impl Monitor {
         self.value.fetch_sub(amount, Ordering::Relaxed);
     }
 
-    fn get_current_val(&self) -> usize {
+    pub(crate) fn get_current_val(&self) -> usize {
         self.value.load(Ordering::Relaxed)
+    }
+}
+
+/// A MemoryPool that supports changing its limit at runtime.
+///
+/// Unlike DataFusion's GreedyMemoryPool (which stores pool_size as a plain usize
+/// set once in the constructor with no setter), DynamicLimitPool uses an AtomicUsize
+/// for the limit, allowing it to be changed at any time via the shared limit handle.
+///
+/// Behavior:
+/// - Increasing the limit takes effect immediately for new allocations.
+/// - Decreasing the limit takes effect for new allocations only.
+///   Existing reservations that exceed the new limit are NOT reclaimed.
+///   They remain until the consumer frees them (e.g., query completes).
+#[derive(Debug)]
+pub struct DynamicLimitPool {
+    used: AtomicUsize,
+    dynamic_limit: Arc<AtomicUsize>,
+}
+
+/// Handle to change the pool limit at runtime.
+/// Can be stored separately from the pool itself.
+#[derive(Debug, Clone)]
+pub struct DynamicLimitHandle {
+    limit: Arc<AtomicUsize>,
+}
+
+impl DynamicLimitHandle {
+    pub fn set_limit(&self, new_limit: usize) {
+        self.limit.store(new_limit, Ordering::SeqCst);
+    }
+
+    pub fn limit(&self) -> usize {
+        self.limit.load(Ordering::SeqCst)
+    }
+}
+
+impl DynamicLimitPool {
+    pub fn new(initial_limit: usize) -> (Self, DynamicLimitHandle) {
+        let limit = Arc::new(AtomicUsize::new(initial_limit));
+        let handle = DynamicLimitHandle { limit: limit.clone() };
+        let pool = Self {
+            used: AtomicUsize::new(0),
+            dynamic_limit: limit,
+        };
+        (pool, handle)
+    }
+
+    pub fn limit(&self) -> usize {
+        self.dynamic_limit.load(Ordering::SeqCst)
+    }
+}
+
+impl MemoryPool for DynamicLimitPool {
+    fn grow(&self, _reservation: &MemoryReservation, additional: usize) {
+        self.used.fetch_add(additional, Ordering::Relaxed);
+    }
+
+    fn shrink(&self, _reservation: &MemoryReservation, shrink: usize) {
+        self.used.fetch_sub(shrink, Ordering::Relaxed);
+    }
+
+    fn try_grow(&self, reservation: &MemoryReservation, additional: usize) -> Result<()> {
+        let limit = self.dynamic_limit.load(Ordering::SeqCst);
+        self.used
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |used| {
+                let new_used = used + additional;
+                (new_used <= limit).then_some(new_used)
+            })
+            .map_err(|used| {
+                DataFusionError::ResourcesExhausted(format!(
+                    "Failed to allocate additional {} for {} with {} already allocated \
+                     for this reservation - {} remain available for the total pool (dynamic limit: {})",
+                    additional,
+                    reservation.consumer().name(),
+                    reservation.size(),
+                    limit.saturating_sub(used),
+                    limit,
+                ))
+            })?;
+        Ok(())
+    }
+
+    fn reserved(&self) -> usize {
+        self.used.load(Ordering::Relaxed)
     }
 }
 
@@ -104,5 +189,162 @@ impl MemoryPool for MonitoredMemoryPool {
 
     fn reserved(&self) -> usize {
         self.inner.reserved()
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::execution::memory_pool::{MemoryConsumer, MemoryPool};
+
+    #[test]
+    fn test_dynamic_limit_pool_initial_limit() {
+        let (pool, handle) = DynamicLimitPool::new(1024);
+        assert_eq!(handle.limit(), 1024);
+        assert_eq!(pool.limit(), 1024);
+        assert_eq!(pool.reserved(), 0);
+    }
+
+    #[test]
+    fn test_dynamic_limit_pool_try_grow_within_limit() {
+        let (pool, _handle) = DynamicLimitPool::new(1024);
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test");
+        let mut reservation = consumer.register(&pool);
+        assert!(reservation.try_grow(512).is_ok());
+        assert_eq!(pool.reserved(), 512);
+    }
+
+    #[test]
+    fn test_dynamic_limit_pool_try_grow_exceeds_limit() {
+        let (pool, _handle) = DynamicLimitPool::new(1024);
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test");
+        let mut reservation = consumer.register(&pool);
+        assert!(reservation.try_grow(2048).is_err());
+        assert_eq!(pool.reserved(), 0);
+    }
+
+    #[test]
+    fn test_dynamic_limit_pool_shrink() {
+        let (pool, _handle) = DynamicLimitPool::new(1024);
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test");
+        let mut reservation = consumer.register(&pool);
+        reservation.try_grow(512).unwrap();
+        assert_eq!(pool.reserved(), 512);
+        reservation.shrink(256);
+        assert_eq!(pool.reserved(), 256);
+    }
+
+    #[test]
+    fn test_dynamic_limit_handle_set_limit_increase() {
+        let (pool, handle) = DynamicLimitPool::new(1024);
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test");
+        let mut reservation = consumer.register(&pool);
+
+        // Fill to near limit
+        reservation.try_grow(900).unwrap();
+        // Can't grow beyond original limit
+        assert!(reservation.try_grow(200).is_err());
+
+        // Increase limit
+        handle.set_limit(2048);
+        assert_eq!(handle.limit(), 2048);
+
+        // Now the grow succeeds
+        assert!(reservation.try_grow(200).is_ok());
+        assert_eq!(pool.reserved(), 1100);
+    }
+
+    #[test]
+    fn test_dynamic_limit_handle_set_limit_decrease() {
+        let (pool, handle) = DynamicLimitPool::new(2048);
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test");
+        let mut reservation = consumer.register(&pool);
+
+        // Allocate 1500 bytes
+        reservation.try_grow(1500).unwrap();
+        assert_eq!(pool.reserved(), 1500);
+
+        // Decrease limit below current usage
+        handle.set_limit(1024);
+        assert_eq!(handle.limit(), 1024);
+
+        // Existing reservation is NOT reclaimed
+        assert_eq!(pool.reserved(), 1500);
+
+        // But new allocations fail
+        assert!(reservation.try_grow(100).is_err());
+
+        // After releasing some memory, new allocations within new limit succeed
+        reservation.shrink(600); // reserved = 900, limit = 1024
+        assert_eq!(pool.reserved(), 900);
+        assert!(reservation.try_grow(100).is_ok()); // 900 + 100 = 1000 <= 1024
+    }
+
+    #[test]
+    fn test_dynamic_limit_pool_grow_bypasses_limit() {
+        let (pool, _handle) = DynamicLimitPool::new(1024);
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test");
+        let mut reservation = consumer.register(&pool);
+
+        // grow() does NOT check the limit (same as GreedyMemoryPool)
+        reservation.grow(2048);
+        assert_eq!(pool.reserved(), 2048); // exceeds limit, but grow allows it
+    }
+
+    #[test]
+    fn test_monitor_tracks_current_and_peak() {
+        let monitor = Monitor::default();
+        assert_eq!(monitor.get_current_val(), 0);
+        assert_eq!(monitor.max(), 0);
+
+        monitor.grow(500);
+        assert_eq!(monitor.get_current_val(), 500);
+        assert_eq!(monitor.max(), 500);
+
+        monitor.grow(300);
+        assert_eq!(monitor.get_current_val(), 800);
+        assert_eq!(monitor.max(), 800);
+
+        monitor.shrink(600);
+        assert_eq!(monitor.get_current_val(), 200);
+        assert_eq!(monitor.max(), 800); // peak unchanged
+
+        monitor.grow(900);
+        assert_eq!(monitor.get_current_val(), 1100);
+        assert_eq!(monitor.max(), 1100); // new peak
+    }
+
+    #[test]
+    fn test_monitored_memory_pool_delegates_and_tracks() {
+        let (pool, handle) = DynamicLimitPool::new(4096);
+        let monitor = Arc::new(Monitor::default());
+        let monitored = Arc::new(MonitoredMemoryPool::new(
+            Arc::new(pool),
+            monitor.clone(),
+        ));
+
+        let pool_ref: Arc<dyn MemoryPool> = monitored;
+        let consumer = MemoryConsumer::new("test");
+        let mut reservation = consumer.register(&pool_ref);
+
+        reservation.try_grow(1000).unwrap();
+        assert_eq!(monitor.get_current_val(), 1000);
+        assert_eq!(pool_ref.reserved(), 1000);
+
+        reservation.shrink(400);
+        assert_eq!(monitor.get_current_val(), 600);
+        assert_eq!(pool_ref.reserved(), 600);
+
+        // Change limit via handle and verify it takes effect
+        handle.set_limit(700);
+        assert!(reservation.try_grow(200).is_err()); // 600 + 200 > 700
+        assert!(reservation.try_grow(50).is_ok());    // 600 + 50 = 650 <= 700
     }
 }

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DataFusionPlugin.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DataFusionPlugin.java
@@ -22,6 +22,7 @@ import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.datafusion.action.DataFusionAction;
+import org.opensearch.datafusion.action.MemoryPoolAction;
 import org.opensearch.datafusion.action.NodesDataFusionInfoAction;
 import org.opensearch.datafusion.action.TransportNodesDataFusionInfoAction;
 import org.opensearch.datafusion.search.DatafusionContext;
@@ -185,7 +186,12 @@ public class DataFusionPlugin extends Plugin implements ActionPlugin, SearchEngi
         if (!isDataFusionEnabled) {
             return Collections.emptyList();
         }
-        return List.of(new DataFusionAction());
+        List<RestHandler> handlers = new ArrayList<>();
+        handlers.add(new DataFusionAction());
+        if (dataFusionService != null) {
+            handlers.add(new MemoryPoolAction(dataFusionService.getRuntimePointer()));
+        }
+        return handlers;
     }
 
     @Override

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/action/MemoryPoolAction.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/action/MemoryPoolAction.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.datafusion.action;
+
+import org.opensearch.datafusion.jni.NativeBridge;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.opensearch.rest.RestRequest.Method.GET;
+
+/**
+ * REST handler for reading memory pool stats.
+ *
+ * GET /_plugins/datafusion/memory — read current pool stats (limit, usage, peak)
+ *
+ * Limit changes should be done via the cluster settings API:
+ *   PUT /_cluster/settings { "transient": { "datafusion.search.memory_pool": "15gb" } }
+ */
+public class MemoryPoolAction extends BaseRestHandler {
+
+    private final long runtimePtr;
+
+    public MemoryPoolAction(long runtimePtr) {
+        this.runtimePtr = runtimePtr;
+    }
+
+    @Override
+    public String getName() {
+        return "datafusion_memory_pool_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(GET, "/_plugins/datafusion/memory"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        return channel -> {
+            long currentUsage = NativeBridge.getMemoryPoolCurrentUsage(runtimePtr);
+            long peakUsage = NativeBridge.getMemoryPoolPeakUsage(runtimePtr);
+            long limit = NativeBridge.getMemoryPoolLimit(runtimePtr);
+
+            String json = String.format(
+                Locale.ROOT,
+                "{\"memory_pool\":{\"limit_bytes\":%d,\"limit_mb\":%d,"
+                + "\"current_usage_bytes\":%d,\"current_usage_mb\":%d,"
+                + "\"peak_usage_bytes\":%d,\"peak_usage_mb\":%d,"
+                + "\"utilization_percent\":%.1f}}",
+                limit, limit / (1024 * 1024),
+                currentUsage, currentUsage / (1024 * 1024),
+                peakUsage, peakUsage / (1024 * 1024),
+                limit > 0 ? (currentUsage * 100.0 / limit) : 0
+            );
+            channel.sendResponse(new BytesRestResponse(RestStatus.OK, "application/json", json));
+        };
+    }
+}

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/core/DataFusionRuntimeEnv.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/core/DataFusionRuntimeEnv.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.datafusion.core;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Setting;
 
@@ -24,17 +26,21 @@ import org.opensearch.datafusion.search.cache.CacheUtils;
  */
 public final class DataFusionRuntimeEnv implements AutoCloseable {
 
+    private static final Logger logger = LogManager.getLogger(DataFusionRuntimeEnv.class);
+
     private final GlobalRuntimeHandle runtimeHandle;
 
     private CacheManager cacheManager;
 
     /**
-     * Controls the memory used for the datafusion query execution
+     * Controls the memory used for the datafusion query execution.
+     * Dynamic: can be changed at runtime via cluster settings API.
+     * The Rust DynamicLimitPool reads the new limit atomically on every try_grow() call.
      */
     public static final Setting<ByteSizeValue> DATAFUSION_MEMORY_POOL_CONFIGURATION = Setting.byteSizeSetting(
         "datafusion.search.memory_pool",
         new ByteSizeValue(10, ByteSizeUnit.GB),
-        Setting.Property.Final,
+        Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
 
@@ -57,8 +63,21 @@ public final class DataFusionRuntimeEnv implements AutoCloseable {
         long cacheManagerConfigPtr = CacheUtils.createCacheConfig(clusterService.getClusterSettings());
         NativeBridge.initTokioRuntimeManager(Runtime.getRuntime().availableProcessors());
         this.runtimeHandle = new GlobalRuntimeHandle(memoryLimit, cacheManagerConfigPtr, spill_dir, spillLimit);
-        System.out.println("Runtime : " + this.runtimeHandle);
+        logger.info("DataFusion runtime created with memory pool limit: {} bytes", memoryLimit);
         this.cacheManager = new CacheManager(this.runtimeHandle);
+
+        // Register dynamic settings listener for memory pool limit changes
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(
+            DATAFUSION_MEMORY_POOL_CONFIGURATION,
+            newValue -> {
+                long newLimitBytes = newValue.getBytes();
+                long runtimePtr = runtimeHandle.getPointer();
+                if (runtimePtr != 0) {
+                    NativeBridge.setMemoryPoolLimit(runtimePtr, newLimitBytes);
+                    logger.info("DataFusion memory pool limit updated to {} bytes via cluster settings", newLimitBytes);
+                }
+            }
+        );
     }
 
     /**

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/NativeBridge.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/NativeBridge.java
@@ -70,6 +70,15 @@ public final class NativeBridge {
     // Memory monitoring
     public static native void printMemoryPoolAllocation(long runtimePtr);
 
+    /** Get current memory pool usage in bytes */
+    public static native long getMemoryPoolCurrentUsage(long runtimePtr);
+    /** Get peak memory pool usage in bytes */
+    public static native long getMemoryPoolPeakUsage(long runtimePtr);
+    /** Get current memory pool limit in bytes */
+    public static native long getMemoryPoolLimit(long runtimePtr);
+    /** Set memory pool limit at runtime. Takes effect for new allocations only. */
+    public static native void setMemoryPoolLimit(long runtimePtr, long newLimitBytes);
+
 
     // Logger initialization
     public static native void initLogger();

--- a/plugins/engine-datafusion/src/test/java/org/opensearch/datafusion/DynamicMemoryPoolTests.java
+++ b/plugins/engine-datafusion/src/test/java/org/opensearch/datafusion/DynamicMemoryPoolTests.java
@@ -1,0 +1,167 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.datafusion;
+
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.datafusion.core.DataFusionRuntimeEnv;
+import org.opensearch.datafusion.jni.NativeBridge;
+import org.opensearch.datafusion.search.cache.CacheSettings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.opensearch.common.settings.Setting;
+
+import static org.opensearch.common.settings.ClusterSettings.BUILT_IN_CLUSTER_SETTINGS;
+import static org.opensearch.datafusion.core.DataFusionRuntimeEnv.DATAFUSION_MEMORY_POOL_CONFIGURATION;
+import static org.opensearch.datafusion.core.DataFusionRuntimeEnv.DATAFUSION_SPILL_MEMORY_LIMIT_CONFIGURATION;
+import static org.opensearch.datafusion.search.cache.CacheSettings.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for dynamic memory pool limit changes via JNI.
+ *
+ * Proves that the DynamicLimitPool can:
+ * 1. Report its initial limit correctly
+ * 2. Report current and peak usage
+ * 3. Accept runtime limit changes via setMemoryPoolLimit
+ * 4. Enforce the new limit on subsequent allocations
+ */
+public class DynamicMemoryPoolTests extends OpenSearchTestCase {
+
+    private DataFusionService service;
+    private ClusterSettings clusterSettings;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        Set<Setting<?>> clusterSettingsToAdd = new HashSet<>(BUILT_IN_CLUSTER_SETTINGS);
+        clusterSettingsToAdd.add(METADATA_CACHE_ENABLED);
+        clusterSettingsToAdd.add(METADATA_CACHE_SIZE_LIMIT);
+        clusterSettingsToAdd.add(METADATA_CACHE_EVICTION_TYPE);
+        clusterSettingsToAdd.add(STATISTICS_CACHE_ENABLED);
+        clusterSettingsToAdd.add(STATISTICS_CACHE_SIZE_LIMIT);
+        clusterSettingsToAdd.add(STATISTICS_CACHE_EVICTION_TYPE);
+        clusterSettingsToAdd.add(DATAFUSION_MEMORY_POOL_CONFIGURATION);
+        clusterSettingsToAdd.add(DATAFUSION_SPILL_MEMORY_LIMIT_CONFIGURATION);
+
+        clusterSettings = new ClusterSettings(Settings.EMPTY, clusterSettingsToAdd);
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        service = new DataFusionService(java.util.Collections.emptyMap(), clusterService, "/tmp");
+        service.doStart();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        if (service != null) {
+            service.doStop();
+        }
+        super.tearDown();
+    }
+
+    /**
+     * Test 1: Verify we can read the initial pool limit.
+     * The default is 10 GB (from DATAFUSION_MEMORY_POOL_CONFIGURATION).
+     */
+    public void testGetInitialPoolLimit() {
+        long runtimePtr = service.getRuntimePointer();
+        assertTrue("Runtime pointer should be non-zero", runtimePtr != 0);
+
+        long limit = NativeBridge.getMemoryPoolLimit(runtimePtr);
+        long expectedDefault = 10L * 1024 * 1024 * 1024; // 10 GB default
+        assertEquals("Initial pool limit should be 10 GB", expectedDefault, limit);
+    }
+
+    /**
+     * Test 2: Verify we can read current and peak usage.
+     * With no queries running, usage should be 0.
+     */
+    public void testGetMemoryUsage() {
+        long runtimePtr = service.getRuntimePointer();
+
+        long currentUsage = NativeBridge.getMemoryPoolCurrentUsage(runtimePtr);
+        long peakUsage = NativeBridge.getMemoryPoolPeakUsage(runtimePtr);
+
+        assertTrue("Current usage should be >= 0", currentUsage >= 0);
+        assertTrue("Peak usage should be >= 0", peakUsage >= 0);
+        assertTrue("Peak usage should be >= current usage", peakUsage >= currentUsage);
+    }
+
+    /**
+     * Test 3: Verify we can change the pool limit at runtime.
+     */
+    public void testSetPoolLimit() {
+        long runtimePtr = service.getRuntimePointer();
+
+        // Read initial limit
+        long initialLimit = NativeBridge.getMemoryPoolLimit(runtimePtr);
+
+        // Increase limit to 20 GB
+        long newLimit = 20L * 1024 * 1024 * 1024;
+        NativeBridge.setMemoryPoolLimit(runtimePtr, newLimit);
+        long afterIncrease = NativeBridge.getMemoryPoolLimit(runtimePtr);
+        assertEquals("Limit should be 20 GB after increase", newLimit, afterIncrease);
+
+        // Decrease limit to 5 GB
+        long smallerLimit = 5L * 1024 * 1024 * 1024;
+        NativeBridge.setMemoryPoolLimit(runtimePtr, smallerLimit);
+        long afterDecrease = NativeBridge.getMemoryPoolLimit(runtimePtr);
+        assertEquals("Limit should be 5 GB after decrease", smallerLimit, afterDecrease);
+
+        // Restore original limit
+        NativeBridge.setMemoryPoolLimit(runtimePtr, initialLimit);
+        long afterRestore = NativeBridge.getMemoryPoolLimit(runtimePtr);
+        assertEquals("Limit should be restored", initialLimit, afterRestore);
+    }
+
+    /**
+     * Test 4: Verify the setting is declared as Dynamic (not Final).
+     */
+    public void testSettingIsDynamic() {
+        assertTrue(
+            "datafusion.search.memory_pool should be a dynamic setting",
+            DATAFUSION_MEMORY_POOL_CONFIGURATION.isDynamic()
+        );
+    }
+
+    /**
+     * Test 5: Verify the settings listener updates the pool limit.
+     */
+    public void testSettingsListenerUpdatesPoolLimit() {
+        long runtimePtr = service.getRuntimePointer();
+
+        // Initial limit should be 10 GB
+        long initialLimit = NativeBridge.getMemoryPoolLimit(runtimePtr);
+        assertEquals(10L * 1024 * 1024 * 1024, initialLimit);
+
+        // Simulate a cluster settings update by applying new settings through ClusterSettings
+        Settings newSettings = Settings.builder()
+            .put("datafusion.search.memory_pool", "15gb")
+            .build();
+        clusterSettings.applySettings(newSettings);
+
+        // The listener should have called setMemoryPoolLimit
+        long updatedLimit = NativeBridge.getMemoryPoolLimit(runtimePtr);
+        assertEquals("Pool limit should be updated to 15 GB", 15L * 1024 * 1024 * 1024, updatedLimit);
+
+        // Restore
+        Settings restoreSettings = Settings.builder()
+            .put("datafusion.search.memory_pool", "10gb")
+            .build();
+        clusterSettings.applySettings(restoreSettings);
+        assertEquals(10L * 1024 * 1024 * 1024, NativeBridge.getMemoryPoolLimit(runtimePtr));
+    }
+}


### PR DESCRIPTION
### Description
**Title:** Add dynamic memory pool limit for DataFusion query execution

**Description:**

### Summary

Replaces the fixed `GreedyMemoryPool` with a `DynamicLimitPool` that supports runtime limit changes via the cluster settings API. Operators can now adjust the DataFusion memory pool limit without restarting nodes.

### Changes

**Rust (`memory.rs`):**
- Added `DynamicLimitPool` implementing DataFusion's `MemoryPool` trait with an `AtomicUsize` limit (instead of plain `usize` in `GreedyMemoryPool`)
- Added `DynamicLimitHandle` for changing the limit externally via shared `Arc<AtomicUsize>`
- Made `Monitor::get_current_val()` accessible for JNI usage
- Added unit tests for pool behavior: grow, shrink, limit increase/decrease, and the full monitored pool chain

**Rust (`lib.rs`):**
- Replaced `GreedyMemoryPool` with `DynamicLimitPool` in `createGlobalRuntime()`
- Stored `DynamicLimitHandle` in `DataFusionRuntime` struct
- Added 4 JNI exports: `getMemoryPoolCurrentUsage`, `getMemoryPoolPeakUsage`, `getMemoryPoolLimit`, `setMemoryPoolLimit`

**Java (`DataFusionRuntimeEnv.java`):**
- Changed `datafusion.search.memory_pool` from `Setting.Property.Final` to `Setting.Property.Dynamic`
- Registered a `ClusterSettings` update consumer that calls `NativeBridge.setMemoryPoolLimit()` on setting change

**Java (`NativeBridge.java`):**
- Added 4 native method declarations for memory pool stats and limit management

**Java (`MemoryPoolAction.java`):**
- New REST handler: `GET /_plugins/datafusion/memory` returns pool stats (limit, current usage, peak, utilization %)

**Java (`DataFusionPlugin.java`):**
- Registered `MemoryPoolAction` in REST handlers

**Java (`DynamicMemoryPoolTests.java`):**
- Tests for initial limit, usage stats, runtime limit changes, setting is dynamic, and settings listener propagation

### Usage

Change limit at runtime:
```
PUT /_cluster/settings
{ "transient": { "datafusion.search.memory_pool": "15gb" } }
```

Read pool stats:
```
GET /_plugins/datafusion/memory
```

### Runtime behavior

- Increasing the limit takes effect immediately for new allocations
- Decreasing the limit only affects new `try_grow()` calls; existing query reservations drain naturally
- Spill-capable operators (sort, GROUP BY) survive limit decreases by spilling to disk
- Non-spillable operators (hash join, cross join) may fail with `ResourcesExhausted` if the new limit is below current usage

### Testing

- Rust unit tests: 9 tests covering DynamicLimitPool, DynamicLimitHandle, Monitor, and MonitoredMemoryPool
- Java unit tests: 5 tests covering JNI round-trip, dynamic setting, and settings listener propagation

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
