### PR TITLE
Validation of the `_source` object in request and deprecation of ambiguous usage 

### DIFF
--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/common/FetchSourceContextProtoUtilsTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/common/FetchSourceContextProtoUtilsTests.java
@@ -18,6 +18,7 @@ import org.opensearch.protobufs.StringArray;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.test.OpenSearchTestCase;
 
+// ISSUE-20612 Source Validation
 public class FetchSourceContextProtoUtilsTests extends OpenSearchTestCase {
 
     public void testParseFromProtoRequestWithBoolValue() {

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/common/FetchSourceContextProtoUtilsTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/common/FetchSourceContextProtoUtilsTests.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.transport.grpc.proto.request.common;
 
-import org.opensearch.OpenSearchException;
 import org.opensearch.core.common.Strings;
 import org.opensearch.protobufs.BulkRequest;
 import org.opensearch.protobufs.SearchRequest;
@@ -368,7 +367,7 @@ public class FetchSourceContextProtoUtilsTests extends OpenSearchTestCase {
             .build();
 
         // Exception when attempting to convert to FetchSourceContext
-        final OpenSearchException e = expectThrows(OpenSearchException.class, () -> FetchSourceContextProtoUtils.fromProto(sourceConfig));
+        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> FetchSourceContextProtoUtils.fromProto(sourceConfig));
 
         assertEquals("The same entry [theSameEntry] cannot be both included and excluded in _source.", e.getMessage());
     }

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/common/FetchSourceContextProtoUtilsTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/common/FetchSourceContextProtoUtilsTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.transport.grpc.proto.request.common;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.core.common.Strings;
 import org.opensearch.protobufs.BulkRequest;
 import org.opensearch.protobufs.SearchRequest;
@@ -18,7 +19,6 @@ import org.opensearch.protobufs.StringArray;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.test.OpenSearchTestCase;
 
-// ISSUE-20612 Source Validation
 public class FetchSourceContextProtoUtilsTests extends OpenSearchTestCase {
 
     public void testParseFromProtoRequestWithBoolValue() {
@@ -352,5 +352,24 @@ public class FetchSourceContextProtoUtilsTests extends OpenSearchTestCase {
         assertTrue("fetchSource should be true", context.fetchSource());
         assertArrayEquals("includes should match", new String[] { "include1", "include2" }, context.includes());
         assertArrayEquals("excludes should match", new String[] { "exclude1", "exclude2" }, context.excludes());
+    }
+
+    public void testFromProtoWithSourceConfigFilterAmbiguousIncludesAndExcludes() {
+        // Create a SourceConfig with filter includes and excludes
+        final SourceConfig sourceConfig = SourceConfig.newBuilder()
+            .setFilter(
+                SourceFilter.newBuilder()
+                    .addIncludes("theSameEntry")
+                    .addIncludes("include2")
+                    .addExcludes("theSameEntry")
+                    .addExcludes("exclude2")
+                    .build()
+            )
+            .build();
+
+        // Exception when attempting to convert to FetchSourceContext
+        final OpenSearchException e = expectThrows(OpenSearchException.class, () -> FetchSourceContextProtoUtils.fromProto(sourceConfig));
+
+        assertEquals("The same entry [theSameEntry] cannot be both included and excluded in _source.", e.getMessage());
     }
 }

--- a/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/common/FetchSourceContextProtoUtilsTests.java
+++ b/modules/transport-grpc/src/test/java/org/opensearch/transport/grpc/proto/request/common/FetchSourceContextProtoUtilsTests.java
@@ -367,7 +367,10 @@ public class FetchSourceContextProtoUtilsTests extends OpenSearchTestCase {
             .build();
 
         // Exception when attempting to convert to FetchSourceContext
-        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> FetchSourceContextProtoUtils.fromProto(sourceConfig));
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> FetchSourceContextProtoUtils.fromProto(sourceConfig)
+        );
 
         assertEquals("The same entry [theSameEntry] cannot be both included and excluded in _source.", e.getMessage());
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
@@ -114,7 +114,7 @@ setup:
           query: { match_all: {} }
       catch: bad_request
   - match: { status: 400 }
-  - match: { error.type: parsing_exception }
+  - match: { error.type: illegal_argument_exception }
   - match: { error.reason: "The same entry [include.field1] cannot be both included and excluded in _source." }
 
 ---

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
@@ -35,6 +35,64 @@ setup:
   - is_false: hits.hits.0._source
 
 ---
+"_source as an empty object":
+  - skip:
+      version: " - 3.6.99"
+      reason: "validation was added later"
+  - do:
+      search: { body: { _source: {  }, query: { match_all: {} } } }
+      catch: bad_request
+  - match: { status: 400 }
+  - match: { error.type: parsing_exception }
+  - match: { error.reason: "Expected at least one of [includes] or [excludes]" }
+
+---
+"_source as an empty includes array":
+  - skip:
+      version: " - 3.6.99"
+      reason: "validation was added later"
+  - do:
+      search: { body: { _source: [], query: { match_all: {} } } }
+      catch: bad_request
+  - match: { status: 400 }
+  - match: { error.type: parsing_exception }
+  - match: { error.reason: "Expected at least one value for an array of [includes]" }
+
+---
+"_source with an empty excludes array":
+  - skip:
+      version: " - 3.6.99"
+      reason: "validation was added later"
+  - do:
+      search:
+        body:
+          _source:
+            includes: [ include.field1, include.field2 ]
+            excludes: []
+          query: { match_all: {} }
+      catch: bad_request
+  - match: { status: 400 }
+  - match: { error.type: parsing_exception }
+  - match: { error.reason: "Expected at least one value for an array of [excludes]" }
+
+---
+"_source with an ambiguous field":
+  - skip:
+      version: " - 3.6.99"
+      reason: "validation was added later"
+  - do:
+      search:
+        body:
+          _source:
+            includes: [ include.field1, include.field2 ]
+            excludes: [ include.field1 ]
+          query: { match_all: {} }
+      catch: bad_request
+  - match: { status: 400 }
+  - match: { error.type: parsing_exception }
+  - match: { error.reason: "The same entry [include.field1] cannot be both included and excluded in _source." }
+
+---
 "no filtering":
   - do: { search: { body: { query: { match_all: {} } } } }
   - length:   { hits.hits: 1  }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/10_source_filtering.yml
@@ -39,41 +39,66 @@ setup:
   - skip:
       version: " - 3.6.99"
       reason: "validation was added later"
+      features: "warnings"
   - do:
+      warnings:
+        - 'An empty object was provided as [_source]. Provide at least one of [includes] or [excludes] or use `_source: true` to fetch the entire source.'
       search: { body: { _source: {  }, query: { match_all: {} } } }
-      catch: bad_request
-  - match: { status: 400 }
-  - match: { error.type: parsing_exception }
-  - match: { error.reason: "Expected at least one of [includes] or [excludes]" }
+  - length:   { hits.hits: 1  }
+  - match: { hits.hits.0._source.count: 1 }
 
 ---
-"_source as an empty includes array":
+"_source as an empty array":
   - skip:
       version: " - 3.6.99"
       reason: "validation was added later"
+      features: "warnings"
   - do:
+      warnings:
+        - 'An empty array was provided as [_source]. Provide at least one field pattern or use `_source: true` to fetch the entire source.'
       search: { body: { _source: [], query: { match_all: {} } } }
-      catch: bad_request
-  - match: { status: 400 }
-  - match: { error.type: parsing_exception }
-  - match: { error.reason: "Expected at least one value for an array of [includes]" }
+  - length:   { hits.hits: 1  }
+  - match: { hits.hits.0._source.count: 1 }
 
 ---
-"_source with an empty excludes array":
+"_source as object with an empty excludes array":
   - skip:
       version: " - 3.6.99"
       reason: "validation was added later"
+      features: "warnings"
   - do:
+      warnings:
+        - 'Expected at least one value for an array of [excludes]'
       search:
         body:
           _source:
             includes: [ include.field1, include.field2 ]
             excludes: []
           query: { match_all: {} }
-      catch: bad_request
-  - match: { status: 400 }
-  - match: { error.type: parsing_exception }
-  - match: { error.reason: "Expected at least one value for an array of [excludes]" }
+  - length:   { hits.hits: 1  }
+  - match:  { hits.hits.0._source.include.field1: v1 }
+  - match:  { hits.hits.0._source.include.field2: v2 }
+  - is_false: hits.hits.0._source.count
+
+---
+"_source as object with an empty includes array":
+  - skip:
+      version: " - 3.6.99"
+      reason: "validation was added later"
+      features: "warnings"
+  - do:
+      warnings:
+        - 'Expected at least one value for an array of [includes]'
+      search:
+        body:
+          _source:
+            includes: []
+            excludes: [ include.field1 ]
+          query: { match_all: {} }
+  - length:   { hits.hits: 1  }
+  - is_false: hits.hits.0._source.include.field1
+  - match:  { hits.hits.0._source.include.field2: v2 }
+  - match: { hits.hits.0._source.count: 1 }
 
 ---
 "_source with an ambiguous field":

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
@@ -50,7 +50,6 @@ import org.opensearch.rest.RestRequest;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -283,7 +282,6 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
             }
         }
         if (includes.length == 0 && excludes.length == 0) {
-            // no valid field names -> empty or unrecognized fields; deprecated
             deprecationLogger.deprecate(
                 "empty_source_object",
                 "An empty object was provided as [_source]. Provide at least one of ["
@@ -296,8 +294,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         return new FetchSourceContext(true, includes, excludes);
     }
 
-    private static String[] parseSourceFieldArray(XContentParser parser, ParseField parseField)
-        throws IOException {
+    private static String[] parseSourceFieldArray(XContentParser parser, ParseField parseField) throws IOException {
         Set<String> sourceArr = new LinkedHashSet<>(); // preserves the order, removes the duplicates
         while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
             if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
@@ -47,12 +47,13 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.RestRequest;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
+// ISSUE-20612 Source Validation
 /**
  * Context used to fetch the {@code _source}.
  *
@@ -142,36 +143,37 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         XContentParser.Token token = parser.currentToken();
         switch (token) {
             case XContentParser.Token.VALUE_BOOLEAN -> {
-                return parser.booleanValue() ? FETCH_SOURCE : DO_NOT_FETCH_SOURCE;
+                return new FetchSourceContext(parser.booleanValue());
             }
             case XContentParser.Token.VALUE_STRING -> {
                 String[] includes = new String[] { parser.text() };
                 return new FetchSourceContext(true, includes, null);
             }
             case XContentParser.Token.START_ARRAY -> {
-                ArrayList<String> list = new ArrayList<>();
-                while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                    list.add(parser.text());
-                }
-                String[] includes = list.toArray(new String[0]);
+                String[] includes = parseSourceArray(parser, INCLUDES_FIELD).toArray(new String[0]);
                 return new FetchSourceContext(true, includes, null);
             }
             case XContentParser.Token.START_OBJECT -> {
                 return parseSourceObject(parser);
             }
-            default -> {
+            default ->
                 throw new ParsingException(
                     parser.getTokenLocation(),
                     "Expected one of ["
                         + XContentParser.Token.VALUE_BOOLEAN
                         + ", "
+                        + XContentParser.Token.VALUE_STRING
+                        + ", "
+                        + XContentParser.Token.START_ARRAY
+                        + ", "
                         + XContentParser.Token.START_OBJECT
                         + "] but found ["
                         + token
-                        + "]"
+                        + "]",
+                    parser.getTokenLocation()
                 );
-            }
         }
+        // MUST never reach here
     }
 
     private static FetchSourceContext parseSourceObject(XContentParser parser) throws IOException {
@@ -179,12 +181,6 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         String[] includes = Strings.EMPTY_ARRAY;
         String[] excludes = Strings.EMPTY_ARRAY;
         String currentFieldName = null;
-        if (token != XContentParser.Token.START_OBJECT) {
-            throw new ParsingException(
-                parser.getTokenLocation(),
-                "Expected a " + XContentParser.Token.START_OBJECT + " but got a " + token + " in [" + parser.currentName() + "]."
-            );
-        }
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -194,47 +190,65 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
             switch (token) {
                 case XContentParser.Token.START_ARRAY -> {
                     if (INCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        includes = parseSourceArray(parser).toArray(new String[0]);
-                    } else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        excludes = parseSourceArray(parser).toArray(new String[0]);
-                    } else {
+                        includes = parseSourceArray(parser, INCLUDES_FIELD).toArray(new String[0]);
+                    }
+                    else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        excludes = parseSourceArray(parser, EXCLUDES_FIELD).toArray(new String[0]);
+                    }
+                    else {
                         throw new ParsingException(
                             parser.getTokenLocation(),
-                            "Unknown key for a " + token + " in [" + currentFieldName + "]."
+                            "Unknown key for a " + token + " in [" + currentFieldName + "].",
+                            parser.getTokenLocation()
                         );
                     }
                 }
                 case XContentParser.Token.VALUE_STRING -> {
                     if (INCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        includes = new String[] { parser.text() };
-                    } else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        excludes = new String[] { parser.text() };
-                    } else {
+                        includes = new String[]{parser.text()};
+                    }
+                    else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        excludes = new String[]{parser.text()};
+                    }
+                    else {
                         throw new ParsingException(
                             parser.getTokenLocation(),
                             "Unknown key for a " + token + " in [" + currentFieldName + "]."
                         );
                     }
                 }
-                default -> {
-                    throw new ParsingException(parser.getTokenLocation(), "Unknown key for a " + token + " in [" + currentFieldName + "].");
+                default ->  {
+                    throw new ParsingException(
+                        parser.getTokenLocation(),
+                        "Unknown key for a " + token + " in [" + currentFieldName + "].",
+                        parser.getTokenLocation()
+                    );
                 }
             }
         }
         return new FetchSourceContext(true, includes, excludes);
     }
 
-    private static List<String> parseSourceArray(XContentParser parser) throws IOException {
-        List<String> sourceArr = new ArrayList<>();
+    private static Set<String> parseSourceArray(XContentParser parser, ParseField parseField) throws IOException {
+        Set<String> sourceArr = new HashSet<>(); // include or exclude lists
         while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
             if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
                 sourceArr.add(parser.text());
-            } else {
+            }
+            else {
                 throw new ParsingException(
                     parser.getTokenLocation(),
-                    "Unknown key for a " + parser.currentToken() + " in [" + parser.currentName() + "]."
+                    "Unknown key for a " + parser.currentToken() + " in [" + parser.currentName() + "].",
+                    parser.getTokenLocation()
                 );
             }
+        }
+        if (sourceArr.isEmpty()) {
+            throw new ParsingException(
+                parser.getTokenLocation(),
+                "Expected at least one value for an array of [" + parseField.getPreferredName() + "]",
+                parser.getTokenLocation()
+            );
         }
         return sourceArr;
     }

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
@@ -51,11 +51,11 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-// ISSUE-20612 Source Validation
 /**
  * Context used to fetch the {@code _source}.
  *
@@ -92,7 +92,6 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         fetchSource = in.readBoolean();
         includes = in.readStringArray();
         excludes = in.readStringArray();
-        validateAmbiguousFields();
     }
 
     /**
@@ -170,7 +169,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 return new FetchSourceContext(true, includes, null);
             }
             case XContentParser.Token.START_ARRAY -> {
-                String[] includes = parseSourceArray(parser, INCLUDES_FIELD, null).toArray(new String[0]);
+                String[] includes = parseSourceFieldArray(parser, INCLUDES_FIELD, null).toArray(new String[0]);
                 return new FetchSourceContext(true, includes, null);
             }
             case XContentParser.Token.START_OBJECT -> {
@@ -189,8 +188,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                         + XContentParser.Token.START_OBJECT
                         + "] but found ["
                         + token
-                        + "]",
-                    parser.getTokenLocation()
+                        + "]"
                 );
             }
         }
@@ -202,6 +200,12 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         Set<String> includes = Collections.emptySet();
         Set<String> excludes = Collections.emptySet();
         String currentFieldName = null;
+        if (token != XContentParser.Token.START_OBJECT) {
+            throw new ParsingException(
+                parser.getTokenLocation(),
+                "Expected a " + XContentParser.Token.START_OBJECT + " but got a " + token + " in [" + parser.currentName() + "]."
+            );
+        }
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -210,24 +214,20 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
             if (currentFieldName == null) {
                 throw new ParsingException(
                     parser.getTokenLocation(),
-                    "Expected a field name but got a " + token + " in [" + parser.currentName() + "].",
-                    parser.getTokenLocation()
+                    "Expected a field name but got a " + token + " in [" + parser.currentName() + "]."
                 );
             }
             // process field value
             switch (token) {
                 case XContentParser.Token.START_ARRAY -> {
                     if (INCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        includes = parseSourceArray(parser, INCLUDES_FIELD, excludes);
-                    }
-                    else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        excludes = parseSourceArray(parser, EXCLUDES_FIELD, includes);
-                    }
-                    else {
+                        includes = parseSourceFieldArray(parser, INCLUDES_FIELD, excludes);
+                    } else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        excludes = parseSourceFieldArray(parser, EXCLUDES_FIELD, includes);
+                    } else {
                         throw new ParsingException(
                             parser.getTokenLocation(),
-                            "Unknown key for a " + token + " in [" + currentFieldName + "].",
-                            parser.getTokenLocation()
+                            "Unknown key for a " + token + " in [" + currentFieldName + "]."
                         );
                     }
                 }
@@ -235,18 +235,16 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                     if (INCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                         String includeEntry = parser.text();
                         if (excludes.contains(includeEntry)) {
-                            throw new OpenSearchException(AMBIGUOUS_FIELD_MESSAGE, includeEntry);
+                            throw new ParsingException(parser.getTokenLocation(), AMBIGUOUS_FIELD_MESSAGE, includeEntry);
                         }
                         includes = Collections.singleton(includeEntry);
-                    }
-                    else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    } else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                         String excludeEntry = parser.text();
                         if (includes.contains(excludeEntry)) {
-                            throw new OpenSearchException(AMBIGUOUS_FIELD_MESSAGE, excludeEntry);
+                            throw new ParsingException(parser.getTokenLocation(), AMBIGUOUS_FIELD_MESSAGE, excludeEntry);
                         }
                         excludes = Collections.singleton(excludeEntry);
-                    }
-                    else {
+                    } else {
                         throw new ParsingException(
                             parser.getTokenLocation(),
                             "Unknown key for a " + token + " in [" + currentFieldName + "]."
@@ -254,48 +252,41 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                     }
                 }
                 default -> {
-                    throw new ParsingException(
-                        parser.getTokenLocation(),
-                        "Unknown key for a " + token + " in [" + currentFieldName + "].",
-                        parser.getTokenLocation()
-                    );
+                    throw new ParsingException(parser.getTokenLocation(), "Unknown key for a " + token + " in [" + currentFieldName + "].");
                 }
             }
         }
-        if (currentFieldName == null) {
-            // no field names -> empty object; empty object is not allowed
+        if (includes.isEmpty() && excludes.isEmpty()) {
+            // no valid field names -> empty or unrecognized fields; not allowed
             throw new ParsingException(
                 parser.getTokenLocation(),
-                "Expected at least one of [" + INCLUDES_FIELD.getPreferredName() + "] or [" + EXCLUDES_FIELD.getPreferredName() + "]",
-                parser.getTokenLocation()
+                "Expected at least one of [" + INCLUDES_FIELD.getPreferredName() + "] or [" + EXCLUDES_FIELD.getPreferredName() + "]"
             );
         }
         return new FetchSourceContext(true, includes.toArray(new String[0]), excludes.toArray(new String[0]));
     }
 
-    private static Set<String> parseSourceArray(XContentParser parser, ParseField parseField, Set<String> opposite) throws IOException {
-        Set<String> sourceArr = new HashSet<>(); // include or exclude lists
+    private static Set<String> parseSourceFieldArray(XContentParser parser, ParseField parseField, Set<String> opposite)
+        throws IOException {
+        Set<String> sourceArr = new LinkedHashSet<>(); // include or exclude lists, LinkedHashSet preserves the order of fields
         while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
             if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
                 String entry = parser.text();
                 if (opposite != null && opposite.contains(entry)) {
-                    throw new OpenSearchException(AMBIGUOUS_FIELD_MESSAGE, entry);
+                    throw new ParsingException(parser.getTokenLocation(), AMBIGUOUS_FIELD_MESSAGE, entry);
                 }
                 sourceArr.add(entry);
-            }
-            else {
+            } else {
                 throw new ParsingException(
                     parser.getTokenLocation(),
-                    "Unknown key for a " + parser.currentToken() + " in [" + parser.currentName() + "].",
-                    parser.getTokenLocation()
+                    "Unknown key for a " + parser.currentToken() + " in [" + parser.currentName() + "]."
                 );
             }
         }
         if (sourceArr.isEmpty()) {
             throw new ParsingException(
                 parser.getTokenLocation(),
-                "Expected at least one value for an array of [" + parseField.getPreferredName() + "]",
-                parser.getTokenLocation()
+                "Expected at least one value for an array of [" + parseField.getPreferredName() + "]"
             );
         }
         return sourceArr;
@@ -303,14 +294,25 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        if (fetchSource) {
-            builder.startObject();
-            builder.array(INCLUDES_FIELD.getPreferredName(), includes);
-            builder.array(EXCLUDES_FIELD.getPreferredName(), excludes);
-            builder.endObject();
-        } else {
+        if (!fetchSource) {
+            // do not fetch source
             builder.value(false);
+            return builder;
         }
+        if (includes.length == 0 && excludes.length == 0) {
+            // no empty arrays
+            builder.value(true);
+            return builder;
+        }
+
+        builder.startObject();
+        if (includes.length > 0) {
+            builder.array(INCLUDES_FIELD.getPreferredName(), includes);
+        }
+        if (excludes.length > 0) {
+            builder.array(EXCLUDES_FIELD.getPreferredName(), excludes);
+        }
+        builder.endObject();
         return builder;
     }
 

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.search.fetch.subphase;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.xcontent.support.XContentMapValues;
@@ -48,6 +49,7 @@ import org.opensearch.rest.RestRequest;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -67,6 +69,9 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
 
     public static final FetchSourceContext FETCH_SOURCE = new FetchSourceContext(true);
     public static final FetchSourceContext DO_NOT_FETCH_SOURCE = new FetchSourceContext(false);
+
+    private static final String AMBIGUOUS_FIELD_MESSAGE = "The same entry [{}] cannot be both included and excluded in _source.";
+
     private final boolean fetchSource;
     private final String[] includes;
     private final String[] excludes;
@@ -76,6 +81,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         this.fetchSource = fetchSource;
         this.includes = includes == null ? Strings.EMPTY_ARRAY : includes;
         this.excludes = excludes == null ? Strings.EMPTY_ARRAY : excludes;
+        validateAmbiguousFields();
     }
 
     public FetchSourceContext(boolean fetchSource) {
@@ -86,6 +92,20 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         fetchSource = in.readBoolean();
         includes = in.readStringArray();
         excludes = in.readStringArray();
+        validateAmbiguousFields();
+    }
+
+    /**
+     * The same entry cannot be both included and excluded in _source.
+     * Since the constructors are public, this validation is required to be called in the constructor.
+     * */
+    private void validateAmbiguousFields() {
+        Set<String> includeSet = new HashSet<>(Arrays.asList(this.includes));
+        for (String exclude : this.excludes) {
+            if (includeSet.contains(exclude)) {
+                throw new OpenSearchException(AMBIGUOUS_FIELD_MESSAGE, exclude);
+            }
+        }
     }
 
     @Override
@@ -150,13 +170,13 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 return new FetchSourceContext(true, includes, null);
             }
             case XContentParser.Token.START_ARRAY -> {
-                String[] includes = parseSourceArray(parser, INCLUDES_FIELD).toArray(new String[0]);
+                String[] includes = parseSourceArray(parser, INCLUDES_FIELD, null).toArray(new String[0]);
                 return new FetchSourceContext(true, includes, null);
             }
             case XContentParser.Token.START_OBJECT -> {
                 return parseSourceObject(parser);
             }
-            default ->
+            default -> {
                 throw new ParsingException(
                     parser.getTokenLocation(),
                     "Expected one of ["
@@ -172,28 +192,36 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                         + "]",
                     parser.getTokenLocation()
                 );
+            }
         }
         // MUST never reach here
     }
 
-    private static FetchSourceContext parseSourceObject(XContentParser parser) throws IOException {
+    public static FetchSourceContext parseSourceObject(XContentParser parser) throws IOException {
         XContentParser.Token token = parser.currentToken();
-        Set<String> includes = new HashSet<>();
-        Set<String> excludes = new HashSet<>();
+        Set<String> includes = Collections.emptySet();
+        Set<String> excludes = Collections.emptySet();
         String currentFieldName = null;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
                 continue; // only field name is required in this iteration
             }
+            if (currentFieldName == null) {
+                throw new ParsingException(
+                    parser.getTokenLocation(),
+                    "Expected a field name but got a " + token + " in [" + parser.currentName() + "].",
+                    parser.getTokenLocation()
+                );
+            }
             // process field value
             switch (token) {
                 case XContentParser.Token.START_ARRAY -> {
                     if (INCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        includes = parseSourceArray(parser, INCLUDES_FIELD);
+                        includes = parseSourceArray(parser, INCLUDES_FIELD, excludes);
                     }
                     else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        excludes = parseSourceArray(parser, EXCLUDES_FIELD);
+                        excludes = parseSourceArray(parser, EXCLUDES_FIELD, includes);
                     }
                     else {
                         throw new ParsingException(
@@ -205,12 +233,18 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 }
                 case XContentParser.Token.VALUE_STRING -> {
                     if (INCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        // safe, field names are unique in objects
-                        includes.add(parser.text());
+                        String includeEntry = parser.text();
+                        if (excludes.contains(includeEntry)) {
+                            throw new OpenSearchException(AMBIGUOUS_FIELD_MESSAGE, includeEntry);
+                        }
+                        includes = Collections.singleton(includeEntry);
                     }
                     else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        // safe, field names are unique in objects
-                        excludes.add(parser.text());
+                        String excludeEntry = parser.text();
+                        if (includes.contains(excludeEntry)) {
+                            throw new OpenSearchException(AMBIGUOUS_FIELD_MESSAGE, excludeEntry);
+                        }
+                        excludes = Collections.singleton(excludeEntry);
                     }
                     else {
                         throw new ParsingException(
@@ -219,7 +253,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                         );
                     }
                 }
-                default ->  {
+                default -> {
                     throw new ParsingException(
                         parser.getTokenLocation(),
                         "Unknown key for a " + token + " in [" + currentFieldName + "].",
@@ -228,15 +262,26 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 }
             }
         }
-        // TODO: validate no intersections: retainAll vs manual loop
+        if (currentFieldName == null) {
+            // no field names -> empty object; empty object is not allowed
+            throw new ParsingException(
+                parser.getTokenLocation(),
+                "Expected at least one of [" + INCLUDES_FIELD.getPreferredName() + "] or [" + EXCLUDES_FIELD.getPreferredName() + "]",
+                parser.getTokenLocation()
+            );
+        }
         return new FetchSourceContext(true, includes.toArray(new String[0]), excludes.toArray(new String[0]));
     }
 
-    private static Set<String> parseSourceArray(XContentParser parser, ParseField parseField) throws IOException {
+    private static Set<String> parseSourceArray(XContentParser parser, ParseField parseField, Set<String> opposite) throws IOException {
         Set<String> sourceArr = new HashSet<>(); // include or exclude lists
         while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
             if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
-                sourceArr.add(parser.text());
+                String entry = parser.text();
+                if (opposite != null && opposite.contains(entry)) {
+                    throw new OpenSearchException(AMBIGUOUS_FIELD_MESSAGE, entry);
+                }
+                sourceArr.add(entry);
             }
             else {
                 throw new ParsingException(

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.search.fetch.subphase;
 
-import org.opensearch.OpenSearchException;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.logging.DeprecationLogger;
@@ -43,6 +42,7 @@ import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.common.logging.LoggerMessageFormat;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
@@ -104,7 +104,8 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         Set<String> includeSet = new HashSet<>(Arrays.asList(this.includes));
         for (String exclude : this.excludes) {
             if (includeSet.contains(exclude)) {
-                throw new OpenSearchException(AMBIGUOUS_FIELD_MESSAGE, exclude);
+                String msg = LoggerMessageFormat.format(null, AMBIGUOUS_FIELD_MESSAGE, exclude);
+                throw new IllegalArgumentException(msg);
             }
         }
     }

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
@@ -231,8 +231,8 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
 
     static FetchSourceContext parseSourceObject(XContentParser parser) throws IOException {
         XContentParser.Token token = parser.currentToken();
-        Set<String> includes = Collections.emptySet();
-        Set<String> excludes = Collections.emptySet();
+        String[] includes = Strings.EMPTY_ARRAY;
+        String[] excludes = Strings.EMPTY_ARRAY;
         String currentFieldName = null;
         if (token != XContentParser.Token.START_OBJECT) {
             throw new ParsingException(
@@ -267,9 +267,9 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 }
                 case XContentParser.Token.VALUE_STRING -> {
                     if (INCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        includes = Collections.singleton(parser.text());
+                        includes = new String[] { parser.text() };
                     } else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        excludes = Collections.singleton(parser.text());
+                        excludes = new String[] { parser.text() };
                     } else {
                         throw new ParsingException(
                             parser.getTokenLocation(),
@@ -282,7 +282,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 }
             }
         }
-        if (includes.isEmpty() && excludes.isEmpty()) {
+        if (includes.length == 0 && excludes.length == 0) {
             // no valid field names -> empty or unrecognized fields; deprecated
             deprecationLogger.deprecate(
                 "empty_source_object",
@@ -293,12 +293,12 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                     + "] or use `_source: true` to fetch the entire source."
             );
         }
-        return new FetchSourceContext(true, includes.toArray(new String[0]), excludes.toArray(new String[0]));
+        return new FetchSourceContext(true, includes, excludes);
     }
 
-    private static Set<String> parseSourceFieldArray(XContentParser parser, ParseField parseField)
+    private static String[] parseSourceFieldArray(XContentParser parser, ParseField parseField)
         throws IOException {
-        Set<String> sourceArr = new LinkedHashSet<>(); // include or exclude lists, LinkedHashSet preserves the order of fields
+        Set<String> sourceArr = new LinkedHashSet<>(); // preserves the order, removes the duplicates
         while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
             if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
                 sourceArr.add(parser.text());
@@ -315,7 +315,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 "Expected at least one value for an array of [" + parseField.getPreferredName() + "]"
             );
         }
-        return sourceArr;
+        return sourceArr.toArray(new String[0]);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
@@ -35,6 +35,7 @@ package org.opensearch.search.fetch.subphase;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.Booleans;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.ParsingException;
@@ -63,12 +64,13 @@ import java.util.function.Function;
  */
 @PublicApi(since = "1.0.0")
 public class FetchSourceContext implements Writeable, ToXContentObject {
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(FetchSourceContext.class);
 
     public static final ParseField INCLUDES_FIELD = new ParseField("includes", "include");
     public static final ParseField EXCLUDES_FIELD = new ParseField("excludes", "exclude");
 
-    public static final FetchSourceContext FETCH_SOURCE = new FetchSourceContext(true);
-    public static final FetchSourceContext DO_NOT_FETCH_SOURCE = new FetchSourceContext(false);
+    public static final FetchSourceContext FETCH_SOURCE = new FetchSourceContext(true, null, null);
+    public static final FetchSourceContext DO_NOT_FETCH_SOURCE = new FetchSourceContext(false, null, null);
 
     private static final String AMBIGUOUS_FIELD_MESSAGE = "The same entry [{}] cannot be both included and excluded in _source.";
 
@@ -162,15 +164,14 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         XContentParser.Token token = parser.currentToken();
         switch (token) {
             case XContentParser.Token.VALUE_BOOLEAN -> {
-                return new FetchSourceContext(parser.booleanValue());
+                return parser.booleanValue() ? FETCH_SOURCE : DO_NOT_FETCH_SOURCE;
             }
             case XContentParser.Token.VALUE_STRING -> {
                 String[] includes = new String[] { parser.text() };
                 return new FetchSourceContext(true, includes, null);
             }
             case XContentParser.Token.START_ARRAY -> {
-                String[] includes = parseSourceFieldArray(parser, INCLUDES_FIELD, null).toArray(new String[0]);
-                return new FetchSourceContext(true, includes, null);
+                return parseSourceArray(parser);
             }
             case XContentParser.Token.START_OBJECT -> {
                 return parseSourceObject(parser);
@@ -192,10 +193,42 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 );
             }
         }
-        // MUST never reach here
     }
 
-    public static FetchSourceContext parseSourceObject(XContentParser parser) throws IOException {
+    static FetchSourceContext parseSourceArray(XContentParser parser) throws IOException {
+        Set<String> includes = new LinkedHashSet<>();
+        if (parser.currentToken() != XContentParser.Token.START_ARRAY) {
+            throw new ParsingException(
+                parser.getTokenLocation(),
+                "Expected a "
+                    + XContentParser.Token.START_ARRAY
+                    + " but got a "
+                    + parser.currentToken()
+                    + " in ["
+                    + parser.currentName()
+                    + "]."
+            );
+        }
+        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+            if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
+                includes.add(parser.text());
+            } else {
+                throw new ParsingException(
+                    parser.getTokenLocation(),
+                    "Unknown key for a " + parser.currentToken() + " in [" + parser.currentName() + "]."
+                );
+            }
+        }
+        if (includes.isEmpty()) {
+            deprecationLogger.deprecate(
+                "empty_source_array",
+                "An empty array was provided as [_source]. Provide at least one field pattern or use `_source: true` to fetch the entire source."
+            );
+        }
+        return new FetchSourceContext(true, includes.toArray(new String[0]), null);
+    }
+
+    static FetchSourceContext parseSourceObject(XContentParser parser) throws IOException {
         XContentParser.Token token = parser.currentToken();
         Set<String> includes = Collections.emptySet();
         Set<String> excludes = Collections.emptySet();
@@ -257,10 +290,14 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
             }
         }
         if (includes.isEmpty() && excludes.isEmpty()) {
-            // no valid field names -> empty or unrecognized fields; not allowed
-            throw new ParsingException(
-                parser.getTokenLocation(),
-                "Expected at least one of [" + INCLUDES_FIELD.getPreferredName() + "] or [" + EXCLUDES_FIELD.getPreferredName() + "]"
+            // no valid field names -> empty or unrecognized fields; deprecated
+            deprecationLogger.deprecate(
+                "empty_source_object",
+                "An empty object was provided as [_source]. Provide at least one of ["
+                    + INCLUDES_FIELD.getPreferredName()
+                    + "] or ["
+                    + EXCLUDES_FIELD.getPreferredName()
+                    + "] or use `_source: true` to fetch the entire source."
             );
         }
         return new FetchSourceContext(true, includes.toArray(new String[0]), excludes.toArray(new String[0]));
@@ -284,8 +321,8 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
             }
         }
         if (sourceArr.isEmpty()) {
-            throw new ParsingException(
-                parser.getTokenLocation(),
+            deprecationLogger.deprecate(
+                "empty_source_" + parseField.getPreferredName(),
                 "Expected at least one value for an array of [" + parseField.getPreferredName() + "]"
             );
         }
@@ -294,25 +331,14 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        if (!fetchSource) {
-            // do not fetch source
-            builder.value(false);
-            return builder;
-        }
-        if (includes.length == 0 && excludes.length == 0) {
-            // no empty arrays
-            builder.value(true);
-            return builder;
-        }
-
-        builder.startObject();
-        if (includes.length > 0) {
+        if (fetchSource) {
+            builder.startObject();
             builder.array(INCLUDES_FIELD.getPreferredName(), includes);
-        }
-        if (excludes.length > 0) {
             builder.array(EXCLUDES_FIELD.getPreferredName(), excludes);
+            builder.endObject();
+        } else {
+            builder.value(false);
         }
-        builder.endObject();
         return builder;
     }
 

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
@@ -178,8 +178,8 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
 
     private static FetchSourceContext parseSourceObject(XContentParser parser) throws IOException {
         XContentParser.Token token = parser.currentToken();
-        String[] includes = Strings.EMPTY_ARRAY;
-        String[] excludes = Strings.EMPTY_ARRAY;
+        Set<String> includes = new HashSet<>();
+        Set<String> excludes = new HashSet<>();
         String currentFieldName = null;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -190,10 +190,10 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
             switch (token) {
                 case XContentParser.Token.START_ARRAY -> {
                     if (INCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        includes = parseSourceArray(parser, INCLUDES_FIELD).toArray(new String[0]);
+                        includes = parseSourceArray(parser, INCLUDES_FIELD);
                     }
                     else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        excludes = parseSourceArray(parser, EXCLUDES_FIELD).toArray(new String[0]);
+                        excludes = parseSourceArray(parser, EXCLUDES_FIELD);
                     }
                     else {
                         throw new ParsingException(
@@ -205,10 +205,12 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 }
                 case XContentParser.Token.VALUE_STRING -> {
                     if (INCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        includes = new String[]{parser.text()};
+                        // safe, field names are unique in objects
+                        includes.add(parser.text());
                     }
                     else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        excludes = new String[]{parser.text()};
+                        // safe, field names are unique in objects
+                        excludes.add(parser.text());
                     }
                     else {
                         throw new ParsingException(
@@ -226,7 +228,8 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 }
             }
         }
-        return new FetchSourceContext(true, includes, excludes);
+        // TODO: validate no intersections: retainAll vs manual loop
+        return new FetchSourceContext(true, includes.toArray(new String[0]), excludes.toArray(new String[0]));
     }
 
     private static Set<String> parseSourceArray(XContentParser parser, ParseField parseField) throws IOException {

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
@@ -255,9 +255,9 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
             switch (token) {
                 case XContentParser.Token.START_ARRAY -> {
                     if (INCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        includes = parseSourceFieldArray(parser, INCLUDES_FIELD, excludes);
+                        includes = parseSourceFieldArray(parser, INCLUDES_FIELD);
                     } else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        excludes = parseSourceFieldArray(parser, EXCLUDES_FIELD, includes);
+                        excludes = parseSourceFieldArray(parser, EXCLUDES_FIELD);
                     } else {
                         throw new ParsingException(
                             parser.getTokenLocation(),
@@ -267,17 +267,9 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 }
                 case XContentParser.Token.VALUE_STRING -> {
                     if (INCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        String includeEntry = parser.text();
-                        if (excludes.contains(includeEntry)) {
-                            throw new ParsingException(parser.getTokenLocation(), AMBIGUOUS_FIELD_MESSAGE, includeEntry);
-                        }
-                        includes = Collections.singleton(includeEntry);
+                        includes = Collections.singleton(parser.text());
                     } else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        String excludeEntry = parser.text();
-                        if (includes.contains(excludeEntry)) {
-                            throw new ParsingException(parser.getTokenLocation(), AMBIGUOUS_FIELD_MESSAGE, excludeEntry);
-                        }
-                        excludes = Collections.singleton(excludeEntry);
+                        excludes = Collections.singleton(parser.text());
                     } else {
                         throw new ParsingException(
                             parser.getTokenLocation(),
@@ -304,16 +296,12 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         return new FetchSourceContext(true, includes.toArray(new String[0]), excludes.toArray(new String[0]));
     }
 
-    private static Set<String> parseSourceFieldArray(XContentParser parser, ParseField parseField, Set<String> opposite)
+    private static Set<String> parseSourceFieldArray(XContentParser parser, ParseField parseField)
         throws IOException {
         Set<String> sourceArr = new LinkedHashSet<>(); // include or exclude lists, LinkedHashSet preserves the order of fields
         while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
             if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
-                String entry = parser.text();
-                if (opposite != null && opposite.contains(entry)) {
-                    throw new ParsingException(parser.getTokenLocation(), AMBIGUOUS_FIELD_MESSAGE, entry);
-                }
-                sourceArr.add(entry);
+                sourceArr.add(parser.text());
             } else {
                 throw new ParsingException(
                     parser.getTokenLocation(),

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
@@ -331,14 +331,25 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        if (fetchSource) {
-            builder.startObject();
-            builder.array(INCLUDES_FIELD.getPreferredName(), includes);
-            builder.array(EXCLUDES_FIELD.getPreferredName(), excludes);
-            builder.endObject();
-        } else {
+        if (!fetchSource) {
+            // do not fetch source
             builder.value(false);
+            return builder;
         }
+        if (includes.length == 0 && excludes.length == 0) {
+            // no empty arrays
+            builder.value(true);
+            return builder;
+        }
+
+        builder.startObject();
+        if (includes.length > 0) {
+            builder.array(INCLUDES_FIELD.getPreferredName(), includes);
+        }
+        if (excludes.length > 0) {
+            builder.array(EXCLUDES_FIELD.getPreferredName(), excludes);
+        }
+        builder.endObject();
         return builder;
     }
 

--- a/server/src/test/java/org/opensearch/search/fetch/subphase/FetchSourceContextTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/subphase/FetchSourceContextTests.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.search.fetch.subphase;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.memory.MemoryIndex;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.fetch.FetchContext;
+import org.opensearch.search.fetch.FetchSubPhase.HitContext;
+import org.opensearch.search.fetch.FetchSubPhaseProcessor;
+import org.opensearch.search.lookup.SourceLookup;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FetchSourceContextTests extends OpenSearchTestCase {
+
+    public void testFetchSource() throws IOException {
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("field", "value").endObject();
+        FetchSourceContext.fromXContent(source);
+    }
+
+}

--- a/server/src/test/java/org/opensearch/search/fetch/subphase/FetchSourceContextTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/subphase/FetchSourceContextTests.java
@@ -79,14 +79,14 @@ public class FetchSourceContextTests extends OpenSearchTestCase {
         assertEquals(0, result.excludes().length);
     }
 
-    public void testFetchSourceExplicitEmptyArrayNotAllowed() throws IOException {
+    public void testFetchSourceAsArrayAssertWarningExplicitEmptyArray() throws IOException {
         final XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("_source").startArray().endArray().endObject();
         final XContentParser parser = createSourceParser(source);
 
-        ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
-        assertEquals(
-            "Expected at least one value for an array of [" + FetchSourceContext.INCLUDES_FIELD.getPreferredName() + "]",
-            result.getMessage()
+        FetchSourceContext result = FetchSourceContext.fromXContent(parser);
+        assertTrue(result.fetchSource());
+        assertWarnings(
+            "An empty array was provided as [_source]. Provide at least one field pattern or use `_source: true` to fetch the entire source."
         );
     }
 
@@ -134,63 +134,58 @@ public class FetchSourceContextTests extends OpenSearchTestCase {
         assertTrue(Arrays.asList(result.excludes()).containsAll(Arrays.asList("aaa", "bbb")));
     }
 
-    public void testFetchSourceObjectEmptyObjectNotAllowed() throws IOException {
+    public void testFetchSourceAssertWarningEmptyObject() throws IOException {
         final XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("_source").startObject().endObject().endObject();
         final XContentParser parser = createSourceParser(source);
 
-        ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
-        assertEquals(
-            "Expected at least one of ["
+        FetchSourceContext result = FetchSourceContext.fromXContent(parser);
+        assertTrue(result.fetchSource());
+        assertWarnings(
+            "An empty object was provided as [_source]. Provide at least one of ["
                 + FetchSourceContext.INCLUDES_FIELD.getPreferredName()
                 + "] or ["
                 + FetchSourceContext.EXCLUDES_FIELD.getPreferredName()
-                + "]",
-            result.getMessage()
+                + "] or use `_source: true` to fetch the entire source."
         );
     }
 
-    public void testFetchSourceObjectExplicitEmptyArraysNotAllowed() throws IOException {
-        {
-            final XContentBuilder source = XContentFactory.jsonBuilder()
-                .startObject()
-                .field("_source")
-                .startObject()
-                .field("includes", "include1")
-                .field("excludes")
-                .startArray()
-                .endArray()
-                .endObject()
-                .endObject();
-            final XContentParser parser = createSourceParser(source);
+    public void testFetchSourceObjectAssertWarningExplicitEmptyExcludes() throws IOException {
+        final XContentBuilder source = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("_source")
+            .startObject()
+            .field("includes", "include1")
+            .field("excludes")
+            .startArray()
+            .endArray()
+            .endObject()
+            .endObject();
+        final XContentParser parser = createSourceParser(source);
 
-            ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
-            assertEquals(
-                "Expected at least one value for an array of [" + FetchSourceContext.EXCLUDES_FIELD.getPreferredName() + "]",
-                result.getMessage()
-            );
-        }
-        {
-            final XContentBuilder source = XContentFactory.jsonBuilder()
-                .startObject()
-                .field("_source")
-                .startObject()
-                .field("excludes")
-                .startArray()
-                .value("exclude1")
-                .endArray()
-                .field("includes")
-                .startArray()
-                .endArray()
-                .endObject()
-                .endObject();
-            final XContentParser parser = createSourceParser(source);
+        FetchSourceContext result = FetchSourceContext.fromXContent(parser);
+        assertTrue(result.fetchSource());
+        assertWarnings("Expected at least one value for an array of [" + FetchSourceContext.EXCLUDES_FIELD.getPreferredName() + "]");
+    }
 
-            ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
-            assertEquals(
-                "Expected at least one value for an array of [" + FetchSourceContext.INCLUDES_FIELD.getPreferredName() + "]",
-                result.getMessage()
-            );
-        }
+    public void testFetchSourceObjectAssertWarningExplicitEmptyIncludes() throws IOException {
+        final XContentBuilder source = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("_source")
+            .startObject()
+            .field("excludes")
+            .startArray()
+            .value("exclude1")
+            .endArray()
+            .field("includes")
+            .startArray()
+            .endArray()
+            .endObject()
+            .endObject();
+        final XContentParser parser = createSourceParser(source);
+
+        FetchSourceContext result = FetchSourceContext.fromXContent(parser);
+        assertTrue(result.fetchSource());
+        assertWarnings("Expected at least one value for an array of [" + FetchSourceContext.INCLUDES_FIELD.getPreferredName() + "]");
     }
 
     public void testFetchSourceAsObjectConflictingEntries() throws IOException {
@@ -276,7 +271,10 @@ public class FetchSourceContextTests extends OpenSearchTestCase {
         final XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("_source", true).endObject();
         final XContentParser parser = createSourceParser(source);
 
-        ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.parseSourceObject(parser));
-        assertEquals("Expected a START_OBJECT but got a VALUE_BOOLEAN in [_source].", result.getMessage());
+        ParsingException invalidObject = expectThrows(ParsingException.class, () -> FetchSourceContext.parseSourceObject(parser));
+        assertEquals("Expected a START_OBJECT but got a VALUE_BOOLEAN in [_source].", invalidObject.getMessage());
+
+        ParsingException invalidArray = expectThrows(ParsingException.class, () -> FetchSourceContext.parseSourceArray(parser));
+        assertEquals("Expected a START_ARRAY but got a VALUE_BOOLEAN in [_source].", invalidArray.getMessage());
     }
 }

--- a/server/src/test/java/org/opensearch/search/fetch/subphase/FetchSourceContextTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/subphase/FetchSourceContextTests.java
@@ -13,31 +13,270 @@
 
 package org.opensearch.search.fetch.subphase;
 
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.memory.MemoryIndex;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.core.common.Strings;
-import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.ParsingException;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.search.SearchHit;
-import org.opensearch.search.fetch.FetchContext;
-import org.opensearch.search.fetch.FetchSubPhase.HitContext;
-import org.opensearch.search.fetch.FetchSubPhaseProcessor;
-import org.opensearch.search.lookup.SourceLookup;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import java.util.Arrays;
 
 public class FetchSourceContextTests extends OpenSearchTestCase {
 
-    public void testFetchSource() throws IOException {
-        XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("field", "value").endObject();
-        FetchSourceContext.fromXContent(source);
+    private XContentParser createSourceParser(XContentBuilder source) throws IOException {
+        XContentParser parser = createParser(source);
+        parser.nextToken(); // move to start object
+        parser.nextToken(); // move to field name "_source"
+        parser.nextToken(); // move to _source value to parse
+        return parser;
     }
 
+    public void testFetchSource() throws IOException {
+        final XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("_source", true).endObject();
+        final XContentParser parser = createSourceParser(source);
+
+        FetchSourceContext result = FetchSourceContext.fromXContent(parser);
+        assertEquals(FetchSourceContext.FETCH_SOURCE, result);
+    }
+
+    public void testDoNotFetchSource() throws IOException {
+        final XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("_source", false).endObject();
+        final XContentParser parser = createSourceParser(source);
+
+        FetchSourceContext result = FetchSourceContext.fromXContent(parser);
+        assertEquals(FetchSourceContext.DO_NOT_FETCH_SOURCE, result);
+    }
+
+    public void testFetchSourceString() throws IOException {
+        final XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("_source", "include1").endObject();
+        final XContentParser parser = createSourceParser(source);
+
+        FetchSourceContext result = FetchSourceContext.fromXContent(parser);
+        assertTrue(result.fetchSource()); // fetch source
+        assertArrayEquals(new String[] { "include1" }, result.includes()); // single include
+        assertEquals(0, result.excludes().length); // no excludes
+    }
+
+    public void testFetchSourceArray() throws IOException {
+        final XContentBuilder source = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("_source")
+            .startArray()
+            .value("include1")
+            .value("include2")
+            .value("include2")
+            .endArray()
+            .endObject();
+        final XContentParser parser = createSourceParser(source);
+
+        FetchSourceContext result = FetchSourceContext.fromXContent(parser);
+        assertTrue(result.fetchSource()); // fetch source
+        // validate includes
+        assertEquals(2, result.includes().length); // no duplicates
+        assertTrue(Arrays.asList(result.includes()).containsAll(Arrays.asList("include1", "include2")));
+        // validate no excludes
+        assertEquals(0, result.excludes().length);
+    }
+
+    public void testFetchSourceExplicitEmptyArrayNotAllowed() throws IOException {
+        final XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("_source").startArray().endArray().endObject();
+        final XContentParser parser = createSourceParser(source);
+
+        ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
+        assertEquals(
+            "Expected at least one value for an array of [" + FetchSourceContext.INCLUDES_FIELD.getPreferredName() + "]",
+            result.getMessage()
+        );
+    }
+
+    public void testFetchSourceAsObject() throws IOException {
+        final XContentBuilder source = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("_source")
+            .startObject()
+            .field("includes", "include1")
+            .field("excludes", "exclude1")
+            .endObject()
+            .endObject();
+        final XContentParser parser = createSourceParser(source);
+
+        FetchSourceContext result = FetchSourceContext.fromXContent(parser);
+        assertTrue(result.fetchSource()); // fetch source
+        assertArrayEquals(new String[] { "include1" }, result.includes()); // single include
+        assertArrayEquals(new String[] { "exclude1" }, result.excludes()); // single exclude
+    }
+
+    public void testFetchSourceAsObjectBothIncludeAndExcludeArrays() throws IOException {
+        final XContentBuilder source = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("_source")
+            .startObject()
+            .field("includes")
+            .startArray()
+            .value("iii")
+            .endArray()
+            .field("excludes")
+            .startArray()
+            .value("aaa")
+            .value("bbb")
+            .endArray()
+            .endObject()
+            .endObject();
+        final XContentParser parser = createSourceParser(source);
+
+        FetchSourceContext result = FetchSourceContext.fromXContent(parser);
+        assertTrue(result.fetchSource());
+        // validate includes
+        assertArrayEquals(new String[] { "iii" }, result.includes());
+        // validate excludes
+        assertEquals(2, result.excludes().length); // no duplicates
+        assertTrue(Arrays.asList(result.excludes()).containsAll(Arrays.asList("aaa", "bbb")));
+    }
+
+    public void testFetchSourceObjectEmptyObjectNotAllowed() throws IOException {
+        final XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("_source").startObject().endObject().endObject();
+        final XContentParser parser = createSourceParser(source);
+
+        ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
+        assertEquals(
+            "Expected at least one of ["
+                + FetchSourceContext.INCLUDES_FIELD.getPreferredName()
+                + "] or ["
+                + FetchSourceContext.EXCLUDES_FIELD.getPreferredName()
+                + "]",
+            result.getMessage()
+        );
+    }
+
+    public void testFetchSourceObjectExplicitEmptyArraysNotAllowed() throws IOException {
+        {
+            final XContentBuilder source = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("_source")
+                .startObject()
+                .field("includes", "include1")
+                .field("excludes")
+                .startArray()
+                .endArray()
+                .endObject()
+                .endObject();
+            final XContentParser parser = createSourceParser(source);
+
+            ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
+            assertEquals(
+                "Expected at least one value for an array of [" + FetchSourceContext.EXCLUDES_FIELD.getPreferredName() + "]",
+                result.getMessage()
+            );
+        }
+        {
+            final XContentBuilder source = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("_source")
+                .startObject()
+                .field("excludes")
+                .startArray()
+                .value("exclude1")
+                .endArray()
+                .field("includes")
+                .startArray()
+                .endArray()
+                .endObject()
+                .endObject();
+            final XContentParser parser = createSourceParser(source);
+
+            ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
+            assertEquals(
+                "Expected at least one value for an array of [" + FetchSourceContext.INCLUDES_FIELD.getPreferredName() + "]",
+                result.getMessage()
+            );
+        }
+    }
+
+    public void testFetchSourceAsObjectConflictingEntries() throws IOException {
+        {
+            final XContentBuilder source = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("_source")
+                .startObject()
+                .field("includes")
+                .value("AAA")
+                .field("excludes")
+                .value("AAA")
+                .endObject()
+                .endObject();
+            final XContentParser parser = createSourceParser(source);
+
+            ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
+            assertEquals("The same entry [AAA] cannot be both included and excluded in _source.", result.getMessage());
+        }
+        {
+            final XContentBuilder source = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("_source")
+                .startObject()
+                .field("includes")
+                .value("AAA")
+                .field("excludes")
+                .startArray()
+                .value("AAA")
+                .value("BBB")
+                .endArray()
+                .endObject()
+                .endObject();
+            final XContentParser parser = createSourceParser(source);
+
+            ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
+            assertEquals("The same entry [AAA] cannot be both included and excluded in _source.", result.getMessage());
+        }
+        {
+            final XContentBuilder source = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("_source")
+                .startObject()
+                .field("includes")
+                .startArray()
+                .value("AAA")
+                .value("BBB")
+                .endArray()
+                .field("excludes")
+                .value("AAA")
+                .endObject()
+                .endObject();
+            final XContentParser parser = createSourceParser(source);
+
+            ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
+            assertEquals("The same entry [AAA] cannot be both included and excluded in _source.", result.getMessage());
+        }
+        {
+            final XContentBuilder source = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("_source")
+                .startObject()
+                .field("includes")
+                .startArray()
+                .value("AAA")
+                .value("BBB")
+                .endArray()
+                .field("excludes")
+                .startArray()
+                .value("BBB")
+                .value("CCC")
+                .endArray()
+                .endObject()
+                .endObject();
+            final XContentParser parser = createSourceParser(source);
+
+            ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
+            assertEquals("The same entry [BBB] cannot be both included and excluded in _source.", result.getMessage());
+        }
+    }
+
+    public void testParseSourceObjectInvalidInput() throws IOException {
+        final XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("_source", true).endObject();
+        final XContentParser parser = createSourceParser(source);
+
+        ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.parseSourceObject(parser));
+        assertEquals("Expected a START_OBJECT but got a VALUE_BOOLEAN in [_source].", result.getMessage());
+    }
 }

--- a/server/src/test/java/org/opensearch/search/fetch/subphase/FetchSourceContextTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/subphase/FetchSourceContextTests.java
@@ -202,7 +202,7 @@ public class FetchSourceContextTests extends OpenSearchTestCase {
                 .endObject();
             final XContentParser parser = createSourceParser(source);
 
-            ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
+            IllegalArgumentException result = expectThrows(IllegalArgumentException.class, () -> FetchSourceContext.fromXContent(parser));
             assertEquals("The same entry [AAA] cannot be both included and excluded in _source.", result.getMessage());
         }
         {
@@ -221,7 +221,7 @@ public class FetchSourceContextTests extends OpenSearchTestCase {
                 .endObject();
             final XContentParser parser = createSourceParser(source);
 
-            ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
+            IllegalArgumentException result = expectThrows(IllegalArgumentException.class, () -> FetchSourceContext.fromXContent(parser));
             assertEquals("The same entry [AAA] cannot be both included and excluded in _source.", result.getMessage());
         }
         {
@@ -240,7 +240,7 @@ public class FetchSourceContextTests extends OpenSearchTestCase {
                 .endObject();
             final XContentParser parser = createSourceParser(source);
 
-            ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
+            IllegalArgumentException result = expectThrows(IllegalArgumentException.class, () -> FetchSourceContext.fromXContent(parser));
             assertEquals("The same entry [AAA] cannot be both included and excluded in _source.", result.getMessage());
         }
         {
@@ -262,7 +262,7 @@ public class FetchSourceContextTests extends OpenSearchTestCase {
                 .endObject();
             final XContentParser parser = createSourceParser(source);
 
-            ParsingException result = expectThrows(ParsingException.class, () -> FetchSourceContext.fromXContent(parser));
+            IllegalArgumentException result = expectThrows(IllegalArgumentException.class, () -> FetchSourceContext.fromXContent(parser));
             assertEquals("The same entry [BBB] cannot be both included and excluded in _source.", result.getMessage());
         }
     }


### PR DESCRIPTION
### Description
**Validation** of the `_source` object added to avoid confusion and reject contradicting requests:
- `"_source": { "includes": "text", "excludes": ["title", "text"] }` The `text` field is defined in both `includes` and `excludes`. Contradiction. 🚫

**Deprecation** logs added for ambiguous requests:
- `"_source": {}`  At lease one of `includes` or `excludes` shall be defined.  
- `"_source": []` Explicitly defined empty array of `includes` is ambiguous.
- `"_source": { "includes": [], "excludes": ["title"] }` or `_source: { "includes": ["title"], "excludes": [] }` Explicitly defined empty array of `excludes` or `includes` is ambiguous.

To include the whole `_source` object or to exclude it completely, **the existing** `boolean` logic is encouraged.
`"_source": true` and `"_source": false`

Unit tests and [yml tests](https://github.com/opensearch-project/OpenSearch/blob/main/rest-api-spec/src/main/resources/rest-api-spec/test/README.md) added to test behaviour of parsing implementation. 
Existing tests have been extended.  

Follow-up to Pull Request https://github.com/opensearch-project/OpenSearch/pull/21086

### Related Issues
Resolves #20612

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
