### PR TITLE
Support Azure Workload Identity authentication for blob repository

### DIFF
--- a/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/AzureStorageSettings.java
+++ b/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/AzureStorageSettings.java
@@ -11,8 +11,8 @@
  * license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright
  * ownership. Elasticsearch licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
+ * the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
@@ -35,6 +35,7 @@ package org.opensearch.repositories.azure;
 import com.azure.core.util.logging.ClientLogger;
 import com.azure.identity.ManagedIdentityCredential;
 import com.azure.identity.ManagedIdentityCredentialBuilder;
+import com.azure.identity.WorkloadIdentityCredentialBuilder;
 import com.azure.identity.implementation.CredentialBuilderBaseHelper;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.common.implementation.Constants;
@@ -278,7 +279,13 @@ final class AzureStorageSettings {
     ) {
         this.account = account;
         this.tokenCredentialType = tokenCredentialType;
-        if (Strings.hasText(tokenCredentialType) == true) {
+        if (Strings.hasText(tokenCredentialType)) {
+            TokenCredentialType type = TokenCredentialType.valueOfType(tokenCredentialType);
+            if (type == TokenCredentialType.WORKLOAD_IDENTITY) {
+                if (Strings.hasText(key) || Strings.hasText(sasToken)) {
+                    throw new SettingsException("Workload Identity cannot be used with key or sas_token");
+                }
+            }
             this.endpointBuilder = (logger) -> {
                 String tokenCredentialEndpointSuffix = endpointSuffix;
                 if (Strings.hasText(tokenCredentialEndpointSuffix) == false) {
@@ -290,14 +297,21 @@ final class AzureStorageSettings {
                 return new StorageEndpoint(primaryBlobEndpoint, secondaryBlobEndpoint);
             };
 
-            this.clientBuilder = (builder, executor, logger) -> builder.credential(new ManagedIdentityCredentialBuilder() {
-                @Override
-                public ManagedIdentityCredential build() {
-                    // Use the privileged executor with IdentityClient instance
-                    CredentialBuilderBaseHelper.getClientOptions(this).setExecutorService(executor);
-                    return super.build();
+            this.clientBuilder = (builder, executor, logger) -> {
+                if (type == TokenCredentialType.WORKLOAD_IDENTITY) {
+                    return builder.credential(new WorkloadIdentityCredentialBuilder().executorService(executor).build())
+                        .endpoint(endpointBuilder.apply(logger).getPrimaryUri());
+                } else {
+                    return builder.credential(new ManagedIdentityCredentialBuilder() {
+                        @Override
+                        public ManagedIdentityCredential build() {
+                            // Use the privileged executor with IdentityClient instance
+                            CredentialBuilderBaseHelper.getClientOptions(this).setExecutorService(executor);
+                            return super.build();
+                        }
+                    }.build()).endpoint(endpointBuilder.apply(logger).getPrimaryUri());
                 }
-            }.build()).endpoint(endpointBuilder.apply(logger).getPrimaryUri());
+            };
         } else {
             final String connectString = buildConnectString(account, key, sasToken, endpointSuffix);
 

--- a/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/TokenCredentialType.java
+++ b/plugins/repository-azure/src/main/java/org/opensearch/repositories/azure/TokenCredentialType.java
@@ -12,7 +12,8 @@ import java.util.Arrays;
 
 // Type of token credentials that the plugin supports
 public enum TokenCredentialType {
-    MANAGED_IDENTITY("managed");
+    MANAGED_IDENTITY("managed"),
+    WORKLOAD_IDENTITY("workload_identity");
 
     private final String type;
 

--- a/plugins/repository-azure/src/test/java/org/opensearch/repositories/azure/AzureRepositorySettingsTests.java
+++ b/plugins/repository-azure/src/test/java/org/opensearch/repositories/azure/AzureRepositorySettingsTests.java
@@ -34,8 +34,10 @@ package org.opensearch.repositories.azure;
 
 import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.MockSecureSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsException;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -47,6 +49,7 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.junit.AfterClass;
 
 import java.util.List;
+import java.util.Map;
 
 import reactor.core.scheduler.Schedulers;
 import reactor.netty.http.HttpResources;
@@ -201,5 +204,60 @@ public class AzureRepositorySettingsTests extends OpenSearchTestCase {
         assertTrue(restrictedSettings.contains(BlobStoreRepository.REMOTE_STORE_INDEX_SHALLOW_COPY));
         assertTrue(restrictedSettings.contains(AzureRepository.Repository.BASE_PATH_SETTING));
         assertTrue(restrictedSettings.contains(AzureRepository.Repository.LOCATION_MODE_SETTING));
+    }
+
+    public void testAzureStorageSettingsWithWorkloadIdentity() {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString("azure.client.default.account", "teststorage");
+
+        Settings settings = Settings.builder()
+            .setSecureSettings(secureSettings)
+            .put("azure.client.default.token_credential_type", "workload_identity")
+            .build();
+
+        Map<String, AzureStorageSettings> clients = AzureStorageSettings.load(settings);
+        AzureStorageSettings settingsObj = clients.get("default");
+
+        assertNotNull(settingsObj);
+        assertEquals("workload_identity", settingsObj.getTokenCredentialType());
+    }
+
+    public void testAzureStorageSettingsWithManagedIdentity() {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString("azure.client.default.account", "teststorage");
+
+        Settings settings = Settings.builder()
+            .setSecureSettings(secureSettings)
+            .put("azure.client.default.token_credential_type", "managed")
+            .build();
+
+        AzureStorageSettings settingsObj = AzureStorageSettings.load(settings).get("default");
+        assertEquals("managed", settingsObj.getTokenCredentialType());
+    }
+
+    public void testWorkloadIdentityWithKeyThrowsException() {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString("azure.client.default.account", "teststorage");
+        secureSettings.setString("azure.client.default.key", "any_fake_key");
+
+        Settings settings = Settings.builder()
+            .setSecureSettings(secureSettings)
+            .put("azure.client.default.token_credential_type", "workload_identity")
+            .build();
+
+        expectThrows(SettingsException.class, () -> AzureStorageSettings.load(settings));
+    }
+
+    public void testWorkloadIdentityWithSasTokenThrowsException() {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString("azure.client.default.account", "teststorage");
+        secureSettings.setString("azure.client.default.sas_token", "any_fake_sas");
+
+        Settings settings = Settings.builder()
+            .setSecureSettings(secureSettings)
+            .put("azure.client.default.token_credential_type", "workload_identity")
+            .build();
+
+        expectThrows(SettingsException.class, () -> AzureStorageSettings.load(settings));
     }
 }


### PR DESCRIPTION
### Description
Add support for Azure Workload Identity authentication in the Azure repository plugin.
Add configuration validation to prevent mixing Workload Identity with account key or SAS token.
Add corresponding unit tests.

### Related Issues
Resolves #20789

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request, if applicable.
- [ ] Public documentation issue/PR, if applicable.