### PR TITLE
feat: Native Arrow transport path for VectorSchemaRoot in Flight plugin

### DIFF
--- a/plugins/arrow-flight-rpc/docs/native-arrow-transport-design.md
+++ b/plugins/arrow-flight-rpc/docs/native-arrow-transport-design.md
@@ -1,0 +1,42 @@
+# Native Arrow Transport Path — Design
+
+## Problem
+
+The current Arrow Flight transport serializes all responses through `VectorStreamOutput`,
+which stuffs bytes into a `VarBinaryVector`. This is wasteful when the response already
+contains a `VectorSchemaRoot` (e.g., query results from DataFusion). The data gets
+serialized to bytes, packed into a binary vector, sent over Flight (which does its own
+Arrow IPC), then unpacked and deserialized on the other side.
+
+## Solution: Approach A — Dual-Path in FlightOutboundHandler
+
+Add an `instanceof` check in the outbound handler. If the response implements
+`ArrowBatchResponse`, extract the `VectorSchemaRoot` and call `putNext()` directly.
+Otherwise, use the existing byte path unchanged.
+
+### New Interfaces
+
+1. **`ArrowBatchResponse`** — marker interface for responses carrying native Arrow data
+   - `VectorSchemaRoot getArrowRoot()` — returns the native Arrow data
+   - `Schema getArrowSchema()` — returns the Arrow schema
+
+2. **`ArrowStreamHandler<T>`** — marker interface for handlers that can receive native Arrow
+   - `T readArrow(VectorSchemaRoot root)` — reads a batch from native Arrow data
+
+### Server-Side Changes
+
+- `FlightOutboundHandler.processBatchTask()` — instanceof check before `writeTo()`
+- `FlightServerChannel.sendArrowBatch()` — new method that sends VectorSchemaRoot directly
+
+### Client-Side Changes
+
+- `FlightTransportResponse.nextResponse()` — instanceof check on handler before VectorStreamInput
+
+### Fallback
+
+`ArrowBatchResponse` still implements `writeTo(StreamOutput)` for Netty4 transport.
+The fallback path uses `ArrowStreamWriter` to serialize to IPC bytes.
+
+### Scope
+
+Changes are entirely within the `arrow-flight-rpc` plugin. No core OpenSearch changes.

--- a/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeArrowTransportIT.java
+++ b/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeArrowTransportIT.java
@@ -1,0 +1,427 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.ActionType;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.TransportAction;
+import org.opensearch.arrow.flight.transport.ArrowBatchResponse;
+import org.opensearch.arrow.flight.transport.ArrowStreamHandler;
+import org.opensearch.arrow.flight.transport.FlightStreamPlugin;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.plugins.ActionPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.StreamTransportResponseHandler;
+import org.opensearch.transport.StreamTransportService;
+import org.opensearch.transport.TransportChannel;
+import org.opensearch.transport.TransportException;
+import org.opensearch.transport.TransportRequestOptions;
+import org.opensearch.transport.stream.StreamTransportResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.opensearch.common.util.FeatureFlags.STREAM_TRANSPORT;
+
+/**
+ * Integration tests for the native Arrow transport path.
+ * Tests that ArrowBatchResponse + ArrowStreamHandler bypass byte serialization
+ * and deliver typed VectorSchemaRoot data end-to-end over Arrow Flight.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, minNumDataNodes = 2, maxNumDataNodes = 2)
+public class NativeArrowTransportIT extends OpenSearchIntegTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        internalCluster().ensureAtLeastNumDataNodes(2);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(NativeArrowTestPlugin.class, FlightStreamPlugin.class);
+    }
+
+    // ──── Test: Single batch of native Arrow data ────
+
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testSingleBatchNativeArrow() throws Exception {
+        for (DiscoveryNode node : getClusterState().nodes()) {
+            StreamTransportService streamTransportService = internalCluster().getInstance(StreamTransportService.class);
+
+            List<ArrowDataResponse> responses = new ArrayList<>();
+            CountDownLatch latch = new CountDownLatch(1);
+            AtomicReference<Exception> failure = new AtomicReference<>();
+
+            StreamTransportResponseHandler<ArrowDataResponse> handler = createArrowHandler(responses, latch, failure);
+
+            ArrowDataRequest request = new ArrowDataRequest(1, 3); // 1 batch, 3 rows
+            streamTransportService.sendRequest(
+                node,
+                ArrowDataAction.NAME,
+                request,
+                TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build(),
+                handler
+            );
+
+            assertTrue("Stream should complete within 10s", latch.await(10, TimeUnit.SECONDS));
+            assertNull("No exception expected", failure.get());
+            assertEquals("Should receive 1 batch", 1, responses.size());
+
+            ArrowDataResponse response = responses.get(0);
+            VectorSchemaRoot root = response.getArrowRoot();
+            assertNotNull("Root should not be null", root);
+            assertEquals("Should have 3 rows", 3, root.getRowCount());
+
+            // Verify typed columns — NOT VarBinary blobs
+            assertEquals(2, root.getSchema().getFields().size());
+            assertEquals("name", root.getSchema().getFields().get(0).getName());
+            assertEquals("age", root.getSchema().getFields().get(1).getName());
+
+            // Verify actual data
+            VarCharVector nameVector = (VarCharVector) root.getVector("name");
+            IntVector ageVector = (IntVector) root.getVector("age");
+            assertEquals("Alice", new String(nameVector.get(0), StandardCharsets.UTF_8));
+            assertEquals("Bob", new String(nameVector.get(1), StandardCharsets.UTF_8));
+            assertEquals("Carol", new String(nameVector.get(2), StandardCharsets.UTF_8));
+            assertEquals(30, ageVector.get(0));
+            assertEquals(31, ageVector.get(1));
+            assertEquals(32, ageVector.get(2));
+
+            response.close();
+        }
+    }
+
+    // ──── Test: Multiple batches of native Arrow data ────
+
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testMultipleBatchesNativeArrow() throws Exception {
+        for (DiscoveryNode node : getClusterState().nodes()) {
+            StreamTransportService streamTransportService = internalCluster().getInstance(StreamTransportService.class);
+
+            List<ArrowDataResponse> responses = new ArrayList<>();
+            CountDownLatch latch = new CountDownLatch(1);
+            AtomicReference<Exception> failure = new AtomicReference<>();
+
+            StreamTransportResponseHandler<ArrowDataResponse> handler = createArrowHandler(responses, latch, failure);
+
+            ArrowDataRequest request = new ArrowDataRequest(3, 2); // 3 batches, 2 rows each
+            streamTransportService.sendRequest(
+                node,
+                ArrowDataAction.NAME,
+                request,
+                TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build(),
+                handler
+            );
+
+            assertTrue("Stream should complete within 10s", latch.await(10, TimeUnit.SECONDS));
+            assertNull("No exception expected", failure.get());
+            assertEquals("Should receive 3 batches", 3, responses.size());
+
+            for (int i = 0; i < 3; i++) {
+                ArrowDataResponse response = responses.get(i);
+                VectorSchemaRoot root = response.getArrowRoot();
+                assertEquals("Each batch should have 2 rows", 2, root.getRowCount());
+                assertEquals("name", root.getSchema().getFields().get(0).getName());
+                assertEquals("age", root.getSchema().getFields().get(1).getName());
+
+                // Verify data in each batch
+                VarCharVector nameVector = (VarCharVector) root.getVector("name");
+                IntVector ageVector = (IntVector) root.getVector("age");
+                assertNotNull("Name vector should not be null", nameVector.get(0));
+                assertEquals(30, ageVector.get(0));
+                assertEquals(31, ageVector.get(1));
+
+                response.close();
+            }
+        }
+    }
+
+    // ──── Helper: create handler that implements ArrowStreamHandler ────
+
+    private StreamTransportResponseHandler<ArrowDataResponse> createArrowHandler(
+        List<ArrowDataResponse> responses,
+        CountDownLatch latch,
+        AtomicReference<Exception> failure
+    ) {
+        return new ArrowAwareResponseHandler(responses, latch, failure);
+    }
+
+    // ──── Inner classes: Action, Request, Response, Handler, Plugin ────
+
+    /**
+     * Response that carries native Arrow VectorSchemaRoot.
+     * Implements ArrowBatchResponse so FlightOutboundHandler sends it directly.
+     */
+    public static class ArrowDataResponse extends ActionResponse implements ArrowBatchResponse {
+        private VectorSchemaRoot root;
+        private BufferAllocator allocator;
+
+        public ArrowDataResponse(VectorSchemaRoot root) {
+            this.root = root;
+        }
+
+        public ArrowDataResponse(VectorSchemaRoot root, BufferAllocator allocator) {
+            this.root = root;
+            this.allocator = allocator;
+        }
+
+        public ArrowDataResponse(StreamInput in) throws IOException {
+            super(in);
+            // Fallback deserialization for Netty4 — not expected in native Arrow path
+            throw new UnsupportedOperationException("Netty4 fallback not implemented in this test");
+        }
+
+        @Override
+        public VectorSchemaRoot getArrowRoot() {
+            return root;
+        }
+
+        @Override
+        public Schema getArrowSchema() {
+            return root.getSchema();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            // Fallback serialization for Netty4
+            throw new UnsupportedOperationException("Netty4 fallback not implemented in this test");
+        }
+
+        public void close() {
+            if (root != null) {
+                root.close();
+            }
+            if (allocator != null) {
+                allocator.close();
+            }
+        }
+    }
+
+    /**
+     * Request specifying how many batches and rows per batch.
+     */
+    public static class ArrowDataRequest extends ActionRequest {
+        private int batchCount;
+        private int rowsPerBatch;
+
+        public ArrowDataRequest(int batchCount, int rowsPerBatch) {
+            this.batchCount = batchCount;
+            this.rowsPerBatch = rowsPerBatch;
+        }
+
+        public ArrowDataRequest(StreamInput in) throws IOException {
+            super(in);
+            this.batchCount = in.readInt();
+            this.rowsPerBatch = in.readInt();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeInt(batchCount);
+            out.writeInt(rowsPerBatch);
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        public int getBatchCount() {
+            return batchCount;
+        }
+
+        public int getRowsPerBatch() {
+            return rowsPerBatch;
+        }
+    }
+
+    /**
+     * Action type registration.
+     */
+    public static class ArrowDataAction extends ActionType<ArrowDataResponse> {
+        public static final ArrowDataAction INSTANCE = new ArrowDataAction();
+        public static final String NAME = "cluster:internal/test/arrow_data";
+
+        private ArrowDataAction() {
+            super(NAME, ArrowDataResponse::new);
+        }
+    }
+
+    /**
+     * Server-side transport action: creates VectorSchemaRoot and sends via ArrowBatchResponse.
+     */
+    public static class TransportArrowDataAction extends TransportAction<ArrowDataRequest, ArrowDataResponse> {
+
+        private static final String[] NAMES = { "Alice", "Bob", "Carol", "Dave", "Eve" };
+
+        @Inject
+        public TransportArrowDataAction(StreamTransportService streamTransportService, ActionFilters actionFilters) {
+            super(ArrowDataAction.NAME, actionFilters, streamTransportService.getTaskManager());
+            streamTransportService.registerRequestHandler(
+                ArrowDataAction.NAME,
+                ThreadPool.Names.GENERIC,
+                ArrowDataRequest::new,
+                this::handleStreamRequest
+            );
+        }
+
+        @Override
+        protected void doExecute(Task task, ArrowDataRequest request, ActionListener<ArrowDataResponse> listener) {
+            listener.onFailure(new UnsupportedOperationException("Use StreamTransportService"));
+        }
+
+        private void handleStreamRequest(ArrowDataRequest request, TransportChannel channel, Task task) throws IOException {
+            try {
+                for (int batch = 0; batch < request.getBatchCount(); batch++) {
+                    BufferAllocator allocator = new RootAllocator();
+                    VectorSchemaRoot root = createTestBatch(allocator, request.getRowsPerBatch(), batch);
+                    channel.sendResponseBatch(new ArrowDataResponse(root));
+                }
+                channel.completeStream();
+            } catch (Exception e) {
+                channel.sendResponse(e);
+            }
+        }
+
+        private VectorSchemaRoot createTestBatch(BufferAllocator allocator, int rowCount, int batchIndex) {
+            Schema schema = new Schema(
+                List.of(
+                    new Field("name", FieldType.nullable(new ArrowType.Utf8()), null),
+                    new Field("age", FieldType.nullable(new ArrowType.Int(32, true)), null)
+                )
+            );
+            VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+
+            VarCharVector nameVector = (VarCharVector) root.getVector("name");
+            IntVector ageVector = (IntVector) root.getVector("age");
+            nameVector.allocateNew();
+            ageVector.allocateNew();
+
+            for (int i = 0; i < rowCount; i++) {
+                String name = NAMES[(batchIndex * rowCount + i) % NAMES.length];
+                nameVector.setSafe(i, name.getBytes(StandardCharsets.UTF_8));
+                ageVector.setSafe(i, 30 + i);
+            }
+            root.setRowCount(rowCount);
+            return root;
+        }
+    }
+
+    /**
+     * Response handler that implements ArrowStreamHandler to receive native Arrow data.
+     * Deep-copies the VectorSchemaRoot since the Flight stream reuses its internal root.
+     */
+    static class ArrowAwareResponseHandler
+        implements
+            StreamTransportResponseHandler<ArrowDataResponse>,
+            ArrowStreamHandler<ArrowDataResponse> {
+
+        private final List<ArrowDataResponse> responses;
+        private final CountDownLatch latch;
+        private final AtomicReference<Exception> failure;
+
+        ArrowAwareResponseHandler(List<ArrowDataResponse> responses, CountDownLatch latch, AtomicReference<Exception> failure) {
+            this.responses = responses;
+            this.latch = latch;
+            this.failure = failure;
+        }
+
+        @Override
+        public ArrowDataResponse readArrow(VectorSchemaRoot root) {
+            // Deep-copy: the Flight stream reuses its root between next() calls,
+            // so we must copy the data to an independent allocator/root.
+            // Use a child allocator from the stream's allocator tree to avoid
+            // "buffers must share the same root" errors with Arrow buffer operations.
+            BufferAllocator streamAllocator = root.getFieldVectors().get(0).getAllocator();
+            BufferAllocator childAllocator = streamAllocator.newChildAllocator("native-arrow-copy", 0, Long.MAX_VALUE);
+            VectorSchemaRoot copy = VectorSchemaRoot.create(root.getSchema(), childAllocator);
+            for (int i = 0; i < root.getFieldVectors().size(); i++) {
+                FieldVector source = root.getFieldVectors().get(i);
+                FieldVector target = copy.getFieldVectors().get(i);
+                source.makeTransferPair(target).splitAndTransfer(0, root.getRowCount());
+            }
+            copy.setRowCount(root.getRowCount());
+            return new ArrowDataResponse(copy, childAllocator);
+        }
+
+        @Override
+        public void handleStreamResponse(StreamTransportResponse<ArrowDataResponse> streamResponse) {
+            try {
+                ArrowDataResponse response;
+                while ((response = streamResponse.nextResponse()) != null) {
+                    responses.add(response);
+                }
+                streamResponse.close();
+                latch.countDown();
+            } catch (Exception e) {
+                failure.set(e);
+                streamResponse.cancel("Test error", e);
+                latch.countDown();
+            }
+        }
+
+        @Override
+        public void handleException(TransportException exp) {
+            failure.set(exp);
+            latch.countDown();
+        }
+
+        @Override
+        public String executor() {
+            return ThreadPool.Names.GENERIC;
+        }
+
+        @Override
+        public ArrowDataResponse read(StreamInput in) throws IOException {
+            // Fallback for Netty4 — not expected in this test
+            return new ArrowDataResponse(in);
+        }
+    }
+
+    /**
+     * Plugin that registers the Arrow-native transport action.
+     */
+    public static class NativeArrowTestPlugin extends Plugin implements ActionPlugin {
+        public NativeArrowTestPlugin() {}
+
+        @Override
+        public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+            return Collections.singletonList(new ActionHandler<>(ArrowDataAction.INSTANCE, TransportArrowDataAction.class));
+        }
+    }
+}

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponse.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+/**
+ * Marker interface for {@link org.opensearch.core.transport.TransportResponse} instances
+ * that carry native Arrow columnar data. When the Arrow Flight transport detects a response
+ * implementing this interface, it sends the {@link VectorSchemaRoot} directly via
+ * {@code putNext()} — bypassing the byte-oriented {@link VectorStreamOutput} serialization path.
+ *
+ * <p>The caller retains ownership of the {@link VectorSchemaRoot}. The Flight transport
+ * reads from it during {@code putNext()} but does not close it. The caller is responsible
+ * for closing the root after the response has been sent.
+ *
+ * <p>Implementations must also implement {@code writeTo(StreamOutput)} as a fallback
+ * for non-Flight transports (e.g., Netty4).
+ *
+ * @opensearch.experimental
+ */
+public interface ArrowBatchResponse {
+
+    /**
+     * Returns the native Arrow data for this batch.
+     */
+    VectorSchemaRoot getArrowRoot();
+
+    /**
+     * Returns the Arrow schema for this response.
+     */
+    Schema getArrowSchema();
+}

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowStreamHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowStreamHandler.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.opensearch.core.transport.TransportResponse;
+
+/**
+ * Marker interface for {@link org.opensearch.transport.TransportResponseHandler} instances
+ * that can consume native Arrow columnar data. When the Arrow Flight transport detects a handler
+ * implementing this interface, it passes the received {@link VectorSchemaRoot} directly —
+ * bypassing the byte-oriented {@link VectorStreamInput} deserialization path.
+ *
+ * <p>Implementations must also implement {@code read(StreamInput)} as a fallback
+ * for non-Flight transports (e.g., Netty4).
+ *
+ * @opensearch.experimental
+ */
+public interface ArrowStreamHandler<T extends TransportResponse> {
+
+    /**
+     * Reads a response directly from a native Arrow {@link VectorSchemaRoot}.
+     * Called instead of {@code read(StreamInput)} when the Flight transport
+     * receives native Arrow data (i.e., the server sent an {@link ArrowBatchResponse}).
+     *
+     * @param root the Arrow columnar data for this batch
+     * @return the deserialized response
+     */
+    T readArrow(VectorSchemaRoot root);
+}

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java
@@ -151,11 +151,17 @@ class FlightOutboundHandler extends ProtocolOutboundHandler {
         }
 
         try {
-            try (VectorStreamOutput out = new VectorStreamOutput(flightChannel.getAllocator(), flightChannel.getRoot())) {
-                task.response().writeTo(out);
-                flightChannel.sendBatch(getHeaderBuffer(task.requestId(), task.nodeVersion(), task.features()), out);
-                messageListener.onResponseSent(task.requestId(), task.action(), task.response());
+            if (task.response() instanceof ArrowBatchResponse arrowResponse) {
+                // Native Arrow path: send VectorSchemaRoot directly, skip byte serialization
+                flightChannel.sendArrowBatch(getHeaderBuffer(task.requestId(), task.nodeVersion(), task.features()), arrowResponse);
+            } else {
+                // Existing byte path: serialize response to VarBinaryVector
+                try (VectorStreamOutput out = new VectorStreamOutput(flightChannel.getAllocator(), flightChannel.getRoot())) {
+                    task.response().writeTo(out);
+                    flightChannel.sendBatch(getHeaderBuffer(task.requestId(), task.nodeVersion(), task.features()), out);
+                }
             }
+            messageListener.onResponseSent(task.requestId(), task.action(), task.response());
         } catch (FlightRuntimeException e) {
             messageListener.onResponseSent(task.requestId(), task.action(), FlightErrorMapper.fromFlightException(e));
         } catch (Exception e) {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightServerChannel.java
@@ -53,6 +53,7 @@ class FlightServerChannel implements TcpChannel {
     private volatile VectorSchemaRoot root = null;
     private final FlightCallTracker callTracker;
     private volatile boolean cancelled = false;
+    private volatile boolean externalRoot = false;
     private final ExecutorService executor;
     private final long correlationId;
     private final AtomicInteger batchNumber = new AtomicInteger(0);
@@ -136,6 +137,49 @@ class FlightServerChannel implements TcpChannel {
             );
         } else {
             logger.debug("Batch #{} sent for correlation ID: {}, putNext: {}ms", batchNumber, correlationId, putNextTime);
+        }
+    }
+
+    /**
+     * Sends a batch of native Arrow data directly, bypassing byte serialization.
+     * Used when the response implements {@link ArrowBatchResponse}.
+     *
+     * @param header the serialized transport header
+     * @param arrowResponse the response carrying native Arrow data
+     */
+    public void sendArrowBatch(ByteBuffer header, ArrowBatchResponse arrowResponse) {
+        if (cancelled) {
+            throw StreamException.cancelled("Cannot flush more batches. Stream cancelled by the client");
+        }
+        if (!open.get()) {
+            throw new IllegalStateException("FlightServerChannel already closed.");
+        }
+        batchNumber.incrementAndGet();
+        long batchStartTime = System.nanoTime();
+        VectorSchemaRoot arrowRoot = arrowResponse.getArrowRoot();
+        externalRoot = true;
+        if (root == null) {
+            middleware.setHeader(header);
+            root = arrowRoot;
+            serverStreamListener.start(root);
+        } else {
+            root = arrowRoot;
+        }
+        logger.debug("Sending native Arrow batch #{} for correlation ID: {}", batchNumber, correlationId);
+        serverStreamListener.putNext();
+        long putNextTime = (System.nanoTime() - batchStartTime) / 1_000_000;
+        if (callTracker != null) {
+            long rootSize = FlightUtils.calculateVectorSchemaRootSize(root);
+            callTracker.recordBatchSent(rootSize, System.nanoTime() - batchStartTime);
+            logger.debug(
+                "Native Arrow batch #{} sent for correlation ID: {}, size: {} bytes, putNext: {}ms",
+                batchNumber,
+                correlationId,
+                rootSize,
+                putNextTime
+            );
+        } else {
+            logger.debug("Native Arrow batch #{} sent for correlation ID: {}, putNext: {}ms", batchNumber, correlationId, putNextTime);
         }
     }
 
@@ -235,7 +279,7 @@ class FlightServerChannel implements TcpChannel {
             return;
         }
         open.set(false);
-        if (root != null) {
+        if (root != null && !externalRoot) {
             root.close();
         }
         notifyCloseListeners();

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -53,6 +53,8 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
     private volatile boolean closed;
     private volatile boolean prefetchStarted;
     private volatile Header initialHeader;
+    private volatile boolean arrowHandlerResolved;
+    private volatile ArrowStreamHandler<T> cachedArrowHandler;
 
     FlightTransportResponse(
         TransportResponseHandler<T> handler,
@@ -123,6 +125,20 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
 
             VectorSchemaRoot root = flightStream.getRoot();
             currentBatchSize = FlightUtils.calculateVectorSchemaRootSize(root);
+
+            // Check if the underlying handler supports native Arrow consumption.
+            // MetricsTrackingResponseHandler is a decorator — unwrap to find the real handler.
+            if (!arrowHandlerResolved) {
+                cachedArrowHandler = resolveArrowStreamHandler();
+                arrowHandlerResolved = true;
+            }
+            ArrowStreamHandler<T> arrowHandler = cachedArrowHandler;
+            if (arrowHandler != null) {
+                // Native Arrow path: hand VectorSchemaRoot directly to the handler
+                return arrowHandler.readArrow(root);
+            }
+
+            // Existing byte path: deserialize via VectorStreamInput
             try (VectorStreamInput input = new VectorStreamInput(root, namedWriteableRegistry)) {
                 input.setVersion(initialHeader.getVersion());
                 return handler.read(input);
@@ -138,6 +154,24 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
             }
             logger.debug("FlightClient.next() for correlationId: {} took {}ms", correlationId, took);
         }
+    }
+
+    /**
+     * Resolves the {@link ArrowStreamHandler} from the handler chain, walking the
+     * decorator chain via {@link TransportResponseHandler#getDelegate()}.
+     *
+     * @return the ArrowStreamHandler, or null if the handler does not support native Arrow
+     */
+    @SuppressWarnings("unchecked")
+    private ArrowStreamHandler<T> resolveArrowStreamHandler() {
+        TransportResponseHandler<T> current = handler;
+        while (current != null) {
+            if (current instanceof ArrowStreamHandler) {
+                return (ArrowStreamHandler<T>) current;
+            }
+            current = current.getDelegate();
+        }
+        return null;
     }
 
     long getCurrentBatchSize() {

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/MetricsTrackingResponseHandler.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/MetricsTrackingResponseHandler.java
@@ -39,6 +39,11 @@ class MetricsTrackingResponseHandler<T extends TransportResponse> implements Tra
     }
 
     @Override
+    public TransportResponseHandler<T> getDelegate() {
+        return delegate;
+    }
+
+    @Override
     public void handleResponse(T response) {
         delegate.handleResponse(response);
     }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseTests.java
@@ -1,0 +1,250 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.arrow.flight.transport;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.Version;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.StatsTracker;
+import org.opensearch.transport.TransportMessageListener;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ArrowBatchResponseTests extends OpenSearchTestCase {
+
+    private ThreadPool threadPool;
+    private FlightOutboundHandler outboundHandler;
+    private ExecutorService executor;
+    private FlightServerChannel mockFlightChannel;
+    private TransportMessageListener mockListener;
+    private BufferAllocator allocator;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        allocator = new RootAllocator();
+        threadPool = new TestThreadPool(getTestName());
+        executor = Executors.newSingleThreadExecutor();
+        outboundHandler = new FlightOutboundHandler("test-node", Version.CURRENT, new String[0], new StatsTracker(), threadPool);
+
+        mockFlightChannel = mock(FlightServerChannel.class);
+        when(mockFlightChannel.getExecutor()).thenReturn(executor);
+        when(mockFlightChannel.getAllocator()).thenReturn(allocator);
+        when(mockFlightChannel.getRoot()).thenReturn(null);
+
+        mockListener = mock(TransportMessageListener.class);
+        outboundHandler.setMessageListener(mockListener);
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        allocator.close();
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+        threadPool.shutdown();
+        super.tearDown();
+    }
+
+    /**
+     * A test TransportResponse that implements ArrowBatchResponse,
+     * carrying a native VectorSchemaRoot.
+     */
+    static class TestArrowResponse extends TransportResponse implements ArrowBatchResponse {
+        private final VectorSchemaRoot root;
+
+        TestArrowResponse(VectorSchemaRoot root) {
+            this.root = root;
+        }
+
+        @Override
+        public VectorSchemaRoot getArrowRoot() {
+            return root;
+        }
+
+        @Override
+        public Schema getArrowSchema() {
+            return root.getSchema();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            // Fallback for non-Flight transports — not expected to be called in native path
+            throw new AssertionError("writeTo should not be called for native Arrow path");
+        }
+    }
+
+    /**
+     * A regular (non-Arrow) test response for comparison.
+     */
+    static class TestByteResponse extends TransportResponse {
+        private final String data;
+
+        TestByteResponse(String data) {
+            this.data = data;
+        }
+
+        TestByteResponse(StreamInput in) throws IOException {
+            this.data = in.readString();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(data);
+        }
+
+        String getData() {
+            return data;
+        }
+    }
+
+    private VectorSchemaRoot createTestRoot() {
+        Schema schema = new Schema(
+            List.of(
+                new Field("name", FieldType.nullable(new ArrowType.Utf8()), null),
+                new Field("age", FieldType.nullable(new ArrowType.Int(32, true)), null)
+            )
+        );
+        VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+
+        VarCharVector nameVector = (VarCharVector) root.getVector("name");
+        IntVector ageVector = (IntVector) root.getVector("age");
+
+        nameVector.allocateNew();
+        ageVector.allocateNew();
+
+        nameVector.setSafe(0, "Alice".getBytes(StandardCharsets.UTF_8));
+        nameVector.setSafe(1, "Bob".getBytes(StandardCharsets.UTF_8));
+        ageVector.setSafe(0, 30);
+        ageVector.setSafe(1, 25);
+
+        root.setRowCount(2);
+        return root;
+    }
+
+    public void testArrowBatchResponseSkipsWriteTo() throws Exception {
+        VectorSchemaRoot testRoot = createTestRoot();
+        TestArrowResponse arrowResponse = new TestArrowResponse(testRoot);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            latch.countDown();
+            return null;
+        }).when(mockListener).onResponseSent(anyLong(), anyString(), any(TransportResponse.class));
+
+        outboundHandler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            mock(FlightTransportChannel.class),
+            1L,
+            "test-action",
+            arrowResponse,
+            false,
+            false
+        );
+
+        assertTrue("Batch should complete", latch.await(5, TimeUnit.SECONDS));
+
+        // Verify sendArrowBatch was called (native path) instead of sendBatch (byte path)
+        verify(mockFlightChannel).sendArrowBatch(any(ByteBuffer.class), any(ArrowBatchResponse.class));
+        verify(mockFlightChannel, never()).sendBatch(any(ByteBuffer.class), any(VectorStreamOutput.class));
+
+        testRoot.close();
+    }
+
+    public void testNonArrowResponseUsesExistingBytePath() throws Exception {
+        TestByteResponse byteResponse = new TestByteResponse("hello");
+
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            latch.countDown();
+            return null;
+        }).when(mockListener).onResponseSent(anyLong(), anyString(), any(TransportResponse.class));
+
+        outboundHandler.sendResponseBatch(
+            Version.CURRENT,
+            Collections.emptySet(),
+            mockFlightChannel,
+            mock(FlightTransportChannel.class),
+            1L,
+            "test-action",
+            byteResponse,
+            false,
+            false
+        );
+
+        assertTrue("Batch should complete", latch.await(5, TimeUnit.SECONDS));
+
+        // Verify sendBatch was called (byte path) instead of sendArrowBatch (native path)
+        verify(mockFlightChannel, never()).sendArrowBatch(any(ByteBuffer.class), any(ArrowBatchResponse.class));
+    }
+
+    public void testArrowBatchResponseInterface() {
+        VectorSchemaRoot testRoot = createTestRoot();
+        TestArrowResponse response = new TestArrowResponse(testRoot);
+
+        assertSame(testRoot, response.getArrowRoot());
+        assertEquals(testRoot.getSchema(), response.getArrowSchema());
+        assertEquals(2, response.getArrowRoot().getRowCount());
+
+        // Verify schema has typed columns (not VarBinary blobs)
+        Schema schema = response.getArrowSchema();
+        assertEquals(2, schema.getFields().size());
+        assertEquals("name", schema.getFields().get(0).getName());
+        assertEquals("age", schema.getFields().get(1).getName());
+
+        testRoot.close();
+    }
+
+    public void testArrowStreamHandlerInterface() {
+        VectorSchemaRoot testRoot = createTestRoot();
+
+        ArrowStreamHandler<TestArrowResponse> handler = root -> new TestArrowResponse(root);
+        TestArrowResponse result = handler.readArrow(testRoot);
+
+        assertSame(testRoot, result.getArrowRoot());
+        assertEquals(2, result.getArrowRoot().getRowCount());
+
+        testRoot.close();
+    }
+}

--- a/server/src/main/java/org/opensearch/telemetry/tracing/handler/TraceableTransportResponseHandler.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/handler/TraceableTransportResponseHandler.java
@@ -114,4 +114,9 @@ public class TraceableTransportResponseHandler<T extends TransportResponse> impl
             span.endSpan();
         }
     }
+
+    @Override
+    public TransportResponseHandler<T> getDelegate() {
+        return delegate;
+    }
 }

--- a/server/src/main/java/org/opensearch/transport/TransportResponseHandler.java
+++ b/server/src/main/java/org/opensearch/transport/TransportResponseHandler.java
@@ -102,6 +102,18 @@ public interface TransportResponseHandler<T extends TransportResponse> extends W
      */
     default void handleRejection(Exception exp) {}
 
+    /**
+     * Returns the delegate handler wrapped by this handler, or {@code null} if this handler
+     * does not wrap another. Used by transport implementations to walk decorator chains
+     * and discover handler capabilities (e.g., native Arrow stream support).
+     *
+     * @return the delegate handler, or null
+     */
+    @ExperimentalApi
+    default TransportResponseHandler<T> getDelegate() {
+        return null;
+    }
+
     default <Q extends TransportResponse> TransportResponseHandler<Q> wrap(Function<Q, T> converter, Writeable.Reader<Q> reader) {
         final TransportResponseHandler<T> self = this;
         return new TransportResponseHandler<Q>() {

--- a/server/src/main/java/org/opensearch/transport/TransportService.java
+++ b/server/src/main/java/org/opensearch/transport/TransportService.java
@@ -1618,6 +1618,11 @@ public class TransportService extends AbstractLifecycleComponent
             return getClass().getName() + "/" + delegate.toString();
         }
 
+        @Override
+        public TransportResponseHandler<T> getDelegate() {
+            return delegate;
+        }
+
         void setTimeoutHandler(TimeoutHandler handler) {
             this.handler = handler;
         }
@@ -1834,6 +1839,11 @@ public class TransportService extends AbstractLifecycleComponent
                     @Override
                     public T read(StreamInput in) throws IOException {
                         return handler.read(in);
+                    }
+
+                    @Override
+                    public TransportResponseHandler<T> getDelegate() {
+                        return handler;
                     }
 
                     @Override


### PR DESCRIPTION
## Context

While building a query engine POC using Apache DataFusion, I found that query results are already in native Arrow format (`VectorSchemaRoot`) on both the sending and receiving sides. However, the current Flight transport path forces serialization for native arrow format.

```
Worker DataFusion → VectorSchemaRoot → writeTo() → bytes → VarBinary vector → Flight → VarBinary vector → read(StreamInput) → bytes → Coordinator DataFusion
```

The data starts as Arrow, gets serialized to bytes, wrapped in a VarBinary vector, sent over Flight, unwrapped, deserialized back to bytes, and then reconstructed — all redundant when both ends already speak Arrow natively.

This PR adds a zero-serialization path so Arrow data can flow directly:

```
Worker DataFusion → VectorSchemaRoot → Flight → VectorSchemaRoot → Coordinator DataFusion
```

## Summary

### Server side (sending)
- **`ArrowBatchResponse`** — marker interface for `TransportResponse` instances carrying native Arrow data. When `FlightOutboundHandler` detects this, it sends the `VectorSchemaRoot` directly via `putNext()`, bypassing `VectorStreamOutput` serialization.
- **`FlightServerChannel.sendArrowBatch()`** — sends the caller's `VectorSchemaRoot` directly. Tracks ownership via `externalRoot` flag so `close()` doesn't free externally-owned roots.

### Client side (receiving)
- **`ArrowStreamHandler`** — interface for response handlers that can consume native `VectorSchemaRoot` data via `readArrow()`. Handlers implementing this receive typed Arrow data instead of byte streams.
- **`FlightTransportResponse.resolveArrowStreamHandler()`** — walks the decorator chain (`MetricsTrackingResponseHandler → ContextRestoreResponseHandler → TraceableTransportResponseHandler → original handler`) to find the `ArrowStreamHandler`. Result is cached after first resolution.

### Handler chain walking
- Added `TransportResponseHandler.getDelegate()` default method to enable generic decorator chain introspection. Implemented in `ContextRestoreResponseHandler`, `TraceableTransportResponseHandler`, and `MetricsTrackingResponseHandler`.

### Key design decisions
- **Caller retains ownership** of `VectorSchemaRoot` on the send side — Flight reads from it but does not close it.
- **`FlightStream` reuses its root** on the receive side — `readArrow()` consumers must deep-copy if they need to hold data across `next()` calls, or process inline for zero-copy.
- **Fallback preserved** — non-`ArrowBatchResponse` responses continue to use the existing byte serialization path. Non-`ArrowStreamHandler` handlers continue to use `VectorStreamInput` deserialization.

## Test plan

- [x] `NativeArrowTransportIT.testSingleBatchNativeArrow` — 1 batch, 3 rows, verifies typed columns (VarChar, Int) and actual data values end-to-end
- [x] `NativeArrowTransportIT.testMultipleBatchesNativeArrow` — 3 batches, 2 rows each, verifies multi-batch streaming with data verification
- [x] `ArrowBatchResponseTests` — unit tests for ownership, serialization bypass, and error handling
- [x] All existing flight integration tests pass (`FlightTransportIT`, `ClientSideChaosIT`, `SubAggregationIT`, etc.)
- [x] All existing flight unit tests pass