### PR TITLE
Added support for Terms query to convert in RelNode format

### DIFF
--- a/sandbox/plugins/dsl-query-executor/README.md
+++ b/sandbox/plugins/dsl-query-executor/README.md
@@ -2,6 +2,12 @@
 
 A front-end sandbox plugin to the analytics engine that intercepts `_search` requests, converts DSL queries into Calcite RelNode logical plans, and executes them through the analytics engine's query pipeline.
 
+## Supported Query Types
+
+- **Term** — equality filter
+- **Terms** — multi-value equality filter (uses query Filter with SEARCH and EQUALS)
+- **Match All** — matches all documents
+
 ## Architecture
 
 ```

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
@@ -35,6 +35,33 @@ public class DslQueryIT extends DslIntegTestBase {
         assertOk(search(new SearchSourceBuilder().query(QueryBuilders.termQuery("name", "laptop"))));
     }
 
+    public void testTermsQuery() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.termsQuery("name", "laptop", "phone"))));
+    }
+
+    public void testTermsQueryWithBoostThrowsException() {
+        createTestIndex();
+        expectThrows(Exception.class, () ->
+            search(new SearchSourceBuilder().query(QueryBuilders.termsQuery("name", "laptop").boost(2.0f)))
+        );
+    }
+
+    public void testTermsQueryWithNameThrowsException() {
+        createTestIndex();
+        expectThrows(Exception.class, () ->
+            search(new SearchSourceBuilder().query(QueryBuilders.termsQuery("name", "laptop").queryName("my_query")))
+        );
+    }
+
+    public void testTermsQueryWithValueTypeThrowsException() {
+        createTestIndex();
+        expectThrows(Exception.class, () ->
+            search(new SearchSourceBuilder().query(QueryBuilders.termsQuery("name", "laptop").valueType(
+                org.opensearch.index.query.TermsQueryBuilder.ValueType.BITMAP)))
+        );
+    }
+
     public void testWildcardQueryWithUnresolvedNode() {
         createTestIndex();
         // Wildcard query is not converted to standard Rex — wraps in UnresolvedQueryCall.

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
@@ -10,6 +10,7 @@ package org.opensearch.dsl;
 
 import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
@@ -42,23 +43,29 @@ public class DslQueryIT extends DslIntegTestBase {
 
     public void testTermsQueryWithBoostThrowsException() {
         createTestIndex();
-        expectThrows(Exception.class, () ->
-            search(new SearchSourceBuilder().query(QueryBuilders.termsQuery("name", "laptop").boost(2.0f)))
+        expectThrows(
+            ConversionException.class,
+            () -> search(new SearchSourceBuilder().query(QueryBuilders.termsQuery("name", "laptop").boost(2.0f)))
         );
     }
 
     public void testTermsQueryWithNameThrowsException() {
         createTestIndex();
-        expectThrows(Exception.class, () ->
-            search(new SearchSourceBuilder().query(QueryBuilders.termsQuery("name", "laptop").queryName("my_query")))
+        expectThrows(
+            ConversionException.class,
+            () -> search(new SearchSourceBuilder().query(QueryBuilders.termsQuery("name", "laptop").queryName("my_query")))
         );
     }
 
     public void testTermsQueryWithValueTypeThrowsException() {
         createTestIndex();
-        expectThrows(Exception.class, () ->
-            search(new SearchSourceBuilder().query(QueryBuilders.termsQuery("name", "laptop").valueType(
-                org.opensearch.index.query.TermsQueryBuilder.ValueType.BITMAP)))
+        expectThrows(
+            ConversionException.class,
+            () -> search(
+                new SearchSourceBuilder().query(
+                    QueryBuilders.termsQuery("name", "laptop").valueType(org.opensearch.index.query.TermsQueryBuilder.ValueType.BITMAP)
+                )
+            )
         );
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
@@ -19,6 +19,7 @@ public class QueryRegistryFactory {
     public static QueryRegistry create() {
         QueryRegistry registry = new QueryRegistry();
         registry.register(new TermQueryTranslator());
+        registry.register(new TermsQueryTranslator());
         registry.register(new MatchAllQueryTranslator());
         registry.register(new ExistsQueryTranslator());
         // TODO: add other query translators

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermsQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermsQueryTranslator.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexNode;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Converts a {@link TermsQueryBuilder} to a Calcite IN RexNode.
+ */
+public class TermsQueryTranslator implements QueryTranslator {
+
+    @Override
+    public Class<? extends QueryBuilder> getQueryType() {
+        return TermsQueryBuilder.class;
+    }
+
+    @Override
+    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+
+        TermsQueryBuilder termsQuery = (TermsQueryBuilder) query;
+
+        if (termsQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
+            throw new ConversionException("Terms query does not support non-default boost");
+        }
+        if (termsQuery.queryName() != null) {
+            throw new ConversionException("Terms query does not support _name");
+        }
+        if (termsQuery.valueType() != TermsQueryBuilder.ValueType.DEFAULT) {
+            throw new ConversionException("Terms query does not support non-default value_type");
+        }
+
+        String fieldName = termsQuery.fieldName();
+        List<?> values = termsQuery.values();
+
+        if (values == null || values.isEmpty()) {
+            throw new ConversionException("Terms query must have values");
+        }
+
+        RelDataTypeField field = ctx.getRowType().getField(fieldName, false, false);
+        if (field == null) {
+            throw new ConversionException("Field '" + fieldName + "' not found in schema");
+        }
+
+        RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
+        List<RexNode> literals = values.stream()
+            .map(value -> ctx.getRexBuilder().makeLiteral(value, field.getType(), false))
+            .collect(Collectors.toList());
+
+        return ctx.getRexBuilder().makeIn(fieldRef, literals);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermsQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermsQueryTranslator.java
@@ -34,6 +34,9 @@ public class TermsQueryTranslator implements QueryTranslator {
 
         TermsQueryBuilder termsQuery = (TermsQueryBuilder) query;
 
+        if (termsQuery.termsLookup() != null) {
+            throw new ConversionException("Terms query does not support terms lookup");
+        }
         if (termsQuery.boost() != AbstractQueryBuilder.DEFAULT_BOOST) {
             throw new ConversionException("Terms query does not support non-default boost");
         }
@@ -58,7 +61,7 @@ public class TermsQueryTranslator implements QueryTranslator {
 
         RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
         List<RexNode> literals = values.stream()
-            .map(value -> ctx.getRexBuilder().makeLiteral(value, field.getType(), false))
+            .map(value -> ctx.getRexBuilder().makeLiteral(value, field.getType(), true))
             .collect(Collectors.toList());
 
         return ctx.getRexBuilder().makeIn(fieldRef, literals);

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/TestUtils.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/TestUtils.java
@@ -38,7 +38,7 @@ import java.util.Properties;
  * RandomizedRunner, so tests use real objects built here.
  *
  * Standard test schema: name (VARCHAR), price (INTEGER), brand (VARCHAR), rating (DOUBLE),
- * created_date (DATE), is_active (BOOLEAN), timestamp (BIGINT), location (VARCHAR),
+ * created_date (DATE), is_active (BOOLEAN), timestamp (BIGINT), location (GEOMETRY),
  * status (VARCHAR), binary_data (VARBINARY).
  */
 public class TestUtils {
@@ -80,7 +80,7 @@ public class TestUtils {
                     .add("created_date", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.DATE), true))
                     .add("is_active", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.BOOLEAN), true))
                     .add("timestamp", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.BIGINT), true))
-                    .add("location", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.VARCHAR), true))
+                    .add("location", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.GEOMETRY), true))
                     .add("status", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.VARCHAR), true))
                     .add("binary_data", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.VARBINARY), true))
                     .build();

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/TestUtils.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/TestUtils.java
@@ -37,7 +37,9 @@ import java.util.Properties;
  * Mockito can't mock Calcite classes due to classloader conflicts with OpenSearch's
  * RandomizedRunner, so tests use real objects built here.
  *
- * Standard test schema: name (VARCHAR), price (INTEGER), brand (VARCHAR), rating (DOUBLE).
+ * Standard test schema: name (VARCHAR), price (INTEGER), brand (VARCHAR), rating (DOUBLE),
+ * created_date (DATE), is_active (BOOLEAN), timestamp (BIGINT), location (VARCHAR),
+ * status (VARCHAR), binary_data (VARBINARY).
  */
 public class TestUtils {
 
@@ -75,6 +77,12 @@ public class TestUtils {
                     .add("price", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.INTEGER), true))
                     .add("brand", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.VARCHAR), true))
                     .add("rating", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.DOUBLE), true))
+                    .add("created_date", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.DATE), true))
+                    .add("is_active", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.BOOLEAN), true))
+                    .add("timestamp", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.BIGINT), true))
+                    .add("location", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.VARCHAR), true))
+                    .add("status", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.VARCHAR), true))
+                    .add("binary_data", tf.createTypeWithNullability(tf.createSqlType(SqlTypeName.VARBINARY), true))
                     .build();
             }
         });

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/ProjectConverterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/converter/ProjectConverterTests.java
@@ -16,6 +16,8 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.List;
+
 public class ProjectConverterTests extends OpenSearchTestCase {
 
     private final ProjectConverter converter = new ProjectConverter();
@@ -85,9 +87,12 @@ public class ProjectConverterTests extends OpenSearchTestCase {
         RelNode result = converter.convert(scan, ctx);
 
         assertTrue(result instanceof LogicalProject);
-        assertEquals(2, result.getRowType().getFieldCount());
-        assertEquals("name", result.getRowType().getFieldNames().get(0));
-        assertEquals("brand", result.getRowType().getFieldNames().get(1));
+        assertEquals(8, result.getRowType().getFieldCount());
+        List<String> fieldNames = result.getRowType().getFieldNames();
+        assertTrue(fieldNames.contains("name"));
+        assertTrue(fieldNames.contains("brand"));
+        assertFalse(fieldNames.contains("price"));
+        assertFalse(fieldNames.contains("rating"));
     }
 
     public void testExcludesWithWildcard() throws ConversionException {
@@ -96,7 +101,7 @@ public class ProjectConverterTests extends OpenSearchTestCase {
         RelNode result = converter.convert(scan, ctx);
 
         assertTrue(result instanceof LogicalProject);
-        assertEquals(3, result.getRowType().getFieldCount());
+        assertEquals(9, result.getRowType().getFieldCount());
         assertFalse(result.getRowType().getFieldNames().contains("rating"));
     }
 
@@ -111,7 +116,7 @@ public class ProjectConverterTests extends OpenSearchTestCase {
     }
 
     public void testWildcardIncludesWithExcludes() throws ConversionException {
-        // Include all fields matching "* ", exclude "rating"
+        // Include all fields matching "*", exclude "rating"
         SearchSourceBuilder source = new SearchSourceBuilder().fetchSource(
             new FetchSourceContext(true, new String[] { "*" }, new String[] { "rating" })
         );
@@ -119,7 +124,7 @@ public class ProjectConverterTests extends OpenSearchTestCase {
         RelNode result = converter.convert(scan, ctx);
 
         assertTrue(result instanceof LogicalProject);
-        assertEquals(3, result.getRowType().getFieldCount());
+        assertEquals(9, result.getRowType().getFieldCount());
         assertFalse(result.getRowType().getFieldNames().contains("rating"));
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/DslQueryPlanExecutorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/DslQueryPlanExecutorTests.java
@@ -42,7 +42,10 @@ public class DslQueryPlanExecutorTests extends OpenSearchTestCase {
         assertEquals(QueryPlans.Type.HITS, result.getType());
         assertNotNull(result.getPlan());
         assertSame(scan, result.getPlan().relNode());
-        assertEquals(List.of("name", "price", "brand", "rating"), result.getFieldNames());
+        assertEquals(
+            List.of("name", "price", "brand", "rating", "created_date", "is_active", "timestamp", "location", "status", "binary_data"),
+            result.getFieldNames()
+        );
     }
 
     // TODO: add test with multiple plans (HITS + AGGREGATION) to verify iteration order

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.opensearch.dsl.TestUtils;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.TermsQueryBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class TermsQueryTranslatorTests extends OpenSearchTestCase {
+
+    private final TermsQueryTranslator translator = new TermsQueryTranslator();
+    private final ConversionContext ctx = TestUtils.createContext();
+
+    public void testSingleValueUsesEquals() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.termsQuery("name", "laptop"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.EQUALS, call.getKind());
+        assertEquals(2, call.getOperands().size());
+    }
+
+    public void testMultipleStringValuesUsesSearch() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.termsQuery("name", "laptop", "phone"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.SEARCH, call.getKind());
+    }
+
+    public void testResolvesCorrectFieldIndex() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.termsQuery("brand", "brandX", "brandY"), ctx);
+
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.SEARCH, call.getKind());
+        RexInputRef fieldRef = (RexInputRef) call.getOperands().get(0);
+        assertEquals(2, fieldRef.getIndex());
+    }
+
+    public void testIntegerValues() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.termsQuery("price", new Object[]{1200, 1500}), ctx);
+
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.SEARCH, call.getKind());
+        RexInputRef fieldRef = (RexInputRef) call.getOperands().get(0);
+        assertEquals(1, fieldRef.getIndex());
+    }
+
+    public void testDoubleValuesUsesSearch() throws ConversionException {
+        RexNode result = translator.convert(
+            QueryBuilders.termsQuery("rating", new Object[]{4.5, 4.8, 5.0}), ctx);
+
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.SEARCH, call.getKind());
+    }
+
+    public void testThrowsForUnknownField() {
+        expectThrows(ConversionException.class,
+            () -> translator.convert(QueryBuilders.termsQuery("nonexistent", "value"), ctx));
+    }
+
+    public void testThrowsForBoost() {
+        expectThrows(ConversionException.class,
+            () -> translator.convert(QueryBuilders.termsQuery("name", "laptop").boost(2.0f), ctx));
+    }
+
+    public void testThrowsForQueryName() {
+        expectThrows(ConversionException.class,
+            () -> translator.convert(QueryBuilders.termsQuery("name", "laptop").queryName("my_query"), ctx));
+    }
+
+    public void testThrowsForValueType() {
+        expectThrows(ConversionException.class,
+            () -> translator.convert(QueryBuilders.termsQuery("name", "laptop")
+                .valueType(TermsQueryBuilder.ValueType.BITMAP), ctx));
+    }
+
+    public void testReportsCorrectQueryType() {
+        assertEquals(TermsQueryBuilder.class, translator.getQueryType());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
@@ -39,15 +39,17 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
 
         assertTrue(result instanceof RexCall);
         RexCall call = (RexCall) result;
-        assertEquals(SqlKind.SEARCH, call.getKind());
+        assertEquals(SqlKind.OR, call.getKind());
     }
 
     public void testResolvesCorrectFieldIndex() throws ConversionException {
         RexNode result = translator.convert(QueryBuilders.termsQuery("brand", "brandX", "brandY"), ctx);
 
         RexCall call = (RexCall) result;
-        assertEquals(SqlKind.SEARCH, call.getKind());
-        RexInputRef fieldRef = (RexInputRef) call.getOperands().get(0);
+        assertEquals(SqlKind.OR, call.getKind());
+        // OR expression has nested structure, get field from first operand
+        RexCall firstEquals = (RexCall) call.getOperands().get(0);
+        RexInputRef fieldRef = (RexInputRef) firstEquals.getOperands().get(0);
         assertEquals(2, fieldRef.getIndex());
     }
 
@@ -55,8 +57,10 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
         RexNode result = translator.convert(QueryBuilders.termsQuery("price", new Object[]{1200, 1500}), ctx);
 
         RexCall call = (RexCall) result;
-        assertEquals(SqlKind.SEARCH, call.getKind());
-        RexInputRef fieldRef = (RexInputRef) call.getOperands().get(0);
+        assertEquals(SqlKind.OR, call.getKind());
+        // OR expression has nested structure, get field from first operand
+        RexCall firstEquals = (RexCall) call.getOperands().get(0);
+        RexInputRef fieldRef = (RexInputRef) firstEquals.getOperands().get(0);
         assertEquals(1, fieldRef.getIndex());
     }
 
@@ -65,7 +69,7 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
             QueryBuilders.termsQuery("rating", new Object[]{4.5, 4.8, 5.0}), ctx);
 
         RexCall call = (RexCall) result;
-        assertEquals(SqlKind.SEARCH, call.getKind());
+        assertEquals(SqlKind.OR, call.getKind());
     }
 
     public void testThrowsForUnknownField() {
@@ -74,8 +78,8 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
     }
 
     public void testThrowsForEmptyValues() {
-        expectThrows(ConversionException.class,
-            () -> translator.convert(QueryBuilders.termsQuery("name"), ctx));
+        expectThrows(IllegalArgumentException.class,
+            () -> translator.convert(QueryBuilders.termsQuery("name", (Object[]) null), ctx));
     }
 
     public void testThrowsForBoost() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
@@ -20,6 +20,8 @@ import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.indices.TermsLookup;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.Date;
+
 public class TermsQueryTranslatorTests extends OpenSearchTestCase {
 
     private final TermsQueryTranslator translator = new TermsQueryTranslator();
@@ -106,5 +108,52 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
 
     public void testReportsCorrectQueryType() {
         assertEquals(TermsQueryBuilder.class, translator.getQueryType());
+    }
+
+    // Supported types: VARCHAR, INTEGER, DOUBLE, BOOLEAN, BIGINT
+    // Date type still throws ClassCastException from Calcite's RexBuilder.makeLiteral()
+    
+    // TODO: Enable when date type support is added
+    public void testDateType() {
+        expectThrows(ClassCastException.class,
+            () -> translator.convert(QueryBuilders.termsQuery("created_date", 
+                new Object[]{new Date(1704067200000L), new Date(1706745600000L)}), ctx));
+    }
+
+    public void testBooleanType() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.termsQuery("is_active", new Object[]{true, false}), ctx);
+
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.OR, call.getKind());
+    }
+
+    public void testLongType() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.termsQuery("timestamp", new Object[]{1234567890L, 9876543210L}), ctx);
+
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.OR, call.getKind());
+    }
+
+    public void testGeoPointType() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.termsQuery("location", 
+            new Object[]{"40.7128,-74.0060", "34.0522,-118.2437"}), ctx);
+
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.OR, call.getKind());
+    }
+
+    public void testKeywordType() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.termsQuery("status", 
+            new Object[]{"active", "pending"}), ctx);
+
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.OR, call.getKind());
+    }
+
+    // TODO: Enable when binary type support is added
+    public void testBinaryType() {
+        expectThrows(ClassCastException.class,
+            () -> translator.convert(QueryBuilders.termsQuery("binary_data", 
+                new Object[]{"U29tZSBiaW5hcnkgYmxvYg==", "QW5vdGhlciBibG9i"}), ctx));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
@@ -134,12 +134,10 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
         assertEquals(SqlKind.OR, call.getKind());
     }
 
-    public void testGeoPointType() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.termsQuery("location", 
-            new Object[]{"40.7128,-74.0060", "34.0522,-118.2437"}), ctx);
-
-        RexCall call = (RexCall) result;
-        assertEquals(SqlKind.OR, call.getKind());
+    public void testGeoPointType() {
+        expectThrows(IllegalArgumentException.class,
+            () -> translator.convert(QueryBuilders.termsQuery("location", 
+                new Object[]{"40.7128,-74.0060", "34.0522,-118.2437"}), ctx));
     }
 
     public void testKeywordType() throws ConversionException {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
@@ -56,7 +56,7 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
     }
 
     public void testIntegerValues() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.termsQuery("price", new Object[]{1200, 1500}), ctx);
+        RexNode result = translator.convert(QueryBuilders.termsQuery("price", new Object[] { 1200, 1500 }), ctx);
 
         RexCall call = (RexCall) result;
         assertEquals(SqlKind.OR, call.getKind());
@@ -67,43 +67,41 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
     }
 
     public void testDoubleValuesUsesSearch() throws ConversionException {
-        RexNode result = translator.convert(
-            QueryBuilders.termsQuery("rating", new Object[]{4.5, 4.8, 5.0}), ctx);
+        RexNode result = translator.convert(QueryBuilders.termsQuery("rating", new Object[] { 4.5, 4.8, 5.0 }), ctx);
 
         RexCall call = (RexCall) result;
         assertEquals(SqlKind.OR, call.getKind());
     }
 
     public void testThrowsForUnknownField() {
-        expectThrows(ConversionException.class,
-            () -> translator.convert(QueryBuilders.termsQuery("nonexistent", "value"), ctx));
+        expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.termsQuery("nonexistent", "value"), ctx));
     }
 
     public void testThrowsForEmptyValues() {
-        expectThrows(IllegalArgumentException.class,
-            () -> translator.convert(QueryBuilders.termsQuery("name", (Object[]) null), ctx));
+        expectThrows(IllegalArgumentException.class, () -> translator.convert(QueryBuilders.termsQuery("name", (Object[]) null), ctx));
     }
 
     public void testThrowsForBoost() {
-        expectThrows(ConversionException.class,
-            () -> translator.convert(QueryBuilders.termsQuery("name", "laptop").boost(2.0f), ctx));
+        expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.termsQuery("name", "laptop").boost(2.0f), ctx));
     }
 
     public void testThrowsForQueryName() {
-        expectThrows(ConversionException.class,
-            () -> translator.convert(QueryBuilders.termsQuery("name", "laptop").queryName("my_query"), ctx));
+        expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.termsQuery("name", "laptop").queryName("my_query"), ctx)
+        );
     }
 
     public void testThrowsForTermsLookup() {
         TermsLookup termsLookup = new TermsLookup("lookup_index", "1", "terms");
-        expectThrows(ConversionException.class,
-            () -> translator.convert(QueryBuilders.termsLookupQuery("name", termsLookup), ctx));
+        expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.termsLookupQuery("name", termsLookup), ctx));
     }
 
     public void testThrowsForValueType() {
-        expectThrows(ConversionException.class,
-            () -> translator.convert(QueryBuilders.termsQuery("name", "laptop")
-                .valueType(TermsQueryBuilder.ValueType.BITMAP), ctx));
+        expectThrows(
+            ConversionException.class,
+            () -> translator.convert(QueryBuilders.termsQuery("name", "laptop").valueType(TermsQueryBuilder.ValueType.BITMAP), ctx)
+        );
     }
 
     public void testReportsCorrectQueryType() {
@@ -112,37 +110,41 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
 
     // Supported types: VARCHAR, INTEGER, DOUBLE, BOOLEAN, BIGINT
     // Date type still throws ClassCastException from Calcite's RexBuilder.makeLiteral()
-    
+
     // TODO: Enable when date type support is added
     public void testDateType() {
-        expectThrows(ClassCastException.class,
-            () -> translator.convert(QueryBuilders.termsQuery("created_date", 
-                new Object[]{new Date(1704067200000L), new Date(1706745600000L)}), ctx));
+        expectThrows(
+            ClassCastException.class,
+            () -> translator.convert(
+                QueryBuilders.termsQuery("created_date", new Object[] { new Date(1704067200000L), new Date(1706745600000L) }),
+                ctx
+            )
+        );
     }
 
     public void testBooleanType() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.termsQuery("is_active", new Object[]{true, false}), ctx);
+        RexNode result = translator.convert(QueryBuilders.termsQuery("is_active", new Object[] { true, false }), ctx);
 
         RexCall call = (RexCall) result;
         assertEquals(SqlKind.OR, call.getKind());
     }
 
     public void testLongType() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.termsQuery("timestamp", new Object[]{1234567890L, 9876543210L}), ctx);
+        RexNode result = translator.convert(QueryBuilders.termsQuery("timestamp", new Object[] { 1234567890L, 9876543210L }), ctx);
 
         RexCall call = (RexCall) result;
         assertEquals(SqlKind.OR, call.getKind());
     }
 
     public void testGeoPointType() {
-        expectThrows(IllegalArgumentException.class,
-            () -> translator.convert(QueryBuilders.termsQuery("location", 
-                new Object[]{"40.7128,-74.0060", "34.0522,-118.2437"}), ctx));
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> translator.convert(QueryBuilders.termsQuery("location", new Object[] { "40.7128,-74.0060", "34.0522,-118.2437" }), ctx)
+        );
     }
 
     public void testKeywordType() throws ConversionException {
-        RexNode result = translator.convert(QueryBuilders.termsQuery("status", 
-            new Object[]{"active", "pending"}), ctx);
+        RexNode result = translator.convert(QueryBuilders.termsQuery("status", new Object[] { "active", "pending" }), ctx);
 
         RexCall call = (RexCall) result;
         assertEquals(SqlKind.OR, call.getKind());
@@ -150,8 +152,12 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
 
     // TODO: Enable when binary type support is added
     public void testBinaryType() {
-        expectThrows(ClassCastException.class,
-            () -> translator.convert(QueryBuilders.termsQuery("binary_data", 
-                new Object[]{"U29tZSBiaW5hcnkgYmxvYg==", "QW5vdGhlciBibG9i"}), ctx));
+        expectThrows(
+            ClassCastException.class,
+            () -> translator.convert(
+                QueryBuilders.termsQuery("binary_data", new Object[] { "U29tZSBiaW5hcnkgYmxvYg==", "QW5vdGhlciBibG9i" }),
+                ctx
+            )
+        );
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/TermsQueryTranslatorTests.java
@@ -17,6 +17,7 @@ import org.opensearch.dsl.converter.ConversionContext;
 import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermsQueryBuilder;
+import org.opensearch.indices.TermsLookup;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class TermsQueryTranslatorTests extends OpenSearchTestCase {
@@ -72,6 +73,11 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
             () -> translator.convert(QueryBuilders.termsQuery("nonexistent", "value"), ctx));
     }
 
+    public void testThrowsForEmptyValues() {
+        expectThrows(ConversionException.class,
+            () -> translator.convert(QueryBuilders.termsQuery("name"), ctx));
+    }
+
     public void testThrowsForBoost() {
         expectThrows(ConversionException.class,
             () -> translator.convert(QueryBuilders.termsQuery("name", "laptop").boost(2.0f), ctx));
@@ -80,6 +86,12 @@ public class TermsQueryTranslatorTests extends OpenSearchTestCase {
     public void testThrowsForQueryName() {
         expectThrows(ConversionException.class,
             () -> translator.convert(QueryBuilders.termsQuery("name", "laptop").queryName("my_query"), ctx));
+    }
+
+    public void testThrowsForTermsLookup() {
+        TermsLookup termsLookup = new TermsLookup("lookup_index", "1", "terms");
+        expectThrows(ConversionException.class,
+            () -> translator.convert(QueryBuilders.termsLookupQuery("name", termsLookup), ctx));
     }
 
     public void testThrowsForValueType() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/ExecutionResultTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/ExecutionResultTests.java
@@ -24,7 +24,10 @@ public class ExecutionResultTests extends OpenSearchTestCase {
         assertSame(plan, result.getPlan());
         assertSame(rows, result.getRows());
         assertEquals(QueryPlans.Type.HITS, result.getType());
-        assertEquals(List.of("name", "price", "brand", "rating"), result.getFieldNames());
+        assertEquals(
+            List.of("name", "price", "brand", "rating", "created_date", "is_active", "timestamp", "location", "status", "binary_data"),
+            result.getFieldNames()
+        );
     }
 
     public void testRejectsNullArguments() {


### PR DESCRIPTION
### Summary
This PR adds support for converting OpenSearch terms queries into Calcite RelNode format, enabling the query-dsl-calcite plugin to handle multi-value equality checks.

### Changes
• **New Translator**: Implemented TermsQueryTranslator that converts TermsQueryBuilder to Calcite SEARCH(IN) operator
• **Registration**: Added the new translator to QueryRegistryFactory
• **Tests**: Added comprehensive integration tests covering:
  • Basic terms query conversion
  • Validation for unsupported boost parameter
  • Validation for unsupported _name parameter  
  • Validation for unsupported value_type parameter

### Technical Details
The TermsQueryTranslator converts a terms query like:
json
{
  "terms": {                                                                                                                                                                         
    "category": ["electronics", "computers", "laptops"]                                                                                                                              
  }                                                                                                                                                                                  
}                                                                                                                                                                                    
                                                                                                                                                                                     

Into a Calcite logical plan:
LogicalFilter(condition=[SEARCH($0, Sarg['electronics':VARCHAR, 'furniture':VARCHAR]:VARCHAR)])
  LogicalTableScan(table=[[products]])             


### Testing:
```
curl -X PUT "localhost:9200/products"                                                                                                              

{"acknowledged":true,"shards_acknowledged":true,"index":"products"}%                                                                                                                 
abhissom@c889f3ee19b7 OpenSearch % curl -X POST "localhost:9200/products/_doc/1" -H 'Content-Type: application/json' -d'                                                              
{                                                                                                                                                                                     
  "name": "Laptop",                                                                                                                                                                   
  "category": "electronics",                                                                                                                                                          
  "price": 999                                                                                                                                                                        
}'
{"_index":"products","_id":"1","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}%                                       
abhissom@c889f3ee19b7 OpenSearch % curl -X POST "localhost:9200/products/_doc/2" -H 'Content-Type: application/json' -d'                                                              
{                                                                                                                                                                                     
  "name": "Phone",                                                                                                                                                                    
  "category": "electronics",                                                                                                                                                          
  "price": 699                                                                                                                                                                        
}'                                                                                                                                                                                    
 

curl -X POST "localhost:9200/products/_doc/3" -H 'Content-Type: application/json' -d'

{

  "name": "Desk",

  "category": "furniture",

  "price": 299

}'
{"_index":"products","_id":"2","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}{"_index":"products","_id":"3","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":2,"_primary_term":1}%                                                                               
abhissom@c889f3ee19b7 OpenSearch % curl -X GET "localhost:9200/products/_search" -H 'Content-Type: application/json' -d'                                                              
{                                                                                                                                                                                     
  "query": {                                                                                                                                                                          
    "terms": {                                                                                                                                                                        
      "category": ["electronics", "furniture"]                                                                                                                                        
    }                                                                                                                                                                                 
  }                                                                                                                                                                                   
}'
{"took":230,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":10,"relation":"eq"},"max_score":null,"hits":[{"_id":"0","_score":null,"_source":{"category":"Apple","category.keyword":1299,"name":"US"},"fields":{"category":["Apple"],"category.keyword":[1299],"name":["US"]}},{"_id":"1","_score":null,"_source":{"category":"Apple","category.keyword":999,"name":"EU"},"fields":{"category":["Apple"],"category.keyword":[999],"name":["EU"]}},{"_id":"2","_score":null,"_source":{"category":"Apple","category.keyword":1099,"name":"US"},"fields":{"category":["Apple"],"category.keyword":[1099],"name":["US"]}},{"_id":"3","_score":null,"_source":{"category":"Apple","category.keyword":1199,"name":"EU"},"fields":{"category":["Apple"],"category.keyword":[1199],"name":["EU"]}},{"_id":"4","_score":null,"_source":{"category":"Samsung","category.keyword":799,"name":"US"},"fields":{"category":["Samsung"],"category.keyword":[799],"name":["US"]}},{"_id":"5","_score":null,"_source":{"category":"Samsung","category.keyword":899,"name":"EU"},"fields":{"category":["Samsung"],"category.keyword":[899],"name":["EU"]}},{"_id":"6","_score":null,"_source":{"category":"Samsung","category.keyword":699,"name":"US"},"fields":{"category":["Samsung"],"category.keyword":[699],"name":["US"]}},{"_id":"7","_score":null,"_source":{"category":"Dell","category.keyword":599,"name":"US"},"fields":{"category":["Dell"],"category.keyword":[599],"name":["US"]}},{"_id":"8","_score":null,"_source":{"category":"Dell","category.keyword":649,"name":"EU"},"fields":{"category":["Dell"],"category.keyword":[649],"name":["EU"]}},{"_id":"9","_score":null,"_source":{"category":"Dell","category.keyword":549,"name":"US"},"fields":{"category":["Dell"],"category.keyword":[549],"name":["US"]}}]}}%   
```
Output:
```
[2026-03-26T21:54:10,075][INFO ][o.o.d.q.DefaultQueryPlanExecutor] [runTask-0] Executing RelNode:
LogicalFilter(condition=[SEARCH($0, Sarg['electronics':VARCHAR, 'furniture':VARCHAR]:VARCHAR)])
  LogicalTableScan(table=[[products]])
```                                                                                                                              
                                                                                                                                                                                     

### Validation
The implementation enforces that only default values are used for boost, query name, and value type parameters, throwing exceptions for unsupported configurations.
<!--  Thanks for sending a pull request, here are some tips:



### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- NA -->

### Check List
- [ YES ] Functionality includes testing.
- [ NA ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ NA ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).