### PR TITLE
Implement Directory and IndexInput layers for WritableWarm tiered storage

### DIFF
--- a/server/src/main/java/org/opensearch/index/store/remote/utils/FileTypeUtils.java
+++ b/server/src/main/java/org/opensearch/index/store/remote/utils/FileTypeUtils.java
@@ -40,4 +40,13 @@ public class FileTypeUtils {
     public static boolean isSegmentsFile(String name) {
         return name.startsWith("segments_");
     }
+
+    /**
+     * Checks if the file is a corrupted marker file.
+     * @param name the file name
+     * @return true if the file is a corrupted marker file
+     */
+    public static boolean isCorruptedFile(String name) {
+        return name.startsWith("corrupted_");
+    }
 }

--- a/server/src/main/java/org/opensearch/storage/common/BlockTransferManager.java
+++ b/server/src/main/java/org/opensearch/storage/common/BlockTransferManager.java
@@ -10,41 +10,49 @@ package org.opensearch.storage.common;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.support.GroupedActionListener;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.io.DiskIoBufferPool;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.store.remote.utils.TransferManager;
+import org.opensearch.storage.indexinput.BlockFetchRequest;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 /**
  * This class is responsible for managing download of blocks from remote storage.
  * It uses a ThreadPool to download blocks in parallel.
  * The methods in this class are thread safe.
- *
- * fetchBlocksAsync, download orchestration, temp file management,
- * and listener chaining will be added in the implementation PR.
  */
 public class BlockTransferManager {
-
     private static final Logger logger = LogManager.getLogger(BlockTransferManager.class);
     private static final String REMOTE_DOWNLOAD = "remote_download";
     private static final int TIMEOUT_ONE_HOUR = 1;
     private static final String TMP_BLOCK_FILE_EXTENSION = ".part";
     private final TransferManager.StreamReader streamReader;
-    /** Supplier for the thread pool used for block transfers. */
     protected final Supplier<ThreadPool> threadPoolSupplier;
     private final ConcurrentHashMap<Path, ActionListener<Void>> downloadsInProgress = new ConcurrentHashMap<>();
     private final IndexSettings indexSettings;
 
-    /**
-     * Constructs a new BlockTransferManager.
-     * @param streamReader the stream reader for remote storage
-     * @param indexSettings the index settings
-     * @param threadPoolSupplier supplier for the thread pool used for parallel downloads
-     */
     public BlockTransferManager(
         TransferManager.StreamReader streamReader,
         IndexSettings indexSettings,
@@ -53,5 +61,150 @@ public class BlockTransferManager {
         this.streamReader = streamReader;
         this.indexSettings = indexSettings;
         this.threadPoolSupplier = threadPoolSupplier;
+    }
+
+    /**
+     * This method fetches blocks from remote storage in parallel using the threadPool.
+     * It uses a PlainActionFuture to wait for all the downloads to complete.
+     * @param blockFetchRequests
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public void fetchBlocksAsync(List<BlockFetchRequest> blockFetchRequests) throws IOException, InterruptedException {
+        final PlainActionFuture<Collection<Void>> listener = PlainActionFuture.newFuture();
+        final ActionListener<Void> allFilesListener = new GroupedActionListener<>(listener, blockFetchRequests.size());
+        for (BlockFetchRequest blockFetchRequest : blockFetchRequests) {
+            downloadBlob(allFilesListener, blockFetchRequest);
+        }
+
+        try {
+            listener.get(TIMEOUT_ONE_HOUR, TimeUnit.HOURS);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new IOException(e);
+        } catch (InterruptedException e) {
+            // If the blocking call on the PlainActionFuture itself is interrupted, then we must
+            // cancel the asynchronous work we were waiting on
+            Thread.currentThread().interrupt();
+            throw e;
+        }
+
+    }
+
+    private void downloadBlob(ActionListener<Void> listener, BlockFetchRequest blockFetchRequest) {
+        logger.debug("Fetching block request: {}", blockFetchRequest);
+        Path filePath = blockFetchRequest.getFilePath();
+
+        ActionListener<Void> effectiveListener = registerDownloadRequest(filePath, listener);
+        if (effectiveListener != listener) {
+            /**
+             * Download already in progress. This edge case is not something that we do not expect based on current design
+             * but still handling.
+             */
+            return;
+        }
+
+        submitDownloadTask(blockFetchRequest, filePath);
+    }
+
+    private ActionListener<Void> registerDownloadRequest(Path filePath, ActionListener<Void> listener) {
+        Path tempFilePath = getTempFilePath(filePath);
+
+        return downloadsInProgress.compute(filePath, (key, existingListener) -> {
+            if (existingListener == null) {
+                if (Files.exists(filePath)) {
+                    listener.onResponse(null);
+                    return null;
+                }
+                cleanupTempFile(tempFilePath); // One scenario where this can help, is if the OS process crashes which file download is
+                                               // happening.
+                return listener;
+            } else {
+                logger.debug("Download already in progress for file: {}. Waiting for ongoing download to complete.", filePath.toString());
+                return chainListeners(existingListener, listener);
+            }
+        });
+    }
+
+    private void submitDownloadTask(BlockFetchRequest blockFetchRequest, Path filePath) {
+        try {
+            logger.debug("Submitting BlockFetchRequest to threadpool [{}]", blockFetchRequest.toString());
+            threadPoolSupplier.get().executor(REMOTE_DOWNLOAD).submit(() -> performDownload(blockFetchRequest, filePath));
+        } catch (Exception e) {
+            notifyDownloadFailure(filePath, e);
+        }
+    }
+
+    @SuppressForbidden(reason = "Channel#write")
+    private void performDownload(BlockFetchRequest blockFetchRequest, Path filePath) {
+        Path tempFilePath = getTempFilePath(filePath);
+
+        try {
+            try (
+                InputStream remoteFileInputStream = streamReader.read(
+                    blockFetchRequest.getFileName(),
+                    blockFetchRequest.getBlockStart(),
+                    blockFetchRequest.getBlockSize()
+                );
+                ReadableByteChannel inputChannel = Channels.newChannel(remoteFileInputStream);
+                FileChannel outputChannel = FileChannel.open(tempFilePath, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)
+            ) {
+
+                ByteBuffer directBuffer = DiskIoBufferPool.getIoBuffer();
+                while (inputChannel.read(directBuffer) != -1) {
+                    directBuffer.flip();
+                    while (directBuffer.hasRemaining()) {
+                        outputChannel.write(directBuffer);
+                    }
+                    directBuffer.clear();
+                }
+                outputChannel.force(true); // Ensure data is written to disk
+            }
+            Files.move(tempFilePath, filePath, StandardCopyOption.ATOMIC_MOVE);
+            notifyDownloadSuccess(filePath);
+        } catch (Exception e) {
+            cleanupTempFile(tempFilePath);
+            notifyDownloadFailure(filePath, e);
+        }
+    }
+
+    private Path getTempFilePath(Path filePath) {
+        return filePath.getParent().resolve(filePath.getFileName() + TMP_BLOCK_FILE_EXTENSION);
+    }
+
+    private void cleanupTempFile(Path tempFilePath) {
+        if (Files.exists(tempFilePath)) {
+            try {
+                logger.debug("Cleaning temp file: {}", tempFilePath.toString());
+                Files.delete(tempFilePath);
+            } catch (IOException e) {
+                logger.error("Failed to delete existing temp file: " + tempFilePath, e);
+            }
+        }
+    }
+
+    private ActionListener<Void> chainListeners(ActionListener<Void> existing, ActionListener<Void> newListener) {
+        return ActionListener.wrap(v -> {
+            existing.onResponse(v);
+            newListener.onResponse(v);
+        }, e -> {
+            existing.onFailure(e);
+            newListener.onFailure(e);
+        });
+    }
+
+    private void notifyDownloadSuccess(Path filePath) {
+        downloadsInProgress.compute(filePath, (key, listener) -> {
+            assert listener != null : "Listener should not be null";
+            listener.onResponse(null);
+            return null;
+        });
+    }
+
+    private void notifyDownloadFailure(Path filePath, Exception e) {
+        downloadsInProgress.compute(filePath, (key, listener) -> {
+            assert listener != null : "Listener should not be null";
+            listener.onFailure(e);
+            return null;
+        });
     }
 }

--- a/server/src/main/java/org/opensearch/storage/directory/TieredDirectory.java
+++ b/server/src/main/java/org/opensearch/storage/directory/TieredDirectory.java
@@ -10,29 +10,220 @@ package org.opensearch.storage.directory;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
 import org.opensearch.index.store.CompositeDirectory;
+import org.opensearch.index.store.RemoteSegmentStoreDirectory;
+import org.opensearch.index.store.remote.filecache.CachedIndexInput;
 import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.index.store.remote.utils.FileTypeUtils;
+import org.opensearch.storage.indexinput.CachedSwitchableIndexInput;
+import org.opensearch.storage.indexinput.SwitchableIndexInput;
+import org.opensearch.storage.indexinput.SwitchableIndexInputWrapper;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import static org.opensearch.index.store.remote.utils.FileTypeUtils.BLOCK_FILE_IDENTIFIER;
+import static org.opensearch.storage.utils.DirectoryUtils.getFilePathSwitchable;
+import static org.apache.lucene.index.IndexFileNames.SEGMENTS;
+
 /**
- * Extension of CompositeDirectory to support writable warm and other related features.
- * TieredStoragePrefetchSettings dependency will be added in the implementation PR.
- * Directory overrides (listAll, deleteFile, rename, openInput, close, sync, afterSyncToRemote),
- * file caching, and full-file-to-block switching logic will be added in the implementation PR.
+ * Extension of Composite directory to support writable warm and other related features
  */
 public class TieredDirectory extends CompositeDirectory {
 
     private static final Logger logger = LogManager.getLogger(TieredDirectory.class);
 
-    /**
-     * Constructs a new TieredDirectory.
-     * @param localDirectory the local directory
-     * @param remoteDirectory the remote directory
-     * @param fileCache the file cache
-     * @param threadPool the thread pool
-     */
     public TieredDirectory(Directory localDirectory, Directory remoteDirectory, FileCache fileCache, ThreadPool threadPool) {
         super(localDirectory, remoteDirectory, fileCache, threadPool);
+    }
+
+    @Override
+    public String[] listAll() throws IOException {
+        ensureOpen();
+        String[] localFiles = localDirectory.listAll();
+        String[] remoteFiles;
+
+        // Check if local directory has any segments_n files
+        boolean hasLocalSegments = Arrays.stream(localFiles).anyMatch(fileName -> fileName.startsWith(IndexFileNames.SEGMENTS));
+
+        try {
+            if (hasLocalSegments) {
+                // If local has segments_n, filter out segments_n from remote
+                remoteFiles = Arrays.stream(remoteDirectory.listAll())
+                    .filter(fileName -> !fileName.startsWith(IndexFileNames.SEGMENTS))
+                    .toArray(String[]::new);
+            } else {
+                // If local doesn't have segments_n, include all remote files
+                remoteFiles = remoteDirectory.listAll();
+            }
+        } catch (NullPointerException e) {
+            remoteFiles = new String[] {};
+        }
+
+        return Stream.concat(Arrays.stream(localFiles), Arrays.stream(remoteFiles))
+            .map(s -> s.contains(BLOCK_FILE_IDENTIFIER) ? s.substring(0, s.indexOf(BLOCK_FILE_IDENTIFIER)) : s)
+            .distinct()
+            .sorted()
+            .toArray(String[]::new);
+    }
+
+    @Override
+    public void deleteFile(String name) throws IOException {
+        super.deleteFile(name);
+        // If entry doesn't exist, remove will be a NoOp
+        fileCache.remove(getFilePathSwitchable(localDirectory, name));
+    }
+
+    @Override
+    public void rename(String source, String dest) throws IOException {
+        super.rename(source, dest);
+        // remove switchable entry of source
+        fileCache.remove(getFilePathSwitchable(localDirectory, source));
+        // remove block entries of source (along with the full file) if any from file cache
+        for (String file : listBlockFiles(source)) {
+            fileCache.remove(getFilePath(file));
+        }
+    }
+
+    /**
+     * Whenever we write a file to the directory we add a switchable entry in the FileCache (logic in cacheFile method below)
+     *
+     * But for replicas where we download the file from remote, this entry would be missing hence we first check if file is present in remote or not
+     * and then depending upon if it is present, we add the switchable entry to the FileCache.
+     *
+     * For reading any file (that is not .tmp) we rely on this switchable entry in the FileCache
+     *
+     * Detailed step wise flow below:
+     *
+     * 1. Check if file is .tmp file - read it from the local directory
+     * 2. Check if the file cache contains switchable entry of the file (we create an entry when writing the file to the directory) - clone the entry and read it
+     * 3. If 2 is false, then check if file exists in remote or not - if not throw NoSuchFileException since file doesn't exist in directory
+     * 4. If file is present in remote, then add a corresponding switchable entry in the file cache. Now once file cache has the entry we can follow step 2
+     *
+     */
+    @Override
+    public IndexInput openInput(String name, IOContext context) throws IOException {
+        ensureOpen();
+        // We aren't tracking temporary files (created via createTempOutput) currently in FileCache as these are created and then deleted
+        // within a very short span of time
+        // We will be reading them directory from the local directory
+        if (FileTypeUtils.isTempFile(name) || FileTypeUtils.isCorruptedFile(name)) {
+            return localDirectory.openInput(name, context);
+        }
+        Path key = getFilePathSwitchable(localDirectory, name);
+        CachedIndexInput indexInput = fileCache.get(key);
+        if (indexInput == null) {
+            RemoteSegmentStoreDirectory.UploadedSegmentMetadata uploadedSegmentMetadata = remoteDirectory.getSegmentsUploadedToRemoteStore()
+                .get(name);
+            if (uploadedSegmentMetadata == null) {
+                throw new NoSuchFileException("File " + name + " not found in directory");
+            }
+            // For pre-created files already in remote, switchable entry would not be cached already locally, we need to download from
+            // remote and cache it in FileCache
+            cacheFile(name, true);
+            indexInput = fileCache.get(key);
+            // decrementing the ref here since refCount increases in cacheFile method, but since afterSyncToRemote won't be called (where we
+            // decRef) for files already in remote
+            fileCache.decRef(key);
+        }
+        try {
+            return new SwitchableIndexInputWrapper(
+                "SwitchableIndexInput (path=" + getFilePath(name) + ")",
+                (SwitchableIndexInput) indexInput.getIndexInput().clone()
+            );
+        } finally {
+            fileCache.decRef(key);
+        }
+    }
+
+    @Override
+    public void afterSyncToRemote(String file) {
+        super.afterSyncToRemote(file);
+
+        // once file is uploaded to remote, we can decrement the ref count of the switchable entry in file cache
+        fileCache.decRef(getFilePathSwitchable(localDirectory, file));
+
+        // perform the full file to block switch for the switchable index input (currently called here for testing)
+        switchFileToRemote(file);
+    }
+
+    @Override
+    public void sync(Collection<String> names) {
+        logger.trace("Tiered Directory[{}]: sync() called {}; Skipping sync.", this::toString, () -> names);
+    }
+
+    /**
+     * Switch the file from local based full-file to remote based blocked-file
+     * @param file
+     */
+    public void switchFileToRemote(String file) {
+        Path filePath = getFilePathSwitchable(localDirectory, file);
+        try {
+            SwitchableIndexInput switchableIndexInput = ((SwitchableIndexInput) fileCache.get(filePath).getIndexInput());
+            switchableIndexInput.switchToRemote();
+        } catch (IOException | IllegalStateException e) {
+            logger.error("Failed to switch full file to blocked - " + file, e);
+        } finally {
+            fileCache.decRef(filePath);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        ensureOpen();
+        logger.trace("Stormborn Directory[{}]: close() called", this::toString);
+        String[] localFiles = listLocalFiles();
+        for (String localFile : localFiles) {
+            // Delete segments_N file with ref count 1 created during index creation on replica shards
+            // TODO: https://github.com/opensearch-project/OpenSearch/issues/17534
+            if (localFile.startsWith(SEGMENTS)) {
+                fileCache.remove(getFilePath(localFile));
+            }
+            String finalFileName = localFile;
+            if (localFile.contains(BLOCK_FILE_IDENTIFIER)) {
+                String[] segments = localFile.split(BLOCK_FILE_IDENTIFIER);
+                finalFileName = segments[0].strip();
+            }
+            fileCache.remove(getFilePathSwitchable(localDirectory, finalFileName));
+        }
+        localDirectory.close();
+    }
+
+    public String[] listLocalFiles() throws IOException {
+        ensureOpen();
+        logger.trace("Stormborn Directory[{}]: listLocalOnly() called", this::toString);
+        return localDirectory.listAll();
+    }
+
+    @Override
+    protected void cacheFile(String fileName) throws IOException {
+        cacheFile(fileName, false);
+    }
+
+    // protected for testing
+    protected void cacheFile(String fileName, boolean cacheFromRemote) throws IOException {
+        Path switchableFilePath = getFilePathSwitchable(localDirectory, fileName);
+        fileCache.put(
+            switchableFilePath,
+            new CachedSwitchableIndexInput(
+                fileCache,
+                fileName,
+                (FSDirectory) localDirectory,
+                remoteDirectory,
+                transferManager,
+                cacheFromRemote,
+                threadPool
+            )
+        );
     }
 }

--- a/server/src/main/java/org/opensearch/storage/directory/TieredDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/storage/directory/TieredDirectoryFactory.java
@@ -5,7 +5,6 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-
 package org.opensearch.storage.directory;
 
 import org.apache.logging.log4j.LogManager;
@@ -20,26 +19,25 @@ import org.opensearch.threadpool.ThreadPool;
 import java.io.IOException;
 
 /**
- * Factory to create TieredDirectory.
- * TieredStoragePrefetchSettings dependency will be added in the implementation PR.
- * The newDirectory implementation will be added in the implementation PR.
+ * Factory for creating {@link TieredDirectory} instances that combine local and remote storage.
  */
 public class TieredDirectoryFactory implements IndexStorePlugin.CompositeDirectoryFactory {
 
     private static final Logger logger = LogManager.getLogger(TieredDirectoryFactory.class);
 
-    /** Constructs a new TieredDirectoryFactory. */
     public TieredDirectoryFactory() {}
 
     @Override
     public Directory newDirectory(
         IndexSettings indexSettings,
         ShardPath shardPath,
-        IndexStorePlugin.DirectoryFactory directoryFactory,
-        Directory directory,
+        IndexStorePlugin.DirectoryFactory localDirectoryFactory,
+        Directory remoteDirectory,
         FileCache fileCache,
         ThreadPool threadPool
     ) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        logger.trace("Creating composite directory from TieredDirectoryFactory");
+        Directory localDirectory = localDirectoryFactory.newDirectory(indexSettings, shardPath);
+        return new TieredDirectory(localDirectory, remoteDirectory, fileCache, threadPool);
     }
 }

--- a/server/src/main/java/org/opensearch/storage/indexinput/BlockFetchRequest.java
+++ b/server/src/main/java/org/opensearch/storage/indexinput/BlockFetchRequest.java
@@ -16,17 +16,20 @@ import java.nio.file.Path;
 
 /**
  * Class to represent a fetch request for a block of a file.
- * Field names: directory, fileName, blockFileName, blockStart, blockSize, filePath.
- * Builder pattern and getters will be added in the implementation PR.
  */
 @ExperimentalApi
 public class BlockFetchRequest {
 
     private final Directory directory;
+
     private final String fileName;
+
     private final String blockFileName;
+
     private final long blockStart;
+
     private final long blockSize;
+
     private final Path filePath;
 
     private BlockFetchRequest(Builder builder) {
@@ -38,65 +41,57 @@ public class BlockFetchRequest {
         this.blockStart = builder.blockStart;
     }
 
-    /**
-     * Creates a new Builder.
-     * @return a new Builder
-     */
     public static Builder builder() {
         return new Builder();
     }
 
-    /**
-     * Returns the file path.
-     * @return the file path
-     */
     public Path getFilePath() {
         return filePath;
     }
 
-    /**
-     * Returns the directory.
-     * @return the directory
-     */
     public Directory getDirectory() {
         return directory;
     }
 
-    /**
-     * Returns the file name.
-     * @return the file name
-     */
     public String getFileName() {
         return fileName;
     }
 
-    /**
-     * Returns the block file name.
-     * @return the block file name
-     */
     public String getBlockFileName() {
         return blockFileName;
     }
 
-    /**
-     * Returns the block size.
-     * @return the block size
-     */
     public long getBlockSize() {
         return blockSize;
     }
 
-    /**
-     * Returns the block start.
-     * @return the block start
-     */
     public long getBlockStart() {
         return blockStart;
     }
 
+    @Override
+    public String toString() {
+        return "BlockFetchRequest{"
+            + "filePath="
+            + filePath.toString()
+            + ", directory="
+            + directory.toString()
+            + ", fileName='"
+            + fileName
+            + ", blockFileName='"
+            + blockFileName
+            + ", blockStart="
+            + blockStart
+            + ", blockSize="
+            + blockSize
+            + ", filePath="
+            + filePath
+            + '}';
+    }
+
     /**
-    * Builder for BlobFetchRequest
-    */
+     * Builder for BlobFetchRequest
+     */
     @ExperimentalApi
     public static final class Builder {
         private FSDirectory directory;
@@ -157,7 +152,6 @@ public class BlockFetchRequest {
             return this;
         }
 
-        /** Builds the BlockFetchRequest. @return the built request */
         public BlockFetchRequest build() {
             return new BlockFetchRequest(this);
         }

--- a/server/src/main/java/org/opensearch/storage/indexinput/BlockIndexInput.java
+++ b/server/src/main/java/org/opensearch/storage/indexinput/BlockIndexInput.java
@@ -8,52 +8,170 @@
 
 package org.opensearch.storage.indexinput;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.index.store.remote.file.AbstractBlockIndexInput;
 
+import java.io.IOException;
+import java.util.Objects;
+
 /**
- * A virtual index input backed by block files downloaded from remote store.
- * Block files are a sequence of bytes of fixed block size belonging to a segment file.
- * Clone, slice, fetchBlock, and Builder will be added in the implementation PR.
+ * This is a virtual index input that is backed by block files. The block files are downloaded from remote store.
+ * The block files are a sequence of bytes of fixed block size belonging to a segment file and is persisted as blocks.
  */
 public class BlockIndexInput extends AbstractBlockIndexInput {
+    /**
+     * logger
+     */
+    private static final Logger logger = LogManager.getLogger(BlockIndexInput.class);
 
-    /** The file name. */
+    /**
+     * file name
+     */
     protected final String fileName;
-    /** The size of the file. */
+
+    /**
+     * size of the file, larger than length if it's a slice
+     */
     protected final long fileSize;
-    /** The underlying Lucene directory. */
+
+    /**
+     * underlying lucene directory to open block files.
+     */
     protected final FSDirectory directory;
-    /** The IO context. */
+
     protected final IOContext context;
 
-    // Placeholder constructor. Real constructor via Builder will be added in the implementation PR.
-    BlockIndexInput(AbstractBlockIndexInput.Builder<?> builder) {
+    /**
+     * Constructor to create BlockIndexInput using builder.
+     * @param builder blocked indexinput builder
+     */
+    BlockIndexInput(Builder builder) {
         super(builder);
-        this.fileName = null;
-        this.fileSize = 0;
-        this.directory = null;
-        this.context = null;
+        this.fileName = builder.name;
+        this.fileSize = builder.fileSize;
+        this.directory = builder.directory;
+        this.context = builder.context;
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     @Override
     public BlockIndexInput clone() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        BlockIndexInput clone = buildSlice("clone", 0, length());
+        // ensures that clones may be positioned at the same point as the blocked file they were cloned from
+        clone.cloneBlock(this);
+        return clone;
     }
 
     @Override
     public IndexInput slice(String sliceDescription, long offset, long length) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        if (offset < 0 || length < 0 || offset + length > this.length()) {
+            throw new IllegalArgumentException(
+                "slice() "
+                    + sliceDescription
+                    + " out of bounds: offset="
+                    + offset
+                    + ",length="
+                    + length
+                    + ",fileLength="
+                    + this.length()
+                    + ": "
+                    + this
+            );
+        }
+
+        // The slice is seeked to the beginning.
+        return buildSlice(sliceDescription, offset, length);
+    }
+
+    /**
+     * Builds the actual sliced IndexInput (may apply extra offset in subclasses).
+     **/
+    public BlockIndexInput buildSlice(String sliceDescription, long offset, long length) {
+        return builder().resourceDescription(getFullSliceDescription(sliceDescription))
+            .name(fileName)
+            .localDirectory(directory)
+            .offset(this.offset + offset)
+            .length(length)
+            .isClone(true)
+            .fileSize(fileSize)
+            .context(this.context)
+            .blockSizeShift(blockSizeShift)
+            .build();
     }
 
     @Override
-    protected IndexInput fetchBlock(int blockId) {
-        throw new UnsupportedOperationException("Not yet implemented");
+    protected IndexInput fetchBlock(int blockId) throws IOException {
+        logger.debug("fetchBlock called with blockId -> {}", blockId);
+        final String blockFileName = getBlockFileName(fileName, blockId);
+
+        final long blockStart = getBlockStart(blockId);
+        final long blockEnd = blockStart + getActualBlockSize(blockId, blockSizeShift, fileSize);
+        logger.debug(
+            "File: {} , Block File: {} , BlockStart: {} , BlockEnd: {} , OriginalFileSize: {}",
+            fileName,
+            blockFileName,
+            blockStart,
+            blockEnd,
+            fileSize
+        );
+        return this.directory.openInput(blockFileName, this.context);
     }
 
-    public BlockIndexInput buildSlice(String sliceDescription, long offset, long length) {
-        throw new UnsupportedOperationException("Not yet implemented");
+    /**
+     * Builder for constructing {@link BlockIndexInput} instances.
+     */
+    public static final class Builder extends AbstractBlockIndexInput.Builder<Builder> {
+
+        private String name;
+        private FSDirectory directory;
+        private long fileSize;
+        private IOContext context;
+
+        private Builder() {
+            super();
+        }
+
+        public Builder name(String fileName) {
+            this.name = Objects.requireNonNull(fileName, "File name cannot be null");
+            return this;
+        }
+
+        public Builder localDirectory(FSDirectory directory) {
+            this.directory = Objects.requireNonNull(directory, "Directory cannot be null");
+            return this;
+        }
+
+        public Builder fileSize(long fileSize) {
+            this.fileSize = fileSize;
+            return this;
+        }
+
+        public Builder context(IOContext context) {
+            this.context = context;
+            return this;
+        }
+
+        public String getResourceDescription() {
+            return resourceDescription != null
+                ? resourceDescription
+                : "BlockedLuceneFile(path=\"" + directory.getDirectory().toString() + "/" + name + "\")";
+        }
+
+        public BlockIndexInput build() {
+            // Validate this class's fields
+            if (name == null) throw new IllegalStateException("File name must be set");
+            if (directory == null) throw new IllegalStateException("Directory must be set");
+            if (fileSize <= 0) throw new IllegalStateException("File size must be positive");
+            if (context == null) throw new IllegalStateException("IOContext must be set");
+
+            return new BlockIndexInput(this);
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/storage/indexinput/CachedSwitchableIndexInput.java
+++ b/server/src/main/java/org/opensearch/storage/indexinput/CachedSwitchableIndexInput.java
@@ -8,45 +8,74 @@
 
 package org.opensearch.storage.indexinput;
 
+import org.apache.lucene.store.AlreadyClosedException;
+import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.IndexInput;
+import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.remote.filecache.CachedIndexInput;
+import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.index.store.remote.utils.TransferManager;
+import org.opensearch.threadpool.ThreadPool;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.opensearch.storage.utils.DirectoryUtils.getFilePath;
+import static org.opensearch.storage.utils.DirectoryUtils.getFilePathSwitchable;
+
 /**
- * CachedIndexInput implementation that wraps a SwitchableIndexInput for use with FileCache.
- * Constructor will accept FileCache, fileName, localDirectory, remoteDirectory, transferManager,
- * cacheFromRemote flag, threadPool, and tieredStoragePrefetchSettingsSupplier.
- * getIndexInput, length, isClosed, and close will be added in the implementation PR.
+ * A {@link CachedIndexInput} implementation that wraps a {@link SwitchableIndexInput} for use with the file cache.
  */
 public class CachedSwitchableIndexInput implements CachedIndexInput {
 
     private final SwitchableIndexInput switchableIndexInput;
     private final AtomicBoolean isClosed;
 
-    // Placeholder constructor. Real constructor will be added in the implementation PR.
-    CachedSwitchableIndexInput() {
-        this.switchableIndexInput = null;
-        this.isClosed = new AtomicBoolean(false);
+    public CachedSwitchableIndexInput(
+        FileCache fileCache,
+        String fileName,
+        FSDirectory localDirectory,
+        RemoteSegmentStoreDirectory remoteDirectory,
+        TransferManager transferManager,
+        boolean cacheFromRemote,
+        ThreadPool threadPool
+    ) throws IOException {
+        isClosed = new AtomicBoolean(false);
+        String resourceDescription = "SwitchableIndexInput (path=" + getFilePath(localDirectory, fileName) + ")";
+        switchableIndexInput = new SwitchableIndexInput(
+            resourceDescription,
+            fileName,
+            getFilePath(localDirectory, fileName),
+            getFilePathSwitchable(localDirectory, fileName),
+            fileCache,
+            localDirectory,
+            remoteDirectory,
+            transferManager,
+            cacheFromRemote,
+            threadPool
+        );
     }
 
     @Override
     public IndexInput getIndexInput() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        if (isClosed.get()) throw new AlreadyClosedException("Index input is already closed");
+        return switchableIndexInput;
     }
 
     @Override
     public long length() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return 0;
     }
 
     @Override
     public boolean isClosed() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return isClosed.get();
     }
 
     @Override
-    public void close() {
-        throw new UnsupportedOperationException("Not yet implemented");
+    public void close() throws Exception {
+        if (!isClosed.getAndSet(true)) {
+            switchableIndexInput.close();
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/storage/indexinput/OnDemandPrefetchBlockSnapshotIndexInput.java
+++ b/server/src/main/java/org/opensearch/storage/indexinput/OnDemandPrefetchBlockSnapshotIndexInput.java
@@ -11,41 +11,166 @@ package org.opensearch.storage.indexinput;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IndexInput;
 import org.opensearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.opensearch.index.store.remote.file.AbstractBlockIndexInput;
 import org.opensearch.index.store.remote.file.OnDemandBlockSnapshotIndexInput;
 import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.index.store.remote.utils.BlobFetchRequest;
 import org.opensearch.index.store.remote.utils.TransferManager;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.io.IOException;
+import java.nio.file.Path;
+
 /**
- * Extension of OnDemandBlockSnapshotIndexInput that adds prefetch and read-ahead capabilities.
- * TieredStoragePrefetchSettings dependency will be added in the implementation PR.
- * Records per-query file cache hit/miss metrics via TieredStorageQueryMetricService.
- * Constructors, fetchBlock override, prefetch, read-ahead, clone/slice,
- * and async block download logic will be added in the implementation PR.
+ * Block-based index input that prefetches subsequent blocks from remote storage on demand.
  */
 public class OnDemandPrefetchBlockSnapshotIndexInput extends OnDemandBlockSnapshotIndexInput {
 
-    // TieredStoragePrefetchSettings supplier will be added in the implementation PR
-    /** The thread pool. */
     protected final ThreadPool threadPool;
-    /** The file cache. */
     protected FileCache fileCache;
-    /** The resource description. */
     protected final String resourceDescription;
     private static final Logger logger = LogManager.getLogger(OnDemandPrefetchBlockSnapshotIndexInput.class);
 
-    // Placeholder constructor. Real constructors will be added in the implementation PR.
-    OnDemandPrefetchBlockSnapshotIndexInput(
+    public OnDemandPrefetchBlockSnapshotIndexInput(
+        String resourceDescription,
+        BlobStoreIndexShardSnapshot.FileInfo fileInfo,
+        long offset,
+        long length,
+        boolean isClone,
+        FSDirectory directory,
+        TransferManager transferManager,
+        ThreadPool threadPool,
+        FileCache fileCache
+    ) {
+        super(resourceDescription, fileInfo, offset, length, isClone, directory, transferManager);
+        this.threadPool = threadPool;
+        this.fileCache = fileCache;
+        this.resourceDescription = resourceDescription;
+    }
+
+    @Override
+    protected IndexInput fetchBlock(int blockId) throws IOException {
+        // TODO: Metric recording will be added when TieredStorageQueryMetricService is available
+        fetchNextNBlocks(blockId);
+        return super.fetchBlock(blockId);
+    }
+
+    public OnDemandPrefetchBlockSnapshotIndexInput(
         AbstractBlockIndexInput.Builder<?> builder,
+        String resourceDescription,
         BlobStoreIndexShardSnapshot.FileInfo fileInfo,
         FSDirectory directory,
-        TransferManager transferManager
+        TransferManager transferManager,
+        ThreadPool threadPool,
+        FileCache fileCache
     ) {
         super(builder, fileInfo, directory, transferManager);
-        this.threadPool = null;
-        this.fileCache = null;
-        this.resourceDescription = null;
+        this.threadPool = threadPool;
+        this.fileCache = fileCache;
+        this.resourceDescription = resourceDescription;
+    }
+
+    @Override
+    protected OnDemandPrefetchBlockSnapshotIndexInput buildSlice(String sliceDescription, long offset, long length) {
+        return new OnDemandPrefetchBlockSnapshotIndexInput(
+            AbstractBlockIndexInput.builder()
+                .blockSizeShift(blockSizeShift)
+                .isClone(true)
+                .offset(this.offset + offset)
+                .length(length)
+                .resourceDescription(sliceDescription),
+            sliceDescription,
+            fileInfo,
+            directory,
+            transferManager,
+            threadPool,
+            fileCache
+        );
+    }
+
+    protected void fetchNextNBlocks(int blockId) {
+        // TODO: Read-ahead with configurable block count. TieredStoragePrefetchSettings integration will be added later.
+        int readAheadBlockCount = 4; // DEFAULT_READ_AHEAD_BLOCK_COUNT
+        readAheadBlockCount = Math.min(readAheadBlockCount, getTotalBlocks() - 1 - blockId);
+        if (readAheadBlockCount <= 0) {
+            logger.trace("read ahead block is <=0, for File: {} and Block ID: {}", fileName, blockId);
+            return;
+        }
+        logger.trace("Prefetching Read Ahead Block Count: {} from Block ID: {} for File: {}", readAheadBlockCount, blockId, fileName);
+        downloadBlocksAsync(blockId + 1, blockId + readAheadBlockCount, true);
+    }
+
+    @Override
+    public void prefetch(long offset, long length) throws IOException {
+        offset = offset + this.offset;
+        final int startBlock = getBlock(offset);
+        final int endBlock = Math.min(getTotalBlocks() - 1, getBlock(offset + length - 1L));
+        logger.trace("Prefetching Index Input Block From {} to {} for File {}", startBlock, endBlock, fileName);
+        downloadBlocksAsync(startBlock, endBlock, false);
+    }
+
+    protected void downloadBlocksAsync(int startBlock, int endBlock, boolean isReadAhead) {
+        for (int nextBlockId = startBlock; nextBlockId <= endBlock; nextBlockId++) {
+            String blockFileName = fileName + "_block_" + nextBlockId;
+            long blockStart = getBlockStart(nextBlockId);
+            long blockEnd = blockStart + getActualBlockSize(nextBlockId, blockSizeShift, originalFileSize);
+            logger.trace(
+                "File: {} , Block File: {} , BlockStart: {} , BlockEnd: {} , OriginalFileSize: {}",
+                fileName,
+                blockFileName,
+                blockStart,
+                blockEnd,
+                originalFileSize
+            );
+            // TODO: Metric recording will be added when TieredStorageQueryMetricService is available
+            // Block may be present on multiple chunks of a file, so we need
+            // to fetch each chunk/blob part separately to fetch an entire block.
+            BlobFetchRequest blobFetchRequest = BlobFetchRequest.builder()
+                .blobParts(getBlobParts(blockStart, blockEnd))
+                .directory(directory)
+                .fileName(blockFileName)
+                .build();
+            try {
+                transferManager.fetchBlobAsync(blobFetchRequest);
+            } catch (Exception e) {
+                logger.error(
+                    "Exception while fetching block asynchronously from remote - "
+                        + "File: {} , Block File: {} , BlockStart: {} , BlockEnd: {} , OriginalFileSize: {}",
+                    fileName,
+                    blockFileName,
+                    blockStart,
+                    blockEnd,
+                    originalFileSize
+                );
+            }
+        }
+    }
+
+    @Override
+    public OnDemandPrefetchBlockSnapshotIndexInput clone() {
+        OnDemandPrefetchBlockSnapshotIndexInput clone = buildSlice("clone", 0L, this.length);
+        // ensures that clones may be positioned at the same point as the blocked file they were cloned from
+        clone.cloneBlock(this);
+        return clone;
+    }
+
+    protected int getTotalBlocks() {
+        return (int) ((originalFileSize - 1) >>> blockSizeShift) + 1;
+    }
+
+    /**
+     * Checks if a block file exists in the file cache.
+     * This method determines cache hit/miss status for transfer manager operations.
+     * TODO: Will be used by TieredStorageQueryMetricService for recording per-query cache metrics.
+     *
+     * @param blockId the id of the block to check
+     * @return true if the block exists in cache (cache hit), false otherwise (cache miss)
+     */
+    protected boolean checkCacheHit(int blockId) {
+        final String blockFileName = fileName + "_block_" + blockId;
+        Path filePath = directory.getDirectory().resolve(blockFileName);
+        return fileCache.getRef(filePath) != null;// File exists (cache hit)
     }
 }

--- a/server/src/main/java/org/opensearch/storage/indexinput/SwitchableIndexInput.java
+++ b/server/src/main/java/org/opensearch/storage/indexinput/SwitchableIndexInput.java
@@ -11,9 +11,16 @@ package org.opensearch.storage.indexinput;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.IORunnable;
+import org.apache.lucene.util.Version;
+import org.opensearch.common.util.concurrent.ConcurrentCollections;
+import org.opensearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
+import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.index.store.remote.filecache.CachedFullFileIndexInput;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.index.store.remote.utils.TransferManager;
 import org.opensearch.threadpool.ThreadPool;
@@ -24,26 +31,21 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
- * IndexInput that provides a hook for switching from full file based local index input to block based remote index input.
- * Depending upon the constructor param we either initialize the local or remote based index input and make the underlying
- * index input point to it.
+ * IndexInput that provides a hook for switching from full file based local index input to block based remote index input
+ * Depending upon the constructor param we either initialize the local or remote based index input and make the underlying index input point to it
  *
  * FileCache Interactions with Switchable Index Input:
- * In Directory itself we create a switchable entry when we are writing to the directory.
- * E.g, if filename is _0.cfs, after we have written the file locally, we add an entry _0.cfs_switchable which points
- * to the SwitchableIndexInput we create.
- * If Switchable Index Input hasn't switched we add one more entry _0.cfs pointing to the full file.
- * If Switchable Index Input has switched we add block entries such as _0.cfs_block_0 pointing to the block files.
- * Note that the Directory is only concerned about the switchable entry in FileCache while the SwitchableIndexInput
- * handles the full file and block file entries.
- *
- * Constructors, switchToRemote, IndexInput/RandomAccessInput overrides, clone/slice logic,
- * and lock management will be added in the implementation PR.
+ * In Directory itself we create a switchable entry when we are writing to the directory
+ * E.g, if filename is _0.cfs, after we have written the file locally, we add an entry _0.cfs_switchable which points to the SwitchableIndexInput we create
+ * If Switchable Index Input hasn't switched we add one more entry _0.cfs pointing to the full file
+ * If Switchable Index Input has switched we add block entries such as _0.cfs_block_0 pointing to the block files
+ * Note that the Directory is only concerned about the switchable entry in FileCache while the SwitchableIndexInput handles the full file and block file entries
  */
 public class SwitchableIndexInput extends IndexInput implements Runnable, RandomAccessInput {
-
     private static final Logger logger = LogManager.getLogger(SwitchableIndexInput.class);
     private final AtomicReference<IndexInput> underlyingIndexInput = new AtomicReference<>();
     private final AtomicReference<IndexInput> localIndexInput = new AtomicReference<>();
@@ -62,139 +64,422 @@ public class SwitchableIndexInput extends IndexInput implements Runnable, Random
     private volatile boolean hasSwitchedToRemote;
     private volatile boolean cachedFromRemote;
     private final ConcurrentMap<SwitchableIndexInput, Boolean> clones;
-    // TieredStoragePrefetchSettings supplier will be added in the implementation PR
     private final ThreadPool threadPool;
 
     /*
-    This lock is shared between the original index input and all of its clones/slices.
-    This is to ensure that we do not allow cloning/slicing operations for any of the index inputs when switchToRemote
-    is in progress. Similarly when cloning/slicing is in progress for any of the index inputs, switchToRemote will have
-    to wait, but additional cloning/slicing operations can function.
+    This lock is shared between the original index input and all of its clones/slices
+    This is to ensure that we do not allow cloning/slicing operations for any of the index inputs when switchToRemote is in progress
+    Similarly when cloning/slicing is in progress for any of the index inputs, switchToRemote will have to wait, but additional cloning/slicing operations can function
+    The reason is that whenever we do a clone/slice operation we update the clone map that we maintain, and in switchToRemote we iterate through the map
+    If while switching any entry is cloned/sliced (or vice-versa, while cloning/slicing switch is called), race conditions might occur
+    (since we iterate over a copy of the clone map) and the entry won't be switched and will always remain as a full file.
+    That is the reason we have used a ReadWriteLock here - we take write lock when we want to perform switchToRemote and read lock for cloning/slicing
 
     This lock variable has been intentionally not kept final as we are overwriting this in tests
      */
-    /** Shared lock for clone/slice and switchToRemote synchronization. */
     protected ReadWriteLock sharedLock;
 
     /*
-    Each instance of IndexInput will have its own copy of this lock.
-    This is to ensure that for an IndexInput we do not allow any two operations to run concurrently.
+    Each instance of IndexInput will have its own copy of this lock
+    This is to ensure that for an IndexInput we do not allow any two operations to run concurrently
+    We have created a separate lock instead of making each function synchronised to maintain ordering of lock acquisition
+    and prevent deadlock occurring due to conflicts between the shared lock and object lock
 
     This lock variable has been intentionally not kept final as we are overwriting this in tests
      */
-    /** Per-instance lock for operation synchronization. */
     protected Lock objectLock;
 
-    // Placeholder constructor. Real constructors will be added in the implementation PR.
-    SwitchableIndexInput(String resourceDescription) {
+    // constructor for original index input
+    public SwitchableIndexInput(
+        String resourceDescription,
+        String fileName,
+        Path fullFilePath,
+        Path switchableFilePath,
+        FileCache fileCache,
+        FSDirectory localDirectory,
+        RemoteSegmentStoreDirectory remoteDirectory,
+        TransferManager transferManager,
+        boolean cacheFromRemote,
+        ThreadPool threadPool
+    ) throws IOException {
+        this(
+            resourceDescription,
+            fileName,
+            fullFilePath,
+            switchableFilePath,
+            fileCache,
+            localDirectory,
+            remoteDirectory,
+            transferManager,
+            0,
+            cacheFromRemote ? remoteDirectory.fileLength(fileName) : localDirectory.fileLength(fileName),
+            cacheFromRemote,
+            false,
+            null,
+            null,
+            null,
+            null,
+            threadPool
+        );
+    }
+
+    // constructor for clones/slices
+    SwitchableIndexInput(
+        String resourceDescription,
+        String fileName,
+        Path fullFilePath,
+        Path switchableFilePath,
+        FileCache fileCache,
+        FSDirectory localDirectory,
+        RemoteSegmentStoreDirectory remoteDirectory,
+        TransferManager transferManager,
+        long offset,
+        long fileLength,
+        boolean cacheFromRemote,
+        boolean isClone,
+        IndexInput clonedLocalIndexInput,
+        IndexInput clonedRemoteIndexInput,
+        ConcurrentMap<SwitchableIndexInput, Boolean> clones,
+        ReadWriteLock sharedLock,
+        ThreadPool threadPool
+    ) throws IOException {
         super(resourceDescription);
-        this.fileCache = null;
-        this.fullFilePath = null;
-        this.switchableFilePath = null;
-        this.fileName = null;
-        this.fileLength = 0;
-        this.offset = 0;
-        this.localDirectory = null;
-        this.remoteDirectory = null;
-        this.transferManager = null;
-        this.isClone = false;
-        this.clones = null;
-        this.threadPool = null;
+        this.fileCache = fileCache;
+        this.fullFilePath = fullFilePath;
+        this.switchableFilePath = switchableFilePath;
+        this.localDirectory = localDirectory;
+        this.remoteDirectory = remoteDirectory;
+        this.fileName = fileName;
+        this.offset = offset;
+        this.fileLength = fileLength;
+        this.transferManager = transferManager;
+        this.isClone = isClone;
+        this.cachedFromRemote = cacheFromRemote;
+        this.hasSwitchedToRemote = cacheFromRemote;
+        this.isClosed = false;
+        this.threadPool = threadPool;
+        this.objectLock = new ReentrantLock();
+        if (!isClone) {
+            this.sharedLock = new ReentrantReadWriteLock();
+            this.clones = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+            if (!cacheFromRemote) {
+                fileCache.put(
+                    fullFilePath,
+                    new CachedFullFileIndexInput(fileCache, fullFilePath, localDirectory.openInput(fileName, IOContext.DEFAULT))
+                );
+                localIndexInput.set(getLocalIndexInput());
+                underlyingIndexInput.set(localIndexInput.get());
+            } else {
+                remoteIndexInput.set(getRemoteIndexInput());
+                underlyingIndexInput.set(remoteIndexInput.get());
+            }
+        } else {
+            this.sharedLock = sharedLock;
+            this.clones = clones;
+            if (!hasSwitchedToRemote) {
+                localIndexInput.set(clonedLocalIndexInput);
+                underlyingIndexInput.set(localIndexInput.get());
+            } else {
+                remoteIndexInput.set(clonedRemoteIndexInput);
+                underlyingIndexInput.set(remoteIndexInput.get());
+            }
+        }
+    }
+
+    public void switchToRemote() throws IOException, IllegalStateException {
+        sharedLock.writeLock().lock();
+        try {
+            objectLock.lock();
+            try {
+                if (isClosed || hasSwitchedToRemote) return;
+                validateFilePresentInRemote();
+                remoteIndexInput.set(getRemoteIndexInput());
+                IndexInput localIndexInput = underlyingIndexInput.get();
+                if (isClone) remoteIndexInput.get().seek(localIndexInput.getFilePointer());
+                underlyingIndexInput.set(remoteIndexInput.get());
+                if (!isClone) {
+                    clones.keySet().forEach(c -> {
+                        try {
+                            c.switchToRemote();
+                        } catch (IOException e) {
+                            logger.error("Failed to switch IndexInput to remote - " + c, e);
+                        }
+                    });
+                }
+                localIndexInput.close();
+                hasSwitchedToRemote = true;
+                if (!isClone) fileCache.remove(fullFilePath);
+            } finally {
+                objectLock.unlock();
+            }
+        } finally {
+            sharedLock.writeLock().unlock();
+        }
     }
 
     @Override
     public void close() throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        withOptionalLock(() -> {
+            if (!isClosed) {
+                if (localIndexInput.get() != null) localIndexInput.get().close();
+                if (remoteIndexInput.get() != null) remoteIndexInput.get().close();
+                if (isClone) {
+                    clones.remove(this);
+                    fileCache.decRef(switchableFilePath);
+                } else {
+                    /*
+                     We do not close the clones as it may cause deadlocks - between index-input-cleaner thread and thread which calls composite directory delete
+                     Further since we are using a Wrapper on top of SwitchableIndexInput which is using a Cleaner,
+                     close will automatically be called once object is phantom reachable
+                     */
+                    clones.clear();
+                }
+                isClosed = true;
+            }
+        });
     }
 
     @Override
     public long getFilePointer() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return withOptionalLock(() -> underlyingIndexInput.get().getFilePointer());
     }
 
     @Override
     public void seek(long pos) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        withOptionalLock(() -> underlyingIndexInput.get().seek(pos));
     }
 
     @Override
     public long length() {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public SwitchableIndexInput clone() {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public SwitchableIndexInput slice(String sliceDescription, long offset, long length) {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public byte readByte() throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public short readShort() throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public int readInt() throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public long readLong() throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public int readVInt() throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public long readVLong() throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public void readBytes(byte[] b, int offset, int len) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return withOptionalLock(() -> underlyingIndexInput.get().length());
     }
 
     @Override
     public byte readByte(long pos) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return withOptionalLock(() -> ((RandomAccessInput) underlyingIndexInput.get()).readByte(pos));
     }
 
     @Override
     public short readShort(long pos) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return withOptionalLock(() -> ((RandomAccessInput) underlyingIndexInput.get()).readShort(pos));
     }
 
     @Override
     public int readInt(long pos) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return withOptionalLock(() -> ((RandomAccessInput) underlyingIndexInput.get()).readInt(pos));
     }
 
     @Override
     public long readLong(long pos) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return withOptionalLock(() -> ((RandomAccessInput) underlyingIndexInput.get()).readLong(pos));
+    }
+
+    @Override
+    public SwitchableIndexInput clone() {
+        sharedLock.readLock().lock();
+        try {
+            return withOptionalLock(() -> {
+                fileCache.incRef(switchableFilePath);
+                try {
+                    SwitchableIndexInput clonedIndexInput = new SwitchableIndexInput(
+                        "SwitchableIndexInput Clone (path=" + fullFilePath.toString() + ")\"",
+                        fileName,
+                        fullFilePath,
+                        switchableFilePath,
+                        fileCache,
+                        localDirectory,
+                        remoteDirectory,
+                        transferManager,
+                        this.offset,
+                        this.fileLength,
+                        hasSwitchedToRemote,
+                        true,
+                        (!hasSwitchedToRemote && localIndexInput.get() != null) ? localIndexInput.get().clone() : null,
+                        (hasSwitchedToRemote && remoteIndexInput.get() != null) ? remoteIndexInput.get().clone() : null,
+                        clones,
+                        sharedLock,
+                        threadPool
+                    );
+                    clonedIndexInput.seek(getFilePointer());
+                    clones.put(clonedIndexInput, true);
+                    return clonedIndexInput;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } finally {
+            sharedLock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public SwitchableIndexInput slice(String sliceDescription, long offset, long length) {
+        sharedLock.readLock().lock();
+        try {
+            return withOptionalLock(() -> {
+                fileCache.incRef(switchableFilePath);
+                try {
+                    SwitchableIndexInput slicedIndexInput = new SwitchableIndexInput(
+                        "SwitchableIndexInput Slice " + sliceDescription + "(path=" + fullFilePath.toString() + ")\"",
+                        fileName,
+                        fullFilePath,
+                        switchableFilePath,
+                        fileCache,
+                        localDirectory,
+                        remoteDirectory,
+                        transferManager,
+                        this.offset + offset,
+                        length,
+                        hasSwitchedToRemote,
+                        true,
+                        (!hasSwitchedToRemote && localIndexInput.get() != null)
+                            ? localIndexInput.get().slice(sliceDescription, offset, length)
+                            : null,
+                        (hasSwitchedToRemote && remoteIndexInput.get() != null)
+                            ? remoteIndexInput.get().slice(sliceDescription, offset, length)
+                            : null,
+                        clones,
+                        sharedLock,
+                        threadPool
+                    );
+                    slicedIndexInput.seek(0);
+                    clones.put(slicedIndexInput, true);
+                    return slicedIndexInput;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } finally {
+            sharedLock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+        return withOptionalLock(() -> underlyingIndexInput.get().readByte());
+    }
+
+    @Override
+    public short readShort() throws IOException {
+        return withOptionalLock(() -> underlyingIndexInput.get().readShort());
+    }
+
+    @Override
+    public int readInt() throws IOException {
+        return withOptionalLock(() -> underlyingIndexInput.get().readInt());
+    }
+
+    @Override
+    public long readLong() throws IOException {
+        return withOptionalLock(() -> underlyingIndexInput.get().readLong());
+    }
+
+    @Override
+    public int readVInt() throws IOException {
+        return withOptionalLock(() -> underlyingIndexInput.get().readVInt());
+    }
+
+    @Override
+    public long readVLong() throws IOException {
+        return withOptionalLock(() -> underlyingIndexInput.get().readVLong());
+    }
+
+    @Override
+    public void readBytes(byte[] b, int offset, int len) throws IOException {
+        withOptionalLock(() -> underlyingIndexInput.get().readBytes(b, offset, len));
+    }
+
+    // Visible for testing
+    public boolean hasSwitchedToRemote() {
+        return hasSwitchedToRemote;
+    }
+
+    // Visible for testing
+    public boolean isCachedFromRemote() {
+        return cachedFromRemote;
+    }
+
+    private void validateFilePresentInRemote() {
+        RemoteSegmentStoreDirectory.UploadedSegmentMetadata uploadedSegmentMetadata = remoteDirectory.getSegmentsUploadedToRemoteStore()
+            .get(fileName);
+        if (uploadedSegmentMetadata == null) {
+            throw new IllegalStateException("Cannot switch to remote as file " + fileName + " not present in remote");
+        }
+    }
+
+    protected IndexInput getLocalIndexInput() throws IOException {
+        IndexInput indexInput = fileCache.get(fullFilePath).getIndexInput();
+        fileCache.decRef(fullFilePath);
+        return indexInput;
+    }
+
+    protected IndexInput getRemoteIndexInput() {
+        RemoteSegmentStoreDirectory.UploadedSegmentMetadata uploadedSegmentMetadata = remoteDirectory.getSegmentsUploadedToRemoteStore()
+            .get(fileName);
+        BlobStoreIndexShardSnapshot.FileInfo fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(
+            fileName,
+            new StoreFileMetadata(fileName, uploadedSegmentMetadata.getLength(), uploadedSegmentMetadata.getChecksum(), Version.LATEST),
+            null
+        );
+        return new OnDemandPrefetchBlockSnapshotIndexInput(
+            "Remote Index Input",
+            fileInfo,
+            offset,
+            fileLength,
+            false,
+            localDirectory,
+            transferManager,
+            threadPool,
+            fileCache
+        );
+    }
+
+    /**
+     * Used only for testing
+     *
+     * @return returns underlying index input
+     */
+    public IndexInput getUnderlyingIndexInput() {
+        return underlyingIndexInput.get();
     }
 
     @Override
     public void prefetch(long offset, long length) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        this.underlyingIndexInput.get().prefetch(offset, length);
     }
 
     @Override
     public void run() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        try {
+            close();
+        } catch (Exception e) {
+            logger.error("Error while cleaning up Switchable Index Input", e);
+        }
+    }
+
+    private void withOptionalLock(IORunnable operation) throws IOException {
+        if (hasSwitchedToRemote) {
+            operation.run();
+            return;
+        }
+        objectLock.lock();
+        try {
+            operation.run();
+        } finally {
+            objectLock.unlock();
+        }
+    }
+
+    private <T, E extends Exception> T withOptionalLock(ThrowingSupplier<T, E> operation) throws E {
+        if (hasSwitchedToRemote) {
+            return operation.get();
+        }
+        objectLock.lock();
+        try {
+            return operation.get();
+        } finally {
+            objectLock.unlock();
+        }
     }
 
     @FunctionalInterface

--- a/server/src/main/java/org/opensearch/storage/indexinput/SwitchableIndexInputWrapper.java
+++ b/server/src/main/java/org/opensearch/storage/indexinput/SwitchableIndexInputWrapper.java
@@ -8,46 +8,103 @@
 
 package org.opensearch.storage.indexinput;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
+
+import java.io.IOException;
+import java.lang.ref.Cleaner;
 
 /**
- * Wrapper around SwitchableIndexInput that implements RandomAccessInput.
- * Delegates all read operations to the underlying SwitchableIndexInput.
- * Clone, slice, RandomAccessInput methods, and Cleaner registration
- * will be added in the implementation PR.
+ * Wrapper around {@link SwitchableIndexInput} that uses a {@link java.lang.ref.Cleaner} to ensure resources are released.
  */
 public class SwitchableIndexInputWrapper extends FilterIndexInput implements RandomAccessInput {
 
+    private final String resourceDescription;
     private final SwitchableIndexInput switchableIndexInput;
+    private static final Logger logger = LogManager.getLogger(SwitchableIndexInputWrapper.class);
+    private static final Cleaner CLEANER = Cleaner.create(OpenSearchExecutors.daemonThreadFactory("index-input-cleaner"));
 
-    /**
-     * Constructs a new SwitchableIndexInputWrapper.
-     * @param resourceDescription the resource description
-     * @param in the switchable index input
-     */
     public SwitchableIndexInputWrapper(String resourceDescription, SwitchableIndexInput in) {
         super(resourceDescription, in);
-        this.switchableIndexInput = in;
+        this.resourceDescription = resourceDescription;
+        switchableIndexInput = in;
+        CLEANER.register(this, switchableIndexInput);
     }
 
     @Override
-    public byte readByte(long pos) {
-        throw new UnsupportedOperationException("Not yet implemented");
+    public IndexInput clone() {
+        return new SwitchableIndexInputWrapper("Cloned " + resourceDescription, switchableIndexInput.clone());
     }
 
     @Override
-    public short readShort(long pos) {
-        throw new UnsupportedOperationException("Not yet implemented");
+    public byte readByte(long pos) throws IOException {
+        return switchableIndexInput.readByte(pos);
     }
 
     @Override
-    public int readInt(long pos) {
-        throw new UnsupportedOperationException("Not yet implemented");
+    public short readShort(long pos) throws IOException {
+        return switchableIndexInput.readShort(pos);
     }
 
     @Override
-    public long readLong(long pos) {
-        throw new UnsupportedOperationException("Not yet implemented");
+    public int readInt(long pos) throws IOException {
+        return switchableIndexInput.readInt(pos);
+    }
+
+    @Override
+    public long readLong(long pos) throws IOException {
+        return switchableIndexInput.readLong(pos);
+    }
+
+    @Override
+    public void prefetch(long offset, long length) throws IOException {
+        this.switchableIndexInput.prefetch(offset, length);
+    }
+
+    @Override
+    public IndexInput slice(String sliceDescription, long offset, long length) {
+        return new SwitchableIndexInputWrapper(
+            "Sliced " + resourceDescription,
+            switchableIndexInput.slice(sliceDescription, offset, length)
+        );
+    }
+
+    @Override
+    public void close() throws IOException {
+        switchableIndexInput.close();
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+        return switchableIndexInput.readByte();
+    }
+
+    @Override
+    public short readShort() throws IOException {
+        return switchableIndexInput.readShort();
+    }
+
+    @Override
+    public int readInt() throws IOException {
+        return switchableIndexInput.readInt();
+    }
+
+    @Override
+    public long readLong() throws IOException {
+        return switchableIndexInput.readLong();
+    }
+
+    @Override
+    public int readVInt() throws IOException {
+        return switchableIndexInput.readVInt();
+    }
+
+    @Override
+    public long readVLong() throws IOException {
+        return switchableIndexInput.readVLong();
     }
 }

--- a/server/src/main/java/org/opensearch/storage/utils/DirectoryUtils.java
+++ b/server/src/main/java/org/opensearch/storage/utils/DirectoryUtils.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.utils;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+
+import java.nio.file.Path;
+
+/**
+ * Utility methods for directory path resolution in tiered storage.
+ */
+public class DirectoryUtils {
+
+    public static final String SWITCHABLE_PREFIX = "_switchable";
+
+    public static Path getFilePath(Directory localDirectory, String fileName) {
+        return ((FSDirectory) localDirectory).getDirectory().resolve(fileName);
+    }
+
+    public static Path getFilePathSwitchable(Directory localDirectory, String fileName) {
+        return ((FSDirectory) localDirectory).getDirectory().resolve(fileName + SWITCHABLE_PREFIX);
+    }
+}

--- a/server/src/main/java/org/opensearch/storage/utils/package-info.java
+++ b/server/src/main/java/org/opensearch/storage/utils/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/** Utility classes for tiered storage directory operations. */
+package org.opensearch.storage.utils;

--- a/server/src/test/java/org/opensearch/storage/common/BlockTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/storage/common/BlockTransferManagerTests.java
@@ -1,0 +1,408 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.common;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.UUIDs;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
+import org.opensearch.index.store.remote.utils.TransferManager;
+import org.opensearch.node.Node;
+import org.opensearch.storage.indexinput.BlockFetchRequest;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for BlockTransferManager functionality.
+ * Tests cover single block downloads, failure scenarios, duplicate handling, and concurrent operations.
+ */
+@ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
+public class BlockTransferManagerTests extends LuceneTestCase {
+
+    // Node and index configuration constants
+    private static final String TEST_NODE_NAME = "test-node";
+    private static final String TEST_INDEX_NAME = "test-index";
+    private static final int TEST_NODE_PROCESSORS = 2;
+    private static final int TEST_SHARD_COUNT = 1;
+    private static final int TEST_REPLICA_COUNT = 0;
+
+    // Test file constants
+    private static final String TEST_FILE_NAME = "file1";
+    private static final String TEST_BLOCK_FILE_NAME = "file1_block_0";
+
+    // Test data constants
+    private static final String HELLO_WORLD_CONTENT = "hello world";
+    private static final String TEST_DATA_CONTENT = "test-data";
+    private static final String SIMPLE_TEST_CONTENT = "abc";
+
+    // Error message constants
+    private static final String REMOTE_READ_ERROR_MESSAGE = "Failed to read remote block";
+
+    // Test timing constants
+    private static final long CONCURRENT_TEST_SLEEP_MS = 200L;
+
+    // Block position constants
+    private static final long BLOCK_START_POSITION = 0L;
+
+    // Test instance variables
+    private IndexSettings indexSettings;
+    private FSDirectory fsDirectory;
+    private BlockTransferManager blockTransferManager;
+    private TestThreadPool testThreadPool;
+
+    @Before
+    public void setup() throws IOException {
+        fsDirectory = FSDirectory.open(createTempDir());
+
+        Settings settings = Settings.builder()
+            .put(Node.NODE_NAME_SETTING.getKey(), TEST_NODE_NAME)
+            .put(OpenSearchExecutors.NODE_PROCESSORS_SETTING.getKey(), TEST_NODE_PROCESSORS)
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, TEST_SHARD_COUNT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, TEST_REPLICA_COUNT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
+            .build();
+
+        IndexMetadata indexMetadata = IndexMetadata.builder(TEST_INDEX_NAME).settings(settings).build();
+
+        indexSettings = new IndexSettings(indexMetadata, settings);
+        testThreadPool = new TestThreadPool();
+    }
+
+    @After
+    public void cleanup() throws IOException {
+        Arrays.stream(fsDirectory.listAll()).forEach(fileName -> {
+            try {
+                fsDirectory.deleteFile(fileName);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        fsDirectory.close();
+        if (testThreadPool != null) {
+            testThreadPool.shutdown();
+        }
+    }
+
+    /**
+     * Test successful download of a single block.
+     */
+    public void testSingleBlockDownloadSuccess() throws Exception {
+        byte[] content = HELLO_WORLD_CONTENT.getBytes(StandardCharsets.UTF_8);
+        BlockFetchRequest request = createBlockFetchRequest(
+            fsDirectory,
+            TEST_FILE_NAME,
+            TEST_BLOCK_FILE_NAME,
+            BLOCK_START_POSITION,
+            content.length
+        );
+
+        TransferManager.StreamReader reader = (name, pos, len) -> {
+            if (name.equals(TEST_FILE_NAME) && pos == BLOCK_START_POSITION && len == content.length) {
+                return new ByteArrayInputStream(content);
+            }
+            return null;
+        };
+
+        BlockTransferManager manager = new BlockTransferManager(reader, indexSettings, () -> testThreadPool);
+        manager.fetchBlocksAsync(List.of(request));
+
+        byte[] actualContent = new byte[content.length];
+        fsDirectory.openInput(TEST_BLOCK_FILE_NAME, IOContext.READONCE).readBytes(actualContent, 0, content.length);
+        Assert.assertArrayEquals(actualContent, content);
+    }
+
+    /**
+     * Test handling of block download failures.
+     */
+    public void testBlockDownloadFailure() {
+        byte[] content = HELLO_WORLD_CONTENT.getBytes(StandardCharsets.UTF_8);
+        BlockFetchRequest request = createBlockFetchRequest(
+            fsDirectory,
+            TEST_FILE_NAME,
+            TEST_BLOCK_FILE_NAME,
+            BLOCK_START_POSITION,
+            content.length
+        );
+
+        TransferManager.StreamReader reader = (name, pos, len) -> { throw new IOException(REMOTE_READ_ERROR_MESSAGE); };
+
+        BlockTransferManager manager = new BlockTransferManager(reader, indexSettings, () -> testThreadPool);
+        assertThrows(IOException.class, () -> manager.fetchBlocksAsync(List.of(request)));
+    }
+
+    /**
+     * Test that duplicate downloads are properly skipped.
+     */
+    public void testDuplicateDownloadIsSkipped() throws Exception {
+        byte[] data = TEST_DATA_CONTENT.getBytes(StandardCharsets.UTF_8);
+        BlockFetchRequest request = createBlockFetchRequest(
+            fsDirectory,
+            TEST_FILE_NAME,
+            TEST_BLOCK_FILE_NAME,
+            BLOCK_START_POSITION,
+            data.length
+        );
+
+        TransferManager.StreamReader reader = mock(TransferManager.StreamReader.class);
+        when(reader.read(any(), anyLong(), anyLong())).thenReturn(new ByteArrayInputStream(data));
+
+        BlockTransferManager manager = new BlockTransferManager(reader, indexSettings, () -> testThreadPool);
+
+        // First fetch triggers the download
+        manager.fetchBlocksAsync(List.of(request));
+        // Second fetch should skip download since file exists
+        manager.fetchBlocksAsync(List.of(request));
+
+        verify(reader, times(1)).read(any(), anyLong(), anyLong());
+    }
+
+    /**
+     * Test that concurrent fetches of the same file result in only one download.
+     */
+    public void testConcurrentFetchSameFileOnlyOneDownload() throws Exception {
+        byte[] data = SIMPLE_TEST_CONTENT.getBytes(StandardCharsets.UTF_8);
+        BlockFetchRequest request = createBlockFetchRequest(
+            fsDirectory,
+            TEST_FILE_NAME,
+            TEST_BLOCK_FILE_NAME,
+            BLOCK_START_POSITION,
+            data.length
+        );
+
+        CountDownLatch latch = new CountDownLatch(1);
+        TransferManager.StreamReader reader = (name, pos, len) -> {
+            try {
+                latch.await(); // hold until signaled
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return new ByteArrayInputStream(data);
+        };
+
+        BlockTransferManager manager = new BlockTransferManager(reader, indexSettings, () -> testThreadPool);
+
+        Thread firstThread = new Thread(() -> {
+            try {
+                manager.fetchBlocksAsync(List.of(request));
+            } catch (Exception ignored) {
+                // Exception handling for test thread
+            }
+        });
+
+        Thread secondThread = new Thread(() -> {
+            try {
+                manager.fetchBlocksAsync(List.of(request));
+            } catch (Exception ignored) {
+                // Exception handling for test thread
+            }
+        });
+
+        firstThread.start();
+        secondThread.start();
+
+        Thread.sleep(CONCURRENT_TEST_SLEEP_MS); // let both threads start and block on latch
+        latch.countDown(); // let read proceed
+
+        firstThread.join();
+        secondThread.join();
+
+        assertTrue(Arrays.stream(fsDirectory.listAll()).anyMatch(fileName -> TEST_BLOCK_FILE_NAME.equals(fileName)));
+    }
+
+    // Additional test cases for new functionality
+
+    public void testDownloadBlobWithExistingTempFile() throws Exception {
+        byte[] data = TEST_DATA_CONTENT.getBytes(StandardCharsets.UTF_8);
+        BlockFetchRequest request = createBlockFetchRequest(
+            fsDirectory,
+            TEST_FILE_NAME,
+            TEST_BLOCK_FILE_NAME,
+            BLOCK_START_POSITION,
+            data.length
+        );
+
+        // Create a temp file first
+        Path tempFile = fsDirectory.getDirectory().resolve(TEST_BLOCK_FILE_NAME + ".part");
+        Files.write(tempFile, "old data".getBytes(StandardCharsets.UTF_8));
+        assertTrue(Files.exists(tempFile));
+
+        TransferManager.StreamReader reader = (name, pos, len) -> new ByteArrayInputStream(data);
+        BlockTransferManager manager = new BlockTransferManager(reader, indexSettings, () -> testThreadPool);
+
+        manager.fetchBlocksAsync(List.of(request));
+
+        // Verify temp file was cleaned up and final file exists
+        assertFalse(Files.exists(tempFile));
+        assertTrue(Arrays.stream(fsDirectory.listAll()).anyMatch(fileName -> TEST_BLOCK_FILE_NAME.equals(fileName)));
+    }
+
+    public void testDownloadBlobWithExistingFinalFile() throws Exception {
+        byte[] data = TEST_DATA_CONTENT.getBytes(StandardCharsets.UTF_8);
+        BlockFetchRequest request = createBlockFetchRequest(
+            fsDirectory,
+            TEST_FILE_NAME,
+            TEST_BLOCK_FILE_NAME,
+            BLOCK_START_POSITION,
+            data.length
+        );
+
+        // Create the final file first
+        Path finalFile = fsDirectory.getDirectory().resolve(TEST_BLOCK_FILE_NAME);
+        Files.write(finalFile, "existing data".getBytes(StandardCharsets.UTF_8));
+        assertTrue(Files.exists(finalFile));
+
+        TransferManager.StreamReader reader = mock(TransferManager.StreamReader.class);
+        BlockTransferManager manager = new BlockTransferManager(reader, indexSettings, () -> testThreadPool);
+
+        manager.fetchBlocksAsync(List.of(request));
+
+        // Verify reader was never called since file already exists
+        verify(reader, never()).read(any(), anyLong(), anyLong());
+    }
+
+    public void testDownloadBlobWithIOExceptionDuringCopy() throws Exception {
+        byte[] data = TEST_DATA_CONTENT.getBytes(StandardCharsets.UTF_8);
+        BlockFetchRequest request = createBlockFetchRequest(
+            fsDirectory,
+            TEST_FILE_NAME,
+            TEST_BLOCK_FILE_NAME,
+            BLOCK_START_POSITION,
+            data.length
+        );
+
+        TransferManager.StreamReader reader = (name, pos, len) -> { throw new IOException("Stream read failed"); };
+
+        BlockTransferManager manager = new BlockTransferManager(reader, indexSettings, () -> testThreadPool);
+        assertThrows(IOException.class, () -> manager.fetchBlocksAsync(List.of(request)));
+    }
+
+    public void testMultipleBlockFetchRequests() throws Exception {
+        byte[] data1 = "block1".getBytes(StandardCharsets.UTF_8);
+        byte[] data2 = "block2".getBytes(StandardCharsets.UTF_8);
+
+        BlockFetchRequest request1 = createBlockFetchRequest(fsDirectory, "file1", "file1_block_0", 0L, data1.length);
+        BlockFetchRequest request2 = createBlockFetchRequest(fsDirectory, "file2", "file2_block_0", 0L, data2.length);
+
+        TransferManager.StreamReader reader = (name, pos, len) -> {
+            if ("file1".equals(name)) {
+                return new ByteArrayInputStream(data1);
+            } else if ("file2".equals(name)) {
+                return new ByteArrayInputStream(data2);
+            }
+            throw new IllegalArgumentException("Unknown file: " + name);
+        };
+
+        BlockTransferManager manager = new BlockTransferManager(reader, indexSettings, () -> testThreadPool);
+        manager.fetchBlocksAsync(List.of(request1, request2));
+
+        // Verify both files were created
+        String[] files = fsDirectory.listAll();
+        assertTrue(Arrays.asList(files).contains("file1_block_0"));
+        assertTrue(Arrays.asList(files).contains("file2_block_0"));
+    }
+
+    public void testExecutionExceptionHandling() throws Exception {
+        byte[] data = TEST_DATA_CONTENT.getBytes(StandardCharsets.UTF_8);
+        BlockFetchRequest request = createBlockFetchRequest(
+            fsDirectory,
+            TEST_FILE_NAME,
+            TEST_BLOCK_FILE_NAME,
+            BLOCK_START_POSITION,
+            data.length
+        );
+
+        TransferManager.StreamReader reader = (name, pos, len) -> { throw new IOException("Wrapped IOException"); };
+
+        BlockTransferManager manager = new BlockTransferManager(reader, indexSettings, () -> testThreadPool);
+
+        IOException thrown = assertThrows(IOException.class, () -> { manager.fetchBlocksAsync(List.of(request)); });
+
+        assertEquals("Wrapped IOException", thrown.getCause().getCause().getMessage());
+    }
+
+    /**
+     * Creates a BlockFetchRequest with the specified parameters.
+     *
+     * @param directory the FSDirectory to use
+     * @param fileName the name of the file
+     * @param blockFileName the name of the block file
+     * @param blockStart the starting position of the block
+     * @param blockSize the size of the block
+     * @return a configured BlockFetchRequest
+     */
+    private BlockFetchRequest createBlockFetchRequest(
+        FSDirectory directory,
+        String fileName,
+        String blockFileName,
+        long blockStart,
+        long blockSize
+    ) {
+
+        return BlockFetchRequest.builder()
+            .directory(directory)
+            .fileName(fileName)
+            .blockFileName(blockFileName)
+            .blockStart(blockStart)
+            .blockSize(blockSize)
+            .build();
+    }
+
+    /**
+     * Test ThreadPool implementation with 4 threads for testing BlockTransferManager.
+     */
+    private static class TestThreadPool extends ThreadPool {
+        private final ExecutorService executorService;
+
+        public TestThreadPool() {
+            super(Settings.builder().put("node.name", "test-node").build());
+            this.executorService = Executors.newFixedThreadPool(4);
+        }
+
+        @Override
+        public ExecutorService executor(String name) {
+            return executorService;
+        }
+
+        @Override
+        public void shutdown() {
+            executorService.shutdown();
+            super.shutdown();
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/directory/SwitchableIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/storage/directory/SwitchableIndexInputTests.java
@@ -1,0 +1,489 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.directory;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.opensearch.common.lucene.store.InputStreamIndexInput;
+import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
+import org.opensearch.index.store.remote.filecache.CachedIndexInput;
+import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.index.store.remote.filecache.FileCacheFactory;
+import org.opensearch.index.store.remote.filecache.FullFileCachedIndexInput;
+import org.opensearch.index.store.remote.utils.TransferManager;
+import org.opensearch.storage.indexinput.OnDemandPrefetchBlockSnapshotIndexInput;
+import org.opensearch.storage.indexinput.SwitchableIndexInput;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.function.Consumer;
+
+import static org.opensearch.index.store.remote.utils.FileTypeUtils.BLOCK_FILE_IDENTIFIER;
+import static org.opensearch.storage.utils.DirectoryUtils.getFilePath;
+import static org.opensearch.storage.utils.DirectoryUtils.getFilePathSwitchable;
+
+/**
+ * Tests for {@link SwitchableIndexInput}.
+ */
+@ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
+public class SwitchableIndexInputTests extends TieredStorageBaseTestCase {
+
+    FSDirectory localDirectory;
+    FileCache fileCache;
+    TransferManager transferManager;
+    private static final String FILE_NAME = "_0.si";
+    private static final String FILE_NAME_BLOCK = "_0.si_block_0";
+
+    @Before
+    public void setup() throws IOException {
+        setupRemoteSegmentStoreDirectory();
+        populateMetadata();
+        remoteSegmentStoreDirectory.init();
+        populateData();
+        localDirectory = FSDirectory.open(createTempDir());
+        syncLocalAndRemoteForFile(localDirectory, FILE_NAME);
+        int concurrencyLevel = randomIntBetween(1, 2);
+        fileCache = FileCacheFactory.createConcurrentLRUFileCache(FILE_CACHE_CAPACITY, concurrencyLevel);
+        transferManager = new TransferManager(
+            (name, position, length) -> new InputStreamIndexInput(
+                this.remoteSegmentStoreDirectory.openBlockInput(name, position, length, IOContext.DEFAULT),
+                length
+            ),
+            fileCache,
+            threadPool
+        );
+    }
+
+    public void testSwitchableIndexInputLocal() throws IOException {
+        assertNull(getFileCacheEntry(FILE_NAME));
+
+        SwitchableIndexInput switchableIndexInput = new SwitchableIndexInput(
+            "switchable",
+            FILE_NAME,
+            getFilePath(localDirectory, FILE_NAME),
+            getFilePathSwitchable(localDirectory, FILE_NAME),
+            fileCache,
+            localDirectory,
+            remoteSegmentStoreDirectory,
+            transferManager,
+            false,
+            threadPool
+        );
+
+        CachedIndexInput cachedIndexInput = getFileCacheEntry(FILE_NAME);
+        assertNotNull(cachedIndexInput);
+
+        IndexInput indexInput = cachedIndexInput.getIndexInput();
+        assertTrue(indexInput instanceof FullFileCachedIndexInput);
+        assertFalse(switchableIndexInput.isCachedFromRemote());
+
+        IndexInput localIndexInput = localDirectory.openInput(FILE_NAME, IOContext.DEFAULT);
+        assertEquals(switchableIndexInput.length(), localIndexInput.length());
+        assertEquals(switchableIndexInput.getFilePointer(), localIndexInput.getFilePointer());
+        assertEquals(switchableIndexInput.readByte(), localIndexInput.readByte());
+
+        testCloneSliceRefCounting(switchableIndexInput, FILE_NAME);
+    }
+
+    public void testSwitchableIndexInputRemote() throws IOException {
+        populateData();
+
+        assertNull(getFileCacheEntry(FILE_NAME_BLOCK));
+
+        SwitchableIndexInput switchableIndexInput = new SwitchableIndexInput(
+            "switchable",
+            FILE_NAME,
+            getFilePath(localDirectory, FILE_NAME),
+            getFilePathSwitchable(localDirectory, FILE_NAME),
+            fileCache,
+            localDirectory,
+            remoteSegmentStoreDirectory,
+            transferManager,
+            true,
+            threadPool
+        );
+
+        CachedIndexInput cachedIndexInput = getFileCacheEntry(FILE_NAME_BLOCK);
+        assertNull(cachedIndexInput);
+
+        SwitchableIndexInput switchableIndexInput1 = switchableIndexInput.clone();
+        byte b0 = switchableIndexInput1.readByte();
+
+        cachedIndexInput = getFileCacheEntry(FILE_NAME_BLOCK);
+        assertNotNull(cachedIndexInput);
+
+        assertTrue(switchableIndexInput.isCachedFromRemote());
+
+        IndexInput remoteIndexInput = remoteSegmentStoreDirectory.openInput(FILE_NAME, IOContext.DEFAULT);
+        byte b1 = remoteIndexInput.readByte();
+        assertEquals(switchableIndexInput1.length(), remoteIndexInput.length());
+        assertEquals(switchableIndexInput1.getFilePointer(), remoteIndexInput.getFilePointer());
+        assertEquals(b0, b1);
+
+        switchableIndexInput1.close();
+
+        testCloneSliceRefCounting(switchableIndexInput, FILE_NAME_BLOCK);
+    }
+
+    public void testSwitchToRemote() throws IOException {
+        SwitchableIndexInput switchableIndexInput = new SwitchableIndexInput(
+            "switchable",
+            FILE_NAME,
+            getFilePath(localDirectory, FILE_NAME),
+            getFilePathSwitchable(localDirectory, FILE_NAME),
+            fileCache,
+            localDirectory,
+            remoteSegmentStoreDirectory,
+            transferManager,
+            false,
+            threadPool
+        );
+
+        SwitchableIndexInput clonedIndexInput = switchableIndexInput.clone();
+        SwitchableIndexInput slicedIndexInput = switchableIndexInput.slice("slice", 0, switchableIndexInput.length());
+
+        assertFalse(switchableIndexInput.hasSwitchedToRemote());
+        assertFalse(clonedIndexInput.hasSwitchedToRemote());
+        assertFalse(slicedIndexInput.hasSwitchedToRemote());
+        assertNotNull(getFileCacheEntry(FILE_NAME));
+        assertNull(getFileCacheEntry(FILE_NAME_BLOCK));
+
+        long filePointerBeforeSwitching = switchableIndexInput.getFilePointer();
+        switchableIndexInput.switchToRemote();
+        long filePointerAfterSwitching = switchableIndexInput.getFilePointer();
+
+        switchableIndexInput.readByte();
+        assertTrue(switchableIndexInput.hasSwitchedToRemote());
+        assertTrue(clonedIndexInput.hasSwitchedToRemote());
+        assertTrue(slicedIndexInput.hasSwitchedToRemote());
+        assertNull(getFileCacheEntry(FILE_NAME));
+        assertNotNull(getFileCacheEntry(FILE_NAME_BLOCK));
+
+        assertEquals(filePointerAfterSwitching, filePointerBeforeSwitching);
+    }
+
+    public void testPrefetch() throws IOException {
+        SwitchableIndexInput switchableIndexInput = new SwitchableIndexInput(
+            "switchable",
+            FILE_NAME,
+            getFilePath(localDirectory, FILE_NAME),
+            getFilePathSwitchable(localDirectory, FILE_NAME),
+            fileCache,
+            localDirectory,
+            remoteSegmentStoreDirectory,
+            transferManager,
+            false,
+            threadPool
+        );
+
+        switchableIndexInput.prefetch(0, 10);
+        IndexInput indexInput = switchableIndexInput.getUnderlyingIndexInput();
+        assertTrue(indexInput instanceof FullFileCachedIndexInput);
+        switchableIndexInput.switchToRemote();
+        assertTrue(switchableIndexInput.hasSwitchedToRemote());
+        switchableIndexInput.prefetch(0, 10);
+        indexInput = switchableIndexInput.getUnderlyingIndexInput();
+        assertTrue(indexInput instanceof OnDemandPrefetchBlockSnapshotIndexInput);
+    }
+
+    public void testConcurrencySingleIndexInput() throws IOException, InterruptedException {
+        MockSwitchableIndexInput switchableIndexInput = getMockSwitchableIndexInput();
+        List<SwitchableIndexInput> indexInputs = new ArrayList<>();
+        indexInputs.add(switchableIndexInput);
+        final ExecutorService testRunner = Executors.newFixedThreadPool(8);
+        try {
+            InjectableLock objectLock = switchableIndexInput.getObjectLock();
+            List<Consumer<SwitchableIndexInput>> operations = getOperationsToExecute();
+            runOperationsConcurrently(testRunner, operations, indexInputs, 10, true);
+            objectLock.setDelayEnabled(true);
+            runOperationsConcurrently(testRunner, operations, indexInputs, 10, false);
+            objectLock.setDelayEnabled(false);
+        } finally {
+            assertTrue(terminate(testRunner));
+        }
+    }
+
+    public void testConcurrencyMultipleIndexInput() throws IOException, InterruptedException {
+        MockSwitchableIndexInput switchableIndexInput = getMockSwitchableIndexInput();
+        SwitchableIndexInput clone1 = switchableIndexInput.clone();
+        SwitchableIndexInput clone2 = clone1.clone();
+        List<SwitchableIndexInput> indexInputs = new ArrayList<>();
+        indexInputs.add(clone1);
+        indexInputs.add(clone2);
+        final ExecutorService testRunner = Executors.newFixedThreadPool(8);
+        try {
+            InjectableReadWriteLock sharedLock = switchableIndexInput.getSharedLock();
+            List<Consumer<SwitchableIndexInput>> operations = getOperationsToExecute();
+            runOperationsConcurrently(testRunner, operations, indexInputs, 10, true);
+            sharedLock.setWriteDelayEnabled(true);
+            runOperationsConcurrently(testRunner, operations, indexInputs, 10, false);
+            sharedLock.setWriteDelayEnabled(false);
+        } finally {
+            assertTrue(terminate(testRunner));
+        }
+    }
+
+    private void testCloneSliceRefCounting(SwitchableIndexInput switchableIndexInput, String fileName) throws IOException {
+        IndexInput clonedIndexInput = switchableIndexInput.clone();
+        IndexInput slicedIndexInput = switchableIndexInput.slice("slice", 0, switchableIndexInput.length());
+        fileCache.prune();
+        long parentPointer = switchableIndexInput.getFilePointer();
+
+        assertEquals(switchableIndexInput.getFilePointer(), clonedIndexInput.getFilePointer());
+        assertEquals(slicedIndexInput.getFilePointer(), 0);
+
+        clonedIndexInput.seek(clonedIndexInput.getFilePointer() + 1);
+        slicedIndexInput.seek(slicedIndexInput.getFilePointer() + 2);
+
+        assertNotEquals(switchableIndexInput.getFilePointer(), clonedIndexInput.getFilePointer());
+        assertNotEquals(switchableIndexInput.getFilePointer(), slicedIndexInput.getFilePointer());
+        assertEquals(switchableIndexInput.getFilePointer(), parentPointer);
+
+        CachedIndexInput cachedIndexInput = getFileCacheEntry(fileName);
+        assertNotNull(cachedIndexInput);
+
+        clonedIndexInput.close();
+        slicedIndexInput.close();
+
+        cachedIndexInput = getFileCacheEntry(fileName);
+        assertNotNull(cachedIndexInput);
+
+        if (fileName.contains(BLOCK_FILE_IDENTIFIER) == false) {
+            uploadToRemote(fileName);
+        }
+
+        fileCache.prune();
+
+        cachedIndexInput = getFileCacheEntry(fileName);
+        assertNull(cachedIndexInput);
+    }
+
+    private CachedIndexInput getFileCacheEntry(String name) {
+        Path path = getFilePath(localDirectory, name);
+        CachedIndexInput cachedIndexInput = fileCache.get(path);
+        fileCache.decRef(path);
+        return cachedIndexInput;
+    }
+
+    private void uploadToRemote(String file) {
+        fileCache.decRef(getFilePath(localDirectory, file));
+        fileCache.decRef(getFilePathSwitchable(localDirectory, file));
+    }
+
+    private MockSwitchableIndexInput getMockSwitchableIndexInput() throws IOException {
+        return new MockSwitchableIndexInput(
+            "switchable",
+            FILE_NAME,
+            fileCache,
+            localDirectory,
+            remoteSegmentStoreDirectory,
+            transferManager,
+            false,
+            threadPool
+        );
+    }
+
+    private Runnable createOperationRunner(
+        CountDownLatch startTogether,
+        Consumer<SwitchableIndexInput> operation,
+        SwitchableIndexInput switchableIndexInput,
+        CountDownLatch latch
+    ) {
+        return () -> {
+            try {
+                startTogether.await();
+                operation.accept(switchableIndexInput);
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            } finally {
+                latch.countDown();
+            }
+        };
+    }
+
+    private List<Consumer<SwitchableIndexInput>> getOperationsToExecute() {
+        List<Consumer<SwitchableIndexInput>> operations = new ArrayList<>();
+        operations.add(SwitchableIndexInput::getFilePointer);
+        operations.add(SwitchableIndexInput::clone);
+        operations.add(SwitchableIndexInput::length);
+        operations.add(indexInput -> {
+            try {
+                indexInput.switchToRemote();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        operations.add(indexInput -> {
+            try {
+                indexInput.readByte();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        return operations;
+    }
+
+    private void runOperationsConcurrently(
+        ExecutorService testRunner,
+        List<Consumer<SwitchableIndexInput>> operations,
+        List<SwitchableIndexInput> indexInputs,
+        int numTimesToExecute,
+        boolean shouldComplete
+    ) throws InterruptedException {
+        for (int i = 0; i <= numTimesToExecute; i++) {
+            CountDownLatch latch = new CountDownLatch(indexInputs.size() * operations.size());
+            CountDownLatch startTogether = new CountDownLatch(1);
+            for (Consumer<SwitchableIndexInput> operation : operations) {
+                for (SwitchableIndexInput indexInput : indexInputs) {
+                    testRunner.submit(createOperationRunner(startTogether, operation, indexInput, latch));
+                }
+            }
+            startTogether.countDown();
+            assertEquals(shouldComplete, latch.await(5, TimeUnit.SECONDS));
+        }
+    }
+
+    private static class MockSwitchableIndexInput extends SwitchableIndexInput {
+
+        public MockSwitchableIndexInput(
+            String resourceDescription,
+            String fileName,
+            FileCache fileCache,
+            FSDirectory localDirectory,
+            org.opensearch.index.store.RemoteSegmentStoreDirectory remoteDirectory,
+            TransferManager transferManager,
+            boolean cacheFromRemote,
+            ThreadPool threadPool
+        ) throws IOException {
+            super(
+                resourceDescription,
+                fileName,
+                getFilePath(localDirectory, FILE_NAME),
+                getFilePathSwitchable(localDirectory, FILE_NAME),
+                fileCache,
+                localDirectory,
+                remoteDirectory,
+                transferManager,
+                cacheFromRemote,
+                threadPool
+            );
+            sharedLock = new InjectableReadWriteLock(sharedLock);
+            objectLock = new InjectableLock(objectLock);
+        }
+
+        InjectableReadWriteLock getSharedLock() {
+            return (InjectableReadWriteLock) sharedLock;
+        }
+
+        InjectableLock getObjectLock() {
+            return (InjectableLock) objectLock;
+        }
+    }
+
+    private static class InjectableLock implements Lock {
+        private final Lock delegate;
+        private final Object delayMonitor = new Object();
+        private volatile boolean delayEnabled = false;
+
+        public InjectableLock(Lock delegate) {
+            this.delegate = delegate;
+        }
+
+        public void setDelayEnabled(boolean enabled) {
+            synchronized (delayMonitor) {
+                delayEnabled = enabled;
+                if (!enabled) {
+                    delayMonitor.notifyAll();
+                }
+            }
+        }
+
+        private void maybeDelay() {
+            synchronized (delayMonitor) {
+                while (delayEnabled) {
+                    try {
+                        delayMonitor.wait();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("Interrupted during delay", e);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void lock() {
+            delegate.lock();
+            maybeDelay();
+        }
+
+        @Override
+        public void lockInterruptibly() throws InterruptedException {
+            delegate.lockInterruptibly();
+        }
+
+        @Override
+        public boolean tryLock() {
+            return delegate.tryLock();
+        }
+
+        @Override
+        public boolean tryLock(long time, java.util.concurrent.TimeUnit unit) throws InterruptedException {
+            return delegate.tryLock(time, unit);
+        }
+
+        @Override
+        public void unlock() {
+            delegate.unlock();
+        }
+
+        @Override
+        public Condition newCondition() {
+            return delegate.newCondition();
+        }
+    }
+
+    private static class InjectableReadWriteLock implements ReadWriteLock {
+        private final InjectableLock readLockWrapper;
+        private final InjectableLock writeLockWrapper;
+
+        public InjectableReadWriteLock(ReadWriteLock delegate) {
+            this.readLockWrapper = new InjectableLock(delegate.readLock());
+            this.writeLockWrapper = new InjectableLock(delegate.writeLock());
+        }
+
+        public void setWriteDelayEnabled(boolean enabled) {
+            writeLockWrapper.setDelayEnabled(enabled);
+        }
+
+        @Override
+        public Lock readLock() {
+            return readLockWrapper;
+        }
+
+        @Override
+        public Lock writeLock() {
+            return writeLockWrapper;
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/directory/TieredDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/storage/directory/TieredDirectoryTests.java
@@ -1,0 +1,277 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.directory;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
+import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.index.store.remote.filecache.FileCacheFactory;
+import org.opensearch.index.store.remote.utils.FileTypeUtils;
+import org.opensearch.storage.indexinput.SwitchableIndexInput;
+import org.opensearch.storage.indexinput.SwitchableIndexInputWrapper;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.storage.utils.DirectoryUtils.getFilePath;
+import static org.opensearch.storage.utils.DirectoryUtils.getFilePathSwitchable;
+
+/**
+ * Tests for {@link TieredDirectory}.
+ */
+@ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
+public class TieredDirectoryTests extends TieredStorageBaseTestCase {
+
+    private FileCache fileCache;
+    private FSDirectory localDirectory;
+    private TieredDirectory tieredDirectory;
+
+    private static final String[] LOCAL_FILES = new String[] {
+        "_1.cfe",
+        "_1.cfe_block_0",
+        "_1.cfe_block_1",
+        "_2.cfe",
+        "_0.cfe_block_7",
+        "_0.cfs_block_7",
+        "_x.abc_block_0",
+        "temp_file.tmp" };
+    private static final String FILE_PRESENT_LOCALLY = "_1.cfe";
+    private static final String FILE_RENAMED = "_1_new.cfe";
+    private static final String FILE_PRESENT_IN_REMOTE_ONLY = "_0.si";
+    private static final String NON_EXISTENT_FILE = "non_existent_file";
+    private static final String TEMP_FILE = "temp_file.tmp";
+
+    @Before
+    public void setup() throws IOException {
+        setupRemoteSegmentStoreDirectory();
+        populateMetadata();
+        remoteSegmentStoreDirectory.init();
+        localDirectory = FSDirectory.open(createTempDir());
+        removeExtraFSFiles();
+        int concurrencyLevel = randomIntBetween(1, 2);
+        fileCache = FileCacheFactory.createConcurrentLRUFileCache(FILE_CACHE_CAPACITY, concurrencyLevel);
+        tieredDirectory = new TieredDirectory(localDirectory, remoteSegmentStoreDirectory, fileCache, threadPool);
+        addFilesToDirectory(LOCAL_FILES);
+    }
+
+    public void testListAll() throws IOException {
+        String[] actualFileNames = tieredDirectory.listAll();
+        String[] expectedFileNames = new String[] {
+            "_0.cfe",
+            "_0.cfs",
+            "_0.si",
+            "_1.cfe",
+            "_2.cfe",
+            "_x.abc",
+            "segments_1",
+            "temp_file.tmp" };
+        assertArrayEquals(expectedFileNames, actualFileNames);
+    }
+
+    public void testDeleteFile() throws IOException {
+        assertTrue(existsInTieredDirectory(TEMP_FILE));
+        tieredDirectory.deleteFile(TEMP_FILE);
+        assertFalse(existsInTieredDirectory(TEMP_FILE));
+
+        assertFalse(existsInTieredDirectory(NON_EXISTENT_FILE));
+        Exception exception = null;
+        try {
+            tieredDirectory.deleteFile(NON_EXISTENT_FILE);
+        } catch (Exception e) {
+            exception = e;
+        }
+        assertNull(exception);
+
+        assertTrue(existsInTieredDirectory(FILE_PRESENT_LOCALLY));
+        assertTrue(existsInLocalDirectory(FILE_PRESENT_LOCALLY));
+        assertTrue(existsInFileCache(getFilePathSwitchable(localDirectory, FILE_PRESENT_LOCALLY)));
+        assertTrue(existsInFileCache(getFilePath(localDirectory, FILE_PRESENT_LOCALLY)));
+        tieredDirectory.deleteFile(FILE_PRESENT_LOCALLY);
+        assertFalse(existsInTieredDirectory(FILE_PRESENT_LOCALLY));
+        assertFalse(existsInLocalDirectory(FILE_PRESENT_LOCALLY));
+        assertFalse(existsInFileCache(getFilePathSwitchable(localDirectory, FILE_PRESENT_LOCALLY)));
+        assertFalse(existsInFileCache(getFilePath(localDirectory, FILE_PRESENT_LOCALLY)));
+
+        assertTrue(existsInTieredDirectory(FILE_PRESENT_IN_REMOTE_ONLY));
+        assertTrue(existsInRemoteDirectory(FILE_PRESENT_IN_REMOTE_ONLY));
+        tieredDirectory.deleteFile(FILE_PRESENT_IN_REMOTE_ONLY);
+        assertTrue(existsInTieredDirectory(FILE_PRESENT_IN_REMOTE_ONLY));
+        assertTrue(existsInRemoteDirectory(FILE_PRESENT_IN_REMOTE_ONLY));
+    }
+
+    public void testRename() throws IOException {
+        assertThrows(NoSuchFileException.class, () -> tieredDirectory.rename(NON_EXISTENT_FILE, FILE_RENAMED));
+
+        assertTrue(existsInTieredDirectory(FILE_PRESENT_LOCALLY));
+        assertTrue(existsInFileCache(getFilePathSwitchable(localDirectory, FILE_PRESENT_LOCALLY)));
+        assertFalse(existsInFileCache(getFilePathSwitchable(localDirectory, FILE_RENAMED)));
+        tieredDirectory.rename(FILE_PRESENT_LOCALLY, FILE_RENAMED);
+        assertFalse(existsInTieredDirectory(FILE_PRESENT_LOCALLY));
+        assertFalse(existsInFileCache(getFilePathSwitchable(localDirectory, FILE_PRESENT_LOCALLY)));
+        assertTrue(existsInFileCache(getFilePathSwitchable(localDirectory, FILE_RENAMED)));
+    }
+
+    public void testOpenInput() throws IOException {
+        populateData();
+
+        assertFalse(existsInTieredDirectory(NON_EXISTENT_FILE));
+        assertThrows(NoSuchFileException.class, () -> tieredDirectory.openInput(NON_EXISTENT_FILE, IOContext.DEFAULT));
+
+        assertTrue(existsInLocalDirectory(TEMP_FILE) && FileTypeUtils.isTempFile(TEMP_FILE));
+
+        assertEquals(
+            tieredDirectory.openInput(TEMP_FILE, IOContext.DEFAULT).toString(),
+            localDirectory.openInput(TEMP_FILE, IOContext.DEFAULT).toString()
+        );
+
+        assertNotNull(fileCache.get(getFilePathSwitchable(localDirectory, FILE_PRESENT_LOCALLY)));
+        IndexInput indexInput = tieredDirectory.openInput(FILE_PRESENT_LOCALLY, IOContext.DEFAULT);
+        assertNotNull(indexInput);
+        assertTrue(indexInput instanceof SwitchableIndexInputWrapper);
+        assertFalse(getSwitchableIndexInputFromWrapper(indexInput).isCachedFromRemote());
+
+        assertNull(fileCache.get(getFilePathSwitchable(localDirectory, FILE_PRESENT_IN_REMOTE_ONLY)));
+        indexInput = tieredDirectory.openInput(FILE_PRESENT_IN_REMOTE_ONLY, IOContext.DEFAULT);
+        assertNotNull(indexInput);
+        assertTrue(indexInput instanceof SwitchableIndexInputWrapper);
+        assertTrue(getSwitchableIndexInputFromWrapper(indexInput).isCachedFromRemote());
+    }
+
+    public void testIndexInputCleanup() throws IOException {
+        populateData();
+        Path path = getFilePathSwitchable(localDirectory, FILE_PRESENT_LOCALLY);
+        assertEquals(1, (int) fileCache.getRef(path));
+        IndexInput indexInput = tieredDirectory.openInput(FILE_PRESENT_LOCALLY, IOContext.DEFAULT);
+        assertEquals(2, (int) fileCache.getRef(path));
+        decRefToZero(path);
+        createUnclosedClones(indexInput, path);
+        triggerGarbageCollectionAndAssertClonesClosed(path);
+    }
+
+    public void testAfterSyncToRemote() throws IOException {
+        populateData();
+        String fileName = "_0.si";
+        String fileNameBlock = "_0.si_block_0";
+        addFilesToDirectory(new String[] { fileName });
+
+        assertTrue(existsInLocalDirectory(fileName));
+        assertEquals(1, (int) fileCache.getRef(getFilePathSwitchable(localDirectory, fileName)));
+        assertEquals(1, (int) fileCache.getRef(getFilePath(localDirectory, fileName)));
+        assertNull(fileCache.getRef(getFilePath(localDirectory, fileNameBlock)));
+
+        IndexInput indexInput = tieredDirectory.openInput(fileName, IOContext.DEFAULT);
+
+        assertTrue(indexInput instanceof SwitchableIndexInputWrapper);
+        assertEquals(2, (int) fileCache.getRef(getFilePathSwitchable(localDirectory, fileName)));
+        assertEquals(2, (int) fileCache.getRef(getFilePath(localDirectory, fileName)));
+        assertFalse(getSwitchableIndexInputFromWrapper(indexInput).isCachedFromRemote());
+
+        indexInput.close();
+
+        assertEquals(1, (int) fileCache.getRef(getFilePathSwitchable(localDirectory, fileName)));
+        assertEquals(1, (int) fileCache.getRef(getFilePath(localDirectory, fileName)));
+
+        tieredDirectory.afterSyncToRemote(fileName);
+
+        assertFalse(existsInLocalDirectory(fileName));
+        assertTrue(existsInRemoteDirectory(fileName));
+        assertEquals(0, (int) fileCache.getRef(getFilePathSwitchable(localDirectory, fileName)));
+        assertNull(fileCache.getRef(getFilePath(localDirectory, fileName)));
+        assertNull(fileCache.getRef(getFilePath(localDirectory, fileNameBlock)));
+
+        indexInput = tieredDirectory.openInput(fileName, IOContext.DEFAULT);
+
+        assertEquals(1, (int) fileCache.getRef(getFilePathSwitchable(localDirectory, fileName)));
+        assertEquals(1, (int) fileCache.getRef(getFilePath(localDirectory, fileNameBlock)));
+
+        indexInput.close();
+
+        assertEquals(0, (int) fileCache.getRef(getFilePathSwitchable(localDirectory, fileName)));
+        assertEquals(0, (int) fileCache.getRef(getFilePath(localDirectory, fileNameBlock)));
+
+        fileCache.prune();
+        assertNull(fileCache.getRef(getFilePathSwitchable(localDirectory, fileName)));
+        assertNull(fileCache.getRef(getFilePath(localDirectory, fileNameBlock)));
+    }
+
+    private void removeExtraFSFiles() throws IOException {
+        HashSet<String> allFiles = new HashSet<>(Arrays.asList(localDirectory.listAll()));
+        allFiles.stream().filter(FileTypeUtils::isExtraFSFile).forEach(file -> {
+            try {
+                localDirectory.deleteFile(file);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private void addFilesToDirectory(String[] files) throws IOException {
+        for (String file : files) {
+            IndexOutput indexOutput = tieredDirectory.createOutput(file, IOContext.DEFAULT);
+            indexOutput.close();
+        }
+    }
+
+    private SwitchableIndexInput getSwitchableIndexInputFromWrapper(IndexInput indexInput) {
+        assertTrue(indexInput instanceof SwitchableIndexInputWrapper);
+        return (SwitchableIndexInput) (((FilterIndexInput) indexInput).getDelegate());
+    }
+
+    private void decRefToZero(Path path) {
+        int refCount = fileCache.getRef(path);
+        for (int i = 0; i < refCount; i++) {
+            fileCache.decRef(path);
+        }
+    }
+
+    private void createUnclosedClones(IndexInput indexInput, Path path) {
+        IndexInput clone = indexInput.clone();
+        IndexInput cloneOfClone = clone.clone();
+        assertEquals(2, (int) fileCache.getRef(path));
+    }
+
+    private void triggerGarbageCollectionAndAssertClonesClosed(Path path) {
+        try {
+            assertBusy(() -> {
+                System.gc();
+                assertEquals("Expected refCount to drop to original count", (int) fileCache.getRef(path), 0);
+            }, 5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            logger.error("Exception thrown while triggering gc", e);
+            fail();
+        }
+    }
+
+    private boolean existsInLocalDirectory(String name) throws IOException {
+        return Arrays.asList(localDirectory.listAll()).contains(name);
+    }
+
+    private boolean existsInRemoteDirectory(String name) throws IOException {
+        return Arrays.asList(remoteSegmentStoreDirectory.listAll()).contains(name);
+    }
+
+    private boolean existsInTieredDirectory(String name) throws IOException {
+        return Arrays.asList(tieredDirectory.listAll()).contains(name);
+    }
+
+    private boolean existsInFileCache(Path path) {
+        return (fileCache.get(path) != null);
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/directory/TieredStorageBaseTestCase.java
+++ b/server/src/test/java/org/opensearch/storage/directory/TieredStorageBaseTestCase.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.directory;
+
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.index.store.BaseRemoteSegmentStoreDirectoryTests;
+import org.opensearch.index.store.RemoteDirectory;
+
+import java.io.IOException;
+
+import static java.lang.Math.min;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Extension of the existing BaseRemoteSegmentStoreDirectoryTests with additional
+ * helper methods for writable warm tiered storage tests.
+ */
+public abstract class TieredStorageBaseTestCase extends BaseRemoteSegmentStoreDirectoryTests {
+
+    protected static final int EIGHT_MB = 1024 * 1024 * 8;
+    protected static final int FILE_CACHE_CAPACITY = 10000000;
+
+    protected void populateData() throws IOException {
+        long fileLength = remoteSegmentStoreDirectory.fileLength("_0.si");
+        IndexInput fullIndexInput = new ByteArrayIndexInput("full", new byte[(int) fileLength]);
+        IndexInput blockIndexInput = fullIndexInput.slice("slice", 0, min(fileLength, EIGHT_MB));
+        when(((RemoteDirectory) remoteDataDirectory).openBlockInput(anyString(), anyLong(), anyLong(), anyLong(), any())).thenReturn(
+            blockIndexInput
+        );
+        when(((RemoteDirectory) remoteDataDirectory).openInput(anyString(), anyLong(), any())).thenReturn(fullIndexInput);
+    }
+
+    protected void syncLocalAndRemoteForFile(FSDirectory localDirectory, String fileName) throws IOException {
+        try (
+            IndexInput input = remoteSegmentStoreDirectory.openInput(fileName, IOContext.DEFAULT);
+            IndexOutput output = localDirectory.createOutput(fileName, IOContext.DEFAULT)
+        ) {
+            byte[] buffer = new byte[8192];
+            long len = input.length();
+            long pos = 0;
+            while (pos < len) {
+                int size = (int) Math.min(buffer.length, len - pos);
+                input.readBytes(buffer, 0, size);
+                output.writeBytes(buffer, 0, size);
+                pos += size;
+            }
+        }
+    }
+
+    public static byte[] createData() {
+        final byte[] data = new byte[EIGHT_MB];
+        data[0] = data[EIGHT_MB - 1] = 7;
+        return data;
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/indexinput/BlockIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/storage/indexinput/BlockIndexInputTests.java
@@ -1,0 +1,224 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.indexinput;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+/**
+ * Unit tests for BlockIndexInput.
+ */
+@ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
+public class BlockIndexInputTests extends LuceneTestCase {
+
+    private static final String FILE_NAME = "_1.cfe";
+    private static final String BLOCK_FILE_0 = "_1.cfe_block_0";
+    private static final String BLOCK_FILE_1 = "_1.cfe_block_1";
+    private static final long TEST_FILE_SIZE = 10_485_760L; // 10MB
+    private static final int BLOCK_SIZE_SHIFT = 23; // 8MB blocks
+    private static final long BLOCK_SIZE = 1L << BLOCK_SIZE_SHIFT; // 8MB
+
+    private Path tempDir;
+    private FSDirectory directory;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        tempDir = createTempDir();
+        directory = FSDirectory.open(tempDir);
+        // Create block files with test data
+        createBlockFile(BLOCK_FILE_0, BLOCK_SIZE);
+        createBlockFile(BLOCK_FILE_1, TEST_FILE_SIZE - BLOCK_SIZE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        directory.close();
+        super.tearDown();
+    }
+
+    private void createBlockFile(String name, long size) throws IOException {
+        Path filePath = tempDir.resolve(name);
+        try (OutputStream os = Files.newOutputStream(filePath)) {
+            byte[] buffer = new byte[8192];
+            Arrays.fill(buffer, (byte) 7);
+            long written = 0;
+            while (written < size) {
+                int toWrite = (int) Math.min(buffer.length, size - written);
+                os.write(buffer, 0, toWrite);
+                written += toWrite;
+            }
+        }
+    }
+
+    public void testBuildBlockIndexInput() throws IOException {
+        BlockIndexInput input = BlockIndexInput.builder()
+            .resourceDescription("test")
+            .resourceDescription("test")
+            .name(FILE_NAME)
+            .localDirectory(directory)
+            .fileSize(TEST_FILE_SIZE)
+            .context(IOContext.DEFAULT)
+            .length(TEST_FILE_SIZE)
+            .offset(0)
+            .blockSizeShift(BLOCK_SIZE_SHIFT)
+            .build();
+        assertNotNull(input);
+        assertTrue(input.length() >= 0);
+        input.close();
+    }
+
+    public void testBuilderValidation() {
+        // Missing file name
+        expectThrows(
+            IllegalStateException.class,
+            () -> BlockIndexInput.builder()
+                .resourceDescription("test")
+                .localDirectory(directory)
+                .fileSize(TEST_FILE_SIZE)
+                .context(IOContext.DEFAULT)
+                .length(TEST_FILE_SIZE)
+                .offset(0)
+                .blockSizeShift(BLOCK_SIZE_SHIFT)
+                .build()
+        );
+
+        // Missing directory
+        expectThrows(
+            IllegalStateException.class,
+            () -> BlockIndexInput.builder()
+                .resourceDescription("test")
+                .name(FILE_NAME)
+                .fileSize(TEST_FILE_SIZE)
+                .context(IOContext.DEFAULT)
+                .length(TEST_FILE_SIZE)
+                .offset(0)
+                .blockSizeShift(BLOCK_SIZE_SHIFT)
+                .build()
+        );
+    }
+
+    public void testReadByte() throws IOException {
+        BlockIndexInput input = BlockIndexInput.builder()
+            .resourceDescription("test")
+            .name(FILE_NAME)
+            .localDirectory(directory)
+            .fileSize(TEST_FILE_SIZE)
+            .context(IOContext.DEFAULT)
+            .length(TEST_FILE_SIZE)
+            .offset(0)
+            .blockSizeShift(BLOCK_SIZE_SHIFT)
+            .build();
+        byte b = input.readByte();
+        assertEquals(7, b);
+        input.close();
+    }
+
+    public void testClone() throws IOException {
+        BlockIndexInput input = BlockIndexInput.builder()
+            .resourceDescription("test")
+            .name(FILE_NAME)
+            .localDirectory(directory)
+            .fileSize(TEST_FILE_SIZE)
+            .context(IOContext.DEFAULT)
+            .length(TEST_FILE_SIZE)
+            .offset(0)
+            .blockSizeShift(BLOCK_SIZE_SHIFT)
+            .build();
+        input.readByte(); // advance position
+        BlockIndexInput clone = input.clone();
+        assertNotNull(clone);
+        assertEquals(input.length(), clone.length());
+        clone.close();
+        input.close();
+    }
+
+    public void testSlice() throws IOException {
+        BlockIndexInput input = BlockIndexInput.builder()
+            .resourceDescription("test")
+            .name(FILE_NAME)
+            .localDirectory(directory)
+            .fileSize(TEST_FILE_SIZE)
+            .context(IOContext.DEFAULT)
+            .length(TEST_FILE_SIZE)
+            .offset(0)
+            .blockSizeShift(BLOCK_SIZE_SHIFT)
+            .build();
+        IndexInput slice = input.slice("test-slice", 0, 1024);
+        assertNotNull(slice);
+        assertEquals(1024, slice.length());
+        slice.close();
+        input.close();
+    }
+
+    public void testSliceOutOfBounds() throws IOException {
+        BlockIndexInput input = BlockIndexInput.builder()
+            .resourceDescription("test")
+            .name(FILE_NAME)
+            .localDirectory(directory)
+            .fileSize(TEST_FILE_SIZE)
+            .context(IOContext.DEFAULT)
+            .length(TEST_FILE_SIZE)
+            .offset(0)
+            .blockSizeShift(BLOCK_SIZE_SHIFT)
+            .build();
+        expectThrows(IllegalArgumentException.class, () -> input.slice("bad", 0, TEST_FILE_SIZE + 1));
+        input.close();
+    }
+
+    public void testReadBytes() throws IOException {
+        BlockIndexInput input = BlockIndexInput.builder()
+            .resourceDescription("test")
+            .name(FILE_NAME)
+            .localDirectory(directory)
+            .fileSize(TEST_FILE_SIZE)
+            .context(IOContext.DEFAULT)
+            .length(TEST_FILE_SIZE)
+            .offset(0)
+            .blockSizeShift(BLOCK_SIZE_SHIFT)
+            .build();
+        byte[] buffer = new byte[100];
+        input.readBytes(buffer, 0, 100);
+        for (byte b : buffer) {
+            assertEquals(7, b);
+        }
+        input.close();
+    }
+
+    public void testSeekAndRead() throws IOException {
+        BlockIndexInput input = BlockIndexInput.builder()
+            .resourceDescription("test")
+            .name(FILE_NAME)
+            .localDirectory(directory)
+            .fileSize(TEST_FILE_SIZE)
+            .context(IOContext.DEFAULT)
+            .length(TEST_FILE_SIZE)
+            .offset(0)
+            .blockSizeShift(BLOCK_SIZE_SHIFT)
+            .build();
+        input.seek(100);
+        assertEquals(100, input.getFilePointer());
+        byte b = input.readByte();
+        assertEquals(7, b);
+        input.close();
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/indexinput/OnDemandPrefetchBlockSnapshotIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/storage/indexinput/OnDemandPrefetchBlockSnapshotIndexInputTests.java
@@ -1,0 +1,311 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.indexinput;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.LockFactory;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.SimpleFSLockFactory;
+import org.apache.lucene.util.Constants;
+import org.apache.lucene.util.Version;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
+import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.index.store.remote.file.AbstractBlockIndexInput;
+import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
+import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.index.store.remote.filecache.FileCacheFactory;
+import org.opensearch.index.store.remote.utils.BlobFetchRequest;
+import org.opensearch.index.store.remote.utils.TransferManager;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.Before;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link OnDemandPrefetchBlockSnapshotIndexInput}.
+ */
+@ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
+public class OnDemandPrefetchBlockSnapshotIndexInputTests extends OpenSearchTestCase {
+
+    private static final String RESOURCE_DESCRIPTION = "Test OnDemandPrefetchBlockSnapshotIndexInput";
+    private static final long BLOCK_SNAPSHOT_FILE_OFFSET = 0;
+    private static final String FILE_NAME = "File_Name";
+    private static final String BLOCK_FILE_PREFIX = FILE_NAME;
+    private static final boolean IS_CLONE = false;
+    private static final int FILE_SIZE = 29360128;
+    private static final int FILE_CACHE_CAPACITY = 10000000;
+
+    private TransferManager transferManager;
+    private LockFactory lockFactory;
+    private BlobStoreIndexShardSnapshot.FileInfo fileInfo;
+    private Path path;
+    private ThreadPool threadPool;
+    private FileCache fileCache;
+
+    @Before
+    public void init() {
+        assumeFalse("Awaiting Windows fix", Constants.WINDOWS);
+        transferManager = mock(TransferManager.class);
+        lockFactory = SimpleFSLockFactory.INSTANCE;
+        threadPool = new TestThreadPool("OnDemandPrefetchTests");
+        path = createTempDir("TestOnDemandPrefetchBlockSnapshotIndexInputTests");
+        int concurrencyLevel = randomIntBetween(1, 2);
+        fileCache = FileCacheFactory.createConcurrentLRUFileCache(FILE_CACHE_CAPACITY, concurrencyLevel);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdownNow();
+    }
+
+    public void test8MBBlock() throws Exception {
+        runAllTestsFor(23);
+    }
+
+    public void test4KBBlock() throws Exception {
+        runAllTestsFor(12);
+    }
+
+    public void test1MBBlock() throws Exception {
+        runAllTestsFor(20);
+    }
+
+    public void test4MBBlock() throws Exception {
+        runAllTestsFor(22);
+    }
+
+    public void testPrefetch() throws Exception {
+        final OnDemandPrefetchBlockSnapshotIndexInput blockedSnapshotFile = createIndexInput(23);
+
+        blockedSnapshotFile.prefetch(0, 10);
+        verify(transferManager, times(1)).fetchBlobAsync(any(BlobFetchRequest.class));
+        blockedSnapshotFile.prefetch(0, 8388670);
+        verify(transferManager, times(3)).fetchBlobAsync(any(BlobFetchRequest.class));
+        blockedSnapshotFile.prefetch(0, 16777350);
+        verify(transferManager, times(6)).fetchBlobAsync(any(BlobFetchRequest.class));
+    }
+
+    public void testCloneAndSlice() throws Exception {
+        final OnDemandPrefetchBlockSnapshotIndexInput input = createIndexInput(23);
+        int blockSize = 1 << 23;
+
+        input.seek(blockSize + 1);
+        OnDemandPrefetchBlockSnapshotIndexInput cloned = input.clone();
+        assertEquals(cloned.getFilePointer(), input.getFilePointer());
+        cloned.seek(blockSize + 11);
+        assertNotEquals(cloned.getFilePointer(), input.getFilePointer());
+
+        IndexInput slice = input.slice("slice", blockSize - 11, 22);
+        assertTrue(slice instanceof OnDemandPrefetchBlockSnapshotIndexInput);
+        assertEquals("slice", slice.toString());
+        slice.seek(0);
+        assertEquals(0, slice.getFilePointer());
+    }
+
+    public void testCheckCacheHit() throws Exception {
+        final OnDemandPrefetchBlockSnapshotIndexInput input = createIndexInput(23);
+        // Block files exist on disk from initBlockFiles, but not in fileCache
+        // checkCacheHit checks fileCache, not disk
+        assertFalse(input.checkCacheHit(0));
+    }
+
+    public void testFetchNextNBlocksAtEnd() throws Exception {
+        final OnDemandPrefetchBlockSnapshotIndexInput input = createIndexInput(23);
+        int totalBlocks = input.getTotalBlocks();
+        // fetchNextNBlocks at last block should not throw
+        input.fetchNextNBlocks(totalBlocks - 1);
+    }
+
+    public void testDownloadBlocksAsync() throws Exception {
+        final OnDemandPrefetchBlockSnapshotIndexInput input = createIndexInput(23);
+        input.downloadBlocksAsync(0, 1, false);
+        verify(transferManager, times(2)).fetchBlobAsync(any(BlobFetchRequest.class));
+    }
+
+    public void testChunkedRepositoryWithBlockSizeGreaterThanChunkSize() throws IOException {
+        verifyChunkedRepository(8192, 2048, 15360);
+    }
+
+    public void testChunkedRepositoryWithBlockSizeLessThanChunkSize() throws IOException {
+        verifyChunkedRepository(1024, 2048, 3072);
+    }
+
+    public void testChunkedRepositoryWithBlockSizeEqualToChunkSize() throws IOException {
+        verifyChunkedRepository(2048, 2048, 15360);
+    }
+
+    private void verifyChunkedRepository(long blockSize, long repositoryChunkSize, long fileSize) throws IOException {
+        when(transferManager.fetchBlob(any())).thenReturn(new ByteArrayIndexInput("test", new byte[(int) blockSize]));
+        try (
+            FSDirectory directory = new MMapDirectory(path, lockFactory);
+            IndexInput indexInput = new OnDemandPrefetchBlockSnapshotIndexInput(
+                AbstractBlockIndexInput.builder()
+                    .resourceDescription(RESOURCE_DESCRIPTION)
+                    .offset(BLOCK_SNAPSHOT_FILE_OFFSET)
+                    .length(FILE_SIZE)
+                    .blockSizeShift((int) (Math.log(blockSize) / Math.log(2)))
+                    .isClone(IS_CLONE),
+                RESOURCE_DESCRIPTION,
+                new BlobStoreIndexShardSnapshot.FileInfo(
+                    FILE_NAME,
+                    new StoreFileMetadata(FILE_NAME, fileSize, "", Version.LATEST),
+                    new org.opensearch.core.common.unit.ByteSizeValue(repositoryChunkSize)
+                ),
+                directory,
+                transferManager,
+                threadPool,
+                fileCache
+            )
+        ) {
+            indexInput.seek(repositoryChunkSize);
+        }
+        verify(transferManager).fetchBlob(argThat(request -> request.getBlobLength() == blockSize));
+    }
+
+    private void runAllTestsFor(int blockSizeShift) throws Exception {
+        final OnDemandPrefetchBlockSnapshotIndexInput input = createIndexInput(blockSizeShift);
+        final int blockSize = 1 << blockSizeShift;
+
+        // testReadByte
+        input.seek(0);
+        assertEquals((byte) 48, input.readByte());
+        input.seek(1);
+        assertEquals((byte) -80, input.readByte());
+        input.seek(blockSize);
+        assertEquals((byte) 48, input.readByte());
+
+        // testReadShort
+        input.seek(0);
+        assertEquals(-20432, input.readShort());
+        input.seek(blockSize - 1);
+        assertEquals(12464, input.readShort());
+
+        // testReadInt
+        input.seek(0);
+        assertEquals(-1338986448, input.readInt());
+        input.seek(blockSize - 1);
+        assertEquals(816853168, input.readInt());
+
+        // testReadLong
+        input.seek(0);
+        assertEquals(-5750903000991223760L, input.readLong());
+
+        // testSeek
+        input.seek(0);
+        assertEquals(0, input.getFilePointer());
+        input.seek(blockSize + 11);
+        assertEquals(blockSize + 11, input.getFilePointer());
+        try {
+            input.seek(FILE_SIZE + 1);
+            fail("Should throw EOFException");
+        } catch (EOFException e) {
+            // expected
+        }
+
+        // testReadBytes
+        input.seek(0);
+        byte[] buf = new byte[4];
+        input.readBytes(buf, 0, 4);
+        assertEquals((byte) 48, buf[0]);
+        assertEquals((byte) -80, buf[1]);
+        assertEquals((byte) 48, buf[2]);
+        assertEquals((byte) -80, buf[3]);
+    }
+
+    private OnDemandPrefetchBlockSnapshotIndexInput createIndexInput(int blockSizeShift) throws IOException {
+        fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(
+            FILE_NAME,
+            new StoreFileMetadata(FILE_NAME, FILE_SIZE, "", Version.LATEST),
+            null
+        );
+
+        int blockSize = 1 << blockSizeShift;
+
+        doAnswer(invocation -> {
+            BlobFetchRequest blobFetchRequest = invocation.getArgument(0);
+            return blobFetchRequest.getDirectory().openInput(blobFetchRequest.getFileName(), IOContext.READONCE);
+        }).when(transferManager).fetchBlob(any());
+
+        FSDirectory directory;
+        try {
+            directory = new MMapDirectory(path, lockFactory);
+        } catch (IOException e) {
+            fail("fail to create MMapDirectory: " + e.getMessage());
+            return null;
+        }
+
+        initBlockFiles(blockSize, directory);
+
+        return new OnDemandPrefetchBlockSnapshotIndexInput(
+            AbstractBlockIndexInput.builder()
+                .resourceDescription(RESOURCE_DESCRIPTION)
+                .offset(BLOCK_SNAPSHOT_FILE_OFFSET)
+                .length(FILE_SIZE)
+                .blockSizeShift(blockSizeShift)
+                .isClone(IS_CLONE),
+            RESOURCE_DESCRIPTION,
+            fileInfo,
+            directory,
+            transferManager,
+            threadPool,
+            fileCache
+        );
+    }
+
+    private void initBlockFiles(int blockSize, FSDirectory fsDirectory) {
+        int numOfBlocks = FILE_SIZE / blockSize;
+        int sizeOfLastBlock = FILE_SIZE % blockSize;
+
+        try {
+            for (int i = 0; i < numOfBlocks; i++) {
+                String blockName = BLOCK_FILE_PREFIX + "_block_" + i;
+                IndexOutput output = fsDirectory.createOutput(blockName, null);
+                for (int j = 0; j < blockSize / 2; j++) {
+                    output.writeByte((byte) 48);
+                    output.writeByte((byte) -80);
+                }
+                output.close();
+            }
+
+            if (numOfBlocks > 1 && sizeOfLastBlock != 0) {
+                String lastBlockName = BLOCK_FILE_PREFIX + "_block_" + numOfBlocks;
+                IndexOutput output = fsDirectory.createOutput(lastBlockName, null);
+                for (int i = 0; i < sizeOfLastBlock; i++) {
+                    if ((i & 1) == 0) {
+                        output.writeByte((byte) 48);
+                    } else {
+                        output.writeByte((byte) -80);
+                    }
+                }
+                output.close();
+            }
+        } catch (IOException e) {
+            fail("fail to initialize block files: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Description
Directory Layer:

TieredDirectory — Composite directory that transparently reads/writes across local and remote storage. Handles file listing (merging local + remote), file caching via FileCache, opening inputs through SwitchableIndexInput, and local-to-remote switching after sync.
TieredDirectoryFactory — Factory that creates TieredDirectory instances for each shard.
DirectoryUtils — Utility for resolving file paths and switchable file paths from FSDirectory.
IndexInput Layer:

SwitchableIndexInput — IndexInput that starts reading from local full file and can switch to remote block-based reading. Manages clones/slices with shared read-write lock to prevent race conditions during switching.
CachedSwitchableIndexInput — Wraps SwitchableIndexInput for use with FileCache.
SwitchableIndexInputWrapper — Thin wrapper with Cleaner for GC-based cleanup of unclosed index inputs.
OnDemandPrefetchBlockSnapshotIndexInput — Block-level fetching from remote with read-ahead support (default 4 blocks).
BlockIndexInput — Block-based index input backed by downloaded block files.
BlockFetchRequest — Data class representing a block fetch request.
BlockTransferManager — Manages parallel block downloads from remote storage with deduplication.
Note: TieredStoragePrefetchSettings and per-query metric recording (TieredStorageQueryMetricService) are not yet integrated as those classes are not available upstream. Read-ahead uses a hardcoded default of 4 blocks. These will be plugged in via follow-up PRs.

Related Issues
Part of the tiered storage implementation — resolves https://github.com/opensearch-project/OpenSearch/issues/21078

Check List
 Functionality includes testing.
 API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
 Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).