### PR TITLE
Added DSL to relnode support for fields project converter and sort.mi…

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslProjectIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslProjectIT.java
@@ -46,4 +46,9 @@ public class DslProjectIT extends DslIntegTestBase {
         createTestIndex();
         assertOk(search(new SearchSourceBuilder().fetchSource(new String[]{}, new String[]{"ra*"})));
     }
+
+    public void testDocValueFields() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().docValueField("name").docValueField("price")));
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslSortIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslSortIT.java
@@ -55,4 +55,22 @@ public class DslSortIT extends DslIntegTestBase {
         createTestIndex();
         assertOk(search(new SearchSourceBuilder().from(10).size(5)));
     }
+
+    public void testSortMissingFirst() {
+        createTestIndex();
+        assertOk(search(
+            new SearchSourceBuilder().sort(
+                org.opensearch.search.sort.SortBuilders.fieldSort("price").order(SortOrder.ASC).missing("_first")
+            )
+        ));
+    }
+
+    public void testSortMissingLast() {
+        createTestIndex();
+        assertOk(search(
+            new SearchSourceBuilder().sort(
+                org.opensearch.search.sort.SortBuilders.fieldSort("price").order(SortOrder.DESC).missing("_last")
+            )
+        ));
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/ProjectConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/ProjectConverter.java
@@ -33,15 +33,26 @@ public class ProjectConverter extends AbstractDslConverter {
 
     @Override
     protected boolean isApplicable(ConversionContext ctx) {
-        return ctx.getSearchSource().fetchSource() != null;
+        return ctx.getSearchSource().fetchSource() != null || hasDocValueFields(ctx);
     }
 
     @Override
     protected RelNode doConvert(RelNode input, ConversionContext ctx) throws ConversionException {
         FetchSourceContext fetchSource = ctx.getSearchSource().fetchSource();
+        List<org.opensearch.search.fetch.subphase.FieldAndFormat> docValueFields = ctx.getSearchSource().docValueFields();
 
-        if (!fetchSource.fetchSource()) {
+        // Handle fields parameter (doc_value fields)
+        if (docValueFields != null && !docValueFields.isEmpty()) {
+            return createFieldsProjection(input, docValueFields, ctx.getRexBuilder());
+        }
+
+        // Handle _source parameter
+        if (fetchSource != null && !fetchSource.fetchSource()) {
             return LogicalProject.create(input, List.of(), List.of(), List.of());
+        }
+
+        if (fetchSource == null) {
+            return input;
         }
 
         String[] includes = fetchSource.includes();
@@ -54,6 +65,31 @@ public class ProjectConverter extends AbstractDslConverter {
         }
 
         return createProjection(input, includes, excludes, ctx.getRexBuilder());
+    }
+
+    private boolean hasDocValueFields(ConversionContext ctx) {
+        List<org.opensearch.search.fetch.subphase.FieldAndFormat> fields = ctx.getSearchSource().docValueFields();
+        return fields != null && !fields.isEmpty();
+    }
+
+    private RelNode createFieldsProjection(RelNode input, 
+            List<org.opensearch.search.fetch.subphase.FieldAndFormat> docValueFields, 
+            RexBuilder rexBuilder) throws ConversionException {
+        RelDataType rowType = input.getRowType();
+        List<RexNode> projects = new ArrayList<>();
+        List<String> fieldNames = new ArrayList<>();
+
+        for (org.opensearch.search.fetch.subphase.FieldAndFormat fieldAndFormat : docValueFields) {
+            String fieldName = fieldAndFormat.field;
+            RelDataTypeField field = rowType.getField(fieldName, false, false);
+            if (field == null) {
+                throw new ConversionException("Field '" + fieldName + "' not found in schema");
+            }
+            projects.add(rexBuilder.makeInputRef(field.getType(), field.getIndex()));
+            fieldNames.add(field.getName());
+        }
+
+        return LogicalProject.create(input, List.of(), projects, fieldNames);
     }
 
     private RelNode createProjection(RelNode input, String[] includes, String[] excludes, RexBuilder rexBuilder)

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SortConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SortConverter.java
@@ -72,9 +72,7 @@ public class SortConverter extends AbstractDslConverter {
                     ? RelFieldCollation.Direction.ASCENDING
                     : RelFieldCollation.Direction.DESCENDING;
 
-                RelFieldCollation.NullDirection nullDirection = (fieldSort.order() == SortOrder.ASC)
-                    ? RelFieldCollation.NullDirection.LAST
-                    : RelFieldCollation.NullDirection.FIRST;
+                RelFieldCollation.NullDirection nullDirection = resolveNullDirection(fieldSort);
 
                 fieldCollations.add(new RelFieldCollation(field.getIndex(), direction, nullDirection));
             } else {
@@ -83,6 +81,21 @@ public class SortConverter extends AbstractDslConverter {
         }
 
         return RelCollations.of(fieldCollations);
+    }
+
+    private RelFieldCollation.NullDirection resolveNullDirection(FieldSortBuilder fieldSort) {
+        Object missing = fieldSort.missing();
+        if (missing != null) {
+            String missingStr = missing.toString();
+            if ("_first".equals(missingStr)) {
+                return RelFieldCollation.NullDirection.FIRST;
+            } else if ("_last".equals(missingStr)) {
+                return RelFieldCollation.NullDirection.LAST;
+            }
+        }
+        return (fieldSort.order() == SortOrder.ASC)
+            ? RelFieldCollation.NullDirection.LAST
+            : RelFieldCollation.NullDirection.FIRST;
     }
 
     private RexNode buildOffset(ConversionContext ctx) {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/ProjectConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/ProjectConverterTests.java
@@ -112,4 +112,24 @@ public class ProjectConverterTests extends OpenSearchTestCase {
         assertTrue(result instanceof LogicalProject);
         assertEquals(0, result.getRowType().getFieldCount());
     }
+
+    public void testDocValueFields() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder()
+            .docValueField("name")
+            .docValueField("price");
+        ConversionContext ctx = TestUtils.createContext(source);
+        RelNode result = converter.convert(scan, ctx);
+
+        assertTrue(result instanceof LogicalProject);
+        assertEquals(2, result.getRowType().getFieldCount());
+        assertEquals("name", result.getRowType().getFieldNames().get(0));
+        assertEquals("price", result.getRowType().getFieldNames().get(1));
+    }
+
+    public void testDocValueFieldsThrowsForUnknownField() {
+        SearchSourceBuilder source = new SearchSourceBuilder().docValueField("nonexistent");
+        ConversionContext ctx = TestUtils.createContext(source);
+
+        expectThrows(ConversionException.class, () -> converter.convert(scan, ctx));
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SortConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SortConverterTests.java
@@ -102,4 +102,28 @@ public class SortConverterTests extends OpenSearchTestCase {
 
         expectThrows(ConversionException.class, () -> converter.convert(scan, ctx));
     }
+
+    public void testSortMissingFirst() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().sort(
+            org.opensearch.search.sort.SortBuilders.fieldSort("price").order(SortOrder.ASC).missing("_first")
+        );
+        ConversionContext ctx = TestUtils.createContext(source);
+        RelNode result = converter.convert(scan, ctx);
+
+        LogicalSort sort = (LogicalSort) result;
+        RelFieldCollation fieldCollation = sort.getCollation().getFieldCollations().get(0);
+        assertEquals(RelFieldCollation.NullDirection.FIRST, fieldCollation.nullDirection);
+    }
+
+    public void testSortMissingLast() throws ConversionException {
+        SearchSourceBuilder source = new SearchSourceBuilder().sort(
+            org.opensearch.search.sort.SortBuilders.fieldSort("price").order(SortOrder.DESC).missing("_last")
+        );
+        ConversionContext ctx = TestUtils.createContext(source);
+        RelNode result = converter.convert(scan, ctx);
+
+        LogicalSort sort = (LogicalSort) result;
+        RelFieldCollation fieldCollation = sort.getCollation().getFieldCollations().get(0);
+        assertEquals(RelFieldCollation.NullDirection.LAST, fieldCollation.nullDirection);
+    }
 }


### PR DESCRIPTION
## Summary

Added DSL to RelNode support for fields projection and sort.missing handling

### Changes

ProjectConverter enhancements:
• Added support for docValueFields (fields parameter) in addition to existing _source filtering
• New createFieldsProjection() method to handle doc value field projections
• Added validation to throw ConversionException for non-existent fields
• Updated isApplicable() to check for both fetchSource and docValueFields

SortConverter enhancements:
• Added support for missing parameter in field sorts (_first and _last)
• New resolveNullDirection() method to handle explicit null positioning
• Falls back to default behavior (ASC: nulls last, DESC: nulls first) when missing parameter is not specified

Test coverage:
• Added integration tests: testDocValueFields(), testSortMissingFirst(), testSortMissingLast()
• Added unit tests for both converters with positive and negative test cases
• Validates error handling for unknown fields

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- NA -->

### Check List
- [Y ] Functionality includes testing.
- [Y ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [Y ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
