### PR TITLE
Update README: add analytics-engine to installedPlugins

### DIFF
--- a/plugins/engine-datafusion/README.md
+++ b/plugins/engine-datafusion/README.md
@@ -13,7 +13,7 @@
 ```
 4. Run opensearch with following parameters
 ```
- ./gradlew run --preserve-data -PremotePlugins="['org.opensearch.plugin:opensearch-job-scheduler:3.3.0.0', 'org.opensearch.plugin:opensearch-sql-plugin:3.3.0.0']" -PinstalledPlugins="['engine-datafusion']" -Dbuild.snapshot=false --debug-jvm
+./gradlew run --preserve-data -PremotePlugins="['org.opensearch.plugin:opensearch-job-scheduler:3.3.0.0', 'org.opensearch.plugin:opensearch-sql-plugin:3.3.0.0']" -PinstalledPlugins="['analytics-engine', 'engine-datafusion']" -Dbuild.snapshot=false --debug-jvm
 ```
 
 


### PR DESCRIPTION
### Description

Update the engine-datafusion README run command to include `analytics-engine` in `installedPlugins`. The `engine-datafusion` plugin now depends on `analytics-engine` via `extendedPlugins`, so it must be installed alongside it for the local development server to start.
