### PR TITLE
Fix per-query search latency due to schema inference and file listing overhead in DataFusion engine

### DIFF
--- a/plugins/engine-datafusion/jni/src/eviction_policy.rs
+++ b/plugins/engine-datafusion/jni/src/eviction_policy.rs
@@ -126,7 +126,7 @@ impl CachePolicy for LruPolicy {
     }
 
     fn select_for_eviction(&self, target_size: usize) -> Vec<String> {
-        println!("info seleectpon");
+        // println!("info seleectpon");
         if target_size == 0 {
             return Vec::new();
         }

--- a/plugins/engine-datafusion/jni/src/lib.rs
+++ b/plugins/engine-datafusion/jni/src/lib.rs
@@ -21,6 +21,7 @@ use std::sync::{Arc, OnceLock};
 use arrow_array::{Array, RecordBatch, StructArray};
 use arrow_array::ffi::FFI_ArrowArray;
 use arrow_schema::ffi::FFI_ArrowSchema;
+use arrow_schema::SchemaRef;
 use datafusion::{
     common::DataFusionError,
     datasource::listing::ListingTableUrl,
@@ -544,7 +545,16 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_createDat
         }
     };
 
-    let shard_view = ShardView::new(table_url, files_metadata);
+    let mut shard_view = ShardView::new(table_url, files_metadata);
+
+    if let Some(first_meta) = shard_view.files_metadata().first() {
+        let file_path = format!("/{}", first_meta.object_meta.location.as_ref().trim_start_matches('/'));
+        if let Ok(file) = std::fs::File::open(&file_path) {
+            if let Ok(builder) = datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file) {
+                shard_view.set_cached_schema(builder.schema().clone());
+            }
+        }
+    }
 
     Box::into_raw(Box::new(shard_view)) as jlong
 }
@@ -572,6 +582,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_destroyTo
 pub struct ShardView {
     table_path: ListingTableUrl,
     files_metadata: Arc<Vec<CustomFileMeta>>,
+    cached_schema: Option<SchemaRef>,
 }
 
 impl ShardView {
@@ -580,6 +591,7 @@ impl ShardView {
         ShardView {
             table_path,
             files_metadata,
+            cached_schema: None,
         }
     }
 
@@ -589,6 +601,14 @@ impl ShardView {
 
     pub fn files_metadata(&self) -> Arc<Vec<CustomFileMeta>> {
         self.files_metadata.clone()
+    }
+
+    pub fn cached_schema(&self) -> Option<SchemaRef> {
+        self.cached_schema.clone()
+    }
+
+    pub fn set_cached_schema(&mut self, schema: SchemaRef) {
+        self.cached_schema = Some(schema);
     }
 }
 
@@ -712,6 +732,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeQu
 
     let table_path = shard_view.table_path();
     let files_meta = shard_view.files_metadata();
+    let cached_schema = shard_view.cached_schema();
 
     spawn_jni_task(
         &io_runtime,
@@ -726,6 +747,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeQu
             target_partitions,
             runtime,
             cpu_executor,
+            cached_schema,
         )),
         |env, listener_ref, stream_pointer| set_action_listener_ok_global(env, listener_ref, stream_pointer),
     );
@@ -887,6 +909,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeFe
 
     let table_path = shard_view.table_path();
     let files_metadata = shard_view.files_metadata();
+    let cached_schema = shard_view.cached_schema();
 
     let include_fields: Vec<String> =
         parse_string_arr(&mut env, include_fields).expect("Expected list of files");
@@ -950,6 +973,7 @@ pub extern "system" fn Java_org_opensearch_datafusion_jni_NativeBridge_executeFe
             exclude_fields,
             runtime,
             cpu_executor,
+            cached_schema,
         ).await {
             Ok(stream_ptr) => stream_ptr,
             Err(e) => {

--- a/plugins/engine-datafusion/jni/src/listing_table.rs
+++ b/plugins/engine-datafusion/jni/src/listing_table.rs
@@ -1425,37 +1425,62 @@ impl ListingTable {
         } else {
             return Ok((vec![], Statistics::new_unknown(&self.file_schema)));
         };
-        // list files (with partitions)
-        let table_partition_cols: Vec<(String, DataType)> = vec![]; // Passing empty partition cols as current partition cols are not mapped to directory path
-        let file_list = future::try_join_all(self.table_paths.iter().map(|table_path| {
-            pruned_partition_list(
-                ctx,
-                store.as_ref(),
-                table_path,
-                filters,
-                &self.options.file_extension,
-                &table_partition_cols,
-            )
-        }))
-        .await?;
-        let meta_fetch_concurrency = ctx.config_options().execution.meta_fetch_concurrency;
-        let file_list = stream::iter(file_list).flatten_unordered(meta_fetch_concurrency);
-        // collect the statistics if required by the config
-        let files = file_list
-            .map(|part_file| async {
-                let part_file = part_file?;
-                let statistics = if self.options.collect_stat {
-                    self.do_collect_statistics(ctx, &store, &part_file).await?
-                } else {
-                    Arc::new(Statistics::new_unknown(&self.file_schema))
-                };
-                Ok(part_file.with_statistics(statistics))
-            })
-            .boxed()
-            .buffer_unordered(ctx.config_options().execution.meta_fetch_concurrency);
 
-        let (file_group, inexact_stats) =
-            get_files_with_limit(files, limit, self.options.collect_stat).await?;
+        // build PartitionedFiles directly from pre-cached files_metadata,
+        // avoiding expensive object store LIST calls via pruned_partition_list
+        let (file_group, inexact_stats) = if !self.options.files_metadata.is_empty() {
+            let mut files = Vec::with_capacity(self.options.files_metadata.len());
+            for meta in self.options.files_metadata.iter() {
+                let part_file = PartitionedFile {
+                    object_meta: (*meta.object_meta).clone(),
+                    partition_values: vec![],
+                    range: None,
+                    statistics: None,
+                    extensions: None,
+                    metadata_size_hint: None,
+                };
+                if self.options.collect_stat {
+                    let statistics = self.do_collect_statistics(ctx, &store, &part_file).await?;
+                    files.push(part_file.with_statistics(statistics));
+                } else {
+                    files.push(part_file);
+                }
+            }
+            get_files_with_limit(
+                stream::iter(files.into_iter().map(Ok)),
+                limit,
+                self.options.collect_stat,
+            ).await?
+        } else {
+            let table_partition_cols: Vec<(String, DataType)> = vec![];
+            let file_list = future::try_join_all(self.table_paths.iter().map(|table_path| {
+                pruned_partition_list(
+                    ctx,
+                    store.as_ref(),
+                    table_path,
+                    filters,
+                    &self.options.file_extension,
+                    &table_partition_cols,
+                )
+            }))
+            .await?;
+            let meta_fetch_concurrency = ctx.config_options().execution.meta_fetch_concurrency;
+            let file_list = stream::iter(file_list).flatten_unordered(meta_fetch_concurrency);
+            let files = file_list
+                .map(|part_file| async {
+                    let part_file = part_file?;
+                    let statistics = if self.options.collect_stat {
+                        self.do_collect_statistics(ctx, &store, &part_file).await?
+                    } else {
+                        Arc::new(Statistics::new_unknown(&self.file_schema))
+                    };
+                    Ok(part_file.with_statistics(statistics))
+                })
+                .boxed()
+                .buffer_unordered(ctx.config_options().execution.meta_fetch_concurrency);
+
+            get_files_with_limit(files, limit, self.options.collect_stat).await?
+        };
 
         let file_groups = file_group.split_files(self.options.target_partitions);
         let (mut file_groups, mut stats) = compute_all_files_statistics(

--- a/plugins/engine-datafusion/jni/src/query_executor.rs
+++ b/plugins/engine-datafusion/jni/src/query_executor.rs
@@ -113,6 +113,7 @@ pub async fn execute_query_with_cross_rt_stream(
     target_partitions: usize,
     runtime: &DataFusionRuntime,
     cpu_executor: DedicatedExecutor,
+    cached_schema: Option<SchemaRef>,
 ) -> Result<jlong, DataFusionError> {
     let object_meta: Arc<Vec<ObjectMeta>> = Arc::new(
         files_meta
@@ -137,7 +138,7 @@ pub async fn execute_query_with_cross_rt_stream(
                 .with_file_metadata_cache(Some(runtimeEnv.cache_manager.get_file_metadata_cache()))
                 .with_files_statistics_cache(runtimeEnv.cache_manager.get_file_statistic_cache()),
         )
-        .with_metadata_cache_limit(250 * 1024 * 1024) // 250 MB
+        .with_metadata_cache_limit(runtimeEnv.cache_manager.get_file_metadata_cache().cache_limit())
         .build() {
         Ok(env) => env,
         Err(e) => {
@@ -147,7 +148,8 @@ pub async fn execute_query_with_cross_rt_stream(
     };
 
     let mut config = SessionConfig::new();
-    config.options_mut().execution.parquet.pushdown_filters = false;
+    config.options_mut().execution.parquet.pushdown_filters = true;
+    config.options_mut().execution.parquet.reorder_filters = true;
     config.options_mut().execution.target_partitions = 4;
     config.options_mut().execution.batch_size = 8192;
 
@@ -173,13 +175,16 @@ pub async fn execute_query_with_cross_rt_stream(
         // the AbsoluteRowIdOptimizer to convert relative row IDs to absolute ones
         .with_table_partition_cols(vec![(ROW_BASE_FIELD_NAME.to_string(), DataType::Int64)]);
 
-    let resolved_schema = match listing_options
-        .infer_schema(&ctx.state(), &table_path)
-        .await {
-        Ok(schema) => schema,
-        Err(e) => {
-            error!("Failed to infer schema: {}", e);
-            return Err(e);
+    let resolved_schema = match cached_schema {
+        Some(schema) => schema,
+        None => {
+            match listing_options.infer_schema(&ctx.state(), &table_path).await {
+                Ok(schema) => schema,
+                Err(e) => {
+                    error!("Failed to infer schema: {}", e);
+                    return Err(e);
+                }
+            }
         }
     };
 
@@ -188,7 +193,10 @@ pub async fn execute_query_with_cross_rt_stream(
         .with_schema(resolved_schema);
 
     let provider = match ListingTable::try_new(table_config) {
-        Ok(table) => Arc::new(table),
+        Ok(table) => {
+            let table = table.with_cache(runtimeEnv.cache_manager.get_file_statistic_cache());
+            Arc::new(table)
+        },
         Err(e) => {
             error!("Failed to create listing table: {}", e);
             return Err(e);
@@ -199,7 +207,7 @@ pub async fn execute_query_with_cross_rt_stream(
         error!("Failed to register table: {}", e);
         return Err(e);
     }
-
+    
     // Decode substrait
     let substrait_plan = match Plan::decode(plan_bytes_vec.as_slice()) {
         Ok(plan) => plan,
@@ -352,6 +360,7 @@ pub async fn execute_fetch_phase(
     exclude_fields: Vec<String>,
     runtime: &DataFusionRuntime,
     cpu_executor: DedicatedExecutor,
+    cached_schema: Option<SchemaRef>,
 ) -> Result<jlong, DataFusionError> {
     // Create optimized Parquet access plans for targeted row retrieval
     // This converts absolute row IDs back to file-relative positions and creates
@@ -396,7 +405,10 @@ pub async fn execute_fetch_phase(
     let file_format = ParquetFormat::new();
     let listing_options = ListingOptions::new(Arc::new(file_format)).with_file_extension(".parquet").with_collect_stat(true);
 
-    let parquet_schema = listing_options.infer_schema(&ctx.state(), &table_path).await?;
+    let parquet_schema = match cached_schema {
+        Some(schema) => schema,
+        None => listing_options.infer_schema(&ctx.state(), &table_path).await?,
+    };
     let projections = create_projections(include_fields, exclude_fields, parquet_schema.clone());
 
     let partitioned_files: Vec<PartitionedFile> = files_metadata


### PR DESCRIPTION
### Problem

Every query was rebuilding the entire DataFusion execution context from scratch — inferring schema from all parquet files, listing files from the object store, and collecting statistics per file. With ~1900 parquet files per shard, query planning alone took 60-76 seconds before any data was scanned.

Root causes identified:

<img width="1728" height="951" alt="Screenshot 2026-04-11 at 1 47 17 PM" src="https://github.com/user-attachments/assets/35d2b403-49c5-4878-83e0-f15bfc8065c6" />

- `infer_schema` called `list_all_files()` + read parquet metadata from every file on every query
- `list_files_for_scan` called `pruned_partition_list` to re-discover files from the object store, even though `files_metadata` already had all the file info
- Metadata cache was sized at 250MB but ~1900 files needed ~2.3GB, causing 95% cache miss rate (constant evict/re-read thrashing)
-  Fresh Statistics Cache was being initialized at every query time.
- `ListingTable` was not using the shared `CustomStatisticsCache` from the runtime

### Changes

**`lib.rs`** — Cache parquet schema on `ShardView` at shard creation time. Read schema once from the first parquet file and reuse it on every query, eliminating per-query `infer_schema`.

**`listing_table.rs`** — Add fast path in `list_files_for_scan`: when `files_metadata` is available (set at shard creation), build `PartitionedFile`s directly instead of calling `pruned_partition_list` which does object store LIST + string matching on every file path.

**`query_executor.rs`** — Use cached schema when available, increase metadata cache limit from 250MB to 4GB, enable predicate pushdown (`pushdown_filters = true`, `reorder_filters = true`), pass shared `CustomStatisticsCache` to `ListingTable` via `with_cache()`.

**`eviction_policy.rs`** — Minor formatting fix.

### Results (ClickBench, ~100M rows, 3 shards)

| Query | Before | After |
|-------|--------|-------|
| q01 (count) | 56-76s | 23ms |
| q02 (filter+count) | 62-69s | 73ms |
| q07 (min/max) | 65-73s | 27ms |
| q05 (distinct) | 68-76s | 249ms |
| q16 (group by + sort) | 70s | 2.2s |
| Rust query setup | 60-170s | 2-3ms |

### Testing

Tested on EC2 with ClickBench (~100M rows, ~1900 files per shard). Verified schema caching, fast path activation, and metadata cache hit rates via diagnostic logging (removed before final commit).
