### PR TITLE
Deprecate boolean constructor of FetchSourceContext

### DIFF
--- a/client/rest-high-level/src/test/java/org/opensearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/CrudIT.java
@@ -509,7 +509,7 @@ public class CrudIT extends OpenSearchRestHighLevelClientTestCase {
         }
         {
             GetSourceRequest getRequest = new GetSourceRequest("index", "id");
-            getRequest.fetchSourceContext(new FetchSourceContext(false));
+            getRequest.fetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE);
             OpenSearchException exception = expectThrows(
                 OpenSearchException.class,
                 () -> execute(getRequest, highLevelClient()::getSource, highLevelClient()::getSourceAsync)

--- a/client/rest-high-level/src/test/java/org/opensearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/CrudIT.java
@@ -351,7 +351,7 @@ public class CrudIT extends OpenSearchRestHighLevelClientTestCase {
         }
         {
             GetRequest getRequest = new GetRequest("index", "id");
-            getRequest.fetchSourceContext(new FetchSourceContext(false, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY));
+            getRequest.fetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE);
             GetResponse getResponse = execute(getRequest, highLevelClient()::get, highLevelClient()::getAsync);
             assertEquals("index", getResponse.getIndex());
             assertEquals("id", getResponse.getId());
@@ -484,7 +484,7 @@ public class CrudIT extends OpenSearchRestHighLevelClientTestCase {
         }
         {
             GetSourceRequest getRequest = new GetSourceRequest("index", "id");
-            getRequest.fetchSourceContext(new FetchSourceContext(true, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY));
+            getRequest.fetchSourceContext(FetchSourceContext.FETCH_SOURCE);
             GetSourceResponse response = execute(getRequest, highLevelClient()::getSource, highLevelClient()::getSourceAsync);
             Map<String, Object> expectedResponse = new HashMap<>();
             expectedResponse.put("field1", "value1");

--- a/client/rest-high-level/src/test/java/org/opensearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/RequestConvertersTests.java
@@ -1972,7 +1972,10 @@ public class RequestConvertersTests extends OpenSearchTestCase {
         if (randomBoolean()) {
             if (randomBoolean()) {
                 boolean fetchSource = randomBoolean();
-                consumer.accept(new FetchSourceContext(fetchSource));
+                FetchSourceContext fetchSourceContext = fetchSource
+                    ? FetchSourceContext.FETCH_SOURCE
+                    : FetchSourceContext.DO_NOT_FETCH_SOURCE;
+                consumer.accept(fetchSourceContext);
                 if (fetchSource == false) {
                     expectedParams.put("_source", "false");
                 }

--- a/client/rest-high-level/src/test/java/org/opensearch/client/documentation/CRUDDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/opensearch/client/documentation/CRUDDocumentationIT.java
@@ -1512,7 +1512,7 @@ public class CRUDDocumentationIT extends OpenSearchRestHighLevelClientTestCase {
         GetRequest getRequest = new GetRequest(
             "posts", // <1>
             "1");    // <2>
-        getRequest.fetchSourceContext(new FetchSourceContext(false)); // <3>
+        getRequest.fetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE); // <3>
         getRequest.storedFields("_none_");                            // <4>
         // end::exists-request
         {

--- a/server/src/internalClusterTest/java/org/opensearch/mget/SimpleMgetIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/mget/SimpleMgetIT.java
@@ -189,7 +189,7 @@ public class SimpleMgetIT extends ParameterizedStaticSettingsOpenSearchIntegTest
                 );
             } else {
                 request.add(
-                    new MultiGetRequest.Item(indexOrAlias(), Integer.toString(i)).fetchSourceContext(new FetchSourceContext(false))
+                    new MultiGetRequest.Item(indexOrAlias(), Integer.toString(i)).fetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE)
                 );
             }
         }

--- a/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/InnerHitsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/fetch/subphase/InnerHitsIT.java
@@ -541,7 +541,7 @@ public class InnerHitsIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
                         new InnerHitBuilder("remark")
                     ),
                     ScoreMode.Avg
-                ).innerHit(new InnerHitBuilder().setFetchSourceContext(new FetchSourceContext(false)))
+                ).innerHit(new InnerHitBuilder().setFetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE))
             )
             .get();
         assertNoFailures(response);
@@ -660,7 +660,7 @@ public class InnerHitsIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
             () -> client().prepareSearch("articles")
                 .setQuery(
                     nestedQuery("comments.messages", matchQuery("comments.messages.message", "fox"), ScoreMode.Avg).innerHit(
-                        new InnerHitBuilder().setFetchSourceContext(new FetchSourceContext(true))
+                        new InnerHitBuilder().setFetchSourceContext(FetchSourceContext.FETCH_SOURCE)
                     )
                 )
                 .get()
@@ -674,7 +674,7 @@ public class InnerHitsIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
         SearchResponse response = client().prepareSearch("articles")
             .setQuery(
                 nestedQuery("comments.messages", matchQuery("comments.messages.message", "fox"), ScoreMode.Avg).innerHit(
-                    new InnerHitBuilder().setFetchSourceContext(new FetchSourceContext(false))
+                    new InnerHitBuilder().setFetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE)
                 )
             )
             .get();
@@ -696,7 +696,7 @@ public class InnerHitsIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
         response = client().prepareSearch("articles")
             .setQuery(
                 nestedQuery("comments.messages", matchQuery("comments.messages.message", "bear"), ScoreMode.Avg).innerHit(
-                    new InnerHitBuilder().setFetchSourceContext(new FetchSourceContext(false))
+                    new InnerHitBuilder().setFetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE)
                 )
             )
             .get();
@@ -731,7 +731,7 @@ public class InnerHitsIT extends ParameterizedStaticSettingsOpenSearchIntegTestC
         response = client().prepareSearch("articles")
             .setQuery(
                 nestedQuery("comments.messages", matchQuery("comments.messages.message", "fox"), ScoreMode.Avg).innerHit(
-                    new InnerHitBuilder().setFetchSourceContext(new FetchSourceContext(false))
+                    new InnerHitBuilder().setFetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE)
                 )
             )
             .get();

--- a/server/src/internalClusterTest/java/org/opensearch/search/source/MetadataFetchingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/source/MetadataFetchingIT.java
@@ -100,7 +100,7 @@ public class MetadataFetchingIT extends ParameterizedStaticSettingsOpenSearchInt
             .setQuery(
                 new NestedQueryBuilder("nested", new TermQueryBuilder("nested.title", "foo"), ScoreMode.Total).innerHit(
                     new InnerHitBuilder().setStoredFieldNames(Collections.singletonList("_none_"))
-                        .setFetchSourceContext(new FetchSourceContext(false))
+                        .setFetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE)
                 )
             )
             .get();

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -295,7 +295,7 @@ public class FetchPhase {
         if (storedFieldsContext == null) {
             // no fields specified, default to return source if no explicit indication
             if (!context.hasScriptFields() && !context.hasFetchSourceContext()) {
-                context.fetchSourceContext(new FetchSourceContext(true));
+                context.fetchSourceContext(FetchSourceContext.FETCH_SOURCE);
             }
             boolean loadSource = sourceRequired(context);
             return new FieldsVisitor(

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java
@@ -85,6 +85,10 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         validateAmbiguousFields();
     }
 
+    /**
+     * @deprecated use {@link #FETCH_SOURCE} or {@link #DO_NOT_FETCH_SOURCE} instead
+     */
+    @Deprecated
     public FetchSourceContext(boolean fetchSource) {
         this(fetchSource, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
     }

--- a/server/src/test/java/org/opensearch/action/get/MultiGetRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/get/MultiGetRequestTests.java
@@ -169,7 +169,7 @@ public class MultiGetRequestTests extends OpenSearchTestCase {
                         generateRandomStringArray(5, 4, false)
                     );
                 } else {
-                    fetchSourceContext = new FetchSourceContext(false);
+                    fetchSourceContext = FetchSourceContext.DO_NOT_FETCH_SOURCE;
                 }
                 item.fetchSourceContext(fetchSourceContext);
             }

--- a/server/src/test/java/org/opensearch/action/get/MultiGetShardRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/get/MultiGetShardRequestTests.java
@@ -72,7 +72,10 @@ public class MultiGetShardRequestTests extends OpenSearchTestCase {
                 item.versionType(randomFrom(VersionType.values()));
             }
             if (randomBoolean()) {
-                item.fetchSourceContext(new FetchSourceContext(randomBoolean()));
+                FetchSourceContext fetchSourceContext = randomBoolean()
+                    ? FetchSourceContext.FETCH_SOURCE
+                    : FetchSourceContext.DO_NOT_FETCH_SOURCE;
+                item.fetchSourceContext(fetchSourceContext);
             }
             multiGetShardRequest.add(0, item);
         }

--- a/server/src/test/java/org/opensearch/index/query/InnerHitBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/InnerHitBuilderTests.java
@@ -189,7 +189,7 @@ public class InnerHitBuilderTests extends OpenSearchTestCase {
                 generateRandomStringArray(12, 16, false)
             );
         } else {
-            randomFetchSourceContext = new FetchSourceContext(randomBoolean());
+            randomFetchSourceContext = randomBoolean() ? FetchSourceContext.FETCH_SOURCE : FetchSourceContext.DO_NOT_FETCH_SOURCE;
         }
         innerHits.setFetchSourceContext(randomFetchSourceContext);
         if (randomBoolean()) {
@@ -248,7 +248,7 @@ public class InnerHitBuilderTests extends OpenSearchTestCase {
         modifiers.add(() -> copy.setFetchSourceContext(randomValueOtherThan(copy.getFetchSourceContext(), () -> {
             FetchSourceContext randomFetchSourceContext;
             if (randomBoolean()) {
-                randomFetchSourceContext = new FetchSourceContext(randomBoolean());
+                randomFetchSourceContext = randomBoolean() ? FetchSourceContext.FETCH_SOURCE : FetchSourceContext.DO_NOT_FETCH_SOURCE;
             } else {
                 randomFetchSourceContext = new FetchSourceContext(
                     true,

--- a/server/src/test/java/org/opensearch/index/query/InnerHitBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/InnerHitBuilderTests.java
@@ -181,7 +181,7 @@ public class InnerHitBuilderTests extends OpenSearchTestCase {
         FetchSourceContext randomFetchSourceContext;
         int randomInt = randomIntBetween(0, 2);
         if (randomInt == 0) {
-            randomFetchSourceContext = new FetchSourceContext(true, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
+            randomFetchSourceContext = FetchSourceContext.FETCH_SOURCE;
         } else if (randomInt == 1) {
             randomFetchSourceContext = new FetchSourceContext(
                 true,

--- a/server/src/test/java/org/opensearch/index/query/InnerHitBuilderTests.java
+++ b/server/src/test/java/org/opensearch/index/query/InnerHitBuilderTests.java
@@ -34,7 +34,6 @@ package org.opensearch.index.query;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;

--- a/server/src/test/java/org/opensearch/search/aggregations/metrics/TopHitsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/metrics/TopHitsTests.java
@@ -128,7 +128,7 @@ public class TopHitsTests extends BaseAggregationTestCase<TopHitsAggregationBuil
             }
             switch (branch) {
                 case 0:
-                    fetchSourceContext = new FetchSourceContext(randomBoolean());
+                    fetchSourceContext = randomBoolean() ? FetchSourceContext.FETCH_SOURCE : FetchSourceContext.DO_NOT_FETCH_SOURCE;
                     break;
                 case 1:
                     fetchSourceContext = new FetchSourceContext(true, includes, excludes);

--- a/server/src/test/java/org/opensearch/search/fetch/FetchPhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/FetchPhaseTests.java
@@ -141,7 +141,7 @@ public class FetchPhaseTests extends OpenSearchTestCase {
         when(context.hasFetchSourceContext()).thenReturn(false);
         when(context.storedFieldsContext()).thenReturn(null);
         when(context.fetchSourceContext(any(FetchSourceContext.class))).thenReturn(null);
-        when(context.fetchSourceContext()).thenReturn(new FetchSourceContext(true));
+        when(context.fetchSourceContext()).thenReturn(FetchSourceContext.FETCH_SOURCE);
 
         QueryShardContext queryShardContext = mock(QueryShardContext.class);
         SearchLookup lookup = new SearchLookup(mock(MapperService.class), (ft, sl) -> null);

--- a/server/src/test/java/org/opensearch/search/fetch/FetchProfilePhaseTests.java
+++ b/server/src/test/java/org/opensearch/search/fetch/FetchProfilePhaseTests.java
@@ -281,7 +281,7 @@ public class FetchProfilePhaseTests extends IndexShardTestCase {
             when(context.hasFetchSourceContext()).thenReturn(enableSourceLoading);
             when(context.sourceRequested()).thenReturn(enableSourceLoading);
             if (enableSourceLoading) {
-                when(context.fetchSourceContext()).thenReturn(new FetchSourceContext(true));
+                when(context.fetchSourceContext()).thenReturn(FetchSourceContext.FETCH_SOURCE);
             }
 
             // Stored fields configuration

--- a/test/framework/src/main/java/org/opensearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/opensearch/search/RandomSearchRequestGenerator.java
@@ -231,7 +231,7 @@ public class RandomSearchRequestGenerator {
             }
             switch (branch) {
                 case 0:
-                    fetchSourceContext = new FetchSourceContext(randomBoolean());
+                    fetchSourceContext = randomBoolean() ? FetchSourceContext.FETCH_SOURCE : FetchSourceContext.DO_NOT_FETCH_SOURCE;
                     break;
                 case 1:
                     fetchSourceContext = new FetchSourceContext(true, includes, excludes);


### PR DESCRIPTION
### Description
Deprecate the boolean constructor of `FetchSourceContext` in favour of `FetchSourceContext.FETCH_SOURCE` and `FetchSourceContext.DO_NOT_FETCH_SOURCE`

### Related Issues
Resolves #20743
Relates to #20612

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
