### PR TITLE
Use binary serde for resource usage headers

### DIFF
--- a/server/src/main/java/org/opensearch/common/io/stream/WriteableBase64.java
+++ b/server/src/main/java/org/opensearch/common/io/stream/WriteableBase64.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.io.stream;
+
+import org.opensearch.common.annotation.InternalApi;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.util.Base64;
+
+/**
+ * Utility for round-tripping a {@link Writeable} through its binary wire format encoded as a
+ * Base64 string. This is useful when a {@link Writeable} needs to travel over a channel that only
+ * carries strings (for example a {@code ThreadContext} response header), where the binary form is
+ * both cheaper to produce/consume than JSON and more compact once Base64-encoded.
+ *
+ * @opensearch.internal
+ */
+@InternalApi
+public final class WriteableBase64 {
+
+    private WriteableBase64() {}
+
+    /**
+     * Serializes a {@link Writeable} to its binary wire format and Base64-encodes the result.
+     *
+     * @param writeable the object to serialize
+     * @return a Base64-encoded string of the object's binary representation
+     * @throws IOException if serialization fails
+     */
+    public static String encode(Writeable writeable) throws IOException {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            writeable.writeTo(out);
+            byte[] bytes = BytesReference.toBytes(out.bytes());
+            return Base64.getEncoder().encodeToString(bytes);
+        }
+    }
+
+    /**
+     * Decodes a Base64 string produced by {@link #encode(Writeable)} back into an object using the
+     * supplied reader.
+     *
+     * @param encoded the Base64-encoded string
+     * @param reader  reconstructs the object from a {@link StreamInput} (for example
+     *                {@code MyType::readFromStream} or {@code MyType::new})
+     * @param <T>     the type produced by {@code reader}
+     * @return the deserialized object
+     * @throws IOException              if deserialization fails
+     * @throws IllegalArgumentException if the input is not valid Base64
+     */
+    public static <T> T decode(String encoded, Writeable.Reader<T> reader) throws IOException {
+        byte[] bytes = Base64.getDecoder().decode(encoded);
+        try (StreamInput in = StreamInput.wrap(bytes)) {
+            return reader.read(in);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -722,6 +722,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 ShardIndexingPressureMemoryManager.MAX_OUTSTANDING_REQUESTS,
                 IndexingPressure.MAX_INDEXING_BYTES,
                 TaskResourceTrackingService.TASK_RESOURCE_TRACKING_ENABLED,
+                TaskResourceTrackingService.BINARY_RESOURCE_USAGE_HEADER_ENABLED,
                 TaskManager.TASK_RESOURCE_CONSUMERS_ENABLED,
                 TopNSearchTasksLogger.LOG_TOP_QUERIES_SIZE_SETTING,
                 TopNSearchTasksLogger.LOG_TOP_QUERIES_FREQUENCY_SETTING,

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -1059,7 +1059,8 @@ public class Node implements Closeable {
             final TaskResourceTrackingService taskResourceTrackingService = new TaskResourceTrackingService(
                 settings,
                 clusterService.getClusterSettings(),
-                threadPool
+                threadPool,
+                clusterService
             );
 
             final SearchRequestStats searchRequestStats = new SearchRequestStats(clusterService.getClusterSettings());

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
@@ -17,14 +17,15 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.search.SearchShardTask;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.common.util.concurrent.ConcurrentMapLong;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.common.xcontent.XContentHelper;
-import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.tasks.resourcetracker.ResourceStats;
 import org.opensearch.core.tasks.resourcetracker.ResourceStatsType;
 import org.opensearch.core.tasks.resourcetracker.ResourceUsageInfo;
@@ -32,16 +33,13 @@ import org.opensearch.core.tasks.resourcetracker.ResourceUsageMetric;
 import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
 import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
 import org.opensearch.core.tasks.resourcetracker.ThreadResourceInfo;
-import org.opensearch.core.xcontent.DeprecationHandler;
-import org.opensearch.core.xcontent.MediaTypeRegistry;
-import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.threadpool.RunnableTaskExecutionListener;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -322,7 +320,7 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
                 )
                 .build();
             // Remove the existing TASK_RESOURCE_USAGE header since it would have come from an earlier phase in the same request.
-            threadPool.getThreadContext().updateResponseHeader(TASK_RESOURCE_USAGE, taskResourceInfo.toString());
+            threadPool.getThreadContext().updateResponseHeader(TASK_RESOURCE_USAGE, serializeToBase64(taskResourceInfo));
         } catch (Exception e) {
             logger.debug("Error during writing task resource usage: ", e);
         }
@@ -336,29 +334,57 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
     }
 
     /**
-     * Get the task resource usages from {@link ThreadContext}
+     * Get the task resource usages from {@link ThreadContext}.
+     * <p>
+     * Deserializes from Base64-encoded binary format. If deserialization fails (e.g., due to a legacy
+     * JSON-formatted header from an older node during a rolling upgrade), the failure is handled gracefully
+     * and null is returned. The resource usage data for that shard is simply skipped.
      *
-     * @return {@link TaskResourceInfo}
+     * @return {@link TaskResourceInfo} or null if the header is absent or cannot be deserialized
      */
     public TaskResourceInfo getTaskResourceUsageFromThreadContext() {
         List<String> taskResourceUsages = threadPool.getThreadContext().getResponseHeaders().get(TASK_RESOURCE_USAGE);
         if (taskResourceUsages != null && taskResourceUsages.size() > 0) {
             String usage = taskResourceUsages.get(0);
             try {
-                if (usage != null && !usage.isEmpty()) {
-                    XContentParser parser = XContentHelper.createParser(
-                        NamedXContentRegistry.EMPTY,
-                        DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                        new BytesArray(usage),
-                        MediaTypeRegistry.JSON
-                    );
-                    return TaskResourceInfo.PARSER.apply(parser, null);
+                if (usage != null && usage.isEmpty() == false) {
+                    return deserializeFromBase64(usage);
                 }
-            } catch (IOException e) {
-                logger.debug("fail to parse phase resource usages: ", e);
+            } catch (Exception e) {
+                logger.debug("failed to parse task resource usage header, skipping: ", e);
             }
         }
         return null;
+    }
+
+    /**
+     * Serializes a {@link TaskResourceInfo} to a Base64-encoded binary string for use in response headers.
+     * Uses the efficient binary serialization instead of JSON to reduce CPU overhead.
+     *
+     * @param taskResourceInfo the task resource info to serialize
+     * @return a Base64-encoded string
+     * @throws IOException if serialization fails
+     */
+    static String serializeToBase64(TaskResourceInfo taskResourceInfo) throws IOException {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            taskResourceInfo.writeTo(out);
+            byte[] bytes = BytesReference.toBytes(out.bytes());
+            return Base64.getEncoder().encodeToString(bytes);
+        }
+    }
+
+    /**
+     * Deserializes a {@link TaskResourceInfo} from a Base64-encoded binary string.
+     *
+     * @param headerValue the Base64-encoded header value
+     * @return the deserialized {@link TaskResourceInfo}
+     * @throws IOException if deserialization fails
+     */
+    static TaskResourceInfo deserializeFromBase64(String headerValue) throws IOException {
+        byte[] bytes = Base64.getDecoder().decode(headerValue);
+        try (StreamInput in = StreamInput.wrap(bytes)) {
+            return TaskResourceInfo.readFromStream(in);
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
@@ -20,7 +20,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.inject.Inject;
-import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.WriteableBase64;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
@@ -29,8 +29,6 @@ import org.opensearch.common.util.concurrent.ConcurrentMapLong;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.common.bytes.BytesArray;
-import org.opensearch.core.common.bytes.BytesReference;
-import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.tasks.resourcetracker.ResourceStats;
 import org.opensearch.core.tasks.resourcetracker.ResourceStatsType;
 import org.opensearch.core.tasks.resourcetracker.ResourceUsageInfo;
@@ -48,7 +46,6 @@ import org.opensearch.threadpool.ThreadPool;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -364,7 +361,9 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
                     )
                 )
                 .build();
-            String headerValue = canCoordinatorReadBinaryHeader(task) ? serializeToBase64(taskResourceInfo) : taskResourceInfo.toString();
+            String headerValue = canCoordinatorReadBinaryHeader(task)
+                ? WriteableBase64.encode(taskResourceInfo)
+                : taskResourceInfo.toString();
             // Remove the existing TASK_RESOURCE_USAGE header since it would have come from an earlier phase in the same request.
             threadPool.getThreadContext().updateResponseHeader(TASK_RESOURCE_USAGE, headerValue);
         } catch (Exception e) {
@@ -419,7 +418,7 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
             return null;
         }
         try {
-            return deserializeFromBase64(usage);
+            return WriteableBase64.decode(usage, TaskResourceInfo::readFromStream);
         } catch (Exception binaryFailure) {
             try {
                 return deserializeFromJson(usage);
@@ -427,36 +426,6 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
                 logger.debug("failed to parse task resource usage header (binary and JSON), skipping: ", jsonFailure);
                 return null;
             }
-        }
-    }
-
-    /**
-     * Serializes a {@link TaskResourceInfo} to a Base64-encoded binary string for use in response headers.
-     * Uses the efficient binary serialization instead of JSON to reduce CPU overhead.
-     *
-     * @param taskResourceInfo the task resource info to serialize
-     * @return a Base64-encoded string
-     * @throws IOException if serialization fails
-     */
-    static String serializeToBase64(TaskResourceInfo taskResourceInfo) throws IOException {
-        try (BytesStreamOutput out = new BytesStreamOutput()) {
-            taskResourceInfo.writeTo(out);
-            byte[] bytes = BytesReference.toBytes(out.bytes());
-            return Base64.getEncoder().encodeToString(bytes);
-        }
-    }
-
-    /**
-     * Deserializes a {@link TaskResourceInfo} from a Base64-encoded binary string.
-     *
-     * @param headerValue the Base64-encoded header value
-     * @return the deserialized {@link TaskResourceInfo}
-     * @throws IOException if deserialization fails
-     */
-    static TaskResourceInfo deserializeFromBase64(String headerValue) throws IOException {
-        byte[] bytes = Base64.getDecoder().decode(headerValue);
-        try (StreamInput in = StreamInput.wrap(bytes)) {
-            return TaskResourceInfo.readFromStream(in);
         }
     }
 

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
@@ -79,7 +79,7 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
 
     // First OpenSearch version that emits and parses the Base64 binary form of the
     // TASK_RESOURCE_USAGE response header. Coordinators older than this only understand JSON.
-    static final Version BINARY_RESOURCE_USAGE_HEADER_VERSION = Version.V_3_7_0;
+    static final Version BINARY_RESOURCE_USAGE_HEADER_VERSION = Version.V_3_8_0;
 
     private static final ThreadMXBean threadMXBean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
 
@@ -376,7 +376,7 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
     // cluster state — falls back to JSON, since the cost of an unwarranted JSON emission is small and
     // bounded, while the cost of an unwarranted binary emission to an old coordinator is a hung search.
     private boolean canCoordinatorReadBinaryHeader(SearchShardTask task) {
-        if (binaryResourceUsageHeaderEnabled == false) {
+        if (isBinaryResourceUsageHeaderEnabled() == false) {
             return false;
         }
         if (clusterService == null) {
@@ -429,7 +429,7 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
         }
     }
 
-    // Legacy JSON parser for headers emitted by pre-V_3_7_0 data nodes during rolling upgrade.
+    // Legacy JSON parser for headers emitted by pre-V_3_8_0 data nodes during rolling upgrade.
     static TaskResourceInfo deserializeFromJson(String headerValue) throws IOException {
         try (
             XContentParser parser = XContentHelper.createParser(

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
@@ -69,6 +69,14 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
+    // Kill-switch for emitting the Base64 binary TASK_RESOURCE_USAGE response header. When false,
+    // data nodes always emit the legacy JSON header. The consumer always falls back to JSON regardless.
+    public static final Setting<Boolean> BINARY_RESOURCE_USAGE_HEADER_ENABLED = Setting.boolSetting(
+        "task_resource_tracking.binary_header.enabled",
+        true,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
     public static final String TASK_ID = "TASK_ID";
     public static final String TASK_RESOURCE_USAGE = "TASK_RESOURCE_USAGE";
 
@@ -83,6 +91,7 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
     private final ThreadPool threadPool;
     private final ClusterService clusterService;
     private volatile boolean taskResourceTrackingEnabled;
+    private volatile boolean binaryResourceUsageHeaderEnabled;
 
     @Inject
     public TaskResourceTrackingService(
@@ -92,9 +101,11 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
         ClusterService clusterService
     ) {
         this.taskResourceTrackingEnabled = TASK_RESOURCE_TRACKING_ENABLED.get(settings);
+        this.binaryResourceUsageHeaderEnabled = BINARY_RESOURCE_USAGE_HEADER_ENABLED.get(settings);
         this.threadPool = threadPool;
         this.clusterService = clusterService;
         clusterSettings.addSettingsUpdateConsumer(TASK_RESOURCE_TRACKING_ENABLED, this::setTaskResourceTrackingEnabled);
+        clusterSettings.addSettingsUpdateConsumer(BINARY_RESOURCE_USAGE_HEADER_ENABLED, this::setBinaryResourceUsageHeaderEnabled);
     }
 
     // Without ClusterService, writeTaskResourceUsage cannot verify the coordinator's version
@@ -109,6 +120,14 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
 
     public boolean isTaskResourceTrackingEnabled() {
         return taskResourceTrackingEnabled;
+    }
+
+    public void setBinaryResourceUsageHeaderEnabled(boolean binaryResourceUsageHeaderEnabled) {
+        this.binaryResourceUsageHeaderEnabled = binaryResourceUsageHeaderEnabled;
+    }
+
+    public boolean isBinaryResourceUsageHeaderEnabled() {
+        return binaryResourceUsageHeaderEnabled;
     }
 
     public boolean isTaskResourceTrackingSupported() {
@@ -354,10 +373,13 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
     }
 
     // Returns true only with positive confirmation that the coordinator can parse the binary header.
-    // Any unknown — no ClusterService, empty parent task, coordinator missing from cluster state — falls
-    // back to JSON, since the cost of an unwarranted JSON emission is small and bounded, while the cost
-    // of an unwarranted binary emission to an old coordinator is a hung search.
+    // Any unknown — kill-switch off, no ClusterService, empty parent task, coordinator missing from
+    // cluster state — falls back to JSON, since the cost of an unwarranted JSON emission is small and
+    // bounded, while the cost of an unwarranted binary emission to an old coordinator is a hung search.
     private boolean canCoordinatorReadBinaryHeader(SearchShardTask task) {
+        if (binaryResourceUsageHeaderEnabled == false) {
+            return false;
+        }
         if (clusterService == null) {
             return false;
         }

--- a/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskResourceTrackingService.java
@@ -14,7 +14,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.Version;
 import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -24,6 +27,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.common.util.concurrent.ConcurrentMapLong;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.tasks.resourcetracker.ResourceStats;
@@ -33,6 +38,10 @@ import org.opensearch.core.tasks.resourcetracker.ResourceUsageMetric;
 import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
 import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
 import org.opensearch.core.tasks.resourcetracker.ThreadResourceInfo;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.threadpool.RunnableTaskExecutionListener;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -63,18 +72,35 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
     public static final String TASK_ID = "TASK_ID";
     public static final String TASK_RESOURCE_USAGE = "TASK_RESOURCE_USAGE";
 
+    // First OpenSearch version that emits and parses the Base64 binary form of the
+    // TASK_RESOURCE_USAGE response header. Coordinators older than this only understand JSON.
+    static final Version BINARY_RESOURCE_USAGE_HEADER_VERSION = Version.V_3_7_0;
+
     private static final ThreadMXBean threadMXBean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
 
     private final ConcurrentMapLong<Task> resourceAwareTasks = ConcurrentCollections.newConcurrentMapLongWithAggressiveConcurrency();
     private final List<TaskCompletionListener> taskCompletionListeners = new ArrayList<>();
     private final ThreadPool threadPool;
+    private final ClusterService clusterService;
     private volatile boolean taskResourceTrackingEnabled;
 
     @Inject
-    public TaskResourceTrackingService(Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool) {
+    public TaskResourceTrackingService(
+        Settings settings,
+        ClusterSettings clusterSettings,
+        ThreadPool threadPool,
+        ClusterService clusterService
+    ) {
         this.taskResourceTrackingEnabled = TASK_RESOURCE_TRACKING_ENABLED.get(settings);
         this.threadPool = threadPool;
+        this.clusterService = clusterService;
         clusterSettings.addSettingsUpdateConsumer(TASK_RESOURCE_TRACKING_ENABLED, this::setTaskResourceTrackingEnabled);
+    }
+
+    // Without ClusterService, writeTaskResourceUsage cannot verify the coordinator's version
+    // and will always emit the legacy JSON header. Forgoes the binary CPU win but is rolling-upgrade safe.
+    public TaskResourceTrackingService(Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool) {
+        this(settings, clusterSettings, threadPool, null);
     }
 
     public void setTaskResourceTrackingEnabled(boolean taskResourceTrackingEnabled) {
@@ -319,11 +345,31 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
                     )
                 )
                 .build();
+            String headerValue = canCoordinatorReadBinaryHeader(task) ? serializeToBase64(taskResourceInfo) : taskResourceInfo.toString();
             // Remove the existing TASK_RESOURCE_USAGE header since it would have come from an earlier phase in the same request.
-            threadPool.getThreadContext().updateResponseHeader(TASK_RESOURCE_USAGE, serializeToBase64(taskResourceInfo));
+            threadPool.getThreadContext().updateResponseHeader(TASK_RESOURCE_USAGE, headerValue);
         } catch (Exception e) {
             logger.debug("Error during writing task resource usage: ", e);
         }
+    }
+
+    // Returns true only with positive confirmation that the coordinator can parse the binary header.
+    // Any unknown — no ClusterService, empty parent task, coordinator missing from cluster state — falls
+    // back to JSON, since the cost of an unwarranted JSON emission is small and bounded, while the cost
+    // of an unwarranted binary emission to an old coordinator is a hung search.
+    private boolean canCoordinatorReadBinaryHeader(SearchShardTask task) {
+        if (clusterService == null) {
+            return false;
+        }
+        String coordinatorNodeId = task.getParentTaskId().getNodeId();
+        if (coordinatorNodeId.isEmpty()) {
+            return false;
+        }
+        DiscoveryNode coordinator = clusterService.state().nodes().get(coordinatorNodeId);
+        if (coordinator == null) {
+            return false;
+        }
+        return coordinator.getVersion().onOrAfter(BINARY_RESOURCE_USAGE_HEADER_VERSION);
     }
 
     /**
@@ -336,25 +382,30 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
     /**
      * Get the task resource usages from {@link ThreadContext}.
      * <p>
-     * Deserializes from Base64-encoded binary format. If deserialization fails (e.g., due to a legacy
-     * JSON-formatted header from an older node during a rolling upgrade), the failure is handled gracefully
-     * and null is returned. The resource usage data for that shard is simply skipped.
+     * Tries the new Base64 binary format first; on failure falls back to the legacy JSON form so
+     * that resource usage from older data nodes is preserved during a rolling upgrade.
      *
      * @return {@link TaskResourceInfo} or null if the header is absent or cannot be deserialized
      */
     public TaskResourceInfo getTaskResourceUsageFromThreadContext() {
         List<String> taskResourceUsages = threadPool.getThreadContext().getResponseHeaders().get(TASK_RESOURCE_USAGE);
-        if (taskResourceUsages != null && taskResourceUsages.size() > 0) {
-            String usage = taskResourceUsages.get(0);
+        if (taskResourceUsages == null || taskResourceUsages.isEmpty()) {
+            return null;
+        }
+        String usage = taskResourceUsages.get(0);
+        if (usage == null || usage.isEmpty()) {
+            return null;
+        }
+        try {
+            return deserializeFromBase64(usage);
+        } catch (Exception binaryFailure) {
             try {
-                if (usage != null && usage.isEmpty() == false) {
-                    return deserializeFromBase64(usage);
-                }
-            } catch (Exception e) {
-                logger.debug("failed to parse task resource usage header, skipping: ", e);
+                return deserializeFromJson(usage);
+            } catch (Exception jsonFailure) {
+                logger.debug("failed to parse task resource usage header (binary and JSON), skipping: ", jsonFailure);
+                return null;
             }
         }
-        return null;
     }
 
     /**
@@ -384,6 +435,20 @@ public class TaskResourceTrackingService implements RunnableTaskExecutionListene
         byte[] bytes = Base64.getDecoder().decode(headerValue);
         try (StreamInput in = StreamInput.wrap(bytes)) {
             return TaskResourceInfo.readFromStream(in);
+        }
+    }
+
+    // Legacy JSON parser for headers emitted by pre-V_3_7_0 data nodes during rolling upgrade.
+    static TaskResourceInfo deserializeFromJson(String headerValue) throws IOException {
+        try (
+            XContentParser parser = XContentHelper.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                new BytesArray(headerValue),
+                MediaTypeRegistry.JSON
+            )
+        ) {
+            return TaskResourceInfo.PARSER.apply(parser, null);
         }
     }
 

--- a/server/src/test/java/org/opensearch/common/io/stream/WriteableBase64Tests.java
+++ b/server/src/test/java/org/opensearch/common/io/stream/WriteableBase64Tests.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.io.stream;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Objects;
+
+public class WriteableBase64Tests extends OpenSearchTestCase {
+
+    /** A minimal {@link Writeable} used to exercise the codec independently of any production type. */
+    private static class Sample implements Writeable {
+        private final String name;
+        private final long value;
+
+        Sample(String name, long value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        Sample(StreamInput in) throws IOException {
+            this.name = in.readString();
+            this.value = in.readLong();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(name);
+            out.writeLong(value);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Sample sample = (Sample) o;
+            return value == sample.value && Objects.equals(name, sample.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, value);
+        }
+    }
+
+    public void testRoundTrip() throws IOException {
+        Sample original = new Sample(randomAlphaOfLength(12), randomLong());
+
+        String encoded = WriteableBase64.encode(original);
+        Sample decoded = WriteableBase64.decode(encoded, Sample::new);
+
+        assertEquals(original, decoded);
+    }
+
+    public void testEncodeProducesValidBase64() throws IOException {
+        Sample original = new Sample("action", 42L);
+
+        String encoded = WriteableBase64.encode(original);
+
+        // Must decode as standard Base64 without throwing; the resulting bytes reconstruct the object.
+        byte[] decodedBytes = Base64.getDecoder().decode(encoded);
+        try (StreamInput in = StreamInput.wrap(decodedBytes)) {
+            assertEquals(original, new Sample(in));
+        }
+    }
+
+    public void testEmptyStringThrows() {
+        // An empty payload has no bytes for the reader to consume.
+        expectThrows(Exception.class, () -> WriteableBase64.decode("", Sample::new));
+    }
+
+    public void testInvalidBase64Throws() {
+        expectThrows(IllegalArgumentException.class, () -> WriteableBase64.decode("not-valid-base64!!!", Sample::new));
+    }
+}

--- a/server/src/test/java/org/opensearch/tasks/TaskResourceTrackingServiceTests.java
+++ b/server/src/test/java/org/opensearch/tasks/TaskResourceTrackingServiceTests.java
@@ -18,6 +18,7 @@ import org.opensearch.core.tasks.TaskId;
 import org.opensearch.core.tasks.resourcetracker.ResourceStatsType;
 import org.opensearch.core.tasks.resourcetracker.ResourceUsageMetric;
 import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
 import org.opensearch.core.tasks.resourcetracker.ThreadResourceInfo;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
@@ -164,23 +165,95 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
     }
 
     public void testGetTaskResourceUsageFromThreadContext() {
+        // Legacy JSON format is no longer supported — should return null gracefully
         String taskResourceUsageJson =
             "{\"action\":\"testAction\",\"taskId\":1,\"parentTaskId\":2,\"nodeId\":\"nodeId\",\"taskResourceUsage\":{\"cpu_time_in_nanos\":1000,\"memory_in_bytes\":2000}}";
         threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, taskResourceUsageJson);
         TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
-        assertNotNull(result);
-        assertEquals("testAction", result.getAction());
-        assertEquals(1L, result.getTaskId());
-        assertEquals(2L, result.getParentTaskId());
-        assertEquals("nodeId", result.getNodeId());
-        assertEquals(1000L, result.getTaskResourceUsage().getCpuTimeInNanos());
-        assertEquals(2000L, result.getTaskResourceUsage().getMemoryInBytes());
+        assertNull("Legacy JSON header should return null since binary format is now required", result);
     }
 
     private void verifyThreadContextFixedHeaders(String key, String value) {
         assertEquals(threadPool.getThreadContext().getHeader(key), value);
         assertEquals(threadPool.getThreadContext().getTransient(key), value);
         assertEquals(threadPool.getThreadContext().getResponseHeaders().get(key).get(0), value);
+    }
+
+    public void testSerializeToBase64RoundTrip() throws Exception {
+        TaskResourceInfo original = new TaskResourceInfo(
+            "indices:data/read/search[phase/query]",
+            12345L,
+            67890L,
+            "U0rMsZg9RGOxdnVfMtMNVA",
+            new TaskResourceUsage(15000000L, 2048000L)
+        );
+
+        String encoded = TaskResourceTrackingService.serializeToBase64(original);
+        TaskResourceInfo deserialized = TaskResourceTrackingService.deserializeFromBase64(encoded);
+        assertEquals(original, deserialized);
+    }
+
+    public void testBinaryHeaderReadFromThreadContext() throws Exception {
+        TaskResourceInfo original = new TaskResourceInfo(
+            "indices:data/read/search[phase/query]",
+            1L,
+            2L,
+            "nodeA",
+            new TaskResourceUsage(1000L, 2000L)
+        );
+
+        String binaryHeader = TaskResourceTrackingService.serializeToBase64(original);
+        threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, binaryHeader);
+
+        TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
+        assertNotNull(result);
+        assertEquals(original, result);
+    }
+
+    public void testJsonFallbackReturnsNullGracefully() {
+        // Simulate a header from an older node that uses JSON format — should fail gracefully
+        String jsonHeader =
+            "{\"action\":\"testAction\",\"taskId\":1,\"parentTaskId\":2,\"nodeId\":\"nodeId\",\"taskResourceUsage\":{\"cpu_time_in_nanos\":1000,\"memory_in_bytes\":2000}}";
+        threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, jsonHeader);
+
+        TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
+        assertNull("Legacy JSON header should return null gracefully without binary prefix", result);
+    }
+
+    public void testCorruptedHeaderReturnsNullGracefully() {
+        threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, "not-valid-base64!!!");
+
+        TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
+        assertNull("Corrupted header should return null gracefully", result);
+    }
+
+    public void testEmptyHeaderReturnsNull() {
+        threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, "");
+
+        TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
+        assertNull(result);
+    }
+
+    public void testWriteTaskResourceUsageUsesBinaryFormat() {
+        SearchShardTask task = new SearchShardTask(1, "test", "test", "task", TaskId.EMPTY_TASK_ID, new HashMap<>());
+        taskResourceTrackingService.setTaskResourceTrackingEnabled(true);
+        taskResourceTrackingService.startTracking(task);
+        task.startThreadResourceTracking(
+            Thread.currentThread().threadId(),
+            ResourceStatsType.WORKER_STATS,
+            new ResourceUsageMetric(CPU, 100),
+            new ResourceUsageMetric(MEMORY, 100)
+        );
+        taskResourceTrackingService.writeTaskResourceUsage(task, "node_1");
+        Map<String, List<String>> headers = threadPool.getThreadContext().getResponseHeaders();
+        String headerValue = headers.get(TASK_RESOURCE_USAGE).get(0);
+        // Binary Base64 headers should not start with '{' (JSON)
+        assertFalse("Header should not be JSON format", headerValue.startsWith("{"));
+
+        // Verify it can be deserialized back
+        TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
+        assertNotNull(result);
+        assertEquals("node_1", result.getNodeId());
     }
 
 }

--- a/server/src/test/java/org/opensearch/tasks/TaskResourceTrackingServiceTests.java
+++ b/server/src/test/java/org/opensearch/tasks/TaskResourceTrackingServiceTests.java
@@ -8,9 +8,15 @@
 
 package org.opensearch.tasks;
 
+import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.node.tasks.TransportTasksActionTests;
 import org.opensearch.action.search.SearchShardTask;
 import org.opensearch.action.search.SearchTask;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -20,12 +26,14 @@ import org.opensearch.core.tasks.resourcetracker.ResourceUsageMetric;
 import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
 import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
 import org.opensearch.core.tasks.resourcetracker.ThreadResourceInfo;
+import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,22 +48,69 @@ import static org.opensearch.tasks.TaskResourceTrackingService.TASK_RESOURCE_USA
 
 public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
 
+    private static final String LOCAL_NODE_ID = "local_node";
+    private static final String OLD_COORDINATOR_ID = "old_coord_node";
+    private static final String NEW_COORDINATOR_ID = "new_coord_node";
+
     private ThreadPool threadPool;
+    private ClusterService clusterService;
     private TaskResourceTrackingService taskResourceTrackingService;
 
     @Before
     public void setup() {
         threadPool = new TestThreadPool(TransportTasksActionTests.class.getSimpleName(), new AtomicReference<>());
+        DiscoveryNode localNode = new DiscoveryNode(
+            LOCAL_NODE_ID,
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            DiscoveryNodeRole.BUILT_IN_ROLES,
+            Version.CURRENT
+        );
+        clusterService = ClusterServiceUtils.createClusterService(threadPool, localNode);
         taskResourceTrackingService = new TaskResourceTrackingService(
             Settings.EMPTY,
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-            threadPool
+            threadPool,
+            clusterService
         );
     }
 
     @After
     public void terminateThreadPool() {
+        clusterService.close();
         terminate(threadPool);
+    }
+
+    private void addCoordinatorNodeWithVersion(String nodeId, Version version) {
+        DiscoveryNode coordinator = new DiscoveryNode(
+            nodeId,
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            DiscoveryNodeRole.BUILT_IN_ROLES,
+            version
+        );
+        ClusterState current = clusterService.state();
+        DiscoveryNodes updated = DiscoveryNodes.builder(current.nodes()).add(coordinator).build();
+        ClusterState newState = ClusterState.builder(current).nodes(updated).build();
+        ClusterServiceUtils.setState(clusterService, newState);
+    }
+
+    private SearchShardTask searchShardTaskWithParent(String coordinatorNodeId) {
+        TaskId parent = new TaskId(coordinatorNodeId, randomLong());
+        SearchShardTask task = new SearchShardTask(randomLong(), "test", "test", "task", parent, new HashMap<>());
+        taskResourceTrackingService.setTaskResourceTrackingEnabled(true);
+        taskResourceTrackingService.startTracking(task);
+        task.startThreadResourceTracking(
+            Thread.currentThread().threadId(),
+            ResourceStatsType.WORKER_STATS,
+            new ResourceUsageMetric(CPU, 100),
+            new ResourceUsageMetric(MEMORY, 100)
+        );
+        return task;
+    }
+
+    private static String legacyJsonOf(TaskResourceInfo info) {
+        return info.toString();
     }
 
     public void testThreadContextUpdateOnTrackingStart() {
@@ -164,13 +219,14 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
         assertTrue(headers.containsKey(TASK_RESOURCE_USAGE));
     }
 
-    public void testGetTaskResourceUsageFromThreadContext() {
-        // Legacy JSON format is no longer supported — should return null gracefully
-        String taskResourceUsageJson =
-            "{\"action\":\"testAction\",\"taskId\":1,\"parentTaskId\":2,\"nodeId\":\"nodeId\",\"taskResourceUsage\":{\"cpu_time_in_nanos\":1000,\"memory_in_bytes\":2000}}";
-        threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, taskResourceUsageJson);
+    public void testGetTaskResourceUsageFromThreadContext() throws Exception {
+        TaskResourceInfo expected = new TaskResourceInfo("testAction", 1L, 2L, "nodeId", new TaskResourceUsage(1000L, 2000L));
+        String binary = TaskResourceTrackingService.serializeToBase64(expected);
+        threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, binary);
+
         TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
-        assertNull("Legacy JSON header should return null since binary format is now required", result);
+        assertNotNull(result);
+        assertEquals(expected, result);
     }
 
     private void verifyThreadContextFixedHeaders(String key, String value) {
@@ -210,16 +266,6 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
         assertEquals(original, result);
     }
 
-    public void testJsonFallbackReturnsNullGracefully() {
-        // Simulate a header from an older node that uses JSON format — should fail gracefully
-        String jsonHeader =
-            "{\"action\":\"testAction\",\"taskId\":1,\"parentTaskId\":2,\"nodeId\":\"nodeId\",\"taskResourceUsage\":{\"cpu_time_in_nanos\":1000,\"memory_in_bytes\":2000}}";
-        threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, jsonHeader);
-
-        TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
-        assertNull("Legacy JSON header should return null gracefully without binary prefix", result);
-    }
-
     public void testCorruptedHeaderReturnsNullGracefully() {
         threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, "not-valid-base64!!!");
 
@@ -234,7 +280,9 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
         assertNull(result);
     }
 
-    public void testWriteTaskResourceUsageUsesBinaryFormat() {
+    public void testWriteTaskResourceUsageRoundTrips() {
+        // EMPTY_TASK_ID means we can't resolve a coordinator, so the producer falls back to JSON;
+        // the consumer's JSON path must still round-trip cleanly.
         SearchShardTask task = new SearchShardTask(1, "test", "test", "task", TaskId.EMPTY_TASK_ID, new HashMap<>());
         taskResourceTrackingService.setTaskResourceTrackingEnabled(true);
         taskResourceTrackingService.startTracking(task);
@@ -245,15 +293,129 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
             new ResourceUsageMetric(MEMORY, 100)
         );
         taskResourceTrackingService.writeTaskResourceUsage(task, "node_1");
-        Map<String, List<String>> headers = threadPool.getThreadContext().getResponseHeaders();
-        String headerValue = headers.get(TASK_RESOURCE_USAGE).get(0);
-        // Binary Base64 headers should not start with '{' (JSON)
-        assertFalse("Header should not be JSON format", headerValue.startsWith("{"));
 
-        // Verify it can be deserialized back
         TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
         assertNotNull(result);
         assertEquals("node_1", result.getNodeId());
+    }
+
+    // Rolling-upgrade BC: one test per (data node, coordinator) quadrant. The TASK_RESOURCE_USAGE
+    // response header is one-way (data node -> coordinator), so the matrix is exhaustive.
+    // Quadrant 4 (old data -> old coord) is the pre-PR baseline; it's exercised by prior releases'
+    // tests and not reachable from this branch, so it has no test here.
+
+    public void testBwc_NewDataNode_NewCoordinator() {
+        addCoordinatorNodeWithVersion(NEW_COORDINATOR_ID, Version.CURRENT);
+
+        SearchShardTask task = searchShardTaskWithParent(NEW_COORDINATOR_ID);
+        taskResourceTrackingService.writeTaskResourceUsage(task, LOCAL_NODE_ID);
+
+        String headerValue = threadPool.getThreadContext().getResponseHeaders().get(TASK_RESOURCE_USAGE).get(0);
+        assertFalse("expected binary header, got: " + headerValue, headerValue.startsWith("{"));
+
+        TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
+        assertNotNull(result);
+        assertEquals(LOCAL_NODE_ID, result.getNodeId());
+    }
+
+    public void testBwc_NewDataNode_OldCoordinator() {
+        // If the data node emits binary here, the old coordinator's IOException-only catch lets
+        // XContentParseException escape, the shard response is silently dropped, and the search hangs.
+        addCoordinatorNodeWithVersion(OLD_COORDINATOR_ID, Version.CURRENT.minimumCompatibilityVersion());
+
+        SearchShardTask task = searchShardTaskWithParent(OLD_COORDINATOR_ID);
+        taskResourceTrackingService.writeTaskResourceUsage(task, LOCAL_NODE_ID);
+
+        String headerValue = threadPool.getThreadContext().getResponseHeaders().get(TASK_RESOURCE_USAGE).get(0);
+        assertTrue("expected JSON header for old coordinator, got: " + headerValue, headerValue.startsWith("{"));
+    }
+
+    public void testBwc_OldDataNode_NewCoordinator() {
+        TaskResourceInfo fromOldNode = new TaskResourceInfo(
+            "indices:data/read/search[phase/query]",
+            42L,
+            7L,
+            "old_data_node",
+            new TaskResourceUsage(1500L, 2500L)
+        );
+        threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, legacyJsonOf(fromOldNode));
+
+        TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
+        assertNotNull(result);
+        assertEquals(fromOldNode, result);
+    }
+
+    public void testProducerEmitsJsonHeaderWhenCoordinatorMissingFromClusterState() {
+        // Coordinator's version is unknown (left the cluster, or state lag) — emit JSON for safety
+        // rather than risk a hang if the coordinator turns out to be old.
+        SearchShardTask task = searchShardTaskWithParent("ghost_coordinator");
+        taskResourceTrackingService.writeTaskResourceUsage(task, LOCAL_NODE_ID);
+
+        String headerValue = threadPool.getThreadContext().getResponseHeaders().get(TASK_RESOURCE_USAGE).get(0);
+        assertTrue("expected JSON when coordinator is unknown, got: " + headerValue, headerValue.startsWith("{"));
+    }
+
+    public void testProducerEmitsJsonHeaderWhenNoParentTask() {
+        // No parent task means there's no coordinator to verify against — emit JSON for safety.
+        SearchShardTask task = new SearchShardTask(randomLong(), "test", "test", "task", TaskId.EMPTY_TASK_ID, new HashMap<>());
+        taskResourceTrackingService.setTaskResourceTrackingEnabled(true);
+        taskResourceTrackingService.startTracking(task);
+        task.startThreadResourceTracking(
+            Thread.currentThread().threadId(),
+            ResourceStatsType.WORKER_STATS,
+            new ResourceUsageMetric(CPU, 100),
+            new ResourceUsageMetric(MEMORY, 100)
+        );
+        taskResourceTrackingService.writeTaskResourceUsage(task, LOCAL_NODE_ID);
+
+        String headerValue = threadPool.getThreadContext().getResponseHeaders().get(TASK_RESOURCE_USAGE).get(0);
+        assertTrue("expected JSON when no parent task, got: " + headerValue, headerValue.startsWith("{"));
+    }
+
+    public void testProducerEmitsJsonHeaderWhenClusterServiceIsNull() {
+        // 3-arg constructor: no ClusterService, so the coordinator's version cannot be verified.
+        // Producer must default to JSON to remain rolling-upgrade safe.
+        TaskResourceTrackingService noClusterService = new TaskResourceTrackingService(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            threadPool
+        );
+        SearchShardTask task = new SearchShardTask(
+            randomLong(),
+            "test",
+            "test",
+            "task",
+            new TaskId(NEW_COORDINATOR_ID, randomLong()),
+            new HashMap<>()
+        );
+        noClusterService.setTaskResourceTrackingEnabled(true);
+        noClusterService.startTracking(task);
+        task.startThreadResourceTracking(
+            Thread.currentThread().threadId(),
+            ResourceStatsType.WORKER_STATS,
+            new ResourceUsageMetric(CPU, 100),
+            new ResourceUsageMetric(MEMORY, 100)
+        );
+        noClusterService.writeTaskResourceUsage(task, LOCAL_NODE_ID);
+
+        String headerValue = threadPool.getThreadContext().getResponseHeaders().get(TASK_RESOURCE_USAGE).get(0);
+        assertTrue("expected JSON when ClusterService is null, got: " + headerValue, headerValue.startsWith("{"));
+    }
+
+    public void testConsumerPrefersBinaryOverJsonFallback() throws Exception {
+        TaskResourceInfo expected = new TaskResourceInfo(
+            "indices:data/read/search[phase/query]",
+            99L,
+            33L,
+            "node_x",
+            new TaskResourceUsage(7777L, 8888L)
+        );
+        String binary = TaskResourceTrackingService.serializeToBase64(expected);
+        threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, binary);
+
+        TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
+        assertNotNull(result);
+        assertEquals(expected, result);
     }
 
 }

--- a/server/src/test/java/org/opensearch/tasks/TaskResourceTrackingServiceTests.java
+++ b/server/src/test/java/org/opensearch/tasks/TaskResourceTrackingServiceTests.java
@@ -17,6 +17,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.WriteableBase64;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -221,7 +222,7 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
 
     public void testGetTaskResourceUsageFromThreadContext() throws Exception {
         TaskResourceInfo expected = new TaskResourceInfo("testAction", 1L, 2L, "nodeId", new TaskResourceUsage(1000L, 2000L));
-        String binary = TaskResourceTrackingService.serializeToBase64(expected);
+        String binary = WriteableBase64.encode(expected);
         threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, binary);
 
         TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
@@ -235,20 +236,6 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
         assertEquals(threadPool.getThreadContext().getResponseHeaders().get(key).get(0), value);
     }
 
-    public void testSerializeToBase64RoundTrip() throws Exception {
-        TaskResourceInfo original = new TaskResourceInfo(
-            "indices:data/read/search[phase/query]",
-            12345L,
-            67890L,
-            "U0rMsZg9RGOxdnVfMtMNVA",
-            new TaskResourceUsage(15000000L, 2048000L)
-        );
-
-        String encoded = TaskResourceTrackingService.serializeToBase64(original);
-        TaskResourceInfo deserialized = TaskResourceTrackingService.deserializeFromBase64(encoded);
-        assertEquals(original, deserialized);
-    }
-
     public void testBinaryHeaderReadFromThreadContext() throws Exception {
         TaskResourceInfo original = new TaskResourceInfo(
             "indices:data/read/search[phase/query]",
@@ -258,7 +245,7 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
             new TaskResourceUsage(1000L, 2000L)
         );
 
-        String binaryHeader = TaskResourceTrackingService.serializeToBase64(original);
+        String binaryHeader = WriteableBase64.encode(original);
         threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, binaryHeader);
 
         TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
@@ -426,7 +413,7 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
             "data_node",
             new TaskResourceUsage(11L, 22L)
         );
-        String binary = TaskResourceTrackingService.serializeToBase64(expected);
+        String binary = WriteableBase64.encode(expected);
         threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, binary);
 
         TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
@@ -442,7 +429,7 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
             "node_x",
             new TaskResourceUsage(7777L, 8888L)
         );
-        String binary = TaskResourceTrackingService.serializeToBase64(expected);
+        String binary = WriteableBase64.encode(expected);
         threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, binary);
 
         TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();

--- a/server/src/test/java/org/opensearch/tasks/TaskResourceTrackingServiceTests.java
+++ b/server/src/test/java/org/opensearch/tasks/TaskResourceTrackingServiceTests.java
@@ -402,6 +402,38 @@ public class TaskResourceTrackingServiceTests extends OpenSearchTestCase {
         assertTrue("expected JSON when ClusterService is null, got: " + headerValue, headerValue.startsWith("{"));
     }
 
+    public void testProducerEmitsJsonHeaderWhenBinaryHeaderKillSwitchIsOff() {
+        // Operator-controlled kill switch: when disabled, the producer must emit JSON even
+        // when the coordinator is on the current version and would otherwise accept binary.
+        addCoordinatorNodeWithVersion(NEW_COORDINATOR_ID, Version.CURRENT);
+        taskResourceTrackingService.setBinaryResourceUsageHeaderEnabled(false);
+
+        SearchShardTask task = searchShardTaskWithParent(NEW_COORDINATOR_ID);
+        taskResourceTrackingService.writeTaskResourceUsage(task, LOCAL_NODE_ID);
+
+        String headerValue = threadPool.getThreadContext().getResponseHeaders().get(TASK_RESOURCE_USAGE).get(0);
+        assertTrue("expected JSON when kill switch is off, got: " + headerValue, headerValue.startsWith("{"));
+    }
+
+    public void testConsumerStillReadsBinaryWhenKillSwitchIsOff() throws Exception {
+        // The kill switch only gates the producer. The consumer must still decode binary so that
+        // a coordinator can read headers from data nodes that haven't yet picked up the flip.
+        taskResourceTrackingService.setBinaryResourceUsageHeaderEnabled(false);
+        TaskResourceInfo expected = new TaskResourceInfo(
+            "indices:data/read/search[phase/query]",
+            5L,
+            6L,
+            "data_node",
+            new TaskResourceUsage(11L, 22L)
+        );
+        String binary = TaskResourceTrackingService.serializeToBase64(expected);
+        threadPool.getThreadContext().addResponseHeader(TASK_RESOURCE_USAGE, binary);
+
+        TaskResourceInfo result = taskResourceTrackingService.getTaskResourceUsageFromThreadContext();
+        assertNotNull(result);
+        assertEquals(expected, result);
+    }
+
     public void testConsumerPrefersBinaryOverJsonFallback() throws Exception {
         TaskResourceInfo expected = new TaskResourceInfo(
             "indices:data/read/search[phase/query]",


### PR DESCRIPTION
### Description

Replaces JSON serialization/deserialization of `TaskResourceInfo` in the `TASK_RESOURCE_USAGE` response header with Base64-encoded binary using the existing `Writeable` interface. This reduces CPU overhead on the search path where the resource usage header is parsed for every shard.

### Problem

The `TASK_RESOURCE_USAGE` header carries per-shard resource usage data (CPU, memory) from data nodes to the coordinator. The current implementation serializes via `toXContent` (JSON) and deserializes via `XContentParser` (Jackson) on every shard response. Since a single search request can hit thousands of shards, this serde cost is multiplied accordingly. Profiling has shown ~7% CPU overhead from this serde.

### Solution

Serialize `TaskResourceInfo` using `writeTo`/`readFromStream` (binary), Base64-encode the result into a string. Base64 encoding is necessary because `ThreadContext` response headers only support string values. Even if `ThreadContext` supported raw `byte[]` headers, benchmarks show the additional speedup is marginal (see data below), making the Base64 approach a good tradeoff that avoids modifying the public `ThreadContext` class.

### Backwards compatibility

This change is fully BWC across a rolling upgrade.
- Data nodes serialize with binary only when the receiving coordinator is on `V_3_7_0` or later (resolved from the parent task ID via cluster state), otherwise serialize using the original JSON format.
- On the deserialization path, coordinators try binary first, then fall back to JSON so they can read headers from new and old data nodes. This try/catch fallback is acceptable because the majority of the time the domain will not be mid-upgrade.

**Rolling upgrade verification:** Verified end-to-end with a 3-node cluster running released `3.6.1`, upgrading one node at a time to this PR (`3.7.0`). Search workload driven against all three nodes at every phase: 852 searches total, 0 failures, no hangs, no stuck tasks, no parse errors on any node.

### Benchmark Results (JMH, per 1000 shards)

The end-to-end round-trip (serialize on data node + deserialize on coordinator) is **5.9x faster with Binary+Base64 compared to JSON**. Raw binary column is included to show the theoretical outcome if `ThreadContext` supported `byte[]` headers natively.

| Operation | JSON | Binary+Base64 | Raw Binary | JSON→Base64 | JSON→Raw |
|---|---|---|---|---|---|
| Serialize | 227 μs | 95 μs | 81 μs | 2.4x | 2.8x |
| Deserialize | 785 μs | 220 μs | 139 μs | 3.6x | 5.6x |
| Round-trip | 1,647 μs | 279 μs | 252 μs | 5.9x | 6.5x |

Each test result ran:
- 3 warmup iterations
- 3 measurement iterations

One iteration means JMH ran the target operation continuously for 10 seconds, then divided the total time by the number of completed operations to get a time per operation. Each operation performs 1000 TaskResourceInfo serde cycles — one per shard — to simulate a large search request hitting 1000 shards. The final values in the table are the average ns/op across all 3 measurement iterations.

### Header Size Reduction

Based on a typical `TaskResourceInfo`:

```json
{
  "action": "indices:data/read/search[phase/query]",
  "taskId": 1234567,
  "parentTaskId": 1234566,
  "nodeId": "U0rMsZg9RGOxdnVfMtMNVA",
  "taskResourceUsage": {
    "cpuTimeInNanos": 15000000,
    "memoryInBytes": 2048000
  }
}
```

Format | Size
-- | --
JSON | ~196 bytes
Binary+Base64 | ~136 bytes

**Binary+Base64 reduces bytes sent over the wire by ~31% compared to JSON.**

### Related Issues
Resolves #17407

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
