### PR TITLE
Skip zone awareness when auto-expand replicas set to all

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/AwarenessAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/AwarenessAllocationIT.java
@@ -533,4 +533,68 @@ public class AwarenessAllocationIT extends OpenSearchIntegTestCase {
             assertAcked(client().admin().indices().prepareUpdateSettings("test-idx").setSettings(newsettings));
         });
     }
+
+    public void testAwarenessZonesWithAutoExpand() {
+        Settings commonSettings = Settings.builder()
+            .put(AwarenessReplicaBalance.CLUSTER_ROUTING_ALLOCATION_AWARENESS_BALANCE_SETTING.getKey(), true)
+            .put(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP_SETTING.getKey() + "zone.values", "a")
+            .put(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.getKey(), "zone")
+            .build();
+
+        logger.info("--> starting 2 nodes on same zone");
+        List<String> nodes = internalCluster().startNodes(
+            Settings.builder().put(commonSettings).put("node.attr.zone", "a").build(),
+            Settings.builder().put(commonSettings).put("node.attr.zone", "a").build()
+        );
+        String A = nodes.get(0);
+        String B = nodes.get(1);
+
+        logger.info("--> waiting for nodes to form a cluster");
+        ClusterHealthResponse health = client().admin().cluster().prepareHealth().setWaitForNodes("2").execute().actionGet();
+        assertThat(health.isTimedOut(), equalTo(false));
+
+        createIndex(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2)
+                .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-all")
+                .build()
+        );
+
+        if (randomBoolean()) {
+            assertAcked(client().admin().indices().prepareClose("test"));
+        }
+
+        logger.info("--> waiting for shards to be allocated");
+        health = client().admin()
+            .cluster()
+            .prepareHealth()
+            .setIndices("test")
+            .setWaitForEvents(Priority.LANGUID)
+            .setWaitForGreenStatus()
+            .setWaitForNoRelocatingShards(true)
+            .execute()
+            .actionGet();
+        assertThat(health.isTimedOut(), equalTo(false));
+
+        ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(4));
+
+        final Map<String, Integer> counts = new HashMap<>();
+        int replicaCount = 0;
+
+        for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
+            for (IndexShardRoutingTable indexShardRoutingTable : indexRoutingTable) {
+                for (ShardRouting shardRouting : indexShardRoutingTable) {
+                    if (!shardRouting.primary()) {
+                        replicaCount++;
+                    }
+                    counts.merge(clusterState.nodes().get(shardRouting.currentNodeId()).getName(), 1, Integer::sum);
+                }
+            }
+        }
+        assertThat(counts.get(A), anyOf(equalTo(1), equalTo(2)));
+        assertThat(counts.get(B), anyOf(equalTo(1), equalTo(2)));
+        assertThat(replicaCount, equalTo(2));
+    }
 }

--- a/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/AutoExpandReplicas.java
@@ -139,6 +139,10 @@ public final class AutoExpandReplicas {
         return enabled;
     }
 
+    public boolean autoExpandToAll() {
+        return enabled && maxReplicas == Integer.MAX_VALUE;
+    }
+
     private OptionalInt getDesiredNumberOfReplicas(IndexMetadata indexMetadata, RoutingAllocation allocation) {
         if (enabled) {
             int numMatchingDataNodes = (int) allocation.nodes()

--- a/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
+++ b/server/src/main/java/org/opensearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
@@ -51,6 +51,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
+import static org.opensearch.cluster.metadata.IndexMetadata.INDEX_AUTO_EXPAND_REPLICAS_SETTING;
 
 /**
  * This {@link AllocationDecider} controls shard allocation based on
@@ -161,6 +162,9 @@ public class AwarenessAllocationDecider extends AllocationDecider {
         }
 
         IndexMetadata indexMetadata = allocation.metadata().getIndexSafe(shardRouting.index());
+        if (INDEX_AUTO_EXPAND_REPLICAS_SETTING.get(indexMetadata.getSettings()).autoExpandToAll()) {
+            return allocation.decision(Decision.YES, NAME, "allocation awareness is ignored, this index is set to auto-expand to all");
+        }
         int shardCount = shardRouting.isSearchOnly()
             ? indexMetadata.getNumberOfSearchOnlyReplicas()
             : indexMetadata.getNumberOfReplicas() + 1; // 1 for primary

--- a/server/src/test/java/org/opensearch/cluster/metadata/AutoExpandReplicasTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/AutoExpandReplicasTests.java
@@ -79,17 +79,23 @@ public class AutoExpandReplicasTests extends OpenSearchTestCase {
         assertEquals(0, autoExpandReplicas.getMinReplicas());
         assertEquals(5, autoExpandReplicas.getMaxReplicas(8));
         assertEquals(2, autoExpandReplicas.getMaxReplicas(3));
+        assertFalse(autoExpandReplicas.autoExpandToAll());
 
         autoExpandReplicas = AutoExpandReplicas.SETTING.get(Settings.builder().put("index.auto_expand_replicas", "0-all").build());
         assertEquals(0, autoExpandReplicas.getMinReplicas());
         assertEquals(5, autoExpandReplicas.getMaxReplicas(6));
         assertEquals(2, autoExpandReplicas.getMaxReplicas(3));
+        assertTrue(autoExpandReplicas.autoExpandToAll());
 
         autoExpandReplicas = AutoExpandReplicas.SETTING.get(Settings.builder().put("index.auto_expand_replicas", "1-all").build());
         assertEquals(1, autoExpandReplicas.getMinReplicas());
         assertEquals(5, autoExpandReplicas.getMaxReplicas(6));
         assertEquals(2, autoExpandReplicas.getMaxReplicas(3));
+        assertTrue(autoExpandReplicas.autoExpandToAll());
 
+        autoExpandReplicas = AutoExpandReplicas.SETTING.get(Settings.builder().put("index.auto_expand_replicas", "false").build());
+        assertFalse(autoExpandReplicas.isEnabled());
+        assertFalse(autoExpandReplicas.autoExpandToAll());
     }
 
     public void testInvalidValues() {

--- a/server/src/test/java/org/opensearch/cluster/routing/allocation/AwarenessAllocationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/allocation/AwarenessAllocationTests.java
@@ -1119,4 +1119,39 @@ public class AwarenessAllocationTests extends OpenSearchAllocationTestCase {
             decisions.get(0).getExplanation()
         );
     }
+
+    public void testIgnoredByAutoExpandReplicasToAll() {
+        final Settings settings = Settings.builder()
+            .put(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.getKey(), "zone")
+            .build();
+
+        final AllocationService strategy = createAllocationService(settings);
+
+        final IndexMetadata.Builder metadataBuilder = IndexMetadata.builder("test")
+            .settings(
+                settings(Version.CURRENT).put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 100)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-all")
+            );
+
+        final Metadata metadata = Metadata.builder().put(metadataBuilder).build();
+
+        final DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(newNode("A-0", singletonMap("zone", "a")))
+            .add(newNode("A-1", singletonMap("zone", "a")))
+            .add(newNode("A-2", singletonMap("zone", "a")))
+            .add(newNode("B-0", singletonMap("zone", "b")))
+            .build();
+
+        final ClusterState clusterState = applyStartedShardsUntilNoChange(
+            ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.get(Settings.EMPTY))
+                .metadata(metadata)
+                .routingTable(RoutingTable.builder().addAsNew(metadata.index("test")).build())
+                .nodes(nodes)
+                .build(),
+            strategy
+        );
+
+        assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).size(), equalTo(0));
+    }
 }


### PR DESCRIPTION
### Description
When `index.auto_expand_replicas` is set to `0-all`, the `AwarenessAllocationDecider` was blocking shard placement on clusters where all nodes reside in the same zone. This caused shards to remain unassigned (under-replication) even though every available node should be a valid target.

This change makes the decider return `YES` immediately when the index is configured to auto-expand to all nodes, bypassing zone awareness constraints in that specific case.

**Changes:**
- `AutoExpandReplicas`: added `autoExpandToAll()` helper method
- `AwarenessAllocationDecider`: added early-return in `underCapacity()` when auto-expand-to-all is detected
- `AwarenessAllocationTests`: added unit test `testIgnoredByAutoExpandReplicasToAll`
- `AwarenessAllocationIT`: added integration test `testAwarenessZonesWithAutoExpand`

> Implementation ported from #16031, original work by @amberzsy. Thank you!

### Related Issues
Resolves #14603

### Checklist
- [x] Functionality includes testing
- [ ] API changes companion PR created (N/A — no REST API changes)
- [ ] Public documentation issue/PR created (N/A)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.