### PR TITLE
IO runtime task cancellation support for DataFusion queries

### DIFF
--- a/plugins/engine-datafusion/Cargo.toml
+++ b/plugins/engine-datafusion/Cargo.toml
@@ -31,6 +31,7 @@ prost = "0.14"
 
 # Async runtime
 tokio = { version = "1.0", features = ["full"] }
+tokio-util = { version = "0.7" }
 futures = "0.3"
 #tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-metrics = "0.4"

--- a/plugins/engine-datafusion/jni/Cargo.toml
+++ b/plugins/engine-datafusion/jni/Cargo.toml
@@ -36,6 +36,7 @@ prost = { workspace = true }
 
 # Async runtime
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 futures = { workspace = true }
 #tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-metrics = { workspace = true }

--- a/plugins/engine-datafusion/jni/src/cancellation.rs
+++ b/plugins/engine-datafusion/jni/src/cancellation.rs
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Central cancellation utilities for DataFusion query tasks.
+use std::future::Future;
+use datafusion::common::DataFusionError;
+use tokio_util::sync::CancellationToken;
+
+/// Run a future with cancellation support. If the token fires before the
+/// future completes, returns a cancellation error immediately.
+///
+/// Pass `None` for non-cancellable queries — the future runs directly.
+pub async fn cancellable<F, T>(
+    token: Option<&CancellationToken>,
+    task_id: i64,
+    fut: F,
+) -> Result<T, DataFusionError>
+where
+    F: Future<Output = Result<T, DataFusionError>>,
+{
+    match token {
+        Some(token) => {
+            tokio::select! {
+                result = fut => result,
+                _ = token.cancelled() => {
+                    Err(DataFusionError::Execution(
+                        format!("Query {} cancelled", task_id)
+                    ))
+                }
+            }
+        }
+        None => fut.await,
+    }
+}
+
+/// Run a future with cancellation support. If the token fires before the
+/// future completes, returns a sentinel value immediately.
+///
+/// Pass `None` for non-cancellable queries — the future runs directly.
+pub async fn cancellable_or<F, T>(
+    token: Option<&CancellationToken>,
+    sentinel: T,
+    fut: F,
+) -> Result<T, DataFusionError>
+where
+    F: Future<Output = Result<T, DataFusionError>>,
+{
+    match token {
+        Some(token) => {
+            tokio::select! {
+                result = fut => result,
+                _ = token.cancelled() => Ok(sentinel),
+            }
+        }
+        None => fut.await,
+    }
+}

--- a/plugins/engine-datafusion/jni/src/lib.rs
+++ b/plugins/engine-datafusion/jni/src/lib.rs
@@ -52,6 +52,7 @@ mod cache_jni;
 mod partial_agg_optimizer;
 mod query_executor;
 mod indexed_query_executor;
+mod cancellation;
 mod indexed_table;
 mod project_row_id_analyzer;
 pub mod logger;
@@ -59,6 +60,8 @@ pub mod logger;
 // Import logger macros from shared crate
 use vectorized_exec_spi::{log_info, log_error, log_debug};
 
+use dashmap::DashMap;
+use tokio_util::sync::CancellationToken;
 use crate::custom_cache_manager::CustomCacheManager;
 use crate::util::{create_file_meta_from_filenames, parse_string_arr, set_action_listener_error, set_action_listener_error_global, set_action_listener_ok, set_action_listener_ok_global, set_action_listener_ok_global_with_map};
 use datafusion::execution::memory_pool::{GreedyMemoryPool, TrackConsumersPool};
@@ -112,6 +115,22 @@ static SEGMENT_STATS_MONITOR: Lazy<TaskMonitor> = Lazy::new(|| {
 static INDEXED_QUERY_EXECUTION_MONITOR: Lazy<TaskMonitor> = Lazy::new(|| {
     TaskMonitor::with_slow_poll_threshold(Duration::from_micros(100)).clone()
 });
+
+/// Per-query context
+pub struct QueryContext {
+    pub cancellation_token: CancellationToken,
+}
+
+impl QueryContext {
+    fn new() -> Self {
+        Self {
+            cancellation_token: CancellationToken::new(),
+        }
+    }
+}
+
+/// Registry of all in-flight queries on this node, keyed by ShardSearchContextId.
+static ACTIVE_QUERIES: Lazy<DashMap<i64, QueryContext>> = Lazy::new(DashMap::new);
 
 // Global runtime manager
 static TOKIO_RUNTIME_MANAGER: OnceLock<Arc<RuntimeManager>> = OnceLock::new();
@@ -321,6 +340,7 @@ fn log_runtime_metrics(metrics: &tokio_metrics::RuntimeMetrics) {
     log_info!("  Total overflow: {}", metrics.total_overflow_count);
     log_info!("  Global queue depth: {}", metrics.global_queue_depth);
     log_info!("  Blocking queue depth: {}", metrics.blocking_queue_depth);
+    log_info!("  Active queries (ACTIVE_QUERIES): {}", ACTIVE_QUERIES.len());
     let query_metrics = QUERY_EXECUTION_MONITOR.cumulative();
     log_task_metrics("Query exec (via CrossRtStream)", &query_metrics);
     let stream_metrics = STREAM_NEXT_MONITOR.cumulative();
@@ -657,6 +677,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeQu
     is_query_plan_explain_enabled: jboolean,
     target_partitions: jint,
     runtime_ptr: jlong,
+    task_id: jlong,
     listener: JObject,
 ) {
     let manager = match TOKIO_RUNTIME_MANAGER.get() {
@@ -713,20 +734,34 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeQu
     let table_path = shard_view.table_path();
     let files_meta = shard_view.files_metadata();
 
+    // Register this query before spawning so cancelQuery() can interrupt setup.
+    ACTIVE_QUERIES.insert(task_id, QueryContext::new());
+    let token = ACTIVE_QUERIES.get(&task_id).map(|ctx| ctx.cancellation_token.clone());
+
     spawn_jni_task(
         &io_runtime,
         "executeQueryPhaseAsync",
         listener_ref,
-        QUERY_EXECUTION_MONITOR.instrument(query_executor::execute_query_with_cross_rt_stream(
-            table_path,
-            files_meta,
-            table_name,
-            plan_bytes_vec,
-            is_query_plan_explain_enabled,
-            target_partitions,
-            runtime,
-            cpu_executor,
-        )),
+        async move {
+            let result = cancellation::cancellable(
+                token.as_ref(),
+                task_id,
+                QUERY_EXECUTION_MONITOR.instrument(query_executor::execute_query_with_cross_rt_stream(
+                    table_path,
+                    files_meta,
+                    table_name,
+                    plan_bytes_vec,
+                    is_query_plan_explain_enabled,
+                    target_partitions,
+                    runtime,
+                    cpu_executor,
+                )),
+            ).await;
+            if result.is_err() {
+                ACTIVE_QUERIES.remove(&task_id);
+            }
+            result
+        },
         |env, listener_ref, stream_pointer| set_action_listener_ok_global(env, listener_ref, stream_pointer),
     );
 }
@@ -778,6 +813,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_streamNex
     _class: JClass,
     runtime_ptr: jlong,
     stream: jlong,
+    task_id: jlong,
     listener: JObject,
 ) {
     let manager = match TOKIO_RUNTIME_MANAGER.get() {
@@ -806,6 +842,9 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_streamNex
     let stream_ptr = stream;
     let io_runtime = manager.io_runtime.clone();
 
+    // Look up the cancellation token for this query.
+    let token = ACTIVE_QUERIES.get(&task_id).map(|ctx| ctx.cancellation_token.clone());
+
     // Ensure stream_ptr lifetime is guaranteed beyond the spawn boundary
     // (e.g., wrap in Arc<Mutex<...>> or ensure sequential access contract)
     spawn_jni_task(
@@ -815,9 +854,13 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_streamNex
         STREAM_NEXT_MONITOR.instrument(async move {
             let stream = unsafe { &mut *(stream_ptr as *mut RecordBatchStreamAdapter<CrossRtStream>) };
             // Poll the stream with monitoring
-            let result = stream.try_next().await?;
+            let maybe_batch = cancellation::cancellable_or(
+                token.as_ref(),
+                None,
+                async { stream.try_next().await.map_err(Into::into) },
+            ).await?;
 
-            match result {
+            match maybe_batch {
                 Some(batch) => {
                     log_info!("[RUST streamNext] Batch produced: {} rows, {} columns, schema: {:?}",
                         batch.num_rows(), batch.num_columns(), batch.schema().fields().iter().map(|f| f.name().as_str()).collect::<Vec<_>>());
@@ -880,6 +923,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeFe
     include_fields: JObjectArray,
     exclude_fields: JObjectArray,
     runtime_ptr: jlong,
+    task_id: jlong,
     callback: JObject,
 ) -> jlong {
     let shard_view = unsafe { &*(shard_view_ptr as *const ShardView) };
@@ -887,6 +931,15 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeFe
 
     let table_path = shard_view.table_path();
     let files_metadata = shard_view.files_metadata();
+
+    // Skip execution if this query was already cancelled before the fetch phase begins.
+    if ACTIVE_QUERIES.get(&task_id).map_or(false, |ctx| ctx.cancellation_token.is_cancelled()) {
+        let _ = env.throw_new(
+            "java/lang/RuntimeException",
+            format!("Fetch phase skipped: query {} cancelled", task_id),
+        );
+        return 0;
+    }
 
     let include_fields: Vec<String> =
         parse_string_arr(&mut env, include_fields).expect("Expected list of files");
@@ -968,7 +1021,9 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_streamClo
     _env: JNIEnv,
     _class: JClass,
     stream: jlong,
+    task_id: jlong,
 ) {
+    ACTIVE_QUERIES.remove(&task_id);
     let _ = unsafe { Box::from_raw(stream as *mut RecordBatchStreamAdapter<CrossRtStream>) };
 }
 
@@ -1138,5 +1193,22 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeIn
             log_error!("Indexed query execution failed: {}", e);
             set_action_listener_error(&mut env, listener, &e);
         }
+    }
+}
+
+/// Signals cancellation for the query registered under the given task ID.
+/// The cancellation token is picked up by the select! in executeQueryPhaseAsync
+/// and streamNext, causing them to return early to Java.
+#[no_mangle]
+pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_cancelQuery(
+    _env: JNIEnv,
+    _class: JClass,
+    task_id: jlong,
+) {
+    if let Some(ctx) = ACTIVE_QUERIES.get(&task_id) {
+        ctx.cancellation_token.cancel();
+        log_info!("Cancelled query with task_id={}", task_id);
+    } else {
+        log_debug!("cancelQuery called for unknown/completed task_id={}", task_id);
     }
 }

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DataFusionBridge.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DataFusionBridge.java
@@ -38,6 +38,7 @@ import java.io.Closeable;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 /**
@@ -53,6 +54,9 @@ import java.util.stream.Collectors;
  */
 
 public class DataFusionBridge implements EngineBridge<byte[], DataFusionResultStream, RelNode>, Closeable {
+
+    /** Negative IDs for bridge-path queries to avoid collision with ShardSearchContextId. */
+    private static final AtomicLong BRIDGE_TASK_ID_COUNTER = new AtomicLong(-1L);
 
     private static final Logger logger = LogManager.getLogger(DataFusionBridge.class);
 
@@ -196,6 +200,7 @@ public class DataFusionBridge implements EngineBridge<byte[], DataFusionResultSt
      */
     @Override
     public DataFusionResultStream execute(byte[] fragment) {
+        long taskId = BRIDGE_TASK_ID_COUNTER.getAndDecrement();
         CompletableFuture<Long> future = new CompletableFuture<>();
         NativeBridge.executeQueryPhaseAsync(
             reader.getReaderPtr(),
@@ -204,6 +209,7 @@ public class DataFusionBridge implements EngineBridge<byte[], DataFusionResultSt
             false,    // isQueryPlanExplainEnabled
             0,        // partitionCount — use engine default
             runtimePointer,
+            taskId,
             new ActionListener<Long>() {
                 @Override
                 public void onResponse(Long streamPointer) {
@@ -223,7 +229,7 @@ public class DataFusionBridge implements EngineBridge<byte[], DataFusionResultSt
         } catch (Exception e) {
             throw new RuntimeException("Failed to execute query phase", e);
         }
-        return new DataFusionResultStream(streamPointer, runtimePointer, allocator);
+        return new DataFusionResultStream(streamPointer, runtimePointer, taskId, allocator);
     }
 
     @Override

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DataFusionResultStream.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DataFusionResultStream.java
@@ -38,6 +38,10 @@ public class DataFusionResultStream implements EngineResultStream {
         this.stream = new RecordBatchStream(streamPointer, runtimePointer, allocator);
     }
 
+    public DataFusionResultStream(long streamPointer, long runtimePointer, long taskId, BufferAllocator allocator) {
+        this.stream = new RecordBatchStream(streamPointer, runtimePointer, taskId, allocator);
+    }
+
     @Override
     public EngineResultBatchIterator iterator() {
         if (iteratorInstance == null) {

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DatafusionEngine.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/DatafusionEngine.java
@@ -232,6 +232,7 @@ public class DatafusionEngine extends SearchExecEngine<DatafusionContext, Datafu
     @Override
     public void executeQueryPhase(DatafusionContext context) {
         DatafusionSearcher datafusionSearcher = context.getEngineSearcher();
+        datafusionSearcher.setTaskId(context.getContextId());
         long streamPointer = datafusionSearcher.search(context.getDatafusionQuery(), datafusionService.getRuntimePointer());
         consumeStreamAndSetResults(context, streamPointer);
     }
@@ -247,7 +248,7 @@ public class DatafusionEngine extends SearchExecEngine<DatafusionContext, Datafu
         RecordBatchStream stream = null;
 
         try {
-            stream = new RecordBatchStream(streamPointer, datafusionService.getRuntimePointer(), rootAllocator);
+            stream = new RecordBatchStream(streamPointer, datafusionService.getRuntimePointer(), context.getContextId(), rootAllocator);
 
             // We can have some collectors passed like this which can collect the results and convert to InternalAggregation
             // Is the possible? need to check
@@ -305,6 +306,9 @@ public class DatafusionEngine extends SearchExecEngine<DatafusionContext, Datafu
             context.getDatafusionQuery().setQueryPlanExplainEnabled(context.evaluateSearchQueryExplainMode());
             context.getDatafusionQuery().setTargetPartitionsCount(context.getTargetMaxSliceCount());
 
+            long contextId = context.getContextId();
+            datafusionSearcher.setTaskId(contextId);
+
             datafusionSearcher.searchAsync(context.getDatafusionQuery(), datafusionService.getRuntimePointer()).whenCompleteAsync((streamPointer, error)-> {
                 Map<String, List<Object>> finalResColumns = new HashMap<>();
                 List<Long> rowIdResult = new ArrayList<>();
@@ -332,7 +336,7 @@ public class DatafusionEngine extends SearchExecEngine<DatafusionContext, Datafu
 
     private void collect(DatafusionContext context, Executor executor, ActionListener<QueryResult> listener, Long streamPointer, Map<String, List<Object>> finalRes, List<Long> rowIdResult) {
         RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-        RecordBatchStream stream = new RecordBatchStream(streamPointer, datafusionService.getRuntimePointer() , allocator);
+        RecordBatchStream stream = new RecordBatchStream(streamPointer, datafusionService.getRuntimePointer(), context.getContextId(), allocator);
         SearchResultsCollector<RecordBatchStream> collector = new SearchResultsCollector<RecordBatchStream>() {
             @Override
             public void collect(RecordBatchStream value) {
@@ -449,8 +453,9 @@ public class DatafusionEngine extends SearchExecEngine<DatafusionContext, Datafu
 
         context.getDatafusionQuery().setSource(includeFields, excludeFields);
         DatafusionSearcher datafusionSearcher = context.getEngineSearcher();
+        datafusionSearcher.setTaskId(context.getContextId());
         long streamPointer = datafusionSearcher.search(context.getDatafusionQuery(), datafusionService.getRuntimePointer());
-        RecordBatchStream stream = new RecordBatchStream(streamPointer, datafusionService.getRuntimePointer(), rootAllocator);
+        RecordBatchStream stream = new RecordBatchStream(streamPointer, datafusionService.getRuntimePointer(), context.getContextId(), rootAllocator);
 
         Map<Long, Integer> rowIdToIndex = new HashMap<>();
         for (int idx = 0; idx < rowIds.size(); idx++) {

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/RecordBatchStream.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/RecordBatchStream.java
@@ -37,7 +37,11 @@ public class RecordBatchStream implements Closeable {
      * @param parentAllocator parent allocator to create child from
      */
     public RecordBatchStream(long streamId, long runtimePtr, BufferAllocator parentAllocator) {
-        this.streamHandle = new StreamHandle(streamId, runtimePtr);
+        this(streamId, runtimePtr, 0L, parentAllocator);
+    }
+
+    public RecordBatchStream(long streamId, long runtimePtr, long taskId, BufferAllocator parentAllocator) {
+        this.streamHandle = new StreamHandle(streamId, runtimePtr, taskId);
         this.allocator = parentAllocator.newChildAllocator("stream-" + streamId, 0, Long.MAX_VALUE);
         this.dictionaryProvider = new CDataDictionaryProvider();
         this.schemaFuture = streamHandle.getSchema(allocator, dictionaryProvider)

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/NativeBridge.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/NativeBridge.java
@@ -37,16 +37,19 @@ public final class NativeBridge {
     public static native void shutdownTokioRuntimeManager();
 
     // Query execution
-    public static native void executeQueryPhaseAsync(long readerPtr, String tableName, byte[] plan, boolean isQueryPlanExplainEnabled, int partitionCount, long runtimePtr, ActionListener<Long> listener);
-    public static native long executeFetchPhase(long readerPtr, long[] rowIds, String[] includeFields, String[] excludeFields, long runtimePtr);
+    public static native void executeQueryPhaseAsync(long readerPtr, String tableName, byte[] plan, boolean isQueryPlanExplainEnabled, int partitionCount, long runtimePtr, long taskId, ActionListener<Long> listener);
+    public static native long executeFetchPhase(long readerPtr, long[] rowIds, String[] includeFields, String[] excludeFields, long runtimePtr, long taskId);
 
     // File Stats
     public static native void fetchSegmentStats(long readerPtr, ActionListener<Map<String, FileStats>> listener);
 
     // Stream operations
-    public static native void streamNext(long runtime, long stream, ActionListener<Long> listener);
+    public static native void streamNext(long runtime, long stream, long taskId, ActionListener<Long> listener);
+
+    // Cancellation
+    public static native void cancelQuery(long taskId);
     public static native void streamGetSchema(long stream, ActionListener<Long> listener);
-    public static native void streamClose(long stream);
+    public static native void streamClose(long stream, long taskId);
 
     // Cache management
     public static native long createCustomCacheManager();

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/handle/StreamHandle.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/jni/handle/StreamHandle.java
@@ -32,15 +32,17 @@ import static org.apache.arrow.c.Data.importField;
 public final class StreamHandle extends NativeHandle {
 
     private final long runtimePtr;
+    private final long taskId;
 
-    public StreamHandle(long ptr, long runtimePtr) {
+    public StreamHandle(long ptr, long runtimePtr, long taskId) {
         super(ptr);
         this.runtimePtr = runtimePtr;
+        this.taskId = taskId;
     }
 
     @Override
     protected void doClose() {
-        NativeBridge.streamClose(ptr);
+        NativeBridge.streamClose(ptr, taskId);
     }
 
     /**
@@ -80,7 +82,7 @@ public final class StreamHandle extends NativeHandle {
                                                     CDataDictionaryProvider dictionaryProvider) {
         long runtimePointer = this.runtimePtr;
         CompletableFuture<Boolean> result = new CompletableFuture<>();
-        NativeBridge.streamNext(runtimePointer, ptr, new ActionListener<Long>() {
+        NativeBridge.streamNext(runtimePointer, ptr, taskId, new ActionListener<Long>() {
             @Override
             public void onResponse(Long arrowArrayAddress) {
                 if (arrowArrayAddress == 0) {

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/search/DatafusionContext.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/search/DatafusionContext.java
@@ -233,6 +233,10 @@ public class DatafusionContext extends SearchContext {
         return null;
     }
 
+    public long getContextId() {
+        return readerContext.id().getId();
+    }
+
     @Override
     public String source() {
         return "";

--- a/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/search/DatafusionSearcher.java
+++ b/plugins/engine-datafusion/src/main/java/org/opensearch/datafusion/search/DatafusionSearcher.java
@@ -24,11 +24,16 @@ public class DatafusionSearcher implements EngineSearcher<DatafusionQuery, Recor
     private final String source;
     private DatafusionReader reader;
     private Closeable closeable;
+    private long taskId = 0;
 
     public DatafusionSearcher(String source, DatafusionReader reader, Closeable close) {
         this.source = source;
         this.reader = reader;
         this.closeable = close;
+    }
+
+    public void setTaskId(long taskId) {
+        this.taskId = taskId;
     }
 
     @Override
@@ -47,7 +52,7 @@ public class DatafusionSearcher implements EngineSearcher<DatafusionQuery, Recor
             String[] includeFields = Objects.isNull(datafusionQuery.getIncludeFields()) ? new String[]{} : datafusionQuery.getIncludeFields().toArray(String[]::new);
             String[] excludeFields = Objects.isNull(datafusionQuery.getExcludeFields()) ? new String[]{} : datafusionQuery.getExcludeFields().toArray(String[]::new);
 
-            return NativeBridge.executeFetchPhase(reader.getReaderPtr(), row_ids, includeFields, excludeFields, runtimePtr);
+            return NativeBridge.executeFetchPhase(reader.getReaderPtr(), row_ids, includeFields, excludeFields, runtimePtr, taskId);
         }
         throw new RuntimeException("Can be only called for fetch phase");
     }
@@ -55,7 +60,7 @@ public class DatafusionSearcher implements EngineSearcher<DatafusionQuery, Recor
     @Override
     public CompletableFuture<Long> searchAsync(DatafusionQuery datafusionQuery, Long runtimePtr) {
         CompletableFuture<Long> result = new CompletableFuture<>();
-        NativeBridge.executeQueryPhaseAsync(reader.getReaderPtr(), datafusionQuery.getIndexName(), datafusionQuery.getSubstraitBytes(), datafusionQuery.getQueryPlanExplainEnabled(), datafusionQuery.getTargetPartitionsCount(), runtimePtr, new ActionListener<Long>() {
+        NativeBridge.executeQueryPhaseAsync(reader.getReaderPtr(), datafusionQuery.getIndexName(), datafusionQuery.getSubstraitBytes(), datafusionQuery.getQueryPlanExplainEnabled(), datafusionQuery.getTargetPartitionsCount(), runtimePtr, taskId, new ActionListener<Long>() {
             @Override
             public void onResponse(Long streamPointer) {
                 if (streamPointer == 0) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds cancellation support for DataFusion query tasks running on the `io_runtime`. When a `SearchShardTask` is cancelled, the Java side can now call `cancelQuery(taskId)` to immediately interrupt in-flight IO work on the Rust side.

The PR adds:
- `ACTIVE_QUERIES` registry — A global `DashMap<i64, QueryContext>` keyed by ShardSearchContextId. Each entry holds a `CancellationToken`. Entries are inserted at `executeQueryPhaseAsync` start and removed at `streamClose` (or on setup error).

- `cancellation.rs` utility — Helpers that race a future against a `CancellationToken`.

- New JNI method: `cancelQuery(long taskId)` — fires the cancellation token

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
