### PR TITLE
Switch executeQueryPhaseAsync and streamNext from block_on to spawn

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/jni/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/jni/src/lib.rs
@@ -20,10 +20,12 @@ use std::cell::RefCell;
 use std::sync::{Arc, OnceLock};
 
 use datafusion::common::DataFusionError;
-use jni::objects::{JByteArray, JClass, JObject, JObjectArray, JString};
+use jni::objects::{GlobalRef, JByteArray, JClass, JObject, JObjectArray, JString};
 use jni::sys::{jint, jlong};
 use jni::{JNIEnv, JavaVM};
 use log::error;
+use std::future::Future;
+use futures::FutureExt;
 
 pub mod api;
 pub mod cross_rt_stream;
@@ -67,6 +69,55 @@ fn get_tokio_rt_manager() -> Result<&'static Arc<RuntimeManager>, DataFusionErro
     TOKIO_RUNTIME_MANAGER
         .get()
         .ok_or_else(|| DataFusionError::Execution("Runtime manager not initialized".to_string()))
+}
+
+/// Extract a human-readable message from a panic payload.
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic payload".to_string()
+    }
+}
+
+/// Spawn an async task on `runtime` that calls an ActionListener exactly once.
+///
+/// The entire `task` future runs inside `catch_unwind`. Any panic is converted
+/// to a `DataFusionError` and surfaced to the Java caller via `listener_ref`.
+/// This ensures the `CompletableFuture` on the Java side is always completed,
+/// never left hanging.
+fn spawn_jni_task<Fut, T, FOk>(
+    runtime: &tokio::runtime::Handle,
+    task_name: &'static str,
+    listener_ref: GlobalRef,
+    task: Fut,
+    on_ok: FOk,
+)
+where
+    Fut: Future<Output = Result<T, DataFusionError>> + Send + 'static,
+    T: Send + 'static,
+    FOk: FnOnce(&mut JNIEnv, &GlobalRef, T) + Send + 'static,
+{
+    let _ = runtime.spawn(async move {
+        let result = std::panic::AssertUnwindSafe(task)
+            .catch_unwind()
+            .await
+            .unwrap_or_else(|panic| {
+                let msg = panic_message(&panic);
+                error!("{} panicked: {}", task_name, msg);
+                Err(DataFusionError::Execution(format!("{} panicked: {}", task_name, msg)))
+            });
+
+        with_jni_env(|env| match result {
+            Ok(value) => on_ok(env, &listener_ref, value),
+            Err(e) => {
+                error!("{} failed: {}", task_name, e);
+                set_action_listener_error_global(env, &listener_ref, &e);
+            }
+        });
+    });
 }
 
 // Tokio runtime management
@@ -224,18 +275,16 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_execut
         }
     };
 
-    // Delegate to bridge-agnostic API — bridge does the block_on
-    let result = tokio_rt_mgr.io_runtime.block_on(unsafe {
-        api::execute_query(shard_view_ptr as i64, &table_name, &plan_bytes, runtime_ptr as i64, tokio_rt_mgr)
-    });
-
-    with_jni_env(|env| match result {
-        Ok(stream_ptr) => set_action_listener_ok_global(env, &listener_ref, stream_ptr as jlong),
-        Err(e) => {
-            error!("Query execution failed: {}", e);
-            set_action_listener_error_global(env, &listener_ref, &e);
-        }
-    });
+    // Delegate to bridge-agnostic API — non-blocking spawn
+    spawn_jni_task(
+        &tokio_rt_mgr.io_runtime,
+        "executeQueryAsync",
+        listener_ref,
+        async move {
+            unsafe { api::execute_query(shard_view_ptr as i64, &table_name, &plan_bytes, runtime_ptr as i64, tokio_rt_mgr) }.await
+        },
+        |env, listener_ref, stream_ptr| set_action_listener_ok_global(env, listener_ref, stream_ptr as jlong),
+    );
 }
 
 // Get schema for the stream
@@ -282,15 +331,13 @@ pub extern "system" fn Java_org_opensearch_be_datafusion_jni_NativeBridge_stream
         }
     };
 
-    let result = manager.io_runtime.block_on(unsafe { api::stream_next(stream_ptr as i64) });
-
-    with_jni_env(|env| match result {
-        Ok(array_ptr) => set_action_listener_ok_global(env, &listener_ref, array_ptr as jlong),
-        Err(e) => {
-            error!("Stream next failed: {}", e);
-            set_action_listener_error_global(env, &listener_ref, &e);
-        }
-    });
+    spawn_jni_task(
+        &manager.io_runtime,
+        "streamNext",
+        listener_ref,
+        unsafe { api::stream_next(stream_ptr as i64) },
+        |env, listener_ref, array_ptr| set_action_listener_ok_global(env, listener_ref, array_ptr as jlong),
+    );
 }
 
 #[jni_safe]

--- a/sandbox/plugins/analytics-backend-datafusion/jni/src/runtime_manager.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/jni/src/runtime_manager.rs
@@ -8,12 +8,18 @@
 use crate::executor::DedicatedExecutor;
 use crate::io::register_io_runtime;
 use log::info;
-use std::sync::Arc;
-use tokio::runtime::{Builder, Runtime};
+use std::sync::Mutex;
+use std::time::Duration;
+use tokio::runtime::{Builder, Handle, Runtime};
 
 // RuntimeManager — owns IO runtime + CPU DedicatedExecutor.
 pub struct RuntimeManager {
-    pub io_runtime: Arc<Runtime>,
+    /// Cloneable handle to the IO runtime, used by all JNI entry points to submit
+    /// tasks without taking ownership of the runtime.
+    pub io_runtime: Handle,
+    /// Owned runtime kept behind a Mutex so shutdown() can take() it and call
+    /// shutdown_timeout(), which blocks until all IO threads have fully stopped.
+    io_runtime_owned: Mutex<Option<Runtime>>,
     pub cpu_executor: DedicatedExecutor,
 }
 
@@ -21,31 +27,34 @@ impl RuntimeManager {
     pub fn new(cpu_threads: usize) -> Self {
         let io_threads = cpu_threads * 2;
 
-        let io_runtime = Arc::new(
-            Builder::new_multi_thread()
-                .worker_threads(io_threads)
-                .thread_name("datafusion-io")
-                .enable_all()
-                .build()
-                .expect("Failed to create IO runtime"),
-        );
+        // IO Runtime — build first so we can extract a Handle for sharing
+        let io_runtime_rt = Builder::new_multi_thread()
+            .worker_threads(io_threads)
+            .thread_name("datafusion-io")
+            .enable_all()
+            .build()
+            .expect("Failed to create IO runtime");
 
-        register_io_runtime(Some(io_runtime.handle().clone()));
+        let io_handle = io_runtime_rt.handle().clone();
 
-        let io_handle = io_runtime.handle().clone();
+        // Register IO runtime for the calling (JNI) thread.
+        register_io_runtime(Some(io_handle.clone()));
+
+        let io_handle_for_cpu = io_handle.clone();
         let mut cpu_runtime_builder = Builder::new_multi_thread();
         cpu_runtime_builder
             .worker_threads(cpu_threads)
             .thread_name("datafusion-cpu")
             .enable_all()
             .on_thread_start(move || {
-                register_io_runtime(Some(io_handle.clone()));
+                register_io_runtime(Some(io_handle_for_cpu.clone()));
             });
 
         let cpu_executor = DedicatedExecutor::new("datafusion-cpu", cpu_runtime_builder);
 
         Self {
-            io_runtime,
+            io_runtime: io_handle,
+            io_runtime_owned: Mutex::new(Some(io_runtime_rt)),
             cpu_executor,
         }
     }
@@ -56,7 +65,14 @@ impl RuntimeManager {
 
     pub fn shutdown(&self) {
         info!("Shutting down RuntimeManager");
+        // Shut down CPU executor first — waits for all in-flight CPU tasks to finish.
         self.cpu_executor.join_blocking();
+        // Take the owned IO runtime out of the Option and call shutdown_timeout, which
+        // blocks until every datafusion-io-* thread has fully terminated.
+        if let Some(rt) = self.io_runtime_owned.lock().unwrap().take() {
+            rt.shutdown_timeout(Duration::from_secs(10));
+        }
+        info!("RuntimeManager shut down complete");
     }
 }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionQueryExecutionTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionQueryExecutionTests.java
@@ -19,6 +19,8 @@ import org.opensearch.be.datafusion.jni.NativeBridge;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.test.OpenSearchTestCase;
 
+import org.junit.AfterClass;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -38,6 +40,14 @@ public class DataFusionQueryExecutionTests extends OpenSearchTestCase {
     private long readerPtr;
 
     private static boolean runtimeInitialized = false;
+
+    @AfterClass
+    public static void cleanUpRuntime() {
+        if (runtimeInitialized) {
+            NativeBridge.shutdownTokioRuntimeManager();
+            runtimeInitialized = false;
+        }
+    }
 
     @Override
     public void setUp() throws Exception {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
@@ -11,6 +11,8 @@ package org.opensearch.be.datafusion;
 import org.opensearch.be.datafusion.jni.NativeBridge;
 import org.opensearch.test.OpenSearchTestCase;
 
+import org.junit.AfterClass;
+
 import java.nio.file.Path;
 
 /**
@@ -19,6 +21,14 @@ import java.nio.file.Path;
 public class DataFusionServiceTests extends OpenSearchTestCase {
 
     private static boolean runtimeInitialized = false;
+
+    @AfterClass
+    public static void cleanUpRuntime() {
+        if (runtimeInitialized) {
+            NativeBridge.shutdownTokioRuntimeManager();
+            runtimeInitialized = false;
+        }
+    }
 
     private void ensureTokioInit() {
         if (runtimeInitialized == false) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionResultStreamTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionResultStreamTests.java
@@ -15,6 +15,8 @@ import org.opensearch.be.datafusion.jni.NativeBridge;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.test.OpenSearchTestCase;
 
+import org.junit.AfterClass;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
@@ -32,6 +34,14 @@ public class DatafusionResultStreamTests extends OpenSearchTestCase {
     private RootAllocator testRootAllocator;
 
     private static boolean runtimeInitialized = false;
+
+    @AfterClass
+    public static void cleanUpRuntime() {
+        if (runtimeInitialized) {
+            NativeBridge.shutdownTokioRuntimeManager();
+            runtimeInitialized = false;
+        }
+    }
 
     @Override
     public void setUp() throws Exception {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSearchExecEngineTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSearchExecEngineTests.java
@@ -13,6 +13,8 @@ import org.opensearch.analytics.backend.EngineResultStream;
 import org.opensearch.be.datafusion.jni.NativeBridge;
 import org.opensearch.test.OpenSearchTestCase;
 
+import org.junit.AfterClass;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -30,6 +32,14 @@ public class DatafusionSearchExecEngineTests extends OpenSearchTestCase {
     private NativeRuntimeHandle runtimeHandle;
 
     private static boolean runtimeInitialized = false;
+
+    @AfterClass
+    public static void cleanUpRuntime() {
+        if (runtimeInitialized) {
+            NativeBridge.shutdownTokioRuntimeManager();
+            runtimeInitialized = false;
+        }
+    }
 
     @Override
     public void setUp() throws Exception {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Switch `executeQueryPhaseAsync` and `streamNext` from `block_on` to `spawn`.

This makes the JVM thread spawn tokio tasks, and returns immediately after submitting work. This will also help with task cancellation and better collection of query metrics.

Panics are caught using `catch_unwind` and surfaced as errors to the listener.

To prevent thread leak in tests, in `runtime_manager.rs`, split `io_runtime` into a cheap `Handle` (for sharing) and `Mutex<Option<Runtime>>` (for owned shutdown). `shutdown()` now calls `io_runtime.shutdown_timeout(10s)` after `cpu_executor.join_blocking()`, blocking until all datafusion-io-* threads have fully terminated.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
