### PR TITLE
Added support for DSL Exists query to convert in RelNode format

### DIFF
--- a/sandbox/plugins/dsl-query-executor/README.md
+++ b/sandbox/plugins/dsl-query-executor/README.md
@@ -18,6 +18,14 @@ _search request
 - `analytics-engine` — provides `QueryPlanExecutor` and `EngineContext` via Guice (declared as `extendedPlugins`)
 - `analytics-framework` — provides Calcite and shared SPI interfaces
 
+## Supported Queries
+
+| DSL Query | Calcite Representation |
+|-----------|------------------------|
+| `term` | `=($field, value)` — equality filter |
+| `match_all` | Skipped (boolean literal `TRUE`) |
+| `exists` | `IS NOT NULL($field)` — field existence check (boost not supported) |
+
 ## Running locally
 
 ```bash

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
@@ -66,19 +66,19 @@ public class DslQueryIT extends DslIntegTestBase {
 
     public void testExistsQueryWithBoostFails() {
         createTestIndex();
-        expectThrows(Exception.class, () ->
-            search(new SearchSourceBuilder().query(QueryBuilders.existsQuery("name").boost(2.0f)))
-        );
+        expectThrows(Exception.class, () -> search(new SearchSourceBuilder().query(QueryBuilders.existsQuery("name").boost(2.0f))));
     }
 
     // TODO: Enable once BooleanQueryTranslatorExists is supported
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/TODO")
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/21442")
     public void testExistsQueryWithBool() {
         createTestIndex();
-        assertOk(search(new SearchSourceBuilder().query(
-            QueryBuilders.boolQuery()
-                .must(QueryBuilders.existsQuery("name"))
-                .filter(QueryBuilders.termQuery("brand", "brandX"))
-        )));
+        assertOk(
+            search(
+                new SearchSourceBuilder().query(
+                    QueryBuilders.boolQuery().must(QueryBuilders.existsQuery("name")).filter(QueryBuilders.termQuery("brand", "brandX"))
+                )
+            )
+        );
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
@@ -58,4 +58,25 @@ public class DslQueryIT extends DslIntegTestBase {
             () -> client().search(new SearchRequest(INDEX, "test-index-2").source(new SearchSourceBuilder())).actionGet()
         );
     }
+
+    public void testExistsQuery() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.existsQuery("name"))));
+    }
+
+    public void testExistsQueryWithBoostFails() {
+        createTestIndex();
+        expectThrows(Exception.class, () ->
+            search(new SearchSourceBuilder().query(QueryBuilders.existsQuery("name").boost(2.0f)))
+        );
+    }
+
+    public void testExistsQueryWithBool() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.existsQuery("name"))
+                .filter(QueryBuilders.termQuery("brand", "brandX"))
+        )));
+    }
 }

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
@@ -71,6 +71,8 @@ public class DslQueryIT extends DslIntegTestBase {
         );
     }
 
+    // TODO: Enable once BooleanQueryTranslatorExists is supported
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/TODO")
     public void testExistsQueryWithBool() {
         createTestIndex();
         assertOk(search(new SearchSourceBuilder().query(

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/ConversionContext.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/ConversionContext.java
@@ -11,7 +11,9 @@ package org.opensearch.dsl.converter;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
 import org.opensearch.dsl.aggregation.AggregationMetadata;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
@@ -88,5 +90,35 @@ public class ConversionContext {
      */
     public ConversionContext withAggregationMetadata(AggregationMetadata metadata) {
         return new ConversionContext(searchSource, cluster, table, metadata);
+    }
+
+    /**
+     * Looks up a field by name and returns a RexNode input reference.
+     *
+     * @param fieldName the field name to look up
+     * @return a RexNode representing the field reference
+     * @throws ConversionException if the field is not found in the schema
+     */
+    public RexNode makeFieldRef(String fieldName) throws ConversionException {
+        RelDataTypeField field = getRowType().getField(fieldName, false, false);
+        if (field == null) {
+            throw new ConversionException("Field '" + fieldName + "' not found in schema");
+        }
+        return getRexBuilder().makeInputRef(field.getType(), field.getIndex());
+    }
+
+    /**
+     * Looks up a field by name and returns the field descriptor.
+     *
+     * @param fieldName the field name to look up
+     * @return the RelDataTypeField descriptor
+     * @throws ConversionException if the field is not found in the schema
+     */
+    public RelDataTypeField getField(String fieldName) throws ConversionException {
+        RelDataTypeField field = getRowType().getField(fieldName, false, false);
+        if (field == null) {
+            throw new ConversionException("Field '" + fieldName + "' not found in schema");
+        }
+        return field;
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ExistsQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ExistsQueryTranslator.java
@@ -37,12 +37,7 @@ public class ExistsQueryTranslator implements QueryTranslator {
             throw new ConversionException("boost is unsupported for Exists query type");
         }
 
-        RelDataTypeField field = ctx.getRowType().getField(fieldName, false, false);
-        if (field == null) {
-            throw new ConversionException("Field '" + fieldName + "' not found in schema");
-        }
-
-        RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
+        RexNode fieldRef = ctx.makeFieldRef(fieldName);
         return ctx.getRexBuilder().makeCall(SqlStdOperatorTable.IS_NOT_NULL, fieldRef);
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ExistsQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ExistsQueryTranslator.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.dsl.query;
 
-import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.opensearch.dsl.converter.ConversionContext;

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ExistsQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/ExistsQueryTranslator.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.ExistsQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+
+/**
+ * Converts an {@link ExistsQueryBuilder} to a Calcite IS NOT NULL RexNode.
+ */
+public class ExistsQueryTranslator implements QueryTranslator {
+
+    @Override
+    public Class<? extends QueryBuilder> getQueryType() {
+        return ExistsQueryBuilder.class;
+    }
+
+    @Override
+    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+        ExistsQueryBuilder existsQuery = (ExistsQueryBuilder) query;
+        String fieldName = existsQuery.fieldName();
+        float boost = existsQuery.boost();
+
+        if (boost != AbstractQueryBuilder.DEFAULT_BOOST) {
+            throw new ConversionException("boost is unsupported for Exists query type");
+        }
+
+        RelDataTypeField field = ctx.getRowType().getField(fieldName, false, false);
+        if (field == null) {
+            throw new ConversionException("Field '" + fieldName + "' not found in schema");
+        }
+
+        RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
+        return ctx.getRexBuilder().makeCall(SqlStdOperatorTable.IS_NOT_NULL, fieldRef);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
@@ -20,6 +20,7 @@ public class QueryRegistryFactory {
         QueryRegistry registry = new QueryRegistry();
         registry.register(new TermQueryTranslator());
         registry.register(new MatchAllQueryTranslator());
+        registry.register(new ExistsQueryTranslator());
         // TODO: add other query translators
         return registry;
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermQueryTranslator.java
@@ -36,13 +36,8 @@ public class TermQueryTranslator implements QueryTranslator {
         String fieldName = termQuery.fieldName();
         Object value = termQuery.value();
 
-        RelDataTypeField field = ctx.getRowType().getField(fieldName, false, false);
-        if (field == null) {
-            throw new ConversionException("Field '" + fieldName + "' not found in schema");
-        }
-
-        RexNode fieldRef = ctx.getRexBuilder().makeInputRef(field.getType(), field.getIndex());
-        RexNode literal = ctx.getRexBuilder().makeLiteral(value, field.getType(), true);
+        RexNode fieldRef = ctx.makeFieldRef(fieldName);
+        RexNode literal = ctx.getRexBuilder().makeLiteral(value, ctx.getField(fieldName).getType(), true);
 
         return ctx.getRexBuilder().makeCall(SqlStdOperatorTable.EQUALS, fieldRef, literal);
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/TermQueryTranslator.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.dsl.query;
 
-import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.opensearch.dsl.converter.ConversionContext;

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/ExistsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/ExistsQueryTranslatorTests.java
@@ -44,13 +44,11 @@ public class ExistsQueryTranslatorTests extends OpenSearchTestCase {
     }
 
     public void testThrowsForUnknownField() {
-        expectThrows(ConversionException.class,
-            () -> translator.convert(QueryBuilders.existsQuery("nonexistent"), ctx));
+        expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.existsQuery("nonexistent"), ctx));
     }
 
     public void testThrowsForBoost() {
-        expectThrows(ConversionException.class,
-            () -> translator.convert(QueryBuilders.existsQuery("name").boost(2.0f), ctx));
+        expectThrows(ConversionException.class, () -> translator.convert(QueryBuilders.existsQuery("name").boost(2.0f), ctx));
     }
 
     public void testReportsCorrectQueryType() {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/ExistsQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/ExistsQueryTranslatorTests.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.opensearch.dsl.TestUtils;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.ExistsQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ExistsQueryTranslatorTests extends OpenSearchTestCase {
+
+    private final ExistsQueryTranslator translator = new ExistsQueryTranslator();
+    private final ConversionContext ctx = TestUtils.createContext();
+
+    public void testConvertsExistsQueryToIsNotNull() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.existsQuery("name"), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.IS_NOT_NULL, call.getKind());
+        assertEquals(1, call.getOperands().size());
+        assertTrue(call.getOperands().get(0) instanceof RexInputRef);
+    }
+
+    public void testResolvesCorrectFieldIndex() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.existsQuery("brand"), ctx);
+
+        RexCall call = (RexCall) result;
+        RexInputRef fieldRef = (RexInputRef) call.getOperands().get(0);
+        // brand is the 3rd field (index 2) in TestUtils schema: name, price, brand, rating
+        assertEquals(2, fieldRef.getIndex());
+    }
+
+    public void testThrowsForUnknownField() {
+        expectThrows(ConversionException.class,
+            () -> translator.convert(QueryBuilders.existsQuery("nonexistent"), ctx));
+    }
+
+    public void testThrowsForBoost() {
+        expectThrows(ConversionException.class,
+            () -> translator.convert(QueryBuilders.existsQuery("name").boost(2.0f), ctx));
+    }
+
+    public void testReportsCorrectQueryType() {
+        assertEquals(ExistsQueryBuilder.class, translator.getQueryType());
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Implements the `QueryTranslator` interface to convert OpenSearch `ExistsQueryBuilder` to Calcite `IS NOT NULL` RexNode.

### 1. Created ExistsQueryTranslator
**Key Logic:**
- Extracts field name from `ExistsQueryBuilder`
- Looks up field in schema to get field index and throw exception if boost is passed with not default value or field is not passed.
- Creates `IS NOT NULL($fieldIndex)` RexNode using Calcite's `SqlStdOperatorTable.IS_NOT_NULL`

**Calcite Output:**
```
LogicalFilter(condition=[IS NOT NULL($N)])
  LogicalTableScan(table=[[index-name]])
```
### 2. Registered ExistsQueryTranslator
**File:** `src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java`

Added registration in the `create()` method:
```java
registry.register(new ExistsQueryTranslator());
```

This makes the translator available for all exists queries.

### 3. Added Integration Tests
**File:** `src/internalClusterTest/java/org/opensearch/dsl/DslLogicalPlanIntegrationIT.java`

Added three comprehensive tests.
1. Exists query test
2. Exists query with bool.
3. Exist query not supported for boost.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
NA

### Check List
- [Done ] Functionality includes testing.
- [NA ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ NA] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
