### PR TITLE
DissectMatch: fix 'occured' -> 'occurred' in Javadoc

### DIFF
--- a/libs/dissect/src/main/java/org/opensearch/dissect/DissectMatch.java
+++ b/libs/dissect/src/main/java/org/opensearch/dissect/DissectMatch.java
@@ -117,7 +117,7 @@ final class DissectMatch {
     }
 
     /**
-     * Gets all the current matches. Pass the results of this to isValid to determine if a fully successful match has occured.
+     * Gets all the current matches. Pass the results of this to isValid to determine if a fully successful match has occurred.
      *
      * @return the map of the results.
      */


### PR DESCRIPTION
### Description
Javadoc in `libs/dissect/src/main/java/org/opensearch/dissect/DissectMatch.java` line 120 reads `match has occured`. Fixed to `occurred`. Comment-only change.

### Issues Resolved
N/A — typo fix only.

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented above
- [x] Commits are signed per the DCO using `--signoff`