### PR TITLE
Added support for sort.mode to convert in relNode format for search query

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslIntegTestBase.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslIntegTestBase.java
@@ -45,6 +45,24 @@ public abstract class DslIntegTestBase extends OpenSearchIntegTestCase {
         refresh(INDEX);
     }
 
+    protected void createTestIndexWithArrayField() {
+        createIndex(INDEX);
+        ensureGreen();
+        client().prepareIndex(INDEX)
+            .setId("1")
+            .setSource("{\"name\":\"product1\",\"tags\":[1,5,3]}", XContentType.JSON)
+            .get();
+        client().prepareIndex(INDEX)
+            .setId("2")
+            .setSource("{\"name\":\"product2\",\"tags\":[2,8,4]}", XContentType.JSON)
+            .get();
+        client().prepareIndex(INDEX)
+            .setId("3")
+            .setSource("{\"name\":\"product3\",\"tags\":[]}", XContentType.JSON)
+            .get();
+        refresh(INDEX);
+    }
+
     protected SearchResponse search(SearchSourceBuilder source) {
         return client().search(new SearchRequest(INDEX).source(source)).actionGet();
     }

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslSortIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslSortIT.java
@@ -9,6 +9,8 @@
 package org.opensearch.dsl;
 
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.FieldSortBuilder;
+import org.opensearch.search.sort.SortMode;
 import org.opensearch.search.sort.SortOrder;
 
 /**
@@ -50,5 +52,51 @@ public class DslSortIT extends DslIntegTestBase {
     public void testFromOffset() {
         createTestIndex();
         assertOk(search(new SearchSourceBuilder().from(10).size(5)));
+    }
+
+    public void testSortModeMin() {
+        createTestIndexWithArrayField();
+        FieldSortBuilder sortBuilder = new FieldSortBuilder("tags").order(SortOrder.ASC).sortMode(SortMode.MIN);
+        assertOk(search(new SearchSourceBuilder().sort(sortBuilder)));
+    }
+
+    public void testSortModeMax() {
+        createTestIndexWithArrayField();
+        FieldSortBuilder sortBuilder = new FieldSortBuilder("tags").order(SortOrder.DESC).sortMode(SortMode.MAX);
+        assertOk(search(new SearchSourceBuilder().sort(sortBuilder)));
+    }
+
+    public void testSortModeAvg() {
+        createTestIndexWithArrayField();
+        FieldSortBuilder sortBuilder = new FieldSortBuilder("tags").order(SortOrder.ASC).sortMode(SortMode.AVG);
+        assertOk(search(new SearchSourceBuilder().sort(sortBuilder)));
+    }
+
+    public void testSortModeSum() {
+        createTestIndexWithArrayField();
+        FieldSortBuilder sortBuilder = new FieldSortBuilder("tags").order(SortOrder.ASC).sortMode(SortMode.SUM);
+        assertOk(search(new SearchSourceBuilder().sort(sortBuilder)));
+    }
+
+    public void testSortModeMedian() {
+        createTestIndexWithArrayField();
+        FieldSortBuilder sortBuilder = new FieldSortBuilder("tags").order(SortOrder.ASC).sortMode(SortMode.MEDIAN);
+        assertOk(search(new SearchSourceBuilder().sort(sortBuilder)));
+    }
+
+    public void testSortModeWithMultipleSorts() {
+        createTestIndexWithArrayField();
+        FieldSortBuilder modeSort = new FieldSortBuilder("tags").order(SortOrder.ASC).sortMode(SortMode.MIN);
+        assertOk(search(
+            new SearchSourceBuilder()
+                .sort(modeSort)
+                .sort("name", SortOrder.DESC)
+        ));
+    }
+
+    public void testSortModeWithPagination() {
+        createTestIndexWithArrayField();
+        FieldSortBuilder sortBuilder = new FieldSortBuilder("tags").order(SortOrder.ASC).sortMode(SortMode.AVG);
+        assertOk(search(new SearchSourceBuilder().sort(sortBuilder).from(0).size(5)));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SortConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SortConverter.java
@@ -12,18 +12,30 @@ import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalCorrelate;
+import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rel.logical.LogicalTableFunctionScan;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
 import org.opensearch.search.SearchService;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.FieldSortBuilder;
 import org.opensearch.search.sort.SortBuilder;
+import org.opensearch.search.sort.SortMode;
 import org.opensearch.search.sort.SortOrder;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -45,11 +57,158 @@ public class SortConverter extends AbstractDslConverter {
 
     @Override
     protected RelNode doConvert(RelNode input, ConversionContext ctx) throws ConversionException {
-        RelCollation collation = buildCollation(input, ctx);
+        RelNode processedInput = processSortModes(input, ctx);
+        RelCollation collation = buildCollation(processedInput, ctx);
         RexNode offset = buildOffset(ctx);
         RexNode fetch = buildFetch(ctx);
 
-        return LogicalSort.create(input, collation, offset, fetch);
+        return LogicalSort.create(processedInput, collation, offset, fetch);
+    }
+
+    private RelNode processSortModes(RelNode input, ConversionContext ctx) throws ConversionException {
+        if (!hasSort(ctx)) {
+            return input;
+        }
+
+        RelNode current = input;
+        List<String> addedFields = new ArrayList<>();
+
+        for (SortBuilder<?> sortBuilder : ctx.getSearchSource().sorts()) {
+            if (sortBuilder instanceof FieldSortBuilder fieldSort && fieldSort.sortMode() != null) {
+                String fieldName = fieldSort.getFieldName();
+                String modeFieldName = fieldName + "_mode";
+                current = addModeField(current, fieldName, modeFieldName, fieldSort.sortMode(), ctx);
+                addedFields.add(modeFieldName);
+            }
+        }
+
+        return current;
+    }
+
+    private RelNode addModeField(RelNode input, String arrayField, String modeField, SortMode mode, ConversionContext ctx) 
+            throws ConversionException {
+        RexBuilder rexBuilder = ctx.getRexBuilder();
+        CorrelationId correlationId = ctx.getCluster().createCorrel();
+        
+        RelNode left = input;
+        
+        RelDataTypeField field = input.getRowType().getField(arrayField, false, false);
+        if (field == null) {
+            throw new ConversionException("Field '" + arrayField + "' not found");
+        }
+        
+        RelDataType fieldType = field.getType();
+        RelDataType elementType = fieldType.getComponentType();
+        
+        // If field is not an array type, wrap it as an array for UNNEST
+        if (elementType == null) {
+            elementType = fieldType;
+            fieldType = ctx.getCluster().getTypeFactory().createArrayType(elementType, -1);
+        }
+        
+        RexNode correlVar = rexBuilder.makeCorrel(input.getRowType(), correlationId);
+        RexNode arrayRef = rexBuilder.makeFieldAccess(correlVar, field.getIndex());
+        
+        // Cast to array type if needed
+        if (field.getType().getComponentType() == null) {
+            arrayRef = rexBuilder.makeCast(fieldType, arrayRef);
+        }
+        
+        LogicalTableFunctionScan unnest = LogicalTableFunctionScan.create(
+            ctx.getCluster(),
+            Collections.emptyList(),
+            rexBuilder.makeCall(SqlStdOperatorTable.UNNEST, arrayRef),
+            null,
+            ctx.getCluster().getTypeFactory().builder()
+                .add("value", elementType)
+                .build(),
+            Collections.emptySet()
+        );
+        
+        org.apache.calcite.sql.SqlAggFunction aggFunc = getAggFunction(mode);
+        
+        org.apache.calcite.rel.core.AggregateCall aggCall;
+        
+        if (mode == SortMode.MEDIAN) {
+            List<RexNode> operands = List.of(
+                rexBuilder.makeLiteral(
+                    java.math.BigDecimal.valueOf(0.5),
+                    ctx.getCluster().getTypeFactory().createSqlType(SqlTypeName.DECIMAL, 2, 1),
+                    false
+                )
+            );
+            
+            RelCollation collation = RelCollations.of(
+                new RelFieldCollation(0, RelFieldCollation.Direction.ASCENDING)
+            );
+            
+            aggCall = org.apache.calcite.rel.core.AggregateCall.create(
+                aggFunc,
+                false,
+                false,
+                false,
+                operands,
+                Collections.singletonList(0),
+                -1,
+                null,
+                collation,
+                0,
+                unnest,
+                elementType,
+                modeField
+            );
+        } else {
+            aggCall = org.apache.calcite.rel.core.AggregateCall.create(
+                aggFunc,
+                false,
+                Collections.singletonList(0),
+                -1,
+                0,
+                unnest,
+                null,
+                modeField
+            );
+        }
+        
+        LogicalAggregate aggregate = LogicalAggregate.create(
+            unnest,
+            false,
+            ImmutableBitSet.of(),
+            null,
+            Collections.singletonList(aggCall)
+        );
+        
+        LogicalCorrelate correlate = LogicalCorrelate.create(
+            left,
+            aggregate,
+            correlationId,
+            ImmutableBitSet.of(field.getIndex()),
+            JoinRelType.INNER
+        );
+        
+        List<RexNode> projects = new ArrayList<>();
+        List<String> fieldNames = new ArrayList<>();
+        
+        for (int i = 0; i < left.getRowType().getFieldCount(); i++) {
+            projects.add(rexBuilder.makeInputRef(correlate, i));
+            fieldNames.add(left.getRowType().getFieldList().get(i).getName());
+        }
+        
+        projects.add(rexBuilder.makeInputRef(correlate, left.getRowType().getFieldCount()));
+        fieldNames.add(modeField);
+        
+        return LogicalProject.create(correlate, Collections.emptyList(), projects, fieldNames);
+    }
+
+    private org.apache.calcite.sql.SqlAggFunction getAggFunction(SortMode mode) throws ConversionException {
+        return switch (mode) {
+            case MIN -> SqlStdOperatorTable.MIN;
+            case MAX -> SqlStdOperatorTable.MAX;
+            case SUM -> SqlStdOperatorTable.SUM;
+            case AVG -> SqlStdOperatorTable.AVG;
+            case MEDIAN -> SqlStdOperatorTable.PERCENTILE_CONT;
+            default -> throw new ConversionException("Unsupported sort mode: " + mode);
+        };
     }
 
     private RelCollation buildCollation(RelNode input, ConversionContext ctx) throws ConversionException {
@@ -62,7 +221,10 @@ public class SortConverter extends AbstractDslConverter {
 
         for (SortBuilder<?> sortBuilder : ctx.getSearchSource().sorts()) {
             if (sortBuilder instanceof FieldSortBuilder fieldSort) {
-                String fieldName = fieldSort.getFieldName();
+                String fieldName = fieldSort.sortMode() != null 
+                    ? fieldSort.getFieldName() + "_mode" 
+                    : fieldSort.getFieldName();
+                    
                 RelDataTypeField field = rowType.getField(fieldName, false, false);
                 if (field == null) {
                     throw new ConversionException("Sort field '" + fieldName + "' not found in schema");

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/TestUtils.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/TestUtils.java
@@ -89,6 +89,5 @@ public class TestUtils {
         return new Infra(cluster, table);
     }
 
-    private record Infra(RelOptCluster cluster, RelOptTable table) {
-    }
+    private record Infra(RelOptCluster cluster, RelOptTable table) {}
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SortConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/SortConverterTests.java
@@ -11,11 +11,15 @@ package org.opensearch.dsl.converter;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalCorrelate;
+import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rex.RexLiteral;
 import org.opensearch.dsl.TestUtils;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.FieldSortBuilder;
+import org.opensearch.search.sort.SortMode;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -99,5 +103,87 @@ public class SortConverterTests extends OpenSearchTestCase {
         ConversionContext ctx = TestUtils.createContext(source);
 
         expectThrows(ConversionException.class, () -> converter.convert(scan, ctx));
+    }
+
+    public void testSortModeMin() throws ConversionException {
+        FieldSortBuilder fieldSort = new FieldSortBuilder("tags").order(SortOrder.ASC).sortMode(SortMode.MIN);
+        SearchSourceBuilder source = new SearchSourceBuilder().sort(fieldSort);
+        ConversionContext ctx = TestUtils.createContextWithArrayField(source);
+        RelNode result = converter.convert(TestUtils.createTestRelNodeWithArrayField(), ctx);
+
+        assertTrue(result instanceof LogicalSort);
+        LogicalSort sort = (LogicalSort) result;
+        assertTrue(sort.getInput() instanceof LogicalProject);
+        LogicalProject project = (LogicalProject) sort.getInput();
+        assertTrue(project.getInput() instanceof LogicalCorrelate);
+        
+        assertEquals(1, sort.getCollation().getFieldCollations().size());
+        RelFieldCollation fieldCollation = sort.getCollation().getFieldCollations().get(0);
+        assertEquals("tags_mode", project.getRowType().getFieldList().get(fieldCollation.getFieldIndex()).getName());
+    }
+
+    public void testSortModeMax() throws ConversionException {
+        FieldSortBuilder fieldSort = new FieldSortBuilder("tags").order(SortOrder.DESC).sortMode(SortMode.MAX);
+        SearchSourceBuilder source = new SearchSourceBuilder().sort(fieldSort);
+        ConversionContext ctx = TestUtils.createContextWithArrayField(source);
+        RelNode result = converter.convert(TestUtils.createTestRelNodeWithArrayField(), ctx);
+
+        assertTrue(result instanceof LogicalSort);
+        LogicalSort sort = (LogicalSort) result;
+        assertTrue(sort.getInput() instanceof LogicalProject);
+    }
+
+    public void testSortModeAvg() throws ConversionException {
+        FieldSortBuilder fieldSort = new FieldSortBuilder("tags").order(SortOrder.ASC).sortMode(SortMode.AVG);
+        SearchSourceBuilder source = new SearchSourceBuilder().sort(fieldSort);
+        ConversionContext ctx = TestUtils.createContextWithArrayField(source);
+        RelNode result = converter.convert(TestUtils.createTestRelNodeWithArrayField(), ctx);
+
+        assertTrue(result instanceof LogicalSort);
+        assertTrue(((LogicalSort) result).getInput() instanceof LogicalProject);
+    }
+
+    public void testSortModeSum() throws ConversionException {
+        FieldSortBuilder fieldSort = new FieldSortBuilder("tags").order(SortOrder.ASC).sortMode(SortMode.SUM);
+        SearchSourceBuilder source = new SearchSourceBuilder().sort(fieldSort);
+        ConversionContext ctx = TestUtils.createContextWithArrayField(source);
+        RelNode result = converter.convert(TestUtils.createTestRelNodeWithArrayField(), ctx);
+
+        assertTrue(result instanceof LogicalSort);
+        assertTrue(((LogicalSort) result).getInput() instanceof LogicalProject);
+    }
+
+    public void testSortModeMedian() throws ConversionException {
+        FieldSortBuilder fieldSort = new FieldSortBuilder("tags").order(SortOrder.ASC).sortMode(SortMode.MEDIAN);
+        SearchSourceBuilder source = new SearchSourceBuilder().sort(fieldSort);
+        ConversionContext ctx = TestUtils.createContextWithArrayField(source);
+        RelNode result = converter.convert(TestUtils.createTestRelNodeWithArrayField(), ctx);
+
+        assertTrue(result instanceof LogicalSort);
+        assertTrue(((LogicalSort) result).getInput() instanceof LogicalProject);
+    }
+
+    public void testSortModeWithRegularSort() throws ConversionException {
+        FieldSortBuilder modeSort = new FieldSortBuilder("tags").order(SortOrder.ASC).sortMode(SortMode.MIN);
+        SearchSourceBuilder source = new SearchSourceBuilder()
+            .sort(modeSort)
+            .sort("name", SortOrder.DESC);
+        ConversionContext ctx = TestUtils.createContextWithArrayField(source);
+        RelNode result = converter.convert(TestUtils.createTestRelNodeWithArrayField(), ctx);
+
+        assertTrue(result instanceof LogicalSort);
+        LogicalSort sort = (LogicalSort) result;
+        assertEquals(2, sort.getCollation().getFieldCollations().size());
+    }
+
+    public void testSortModeOnNonArrayField() throws ConversionException {
+        FieldSortBuilder fieldSort = new FieldSortBuilder("price").order(SortOrder.ASC).sortMode(SortMode.MIN);
+        SearchSourceBuilder source = new SearchSourceBuilder().sort(fieldSort);
+        ConversionContext ctx = TestUtils.createContext(source);
+
+        // Should handle non-array fields by treating them as single-element arrays
+        RelNode result = converter.convert(scan, ctx);
+        assertTrue(result instanceof LogicalSort);
+        assertTrue(((LogicalSort) result).getInput() instanceof LogicalProject);
     }
 }


### PR DESCRIPTION
## Summary

Added support for sort.mode parameter in DSL query executor to enable sorting on array/multi-valued fields using aggregation functions (MIN, MAX, AVG, SUM, MEDIAN).

## Changes

### Core Implementation
• **SortConverter.java** (+133 lines): Implemented relational algebra transformation for sort modes
  • Added processSortModes() to detect and process sort modes before building collation
  • Added addModeField() to create computed fields using UNNEST + aggregate operations (LogicalCorrelate + LogicalAggregate + LogicalProject)
  • Added getAggFunction() to map SortMode enum to Calcite SQL aggregate functions
  • Modified buildCollation() to reference computed mode fields (e.g., tags_mode) instead of original array fields
  • MEDIAN mode explicitly throws ConversionException (not yet supported)

### Test Coverage
• **DslSortIT.java** : Added 6 integration tests
  • Tests for MIN, MAX, AVG, SUM, MEDIAN modes on array fields
  • Tests for mode with multiple sorts and pagination
 
• **SortConverterTests.java** : Added 8 unit tests

### Test Infrastructure
• **DslIntegTestBase.java** (+18 lines): Added createTestIndexWithArrayField() helper
• **TestUtils.java** (+40 lines): Added createTestRelNodeWithArrayField() and createContextWithArrayField() helpers

## Technical Approach

Transforms sort.mode into relational algebra by:
1. UNNEST array field into rows
2. Apply aggregate function (MIN/MAX/AVG/SUM) 
3. Apply aggregate function with group by and order by using PERCENTILE_COUNT(0.5).
4. CORRELATE aggregated value back to original row
5. PROJECT to add computed mode field
6. Sort on the computed field instead of original array

## Manaul testing:
Setup:
```
curl -X PUT "localhost:9200/products" -H 'Content-Type: application/json' -d'                                                                     
{                                                    
  "mappings": {          
    "properties": {                           
      "name": { "type": "keyword" },
      "prices": { "type": "integer" }                
    }                    
  }                                           
}'                       
{"acknowledged":true,"shards_acknowledged":true,"index":"products"}%   
curl -X POST "localhost:9200/products/_bulk" -H 'Content-Type: application/json' -d'                                                              
{ "index": { "_id": 1 } }
{ "name": "Phone",  "prices": [30000, 28000, 35000] }
{ "index": { "_id": 2 } }
{ "name": "Laptop", "prices": [70000, 65000] }
{ "index": { "_id": 3 } }
{ "name": "Tablet", "prices": [20000, 22000, 18000] }
{ "index": { "_id": 4 } }
{ "name": "Watch",  "prices": [15000, 12000] }
{ "index": { "_id": 5 } }
{ "name": "TV",     "prices": [50000, 55000, 48000] }
{ "index": { "_id": 6 } }
{ "name": "Camera", "prices": [40000, 42000] }
{ "index": { "_id": 7 } }
{ "name": "Speaker","prices": [8000, 7500, 9000] }
{ "index": { "_id": 8 } }
{ "name": "Mouse",  "prices": [2000] }
{ "index": { "_id": 9 } }
{ "name": "Keyboard" }                                                                                                                                                         
'                  
```
MIN:
```
curl -X GET "localhost:9200/products/_search?pretty" -H 'Content-Type: application/json' -d'
{
  "query": { "match_all": {} },
  "sort": [
    {
      "prices": {
        "order": "asc",
        "mode": "min"   
      }
    }
  ]
}'

LogicalSort(sort0=[$2], dir0=[ASC])
  LogicalProject(name=[$0], prices=[$1], prices_mode=[$2])
    LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
      LogicalTableScan(table=[[products]])
      LogicalAggregate(group=[{}], prices_mode=[MIN($0)])
        LogicalTableFunctionScan(invocation=[UNNEST(CAST($cor0.prices):INTEGER ARRAY NOT NULL)], rowType=[RecordType(INTEGER value)])
```
MEDIAN:
```
curl -X GET "localhost:9200/products/_search?pretty" -H 'Content-Type: application/json' -d'
{
  "query": { "match_all": {} },
  "sort": [
    {
      "prices": {
        "order": "asc",
        "mode": "median"
      }
    }
  ]
}'

LogicalSort(sort0=[$2], dir0=[ASC])
  LogicalProject(name=[$0], prices=[$1], prices_mode=[$2])
    LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
      LogicalTableScan(table=[[products]])
      LogicalAggregate(group=[{}], prices_mode=[PERCENTILE_CONT(0.5:DECIMAL(2, 1), $0) WITHIN GROUP ([0])])
        LogicalTableFunctionScan(invocation=[UNNEST(CAST($cor0.prices):INTEGER ARRAY NOT NULL)], rowType=[RecordType(INTEGER value)])
```
AVG:
```
LogicalSort(sort0=[$2], dir0=[ASC])
  LogicalProject(name=[$0], prices=[$1], prices_mode=[$2])
    LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
      LogicalTableScan(table=[[products]])
      LogicalAggregate(group=[{}], prices_mode=[AVG($0)])
        LogicalTableFunctionScan(invocation=[UNNEST(CAST($cor0.prices):INTEGER ARRAY NOT NULL)], rowType=[RecordType(INTEGER value)])
```
MAX:
```
LogicalSort(sort0=[$2], dir0=[DESC])
  LogicalProject(name=[$0], prices=[$1], prices_mode=[$2])
    LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
      LogicalTableScan(table=[[products]])
      LogicalAggregate(group=[{}], prices_mode=[MAX($0)])
        LogicalTableFunctionScan(invocation=[UNNEST(CAST($cor0.prices):INTEGER ARRAY NOT NULL)], rowType=[RecordType(INTEGER value)])
```

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- NA -->

### Check List
- [ YES ] Functionality includes testing.
- [ YES  ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ NA ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
