### PR TITLE
Fix FlightOutboundHandler clearing caller's ThreadContext

### DIFF
--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
@@ -20,7 +20,6 @@ import org.apache.arrow.flight.FlightRuntimeException;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.BytesStreamOutput;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.threadpool.ThreadPool;
@@ -37,7 +36,6 @@ import org.opensearch.transport.stream.StreamException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Set;
-import java.util.function.Supplier;
 
 /**
  * Outbound handler for Arrow Flight streaming responses.

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
@@ -37,6 +37,7 @@ import org.opensearch.transport.stream.StreamException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Outbound handler for Arrow Flight streaming responses.
@@ -115,7 +116,6 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
         final boolean compress,
         final boolean isHandshake
     ) throws IOException {
-        ThreadContext.StoredContext storedContext = threadPool.getThreadContext().stashContext();
         BatchTask task = new BatchTask(
             nodeVersion,
             features,
@@ -128,8 +128,7 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
             isHandshake,
             false,
             false,
-            null,
-            storedContext
+            null
         );
 
         if (!(channel instanceof FlightServerChannel flightChannel)) {
@@ -137,17 +136,16 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
             return;
         }
 
-        flightChannel.getExecutor().execute(() -> {
+        flightChannel.getExecutor().execute(threadPool.getThreadContext().preserveContext(() -> {
             try (BatchTask ignored = task) {
                 processBatchTask(task);
             } catch (Exception e) {
                 messageListener.onResponseSent(requestId, action, e);
             }
-        });
+        }));
     }
 
     private void processBatchTask(BatchTask task) {
-        task.storedContext().restore();
         if (!(task.channel() instanceof FlightServerChannel flightChannel)) {
             Exception error = new IllegalStateException("Expected FlightServerChannel, got " + task.channel().getClass().getName());
             messageListener.onResponseSent(task.requestId(), task.action(), error);
@@ -175,7 +173,6 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
         final long requestId,
         final String action
     ) {
-        ThreadContext.StoredContext storedContext = threadPool.getThreadContext().stashContext();
         BatchTask completeTask = new BatchTask(
             nodeVersion,
             features,
@@ -188,8 +185,7 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
             false,
             true,
             false,
-            null,
-            storedContext
+            null
         );
 
         if (!(channel instanceof FlightServerChannel flightChannel)) {
@@ -197,17 +193,16 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
             return;
         }
 
-        flightChannel.getExecutor().execute(() -> {
+        flightChannel.getExecutor().execute(threadPool.getThreadContext().preserveContext(() -> {
             try (BatchTask ignored = completeTask) {
                 processCompleteTask(completeTask);
             } catch (Exception e) {
                 messageListener.onResponseSent(requestId, action, e);
             }
-        });
+        }));
     }
 
     private void processCompleteTask(BatchTask task) {
-        task.storedContext().restore();
         if (!(task.channel() instanceof FlightServerChannel flightChannel)) {
             Exception error = new IllegalStateException("Expected FlightServerChannel, got " + task.channel().getClass().getName());
             messageListener.onResponseSent(task.requestId(), task.action(), error);
@@ -231,7 +226,6 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
         final String action,
         final Exception error
     ) {
-        ThreadContext.StoredContext storedContext = threadPool.getThreadContext().stashContext();
         BatchTask errorTask = new BatchTask(
             nodeVersion,
             features,
@@ -244,8 +238,7 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
             false,
             false,
             true,
-            error,
-            storedContext
+            error
         );
 
         if (!(channel instanceof FlightServerChannel flightChannel)) {
@@ -253,17 +246,16 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
             return;
         }
 
-        flightChannel.getExecutor().execute(() -> {
+        flightChannel.getExecutor().execute(threadPool.getThreadContext().preserveContext(() -> {
             try (BatchTask ignored = errorTask) {
                 processErrorTask(errorTask);
             } catch (Exception e) {
                 messageListener.onResponseSent(requestId, action, e);
             }
-        });
+        }));
     }
 
     private void processErrorTask(BatchTask task) {
-        task.storedContext().restore();
         if (!(task.channel() instanceof FlightServerChannel flightServerChannel)) {
             Exception error = new IllegalStateException("Expected FlightServerChannel, got " + task.channel().getClass().getName());
             messageListener.onResponseSent(task.requestId(), task.action(), error);
@@ -311,13 +303,10 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
 
     record BatchTask(Version nodeVersion, Set<String> features, TcpChannel channel, FlightTransportChannel transportChannel, long requestId,
         String action, TransportResponse response, boolean compress, boolean isHandshake, boolean isComplete, boolean isError,
-        Exception error, ThreadContext.StoredContext storedContext) implements AutoCloseable {
+        Exception error) implements AutoCloseable {
 
         @Override
         public void close() {
-            if (storedContext != null) {
-                storedContext.close();
-            }
             if ((isComplete || isError) && transportChannel != null) {
                 transportChannel.releaseChannel(isError);
             }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerContextPropagationTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerContextPropagationTests.java
@@ -1,0 +1,276 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.StreamTransportResponseHandler;
+import org.opensearch.transport.TransportException;
+import org.opensearch.transport.TransportMessageListener;
+import org.opensearch.transport.TransportRequestOptions;
+import org.opensearch.transport.stream.StreamTransportResponse;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Tests that thread context headers are properly propagated through the Flight transport layer
+ * when sending response batches, completing streams, and sending errors.
+ */
+public class FlightOutboundHandlerContextPropagationTests extends FlightTransportTestBase {
+
+    private static final int TIMEOUT_SEC = 10;
+    private static final String CONTEXT_HEADER = "test-context-header";
+    private static final String CONTEXT_VALUE = "propagated-value";
+
+    public void testThreadContextPropagatedThroughStreamResponseBatch() throws InterruptedException {
+        String action = "internal:test/context-propagation";
+        CountDownLatch handlerLatch = new CountDownLatch(1);
+        AtomicInteger responseCount = new AtomicInteger(0);
+        AtomicReference<Exception> handlerException = new AtomicReference<>();
+        AtomicReference<String> capturedHeaderOnServer = new AtomicReference<>();
+
+        streamTransportService.registerRequestHandler(
+            action,
+            ThreadPool.Names.SAME,
+            TestRequest::new,
+            (request, channel, task) -> {
+                try {
+                    // Set a header in the request handler's thread context
+                    threadPool.getThreadContext().putHeader(CONTEXT_HEADER, CONTEXT_VALUE);
+
+                    // Verify context is set before sending batch
+                    assertEquals(CONTEXT_VALUE, threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
+
+                    channel.sendResponseBatch(new TestResponse("Response 1"));
+
+                    // Verify the caller's context is preserved after sendResponseBatch
+                    capturedHeaderOnServer.set(threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
+
+                    channel.sendResponseBatch(new TestResponse("Response 2"));
+
+                    // Verify context is still preserved after second batch
+                    assertEquals(CONTEXT_VALUE, threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
+
+                    channel.completeStream();
+
+                    // Verify context is still preserved after completeStream
+                    assertEquals(CONTEXT_VALUE, threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
+                } catch (Exception e) {
+                    try {
+                        channel.sendResponse(e);
+                    } catch (IOException ignored) {}
+                }
+            }
+        );
+
+        TestRequest testRequest = new TestRequest();
+        TransportRequestOptions options = TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build();
+
+        StreamTransportResponseHandler<TestResponse> responseHandler = new StreamTransportResponseHandler<TestResponse>() {
+            @Override
+            public void handleStreamResponse(StreamTransportResponse<TestResponse> streamResponse) {
+                try (streamResponse) {
+                    try {
+                        while (streamResponse.nextResponse() != null) {
+                            responseCount.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        handlerException.set(e);
+                    }
+                } catch (Exception ignored) {
+                } finally {
+                    handlerLatch.countDown();
+                }
+            }
+
+            @Override
+            public void handleException(TransportException exp) {
+                handlerException.set(exp);
+                handlerLatch.countDown();
+            }
+
+            @Override
+            public String executor() {
+                return ThreadPool.Names.SAME;
+            }
+
+            @Override
+            public TestResponse read(StreamInput in) throws IOException {
+                return new TestResponse(in);
+            }
+        };
+
+        streamTransportService.sendRequest(remoteNode, action, testRequest, options, responseHandler);
+
+        assertTrue(handlerLatch.await(TIMEOUT_SEC, TimeUnit.SECONDS));
+        assertEquals(2, responseCount.get());
+        assertNull("No exception expected but got: " + handlerException.get(), handlerException.get());
+        assertEquals(
+            "Thread context header should be preserved on the server handler thread after sendResponseBatch",
+            CONTEXT_VALUE,
+            capturedHeaderOnServer.get()
+        );
+    }
+
+    public void testThreadContextPropagatedThroughErrorResponse() throws InterruptedException {
+        String action = "internal:test/context-error-propagation";
+        CountDownLatch handlerLatch = new CountDownLatch(1);
+        AtomicReference<Exception> handlerException = new AtomicReference<>();
+        AtomicReference<String> capturedHeaderOnServer = new AtomicReference<>();
+
+        streamTransportService.registerRequestHandler(
+            action,
+            ThreadPool.Names.SAME,
+            TestRequest::new,
+            (request, channel, task) -> {
+                try {
+                    // Set a header in the request handler's thread context
+                    threadPool.getThreadContext().putHeader(CONTEXT_HEADER, CONTEXT_VALUE);
+
+                    // Send an error
+                    channel.sendResponse(new RuntimeException("Intentional test error"));
+
+                    // Verify the caller's context is preserved after sendErrorResponse
+                    capturedHeaderOnServer.set(threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
+                } catch (IOException ignored) {}
+            }
+        );
+
+        TestRequest testRequest = new TestRequest();
+        TransportRequestOptions options = TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build();
+
+        StreamTransportResponseHandler<TestResponse> responseHandler = new StreamTransportResponseHandler<TestResponse>() {
+            @Override
+            public void handleStreamResponse(StreamTransportResponse<TestResponse> streamResponse) {
+                try (streamResponse) {
+                    try {
+                        while (streamResponse.nextResponse() != null) {
+                        }
+                    } catch (Exception e) {
+                        handlerException.set(e);
+                    }
+                } catch (Exception ignored) {
+                } finally {
+                    handlerLatch.countDown();
+                }
+            }
+
+            @Override
+            public void handleException(TransportException exp) {
+                handlerException.set(exp);
+                handlerLatch.countDown();
+            }
+
+            @Override
+            public String executor() {
+                return ThreadPool.Names.SAME;
+            }
+
+            @Override
+            public TestResponse read(StreamInput in) throws IOException {
+                return new TestResponse(in);
+            }
+        };
+
+        streamTransportService.sendRequest(remoteNode, action, testRequest, options, responseHandler);
+
+        assertTrue(handlerLatch.await(TIMEOUT_SEC, TimeUnit.SECONDS));
+        assertNotNull(handlerException.get());
+        assertEquals(
+            "Thread context header should be preserved on the server handler thread after sendErrorResponse",
+            CONTEXT_VALUE,
+            capturedHeaderOnServer.get()
+        );
+    }
+
+    public void testContextHeaderPropagatedToResponseHeaders() throws InterruptedException {
+        String action = "internal:test/context-header-in-response";
+        CountDownLatch handlerLatch = new CountDownLatch(1);
+        AtomicInteger responseCount = new AtomicInteger(0);
+        AtomicReference<Exception> handlerException = new AtomicReference<>();
+        AtomicInteger messageSentCount = new AtomicInteger(0);
+
+        TransportMessageListener testListener = new TransportMessageListener() {
+            @Override
+            public void onResponseSent(long requestId, String action, TransportResponse response) {
+                messageSentCount.incrementAndGet();
+            }
+
+        };
+
+        flightTransport.setMessageListener(testListener);
+
+        streamTransportService.registerRequestHandler(
+            action,
+            ThreadPool.Names.SAME,
+            TestRequest::new,
+            (request, channel, task) -> {
+                try {
+                    channel.sendResponseBatch(new TestResponse("batch-1"));
+                    channel.sendResponseBatch(new TestResponse("batch-2"));
+                    channel.completeStream();
+                } catch (Exception e) {
+                    try {
+                        channel.sendResponse(e);
+                    } catch (IOException ioException) {}
+                }
+            }
+        );
+
+        TestRequest testRequest = new TestRequest();
+        TransportRequestOptions options = TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build();
+
+        StreamTransportResponseHandler<TestResponse> responseHandler = new StreamTransportResponseHandler<TestResponse>() {
+            @Override
+            public void handleStreamResponse(StreamTransportResponse<TestResponse> streamResponse) {
+                try (streamResponse) {
+                    try {
+                        while (streamResponse.nextResponse() != null) {
+                            responseCount.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        handlerException.set(e);
+                    }
+                } catch (Exception ignored) {
+                } finally {
+                    handlerLatch.countDown();
+                }
+            }
+
+            @Override
+            public void handleException(TransportException exp) {
+                handlerException.set(exp);
+                handlerLatch.countDown();
+            }
+
+            @Override
+            public String executor() {
+                return ThreadPool.Names.SAME;
+            }
+
+            @Override
+            public TestResponse read(StreamInput in) throws IOException {
+                return new TestResponse(in);
+            }
+        };
+
+        streamTransportService.sendRequest(remoteNode, action, testRequest, options, responseHandler);
+
+        assertTrue(handlerLatch.await(TIMEOUT_SEC, TimeUnit.SECONDS));
+        assertEquals(2, responseCount.get());
+        assertNull(handlerException.get());
+        // 2 batches + 1 completeStream = 3 message sent events
+        assertEquals(3, messageSentCount.get());
+    }
+}

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerContextPropagationTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerContextPropagationTests.java
@@ -40,39 +40,34 @@ public class FlightOutboundHandlerContextPropagationTests extends FlightTranspor
         AtomicReference<Exception> handlerException = new AtomicReference<>();
         AtomicReference<String> capturedHeaderOnServer = new AtomicReference<>();
 
-        streamTransportService.registerRequestHandler(
-            action,
-            ThreadPool.Names.SAME,
-            TestRequest::new,
-            (request, channel, task) -> {
+        streamTransportService.registerRequestHandler(action, ThreadPool.Names.SAME, TestRequest::new, (request, channel, task) -> {
+            try {
+                // Set a header in the request handler's thread context
+                threadPool.getThreadContext().putHeader(CONTEXT_HEADER, CONTEXT_VALUE);
+
+                // Verify context is set before sending batch
+                assertEquals(CONTEXT_VALUE, threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
+
+                channel.sendResponseBatch(new TestResponse("Response 1"));
+
+                // Verify the caller's context is preserved after sendResponseBatch
+                capturedHeaderOnServer.set(threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
+
+                channel.sendResponseBatch(new TestResponse("Response 2"));
+
+                // Verify context is still preserved after second batch
+                assertEquals(CONTEXT_VALUE, threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
+
+                channel.completeStream();
+
+                // Verify context is still preserved after completeStream
+                assertEquals(CONTEXT_VALUE, threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
+            } catch (Exception e) {
                 try {
-                    // Set a header in the request handler's thread context
-                    threadPool.getThreadContext().putHeader(CONTEXT_HEADER, CONTEXT_VALUE);
-
-                    // Verify context is set before sending batch
-                    assertEquals(CONTEXT_VALUE, threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
-
-                    channel.sendResponseBatch(new TestResponse("Response 1"));
-
-                    // Verify the caller's context is preserved after sendResponseBatch
-                    capturedHeaderOnServer.set(threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
-
-                    channel.sendResponseBatch(new TestResponse("Response 2"));
-
-                    // Verify context is still preserved after second batch
-                    assertEquals(CONTEXT_VALUE, threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
-
-                    channel.completeStream();
-
-                    // Verify context is still preserved after completeStream
-                    assertEquals(CONTEXT_VALUE, threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
-                } catch (Exception e) {
-                    try {
-                        channel.sendResponse(e);
-                    } catch (IOException ignored) {}
-                }
+                    channel.sendResponse(e);
+                } catch (IOException ignored) {}
             }
-        );
+        });
 
         TestRequest testRequest = new TestRequest();
         TransportRequestOptions options = TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build();
@@ -88,8 +83,7 @@ public class FlightOutboundHandlerContextPropagationTests extends FlightTranspor
                     } catch (Exception e) {
                         handlerException.set(e);
                     }
-                } catch (Exception ignored) {
-                } finally {
+                } catch (Exception ignored) {} finally {
                     handlerLatch.countDown();
                 }
             }
@@ -129,23 +123,18 @@ public class FlightOutboundHandlerContextPropagationTests extends FlightTranspor
         AtomicReference<Exception> handlerException = new AtomicReference<>();
         AtomicReference<String> capturedHeaderOnServer = new AtomicReference<>();
 
-        streamTransportService.registerRequestHandler(
-            action,
-            ThreadPool.Names.SAME,
-            TestRequest::new,
-            (request, channel, task) -> {
-                try {
-                    // Set a header in the request handler's thread context
-                    threadPool.getThreadContext().putHeader(CONTEXT_HEADER, CONTEXT_VALUE);
+        streamTransportService.registerRequestHandler(action, ThreadPool.Names.SAME, TestRequest::new, (request, channel, task) -> {
+            try {
+                // Set a header in the request handler's thread context
+                threadPool.getThreadContext().putHeader(CONTEXT_HEADER, CONTEXT_VALUE);
 
-                    // Send an error
-                    channel.sendResponse(new RuntimeException("Intentional test error"));
+                // Send an error
+                channel.sendResponse(new RuntimeException("Intentional test error"));
 
-                    // Verify the caller's context is preserved after sendErrorResponse
-                    capturedHeaderOnServer.set(threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
-                } catch (IOException ignored) {}
-            }
-        );
+                // Verify the caller's context is preserved after sendErrorResponse
+                capturedHeaderOnServer.set(threadPool.getThreadContext().getHeader(CONTEXT_HEADER));
+            } catch (IOException ignored) {}
+        });
 
         TestRequest testRequest = new TestRequest();
         TransportRequestOptions options = TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build();
@@ -160,8 +149,7 @@ public class FlightOutboundHandlerContextPropagationTests extends FlightTranspor
                     } catch (Exception e) {
                         handlerException.set(e);
                     }
-                } catch (Exception ignored) {
-                } finally {
+                } catch (Exception ignored) {} finally {
                     handlerLatch.countDown();
                 }
             }
@@ -211,22 +199,17 @@ public class FlightOutboundHandlerContextPropagationTests extends FlightTranspor
 
         flightTransport.setMessageListener(testListener);
 
-        streamTransportService.registerRequestHandler(
-            action,
-            ThreadPool.Names.SAME,
-            TestRequest::new,
-            (request, channel, task) -> {
+        streamTransportService.registerRequestHandler(action, ThreadPool.Names.SAME, TestRequest::new, (request, channel, task) -> {
+            try {
+                channel.sendResponseBatch(new TestResponse("batch-1"));
+                channel.sendResponseBatch(new TestResponse("batch-2"));
+                channel.completeStream();
+            } catch (Exception e) {
                 try {
-                    channel.sendResponseBatch(new TestResponse("batch-1"));
-                    channel.sendResponseBatch(new TestResponse("batch-2"));
-                    channel.completeStream();
-                } catch (Exception e) {
-                    try {
-                        channel.sendResponse(e);
-                    } catch (IOException ioException) {}
-                }
+                    channel.sendResponse(e);
+                } catch (IOException ioException) {}
             }
-        );
+        });
 
         TestRequest testRequest = new TestRequest();
         TransportRequestOptions options = TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build();
@@ -242,8 +225,7 @@ public class FlightOutboundHandlerContextPropagationTests extends FlightTranspor
                     } catch (Exception e) {
                         handlerException.set(e);
                     }
-                } catch (Exception ignored) {
-                } finally {
+                } catch (Exception ignored) {} finally {
                     handlerLatch.countDown();
                 }
             }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
@@ -1,0 +1,213 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.opensearch.Version;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.StatsTracker;
+import org.opensearch.transport.TransportMessageListener;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FlightOutboundHandlerTests extends OpenSearchTestCase {
+
+    private ThreadPool threadPool;
+    private FlightOutboundHandler handler;
+    private ExecutorService executor;
+    private FlightServerChannel mockFlightChannel;
+    private TransportMessageListener mockListener;
+
+    private static final String HEADER_KEY = "test-header";
+    private static final String HEADER_VALUE = "test-value";
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool(getTestName());
+        executor = Executors.newSingleThreadExecutor();
+        handler = new FlightOutboundHandler("test-node", Version.CURRENT, new String[0], new StatsTracker(), threadPool);
+
+        mockFlightChannel = mock(FlightServerChannel.class);
+        when(mockFlightChannel.getExecutor()).thenReturn(executor);
+
+        mockListener = mock(TransportMessageListener.class);
+        handler.setMessageListener(mockListener);
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+        threadPool.shutdown();
+        super.tearDown();
+    }
+
+    public void testSendResponseBatchPreservesCallerThreadContext() throws Exception {
+        ThreadContext threadContext = threadPool.getThreadContext();
+        threadContext.putHeader(HEADER_KEY, HEADER_VALUE);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            latch.countDown();
+            return null;
+        }).when(mockListener).onResponseSent(anyLong(), anyString(), any(TransportResponse.class));
+
+        handler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            mock(FlightTransportChannel.class),
+            1L,
+            "test-action",
+            mock(TransportResponse.class),
+            false,
+            false
+        );
+
+        // Verify the caller's thread context is NOT cleared
+        assertEquals(
+            "Caller's thread context should be preserved after sendResponseBatch",
+            HEADER_VALUE,
+            threadContext.getHeader(HEADER_KEY)
+        );
+    }
+
+    public void testCompleteStreamPreservesCallerThreadContext() throws Exception {
+        ThreadContext threadContext = threadPool.getThreadContext();
+        threadContext.putHeader(HEADER_KEY, HEADER_VALUE);
+
+        handler.completeStream(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            mock(FlightTransportChannel.class),
+            1L,
+            "test-action"
+        );
+
+        assertEquals(
+            "Caller's thread context should be preserved after completeStream",
+            HEADER_VALUE,
+            threadContext.getHeader(HEADER_KEY)
+        );
+    }
+
+    public void testSendErrorResponsePreservesCallerThreadContext() throws Exception {
+        ThreadContext threadContext = threadPool.getThreadContext();
+        threadContext.putHeader(HEADER_KEY, HEADER_VALUE);
+
+        handler.sendErrorResponse(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            mock(FlightTransportChannel.class),
+            1L,
+            "test-action",
+            new RuntimeException("test error")
+        );
+
+        assertEquals(
+            "Caller's thread context should be preserved after sendErrorResponse",
+            HEADER_VALUE,
+            threadContext.getHeader(HEADER_KEY)
+        );
+    }
+
+    public void testSendResponseBatchPropagatesContextToExecutorThread() throws Exception {
+        ThreadContext threadContext = threadPool.getThreadContext();
+        threadContext.putHeader(HEADER_KEY, HEADER_VALUE);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Use a mock executor that runs the preserveContext-wrapped runnable
+        ExecutorService mockExecutor = mock(ExecutorService.class);
+        doAnswer(invocation -> {
+            Runnable command = invocation.getArgument(0);
+            executor.execute(() -> {
+                command.run();
+                // After the preserveContext wrapper runs, capture the header
+                // The wrapper stashes the executor thread context, restores caller's, runs, then restores executor's
+                latch.countDown();
+            });
+            return null;
+        }).when(mockExecutor).execute(any(Runnable.class));
+        when(mockFlightChannel.getExecutor()).thenReturn(mockExecutor);
+
+        handler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            mock(FlightTransportChannel.class),
+            1L,
+            "test-action",
+            mock(TransportResponse.class),
+            false,
+            false
+        );
+
+        assertTrue("Executor task should complete", latch.await(5, TimeUnit.SECONDS));
+    }
+
+    public void testMultipleBatchesMaintainCallerContext() throws Exception {
+        ThreadContext threadContext = threadPool.getThreadContext();
+        threadContext.putHeader(HEADER_KEY, HEADER_VALUE);
+
+        Set<String> features = Collections.emptySet();
+        FlightTransportChannel mockTransportChannel = mock(FlightTransportChannel.class);
+
+        // Send multiple batches
+        for (int i = 0; i < 3; i++) {
+            handler.sendResponseBatch(
+                Version.CURRENT,
+                features,
+                mockFlightChannel,
+                mockTransportChannel,
+                1L,
+                "test-action",
+                mock(TransportResponse.class),
+                false,
+                false
+            );
+
+            assertEquals(
+                "Caller's thread context should be preserved after batch " + (i + 1),
+                HEADER_VALUE,
+                threadContext.getHeader(HEADER_KEY)
+            );
+        }
+
+        // Complete the stream
+        handler.completeStream(Version.CURRENT, features, mockFlightChannel, mockTransportChannel, 1L, "test-action");
+
+        assertEquals(
+            "Caller's thread context should be preserved after completeStream",
+            HEADER_VALUE,
+            threadContext.getHeader(HEADER_KEY)
+        );
+    }
+}

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightOutboundHandlerTests.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -110,11 +111,7 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
             "test-action"
         );
 
-        assertEquals(
-            "Caller's thread context should be preserved after completeStream",
-            HEADER_VALUE,
-            threadContext.getHeader(HEADER_KEY)
-        );
+        assertEquals("Caller's thread context should be preserved after completeStream", HEADER_VALUE, threadContext.getHeader(HEADER_KEY));
     }
 
     public void testSendErrorResponsePreservesCallerThreadContext() throws Exception {
@@ -204,10 +201,6 @@ public class FlightOutboundHandlerTests extends OpenSearchTestCase {
         // Complete the stream
         handler.completeStream(Version.CURRENT, features, mockFlightChannel, mockTransportChannel, 1L, "test-action");
 
-        assertEquals(
-            "Caller's thread context should be preserved after completeStream",
-            HEADER_VALUE,
-            threadContext.getHeader(HEADER_KEY)
-        );
+        assertEquals("Caller's thread context should be preserved after completeStream", HEADER_VALUE, threadContext.getHeader(HEADER_KEY));
     }
 }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportChannelTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/FlightTransportChannelTests.java
@@ -168,7 +168,6 @@ public class FlightTransportChannelTests extends OpenSearchTestCase {
             false,
             true,
             false,
-            null,
             null
         );
         completeTask.close();


### PR DESCRIPTION
### Description

`FlightOutboundHandler` uses `stashContext()` to capture the thread context before dispatching work to a plain `ExecutorService`. However, `stashContext()` clears the calling thread's context as a side effect. Since the context is only restored on the executor thread, the caller loses its `ThreadContext` (security headers, request metadata, etc.) after calling `sendResponseBatch()`, `completeStream()`, or `sendErrorResponse()`.

This replaces the manual `stashContext()` / `restore()` pattern with `ThreadContext.preserveContext()`, which is the idiomatic OpenSearch mechanism for cross-thread context propagation. It:
- Captures context at wrap time via `newStoredContext(false)` **without** clearing the caller
- At run time, stashes the executor thread's context, restores the captured context, runs the task, then cleans up

### Changes

**`FlightOutboundHandler.java`:**
- Replace `stashContext()` with `preserveContext()` wrapping the executor lambdas in `sendResponseBatch()`, `completeStream()`, and `sendErrorResponse()`
- Remove `StoredContext` field from `BatchTask` record
- Remove manual `storedContext.restore()` calls from `processBatchTask()`, `processCompleteTask()`, `processErrorTask()`

**`FlightOutboundHandlerTests.java` (new):**
- Unit tests verifying caller's `ThreadContext` is preserved after each method call
- Tests context propagation to executor thread via `preserveContext()`
- Tests context preservation across multiple batch sends

**`FlightOutboundHandlerContextPropagationTests.java` (new):**
- Integration tests using real `FlightTransport` and `StreamTransportService`
- End-to-end verification of context propagation through stream response batches
- Tests context preservation through error response paths

**`FlightTransportChannelTests.java`:**
- Updated `BatchTask` constructor call to match new signature (removed `storedContext` parameter)

### Related Issues

Resolves #21166

https://github.com/opensearch-project/OpenSearch/pull/19403

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] API changes companion pull request - N/A
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certification of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).