### PR TITLE
Add SplitToFieldsProcessor and associated tests

### DIFF
--- a/modules/ingest-common/src/main/java/org/opensearch/ingest/common/IngestCommonModulePlugin.java
+++ b/modules/ingest-common/src/main/java/org/opensearch/ingest/common/IngestCommonModulePlugin.java
@@ -94,6 +94,7 @@ public class IngestCommonModulePlugin extends Plugin implements ActionPlugin, In
         processors.put(RenameProcessor.TYPE, new RenameProcessor.Factory(parameters.scriptService));
         processors.put(RemoveProcessor.TYPE, new RemoveProcessor.Factory(parameters.scriptService));
         processors.put(SplitProcessor.TYPE, new SplitProcessor.Factory());
+        processors.put(SplitToFieldsProcessor.TYPE, new SplitToFieldsProcessor.Factory());
         processors.put(JoinProcessor.TYPE, new JoinProcessor.Factory());
         processors.put(UppercaseProcessor.TYPE, new UppercaseProcessor.Factory());
         processors.put(LowercaseProcessor.TYPE, new LowercaseProcessor.Factory());

--- a/modules/ingest-common/src/main/java/org/opensearch/ingest/common/SplitToFieldsProcessor.java
+++ b/modules/ingest-common/src/main/java/org/opensearch/ingest/common/SplitToFieldsProcessor.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.ingest.common;
+
+import org.opensearch.ingest.AbstractProcessor;
+import org.opensearch.ingest.ConfigurationUtils;
+import org.opensearch.ingest.IngestDocument;
+import org.opensearch.ingest.Processor;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Processor that splits a field's string value by a separator and distributes the resulting
+ * parts into user-specified target fields. If more parts exist than target fields, the extra
+ * parts are discarded. If fewer parts exist than target fields, the surplus target fields
+ * are left untouched.
+ */
+public final class SplitToFieldsProcessor extends AbstractProcessor {
+
+    public static final String TYPE = "split_to_fields";
+
+    private final String field;
+    private final String separator;
+    private final List<String> targetFields;
+    private final boolean ignoreMissing;
+    private final boolean preserveTrailing;
+
+    SplitToFieldsProcessor(
+        String tag,
+        String description,
+        String field,
+        String separator,
+        List<String> targetFields,
+        boolean ignoreMissing,
+        boolean preserveTrailing
+    ) {
+        super(tag, description);
+        this.field = field;
+        this.separator = separator;
+        this.targetFields = targetFields;
+        this.ignoreMissing = ignoreMissing;
+        this.preserveTrailing = preserveTrailing;
+    }
+
+    String getField() {
+        return field;
+    }
+
+    String getSeparator() {
+        return separator;
+    }
+
+    List<String> getTargetFields() {
+        return targetFields;
+    }
+
+    boolean isIgnoreMissing() {
+        return ignoreMissing;
+    }
+
+    boolean isPreserveTrailing() {
+        return preserveTrailing;
+    }
+
+    @Override
+    public IngestDocument execute(IngestDocument document) {
+        String oldVal = document.getFieldValue(field, String.class, ignoreMissing);
+
+        if (oldVal == null && ignoreMissing) {
+            return document;
+        } else if (oldVal == null) {
+            throw new IllegalArgumentException("field [" + field + "] is null, cannot split.");
+        }
+
+        String[] parts = oldVal.split(separator, preserveTrailing ? -1 : 0);
+        int limit = Math.min(parts.length, targetFields.size());
+        for (int i = 0; i < limit; i++) {
+            document.setFieldValue(targetFields.get(i), parts[i]);
+        }
+        return document;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    public static class Factory implements Processor.Factory {
+        @Override
+        public SplitToFieldsProcessor create(
+            Map<String, Processor.Factory> registry,
+            String processorTag,
+            String description,
+            Map<String, Object> config
+        ) throws Exception {
+            String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
+            String separator = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "separator");
+            List<String> targetFields = ConfigurationUtils.readList(TYPE, processorTag, config, "target_fields");
+            boolean ignoreMissing = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "ignore_missing", false);
+            boolean preserveTrailing = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "preserve_trailing", false);
+            return new SplitToFieldsProcessor(processorTag, description, field, separator, targetFields, ignoreMissing, preserveTrailing);
+        }
+    }
+}

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/IngestCommonModulePluginTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/IngestCommonModulePluginTests.java
@@ -74,6 +74,7 @@ public class IngestCommonModulePluginTests extends OpenSearchTestCase {
                 "dissect",
                 "uppercase",
                 "split",
+                "split_to_fields",
                 "hierarchical_routing",
                 "temporal_routing",
                 "acl_routing"

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/SplitToFieldsProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/SplitToFieldsProcessorFactoryTests.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.ingest.common;
+
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class SplitToFieldsProcessorFactoryTests extends OpenSearchTestCase {
+
+    public void testCreate() throws Exception {
+        SplitToFieldsProcessor.Factory factory = new SplitToFieldsProcessor.Factory();
+        boolean ignoreMissing = randomBoolean();
+        boolean preserveTrailing = randomBoolean();
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "source_field");
+        config.put("separator", ">");
+        config.put("target_fields", Arrays.asList("out1", "out2", "out3"));
+        config.put("ignore_missing", ignoreMissing);
+        config.put("preserve_trailing", preserveTrailing);
+        String processorTag = randomAlphaOfLength(10);
+        SplitToFieldsProcessor processor = factory.create(null, processorTag, null, config);
+        assertThat(processor.getTag(), equalTo(processorTag));
+        assertThat(processor.getField(), equalTo("source_field"));
+        assertThat(processor.getSeparator(), equalTo(">"));
+        assertThat(processor.getTargetFields(), equalTo(Arrays.asList("out1", "out2", "out3")));
+        assertThat(processor.isIgnoreMissing(), equalTo(ignoreMissing));
+        assertThat(processor.isPreserveTrailing(), equalTo(preserveTrailing));
+    }
+
+    public void testCreateNoFieldPresent() throws Exception {
+        SplitToFieldsProcessor.Factory factory = new SplitToFieldsProcessor.Factory();
+        Map<String, Object> config = new HashMap<>();
+        config.put("separator", ">");
+        config.put("target_fields", Arrays.asList("out1", "out2"));
+        try {
+            factory.create(null, null, null, config);
+            fail("factory create should have failed");
+        } catch (OpenSearchParseException e) {
+            assertThat(e.getMessage(), equalTo("[field] required property is missing"));
+        }
+    }
+
+    public void testCreateNoSeparatorPresent() throws Exception {
+        SplitToFieldsProcessor.Factory factory = new SplitToFieldsProcessor.Factory();
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "source_field");
+        config.put("target_fields", Arrays.asList("out1", "out2"));
+        try {
+            factory.create(null, null, null, config);
+            fail("factory create should have failed");
+        } catch (OpenSearchParseException e) {
+            assertThat(e.getMessage(), equalTo("[separator] required property is missing"));
+        }
+    }
+
+    public void testCreateNoTargetFieldsPresent() throws Exception {
+        SplitToFieldsProcessor.Factory factory = new SplitToFieldsProcessor.Factory();
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "source_field");
+        config.put("separator", ">");
+        try {
+            factory.create(null, null, null, config);
+            fail("factory create should have failed");
+        } catch (OpenSearchParseException e) {
+            assertThat(e.getMessage(), equalTo("[target_fields] required property is missing"));
+        }
+    }
+}

--- a/modules/ingest-common/src/test/java/org/opensearch/ingest/common/SplitToFieldsProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/opensearch/ingest/common/SplitToFieldsProcessorTests.java
@@ -1,0 +1,177 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.ingest.common;
+
+import org.opensearch.ingest.IngestDocument;
+import org.opensearch.ingest.Processor;
+import org.opensearch.ingest.RandomDocumentPicks;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.ingest.IngestDocumentMatcher.assertIngestDocument;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class SplitToFieldsProcessorTests extends OpenSearchTestCase {
+
+    public void testSplitToFields() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, "a>b>c");
+        List<String> targetFields = Arrays.asList("out1", "out2", "out3");
+        Processor processor = new SplitToFieldsProcessor(randomAlphaOfLength(10), null, fieldName, ">", targetFields, false, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue("out1", String.class), equalTo("a"));
+        assertThat(ingestDocument.getFieldValue("out2", String.class), equalTo("b"));
+        assertThat(ingestDocument.getFieldValue("out3", String.class), equalTo("c"));
+    }
+
+    public void testSplitToFieldsWithRegexSeparator() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, "127.0.0.1");
+        List<String> targetFields = Arrays.asList("octet1", "octet2", "octet3", "octet4");
+        Processor processor = new SplitToFieldsProcessor(randomAlphaOfLength(10), null, fieldName, "\\.", targetFields, false, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue("octet1", String.class), equalTo("127"));
+        assertThat(ingestDocument.getFieldValue("octet2", String.class), equalTo("0"));
+        assertThat(ingestDocument.getFieldValue("octet3", String.class), equalTo("0"));
+        assertThat(ingestDocument.getFieldValue("octet4", String.class), equalTo("1"));
+    }
+
+    public void testSplitToFieldsMorePartsThanFields() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, "a>b>c>d>e");
+        List<String> targetFields = Arrays.asList("out1", "out2", "out3");
+        Processor processor = new SplitToFieldsProcessor(randomAlphaOfLength(10), null, fieldName, ">", targetFields, false, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue("out1", String.class), equalTo("a"));
+        assertThat(ingestDocument.getFieldValue("out2", String.class), equalTo("b"));
+        assertThat(ingestDocument.getFieldValue("out3", String.class), equalTo("c"));
+    }
+
+    public void testSplitToFieldsFewerPartsThanFields() throws Exception {
+        Map<String, Object> source = new HashMap<>();
+        source.put("input", "a>b");
+        IngestDocument ingestDocument = new IngestDocument(source, new HashMap<>());
+        List<String> targetFields = Arrays.asList("out1", "out2", "out3");
+        Processor processor = new SplitToFieldsProcessor(randomAlphaOfLength(10), null, "input", ">", targetFields, false, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue("out1", String.class), equalTo("a"));
+        assertThat(ingestDocument.getFieldValue("out2", String.class), equalTo("b"));
+        assertFalse(ingestDocument.hasField("out3"));
+    }
+
+    public void testSplitToFieldsFieldNotFound() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
+        String fieldName = RandomDocumentPicks.randomFieldName(random());
+        List<String> targetFields = Arrays.asList("out1", "out2");
+        Processor processor = new SplitToFieldsProcessor(randomAlphaOfLength(10), null, fieldName, ">", targetFields, false, false);
+        try {
+            processor.execute(ingestDocument);
+            fail("split_to_fields processor should have failed");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("not present as part of path [" + fieldName + "]"));
+        }
+    }
+
+    public void testSplitToFieldsNullValue() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", null));
+        List<String> targetFields = Arrays.asList("out1", "out2");
+        Processor processor = new SplitToFieldsProcessor(randomAlphaOfLength(10), null, "field", ">", targetFields, false, false);
+        try {
+            processor.execute(ingestDocument);
+            fail("split_to_fields processor should have failed");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), equalTo("field [field] is null, cannot split."));
+        }
+    }
+
+    public void testSplitToFieldsNullValueWithIgnoreMissing() throws Exception {
+        String fieldName = RandomDocumentPicks.randomFieldName(random());
+        IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(
+            random(),
+            Collections.singletonMap(fieldName, null)
+        );
+        IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
+        List<String> targetFields = Arrays.asList("out1", "out2");
+        Processor processor = new SplitToFieldsProcessor(randomAlphaOfLength(10), null, fieldName, ">", targetFields, true, false);
+        processor.execute(ingestDocument);
+        assertIngestDocument(originalIngestDocument, ingestDocument);
+    }
+
+    public void testSplitToFieldsNonExistentWithIgnoreMissing() throws Exception {
+        IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
+        IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
+        List<String> targetFields = Arrays.asList("out1", "out2");
+        Processor processor = new SplitToFieldsProcessor(randomAlphaOfLength(10), null, "field", ">", targetFields, true, false);
+        processor.execute(ingestDocument);
+        assertIngestDocument(originalIngestDocument, ingestDocument);
+    }
+
+    public void testSplitToFieldsNonStringValue() throws Exception {
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
+        String fieldName = RandomDocumentPicks.randomFieldName(random());
+        ingestDocument.setFieldValue(fieldName, randomInt());
+        List<String> targetFields = Arrays.asList("out1", "out2");
+        Processor processor = new SplitToFieldsProcessor(randomAlphaOfLength(10), null, fieldName, ">", targetFields, false, false);
+        try {
+            processor.execute(ingestDocument);
+            fail("split_to_fields processor should have failed");
+        } catch (IllegalArgumentException e) {
+            assertThat(
+                e.getMessage(),
+                equalTo("field [" + fieldName + "] of type [java.lang.Integer] cannot be cast to [java.lang.String]")
+            );
+        }
+    }
+
+    public void testSplitToFieldsSinglePart() throws Exception {
+        Map<String, Object> source = new HashMap<>();
+        source.put("input", "only_one");
+        IngestDocument ingestDocument = new IngestDocument(source, new HashMap<>());
+        List<String> targetFields = Arrays.asList("out1", "out2", "out3");
+        Processor processor = new SplitToFieldsProcessor(randomAlphaOfLength(10), null, "input", ">", targetFields, false, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue("out1", String.class), equalTo("only_one"));
+        assertFalse(ingestDocument.hasField("out2"));
+        assertFalse(ingestDocument.hasField("out3"));
+    }
+
+    public void testSplitToFieldsWithPreserveTrailing() throws Exception {
+        Map<String, Object> source = new HashMap<>();
+        source.put("input", "a|b|c||");
+        IngestDocument ingestDocument = new IngestDocument(source, new HashMap<>());
+        List<String> targetFields = Arrays.asList("out1", "out2", "out3", "out4", "out5");
+        Processor processor = new SplitToFieldsProcessor(randomAlphaOfLength(10), null, "input", "\\|", targetFields, false, true);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue("out1", String.class), equalTo("a"));
+        assertThat(ingestDocument.getFieldValue("out2", String.class), equalTo("b"));
+        assertThat(ingestDocument.getFieldValue("out3", String.class), equalTo("c"));
+        assertThat(ingestDocument.getFieldValue("out4", String.class), equalTo(""));
+        assertThat(ingestDocument.getFieldValue("out5", String.class), equalTo(""));
+    }
+
+    public void testSplitToFieldsWithoutPreserveTrailing() throws Exception {
+        Map<String, Object> source = new HashMap<>();
+        source.put("input", "a|b|c||");
+        IngestDocument ingestDocument = new IngestDocument(source, new HashMap<>());
+        List<String> targetFields = Arrays.asList("out1", "out2", "out3", "out4", "out5");
+        Processor processor = new SplitToFieldsProcessor(randomAlphaOfLength(10), null, "input", "\\|", targetFields, false, false);
+        processor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue("out1", String.class), equalTo("a"));
+        assertThat(ingestDocument.getFieldValue("out2", String.class), equalTo("b"));
+        assertThat(ingestDocument.getFieldValue("out3", String.class), equalTo("c"));
+        assertFalse(ingestDocument.hasField("out4"));
+        assertFalse(ingestDocument.hasField("out5"));
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Add SplitToFieldsProcessor to more efficiently achieve what was described [here](https://docs.opensearch.org/latest/tutorials/faceted-search/#hierarchical-faceting), essentially it has a similar interface as `SplitProcessor` but instead of put it back into the original field, this one distribute it to target fields.

### Related Issues
n/a

### Check List
- [X] Functionality includes testing.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
