### PR TITLE
Add server-side implementation for tiering status APIs (GetTieringStatus & ListTieringStatus)

### DIFF
--- a/server/src/main/java/org/opensearch/action/ActionModule.java
+++ b/server/src/main/java/org/opensearch/action/ActionModule.java
@@ -500,6 +500,12 @@ import org.opensearch.rest.action.search.RestMultiSearchAction;
 import org.opensearch.rest.action.search.RestPutSearchPipelineAction;
 import org.opensearch.rest.action.search.RestSearchAction;
 import org.opensearch.rest.action.search.RestSearchScrollAction;
+import org.opensearch.storage.action.tiering.status.GetTieringStatusAction;
+import org.opensearch.storage.action.tiering.status.ListTieringStatusAction;
+import org.opensearch.storage.action.tiering.status.rest.RestGetTieringStatusAction;
+import org.opensearch.storage.action.tiering.status.rest.RestListTieringStatusAction;
+import org.opensearch.storage.action.tiering.status.transport.TransportGetTieringStatusAction;
+import org.opensearch.storage.action.tiering.status.transport.TransportListTieringStatusAction;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.node.NodeClient;
@@ -841,6 +847,12 @@ public class ActionModule extends AbstractModule {
         actions.register(GetIngestionStateAction.INSTANCE, TransportGetIngestionStateAction.class);
         actions.register(UpdateIngestionStateAction.INSTANCE, TransportUpdateIngestionStateAction.class);
 
+        // Tiering status actions
+        if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)) {
+            actions.register(ListTieringStatusAction.INSTANCE, TransportListTieringStatusAction.class);
+            actions.register(GetTieringStatusAction.INSTANCE, TransportGetTieringStatusAction.class);
+        }
+
         return unmodifiableMap(actions.getRegistry());
     }
 
@@ -1081,6 +1093,12 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestPauseIngestionAction());
         registerHandler.accept(new RestResumeIngestionAction());
         registerHandler.accept(new RestGetIngestionStateAction());
+
+        // Tiering status api
+        if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)) {
+            registerHandler.accept(new RestListTieringStatusAction());
+            registerHandler.accept(new RestGetTieringStatusAction());
+        }
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -268,6 +268,8 @@ import org.opensearch.snapshots.RestoreService;
 import org.opensearch.snapshots.SnapshotShardsService;
 import org.opensearch.snapshots.SnapshotsInfoService;
 import org.opensearch.snapshots.SnapshotsService;
+import org.opensearch.storage.tiering.HotToWarmTieringService;
+import org.opensearch.storage.tiering.WarmToHotTieringService;
 import org.opensearch.task.commons.clients.TaskManagerClient;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskCancellationMonitoringService;
@@ -1696,6 +1698,11 @@ public class Node implements Closeable {
                 b.bind(MergedSegmentPublisher.class).asEagerSingleton();
 
                 taskManagerClientOptional.ifPresent(value -> b.bind(TaskManagerClient.class).toInstance(value));
+
+                if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)) {
+                    b.bind(HotToWarmTieringService.class).asEagerSingleton();
+                    b.bind(WarmToHotTieringService.class).asEagerSingleton();
+                }
             });
             injector = modules.createInjector();
 

--- a/server/src/main/java/org/opensearch/storage/action/tiering/status/model/GetTieringStatusRequest.java
+++ b/server/src/main/java/org/opensearch/storage/action/tiering/status/model/GetTieringStatusRequest.java
@@ -15,6 +15,8 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
+import static org.opensearch.action.ValidateActions.addValidationError;
+
 /**
  * Migration status request for a single index.
  */
@@ -65,17 +67,24 @@ public class GetTieringStatusRequest extends ClusterManagerNodeReadRequest<GetTi
      */
     public GetTieringStatusRequest(StreamInput in) throws IOException {
         super(in);
-        throw new UnsupportedOperationException("Not yet implemented");
+        index = in.readString();
+        isDetailedFlagEnabled = in.readBoolean();
     }
 
     @Override
     public ActionRequestValidationException validate() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        ActionRequestValidationException validationException = null;
+        if (index == null) {
+            validationException = addValidationError("index is missing", validationException);
+        }
+        return validationException;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        super.writeTo(out);
+        out.writeString(index);
+        out.writeBoolean(isDetailedFlagEnabled);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/storage/action/tiering/status/model/GetTieringStatusResponse.java
+++ b/server/src/main/java/org/opensearch/storage/action/tiering/status/model/GetTieringStatusResponse.java
@@ -42,16 +42,19 @@ public class GetTieringStatusResponse extends ActionResponse implements ToXConte
      * @throws IOException if an I/O error occurs
      */
     public GetTieringStatusResponse(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        tieringStatus = TieringStatus.readFrom(in);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        builder.startObject();
+        tieringStatus.toXContent(builder, params);
+        builder.endObject();
+        return builder;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        tieringStatus.writeTo(out);
     }
 }

--- a/server/src/main/java/org/opensearch/storage/action/tiering/status/model/ListTieringStatusRequest.java
+++ b/server/src/main/java/org/opensearch/storage/action/tiering/status/model/ListTieringStatusRequest.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.storage.action.tiering.status.model;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.support.clustermanager.ClusterManagerNodeReadRequest;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -26,6 +28,7 @@ import java.util.Locale;
  */
 public class ListTieringStatusRequest extends ClusterManagerNodeReadRequest<ListTieringStatusRequest> {
 
+    private static final Logger log = LogManager.getLogger(ListTieringStatusRequest.class);
     private String targetTier;
 
     /** Returns the target tier. */
@@ -57,7 +60,7 @@ public class ListTieringStatusRequest extends ClusterManagerNodeReadRequest<List
      */
     public ListTieringStatusRequest(StreamInput in) throws IOException {
         super(in);
-        throw new UnsupportedOperationException("Not yet implemented");
+        targetTier = in.readOptionalString();
     }
 
     @Override
@@ -67,7 +70,8 @@ public class ListTieringStatusRequest extends ClusterManagerNodeReadRequest<List
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        super.writeTo(out);
+        out.writeOptionalString(targetTier != null ? targetTier.toString() : null);
     }
 
 }

--- a/server/src/main/java/org/opensearch/storage/action/tiering/status/model/ListTieringStatusResponse.java
+++ b/server/src/main/java/org/opensearch/storage/action/tiering/status/model/ListTieringStatusResponse.java
@@ -13,6 +13,8 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /** Response containing tiering status for all indices. */
@@ -39,11 +41,20 @@ public class ListTieringStatusResponse extends ActionResponse {
      * @throws IOException if error
      */
     public ListTieringStatusResponse(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+
+        int size = in.readVInt();
+        List<TieringStatus> builder = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            builder.add(TieringStatus.readFrom(in));
+        }
+        tieringStatusList = Collections.unmodifiableList(builder);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        out.writeVInt(tieringStatusList.size());
+        for (TieringStatus tieringStatus : tieringStatusList) {
+            tieringStatus.writeTo(out);
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/storage/action/tiering/status/model/TieringStatus.java
+++ b/server/src/main/java/org/opensearch/storage/action/tiering/status/model/TieringStatus.java
@@ -8,6 +8,10 @@
 
 package org.opensearch.storage.action.tiering.status.model;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -15,13 +19,19 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Migration status object.
  */
 public class TieringStatus implements ToXContentObject, Writeable {
+
+    private static final Logger logger = LogManager.getLogger(TieringStatus.class);
 
     /** Key for tiering status. */
     public static final String TIERING_STATUS = "tiering_status";
@@ -158,12 +168,27 @@ public class TieringStatus implements ToXContentObject, Writeable {
 
     @Override
     public void writeTo(StreamOutput streamOutput) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        streamOutput.writeString(indexName);
+        streamOutput.writeString(status);
+        streamOutput.writeString(source);
+        streamOutput.writeString(target);
+        streamOutput.writeLong(startTime);
+        streamOutput.writeOptionalWriteable(shardLevelStatus);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        xContentBuilder.startObject(TIERING_STATUS);
+        xContentBuilder.field(INDEX, this.getIndexName());
+        xContentBuilder.field(STATE, this.getStatus());
+        xContentBuilder.field(SOURCE, this.getSource());
+        xContentBuilder.field(TARGET, this.getTarget());
+        xContentBuilder.field(START_TIME, this.getStartTime());
+        if (shardLevelStatus != null) {
+            shardLevelStatus.toXContent(xContentBuilder, params);
+        }
+        xContentBuilder.endObject();
+        return xContentBuilder;
     }
 
     /**
@@ -173,7 +198,15 @@ public class TieringStatus implements ToXContentObject, Writeable {
      * @throws IOException if error
      */
     public static TieringStatus readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        final TieringStatus tieringStatus = new TieringStatus();
+        tieringStatus.setIndexName(in.readString());
+        tieringStatus.setStatus(in.readString());
+        tieringStatus.setSource(in.readString());
+        tieringStatus.setTarget(in.readString());
+        tieringStatus.setStartTime(in.readLong());
+        tieringStatus.setShardLevelStatus(in.readOptionalWriteable(ShardLevelStatus::new));
+
+        return tieringStatus;
     }
 
     /** Shard-level status with counters. */
@@ -198,7 +231,13 @@ public class TieringStatus implements ToXContentObject, Writeable {
          * @throws IOException if error
          */
         public ShardLevelStatus(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException("Not yet implemented");
+            shardLevelCounters = new HashMap<>();
+            final Map<String, Object> inputMap = in.readMap();
+            for (Map.Entry<String, Object> entry : inputMap.entrySet()) {
+                shardLevelCounters.put(entry.getKey(), Integer.parseInt(entry.getValue().toString()));
+            }
+            List<OngoingShard> shards = in.readList(OngoingShard::new);
+            ongoingShards = shards != null ? shards : Collections.emptyList();
         }
 
         /**
@@ -211,14 +250,93 @@ public class TieringStatus implements ToXContentObject, Writeable {
             this.ongoingShards = ongoingShards;
         }
 
+        public static ShardLevelStatus fromRoutingTable(
+            ClusterState clusterState,
+            String index,
+            Boolean isDetailedFlagEnabled,
+            String targetTier
+        ) {
+            final List<ShardRouting> routingTable = clusterState.routingTable().allShards(index);
+            final Map<String, Integer> shardLevelCounters = new HashMap<>();
+            final List<OngoingShard> ongoingShards = new ArrayList<>();
+
+            int pending = 0;
+            int running = 0;
+            int succeeded = 0;
+            boolean isTargetWarm = "WARM".equalsIgnoreCase(targetTier);
+
+            for (ShardRouting shard : routingTable) {
+                // Switch based on shard routing state. Note that INITIALIZING is missing below since we will have a
+                // corresponding shard in RELOCATING state.
+                switch (shard.state()) {
+                    case STARTED:
+                        // Only count STARTED shards as done if they're placed on target nodes.
+                        final boolean isWarmNode = clusterState.getNodes().get(shard.currentNodeId()).isWarmNode();
+                        if (isTargetWarm == isWarmNode) {
+                            succeeded++;
+                        } else {
+                            pending++;
+                        }
+                        break;
+                    case UNASSIGNED:
+                        pending++;
+                        break;
+                    case RELOCATING:
+                        running++;
+                        if (isDetailedFlagEnabled) {
+                            ongoingShards.add(new OngoingShard(shard.shardId().id(), shard.relocatingNodeId()));
+                        }
+                        break;
+                    default:
+                        logger.warn("Unexpected shard state [{}] for index [{}]", shard.state(), index);
+                        break;
+
+                }
+            }
+            shardLevelCounters.put(PENDING_SHARDS, pending);
+            shardLevelCounters.put(SUCCEEDED_SHARDS, succeeded);
+            shardLevelCounters.put(RUNNING_SHARDS, running);
+            shardLevelCounters.put(TOTAL_SHARDS, pending + succeeded + running);
+            return new ShardLevelStatus(shardLevelCounters, ongoingShards);
+        }
+
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            throw new UnsupportedOperationException("Not yet implemented");
+            out.writeMapWithConsistentOrder(shardLevelCounters);
+            out.writeList(ongoingShards != null ? ongoingShards : Collections.emptyList());
         }
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            throw new UnsupportedOperationException("Not yet implemented");
+            builder.startObject(SHARD_LEVEL_STATUS);
+            for (Map.Entry<String, Integer> counter : shardLevelCounters.entrySet()) {
+                builder.field(counter.getKey(), counter.getValue());
+            }
+
+            if (ongoingShards != null && !ongoingShards.isEmpty()) {
+                builder.startArray(SHARD_RELOCATION_STATUS);
+                for (OngoingShard shard : ongoingShards) {
+                    if (shard != null) {
+                        shard.toXContent(builder, params);
+                    }
+                }
+                builder.endArray();
+            }
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ShardLevelStatus that = (ShardLevelStatus) o;
+            return Objects.equals(shardLevelCounters, that.shardLevelCounters) && Objects.equals(ongoingShards, that.ongoingShards);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(shardLevelCounters, ongoingShards);
         }
     }
 
@@ -243,17 +361,38 @@ public class TieringStatus implements ToXContentObject, Writeable {
          * @throws IOException if error
          */
         public OngoingShard(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException("Not yet implemented");
+            this.sourceShardId = in.readInt();
+            this.relocatingNodeId = in.readString();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            throw new UnsupportedOperationException("Not yet implemented");
+            out.writeInt(sourceShardId);
+            out.writeString(relocatingNodeId != null ? relocatingNodeId : "");
         }
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            throw new UnsupportedOperationException("Not yet implemented");
+            builder.startObject().field(SOURCE_SHARD_ID, sourceShardId).field(RELOCATING_NODE_ID, relocatingNodeId).endObject();
+            return builder;
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TieringStatus that = (TieringStatus) o;
+        return Objects.equals(indexName, that.indexName)
+            && Objects.equals(status, that.status)
+            && Objects.equals(source, that.source)
+            && Objects.equals(target, that.target)
+            && (startTime == that.startTime)
+            && Objects.equals(shardLevelStatus, that.shardLevelStatus);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(indexName, status, source, target, startTime, shardLevelStatus);
     }
 }

--- a/server/src/main/java/org/opensearch/storage/action/tiering/status/rest/RestGetTieringStatusAction.java
+++ b/server/src/main/java/org/opensearch/storage/action/tiering/status/rest/RestGetTieringStatusAction.java
@@ -8,12 +8,17 @@
 
 package org.opensearch.storage.action.tiering.status.rest;
 
+import org.opensearch.core.common.Strings;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+import org.opensearch.storage.action.tiering.status.GetTieringStatusAction;
+import org.opensearch.storage.action.tiering.status.model.GetTieringStatusRequest;
 import org.opensearch.transport.client.node.NodeClient;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 
 import static java.util.Collections.singletonList;
 import static org.opensearch.rest.RestRequest.Method.GET;
@@ -23,9 +28,6 @@ import static org.opensearch.rest.RestRequest.Method.GET;
  * prepareRequest logic will be added in the implementation PR.
  */
 public class RestGetTieringStatusAction extends BaseRestHandler {
-
-    /** Constructs a new RestGetTieringStatusAction. */
-    public RestGetTieringStatusAction() {}
 
     private static final String DETAILED_FLAG = "detailed";
     private static final String INDEX_NAME = "index";
@@ -42,6 +44,18 @@ public class RestGetTieringStatusAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        String[] indices = Strings.splitStringByCommaToArray(request.param(INDEX_NAME));
+        Boolean isDetailedFlagEnabled = Boolean.parseBoolean(request.param(DETAILED_FLAG));
+
+        if (indices.length != 1) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "request should contain single index"));
+        }
+
+        final GetTieringStatusRequest getTieringStatusRequest = new GetTieringStatusRequest();
+        getTieringStatusRequest.setIndex(indices[0]);
+        getTieringStatusRequest.setDetailedFlagEnabled(isDetailedFlagEnabled);
+        return channel -> client.admin()
+            .cluster()
+            .execute(GetTieringStatusAction.INSTANCE, getTieringStatusRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/main/java/org/opensearch/storage/action/tiering/status/rest/RestListTieringStatusAction.java
+++ b/server/src/main/java/org/opensearch/storage/action/tiering/status/rest/RestListTieringStatusAction.java
@@ -10,10 +10,19 @@ package org.opensearch.storage.action.tiering.status.rest;
 
 import org.opensearch.common.Table;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.RestResponse;
+import org.opensearch.rest.action.RestResponseListener;
 import org.opensearch.rest.action.cat.AbstractCatAction;
+import org.opensearch.rest.action.cat.RestTable;
+import org.opensearch.storage.action.tiering.status.ListTieringStatusAction;
+import org.opensearch.storage.action.tiering.status.model.ListTieringStatusRequest;
+import org.opensearch.storage.action.tiering.status.model.ListTieringStatusResponse;
+import org.opensearch.storage.action.tiering.status.model.TieringStatus;
+import org.opensearch.storage.common.tiering.TieringUtils;
 import org.opensearch.transport.client.node.NodeClient;
 
 import java.util.List;
+import java.util.Locale;
 
 import static java.util.Collections.singletonList;
 import static org.opensearch.rest.RestRequest.Method.GET;
@@ -22,9 +31,6 @@ import static org.opensearch.rest.RestRequest.Method.GET;
  * REST handler for listing tiering status of all indices.
  */
 public class RestListTieringStatusAction extends AbstractCatAction {
-
-    /** Constructs a new RestListTieringStatusAction. */
-    public RestListTieringStatusAction() {}
 
     private static final String TARGET_TIER = "target";
 
@@ -40,7 +46,22 @@ public class RestListTieringStatusAction extends AbstractCatAction {
 
     @Override
     public RestChannelConsumer doCatRequest(RestRequest request, NodeClient client) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        String targetTier = request.param(TARGET_TIER);
+
+        targetTier = parseAndValidateTargetTier(targetTier);
+        ListTieringStatusRequest listTieringStatusRequest = new ListTieringStatusRequest(targetTier);
+        return channel -> client.admin()
+            .cluster()
+            .execute(
+                ListTieringStatusAction.INSTANCE,
+                listTieringStatusRequest,
+                new RestResponseListener<ListTieringStatusResponse>(channel) {
+                    @Override
+                    public RestResponse buildResponse(ListTieringStatusResponse listTieringStatusResponse) throws Exception {
+                        return RestTable.buildResponse(buildTable(request, listTieringStatusResponse), channel);
+                    }
+                }
+            );
     }
 
     @Override
@@ -49,7 +70,51 @@ public class RestListTieringStatusAction extends AbstractCatAction {
     }
 
     @Override
-    public Table getTableWithHeader(RestRequest request) {
-        throw new UnsupportedOperationException("Not yet implemented");
+    public Table getTableWithHeader(RestRequest restRequest) {
+        Table table = new Table();
+        table.startHeaders();
+        table.addCell("index", "alias:i,idx;desc:index name");
+        table.addCell("state", "desc: the current state of the migration");
+        table.addCell("source", "desc: source tier");
+        table.addCell("target", "desc: destination tier");
+        table.endHeaders();
+        return table;
+    }
+
+    public Table buildTable(RestRequest request, ListTieringStatusResponse response) {
+        Table table = getTableWithHeader(request);
+        for (TieringStatus tieringStatus : response.getTieringStatusList()) {
+            table.startRow();
+            table.addCell(tieringStatus.getIndexName());
+            table.addCell(tieringStatus.getStatus());
+            table.addCell(tieringStatus.getSource());
+            table.addCell(tieringStatus.getTarget());
+            table.endRow();
+        }
+        return table;
+    }
+
+    // parse target tier '_hot' and '_warm'
+    public String parseAndValidateTargetTier(String targetTier) {
+        if (targetTier == null) {
+            return null;
+        }
+
+        // Extract the part after the underscore
+        String[] parts = targetTier.split("_");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Invalid format. Target Tier must be in the form '_tier'");
+        }
+
+        // Convert to lowercase for case-insensitive comparison
+        String extractedTier = parts[1].toUpperCase(Locale.ROOT);
+
+        // Validate the extracted tier
+        if (!TieringUtils.isTerminalTier(extractedTier)) {
+            throw new IllegalArgumentException("Invalid target tier. Target Tier must be either '_hot' or '_warm'");
+        }
+
+        return extractedTier;
+
     }
 }

--- a/server/src/main/java/org/opensearch/storage/action/tiering/status/transport/TransportGetTieringStatusAction.java
+++ b/server/src/main/java/org/opensearch/storage/action/tiering/status/transport/TransportGetTieringStatusAction.java
@@ -14,18 +14,28 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeReadAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.block.ClusterBlockLevel;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.IndexModule;
 import org.opensearch.storage.action.tiering.status.GetTieringStatusAction;
 import org.opensearch.storage.action.tiering.status.model.GetTieringStatusRequest;
 import org.opensearch.storage.action.tiering.status.model.GetTieringStatusResponse;
+import org.opensearch.storage.common.tiering.TieringUtils;
+import org.opensearch.storage.tiering.HotToWarmTieringService;
+import org.opensearch.storage.tiering.TieringService;
+import org.opensearch.storage.tiering.WarmToHotTieringService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Transport handler for getting tiering status of a single index.
@@ -37,6 +47,7 @@ public class TransportGetTieringStatusAction extends TransportClusterManagerNode
     GetTieringStatusResponse> {
 
     private static final Logger logger = LogManager.getLogger(TransportGetTieringStatusAction.class);
+    private final Map<IndexModule.TieringState, TieringService> migrationServiceMap = new HashMap<>();
 
     /**
      * Constructs a TransportGetTieringStatusAction.
@@ -51,6 +62,8 @@ public class TransportGetTieringStatusAction extends TransportClusterManagerNode
     public TransportGetTieringStatusAction(
         TransportService transportService,
         ClusterService clusterService,
+        HotToWarmTieringService hotToWarmTieringService,
+        WarmToHotTieringService warmToHotTieringService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver
@@ -64,16 +77,18 @@ public class TransportGetTieringStatusAction extends TransportClusterManagerNode
             GetTieringStatusRequest::new,
             indexNameExpressionResolver
         );
+        migrationServiceMap.put(IndexModule.TieringState.HOT_TO_WARM, hotToWarmTieringService);
+        migrationServiceMap.put(IndexModule.TieringState.WARM_TO_HOT, warmToHotTieringService);
     }
 
     @Override
     public String executor() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return ThreadPool.Names.SAME;
     }
 
     @Override
-    protected GetTieringStatusResponse read(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+    protected GetTieringStatusResponse read(StreamInput streamInput) throws IOException {
+        return new GetTieringStatusResponse(streamInput);
     }
 
     @Override
@@ -82,11 +97,22 @@ public class TransportGetTieringStatusAction extends TransportClusterManagerNode
         ClusterState clusterState,
         ActionListener<GetTieringStatusResponse> listener
     ) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        try {
+            final Index index = TieringUtils.resolveRequestIndex(indexNameExpressionResolver, request.getIndex(), clusterService.state());
+            final IndexMetadata indexMeta = clusterState.getMetadata().index(index);
+            final IndexModule.TieringState tieringState = TieringUtils.getTieringStatefromIndexSettings(indexMeta.getSettings());
+            listener.onResponse(
+                new GetTieringStatusResponse(
+                    migrationServiceMap.get(tieringState).getTieringStatus(request.getIndex(), request.getDetailedFlag())
+                )
+            );
+        } catch (Exception ex) {
+            listener.onFailure(ex);
+        }
     }
 
     @Override
     public ClusterBlockException checkBlock(GetTieringStatusRequest request, ClusterState state) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
     }
 }

--- a/server/src/main/java/org/opensearch/storage/action/tiering/status/transport/TransportListTieringStatusAction.java
+++ b/server/src/main/java/org/opensearch/storage/action/tiering/status/transport/TransportListTieringStatusAction.java
@@ -14,18 +14,30 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeReadAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.index.IndexModule;
 import org.opensearch.storage.action.tiering.status.ListTieringStatusAction;
 import org.opensearch.storage.action.tiering.status.model.ListTieringStatusRequest;
 import org.opensearch.storage.action.tiering.status.model.ListTieringStatusResponse;
+import org.opensearch.storage.action.tiering.status.model.TieringStatus;
+import org.opensearch.storage.common.tiering.TieringUtils;
+import org.opensearch.storage.tiering.HotToWarmTieringService;
+import org.opensearch.storage.tiering.TieringService;
+import org.opensearch.storage.tiering.WarmToHotTieringService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Transport handler for listing tiering status of all indices.
@@ -37,6 +49,7 @@ public class TransportListTieringStatusAction extends TransportClusterManagerNod
     ListTieringStatusResponse> {
 
     private static final Logger logger = LogManager.getLogger(TransportListTieringStatusAction.class);
+    private final Map<IndexModule.TieringState, TieringService> migrationServiceMap = new HashMap<>();
 
     /**
      * Constructs a TransportListTieringStatusAction.
@@ -52,6 +65,8 @@ public class TransportListTieringStatusAction extends TransportClusterManagerNod
         TransportService transportService,
         ClusterService clusterService,
         ThreadPool threadPool,
+        HotToWarmTieringService hotToWarmTieringService,
+        WarmToHotTieringService warmToHotTieringService,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver
     ) {
@@ -64,16 +79,18 @@ public class TransportListTieringStatusAction extends TransportClusterManagerNod
             ListTieringStatusRequest::new,
             indexNameExpressionResolver
         );
+        migrationServiceMap.put(IndexModule.TieringState.HOT_TO_WARM, hotToWarmTieringService);
+        migrationServiceMap.put(IndexModule.TieringState.WARM_TO_HOT, warmToHotTieringService);
     }
 
     @Override
     public String executor() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return ThreadPool.Names.SAME;
     }
 
     @Override
     protected ListTieringStatusResponse read(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return new ListTieringStatusResponse(in);
     }
 
     @Override
@@ -81,12 +98,23 @@ public class TransportListTieringStatusAction extends TransportClusterManagerNod
         ListTieringStatusRequest request,
         ClusterState clusterState,
         ActionListener<ListTieringStatusResponse> listener
-    ) {
-        throw new UnsupportedOperationException("Not yet implemented");
+    ) throws IOException {
+        List<TieringStatus> tieringStatusList = new ArrayList<>();
+
+        if (request.getTargetTier() != null) {
+            tieringStatusList = migrationServiceMap.get(TieringUtils.getTieringStatefromTargetTier(request.getTargetTier()))
+                .listTieringStatus();
+        } else {
+            tieringStatusList = migrationServiceMap.values()
+                .stream()
+                .flatMap(service -> service.listTieringStatus().stream())
+                .collect(Collectors.toList());
+        }
+        listener.onResponse(new ListTieringStatusResponse(tieringStatusList));
     }
 
     @Override
     public ClusterBlockException checkBlock(ListTieringStatusRequest request, ClusterState clusterState) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return clusterState.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
     }
 }

--- a/server/src/main/java/org/opensearch/storage/common/tiering/TieringUtils.java
+++ b/server/src/main/java/org/opensearch/storage/common/tiering/TieringUtils.java
@@ -10,10 +10,24 @@ package org.opensearch.storage.common.tiering;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.IndexModule;
 
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+
+import static org.opensearch.index.IndexModule.INDEX_TIERING_STATE;
+import static org.opensearch.index.IndexModule.TieringState.HOT;
+import static org.opensearch.index.IndexModule.TieringState.HOT_TO_WARM;
+import static org.opensearch.index.IndexModule.TieringState.WARM;
+import static org.opensearch.index.IndexModule.TieringState.WARM_TO_HOT;
 
 /**
  * Utility class for handling tiering operations in OpenSearch Warm.
@@ -94,6 +108,119 @@ public class TieringUtils {
     private static final Set<String> ALLOWLISTED_INDEX_PREFIXES = Set.of(".ds-");
     private static final Set<String> BLOCKLISTED_INDEX_PREFIXES = Set.of(".");
     private static final String CCR_LEADER_INDEX_SETTING_KEY = "index.plugins.replication.follower.leader_index";
+
+    /**
+     * Resolves the concrete index from a request index name.
+     *
+     * @param indexNameExpressionResolver resolver for index names
+     * @param requestIndex                the requested index name
+     * @param currentState                current cluster state
+     * @return resolved Index object
+     */
+    public static Index resolveRequestIndex(
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        String requestIndex,
+        ClusterState currentState
+    ) {
+        try {
+            final Index[] requestIndices = indexNameExpressionResolver.concreteIndices(
+                currentState,
+                IndicesOptions.STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED,
+                requestIndex
+            );
+            if (requestIndices.length != 1) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "Expected single index but got %d indices", requestIndices.length)
+                );
+            }
+            logger.info(() -> String.format(Locale.ROOT, "Resolved index [%s] to [%s]", requestIndex, requestIndices[0].getName()));
+            return requestIndices[0];
+        } catch (Exception e) {
+            logger.error(() -> String.format(Locale.ROOT, "Failed to resolve index: [%s]", requestIndex), e);
+            throw new IllegalArgumentException("Failed to resolve index: " + requestIndex, e);
+        }
+    }
+
+    /**
+     * Returns the TieringState based on the index settings.
+     * @param indexSettings the index settings
+     * @return the TieringState
+     */
+    public static IndexModule.TieringState getTieringStatefromIndexSettings(Settings indexSettings) {
+        final IndexModule.TieringState tieringState = IndexModule.TieringState.valueOf(
+            indexSettings.get(INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT.name())
+        );
+        switch (tieringState) {
+            case HOT_TO_WARM:
+            case WARM:
+                return HOT_TO_WARM;
+            case HOT:
+            case WARM_TO_HOT:
+                return WARM_TO_HOT;
+            default:
+                throw new IllegalArgumentException("Unsupported index migration state: " + tieringState);
+        }
+    }
+
+    /**
+     * Returns an array of tier names representing the source and target tiers for a given tiering state.
+     *
+     * @param tieringState The target tiering state of the index
+     * @return String array containing source and target tier names in order [source, target]
+     * @throws IllegalArgumentException if the tiering state is not recognized
+     */
+    public static String[] getTierPairForTargetTier(IndexModule.TieringState tieringState) {
+        return switch (tieringState) {
+            case WARM -> new String[] { HOT.toString(), WARM.toString() };
+            case HOT -> new String[] { WARM.toString(), HOT.toString() };
+            default -> throw new IllegalArgumentException("Unknown state: " + tieringState);
+        };
+    }
+
+    /**
+     * Determines the tiering state based on the target tier.
+     *
+     * @param tieringState String representation of the target tier state
+     * @return The corresponding TieringState enum value
+     * @throws IllegalArgumentException if the tiering state is not recognized
+     */
+    public static IndexModule.TieringState getTieringStatefromTargetTier(String tieringState) {
+        return switch (IndexModule.TieringState.valueOf(tieringState)) {
+            case HOT -> WARM_TO_HOT;
+            case WARM -> HOT_TO_WARM;
+            default -> throw new IllegalArgumentException("Unknown state: " + tieringState);
+        };
+    }
+
+    /**
+     * Checks if the given tier is a terminal tier (HOT or WARM).
+     *
+     * @param targetTier The tier to check
+     * @return true if the tier is terminal (HOT or WARM), false otherwise
+     */
+    public static boolean isTerminalTier(String targetTier) {
+        return Arrays.asList(IndexModule.TieringState.HOT.toString(), IndexModule.TieringState.WARM.toString())
+            .contains(targetTier.toUpperCase(Locale.ROOT));
+    }
+
+    /**
+     * Retrieves the start time of a tiering operation for a specific index.
+     * The time is stored as a custom metadata field in the cluster state.
+     *
+     * @param clusterState The current state of the cluster
+     * @param index The index for which to retrieve the tiering start time
+     * @param tieringStartTimeKey The key used to store the tiering start time in custom metadata
+     * @return The timestamp when the tiering operation started (in milliseconds since epoch)
+     * @throws NullPointerException if the tiering metadata or start time is not found
+     * @throws NumberFormatException if the stored start time value cannot be parsed as a long
+     */
+    public static long getTieringStartTime(ClusterState clusterState, Index index, String tieringStartTimeKey) {
+        Map<String, String> customData = clusterState.getMetadata().getIndexSafe(index).getCustomData(TIERING_CUSTOM_KEY);
+        if (customData == null || customData.get(tieringStartTimeKey) == null) {
+            throw new IllegalStateException("Tiering metadata not found for index [" + index.getName() + "]");
+        }
+        return Long.parseLong(customData.get(tieringStartTimeKey));
+    }
 
     /** Represents the storage tiers available in tiered storage. */
     public enum Tier {

--- a/server/src/main/java/org/opensearch/storage/tiering/HotToWarmTieringService.java
+++ b/server/src/main/java/org/opensearch/storage/tiering/HotToWarmTieringService.java
@@ -23,6 +23,9 @@ import org.opensearch.indices.ShardLimitValidator;
 
 import java.util.Set;
 
+import static org.opensearch.index.IndexModule.TieringState.WARM;
+import static org.opensearch.storage.common.tiering.TieringUtils.H2W_TIERING_START_TIME_KEY;
+
 /**
  * Service responsible for tiering indices from hot to warm.
  * validateTieringRequest, getTieringStartSettingsToAdd, getIndexTierSettingsToRestoreAfterCancellation,
@@ -95,12 +98,12 @@ public class HotToWarmTieringService extends TieringService {
 
     @Override
     protected String getTieringStartTimeKey() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return H2W_TIERING_START_TIME_KEY;
     }
 
     @Override
     protected IndexModule.TieringState getTargetTieringState() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return WARM;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/storage/tiering/TieringService.java
+++ b/server/src/main/java/org/opensearch/storage/tiering/TieringService.java
@@ -25,9 +25,15 @@ import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.store.remote.filecache.FileCacheSettings;
 import org.opensearch.indices.ShardLimitValidator;
+import org.opensearch.storage.action.tiering.status.model.TieringStatus;
+import org.opensearch.storage.common.tiering.TieringUtils;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+
+import static org.opensearch.storage.common.tiering.TieringUtils.resolveRequestIndex;
 
 /**
  * Abstract base class for managing tiering operations in OpenSearch.
@@ -135,4 +141,70 @@ public abstract class TieringService implements ClusterStateListener {
 
     /** Returns the tiering type. @return the tiering type */
     protected abstract IndexModule.TieringState getTieringType();
+
+    /**
+     * Retrieves the tiering status for a specific index.
+     * This method provides detailed information about an ongoing tiering operation
+     * including source and target tiers, start time, and shard-level status.
+     *
+     * @param requestIndex The name of the index to check
+     * @param isDetailedFlagEnabled If true, includes detailed shard-level status information
+     * @return TieringStatus object containing detailed status information
+     * @throws IllegalArgumentException if the specified index has no active migrations
+     */
+    public TieringStatus getTieringStatus(String requestIndex, Boolean isDetailedFlagEnabled) {
+        final Index index = resolveRequestIndex(indexNameExpressionResolver, requestIndex, clusterService.state());
+
+        if (tieringIndices.contains(index)) {
+            try {
+                return constructTieringStatus(index, true, isDetailedFlagEnabled);
+            } catch (IllegalStateException e) {
+                throw new IllegalArgumentException("Index [" + requestIndex + "] has no active migrations");
+            }
+
+        }
+        throw new IllegalArgumentException("Index [" + requestIndex + "] has no active migrations");
+    }
+
+    /**
+     * Retrieves a list of tiering status for all indices currently undergoing tiering operations.
+     * This method provides a summary view of all active tiering operations in the cluster.
+     *
+     * @return List of TieringStatus objects, each representing the status of an ongoing tiering operation
+     * Returns an empty list if no tiering operations are active
+     */
+    public List<TieringStatus> listTieringStatus() {
+        final List<TieringStatus> tieringStatusList = new ArrayList<>();
+
+        for (Index tieringIndex : tieringIndices) {
+            try {
+                tieringStatusList.add(constructTieringStatus(tieringIndex, false, false));
+            } catch (IllegalStateException e) {
+                continue;
+            }
+        }
+        return tieringStatusList;
+    }
+
+    private TieringStatus constructTieringStatus(Index index, boolean shardLevelStatus, boolean isDetailedFlagEnabled) {
+        TieringStatus tieringStatus;
+        long tieringStartTime = TieringUtils.getTieringStartTime(clusterService.state(), index, getTieringStartTimeKey());
+
+        String[] tiers = TieringUtils.getTierPairForTargetTier(getTargetTieringState());
+        String sourceTier = tiers[0];
+        String destinationTier = tiers[1];
+        tieringStatus = new TieringStatus(index.getName(), TIERING_IN_PROGRESS_STATUS, sourceTier, destinationTier, tieringStartTime);
+
+        if (shardLevelStatus) {
+            tieringStatus.setShardLevelStatus(
+                TieringStatus.ShardLevelStatus.fromRoutingTable(
+                    clusterService.state(),
+                    index.getName(),
+                    isDetailedFlagEnabled,
+                    destinationTier
+                )
+            );
+        }
+        return tieringStatus;
+    }
 }

--- a/server/src/main/java/org/opensearch/storage/tiering/WarmToHotTieringService.java
+++ b/server/src/main/java/org/opensearch/storage/tiering/WarmToHotTieringService.java
@@ -23,6 +23,9 @@ import org.opensearch.indices.ShardLimitValidator;
 
 import java.util.Set;
 
+import static org.opensearch.index.IndexModule.TieringState.HOT;
+import static org.opensearch.storage.common.tiering.TieringUtils.W2H_TIERING_START_TIME_KEY;
+
 /**
  * Service responsible for tiering indices from warm to hot.
  * validateTieringRequest, getTieringStartSettingsToAdd, getIndexTierSettingsToRestoreAfterCancellation
@@ -85,7 +88,7 @@ public class WarmToHotTieringService extends TieringService {
 
     @Override
     protected String getTieringStartTimeKey() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return W2H_TIERING_START_TIME_KEY;
     }
 
     @Override
@@ -95,7 +98,7 @@ public class WarmToHotTieringService extends TieringService {
 
     @Override
     protected IndexModule.TieringState getTargetTieringState() {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return HOT;
     }
 
     @Override

--- a/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/model/GetTieringStatusRequestTests.java
+++ b/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/model/GetTieringStatusRequestTests.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.action.admin.tiering.status.model;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.storage.action.tiering.status.model.GetTieringStatusRequest;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class GetTieringStatusRequestTests extends OpenSearchTestCase {
+
+    public void testInvalidRequest() {
+        GetTieringStatusRequest request = new GetTieringStatusRequest();
+        ActionRequestValidationException validate = request.validate();
+        assertThat(validate, notNullValue());
+        assertThat(validate.getMessage(), containsString("index is missing"));
+    }
+
+    public void testSerialization() throws IOException {
+        final GetTieringStatusRequest request = new GetTieringStatusRequest();
+        request.setIndex("foo");
+        request.setDetailedFlagEnabled(Boolean.TRUE);
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            request.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                GetTieringStatusRequest newRequest = new GetTieringStatusRequest(in);
+                assertEquals("foo", newRequest.getIndex());
+                assertEquals(true, newRequest.getDetailedFlag());
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/model/GetTieringStatusResponseTests.java
+++ b/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/model/GetTieringStatusResponseTests.java
@@ -1,0 +1,248 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.action.admin.tiering.status.model;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.storage.action.tiering.status.model.GetTieringStatusResponse;
+import org.opensearch.storage.action.tiering.status.model.TieringStatus;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GetTieringStatusResponseTests extends OpenSearchTestCase {
+
+    public void testXContent() throws IOException {
+        TieringStatus status = new TieringStatus("test-index", "RUNNING", "hot", "warm", 123);
+
+        final GetTieringStatusResponse response = new GetTieringStatusResponse(status);
+
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
+
+        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+        assertEquals(TieringStatus.TIERING_STATUS, parser.currentName());
+        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            parser.nextToken();
+            // assertEquals(XContentParser.Token.VALUE_STRING, parser.nextToken());
+            final String currentFieldName = parser.currentName();
+            if (currentFieldName.equals(TieringStatus.INDEX)) {
+                assertEquals("test-index", parser.text());
+            } else if (currentFieldName.equals(TieringStatus.STATE)) {
+                assertEquals("RUNNING", parser.text());
+            } else if (currentFieldName.equals(TieringStatus.SOURCE)) {
+                assertEquals("hot", parser.text());
+            } else if (currentFieldName.equals(TieringStatus.TARGET)) {
+                assertEquals("warm", parser.text());
+            } else if (currentFieldName.equals(TieringStatus.START_TIME)) {
+                assertEquals(123, parser.longValue());
+            }
+        }
+        assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
+    }
+
+    public void testStreamSerialization_withRelocatingShards() throws IOException {
+        // Create original object
+        TieringStatus originalStatus = new TieringStatus("test-index", "RUNNING", "hot", "warm", 123L);
+        Map<String, Integer> shardCounters = new HashMap<>();
+        shardCounters.put(TieringStatus.PENDING_SHARDS, 2);
+        shardCounters.put(TieringStatus.SUCCEEDED_SHARDS, 3);
+        shardCounters.put(TieringStatus.RUNNING_SHARDS, 1);
+        shardCounters.put(TieringStatus.TOTAL_SHARDS, 6);
+        List<TieringStatus.OngoingShard> ongoingShards = Collections.singletonList(new TieringStatus.OngoingShard(1, "node1"));
+        originalStatus.setShardLevelStatus(new TieringStatus.ShardLevelStatus(shardCounters, ongoingShards));
+
+        // Serialize and deserialize
+        BytesStreamOutput out = new BytesStreamOutput();
+        originalStatus.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        TieringStatus deserializedStatus = TieringStatus.readFrom(in);
+
+        // Verify deserialized object
+        assertEquals(originalStatus.getIndexName(), deserializedStatus.getIndexName());
+        assertEquals(originalStatus.getStatus(), deserializedStatus.getStatus());
+        assertEquals(originalStatus.getSource(), deserializedStatus.getSource());
+        assertEquals(originalStatus.getTarget(), deserializedStatus.getTarget());
+        assertEquals(originalStatus.getStartTime(), deserializedStatus.getStartTime());
+
+        assertNotNull(deserializedStatus.getShardLevelStatus());
+        assertEquals(2, deserializedStatus.getShardLevelStatus().getShardLevelCounters().get(TieringStatus.PENDING_SHARDS).intValue());
+        assertEquals(3, deserializedStatus.getShardLevelStatus().getShardLevelCounters().get(TieringStatus.SUCCEEDED_SHARDS).intValue());
+    }
+
+    public void testStreamSerialization_withNoRelocatingShards() throws IOException {
+        // Create original object
+        TieringStatus originalStatus = new TieringStatus("test-index", "RUNNING", "hot", "warm", 123L);
+        Map<String, Integer> shardCounters = new HashMap<>();
+        shardCounters.put(TieringStatus.PENDING_SHARDS, 2);
+        shardCounters.put(TieringStatus.SUCCEEDED_SHARDS, 3);
+        shardCounters.put(TieringStatus.RUNNING_SHARDS, 1);
+        shardCounters.put(TieringStatus.TOTAL_SHARDS, 6);
+
+        originalStatus.setShardLevelStatus(new TieringStatus.ShardLevelStatus(shardCounters, new ArrayList<>()));
+
+        // Serialize and deserialize
+        BytesStreamOutput out = new BytesStreamOutput();
+        originalStatus.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        TieringStatus deserializedStatus = TieringStatus.readFrom(in);
+
+        // Verify deserialized object
+        assertEquals(originalStatus.getIndexName(), deserializedStatus.getIndexName());
+        assertEquals(originalStatus.getStatus(), deserializedStatus.getStatus());
+        assertEquals(originalStatus.getSource(), deserializedStatus.getSource());
+        assertEquals(originalStatus.getTarget(), deserializedStatus.getTarget());
+        assertEquals(originalStatus.getStartTime(), deserializedStatus.getStartTime());
+
+        assertNotNull(deserializedStatus.getShardLevelStatus());
+        assertEquals(2, deserializedStatus.getShardLevelStatus().getShardLevelCounters().get(TieringStatus.PENDING_SHARDS).intValue());
+        assertEquals(3, deserializedStatus.getShardLevelStatus().getShardLevelCounters().get(TieringStatus.SUCCEEDED_SHARDS).intValue());
+    }
+
+    public void testResponseStreamSerialization() throws IOException {
+        TieringStatus status = new TieringStatus("test-index", "RUNNING", "hot", "warm", 123L);
+        GetTieringStatusResponse original = new GetTieringStatusResponse(status);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        GetTieringStatusResponse deserialized = new GetTieringStatusResponse(in);
+
+        assertEquals(original.getTieringStatus().getIndexName(), deserialized.getTieringStatus().getIndexName());
+        assertEquals(original.getTieringStatus().getStatus(), deserialized.getTieringStatus().getStatus());
+    }
+
+    public void testTieringStatusSerialization() throws IOException {
+        // Create sample data
+        String indexName = "test-index";
+        String state = "RUNNING";
+        String source = "hot";
+        String target = "warm";
+        long startTime = 123L;
+
+        Map<String, Integer> shardCounters = new HashMap<>();
+        shardCounters.put(TieringStatus.PENDING_SHARDS, 2);
+        shardCounters.put(TieringStatus.SUCCEEDED_SHARDS, 3);
+        shardCounters.put(TieringStatus.RUNNING_SHARDS, 1);
+        shardCounters.put(TieringStatus.TOTAL_SHARDS, 6);
+
+        List<TieringStatus.OngoingShard> ongoingShards = Arrays.asList(
+            new TieringStatus.OngoingShard(1, "node1"),
+            new TieringStatus.OngoingShard(2, "node2")
+        );
+
+        TieringStatus.ShardLevelStatus shardStatus = new TieringStatus.ShardLevelStatus(shardCounters, ongoingShards);
+
+        TieringStatus status = new TieringStatus(indexName, state, source, target, startTime);
+        status.setShardLevelStatus(shardStatus);
+
+        final GetTieringStatusResponse response = new GetTieringStatusResponse(status);
+
+        // Test XContent serialization
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
+
+        // Verify the parsed content
+        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+        assertEquals(TieringStatus.TIERING_STATUS, parser.currentName());
+        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case TieringStatus.INDEX:
+                    assertEquals("test-index", parser.text());
+                    break;
+                case TieringStatus.STATE:
+                    assertEquals("RUNNING", parser.text());
+                    break;
+                case TieringStatus.SOURCE:
+                    assertEquals("hot", parser.text());
+                    break;
+                case TieringStatus.TARGET:
+                    assertEquals("warm", parser.text());
+                    break;
+                case TieringStatus.START_TIME:
+                    assertEquals(123L, parser.longValue());
+                    break;
+                case TieringStatus.SHARD_LEVEL_STATUS:
+                    assertEquals(XContentParser.Token.START_OBJECT, parser.currentToken());
+
+                    // Parse shard level counters
+                    while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                        String shardField = parser.currentName();
+                        parser.nextToken();
+
+                        switch (shardField) {
+                            case TieringStatus.PENDING_SHARDS:
+                                assertEquals(2, parser.intValue());
+                                break;
+                            case TieringStatus.SUCCEEDED_SHARDS:
+                                assertEquals(3, parser.intValue());
+                                break;
+                            case TieringStatus.RUNNING_SHARDS:
+                                assertEquals(1, parser.intValue());
+                                break;
+                            case TieringStatus.TOTAL_SHARDS:
+                                assertEquals(6, parser.intValue());
+                                break;
+                            case "shard_relocation_status":
+                                assertEquals(XContentParser.Token.START_ARRAY, parser.currentToken());
+
+                                // First ongoing shard
+                                assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+                                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+                                assertEquals("source_shard_id", parser.currentName());
+                                assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
+                                assertEquals(1, parser.intValue());
+                                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+                                assertEquals("relocating_node_id", parser.currentName());
+                                assertEquals(XContentParser.Token.VALUE_STRING, parser.nextToken());
+                                assertEquals("node1", parser.text());
+                                assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
+
+                                // Second ongoing shard
+                                assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+                                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+                                assertEquals("source_shard_id", parser.currentName());
+                                assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
+                                assertEquals(2, parser.intValue());
+                                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+                                assertEquals("relocating_node_id", parser.currentName());
+                                assertEquals(XContentParser.Token.VALUE_STRING, parser.nextToken());
+                                assertEquals("node2", parser.text());
+                                assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
+
+                                assertEquals(XContentParser.Token.END_ARRAY, parser.nextToken());
+                                break;
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/model/ListTieringStatusRequestTests.java
+++ b/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/model/ListTieringStatusRequestTests.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.action.admin.tiering.status.model;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.storage.action.tiering.status.model.ListTieringStatusRequest;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Locale;
+
+public class ListTieringStatusRequestTests extends OpenSearchTestCase {
+
+    public void testConstructorWithTier() {
+        String tier = "hot";
+        ListTieringStatusRequest request = new ListTieringStatusRequest(tier);
+        assertEquals(tier.toUpperCase(Locale.ROOT), request.getTargetTier());
+    }
+
+    public void testConstructorWithNullTier() {
+        String tier = null;
+        ListTieringStatusRequest request = new ListTieringStatusRequest(tier);
+        assertNull(request.getTargetTier());
+    }
+
+    public void testDefaultConstructor() {
+        ListTieringStatusRequest request = new ListTieringStatusRequest();
+        assertNull(request.getTargetTier());
+    }
+
+    public void testSerializationDeserialization() throws IOException {
+        // Test with tier
+        ListTieringStatusRequest originalRequest = new ListTieringStatusRequest("_warm");
+        BytesStreamOutput output = new BytesStreamOutput();
+        originalRequest.writeTo(output);
+        StreamInput input = output.bytes().streamInput();
+        ListTieringStatusRequest deserializedRequest = new ListTieringStatusRequest(input);
+        assertEquals(originalRequest.getTargetTier(), deserializedRequest.getTargetTier());
+
+        // Test with null tier
+        originalRequest = new ListTieringStatusRequest();
+        output = new BytesStreamOutput();
+        originalRequest.writeTo(output);
+        input = output.bytes().streamInput();
+        deserializedRequest = new ListTieringStatusRequest(input);
+        assertNull(deserializedRequest.getTargetTier());
+    }
+
+    public void testValidate() {
+        // Test with tier
+        ListTieringStatusRequest request = new ListTieringStatusRequest("hot");
+        ActionRequestValidationException validationException = request.validate();
+        assertNull(validationException);
+
+        // Test with null tier
+        request = new ListTieringStatusRequest();
+        validationException = request.validate();
+        assertNull(validationException);
+    }
+
+    public void testGetTargetTier() {
+        String tier = "warm";
+        ListTieringStatusRequest request = new ListTieringStatusRequest(tier);
+        assertEquals(tier.toUpperCase(Locale.ROOT), request.getTargetTier());
+    }
+
+    public void testSerializationWithLargeData() throws IOException {
+        String tier = "hot";
+        ListTieringStatusRequest originalRequest = new ListTieringStatusRequest(tier);
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        originalRequest.writeTo(output);
+
+        StreamInput input = output.bytes().streamInput();
+        ListTieringStatusRequest deserializedRequest = new ListTieringStatusRequest(input);
+
+        assertEquals(originalRequest.getTargetTier(), deserializedRequest.getTargetTier());
+    }
+
+    public void testStreamInputWithCorruptedData() throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        output.writeString("CORRUPTED_DATA"); // Write some data
+        StreamInput input = output.bytes().streamInput();
+
+        // This should throw an IOException because the input stream doesn't contain
+        // the proper format for a ClusterManagerNodeReadRequest
+        assertThrows(IOException.class, () -> new ListTieringStatusRequest(input));
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/model/ListTieringStatusResponseTests.java
+++ b/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/model/ListTieringStatusResponseTests.java
@@ -1,0 +1,141 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.action.admin.tiering.status.model;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.storage.action.tiering.status.model.ListTieringStatusResponse;
+import org.opensearch.storage.action.tiering.status.model.TieringStatus;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ListTieringStatusResponseTests extends OpenSearchTestCase {
+
+    public void testConstructorWithList() {
+        // Arrange
+        List<TieringStatus> statusList = createDummyTieringStatusList();
+
+        // Act
+        ListTieringStatusResponse response = new ListTieringStatusResponse(statusList);
+
+        // Assert
+        assertNotNull(response.getTieringStatusList());
+        assertEquals(2, response.getTieringStatusList().size());
+        assertEquals("index1", response.getTieringStatusList().get(0).getIndexName());
+        assertEquals("index2", response.getTieringStatusList().get(1).getIndexName());
+    }
+
+    public void testSerializationDeserialization() throws IOException {
+        // Arrange
+        List<TieringStatus> statusList = createDummyTieringStatusList();
+        ListTieringStatusResponse originalResponse = new ListTieringStatusResponse(statusList);
+        BytesStreamOutput output = new BytesStreamOutput();
+
+        // Act
+        originalResponse.writeTo(output);
+        StreamInput input = output.bytes().streamInput();
+        ListTieringStatusResponse deserializedResponse = new ListTieringStatusResponse(input);
+
+        // Assert
+        assertEquals(originalResponse.getTieringStatusList().size(), deserializedResponse.getTieringStatusList().size());
+
+        for (int i = 0; i < originalResponse.getTieringStatusList().size(); i++) {
+            TieringStatus original = originalResponse.getTieringStatusList().get(i);
+            TieringStatus deserialized = deserializedResponse.getTieringStatusList().get(i);
+
+            assertEquals(original.getIndexName(), deserialized.getIndexName());
+            assertEquals(original.getStatus(), deserialized.getStatus());
+            assertEquals(original.getStartTime(), deserialized.getStartTime());
+            assertEquals(original.getSource(), deserialized.getSource());
+            assertEquals(original.getTarget(), deserialized.getTarget());
+        }
+    }
+
+    public void testSerializationDeserializationEmptyList() throws IOException {
+        // Arrange
+        ListTieringStatusResponse originalResponse = new ListTieringStatusResponse(Collections.emptyList());
+        BytesStreamOutput output = new BytesStreamOutput();
+
+        // Act
+        originalResponse.writeTo(output);
+        StreamInput input = output.bytes().streamInput();
+        ListTieringStatusResponse deserializedResponse = new ListTieringStatusResponse(input);
+
+        // Assert
+        assertTrue(deserializedResponse.getTieringStatusList().isEmpty());
+    }
+
+    public void testGetTieringStatusList() {
+        // Arrange
+        List<TieringStatus> statusList = createDummyTieringStatusList();
+        ListTieringStatusResponse response = new ListTieringStatusResponse(statusList);
+
+        // Act
+        List<TieringStatus> retrievedList = response.getTieringStatusList();
+
+        // Assert
+        assertNotNull(retrievedList);
+        assertEquals(statusList.size(), retrievedList.size());
+        assertEquals(statusList, retrievedList);
+    }
+
+    public void testSerializationWithLargeList() throws IOException {
+        // Arrange
+        List<TieringStatus> largeStatusList = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            TieringStatus status = new TieringStatus();
+            status.setIndexName("index" + i);
+            status.setStatus("RUNNING");
+            status.setStartTime(System.currentTimeMillis());
+            status.setSource("hot");
+            status.setTarget("warm");
+            largeStatusList.add(status);
+        }
+
+        ListTieringStatusResponse originalResponse = new ListTieringStatusResponse(largeStatusList);
+        BytesStreamOutput output = new BytesStreamOutput();
+
+        // Act
+        originalResponse.writeTo(output);
+        StreamInput input = output.bytes().streamInput();
+        ListTieringStatusResponse deserializedResponse = new ListTieringStatusResponse(input);
+
+        // Assert
+        assertEquals(1000, deserializedResponse.getTieringStatusList().size());
+        assertEquals("index0", deserializedResponse.getTieringStatusList().get(0).getIndexName());
+        assertEquals("index999", deserializedResponse.getTieringStatusList().get(999).getIndexName());
+    }
+
+    private List<TieringStatus> createDummyTieringStatusList() {
+        List<TieringStatus> statusList = new ArrayList<>();
+
+        TieringStatus status1 = new TieringStatus();
+        status1.setIndexName("index1");
+        status1.setStatus("RUNNING");
+        status1.setStartTime(System.currentTimeMillis());
+        status1.setSource("hot");
+        status1.setTarget("warm");
+
+        TieringStatus status2 = new TieringStatus();
+        status2.setIndexName("index2");
+        status2.setStatus("COMPLETED");
+        status2.setStartTime(System.currentTimeMillis());
+        status2.setSource("warm");
+        status2.setTarget("hot");
+
+        statusList.add(status1);
+        statusList.add(status2);
+
+        return statusList;
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/model/TieringStatusTests.java
+++ b/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/model/TieringStatusTests.java
@@ -1,0 +1,269 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.action.admin.tiering.status.model;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.IndexRoutingTable;
+import org.opensearch.cluster.routing.RoutingTable;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.ShardRoutingState;
+import org.opensearch.cluster.routing.TestShardRouting;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.index.Index;
+import org.opensearch.storage.action.tiering.status.model.TieringStatus;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.emptyMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TieringStatusTests extends OpenSearchTestCase {
+
+    public void testTieringStatusConstructor() {
+        String indexName = "test-index";
+        String status = "RUNNING";
+        String source = "hot";
+        String target = "warm";
+        long startTime = System.currentTimeMillis();
+
+        TieringStatus tieringStatus = new TieringStatus(indexName, status, source, target, startTime);
+
+        assertEquals(indexName, tieringStatus.getIndexName());
+        assertEquals(status, tieringStatus.getStatus());
+        assertEquals(source, tieringStatus.getSource());
+        assertEquals(target, tieringStatus.getTarget());
+        assertEquals(startTime, tieringStatus.getStartTime());
+    }
+
+    public void testTieringStatusSerialization() throws IOException {
+        TieringStatus original = new TieringStatus("test-index", "RUNNING", "hot", "warm", 123456L);
+
+        // Mock StreamOutput
+        StreamOutput streamOutput = mock(StreamOutput.class);
+        original.writeTo(streamOutput);
+
+        verify(streamOutput).writeString("test-index");
+        verify(streamOutput).writeString("RUNNING");
+        verify(streamOutput).writeString("hot");
+        verify(streamOutput).writeString("warm");
+        verify(streamOutput).writeLong(123456L);
+    }
+
+    public void testShardLevelStatusCreation() {
+        Map<String, Integer> counters = new HashMap<>();
+        counters.put("pending", 2);
+        counters.put("succeeded", 3);
+        counters.put("running", 1);
+        counters.put("total", 6);
+
+        List<TieringStatus.OngoingShard> ongoingShards = Collections.singletonList(new TieringStatus.OngoingShard(1, "node2"));
+
+        TieringStatus.ShardLevelStatus status = new TieringStatus.ShardLevelStatus(counters, ongoingShards);
+
+        assertEquals(counters, status.getShardLevelCounters());
+    }
+
+    public void testFromRoutingTable() {
+        // Test for WARM tier
+        testForTier(true, true);
+        // Test for HOT tier
+        testForTier(false, true);
+
+        // Test for detailed Flag as false
+        testForTier(false, false);
+    }
+
+    private void testForTier(boolean isWarmTier, boolean isDetailedFlagEnabled) {
+        // Mock ClusterState and its components
+        ClusterState clusterState = mock(ClusterState.class);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+
+        // Create node with appropriate roles
+        Set<DiscoveryNodeRole> roles = new HashSet<>();
+        if (isWarmTier) {
+            roles.add(DiscoveryNodeRole.WARM_ROLE);
+        } else {
+            roles.add(DiscoveryNodeRole.DATA_ROLE);
+        }
+
+        DiscoveryNode node = new DiscoveryNode(
+            "node-" + (isWarmTier ? "warm" : "hot"),
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            roles,
+            Version.CURRENT
+        );
+
+        RoutingTable.Builder routingTableBuilder = new RoutingTable.Builder().add(createRoutingTable(new Index("test-index", "na")));
+
+        when(clusterState.routingTable()).thenReturn(routingTableBuilder.build());
+        when(clusterState.getNodes()).thenReturn(nodes);
+        when(nodes.get(any())).thenReturn(node);
+
+        String targetTier = isWarmTier ? "WARM" : "HOT";
+        TieringStatus.ShardLevelStatus status = TieringStatus.ShardLevelStatus.fromRoutingTable(
+            clusterState,
+            "test-index",
+            false,
+            targetTier
+        );
+
+        assertNotNull(status);
+        Map<String, Integer> counters = status.getShardLevelCounters();
+
+        // Verify counters
+        assertTrue(counters.containsKey("total"));
+        assertTrue(counters.containsKey("pending"));
+        assertTrue(counters.containsKey("succeeded"));
+        assertTrue(counters.containsKey("running"));
+        if (isDetailedFlagEnabled) {
+            assertFalse(counters.containsKey("ongoing_shards"));
+        }
+
+        // Additional assertions specific to tier if needed
+        if (isWarmTier) {
+            assertTrue(node.isWarmNode());
+        } else {
+            assertFalse(node.isWarmNode());
+        }
+    }
+
+    public void testFromRoutingTable_WithMixedShardStates() {
+        ClusterState clusterState = mock(ClusterState.class);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        Index index = new Index("test-index", "uuid");
+
+        Set<DiscoveryNodeRole> warmRoles = new HashSet<>();
+        warmRoles.add(DiscoveryNodeRole.WARM_ROLE);
+        DiscoveryNode warmNode = new DiscoveryNode("warm-node", buildNewFakeTransportAddress(), emptyMap(), warmRoles, Version.CURRENT);
+
+        Set<DiscoveryNodeRole> hotRoles = new HashSet<>();
+        hotRoles.add(DiscoveryNodeRole.DATA_ROLE);
+        DiscoveryNode hotNode = new DiscoveryNode("hot-node", buildNewFakeTransportAddress(), emptyMap(), hotRoles, Version.CURRENT);
+
+        when(nodes.get("warm-node")).thenReturn(warmNode);
+        when(nodes.get("hot-node")).thenReturn(hotNode);
+        when(clusterState.getNodes()).thenReturn(nodes);
+
+        IndexRoutingTable.Builder builder = IndexRoutingTable.builder(index);
+        builder.addShard(TestShardRouting.newShardRouting(index.getName(), 0, "warm-node", true, ShardRoutingState.STARTED));
+        builder.addShard(TestShardRouting.newShardRouting(index.getName(), 1, "hot-node", true, ShardRoutingState.STARTED));
+        builder.addShard(TestShardRouting.newShardRouting(index.getName(), 2, null, true, ShardRoutingState.UNASSIGNED));
+        builder.addShard(TestShardRouting.newShardRouting(index.getName(), 3, "hot-node", "warm-node", true, ShardRoutingState.RELOCATING));
+
+        RoutingTable routingTable = new RoutingTable.Builder().add(builder.build()).build();
+        when(clusterState.routingTable()).thenReturn(routingTable);
+
+        TieringStatus.ShardLevelStatus status = TieringStatus.ShardLevelStatus.fromRoutingTable(clusterState, "test-index", true, "WARM");
+
+        Map<String, Integer> counters = status.getShardLevelCounters();
+        assertEquals(Integer.valueOf(1), counters.get("succeeded"));
+        assertEquals(Integer.valueOf(2), counters.get("pending"));
+        assertEquals(Integer.valueOf(1), counters.get("running"));
+        assertEquals(Integer.valueOf(4), counters.get("total"));
+        assertEquals(1, status.getOngoingShards().size());
+    }
+
+    public void testFromRoutingTable_HotTarget_StartedOnWarmIsPending() {
+        ClusterState clusterState = mock(ClusterState.class);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        Index index = new Index("test-index", "uuid");
+
+        Set<DiscoveryNodeRole> warmRoles = new HashSet<>();
+        warmRoles.add(DiscoveryNodeRole.WARM_ROLE);
+        DiscoveryNode warmNode = new DiscoveryNode("warm-node", buildNewFakeTransportAddress(), emptyMap(), warmRoles, Version.CURRENT);
+        when(nodes.get("warm-node")).thenReturn(warmNode);
+        when(clusterState.getNodes()).thenReturn(nodes);
+
+        IndexRoutingTable.Builder builder = IndexRoutingTable.builder(index);
+        builder.addShard(TestShardRouting.newShardRouting(index.getName(), 0, "warm-node", true, ShardRoutingState.STARTED));
+
+        RoutingTable routingTable = new RoutingTable.Builder().add(builder.build()).build();
+        when(clusterState.routingTable()).thenReturn(routingTable);
+
+        TieringStatus.ShardLevelStatus status = TieringStatus.ShardLevelStatus.fromRoutingTable(clusterState, "test-index", false, "HOT");
+
+        Map<String, Integer> counters = status.getShardLevelCounters();
+        assertEquals(Integer.valueOf(0), counters.get("succeeded"));
+        assertEquals(Integer.valueOf(1), counters.get("pending"));
+    }
+
+    public void testEquals() {
+        TieringStatus s1 = new TieringStatus("idx", "RUNNING", "hot", "warm", 100L);
+        TieringStatus s2 = new TieringStatus("idx", "RUNNING", "hot", "warm", 100L);
+        TieringStatus s3 = new TieringStatus("other", "RUNNING", "hot", "warm", 100L);
+
+        assertEquals(s1, s1);
+        assertEquals(s1, s2);
+        assertNotEquals(s1, s3);
+        assertNotEquals(s1, null);
+        assertNotEquals(s1, "string");
+    }
+
+    public void testHashCode() {
+        TieringStatus s1 = new TieringStatus("idx", "RUNNING", "hot", "warm", 100L);
+        TieringStatus s2 = new TieringStatus("idx", "RUNNING", "hot", "warm", 100L);
+        assertEquals(s1.hashCode(), s2.hashCode());
+    }
+
+    public void testOngoingShardSerialization() throws IOException {
+        TieringStatus.OngoingShard shard = new TieringStatus.OngoingShard(1, "node2");
+
+        StreamOutput streamOutput = mock(StreamOutput.class);
+        shard.writeTo(streamOutput);
+
+        verify(streamOutput).writeInt(1);
+        verify(streamOutput).writeString("node2");
+    }
+
+    private List<ShardRouting> createTestShards() {
+        // Create and return test shard routings
+        // This would be implementation-specific based on your needs
+        return Collections.emptyList();
+    }
+
+    private IndexRoutingTable createRoutingTable(Index index) {
+        IndexRoutingTable.Builder builder = IndexRoutingTable.builder(index);
+        ShardRouting primaryShard = TestShardRouting.newShardRouting(
+            index.getName(),
+            1,
+            "node-2",
+            "node-3",
+            true,
+            ShardRoutingState.RELOCATING
+        );
+
+        builder.addShard(primaryShard);
+        ShardRouting replicaShard = TestShardRouting.newShardRouting(
+            index.getName(),
+            2,
+            "node-2",
+            "node-3",
+            false,
+            ShardRoutingState.RELOCATING
+        );
+        builder.addShard(replicaShard);
+
+        return builder.build();
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/rest/RestGetTieringStatusActionTests.java
+++ b/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/rest/RestGetTieringStatusActionTests.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.action.admin.tiering.status.rest;
+
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.storage.action.tiering.status.rest.RestGetTieringStatusAction;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.opensearch.rest.RestRequest.Method.GET;
+
+public class RestGetTieringStatusActionTests extends OpenSearchTestCase {
+    private RestGetTieringStatusAction handler;
+    @Mock
+    private NodeClient client;
+
+    private ThreadPool threadPool;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        handler = new RestGetTieringStatusAction();
+        threadPool = new TestThreadPool("test");
+        MockitoAnnotations.openMocks(this);
+    }
+
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+    }
+
+    public void testRoutes() {
+        List<RestHandler.Route> routes = handler.routes();
+        assertEquals(1, routes.size());
+        RestHandler.Route route = routes.get(0);
+        assertEquals(GET, route.getMethod());
+        assertEquals("/{index}/_tier", route.getPath());
+    }
+
+    public void testGetName() {
+        assertEquals("get_index_tiering_status", handler.getName());
+    }
+
+    public void testPrepareRequestSingleIndex() throws IOException {
+        // Arrange
+        Map<String, String> params = new HashMap<>();
+        params.put("index", "test-index");
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
+
+        // Act
+        assertNotNull(handler.prepareRequest(request, client));
+
+    }
+
+    public void testPrepareRequestMultipleIndices() {
+        // Arrange
+        Map<String, String> params = new HashMap<>();
+        params.put("index", "index1,index2");
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
+
+        // Act & Assert
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> handler.prepareRequest(request, client));
+        assertEquals("request should contain single index", exception.getMessage());
+    }
+
+    public void testPrepareRequestNoIndex() {
+        // Arrange
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).build();
+
+        // Act & Assert
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> handler.prepareRequest(request, client));
+        assertEquals("request should contain single index", exception.getMessage());
+    }
+
+    public void testPrepareRequestEmptyIndex() {
+        // Arrange
+        Map<String, String> params = new HashMap<>();
+        params.put("index", "");
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
+
+        // Act & Assert
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> handler.prepareRequest(request, client));
+        assertEquals("request should contain single index", exception.getMessage());
+    }
+
+    public void testExecuteRequest() throws IOException {
+        // Arrange
+        Map<String, String> params = new HashMap<>();
+        params.put("index", "test-index");
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
+
+        assertNotNull(handler.prepareRequest(request, client));
+
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/rest/RestListTieringStatusActionTests.java
+++ b/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/rest/RestListTieringStatusActionTests.java
@@ -1,0 +1,172 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.action.admin.tiering.status.rest;
+
+import org.opensearch.common.Table;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.storage.action.tiering.status.model.ListTieringStatusResponse;
+import org.opensearch.storage.action.tiering.status.model.TieringStatus;
+import org.opensearch.storage.action.tiering.status.rest.RestListTieringStatusAction;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class RestListTieringStatusActionTests extends OpenSearchTestCase {
+    private RestListTieringStatusAction handler;
+    @Mock
+    private NodeClient client;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+        handler = new RestListTieringStatusAction();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    public void testRoutes() {
+        List<RestHandler.Route> routes = handler.routes();
+        assertEquals(1, routes.size());
+        RestHandler.Route route = routes.get(0);
+        assertEquals(RestRequest.Method.GET, route.getMethod());
+        assertEquals("/_tier/all", route.getPath());
+    }
+
+    public void testGetName() {
+        assertEquals("list_tiering_status", handler.getName());
+    }
+
+    public void testDocumentation() {
+        StringBuilder sb = new StringBuilder();
+        handler.documentation(sb);
+        assertEquals("/_tier/all\n", sb.toString());
+    }
+
+    public void testGetTableWithHeader() {
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).build();
+        Table table = handler.getTableWithHeader(request);
+
+        List<Table.Cell> headers = table.getHeaders();
+        assertEquals("index", headers.get(0).value);
+        assertEquals("state", headers.get(1).value);
+        assertEquals("source", headers.get(2).value);
+        assertEquals("target", headers.get(3).value);
+    }
+
+    public void testValidateTargetTier() {
+        // Test valid tiers
+        assertEquals("HOT", handler.parseAndValidateTargetTier("_hot"));
+        assertEquals("WARM", handler.parseAndValidateTargetTier("_warm"));
+        assertNull(handler.parseAndValidateTargetTier(null));
+
+        // Test invalid tiers
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> handler.parseAndValidateTargetTier("_cold"));
+        assertEquals("Invalid target tier. Target Tier must be either '_hot' or '_warm'", e.getMessage());
+
+        // Test invalid tiers
+        e = assertThrows(IllegalArgumentException.class, () -> handler.parseAndValidateTargetTier("warm"));
+        assertEquals("Invalid format. Target Tier must be in the form '_tier'", e.getMessage());
+
+    }
+
+    public void testBuildTable() {
+        List<TieringStatus> statusList = new ArrayList<>();
+        TieringStatus status1 = createTieringStatus("index1", "RUNNING", "_hot", "_warm");
+        TieringStatus status2 = createTieringStatus("index2", "COMPLETED", "_warm", "_hot");
+        statusList.add(status1);
+        statusList.add(status2);
+
+        ListTieringStatusResponse response = new ListTieringStatusResponse(statusList);
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).build();
+
+        Table table = handler.buildTable(request, response);
+
+        List<List<Table.Cell>> rows = table.getRows();
+        assertEquals(2, rows.size());
+
+        // Verify first row
+        List<Table.Cell> row1 = rows.get(0);
+        assertEquals("index1", row1.get(0).value);
+        assertEquals("RUNNING", row1.get(1).value);
+        assertEquals("_hot", row1.get(2).value);
+        assertEquals("_warm", row1.get(3).value);
+
+        // Verify second row
+        List<Table.Cell> row2 = rows.get(1);
+        assertEquals("index2", row2.get(0).value);
+        assertEquals("COMPLETED", row2.get(1).value);
+        assertEquals("_warm", row2.get(2).value);
+        assertEquals("_hot", row2.get(3).value);
+    }
+
+    public void testDoCatRequest() {
+        // Test with valid target tier
+        Map<String, String> params = new HashMap<>();
+        params.put("target", "_hot");
+        final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
+
+        assertNotNull(handler.doCatRequest(request, client));
+
+        // Test with invalid target tier
+        params.put("target", "_invalid");
+        final RestRequest request2 = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> handler.doCatRequest(request2, client));
+        assertEquals("Invalid target tier. Target Tier must be either '_hot' or '_warm'", e.getMessage());
+    }
+
+    public void testDoCatRequestWithNoTarget() {
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).build();
+        assertNotNull(handler.doCatRequest(request, client));
+    }
+
+    public void testBuildTableWithEmptyResponse() {
+        ListTieringStatusResponse response = new ListTieringStatusResponse(Collections.emptyList());
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).build();
+
+        Table table = handler.buildTable(request, response);
+        assertTrue(table.getRows().isEmpty());
+    }
+
+    public void testBuildTableWithNullValues() {
+        List<TieringStatus> statusList = new ArrayList<>();
+        TieringStatus status = new TieringStatus();
+        statusList.add(status);
+
+        ListTieringStatusResponse response = new ListTieringStatusResponse(statusList);
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).build();
+
+        Table table = handler.buildTable(request, response);
+        List<List<Table.Cell>> rows = table.getRows();
+        assertEquals(1, rows.size());
+    }
+
+    private TieringStatus createTieringStatus(String indexName, String status, String source, String target) {
+        TieringStatus tieringStatus = new TieringStatus();
+        tieringStatus.setIndexName(indexName);
+        tieringStatus.setStatus(status);
+        tieringStatus.setSource(source);
+        tieringStatus.setTarget(target);
+        return tieringStatus;
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/transport/TransportGetTieringStatusTests.java
+++ b/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/transport/TransportGetTieringStatusTests.java
@@ -1,0 +1,175 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.action.admin.tiering.status.transport;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.IndexModule;
+import org.opensearch.storage.action.tiering.status.model.GetTieringStatusRequest;
+import org.opensearch.storage.action.tiering.status.model.GetTieringStatusResponse;
+import org.opensearch.storage.action.tiering.status.model.TieringStatus;
+import org.opensearch.storage.action.tiering.status.transport.TransportGetTieringStatusAction;
+import org.opensearch.storage.tiering.HotToWarmTieringService;
+import org.opensearch.storage.tiering.WarmToHotTieringService;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.junit.Before;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportGetTieringStatusTests extends OpenSearchTestCase {
+
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private ClusterService clusterService;
+    @Mock
+    private HotToWarmTieringService hotToWarmTieringService;
+    @Mock
+    private WarmToHotTieringService warmToHotTieringService;
+    @Mock
+    private ThreadPool threadPool;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private IndexNameExpressionResolver indexNameExpressionResolver;
+    @Mock
+    private ClusterState clusterState;
+    @Mock
+    private Metadata metadata;
+    @Mock
+    private IndexMetadata indexMetadata;
+    @Mock
+    private ActionListener<GetTieringStatusResponse> listener;
+
+    private TransportGetTieringStatusAction action;
+    private GetTieringStatusRequest request;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+        action = new TransportGetTieringStatusAction(
+            transportService,
+            clusterService,
+            hotToWarmTieringService,
+            warmToHotTieringService,
+            threadPool,
+            actionFilters,
+            indexNameExpressionResolver
+        );
+
+        request = new GetTieringStatusRequest();
+        request.setIndex("test-index");
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.getMetadata()).thenReturn(metadata);
+    }
+
+    public void testExecutor() {
+        assertEquals(ThreadPool.Names.SAME, action.executor());
+    }
+
+    public void testClusterManagerOperation_HotToWarmTiering() {
+        // Arrange
+        Index index = new Index("test-index", "uuid");
+        Settings settings = Settings.builder()
+            .put(IndexModule.INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT_TO_WARM.toString())
+            .build();
+        TieringStatus expectedStatus = new TieringStatus();
+
+        when(indexNameExpressionResolver.concreteIndices(any(), any(), any())).thenReturn(new Index[] { index });
+        when(metadata.index(index)).thenReturn(indexMetadata);
+        when(indexMetadata.getSettings()).thenReturn(settings);
+        when(hotToWarmTieringService.getTieringStatus("test-index", false)).thenReturn(expectedStatus);
+
+        // Act
+        action.clusterManagerOperation(request, clusterState, listener);
+
+        // Assert
+        verify(listener).onResponse(any(GetTieringStatusResponse.class));
+    }
+
+    public void testClusterManagerOperation_WarmToHotTiering() {
+        // Arrange
+        Index index = new Index("test-index", "uuid");
+        Settings settings = Settings.builder()
+            .put(IndexModule.INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.WARM_TO_HOT.toString())
+            .build();
+        TieringStatus expectedStatus = new TieringStatus();
+
+        when(indexNameExpressionResolver.concreteIndices(any(), any(), any())).thenReturn(new Index[] { index });
+        when(metadata.index(index)).thenReturn(indexMetadata);
+        when(indexMetadata.getSettings()).thenReturn(settings);
+        when(warmToHotTieringService.getTieringStatus("test-index", false)).thenReturn(expectedStatus);
+
+        // Act
+        action.clusterManagerOperation(request, clusterState, listener);
+
+        // Assert
+        verify(listener).onResponse(any(GetTieringStatusResponse.class));
+    }
+
+    public void testClusterManagerOperation_WithException() {
+        // Arrange
+        when(indexNameExpressionResolver.concreteIndices(any(), any(), any())).thenThrow(new IllegalArgumentException("Test exception"));
+
+        // Act
+        action.clusterManagerOperation(request, clusterState, listener);
+
+        // Assert
+        verify(listener).onFailure(any(IllegalArgumentException.class));
+    }
+
+    public void testClusterManagerOperation_NullTieringState() {
+        // Arrange
+        Index index = new Index("test-index", "uuid");
+        Settings settings = Settings.builder().build(); // No tiering state
+
+        when(indexNameExpressionResolver.concreteIndices(any(), any(), any())).thenReturn(new Index[] { index });
+        when(metadata.index(index)).thenReturn(indexMetadata);
+        when(indexMetadata.getSettings()).thenReturn(settings);
+
+        // Act
+        action.clusterManagerOperation(request, clusterState, listener);
+    }
+
+    public void testCheckBlock() {
+        when(clusterState.blocks()).thenReturn(mock(org.opensearch.cluster.block.ClusterBlocks.class));
+        when(clusterState.blocks().globalBlockedException(any())).thenReturn(null);
+        assertNull(action.checkBlock(request, clusterState));
+    }
+
+    public void testReadResponse() throws Exception {
+        TieringStatus status = new TieringStatus("test-index", "RUNNING", "hot", "warm", 123L);
+        GetTieringStatusResponse original = new GetTieringStatusResponse(status);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+
+        GetTieringStatusResponse deserialized = new GetTieringStatusResponse(in);
+        assertEquals("test-index", deserialized.getTieringStatus().getIndexName());
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/transport/TransportListTieringStatusTests.java
+++ b/server/src/test/java/org/opensearch/storage/action/admin/tiering/status/transport/TransportListTieringStatusTests.java
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.action.admin.tiering.status.transport;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.block.ClusterBlockLevel;
+import org.opensearch.cluster.block.ClusterBlocks;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.storage.action.tiering.status.model.ListTieringStatusRequest;
+import org.opensearch.storage.action.tiering.status.model.ListTieringStatusResponse;
+import org.opensearch.storage.action.tiering.status.model.TieringStatus;
+import org.opensearch.storage.action.tiering.status.transport.TransportListTieringStatusAction;
+import org.opensearch.storage.tiering.HotToWarmTieringService;
+import org.opensearch.storage.tiering.WarmToHotTieringService;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportListTieringStatusTests extends OpenSearchTestCase {
+
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private ClusterService clusterService;
+    @Mock
+    private ThreadPool threadPool;
+    @Mock
+    private HotToWarmTieringService hotToWarmTieringService;
+    @Mock
+    private WarmToHotTieringService warmToHotTieringService;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private IndexNameExpressionResolver indexNameExpressionResolver;
+    @Mock
+    private ClusterState clusterState;
+    @Mock
+    private ClusterBlocks clusterBlocks;
+    @Mock
+    private ActionListener<ListTieringStatusResponse> listener;
+
+    private TransportListTieringStatusAction action;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+        action = new TransportListTieringStatusAction(
+            transportService,
+            clusterService,
+            threadPool,
+            hotToWarmTieringService,
+            warmToHotTieringService,
+            actionFilters,
+            indexNameExpressionResolver
+        );
+
+        when(clusterState.blocks()).thenReturn(clusterBlocks);
+    }
+
+    public void testExecutor() {
+        assertEquals(ThreadPool.Names.SAME, action.executor());
+    }
+
+    public void testClusterManagerOperation_WithTargetTierWarm() throws IOException {
+        // Arrange
+        ListTieringStatusRequest request = new ListTieringStatusRequest("WARM");
+
+        List<TieringStatus> expectedStatus = Arrays.asList(createDummyTieringStatus("index1"), createDummyTieringStatus("index2"));
+
+        when(hotToWarmTieringService.listTieringStatus()).thenReturn(expectedStatus);
+
+        // Act
+        action.clusterManagerOperation(request, clusterState, listener);
+
+        // Assert
+        verify(listener).onResponse(
+            argThat(response -> response.getTieringStatusList().size() == 2 && response.getTieringStatusList().equals(expectedStatus))
+        );
+    }
+
+    public void testClusterManagerOperation_WithTargetTierHot() throws IOException {
+        // Arrange
+        ListTieringStatusRequest request = new ListTieringStatusRequest("HOT");
+
+        List<TieringStatus> expectedStatus = Arrays.asList(createDummyTieringStatus("index1"), createDummyTieringStatus("index2"));
+
+        when(warmToHotTieringService.listTieringStatus()).thenReturn(expectedStatus);
+
+        // Act
+        action.clusterManagerOperation(request, clusterState, listener);
+
+        // Assert
+        verify(listener).onResponse(
+            argThat(response -> response.getTieringStatusList().size() == 2 && response.getTieringStatusList().equals(expectedStatus))
+        );
+    }
+
+    public void testClusterManagerOperation_WithoutTargetTier() throws IOException {
+        // Arrange
+        String targetTier = null;
+        ListTieringStatusRequest request = new ListTieringStatusRequest(targetTier);
+
+        List<TieringStatus> hotToWarmStatus = Arrays.asList(createDummyTieringStatus("index1"));
+        List<TieringStatus> warmToHotStatus = Arrays.asList(createDummyTieringStatus("index2"));
+
+        when(hotToWarmTieringService.listTieringStatus()).thenReturn(hotToWarmStatus);
+        when(warmToHotTieringService.listTieringStatus()).thenReturn(warmToHotStatus);
+
+        // Act
+        action.clusterManagerOperation(request, clusterState, listener);
+
+        // Assert
+        verify(listener).onResponse(
+            argThat(
+                response -> response.getTieringStatusList().size() == 2
+                    && response.getTieringStatusList().containsAll(hotToWarmStatus)
+                    && response.getTieringStatusList().containsAll(warmToHotStatus)
+            )
+        );
+    }
+
+    public void testCheckBlock() {
+        String targetTier = null;
+        // Arrange
+        ListTieringStatusRequest request = new ListTieringStatusRequest(targetTier);
+
+        // Act
+        ClusterBlockException result = action.checkBlock(request, clusterState);
+
+        // Assert
+        verify(clusterBlocks).globalBlockedException(ClusterBlockLevel.METADATA_READ);
+    }
+
+    private TieringStatus createDummyTieringStatus(String indexName) throws IOException {
+        TieringStatus status = new TieringStatus();
+        status.setIndexName(indexName);
+        status.setStatus("RUNNING");
+        status.setStartTime(System.currentTimeMillis());
+        status.setSource("hot");
+        status.setTarget("warm");
+
+        Map<String, Integer> shardStatusMap = new HashMap<>();
+        shardStatusMap.put("COMPLETED", 0);
+        shardStatusMap.put("IN_PROGRESS", 1);
+        status.setShardLevelStatus(new TieringStatus.ShardLevelStatus(shardStatusMap, null));
+
+        return status;
+    }
+
+    public void testReadResponse() throws Exception {
+        ListTieringStatusResponse original = new ListTieringStatusResponse(Collections.emptyList());
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+
+        ListTieringStatusResponse deserialized = new ListTieringStatusResponse(in);
+        assertTrue(deserialized.getTieringStatusList().isEmpty());
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/common/tiering/TieringUtilsTests.java
+++ b/server/src/test/java/org/opensearch/storage/common/tiering/TieringUtilsTests.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.common.tiering;
+
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.IndexModule;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TieringUtilsTests extends OpenSearchTestCase {
+
+    public void testGetTierPairForTargetTier_Warm() {
+        String[] tiers = TieringUtils.getTierPairForTargetTier(IndexModule.TieringState.WARM);
+        assertEquals("HOT", tiers[0]);
+        assertEquals("WARM", tiers[1]);
+    }
+
+    public void testGetTierPairForTargetTier_Hot() {
+        String[] tiers = TieringUtils.getTierPairForTargetTier(IndexModule.TieringState.HOT);
+        assertEquals("WARM", tiers[0]);
+        assertEquals("HOT", tiers[1]);
+    }
+
+    public void testGetTierPairForTargetTier_Invalid() {
+        expectThrows(IllegalArgumentException.class, () -> TieringUtils.getTierPairForTargetTier(IndexModule.TieringState.HOT_TO_WARM));
+    }
+
+    public void testGetTieringStartTime() {
+        Index index = new Index("test-index", "uuid");
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+
+        when(clusterState.getMetadata()).thenReturn(metadata);
+        when(metadata.getIndexSafe(index)).thenReturn(indexMetadata);
+        when(indexMetadata.getCustomData("tiering")).thenReturn(Map.of("h2w_start_time", "12345"));
+
+        long startTime = TieringUtils.getTieringStartTime(clusterState, index, "h2w_start_time");
+        assertEquals(12345L, startTime);
+    }
+
+    public void testGetTieringStartTime_NullCustomData() {
+        Index index = new Index("test-index", "uuid");
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+
+        when(clusterState.getMetadata()).thenReturn(metadata);
+        when(metadata.getIndexSafe(index)).thenReturn(indexMetadata);
+        when(indexMetadata.getCustomData("tiering")).thenReturn(null);
+
+        expectThrows(IllegalStateException.class, () -> TieringUtils.getTieringStartTime(clusterState, index, "h2w_start_time"));
+    }
+
+    public void testIsTerminalTier_Hot() {
+        assertTrue(TieringUtils.isTerminalTier("HOT"));
+        assertTrue(TieringUtils.isTerminalTier("hot"));
+    }
+
+    public void testIsTerminalTier_Warm() {
+        assertTrue(TieringUtils.isTerminalTier("WARM"));
+        assertTrue(TieringUtils.isTerminalTier("warm"));
+    }
+
+    public void testIsTerminalTier_Invalid() {
+        assertFalse(TieringUtils.isTerminalTier("HOT_TO_WARM"));
+        assertFalse(TieringUtils.isTerminalTier("random"));
+    }
+
+    public void testGetTieringStatefromTargetTier_Hot() {
+        assertEquals(IndexModule.TieringState.WARM_TO_HOT, TieringUtils.getTieringStatefromTargetTier("HOT"));
+    }
+
+    public void testGetTieringStatefromTargetTier_Warm() {
+        assertEquals(IndexModule.TieringState.HOT_TO_WARM, TieringUtils.getTieringStatefromTargetTier("WARM"));
+    }
+
+    public void testGetTieringStatefromTargetTier_Invalid() {
+        expectThrows(IllegalArgumentException.class, () -> TieringUtils.getTieringStatefromTargetTier("HOT_TO_WARM"));
+    }
+
+    public void testGetTieringStatefromIndexSettings_HotToWarm() {
+        org.opensearch.common.settings.Settings settings = org.opensearch.common.settings.Settings.builder()
+            .put(IndexModule.INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.HOT_TO_WARM.toString())
+            .build();
+        assertEquals(IndexModule.TieringState.HOT_TO_WARM, TieringUtils.getTieringStatefromIndexSettings(settings));
+    }
+
+    public void testGetTieringStatefromIndexSettings_WarmToHot() {
+        org.opensearch.common.settings.Settings settings = org.opensearch.common.settings.Settings.builder()
+            .put(IndexModule.INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.WARM_TO_HOT.toString())
+            .build();
+        assertEquals(IndexModule.TieringState.WARM_TO_HOT, TieringUtils.getTieringStatefromIndexSettings(settings));
+    }
+
+    public void testGetTieringStatefromIndexSettings_Warm() {
+        org.opensearch.common.settings.Settings settings = org.opensearch.common.settings.Settings.builder()
+            .put(IndexModule.INDEX_TIERING_STATE.getKey(), IndexModule.TieringState.WARM.toString())
+            .build();
+        assertEquals(IndexModule.TieringState.HOT_TO_WARM, TieringUtils.getTieringStatefromIndexSettings(settings));
+    }
+
+    public void testGetTieringStatefromIndexSettings_Default() {
+        org.opensearch.common.settings.Settings settings = org.opensearch.common.settings.Settings.EMPTY;
+        assertEquals(IndexModule.TieringState.WARM_TO_HOT, TieringUtils.getTieringStatefromIndexSettings(settings));
+    }
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description                                                                                                                                                                                                                          
                                                                                                                                                                                                                                           
  Adds the server-side implementation for GetTieringStatus and ListTieringStatus APIs to support querying the status of tiering operations in OpenSearch.                                                                                  
                                                                                                                                                                                                                                           
  **Changes include:**                                                                                                                                                                                                                     
                                                                                                                                                                                                                                           
  - **Models**: `GetTieringStatusRequest/Response`, `ListTieringStatusRequest/Response`, `TieringStatus` — request/response classes with serialization support                                                                             
  - **REST handlers**: `RestGetTieringStatusAction` (`GET /_tier/{index}`), `RestListTieringStatusAction` (`GET /_tier/all`) — REST endpoints for the APIs                                                                                 
  - **Transport actions**: `TransportGetTieringStatusAction`, `TransportListTieringStatusAction` — cluster manager node read actions wired with `HotToWarmTieringService` and `WarmToHotTieringService`                                    
  - **TieringUtils**: Implemented `resolveRequestIndex`, `getTieringStatefromIndexSettings`, `getTieringStatefromTargetTier`, `isTerminalTier`, `getTieringStartTime`, `getTierPairForTargetTier` utility methods                                                                                
  - **TieringService**: Implemented `getTieringStatus`, `listTieringStatus`, and `constructTieringStatus` with full functionality                                                                                 
  - **Wiring**: Registered actions and REST handlers in `ActionModule`, Guice bindings for tiering services in `Node.java` — all gated behind `WRITABLE_WARM_INDEX` feature flag                                                           
                                                                                                                                                                                                                                           
  **Tests:**                                                                                                                                                                                                                               
  - 9 unit test files covering models, REST handlers, and transport actions                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
  ### Related Issues                                                                                                                                                                                                                       
  Resolves https://github.com/opensearch-project/OpenSearch/issues/21078                                                                                                                                                                   
                                                                                                                                                                                                                                           
  ### Check List                                                                                                                                                                                                                           
  - [x] Functionality includes testing.                                                                                                                                                                                                    
  - [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.                                                                      
  - [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.                                                                                             
                                                                                                                                                                                                                                           
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.                                                                                                                       
  For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).         
                                                                                                                                                                                                                                           
  Fixes: blank line after **Changes include:**, **Tests:** and **Note:** on their own lines with proper markdown formatting, and checked the testing checkbox. 
