### PR TITLE
Add timed_out shard count to _shards response

### DIFF
--- a/modules/lang-mustache/src/test/java/org/opensearch/script/mustache/MultiSearchTemplateResponseTests.java
+++ b/modules/lang-mustache/src/test/java/org/opensearch/script/mustache/MultiSearchTemplateResponseTests.java
@@ -223,6 +223,7 @@ public class MultiSearchTemplateResponseTests extends AbstractXContentTestCase<M
             .field("successful", 2)
             .field("skipped", 0)
             .field("failed", 0)
+            .field("timed_out", 0)
             .endObject()
             .startObject("hits")
             .startObject("total")

--- a/modules/lang-mustache/src/test/java/org/opensearch/script/mustache/SearchTemplateResponseTests.java
+++ b/modules/lang-mustache/src/test/java/org/opensearch/script/mustache/SearchTemplateResponseTests.java
@@ -220,6 +220,7 @@ public class SearchTemplateResponseTests extends AbstractXContentTestCase<Search
             .field("successful", 0)
             .field("skipped", 0)
             .field("failed", 0)
+            .field("timed_out", 0)
             .endObject()
             .startObject("hits")
             .startObject("total")

--- a/server/src/internalClusterTest/java/org/opensearch/search/SearchTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/SearchTimeoutIT.java
@@ -96,6 +96,12 @@ public class SearchTimeoutIT extends ParameterizedStaticSettingsOpenSearchIntegT
             .get();
         assertTrue(searchResponse.isTimedOut());
         assertEquals(0, searchResponse.getFailedShards());
+        // Verify timed_out count in _shards is positive and consistent with the boolean
+        assertTrue("timedOutShards should be > 0 when timed_out is true", searchResponse.getTimedOutShards() > 0);
+        assertTrue(
+            "timedOutShards should be <= successful - skipped",
+            searchResponse.getTimedOutShards() <= searchResponse.getSuccessfulShards() - searchResponse.getSkippedShards()
+        );
     }
 
     public void testSimpleDoesNotTimeout() throws Exception {
@@ -112,6 +118,8 @@ public class SearchTimeoutIT extends ParameterizedStaticSettingsOpenSearchIntegT
         assertFalse(searchResponse.isTimedOut());
         assertEquals(0, searchResponse.getFailedShards());
         assertEquals(numDocs, searchResponse.getHits().getTotalHits().value());
+        // Verify timed_out count is 0 when no timeout occurred
+        assertEquals(0, searchResponse.getTimedOutShards());
     }
 
     public void testPartialResultsIntolerantTimeout() throws Exception {

--- a/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchPhaseController.java
@@ -464,6 +464,7 @@ public final class SearchPhaseController {
                 topDocsStats.fetchHits,
                 topDocsStats.getMaxScore(),
                 false,
+                0,
                 null,
                 null,
                 null,
@@ -538,6 +539,7 @@ public final class SearchPhaseController {
             topDocsStats.fetchHits,
             topDocsStats.getMaxScore(),
             topDocsStats.timedOut,
+            topDocsStats.timedOutShards,
             topDocsStats.terminatedEarly,
             reducedSuggest,
             aggregations,
@@ -682,6 +684,8 @@ public final class SearchPhaseController {
         final float maxScore;
         // <code>true</code> if at least one reduced result timed out
         final boolean timedOut;
+        // the number of shards that timed out during the query phase
+        final int timedOutShards;
         // non null and true if at least one reduced result was terminated early
         final Boolean terminatedEarly;
         // the reduced suggest results
@@ -708,6 +712,7 @@ public final class SearchPhaseController {
             long fetchHits,
             float maxScore,
             boolean timedOut,
+            int timedOutShards,
             Boolean terminatedEarly,
             Suggest suggest,
             InternalAggregations aggregations,
@@ -726,6 +731,7 @@ public final class SearchPhaseController {
             this.fetchHits = fetchHits;
             this.maxScore = maxScore;
             this.timedOut = timedOut;
+            this.timedOutShards = timedOutShards;
             this.terminatedEarly = terminatedEarly;
             this.suggest = suggest;
             this.aggregations = aggregations;
@@ -759,6 +765,7 @@ public final class SearchPhaseController {
                 suggest,
                 mergedProfileResults,
                 timedOut,
+                timedOutShards,
                 terminatedEarly,
                 numReducePhases
             );
@@ -843,6 +850,7 @@ public final class SearchPhaseController {
         long fetchHits;
         private float maxScore = Float.NEGATIVE_INFINITY;
         boolean timedOut;
+        int timedOutShards;
         Boolean terminatedEarly;
 
         TopDocsStats(int trackTotalHitsUpTo) {
@@ -889,6 +897,7 @@ public final class SearchPhaseController {
             }
             if (timedOut) {
                 this.timedOut = true;
+                this.timedOutShards++;
             }
             if (terminatedEarly != null) {
                 if (this.terminatedEarly == null) {

--- a/server/src/main/java/org/opensearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchResponse.java
@@ -190,6 +190,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
         this.phaseTook = phaseTook;
         this.shardFailures = shardFailures;
         assert skippedShards <= totalShards : "skipped: " + skippedShards + " total: " + totalShards;
+        assert internalResponse.timedOutShards() >= 0 : "timedOutShards must be non-negative: " + internalResponse.timedOutShards();
         assert scrollId == null || pointInTimeId == null : "SearchResponse can't have both scrollId ["
             + scrollId
             + "] and searchContextId ["
@@ -279,6 +280,13 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
     }
 
     /**
+     * The number of shards that timed out during the search.
+     */
+    public int getTimedOutShards() {
+        return internalResponse.timedOutShards();
+    }
+
+    /**
      * The failed number of shards the search was executed on.
      */
     public int getFailedShards() {
@@ -362,6 +370,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
             getSuccessfulShards(),
             getSkippedShards(),
             getFailedShards(),
+            getTimedOutShards(),
             getShardFailures()
         );
         clusters.toXContent(builder, params);
@@ -391,6 +400,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
         int successfulShards = -1;
         int totalShards = -1;
         int skippedShards = 0; // 0 for BWC
+        int timedOutShards = 0; // 0 for BWC
         String scrollId = null;
         String searchContextId = null;
         List<ShardSearchFailure> failures = new ArrayList<>();
@@ -438,6 +448,8 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
                                 totalShards = parser.intValue();
                             } else if (RestActions.SKIPPED_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                                 skippedShards = parser.intValue();
+                            } else if (RestActions.TIMED_OUT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                                timedOutShards = parser.intValue();
                             } else {
                                 parser.skipChildren();
                             }
@@ -535,6 +547,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
             aggs,
             suggest,
             timedOut,
+            timedOutShards,
             terminatedEarly,
             profile,
             numReducePhases,

--- a/server/src/main/java/org/opensearch/action/search/SearchResponseSections.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchResponseSections.java
@@ -72,6 +72,7 @@ public class SearchResponseSections implements ToXContentFragment {
     protected final Suggest suggest;
     protected final SearchProfileShardResults profileResults;
     protected final boolean timedOut;
+    protected final int timedOutShards;
     protected final Boolean terminatedEarly;
     protected final int numReducePhases;
     protected final List<SearchExtBuilder> searchExtBuilders = new ArrayList<>();
@@ -91,6 +92,7 @@ public class SearchResponseSections implements ToXContentFragment {
             aggregations,
             suggest,
             timedOut,
+            0,
             terminatedEarly,
             profileResults,
             numReducePhases,
@@ -110,11 +112,38 @@ public class SearchResponseSections implements ToXContentFragment {
         List<SearchExtBuilder> searchExtBuilders,
         List<ProcessorExecutionDetail> processorResult
     ) {
+        this(
+            hits,
+            aggregations,
+            suggest,
+            timedOut,
+            0,
+            terminatedEarly,
+            profileResults,
+            numReducePhases,
+            searchExtBuilders,
+            processorResult
+        );
+    }
+
+    public SearchResponseSections(
+        SearchHits hits,
+        Aggregations aggregations,
+        Suggest suggest,
+        boolean timedOut,
+        int timedOutShards,
+        Boolean terminatedEarly,
+        SearchProfileShardResults profileResults,
+        int numReducePhases,
+        List<SearchExtBuilder> searchExtBuilders,
+        List<ProcessorExecutionDetail> processorResult
+    ) {
         this.hits = hits;
         this.aggregations = aggregations;
         this.suggest = suggest;
         this.profileResults = profileResults;
         this.timedOut = timedOut;
+        this.timedOutShards = timedOutShards;
         this.terminatedEarly = terminatedEarly;
         this.numReducePhases = numReducePhases;
         this.processorResult.addAll(processorResult);
@@ -136,6 +165,7 @@ public class SearchResponseSections implements ToXContentFragment {
             aggregations,
             suggest,
             timedOut,
+            0,
             terminatedEarly,
             profileResults,
             numReducePhases,
@@ -146,6 +176,10 @@ public class SearchResponseSections implements ToXContentFragment {
 
     public final boolean timedOut() {
         return this.timedOut;
+    }
+
+    public final int timedOutShards() {
+        return this.timedOutShards;
     }
 
     public final Boolean terminatedEarly() {

--- a/server/src/main/java/org/opensearch/rest/action/RestActions.java
+++ b/server/src/main/java/org/opensearch/rest/action/RestActions.java
@@ -74,6 +74,7 @@ public class RestActions {
     public static final ParseField SKIPPED_FIELD = new ParseField("skipped");
     public static final ParseField FAILED_FIELD = new ParseField("failed");
     public static final ParseField FAILURES_FIELD = new ParseField("failures");
+    public static final ParseField TIMED_OUT_FIELD = new ParseField("timed_out");
 
     public static long parseVersion(RestRequest request) {
         if (request.hasParam("version")) {
@@ -119,6 +120,34 @@ public class RestActions {
             builder.field(SKIPPED_FIELD.getPreferredName(), skipped);
         }
         builder.field(FAILED_FIELD.getPreferredName(), failed);
+        if (CollectionUtils.isEmpty(shardFailures) == false) {
+            builder.startArray(FAILURES_FIELD.getPreferredName());
+            for (ShardOperationFailedException shardFailure : ExceptionsHelper.groupBy(shardFailures)) {
+                shardFailure.toXContent(builder, params);
+            }
+            builder.endArray();
+        }
+        builder.endObject();
+    }
+
+    public static void buildBroadcastShardsHeader(
+        XContentBuilder builder,
+        Params params,
+        int total,
+        int successful,
+        int skipped,
+        int failed,
+        int timedOut,
+        ShardOperationFailedException[] shardFailures
+    ) throws IOException {
+        builder.startObject(_SHARDS_FIELD.getPreferredName());
+        builder.field(TOTAL_FIELD.getPreferredName(), total);
+        builder.field(SUCCESSFUL_FIELD.getPreferredName(), successful);
+        if (skipped >= 0) {
+            builder.field(SKIPPED_FIELD.getPreferredName(), skipped);
+        }
+        builder.field(FAILED_FIELD.getPreferredName(), failed);
+        builder.field(TIMED_OUT_FIELD.getPreferredName(), timedOut);
         if (CollectionUtils.isEmpty(shardFailures) == false) {
             builder.startArray(FAILURES_FIELD.getPreferredName());
             for (ShardOperationFailedException shardFailure : ExceptionsHelper.groupBy(shardFailures)) {

--- a/server/src/main/java/org/opensearch/search/internal/InternalSearchResponse.java
+++ b/server/src/main/java/org/opensearch/search/internal/InternalSearchResponse.java
@@ -74,12 +74,26 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
         Boolean terminatedEarly,
         int numReducePhases
     ) {
+        this(hits, aggregations, suggest, profileResults, timedOut, 0, terminatedEarly, numReducePhases);
+    }
+
+    public InternalSearchResponse(
+        SearchHits hits,
+        InternalAggregations aggregations,
+        Suggest suggest,
+        SearchProfileShardResults profileResults,
+        boolean timedOut,
+        int timedOutShards,
+        Boolean terminatedEarly,
+        int numReducePhases
+    ) {
         this(
             hits,
             aggregations,
             suggest,
             profileResults,
             timedOut,
+            timedOutShards,
             terminatedEarly,
             numReducePhases,
             Collections.emptyList(),
@@ -98,11 +112,38 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
         List<SearchExtBuilder> searchExtBuilderList,
         List<ProcessorExecutionDetail> processorResult
     ) {
+        this(
+            hits,
+            aggregations,
+            suggest,
+            profileResults,
+            timedOut,
+            0,
+            terminatedEarly,
+            numReducePhases,
+            searchExtBuilderList,
+            processorResult
+        );
+    }
+
+    public InternalSearchResponse(
+        SearchHits hits,
+        InternalAggregations aggregations,
+        Suggest suggest,
+        SearchProfileShardResults profileResults,
+        boolean timedOut,
+        int timedOutShards,
+        Boolean terminatedEarly,
+        int numReducePhases,
+        List<SearchExtBuilder> searchExtBuilderList,
+        List<ProcessorExecutionDetail> processorResult
+    ) {
         super(
             hits,
             aggregations,
             suggest,
             timedOut,
+            timedOutShards,
             terminatedEarly,
             profileResults,
             numReducePhases,
@@ -122,13 +163,14 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
         List<SearchExtBuilder> searchExtBuilderList
 
     ) {
-        super(
+        this(
             hits,
             aggregations,
             suggest,
-            timedOut,
-            terminatedEarly,
             profileResults,
+            timedOut,
+            0,
+            terminatedEarly,
             numReducePhases,
             searchExtBuilderList,
             Collections.emptyList()
@@ -141,6 +183,7 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
             in.readBoolean() ? InternalAggregations.readFrom(in) : null,
             in.readBoolean() ? new Suggest(in) : null,
             in.readBoolean(),
+            in.getVersion().onOrAfter(Version.V_3_7_0) ? in.readVInt() : 0,
             in.readOptionalBoolean(),
             in.readOptionalWriteable(SearchProfileShardResults::new),
             in.readVInt(),
@@ -155,6 +198,9 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
         out.writeOptionalWriteable((InternalAggregations) aggregations);
         out.writeOptionalWriteable(suggest);
         out.writeBoolean(timedOut);
+        if (out.getVersion().onOrAfter(Version.V_3_7_0)) {
+            out.writeVInt(timedOutShards);
+        }
         out.writeOptionalBoolean(terminatedEarly);
         out.writeOptionalWriteable(profileResults);
         out.writeVInt(numReducePhases);

--- a/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
@@ -208,7 +208,12 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
         asyncAction.start();
         latch.await();
         assertTrue(searchPhaseDidRun.get());
-        SearchResponse searchResponse = asyncAction.buildSearchResponse(null, asyncAction.buildShardFailures(), null, null);
+        SearchResponse searchResponse = asyncAction.buildSearchResponse(
+            InternalSearchResponse.empty(),
+            asyncAction.buildShardFailures(),
+            null,
+            null
+        );
         assertEquals(shardsIter.size() - numSkipped, numRequests.get());
         assertEquals(0, searchResponse.getFailedShards());
         assertEquals(numSkipped, searchResponse.getSkippedShards());

--- a/server/src/test/java/org/opensearch/action/search/SearchPhaseControllerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchPhaseControllerTests.java
@@ -1837,6 +1837,63 @@ public class SearchPhaseControllerTests extends OpenSearchTestCase {
         latch.await();
     }
 
+    public void testTopDocsStatsZeroTimedOut() {
+        SearchPhaseController.TopDocsStats stats = new SearchPhaseController.TopDocsStats(SearchContext.TRACK_TOTAL_HITS_ACCURATE);
+        TopDocsAndMaxScore td = emptyTopDocs();
+
+        int count = randomIntBetween(1, 10);
+        for (int i = 0; i < count; i++) {
+            stats.add(td, false, null);
+        }
+        assertEquals(0, stats.timedOutShards);
+        assertFalse(stats.timedOut);
+    }
+
+    public void testTopDocsStatsOneTimedOut() {
+        SearchPhaseController.TopDocsStats stats = new SearchPhaseController.TopDocsStats(SearchContext.TRACK_TOTAL_HITS_ACCURATE);
+        TopDocsAndMaxScore td = emptyTopDocs();
+
+        stats.add(td, false, null);
+        stats.add(td, true, null);
+        stats.add(td, false, null);
+
+        assertEquals(1, stats.timedOutShards);
+        assertTrue(stats.timedOut);
+    }
+
+    public void testTopDocsStatsSomeTimedOut() {
+        SearchPhaseController.TopDocsStats stats = new SearchPhaseController.TopDocsStats(SearchContext.TRACK_TOTAL_HITS_ACCURATE);
+        TopDocsAndMaxScore td = emptyTopDocs();
+
+        int total = randomIntBetween(5, 20);
+        int expectedTimedOut = 0;
+        for (int i = 0; i < total; i++) {
+            boolean timedOut = randomBoolean();
+            if (timedOut) {
+                expectedTimedOut++;
+            }
+            stats.add(td, timedOut, null);
+        }
+        assertEquals(expectedTimedOut, stats.timedOutShards);
+        assertEquals(expectedTimedOut > 0, stats.timedOut);
+    }
+
+    public void testTopDocsStatsAllTimedOut() {
+        SearchPhaseController.TopDocsStats stats = new SearchPhaseController.TopDocsStats(SearchContext.TRACK_TOTAL_HITS_ACCURATE);
+        TopDocsAndMaxScore td = emptyTopDocs();
+
+        int count = randomIntBetween(1, 10);
+        for (int i = 0; i < count; i++) {
+            stats.add(td, true, null);
+        }
+        assertEquals(count, stats.timedOutShards);
+        assertTrue(stats.timedOut);
+    }
+
+    private static TopDocsAndMaxScore emptyTopDocs() {
+        return new TopDocsAndMaxScore(new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]), Float.NaN);
+    }
+
     private static class AssertingCircuitBreaker extends NoopCircuitBreaker {
         private final AtomicBoolean shouldBreak = new AtomicBoolean(false);
 

--- a/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
@@ -35,6 +35,7 @@ package org.opensearch.action.search;
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.ParseField;
@@ -366,7 +367,8 @@ public class SearchResponseTests extends OpenSearchTestCase {
                     expectedString.append("{\"total\":0,");
                     expectedString.append("\"successful\":0,");
                     expectedString.append("\"skipped\":0,");
-                    expectedString.append("\"failed\":0},");
+                    expectedString.append("\"failed\":0,");
+                    expectedString.append("\"timed_out\":0},");
                 }
                 expectedString.append("\"hits\":");
                 {
@@ -448,7 +450,8 @@ public class SearchResponseTests extends OpenSearchTestCase {
                     expectedString.append("{\"total\":0,");
                     expectedString.append("\"successful\":0,");
                     expectedString.append("\"skipped\":0,");
-                    expectedString.append("\"failed\":0},");
+                    expectedString.append("\"failed\":0,");
+                    expectedString.append("\"timed_out\":0},");
                 }
                 expectedString.append("\"_clusters\":");
                 {
@@ -645,5 +648,111 @@ public class SearchResponseTests extends OpenSearchTestCase {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             return builder.field(DUMMY_FIELD.getPreferredName(), id);
         }
+    }
+
+    public void testTimedOutShardsJsonRoundTrip() throws IOException {
+        int timedOutShards = randomIntBetween(1, 50);
+        SearchResponse original = buildTimedOutSearchResponse(true, timedOutShards);
+
+        XContentBuilder builder = XContentBuilder.builder(MediaTypeRegistry.JSON.xContent());
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        BytesReference bytes = BytesReference.bytes(builder);
+
+        try (XContentParser parser = createParser(MediaTypeRegistry.JSON.xContent(), bytes)) {
+            SearchResponse parsed = SearchResponse.fromXContent(parser);
+            assertEquals(timedOutShards, parsed.getTimedOutShards());
+        }
+    }
+
+    public void testTimedOutShardsWireRoundTrip() throws IOException {
+        int timedOutShards = randomIntBetween(1, 100);
+        InternalSearchResponse original = buildTimedOutInternalSearchResponse(true, timedOutShards);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+
+        StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        InternalSearchResponse deserialized = new InternalSearchResponse(in);
+
+        assertEquals(timedOutShards, deserialized.timedOutShards());
+    }
+
+    public void testTimedOutShardsBwcWireRoundTrip() throws IOException {
+        int timedOutShards = randomIntBetween(1, 100);
+        InternalSearchResponse original = buildTimedOutInternalSearchResponse(true, timedOutShards);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(Version.V_2_19_0);
+        original.writeTo(out);
+
+        StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        in.setVersion(Version.V_2_19_0);
+        InternalSearchResponse deserialized = new InternalSearchResponse(in);
+
+        assertEquals(0, deserialized.timedOutShards());
+    }
+
+    public void testTimedOutShardsJsonFieldOrdering() throws IOException {
+        SearchResponse response = buildTimedOutSearchResponse(false, 0);
+
+        XContentBuilder builder = XContentBuilder.builder(MediaTypeRegistry.JSON.xContent());
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = builder.toString();
+
+        // Within the _shards object, "timed_out" must appear after "failed"
+        int failedIdx = json.indexOf("\"failed\"");
+        int timedOutIdx = json.indexOf("\"timed_out\"", json.indexOf("\"_shards\""));
+        assertTrue("timed_out should appear after failed in _shards, json=" + json, timedOutIdx > failedIdx);
+    }
+
+    public void testTimedOutShardsZeroPresent() throws IOException {
+        SearchResponse response = buildTimedOutSearchResponse(false, 0);
+
+        XContentBuilder builder = XContentBuilder.builder(MediaTypeRegistry.JSON.xContent());
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = builder.toString();
+
+        // The _shards section must contain "timed_out":0
+        assertTrue("Expected \"timed_out\":0 in JSON, got: " + json, json.contains("\"timed_out\":0"));
+    }
+
+    public void testTimedOutShardsMissingFieldDefaultsToZero() throws IOException {
+        // Build a JSON string that has _shards without timed_out
+        String json = "{"
+            + "\"took\":1,"
+            + "\"timed_out\":false,"
+            + "\"_shards\":{\"total\":5,\"successful\":5,\"skipped\":0,\"failed\":0},"
+            + "\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[]}"
+            + "}";
+
+        try (XContentParser parser = createParser(MediaTypeRegistry.JSON.xContent(), json)) {
+            SearchResponse parsed = SearchResponse.fromXContent(parser);
+            assertEquals(0, parsed.getTimedOutShards());
+        }
+    }
+
+    public void testTimedOutShardsBooleanCountConsistency() {
+        int timedOutShards = randomIntBetween(1, 50);
+        SearchResponse response = buildTimedOutSearchResponse(true, timedOutShards);
+
+        assertTrue("timed_out should be true when timedOutShards > 0", response.isTimedOut());
+        assertTrue("timedOutShards should be > 0", response.getTimedOutShards() > 0);
+    }
+
+    public void testTimedOutShardsZeroBooleanCountConsistency() {
+        SearchResponse response = buildTimedOutSearchResponse(false, 0);
+
+        assertFalse("timed_out should be false when timedOutShards == 0", response.isTimedOut());
+        assertEquals(0, response.getTimedOutShards());
+    }
+
+    private static InternalSearchResponse buildTimedOutInternalSearchResponse(boolean timedOut, int timedOutShards) {
+        SearchHits hits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        return new InternalSearchResponse(hits, null, null, null, timedOut, timedOutShards, null, 1);
+    }
+
+    private static SearchResponse buildTimedOutSearchResponse(boolean timedOut, int timedOutShards) {
+        InternalSearchResponse internal = buildTimedOutInternalSearchResponse(timedOut, timedOutShards);
+        return new SearchResponse(internal, null, 5, 5, 0, 1, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
     }
 }


### PR DESCRIPTION
### Description

Adds a `timed_out` integer field to the `_shards` section of search responses, reporting how many shards had their query phase time out during Lucene document collection. This addresses the observability gap where `timed_out: true` at the top level gives no indication of whether 1 shard or 99% of shards timed out.

Timed-out shards remain counted as `successful` for backward compatibility (same behaviour as `skipped` shards). The new field is additive and does not change existing response semantics.

### Scope

Only counts shards that timed out during the shard query phase due to the `timeout` request parameter or `search.default_search_timeout` cluster setting. Does not cover `cancel_after_time_interval` (which cancels the entire request without returning a response) or the proposed `request_timeout` in #21088.

### Response format

```json
{
  ...
  "timed_out": true,
  "_shards": {
    "total": 10,
    "successful": 10,
    "skipped": 0,
    "failed": 0,
    "timed_out": 3    // new field
  }
}
```

### Invariants

- `timed_out >= 0`
- `timed_out > 0` iff `timed_out` boolean is `true`

### Testing

No timeout (timed_out count is 0):
```bash
curl -s 'http://localhost:9200/test-index/_search?timeout=10s' \
  -H 'Content-Type: application/json' \
  -d '{"query": {"match_all": {}}, "size": 1}'
```
```json
{
  "timed_out": false,
  "_shards": {
    "total": 3,
    "successful": 3,
    "skipped": 0,
    "failed": 0,
    "timed_out": 0
  }
}
```

With timeout (all 3 shards timed out):
```bash
curl -s 'http://localhost:9200/test-index/_search?timeout=100ms' \
  -H 'Content-Type: application/json' \
  -d '{"query": {"match_all": {}}, "size": 1}'
```
```json
{
  "timed_out": true,
  "_shards": {
    "total": 3,
    "successful": 3,
    "skipped": 0,
    "failed": 0,
    "timed_out": 3
  }
}
```

### Related Issues
Resolves #21087

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
