### PR TITLE
dissect: fix 'occured' -> 'occurred' typo in DissectMatch#getResults javadoc

### DIFF
--- a/libs/dissect/src/main/java/org/opensearch/dissect/DissectMatch.java
+++ b/libs/dissect/src/main/java/org/opensearch/dissect/DissectMatch.java
@@ -117,7 +117,7 @@ final class DissectMatch {
     }
 
     /**
-     * Gets all the current matches. Pass the results of this to isValid to determine if a fully successful match has occured.
+     * Gets all the current matches. Pass the results of this to isValid to determine if a fully successful match has occurred.
      *
      * @return the map of the results.
      */


### PR DESCRIPTION
Javadoc on `getResults()` in `libs/dissect/src/main/java/org/opensearch/dissect/DissectMatch.java:120` read `a fully successful match has occured`. Doc-only change.