### PR TITLE
Extended UT Framework for E2E Query conversion

### DIFF
--- a/sandbox/plugins/dsl-query-executor/build.gradle
+++ b/sandbox/plugins/dsl-query-executor/build.gradle
@@ -14,14 +14,26 @@ opensearchplugin {
   extendedPlugins = ['analytics-engine']
 }
 
+// Guava comes transitively from calcite-core — forbidden on compile classpaths
+// by OpenSearch. Bypass via custom config (mirrors analytics-engine).
+configurations {
+  calciteCompile
+  compileClasspath { exclude group: 'com.google.guava' }
+}
+sourceSets.main.compileClasspath += configurations.calciteCompile
+
 dependencies {
   compileOnly project(':server')
   compileOnly project(':sandbox:libs:analytics-framework')
   compileOnly project(':sandbox:plugins:analytics-engine')
   compileOnly 'org.apache.calcite.avatica:avatica-core:1.27.0'
 
+  // Guava for compilation — Calcite class files reference ImmutableList etc.
+  calciteCompile "com.google.guava:guava:${versions.guava}"
+
   testImplementation project(':test:framework')
   testImplementation "org.mockito:mockito-core:${versions.mockito}"
+  testImplementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
 
   internalClusterTestImplementation project(':server')
   internalClusterTestImplementation project(':test:framework')

--- a/sandbox/plugins/dsl-query-executor/src/test/design.md
+++ b/sandbox/plugins/dsl-query-executor/src/test/design.md
@@ -1,0 +1,448 @@
+# Design Document: DSL Golden Tests
+
+## Overview
+
+This design describes a golden-file-based test framework for the `dsl-query-executor` plugin. The framework validates two conversion paths:
+
+1. **Forward Path**: DSL (`SearchSourceBuilder`) → Calcite `RelNode` logical plan via `SearchSourceConverter.convert()`
+2. **Reverse Path**: Simulated `ExecutionResult` rows → `SearchResponse` via `SearchResponseBuilder.build()`
+
+Each golden file is a self-contained JSON document encoding the input DSL, expected RelNode plan string, simulated execution rows, and expected output DSL. Each test method loads its own specific golden file by name rather than bulk-discovering all files — this keeps tests explicit and avoids hidden coupling between test cases.
+
+The framework runs as pure unit tests with zero cluster dependency. It constructs Calcite infrastructure (RelOptCluster, type factory, catalog reader) directly in test setup, mirroring the pattern already established in `TestUtils` and `SearchSourceConverterTests`.
+
+A system-property-driven update mode (`-Dgolden.update=true`) allows developers to regenerate golden files after intentional conversion logic changes, keeping maintenance low.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph Golden File on Disk
+        GF["golden/*.json"]
+    end
+
+    subgraph GoldenFileTestRunner
+        LOAD["GoldenFileLoader<br/>parse JSON → GoldenTestCase"]
+        FWD["Forward Path Test<br/>DSL → RelNode → explain string"]
+        REV["Reverse Path Test<br/>ExecutionResult → SearchResponse → JSON"]
+        CONSIST["Consistency Check<br/>RelNode field names == Execution_Rows field names"]
+        UPDATE["Update Mode<br/>overwrite golden file with actuals"]
+    end
+
+    GF -->|discovered & parsed| LOAD
+    LOAD --> FWD
+    LOAD --> REV
+    LOAD --> CONSIST
+    FWD -->|if golden.update=true| UPDATE
+    REV -->|if golden.update=true| UPDATE
+    UPDATE -->|writes| GF
+
+    subgraph Production Code Under Test
+        SSC["SearchSourceConverter.convert()"]
+        SRB["SearchResponseBuilder.build()"]
+    end
+
+    FWD -->|invokes| SSC
+    REV -->|invokes| SRB
+```
+
+The architecture has three layers:
+
+1. **Data Layer** — `GoldenTestCase` POJO and `GoldenFileLoader` handle JSON parsing of individual golden files from the resources directory.
+2. **Test Runner Layer** — Dedicated test methods in `DslGoldenFileTests` each load their own golden file by name, executing forward path, reverse path, and consistency checks.
+3. **Update Layer** — When `golden.update=true`, the runner overwrites the golden file's expected fields with actual outputs instead of asserting.
+
+### Key Design Decisions
+
+- **Per-test golden file loading over bulk discovery**: Each test method explicitly loads its own golden file by name (e.g., `GoldenFileLoader.load("term_query_hits.json")`). This makes test dependencies explicit, avoids hidden coupling, and makes it clear which test covers which scenario.
+- **JSON golden files over YAML/text**: JSON is natively supported by OpenSearch's `XContentParser` and `SearchSourceBuilder.fromXContent()`, avoiding extra dependencies.
+- **Deterministic RelNode serialization**: Uses `RelNode.explain()` with `RelWriterImpl` to produce a stable, human-readable plan string. This is Calcite's built-in mechanism and produces consistent output across runs.
+- **Schema from golden file, not from cluster**: Each golden file carries an `indexMapping` field that the test uses to construct a Calcite `RelDataType` directly, eliminating any need for `IndexMappingClient` or a live cluster.
+
+## Components and Interfaces
+
+### GoldenTestCase
+
+A POJO representing a single parsed golden file:
+
+```java
+public class GoldenTestCase {
+    private String testName;
+    private String indexName;
+    private Map<String, String> indexMapping;      // field name → SQL type name
+    private Map<String, Object> inputDsl;          // raw JSON map for SearchSourceBuilder
+    private String expectedRelNodePlan;            // expected RelNode.explain() output
+    private List<String> executionFieldNames;      // column names for execution rows
+    private List<List<Object>> executionRows;      // simulated result rows
+    private Map<String, Object> expectedOutputDsl; // expected SearchResponse JSON
+    private String planType;                       // "HITS" or "AGGREGATION"
+}
+```
+
+### GoldenFileLoader
+
+Responsible for parsing individual golden files:
+
+```java
+public class GoldenFileLoader {
+    /** Parses a single golden file by name from src/test/resources/golden/ */
+    public static GoldenTestCase load(String goldenFileName);
+
+    /** Parses a single golden file into a GoldenTestCase */
+    public static GoldenTestCase load(Path goldenFilePath);
+
+    /** Validates required fields are present, throws descriptive error if not */
+    private static void validate(GoldenTestCase testCase, Path filePath);
+}
+```
+
+### DslGoldenFileTests
+
+Dedicated test methods, each loading its own golden file:
+
+```java
+public class DslGoldenFileTests extends OpenSearchTestCase {
+    void testMatchAllHitsForwardPath();
+    void testMatchAllHitsReversePath();
+    void testTermQueryHitsForwardPath();
+    void testTermQueryHitsReversePath();
+    // ... one pair of test methods per golden file
+    
+    /** Shared helper: loads golden file, runs forward path, asserts or updates */
+    private void runForwardPathTest(String goldenFileName);
+    
+    /** Shared helper: loads golden file, runs reverse path, asserts or updates */
+    private void runReversePathTest(String goldenFileName);
+    
+    /** Shared helper: loads golden file, checks field name consistency */
+    private void runConsistencyCheck(String goldenFileName);
+}
+```
+
+### GoldenFileUpdater
+
+Handles the update-mode logic:
+
+```java
+public class GoldenFileUpdater {
+    /** Returns true if -Dgolden.update=true is set */
+    public static boolean isUpdateMode();
+
+    /** Overwrites the expected fields in the golden file with actual values */
+    public static void update(Path goldenFilePath, String actualRelNodePlan,
+                              Map<String, Object> actualOutputDsl);
+}
+```
+
+### CalciteTestInfra
+
+Extends the existing `TestUtils` pattern to support dynamic schemas from golden files:
+
+```java
+public class CalciteTestInfra {
+    /** Builds a RelOptCluster, schema, and catalog reader from a golden file's indexMapping */
+    public static InfraResult buildFromMapping(String indexName, Map<String, String> indexMapping);
+
+    public record InfraResult(
+        RelOptCluster cluster,
+        RelOptTable table,
+        SchemaPlus schema
+    ) {}
+}
+```
+
+### Interaction Flow
+
+```mermaid
+sequenceDiagram
+    participant JUnit as DslGoldenFileTests
+    participant Loader as GoldenFileLoader
+    participant Infra as CalciteTestInfra
+    participant SSC as SearchSourceConverter
+    participant SRB as SearchResponseBuilder
+    participant Updater as GoldenFileUpdater
+
+    Note over JUnit: Each test method loads its own golden file
+    JUnit->>Loader: load("term_query_hits.json")
+    Loader-->>JUnit: GoldenTestCase
+
+    JUnit->>Infra: buildFromMapping(indexName, indexMapping)
+    Infra-->>JUnit: InfraResult(cluster, table, schema)
+
+    Note over JUnit: Forward Path
+    JUnit->>SSC: convert(searchSource, indexName)
+    SSC-->>JUnit: QueryPlans
+    JUnit->>JUnit: relNode.explain() → actualPlan
+    JUnit->>JUnit: assert actualPlan == expectedRelNodePlan
+
+    Note over JUnit: Reverse Path
+    JUnit->>JUnit: construct ExecutionResult from rows
+    JUnit->>SRB: build(results, tookInMillis)
+    SRB-->>JUnit: SearchResponse
+    JUnit->>JUnit: serialize → actualOutputJson
+    JUnit->>JUnit: assert actualOutputJson == expectedOutputDsl
+
+    Note over JUnit: Consistency Check
+    JUnit->>JUnit: assert relNode fieldNames == executionFieldNames
+
+    alt golden.update=true
+        JUnit->>Updater: update(filePath, actualPlan, actualOutputJson)
+    end
+```
+
+## Data Models
+
+### Golden File JSON Schema
+
+```json
+{
+  "testName": "term_query_hits",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "HITS",
+  "inputDsl": {
+    "query": {
+      "term": { "name": { "value": "laptop" } }
+    },
+    "size": 10
+  },
+  "expectedRelNodePlan": "LogicalSort(fetch=[10])\n  LogicalProject(name=[$0], price=[$1], brand=[$2], rating=[$3])\n    LogicalFilter(condition=[=($0, 'laptop')])\n      LogicalTableScan(table=[[test-index]])\n",
+  "executionFieldNames": ["name", "price", "brand", "rating"],
+  "executionRows": [
+    ["laptop", 999, "BrandA", 4.5],
+    ["laptop", 1299, "BrandB", 4.8]
+  ],
+  "expectedOutputDsl": {
+    "hits": {
+      "total": { "value": 2, "relation": "eq" },
+      "hits": [
+        { "_source": { "name": "laptop", "price": 999, "brand": "BrandA", "rating": 4.5 } },
+        { "_source": { "name": "laptop", "price": 1299, "brand": "BrandB", "rating": 4.8 } }
+      ]
+    }
+  }
+}
+```
+
+### Aggregation Golden File Example
+
+Aggregation test cases use the same schema as hits — no separate metadata needed. The aggregation structure is fully captured in the `inputDsl` (which drives `SearchSourceConverter.convert()`) and validated via the `expectedRelNodePlan` output:
+
+```json
+{
+  "testName": "terms_with_avg_aggregation",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "by_brand": {
+        "terms": { "field": "brand" },
+        "aggregations": {
+          "avg_price": { "avg": { "field": "price" } }
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": "LogicalAggregate(group=[{2}], avg_price=[AVG($1)])\n  LogicalTableScan(table=[[test-index]])\n",
+  "executionFieldNames": ["brand", "avg_price"],
+  "executionRows": [
+    ["BrandA", 850.0],
+    ["BrandB", 1100.0]
+  ],
+  "expectedOutputDsl": {
+    "aggregations": {
+      "by_brand": {
+        "buckets": [
+          { "key": "BrandA", "doc_count": 0, "avg_price": { "value": 850.0 } },
+          { "key": "BrandB", "doc_count": 0, "avg_price": { "value": 1100.0 } }
+        ]
+      }
+    }
+  }
+}
+```
+
+### SQL Type Mapping
+
+The `indexMapping` field uses Calcite `SqlTypeName` strings. The mapping from golden file to Calcite types:
+
+| Golden File Type | SqlTypeName | Java Type |
+|---|---|---|
+| `VARCHAR` | `SqlTypeName.VARCHAR` | `String` |
+| `INTEGER` | `SqlTypeName.INTEGER` | `Integer` |
+| `BIGINT` | `SqlTypeName.BIGINT` | `Long` |
+| `DOUBLE` | `SqlTypeName.DOUBLE` | `Double` |
+| `FLOAT` | `SqlTypeName.FLOAT` | `Float` |
+| `BOOLEAN` | `SqlTypeName.BOOLEAN` | `Boolean` |
+| `DATE` | `SqlTypeName.DATE` | `Date` |
+| `TIMESTAMP` | `SqlTypeName.TIMESTAMP` | `Timestamp` |
+
+All fields are created as nullable (matching `OpenSearchSchemaBuilder` behavior observed in `TestUtils`).
+
+### File Organization
+
+```
+sandbox/plugins/dsl-query-executor/
+├── src/test/
+│   ├── java/org/opensearch/dsl/golden/
+│   │   ├── GoldenTestCase.java
+│   │   ├── GoldenFileLoader.java
+│   │   ├── GoldenFileUpdater.java
+│   │   ├── CalciteTestInfra.java
+│   │   └── DslGoldenFileTests.java
+│   └── resources/golden/
+│       ├── match_all_hits.json
+│       ├── term_query_hits.json
+│       ├── range_query_hits.json
+│       ├── bool_query_hits.json
+│       ├── sort_and_size_hits.json
+│       ├── terms_with_avg_aggregation.json
+│       ├── standalone_avg_metric.json
+│       ├── cardinality_metric.json
+│       ├── multi_terms_aggregation.json
+│       └── hits_and_aggregation_combined.json
+```
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Golden file serialization round-trip
+
+*For any* valid `GoldenTestCase` containing a test name, index name, index mapping, input DSL, expected RelNode plan, execution field names, execution rows, and expected output DSL, serializing the test case to JSON and then parsing it back via `GoldenFileLoader.load()` should produce a `GoldenTestCase` with all fields equal to the original.
+
+**Validates: Requirements 1.1, 2.2, 2.3, 2.4**
+
+### Property 2: Validation rejects golden files with missing required fields
+
+*For any* golden file JSON object where one or more required fields (testName, indexName, indexMapping, inputDsl, expectedRelNodePlan, executionFieldNames, executionRows, expectedOutputDsl) have been removed, `GoldenFileLoader.load()` should throw an error whose message identifies the specific missing field.
+
+**Validates: Requirements 2.5**
+
+### Property 3: File discovery completeness
+
+*For any* directory containing N `.json` files (where N >= 0), `GoldenFileLoader.loadAll()` should return exactly N `GoldenTestCase` instances, one per file.
+
+**Validates: Requirements 2.1**
+
+### Property 4: Forward path produces a valid plan for any well-formed DSL
+
+*For any* valid `SearchSourceBuilder` and matching index schema (as defined by a golden file's `indexMapping`), invoking `SearchSourceConverter.convert()` should produce a non-null `QueryPlans` containing at least one `QueryPlan` whose `RelNode` has a non-empty row type.
+
+**Validates: Requirements 3.2**
+
+### Property 5: RelNode serialization is deterministic
+
+*For any* `RelNode` produced by `SearchSourceConverter.convert()`, calling `relNode.explain()` twice should produce identical strings.
+
+**Validates: Requirements 3.3**
+
+### Property 6: JSON comparison ignores non-deterministic fields
+
+*For any* two SearchResponse JSON objects that are identical except for the values of `took` and shard count fields (`total`, `successful`, `skipped`, `failed` under `_shards`), the framework's comparison function should report them as equal.
+
+**Validates: Requirements 4.4**
+
+### Property 7: Forward and reverse path field name consistency
+
+*For any* golden file where the forward path produces a `RelNode`, the output field names of that `RelNode` (from `relNode.getRowType().getFieldNames()`) should exactly equal the `executionFieldNames` list in the golden file.
+
+**Validates: Requirements 5.1**
+
+### Property 8: Update mode preserves inputs while replacing outputs
+
+*For any* golden file on disk, when `golden.update=true` is set and the test runner executes, the resulting file should have its `inputDsl`, `executionFieldNames`, `executionRows`, `indexName`, and `indexMapping` fields unchanged from the original, while `expectedRelNodePlan` and `expectedOutputDsl` should equal the actual computed values.
+
+**Validates: Requirements 8.1, 8.2**
+
+## Error Handling
+
+### Golden File Loading Errors
+
+| Error Condition | Behavior |
+|---|---|
+| Golden file contains invalid JSON | `GoldenFileLoader` throws `IllegalArgumentException` with file path and parse error details |
+| Required field missing from golden file | `GoldenFileLoader.validate()` throws `IllegalArgumentException` naming the missing field and file path |
+| `indexMapping` contains unsupported SQL type | `CalciteTestInfra.buildFromMapping()` throws `IllegalArgumentException` naming the unsupported type |
+| `indexName` not found in constructed schema | `SearchSourceConverter.convert()` throws `IllegalArgumentException` (existing behavior) |
+
+### Forward Path Errors
+
+| Error Condition | Behavior |
+|---|---|
+| DSL contains unsupported query type | `ConversionException` propagates from `FilterConverter` with query type details |
+| DSL references field not in schema | `ConversionException` from the relevant converter (Filter, Project, or Sort) |
+| RelNode plan mismatch (non-update mode) | JUnit assertion failure showing expected vs actual plan strings |
+
+### Reverse Path Errors
+
+| Error Condition | Behavior |
+|---|---|
+| `SearchResponseBuilder.build()` fails | Exception propagates as test failure with stack trace |
+| Output DSL mismatch (non-update mode) | JUnit assertion failure showing expected vs actual JSON |
+| Field name consistency check fails | JUnit assertion failure listing expected field names (from RelNode) vs actual (from golden file) |
+
+### Update Mode Errors
+
+| Error Condition | Behavior |
+|---|---|
+| Cannot write to golden file (permissions) | `IOException` propagates as test failure |
+| Golden file updated successfully | Warning logged: "GOLDEN FILE UPDATED: {filePath} — review the diff before committing" |
+
+## Testing Strategy
+
+### Unit Testing Approach
+
+**Unit tests** validate specific golden file scenarios (Requirements 6 and 7) and error conditions. Each golden file (match_all, term query, range query, bool query, sort/size, terms+avg, standalone metric, cardinality, multi_terms, hits+aggregation combined) has dedicated test methods that exercise the forward and reverse paths with concrete, known inputs and expected outputs.
+
+### Test Organization
+
+| Test Class | Type | What It Tests |
+|---|---|---|
+| `DslGoldenFileTests` | Unit | Forward path, reverse path, and consistency — dedicated methods per golden file |
+| `CalciteTestInfraTests` | Unit | Schema construction from index mappings |
+
+### Unit Test Coverage Map
+
+| Golden File | Requirements Covered | Pipeline |
+|---|---|---|
+| `match_all_hits.json` | 6.1 | Scan→Project→Sort |
+| `term_query_hits.json` | 6.2 | Scan→Filter→Project→Sort |
+| `range_query_hits.json` | 6.3 | Scan→Filter→Project→Sort |
+| `bool_query_hits.json` | 6.4 | Scan→Filter→Project→Sort |
+| `sort_and_size_hits.json` | 6.5 | Scan→Filter→Project→Sort (explicit sort + size) |
+| `terms_with_avg_aggregation.json` | 7.1 | Scan→Filter→Aggregate |
+| `standalone_avg_metric.json` | 7.2 | Scan→Aggregate (size=0) |
+| `cardinality_metric.json` | 7.3 | Scan→Aggregate |
+| `multi_terms_aggregation.json` | 7.4 | Scan→Aggregate |
+| `hits_and_aggregation_combined.json` | 7.5 | Both HITS and AGGREGATION plans |
+
+### Build Integration
+
+Tests run as part of the standard `testImplementation` source set:
+- `gradle test` runs all golden file tests
+- `brazil-build release` includes them in the standard build cycle
+- No cluster required — all tests are pure unit tests
+- Update mode: `gradle test -Dgolden.update=true` regenerates expected values
+
+### Future Extension: Property-Based Testing
+
+The correctness properties defined above can be validated using property-based testing (PBT) with [jqwik](https://jqwik.net/), a JUnit 5 PBT engine. This would add a `testImplementation 'net.jqwik:jqwik:1.9.1'` dependency and validate universal invariants (serialization round-trips, validation rejection, deterministic serialization, etc.) across randomly generated inputs. This is deferred for now but the properties are documented above for future implementation.
+
+Potential PBT test classes when implemented:
+- `GoldenFileLoaderPropertyTests` — Properties 1, 2, 3
+- `GoldenFileUpdaterPropertyTests` — Property 8
+- `JsonComparisonPropertyTests` — Property 6
+- `RelNodeSerializationPropertyTests` — Property 5

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/CalciteTestInfra.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/CalciteTestInfra.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.golden;
+
+import org.apache.calcite.config.CalciteConnectionConfigImpl;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * Builds Calcite planning infrastructure from a golden file's index mapping.
+ *
+ * <p>Mirrors the pattern in {@code TestUtils} and {@code SearchSourceConverter}'s
+ * constructor, but constructs the schema dynamically from the golden file's
+ * {@code indexMapping} field instead of using a hardcoded schema.
+ */
+public class CalciteTestInfra {
+
+    private CalciteTestInfra() {}
+
+    /**
+     * Builds a complete Calcite infrastructure from a golden file's index mapping.
+     *
+     * @param indexName    the index name to register in the schema
+     * @param indexMapping field name → SQL type name (e.g. "VARCHAR", "INTEGER")
+     * @return an {@link InfraResult} containing the cluster, table, and schema
+     * @throws IllegalArgumentException if indexMapping contains an unsupported type
+     */
+    public static InfraResult buildFromMapping(String indexName, Map<String, String> indexMapping) {
+        Objects.requireNonNull(indexName, "indexName must not be null");
+        Objects.requireNonNull(indexMapping, "indexMapping must not be null");
+
+        RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+        HepPlanner planner = new HepPlanner(HepProgram.builder().build());
+        RelOptCluster cluster = RelOptCluster.create(planner, new RexBuilder(typeFactory));
+
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+        schema.add(indexName, new AbstractTable() {
+            @Override
+            public RelDataType getRowType(RelDataTypeFactory tf) {
+                RelDataTypeFactory.Builder builder = tf.builder();
+                for (Map.Entry<String, String> entry : indexMapping.entrySet()) {
+                    SqlTypeName sqlType = toSqlTypeName(entry.getValue());
+                    builder.add(entry.getKey(), tf.createTypeWithNullability(tf.createSqlType(sqlType), true));
+                }
+                return builder.build();
+            }
+        });
+
+        CalciteCatalogReader reader = new CalciteCatalogReader(
+            CalciteSchema.from(schema),
+            Collections.singletonList(""),
+            typeFactory,
+            new CalciteConnectionConfigImpl(new Properties())
+        );
+        RelOptTable table = Objects.requireNonNull(
+            reader.getTable(List.of(indexName)),
+            "Table not found in schema: " + indexName
+        );
+
+        return new InfraResult(cluster, table, schema);
+    }
+
+    /**
+     * Maps a golden file type string to a Calcite {@link SqlTypeName}.
+     *
+     * @throws IllegalArgumentException for unsupported type strings
+     */
+    private static SqlTypeName toSqlTypeName(String goldenType) {
+        switch (goldenType) {
+            case "VARCHAR":   return SqlTypeName.VARCHAR;
+            case "INTEGER":   return SqlTypeName.INTEGER;
+            case "BIGINT":    return SqlTypeName.BIGINT;
+            case "DOUBLE":    return SqlTypeName.DOUBLE;
+            case "FLOAT":     return SqlTypeName.FLOAT;
+            case "BOOLEAN":   return SqlTypeName.BOOLEAN;
+            case "DATE":      return SqlTypeName.DATE;
+            case "TIMESTAMP": return SqlTypeName.TIMESTAMP;
+            default:
+                throw new IllegalArgumentException("Unsupported SQL type in golden file indexMapping: " + goldenType);
+        }
+    }
+
+    /** Result record containing the Calcite infrastructure built from a golden file mapping. */
+    public record InfraResult(RelOptCluster cluster, RelOptTable table, SchemaPlus schema) {}
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/DslGoldenFileTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/DslGoldenFileTests.java
@@ -1,0 +1,323 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.golden;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.calcite.rel.RelNode;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.dsl.converter.SearchSourceConverter;
+import org.opensearch.dsl.executor.QueryPlans;
+import org.opensearch.dsl.result.ExecutionResult;
+import org.opensearch.dsl.result.SearchResponseBuilder;
+import org.opensearch.search.SearchModule;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Golden file tests for the DSL query executor plugin.
+ *
+ * <p>Each test method loads its own specific golden file by name, keeping
+ * dependencies explicit. Tests validate the forward path (DSL → RelNode),
+ * reverse path (ExecutionResult → SearchResponse), and field name consistency.
+ */
+public class DslGoldenFileTests extends OpenSearchTestCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final NamedXContentRegistry X_CONTENT_REGISTRY = new NamedXContentRegistry(
+        new SearchModule(org.opensearch.common.settings.Settings.EMPTY, Collections.emptyList()).getNamedXContents()
+    );
+
+    // ---- Forward Path Helper ----
+
+    /**
+     * Loads a golden file, parses the inputDsl into a SearchSourceBuilder,
+     * invokes SearchSourceConverter.convert(), serializes the RelNode via
+     * explain(), and compares against expectedRelNodePlan. In update mode,
+     * overwrites the golden file instead of asserting.
+     */
+    private void runForwardPathTest(String goldenFileName) throws Exception {
+        GoldenTestCase tc = GoldenFileLoader.load(goldenFileName);
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping(tc.getIndexName(), tc.getIndexMapping());
+
+        SearchSourceBuilder searchSource = parseSearchSource(tc.getInputDsl());
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(searchSource, tc.getIndexName());
+
+        QueryPlans.Type expectedType = QueryPlans.Type.valueOf(tc.getPlanType());
+        List<QueryPlans.QueryPlan> matchingPlans = plans.get(expectedType);
+        assertFalse("No " + expectedType + " plan produced for " + goldenFileName, matchingPlans.isEmpty());
+
+        RelNode relNode = matchingPlans.get(0).relNode();
+        String actualPlan = relNode.explain().trim();
+
+        // Validate schema (row type) field names match executionFieldNames
+        List<String> relNodeFields = relNode.getRowType().getFieldNames();
+        assertEquals(
+            "Forward path schema mismatch for " + goldenFileName
+                + "\nRelNode row type fields: " + relNodeFields
+                + "\nGolden file executionFieldNames: " + tc.getExecutionFieldNames(),
+            tc.getExecutionFieldNames(),
+            relNodeFields
+        );
+
+        if (GoldenFileUpdater.isUpdateMode()) {
+            Path filePath = goldenFilePath(goldenFileName);
+            GoldenFileUpdater.updatePlan(filePath, actualPlan);
+        } else {
+            assertEquals(
+                "Forward path mismatch for " + goldenFileName
+                    + "\nExpected:\n" + tc.getExpectedRelNodePlan()
+                    + "\nActual:\n" + actualPlan,
+                tc.getExpectedRelNodePlan().trim(),
+                actualPlan
+            );
+        }
+    }
+
+    // ---- Reverse Path Helper ----
+
+    /**
+     * Loads a golden file, constructs an ExecutionResult from executionRows
+     * and field names, invokes SearchResponseBuilder.build(), serializes the
+     * SearchResponse to JSON, and compares against expectedOutputDsl ignoring
+     * non-deterministic fields (took, _shards). In update mode, overwrites
+     * the golden file instead of asserting.
+     */
+    private void runReversePathTest(String goldenFileName) throws Exception {
+        GoldenTestCase tc = GoldenFileLoader.load(goldenFileName);
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping(tc.getIndexName(), tc.getIndexMapping());
+
+        // Build the RelNode so we can construct a proper QueryPlan for ExecutionResult
+        SearchSourceBuilder searchSource = parseSearchSource(tc.getInputDsl());
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(searchSource, tc.getIndexName());
+
+        QueryPlans.Type expectedType = QueryPlans.Type.valueOf(tc.getPlanType());
+        QueryPlans.QueryPlan plan = plans.get(expectedType).get(0);
+
+        // Convert golden file rows to Object[] iterable
+        List<Object[]> rows = new ArrayList<>();
+        for (List<Object> row : tc.getExecutionRows()) {
+            rows.add(row.toArray());
+        }
+        ExecutionResult result = new ExecutionResult(plan, rows);
+
+        // Build SearchResponse
+        var response = SearchResponseBuilder.build(List.of(result), 0L);
+        String responseJson = Strings.toString(MediaTypeRegistry.JSON, response);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> actualOutput = MAPPER.readValue(responseJson, Map.class);
+
+        if (GoldenFileUpdater.isUpdateMode()) {
+            Path filePath = goldenFilePath(goldenFileName);
+            GoldenFileUpdater.update(filePath, tc.getExpectedRelNodePlan(), actualOutput);
+        } else {
+            // Defensive copy to avoid mutating GoldenTestCase internal map
+            Map<String, Object> expectedOutput = MAPPER.readValue(
+                MAPPER.writeValueAsString(tc.getExpectedOutputDsl()),
+                new TypeReference<LinkedHashMap<String, Object>>() {}
+            );
+            // Remove non-deterministic fields before comparison
+            stripNonDeterministicFields(actualOutput);
+            stripNonDeterministicFields(expectedOutput);
+
+            assertOutputEquals(expectedOutput, actualOutput, tc.getPlanType(), goldenFileName);
+        }
+    }
+
+    // ---- Consistency Check Helper ----
+
+    /**
+     * Loads a golden file, runs the forward path to get the RelNode, and
+     * verifies that the RelNode output field names match the executionFieldNames
+     * in the golden file.
+     */
+    private void runConsistencyCheck(String goldenFileName) throws Exception {
+        GoldenTestCase tc = GoldenFileLoader.load(goldenFileName);
+        CalciteTestInfra.InfraResult infra = CalciteTestInfra.buildFromMapping(tc.getIndexName(), tc.getIndexMapping());
+
+        SearchSourceBuilder searchSource = parseSearchSource(tc.getInputDsl());
+        SearchSourceConverter converter = new SearchSourceConverter(infra.schema());
+        QueryPlans plans = converter.convert(searchSource, tc.getIndexName());
+
+        QueryPlans.Type expectedType = QueryPlans.Type.valueOf(tc.getPlanType());
+        RelNode relNode = plans.get(expectedType).get(0).relNode();
+        List<String> relNodeFields = relNode.getRowType().getFieldNames();
+
+        assertEquals(
+            "Field name consistency mismatch for " + goldenFileName
+                + "\nRelNode fields: " + relNodeFields
+                + "\nGolden file executionFieldNames: " + tc.getExecutionFieldNames(),
+            tc.getExecutionFieldNames(),
+            relNodeFields
+        );
+    }
+
+    // ---- Utility Methods ----
+
+    /**
+     * Parses a golden file inputDsl map into a SearchSourceBuilder using
+     * XContentParser with the full SearchModule registry (so query builders
+     * like term, range, bool are recognized).
+     */
+    private SearchSourceBuilder parseSearchSource(Map<String, Object> inputDsl) throws IOException {
+        String json = MAPPER.writeValueAsString(inputDsl);
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                X_CONTENT_REGISTRY,
+                DeprecationHandler.IGNORE_DEPRECATIONS,
+                json
+            )
+        ) {
+            return SearchSourceBuilder.fromXContent(parser);
+        }
+    }
+
+    /**
+     * Resolves the file-system path to a golden file for update mode.
+     * Falls back to classpath resource resolution.
+     */
+    private Path goldenFilePath(String goldenFileName) throws URISyntaxException {
+        URL resource = getClass().getClassLoader().getResource("golden/" + goldenFileName);
+        if (resource == null) {
+            throw new IllegalStateException("Golden file not found on classpath: golden/" + goldenFileName);
+        }
+        return Path.of(resource.toURI());
+    }
+
+    /**
+     * Removes non-deterministic fields (took, _shards, _score) from a serialized
+     * SearchResponse map so that comparisons are stable.
+     */
+    @SuppressWarnings("unchecked")
+    private void stripNonDeterministicFields(Map<String, Object> responseMap) {
+        responseMap.remove("took");
+        responseMap.remove("timed_out");
+        responseMap.remove("_shards");
+
+        // Strip _score from each hit in hits.hits[]
+        Object hitsObj = responseMap.get("hits");
+        if (hitsObj instanceof Map) {
+            Map<String, Object> hitsMap = (Map<String, Object>) hitsObj;
+            Object hitsArray = hitsMap.get("hits");
+            if (hitsArray instanceof List) {
+                for (Object hit : (List<?>) hitsArray) {
+                    if (hit instanceof Map) {
+                        ((Map<String, Object>) hit).remove("_score");
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Compares expected and actual output maps. For aggregation responses,
+     * uses order-insensitive bucket comparison. For hit-only responses,
+     * retains strict ordering.
+     */
+    private void assertOutputEquals(
+        Map<String, Object> expected,
+        Map<String, Object> actual,
+        String planType,
+        String goldenFileName
+    ) throws IOException {
+        if ("AGGREGATION".equals(planType)) {
+            normalizeAggregationBuckets(expected);
+            normalizeAggregationBuckets(actual);
+        }
+        assertEquals(
+            "Reverse path mismatch for " + goldenFileName
+                + "\nExpected:\n" + MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(expected)
+                + "\nActual:\n" + MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(actual),
+            expected,
+            actual
+        );
+    }
+
+    /**
+     * Recursively sorts aggregation bucket lists by their "key" field so that
+     * order-insensitive comparison is possible.
+     */
+    @SuppressWarnings("unchecked")
+    private void normalizeAggregationBuckets(Map<String, Object> map) {
+        Object aggs = map.get("aggregations");
+        if (aggs instanceof Map) {
+            normalizeBucketsRecursive((Map<String, Object>) aggs);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void normalizeBucketsRecursive(Map<String, Object> aggMap) {
+        for (Map.Entry<String, Object> entry : aggMap.entrySet()) {
+            Object value = entry.getValue();
+            if (value instanceof Map) {
+                Map<String, Object> aggBody = (Map<String, Object>) value;
+                Object buckets = aggBody.get("buckets");
+                if (buckets instanceof List) {
+                    List<Map<String, Object>> bucketList = (List<Map<String, Object>>) buckets;
+                    bucketList.sort(Comparator.comparing(
+                        b -> String.valueOf(b.get("key"))
+                    ));
+                    // Recurse into sub-aggregations within each bucket
+                    for (Map<String, Object> bucket : bucketList) {
+                        for (Map.Entry<String, Object> bucketEntry : bucket.entrySet()) {
+                            if (bucketEntry.getValue() instanceof Map) {
+                                Map<String, Object> subAgg = (Map<String, Object>) bucketEntry.getValue();
+                                if (subAgg.containsKey("buckets")) {
+                                    normalizeBucketsRecursive(Map.of(bucketEntry.getKey(), subAgg));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- Common Runner ----
+
+    /**
+     * Runs forward path, reverse path, and consistency checks for a single
+     * golden file.
+     */
+    private void runAllChecks(String goldenFileName) throws Exception {
+        runForwardPathTest(goldenFileName);
+        runReversePathTest(goldenFileName);
+        runConsistencyCheck(goldenFileName);
+    }
+
+    // ---- Test Methods ----
+
+    public void testMatchAllHits() throws Exception {
+        runAllChecks("match_all_hits.json");
+    }
+
+    public void testTermsWithAvgAggregation() throws Exception {
+        runAllChecks("terms_with_avg_aggregation.json");
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenFileLoader.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenFileLoader.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.golden;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.opensearch.dsl.executor.QueryPlans;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Loads and validates golden file test cases.
+ *
+ * <p>Each golden file is a self-contained JSON document parsed into a
+ * {@link GoldenTestCase}. Required fields are validated after parsing;
+ * aggregation test cases must additionally include {@code aggregationMetadata}.
+ */
+public class GoldenFileLoader {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String RESOURCE_DIR = "golden/";
+
+    private GoldenFileLoader() {}
+
+    /**
+     * Loads a golden file by name from the classpath resource directory
+     * {@code src/test/resources/golden/}.
+     *
+     * @param goldenFileName file name (e.g. {@code "term_query_hits.json"})
+     * @return parsed and validated test case
+     * @throws IllegalArgumentException if the file is missing, malformed, or
+     *         has missing required fields
+     */
+    public static GoldenTestCase load(String goldenFileName) {
+        String resourcePath = RESOURCE_DIR + goldenFileName;
+        try (InputStream is = GoldenFileLoader.class.getClassLoader().getResourceAsStream(resourcePath)) {
+            if (is == null) {
+                throw new IllegalArgumentException("Golden file not found on classpath: " + resourcePath);
+            }
+            GoldenTestCase testCase = MAPPER.readValue(is, GoldenTestCase.class);
+            validate(testCase, Path.of(resourcePath));
+            return testCase;
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to parse golden file: " + resourcePath, e);
+        }
+    }
+
+    /**
+     * Loads a golden file from an absolute or relative file-system path.
+     *
+     * @param goldenFilePath path to the JSON golden file
+     * @return parsed and validated test case
+     * @throws IllegalArgumentException if the file is malformed or has missing
+     *         required fields
+     */
+    public static GoldenTestCase load(Path goldenFilePath) {
+        try (InputStream is = Files.newInputStream(goldenFilePath)) {
+            GoldenTestCase testCase = MAPPER.readValue(is, GoldenTestCase.class);
+            validate(testCase, goldenFilePath);
+            return testCase;
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to parse golden file: " + goldenFilePath, e);
+        }
+    }
+
+    /**
+     * Validates that all required fields are present in the parsed test case.
+     * Throws {@link IllegalArgumentException} identifying the file and the
+     * missing field.
+     */
+    private static void validate(GoldenTestCase testCase, Path filePath) {
+        requireNonNull(testCase.getTestName(), "testName", filePath);
+        requireNonNull(testCase.getIndexName(), "indexName", filePath);
+        requireNonNull(testCase.getIndexMapping(), "indexMapping", filePath);
+        requireNonNull(testCase.getInputDsl(), "inputDsl", filePath);
+        requireNonNull(testCase.getExpectedRelNodePlan(), "expectedRelNodePlan", filePath);
+        requireNonNull(testCase.getExecutionFieldNames(), "executionFieldNames", filePath);
+        requireNonNull(testCase.getExecutionRows(), "executionRows", filePath);
+        requireNonNull(testCase.getExpectedOutputDsl(), "expectedOutputDsl", filePath);
+        requireNonNull(testCase.getPlanType(), "planType", filePath);
+        try {
+            QueryPlans.Type.valueOf(testCase.getPlanType());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Golden file " + filePath + " has invalid planType: " + testCase.getPlanType());
+        }
+    }
+
+    private static void requireNonNull(Object value, String fieldName, Path filePath) {
+        if (value == null) {
+            throw new IllegalArgumentException(
+                "Golden file " + filePath + " missing required field: " + fieldName
+            );
+        }
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenFileUpdater.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenFileUpdater.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.golden;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Handles golden file update mode for regenerating expected outputs.
+ *
+ * <p>When the system property {@code golden.update=true} is set, the test
+ * runner calls {@link #update} instead of asserting. This overwrites the
+ * {@code expectedRelNodePlan} and {@code expectedOutputDsl} fields in the
+ * golden file while preserving all input fields.
+ */
+public class GoldenFileUpdater {
+
+    private static final Logger logger = LogManager.getLogger(GoldenFileUpdater.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+    private static final String UPDATE_PROPERTY = "golden.update";
+
+    private GoldenFileUpdater() {}
+
+    /**
+     * Returns {@code true} if the system property {@code golden.update} is
+     * set to {@code "true"}.
+     */
+    public static boolean isUpdateMode() {
+        return "true".equals(System.getProperty(UPDATE_PROPERTY));
+    }
+
+    /**
+     * Overwrites the expected fields in the golden file with actual computed
+     * values while preserving all input fields.
+     *
+     * @param goldenFilePath      path to the golden JSON file on disk
+     * @param actualRelNodePlan   the actual RelNode.explain() output
+     * @param actualOutputDsl     the actual SearchResponse JSON as a map
+     * @throws IOException if the file cannot be read or written
+     */
+    public static void update(Path goldenFilePath, String actualRelNodePlan, Map<String, Object> actualOutputDsl)
+        throws IOException {
+        Map<String, Object> content = MAPPER.readValue(
+            Files.readString(goldenFilePath),
+            new TypeReference<LinkedHashMap<String, Object>>() {}
+        );
+
+        content.put("expectedRelNodePlan", actualRelNodePlan);
+        content.put("expectedOutputDsl", actualOutputDsl);
+
+        MAPPER.writeValue(goldenFilePath.toFile(), content);
+
+        logger.warn("GOLDEN FILE UPDATED: {} — review the diff before committing", goldenFilePath);
+    }
+
+    /**
+     * Overwrites only the {@code expectedRelNodePlan} field in the golden file,
+     * leaving {@code expectedOutputDsl} unchanged. Used by the forward path
+     * update mode to avoid writing stale output DSL data.
+     *
+     * @param goldenFilePath      path to the golden JSON file on disk
+     * @param actualRelNodePlan   the actual RelNode.explain() output
+     * @throws IOException if the file cannot be read or written
+     */
+    public static void updatePlan(Path goldenFilePath, String actualRelNodePlan) throws IOException {
+        Map<String, Object> content = MAPPER.readValue(
+            Files.readString(goldenFilePath),
+            new TypeReference<LinkedHashMap<String, Object>>() {}
+        );
+
+        content.put("expectedRelNodePlan", actualRelNodePlan);
+
+        MAPPER.writeValue(goldenFilePath.toFile(), content);
+
+        logger.warn("GOLDEN FILE PLAN UPDATED: {} — review the diff before committing", goldenFilePath);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenTestCase.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/golden/GoldenTestCase.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.golden;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * POJO representing a single golden file test case.
+ *
+ * <p>Each golden file encodes a complete test scenario: the input DSL, expected
+ * RelNode plan, simulated execution rows, and expected output DSL. The
+ * {@code indexMapping} field allows schema construction without a live cluster.
+ */
+public class GoldenTestCase {
+
+    private String testName;
+    private String indexName;
+    private Map<String, String> indexMapping;
+    private Map<String, Object> inputDsl;
+    private String expectedRelNodePlan;
+    private List<String> executionFieldNames;
+    private List<List<Object>> executionRows;
+    private Map<String, Object> expectedOutputDsl;
+    private String planType;
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public void setTestName(String testName) {
+        this.testName = testName;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public void setIndexName(String indexName) {
+        this.indexName = indexName;
+    }
+
+    public Map<String, String> getIndexMapping() {
+        return indexMapping;
+    }
+
+    public void setIndexMapping(Map<String, String> indexMapping) {
+        this.indexMapping = indexMapping;
+    }
+
+    public Map<String, Object> getInputDsl() {
+        return inputDsl;
+    }
+
+    public void setInputDsl(Map<String, Object> inputDsl) {
+        this.inputDsl = inputDsl;
+    }
+
+    public String getExpectedRelNodePlan() {
+        return expectedRelNodePlan;
+    }
+
+    public void setExpectedRelNodePlan(String expectedRelNodePlan) {
+        this.expectedRelNodePlan = expectedRelNodePlan;
+    }
+
+    public List<String> getExecutionFieldNames() {
+        return executionFieldNames;
+    }
+
+    public void setExecutionFieldNames(List<String> executionFieldNames) {
+        this.executionFieldNames = executionFieldNames;
+    }
+
+    public List<List<Object>> getExecutionRows() {
+        return executionRows;
+    }
+
+    public void setExecutionRows(List<List<Object>> executionRows) {
+        this.executionRows = executionRows;
+    }
+
+    public Map<String, Object> getExpectedOutputDsl() {
+        return expectedOutputDsl;
+    }
+
+    public void setExpectedOutputDsl(Map<String, Object> expectedOutputDsl) {
+        this.expectedOutputDsl = expectedOutputDsl;
+    }
+
+    public String getPlanType() {
+        return planType;
+    }
+
+    public void setPlanType(String planType) {
+        this.planType = planType;
+    }
+
+
+
+    @Override
+    public String toString() {
+        return testName;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/match_all_hits.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/match_all_hits.json
@@ -1,0 +1,33 @@
+{
+  "testName": "match_all_hits",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "HITS",
+  "inputDsl": {
+    "query": {
+      "match_all": {}
+    }
+  },
+  "expectedRelNodePlan": "LogicalTableScan(table=[[test-index]])\n",
+  "executionFieldNames": ["name", "price", "brand", "rating"],
+  "executionRows": [
+    ["laptop", 999, "BrandA", 4.5],
+    ["phone", 699, "BrandB", 4.2]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    }
+  }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_with_avg_aggregation.json
+++ b/sandbox/plugins/dsl-query-executor/src/test/resources/golden/terms_with_avg_aggregation.json
@@ -1,0 +1,45 @@
+{
+  "testName": "terms_with_avg_aggregation",
+  "indexName": "test-index",
+  "indexMapping": {
+    "name": "VARCHAR",
+    "price": "INTEGER",
+    "brand": "VARCHAR",
+    "rating": "DOUBLE"
+  },
+  "planType": "AGGREGATION",
+  "inputDsl": {
+    "size": 0,
+    "aggregations": {
+      "by_brand": {
+        "terms": {
+          "field": "brand"
+        },
+        "aggregations": {
+          "avg_price": {
+            "avg": {
+              "field": "price"
+            }
+          }
+        }
+      }
+    }
+  },
+  "expectedRelNodePlan": "LogicalAggregate(group=[{2}], avg_price=[AVG($1)], _count=[COUNT()])\n  LogicalTableScan(table=[[test-index]])",
+  "executionFieldNames": ["brand", "avg_price", "_count"],
+  "executionRows": [
+    ["BrandA", 850.0, 3],
+    ["BrandB", 1100.0, 2]
+  ],
+  "expectedOutputDsl": {
+    "num_reduce_phases": 0,
+    "hits": {
+      "total": {
+        "value": 0,
+        "relation": "eq"
+      },
+      "max_score": 0.0,
+      "hits": []
+    }
+  }
+}


### PR DESCRIPTION
Changes to test the end to end DSL query conversion without OpenSearch cluster. Currently adds support for match_all and terms with agg for the initial commit.

Previous PR: https://github.com/opensearch-project/OpenSearch/pull/21060 (Got closed because of mistaken deletion of branch)

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This feature introduces a golden-file-based unit test framework for the OpenSearch DSL query executor plugin (`sandbox/plugins/dsl-query-executor/`). The framework validates the correctness of both the forward conversion path (DSL → RelNode) and the reverse conversion path (RelNode execution results → SearchResponse DSL output) by comparing actual outputs against pre-approved golden files. Each golden file encodes a complete test case: the input DSL, the expected RelNode logical plan, simulated execution rows, and the expected DSL output.

### Requirements

- As a developer, I want each golden file to contain all inputs and expected outputs for a single test case, so that test cases are self-contained and easy to review in code reviews.
- As a developer, I want the test framework to automatically discover and parse golden files, so that adding a new test case requires only adding a new golden file.
- As a developer, I want to validate that a given DSL input produces the expected Calcite logical plan, so that regressions in the conversion pipeline are caught automatically.
- As a developer, I want to validate that simulated execution results are correctly converted back into a SearchResponse, so that regressions in the response building logic are caught automatically.
- As a developer, I want to verify that the forward and reverse paths are consistent within a golden file, so that the entire DSL → RelNode → execution → DSL output pipeline is validated end-to-end.
- As a developer, I want golden file test cases covering the hits pipeline scenarios, so that query translation correctness is validated for common query types.
- As a developer, I want golden file test cases covering the aggregation pipeline scenarios, so that aggregation translation correctness is validated for supported metric and bucket types.
- As a developer, I want a way to regenerate golden files when intentional changes are made to the conversion logic, so that maintaining golden files does not become a burden.
- As a developer, I want the golden file tests to run as fast unit tests without requiring a running OpenSearch cluster, so that they can be part of the standard build cycle.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
