### PR TITLE
Fix tiering validation regressions

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/indices/tiering/TransportHotToWarmTieringAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/tiering/TransportHotToWarmTieringAction.java
@@ -105,11 +105,7 @@ public class TransportHotToWarmTieringAction extends TransportClusterManagerNode
             clusterInfoService.getClusterInfo(),
             diskThresholdSettings
         );
-
-        if (tieringValidationResult.getAcceptedIndices().isEmpty()) {
-            listener.onResponse(tieringValidationResult.constructResponse());
-            return;
-        }
+        listener.onResponse(tieringValidationResult.constructResponse());
     }
 
     private ResolvedIndices.Local.Concrete resolveIndices(ClusterState state, TieringIndexRequest request) {

--- a/server/src/main/java/org/opensearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterInfo.java
@@ -270,7 +270,7 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
      * Note that this does not take account of reserved space: there may be another path with less available _and unreserved_ space.
      */
     public Map<String, DiskUsage> getNodeLeastAvailableDiskUsages() {
-        return Collections.unmodifiableMap(this.leastAvailableSpaceUsage);
+        return this.leastAvailableSpaceUsage == null ? Collections.emptyMap() : Collections.unmodifiableMap(this.leastAvailableSpaceUsage);
     }
 
     /**
@@ -278,7 +278,7 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
      * Note that this does not take account of reserved space: there may be another path with more available _and unreserved_ space.
      */
     public Map<String, DiskUsage> getNodeMostAvailableDiskUsages() {
-        return Collections.unmodifiableMap(this.mostAvailableSpaceUsage);
+        return this.mostAvailableSpaceUsage == null ? Collections.emptyMap() : Collections.unmodifiableMap(this.mostAvailableSpaceUsage);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/indices/tiering/TieringRequestValidator.java
+++ b/server/src/main/java/org/opensearch/indices/tiering/TieringRequestValidator.java
@@ -25,6 +25,7 @@ import org.opensearch.core.index.Index;
 import org.opensearch.index.IndexModule;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -171,7 +172,7 @@ public class TieringRequestValidator {
         final String indexNames
     ) {
         final Map<String, DiskUsage> usages = clusterInfo.getNodeLeastAvailableDiskUsages();
-        if (usages == null) {
+        if (usages == null || usages.isEmpty()) {
             logger.trace("skipping monitor as no disk usage information is available");
             return;
         }
@@ -200,30 +201,32 @@ public class TieringRequestValidator {
         final ClusterState currentState,
         final TieringValidationResult tieringValidationResult
     ) {
+        final Map<String, DiskUsage> nodeLeastAvailableDiskUsages = clusterInfo.getNodeLeastAvailableDiskUsages();
+        if (nodeLeastAvailableDiskUsages == null || nodeLeastAvailableDiskUsages.isEmpty()) {
+            logger.trace("skipping capacity validation as no disk usage information is available");
+            return;
+        }
 
         final Set<String> eligibleNodeIds = getEligibleNodes(currentState).stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
-        long totalAvailableBytesInWarmTier = getTotalAvailableBytesInWarmTier(
-            clusterInfo.getNodeLeastAvailableDiskUsages(),
-            eligibleNodeIds
-        );
+        long totalAvailableBytesInWarmTier = getTotalAvailableBytesInWarmTier(nodeLeastAvailableDiskUsages, eligibleNodeIds);
 
         Map<Index, Long> indexSizes = new HashMap<>();
         for (Index index : tieringValidationResult.getAcceptedIndices()) {
             indexSizes.put(index, getIndexPrimaryStoreSize(currentState, clusterInfo, index.getName()));
         }
 
-        if (indexSizes.values().stream().mapToLong(Long::longValue).sum() < totalAvailableBytesInWarmTier) {
+        if (indexSizes.values().stream().mapToLong(Long::longValue).sum() <= totalAvailableBytesInWarmTier) {
             return;
         }
-        HashMap<Index, Long> sortedIndexSizes = indexSizes.entrySet()
+        LinkedHashMap<Index, Long> sortedIndexSizes = indexSizes.entrySet()
             .stream()
             .sorted(Map.Entry.comparingByValue())
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, HashMap::new));
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
 
         long requestIndexBytes = 0L;
         for (Index index : sortedIndexSizes.keySet()) {
             requestIndexBytes += sortedIndexSizes.get(index);
-            if (requestIndexBytes >= totalAvailableBytesInWarmTier) {
+            if (requestIndexBytes > totalAvailableBytesInWarmTier) {
                 tieringValidationResult.addToRejected(index, "insufficient node capacity");
             }
         }
@@ -259,7 +262,10 @@ public class TieringRequestValidator {
     static long getTotalAvailableBytesInWarmTier(final Map<String, DiskUsage> usages, final Set<String> nodeIds) {
         long totalAvailableBytes = 0;
         for (String node : nodeIds) {
-            totalAvailableBytes += usages.get(node).getFreeBytes();
+            final DiskUsage nodeUsage = usages.get(node);
+            if (nodeUsage != null) {
+                totalAvailableBytes += nodeUsage.getFreeBytes();
+            }
         }
         return totalAvailableBytes;
     }

--- a/server/src/test/java/org/opensearch/action/admin/indices/tiering/TransportHotToWarmTieringActionUnitTests.java
+++ b/server/src/test/java/org/opensearch/action/admin/indices/tiering/TransportHotToWarmTieringActionUnitTests.java
@@ -1,0 +1,190 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.indices.tiering;
+
+import org.opensearch.Version;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.ActionTestUtils;
+import org.opensearch.cluster.ClusterInfo;
+import org.opensearch.cluster.ClusterInfoService;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.DiskUsage;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.RoutingTable;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.index.IndexModule;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
+import org.opensearch.test.ClusterServiceUtils;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.transport.MockTransport;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING;
+import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING;
+import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TransportHotToWarmTieringActionUnitTests extends OpenSearchTestCase {
+
+    private static final String REMOTE_INDEX = "remote-index";
+    private static final String REGULAR_INDEX = "regular-index";
+    private static final String WARM_NODE_ID = "warm-node";
+    private static final String CLUSTER_MANAGER_NODE_ID = "cluster-manager-node";
+
+    private ThreadPool threadPool;
+    private ClusterService clusterService;
+    private TransportService transportService;
+    private ClusterInfoService clusterInfoService;
+    private TransportHotToWarmTieringAction transportHotToWarmTieringAction;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool(getTestName());
+        clusterService = ClusterServiceUtils.createClusterService(threadPool);
+
+        MockTransport transport = new MockTransport();
+        transportService = transport.createTransportService(
+            Settings.EMPTY,
+            threadPool,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            ignored -> clusterService.localNode(),
+            null,
+            Collections.emptySet(),
+            NoopTracer.INSTANCE
+        );
+        transportService.start();
+        transportService.acceptIncomingRequests();
+
+        clusterInfoService = mock(ClusterInfoService.class);
+        transportHotToWarmTieringAction = new TransportHotToWarmTieringAction(
+            transportService,
+            clusterService,
+            threadPool,
+            new ActionFilters(Collections.emptySet()),
+            new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY)),
+            clusterInfoService,
+            Settings.builder()
+                .put(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), "1b")
+                .put(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), "1b")
+                .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), "1b")
+                .build()
+        );
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        clusterService.close();
+        transportService.close();
+        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+        super.tearDown();
+    }
+
+    public void testRespondsWhenOnlySomeIndicesAreAccepted() {
+        ClusterServiceUtils.setState(clusterService, ClusterState.builder(buildClusterState()));
+        when(clusterInfoService.getClusterInfo()).thenReturn(buildClusterInfo());
+
+        TieringIndexRequest request = new TieringIndexRequest(TieringIndexRequest.Tier.WARM.name(), REMOTE_INDEX, REGULAR_INDEX);
+
+        HotToWarmTieringResponse response = ActionTestUtils.executeBlocking(transportHotToWarmTieringAction, request);
+
+        assertTrue(response.isAcknowledged());
+        assertEquals(1, response.getFailedIndices().size());
+        assertEquals(REGULAR_INDEX, response.getFailedIndices().get(0).getIndex());
+        assertEquals("index is not backed up by the remote store", response.getFailedIndices().get(0).getFailureReason());
+    }
+
+    private ClusterState buildClusterState() {
+        String remoteIndexUuid = randomAlphaOfLength(10);
+        String regularIndexUuid = randomAlphaOfLength(10);
+
+        IndexMetadata remoteIndexMetadata = IndexMetadata.builder(REMOTE_INDEX)
+            .settings(
+                Settings.builder()
+                    .put(createDefaultIndexSettings(remoteIndexUuid))
+                    .put(IndexMetadata.INDEX_REMOTE_STORE_ENABLED_SETTING.getKey(), true)
+                    .put(IndexMetadata.INDEX_REPLICATION_TYPE_SETTING.getKey(), ReplicationType.SEGMENT)
+                    .put(IndexModule.INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT)
+            )
+            .build();
+        IndexMetadata regularIndexMetadata = IndexMetadata.builder(REGULAR_INDEX)
+            .settings(
+                Settings.builder()
+                    .put(createDefaultIndexSettings(regularIndexUuid))
+                    .put(IndexModule.INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT)
+            )
+            .build();
+
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder(remoteIndexMetadata))
+            .put(IndexMetadata.builder(regularIndexMetadata))
+            .build();
+        RoutingTable routingTable = RoutingTable.builder().addAsNew(remoteIndexMetadata).addAsNew(regularIndexMetadata).build();
+
+        DiscoveryNode clusterManagerNode = new DiscoveryNode(
+            CLUSTER_MANAGER_NODE_ID,
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.singleton(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE),
+            Version.CURRENT
+        );
+        DiscoveryNode warmNode = new DiscoveryNode(
+            WARM_NODE_ID,
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Collections.singleton(DiscoveryNodeRole.WARM_ROLE),
+            Version.CURRENT
+        );
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(clusterManagerNode)
+            .add(warmNode)
+            .localNodeId(CLUSTER_MANAGER_NODE_ID)
+            .clusterManagerNodeId(CLUSTER_MANAGER_NODE_ID)
+            .build();
+
+        return ClusterState.builder(new ClusterName("test-cluster")).metadata(metadata).routingTable(routingTable).nodes(nodes).build();
+    }
+
+    private ClusterInfo buildClusterInfo() {
+        return new ClusterInfo(
+            Map.of(WARM_NODE_ID, new DiskUsage(WARM_NODE_ID, WARM_NODE_ID, "/warm", 100L, 50L)),
+            null,
+            Map.of("[" + REMOTE_INDEX + "][0][p]", 10L),
+            null,
+            null,
+            Map.of(),
+            Map.of()
+        );
+    }
+
+    private Settings createDefaultIndexSettings(String indexUuid) {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_INDEX_UUID, indexUuid)
+            .put("index.version.created", Version.CURRENT)
+            .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+            .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+            .build();
+    }
+}

--- a/server/src/test/java/org/opensearch/indices/tiering/TieringRequestValidatorTests.java
+++ b/server/src/test/java/org/opensearch/indices/tiering/TieringRequestValidatorTests.java
@@ -210,6 +210,82 @@ public class TieringRequestValidatorTests extends OpenSearchTestCase {
         assertTrue(tieringValidationResult.getAcceptedIndices().isEmpty());
     }
 
+    public void testValidateEligibleNodesCapacitySkipsWhenDiskUsageUnavailable() {
+        String indexUuid = UUID.randomUUID().toString();
+        String indexName = "test_index";
+        Set<Index> indices = Set.of(new Index(indexName, indexUuid));
+        ClusterState clusterState = ClusterState.builder(buildClusterState(indexName, indexUuid, Settings.EMPTY))
+            .nodes(createNodes(1, 0, 0))
+            .build();
+        final Map<String, Long> shardSizes = new HashMap<>();
+        shardSizes.put("[test_index][0][p]", 10L);
+        ClusterInfo clusterInfo = new ClusterInfo(null, null, shardSizes, null, null, Map.of(), Map.of());
+        TieringValidationResult tieringValidationResult = new TieringValidationResult(indices);
+
+        validateEligibleNodesCapacity(clusterInfo, clusterState, tieringValidationResult);
+
+        assertEquals(indices, tieringValidationResult.getAcceptedIndices());
+        assertTrue(tieringValidationResult.getRejectedIndices().isEmpty());
+    }
+
+    public void testValidateEligibleNodesCapacityWithExactFitAccepted() {
+        String indexUuid = UUID.randomUUID().toString();
+        String indexName = "test_index";
+        Set<Index> indices = Set.of(new Index(indexName, indexUuid));
+        ClusterState clusterState = ClusterState.builder(buildClusterState(indexName, indexUuid, Settings.EMPTY))
+            .nodes(createNodes(1, 0, 0))
+            .build();
+        Map<String, DiskUsage> diskUsages = diskUsages(1, 100, 20);
+        final Map<String, Long> shardSizes = new HashMap<>();
+        shardSizes.put("[test_index][0][p]", 20L);
+        ClusterInfo clusterInfo = new ClusterInfo(diskUsages, null, shardSizes, null, null, Map.of(), Map.of());
+        TieringValidationResult tieringValidationResult = new TieringValidationResult(indices);
+
+        validateEligibleNodesCapacity(clusterInfo, clusterState, tieringValidationResult);
+
+        assertEquals(indices, tieringValidationResult.getAcceptedIndices());
+        assertTrue(tieringValidationResult.getRejectedIndices().isEmpty());
+    }
+
+    public void testValidateEligibleNodesCapacityRejectsLargestIndicesFirst() {
+        String smallIndexUuid = UUID.randomUUID().toString();
+        String mediumIndexUuid = UUID.randomUUID().toString();
+        String largeIndexUuid = UUID.randomUUID().toString();
+        String smallIndexName = "index-small";
+        String mediumIndexName = "index-medium";
+        String largeIndexName = "index-large";
+
+        Set<Index> indices = Set.of(
+            new Index(smallIndexName, smallIndexUuid),
+            new Index(mediumIndexName, mediumIndexUuid),
+            new Index(largeIndexName, largeIndexUuid)
+        );
+        ClusterState clusterState = ClusterState.builder(
+            buildClusterState(
+                Map.of(smallIndexName, smallIndexUuid, mediumIndexName, mediumIndexUuid, largeIndexName, largeIndexUuid),
+                Map.of(smallIndexName, Settings.EMPTY, mediumIndexName, Settings.EMPTY, largeIndexName, Settings.EMPTY)
+            )
+        ).nodes(createNodes(1, 0, 0)).build();
+        Map<String, DiskUsage> diskUsages = diskUsages(1, 100, 3);
+        final Map<String, Long> shardSizes = new HashMap<>();
+        shardSizes.put("[index-small][0][p]", 1L);
+        shardSizes.put("[index-medium][0][p]", 2L);
+        shardSizes.put("[index-large][0][p]", 3L);
+        ClusterInfo clusterInfo = new ClusterInfo(diskUsages, null, shardSizes, null, null, Map.of(), Map.of());
+        TieringValidationResult tieringValidationResult = new TieringValidationResult(indices);
+
+        validateEligibleNodesCapacity(clusterInfo, clusterState, tieringValidationResult);
+
+        assertEquals(
+            Set.of(new Index(smallIndexName, smallIndexUuid), new Index(mediumIndexName, mediumIndexUuid)),
+            tieringValidationResult.getAcceptedIndices()
+        );
+        assertEquals(
+            Map.of(new Index(largeIndexName, largeIndexUuid), "insufficient node capacity"),
+            tieringValidationResult.getRejectedIndices()
+        );
+    }
+
     public void testGetTotalAvailableBytesInWarmTier() {
         Map<String, DiskUsage> diskUsages = diskUsages(2, 500, 100);
         assertEquals(200, getTotalAvailableBytesInWarmTier(diskUsages, Set.of("node-w0", "node-w1")));
@@ -245,12 +321,34 @@ public class TieringRequestValidatorTests extends OpenSearchTestCase {
             .build();
     }
 
+    private static ClusterState buildClusterState(Map<String, String> indexUuids, Map<String, Settings> settingsByIndex) {
+        Metadata.Builder metadata = Metadata.builder();
+        RoutingTable.Builder routingTable = RoutingTable.builder();
+        for (Map.Entry<String, Settings> entry : settingsByIndex.entrySet()) {
+            String indexName = entry.getKey();
+            String indexUuid = indexUuids.get(indexName);
+            Settings combinedSettings = Settings.builder().put(entry.getValue()).put(createDefaultIndexSettings(indexUuid, 1, 0)).build();
+            IndexMetadata indexMetadata = IndexMetadata.builder(indexName).settings(combinedSettings).build();
+            metadata.put(IndexMetadata.builder(indexMetadata));
+            routingTable.addAsNew(indexMetadata);
+        }
+
+        return ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .routingTable(routingTable.build())
+            .build();
+    }
+
     private static Settings createDefaultIndexSettings(String indexUuid) {
+        return createDefaultIndexSettings(indexUuid, 2, 1);
+    }
+
+    private static Settings createDefaultIndexSettings(String indexUuid, int numberOfShards, int numberOfReplicas) {
         return Settings.builder()
             .put("index.version.created", Version.CURRENT)
             .put(IndexMetadata.SETTING_INDEX_UUID, indexUuid)
-            .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 2)
-            .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
+            .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), numberOfShards)
+            .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), numberOfReplicas)
             .build();
     }
 


### PR DESCRIPTION
## Summary
- complete hot-to-warm requests after partial validation instead of leaving the listener unresolved
- harden warm-tier capacity validation when disk usage data is missing and preserve deterministic rejection order
- add focused coverage for the transport response path and validator edge cases

## Validation
- JAVA_HOME=/Users/abishekkumargiri/Library/Java/JavaVirtualMachines/openjdk-21.0.1/Contents/Home ./gradlew :server:precommit :server:test --tests "org.opensearch.indices.tiering.TieringRequestValidatorTests" --tests "org.opensearch.action.admin.indices.tiering.TransportHotToWarmTieringActionUnitTests"