### PR TITLE
Make sandbox-check always succeed

### DIFF
--- a/.github/workflows/sandbox-check.yml
+++ b/.github/workflows/sandbox-check.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Run sandbox check
-        run: ./gradlew check -p sandbox -Dsandbox.enabled=true
+        run: ./gradlew check -p sandbox -Dsandbox.enabled=true || echo "Sandbox check failed, but this is informational only."
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The sandbox check does not appear to be stable yet. I don't think we want to block PRs on this check failure, but I'd like to avoid normalizing the pattern of merging PRs with failing checks. This change makes sure the sandbox check will always show as green but emit a message if it fails.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
