### PR TITLE
Adding fieldtypecapabilities changes

### DIFF
--- a/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/opensearch/index/mapper/ScaledFloatFieldMapper.java
@@ -48,6 +48,7 @@ import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.xcontent.XContentParser.Token;
 import org.opensearch.index.compositeindex.datacube.DimensionType;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.fielddata.FieldData;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.IndexNumericFieldData;
@@ -71,6 +72,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /** A {@link FieldMapper} for scaled floats. Values are internally multiplied
@@ -250,6 +252,25 @@ public class ScaledFloatFieldMapper extends ParametrizedFieldMapper {
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        /**
+         * Scaled floats use {@link FieldTypeCapabilities.Capability#POINT_RANGE} for indexing
+         * (backed by LongPoint) instead of {@link FieldTypeCapabilities.Capability#FULL_TEXT_SEARCH}.
+         */
+        @Override
+        public Set<FieldTypeCapabilities.Capability> requestedCapabilities() {
+            Set<FieldTypeCapabilities.Capability> caps = new java.util.HashSet<>();
+            if (isSearchable()) {
+                caps.add(FieldTypeCapabilities.Capability.POINT_RANGE);
+            }
+            if (hasDocValues()) {
+                caps.add(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE);
+            }
+            if (isStored()) {
+                caps.add(FieldTypeCapabilities.Capability.STORED_FIELDS);
+            }
+            return caps.isEmpty() ? Set.of() : Set.copyOf(caps);
         }
 
         @Override

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneDataFormat.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneDataFormat.java
@@ -11,18 +11,23 @@ package org.opensearch.be.lucene;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities.Capability;
 
 import java.util.Set;
 
 /**
  * {@link DataFormat} descriptor for Lucene inverted indices.
  * <p>
- * Declares support for {@code text} and {@code keyword} fields with inverted index and
- * stored field capabilities. Used by the composite engine to identify Lucene as a
- * secondary data format alongside Parquet (primary).
- * <p>
- * The priority value ({@code 50}) is lower than the primary Parquet format, ensuring
- * Lucene is treated as a secondary format in the composite engine's format ordering.
+ * Declares support for all standard OpenSearch field types with their Lucene-native capabilities:
+ * <ul>
+ *   <li>Text fields: inverted index ({@code FULL_TEXT_SEARCH}) and stored fields</li>
+ *   <li>Keyword fields: inverted index, doc values ({@code COLUMNAR_STORAGE}), and stored fields</li>
+ *   <li>Numeric fields: BKD tree ({@code POINT_RANGE}), doc values, and stored fields</li>
+ *   <li>Date fields: BKD tree, doc values, and stored fields</li>
+ *   <li>Boolean fields: inverted index, doc values, and stored fields</li>
+ *   <li>IP fields: InetAddressPoint ({@code POINT_RANGE}), doc values, and stored fields</li>
+ *   <li>Binary fields: stored fields only</li>
+ * </ul>
  *
  * @opensearch.experimental
  */
@@ -32,16 +37,65 @@ public class LuceneDataFormat extends DataFormat {
     /** The format name used to register Lucene in the {@link org.opensearch.index.engine.dataformat.DataFormatRegistry}. */
     public static final String LUCENE_FORMAT_NAME = "lucene";
 
+    /** Capabilities common to text-like fields that use inverted index. */
+    private static final Set<Capability> TEXT_CAPABILITIES = Set.of(Capability.FULL_TEXT_SEARCH, Capability.STORED_FIELDS);
+
+    /** Capabilities common to keyword fields: inverted index + doc values. */
+    private static final Set<Capability> KEYWORD_CAPABILITIES = Set.of(
+        Capability.FULL_TEXT_SEARCH,
+        Capability.COLUMNAR_STORAGE,
+        Capability.STORED_FIELDS
+    );
+
+    /** Capabilities common to numeric and date fields: BKD tree + doc values. */
+    private static final Set<Capability> NUMERIC_CAPABILITIES = Set.of(
+        Capability.POINT_RANGE,
+        Capability.COLUMNAR_STORAGE,
+        Capability.STORED_FIELDS
+    );
+
+    /** Capabilities for boolean fields: inverted index + doc values. */
+    private static final Set<Capability> BOOLEAN_CAPABILITIES = Set.of(
+        Capability.FULL_TEXT_SEARCH,
+        Capability.COLUMNAR_STORAGE,
+        Capability.STORED_FIELDS
+    );
+
+    /** Capabilities for binary fields: stored only. */
+    private static final Set<Capability> BINARY_CAPABILITIES = Set.of(Capability.STORED_FIELDS);
+
     private static final Set<FieldTypeCapabilities> SUPPORTED_FIELDS = Set.of(
-        new FieldTypeCapabilities(
-            "text",
-            Set.of(FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH, FieldTypeCapabilities.Capability.STORED_FIELDS)
-        ),
-        new FieldTypeCapabilities(
-            "keyword",
-            Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.STORED_FIELDS)
-        ),
-        new FieldTypeCapabilities("match_only_text", Set.of(FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH))
+        // Text fields — inverted index for full-text search
+        new FieldTypeCapabilities("text", TEXT_CAPABILITIES),
+        new FieldTypeCapabilities("match_only_text", Set.of(Capability.FULL_TEXT_SEARCH)),
+
+        // Keyword — inverted index + doc values (sorted set)
+        new FieldTypeCapabilities("keyword", KEYWORD_CAPABILITIES),
+
+        // Numeric fields — BKD tree + sorted numeric doc values
+        new FieldTypeCapabilities("integer", NUMERIC_CAPABILITIES),
+        new FieldTypeCapabilities("long", NUMERIC_CAPABILITIES),
+        new FieldTypeCapabilities("short", NUMERIC_CAPABILITIES),
+        new FieldTypeCapabilities("byte", NUMERIC_CAPABILITIES),
+        new FieldTypeCapabilities("float", NUMERIC_CAPABILITIES),
+        new FieldTypeCapabilities("half_float", NUMERIC_CAPABILITIES),
+        new FieldTypeCapabilities("double", NUMERIC_CAPABILITIES),
+        new FieldTypeCapabilities("unsigned_long", NUMERIC_CAPABILITIES),
+        new FieldTypeCapabilities("scaled_float", NUMERIC_CAPABILITIES),
+        new FieldTypeCapabilities("token_count", NUMERIC_CAPABILITIES),
+
+        // Date fields — LongPoint + sorted numeric doc values
+        new FieldTypeCapabilities("date", NUMERIC_CAPABILITIES),
+        new FieldTypeCapabilities("date_nanos", NUMERIC_CAPABILITIES),
+
+        // Boolean — inverted index (term query) + sorted numeric doc values
+        new FieldTypeCapabilities("boolean", BOOLEAN_CAPABILITIES),
+
+        // IP — InetAddressPoint + sorted set doc values
+        new FieldTypeCapabilities("ip", NUMERIC_CAPABILITIES),
+
+        // Binary — stored fields only
+        new FieldTypeCapabilities("binary", BINARY_CAPABILITIES)
     );
 
     /** {@inheritDoc} Returns {@code "lucene"}. */
@@ -56,7 +110,7 @@ public class LuceneDataFormat extends DataFormat {
         return 50L;
     }
 
-    /** {@inheritDoc} Returns capabilities for {@code text} and {@code keyword} fields. */
+    /** {@inheritDoc} Returns capabilities for all standard OpenSearch field types. */
     @Override
     public Set<FieldTypeCapabilities> supportedFields() {
         return SUPPORTED_FIELDS;

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngine.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngine.java
@@ -1,3 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.be.lucene.index;
 
 import org.apache.logging.log4j.LogManager;

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CapabilityBasedFieldRoutingIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CapabilityBasedFieldRoutingIT.java
@@ -1,0 +1,330 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities.Capability;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.hasItem;
+
+/**
+ * Integration tests verifying that capability maps are correctly assigned to field types
+ * when creating composite indices with pluggable data formats.
+ * <p>
+ * Each test creates an index, then inspects the actual {@link MappedFieldType#getCapabilityMap()}
+ * to verify that the right data format owns the right capabilities for each field.
+ */
+@AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/TBD - DataFormatRegistry not wired to DocumentMapper.Builder in composite path")
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 1)
+public class CapabilityBasedFieldRoutingIT extends OpenSearchIntegTestCase {
+
+    private static final String PARQUET = "parquet";
+    private static final String LUCENE = "lucene";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(ParquetDataFormatPlugin.class, CompositeDataFormatPlugin.class, LucenePlugin.class, DataFusionPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .build();
+    }
+
+    private Settings parquetOnlySettings() {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", PARQUET)
+            .putList("index.composite.secondary_data_formats")
+            .build();
+    }
+
+    private Settings parquetWithLuceneSettings() {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", PARQUET)
+            .putList("index.composite.secondary_data_formats", LUCENE)
+            .build();
+    }
+
+    /**
+     * Helper to get the capability map for a field from the index's MapperService.
+     */
+    private Map<DataFormat, Set<Capability>> getCapabilityMap(String indexName, String fieldName) {
+        // Get a data node that holds the index
+        Set<String> dataNodes = internalCluster().getDataNodeNames();
+        assertFalse("Should have at least one data node", dataNodes.isEmpty());
+        String node = dataNodes.iterator().next();
+        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, node);
+        IndexService indexService = indicesService.indexServiceSafe(resolveIndex(indexName));
+        MappedFieldType fieldType = indexService.mapperService().fieldType(fieldName);
+        assertNotNull("Field [" + fieldName + "] should exist in mapping", fieldType);
+        return fieldType.getCapabilityMap();
+    }
+
+    /**
+     * Helper to extract format names from a capability map.
+     */
+    private Set<String> formatNames(Map<DataFormat, Set<Capability>> capMap) {
+        return capMap.keySet().stream().map(DataFormat::name).collect(Collectors.toSet());
+    }
+
+    /**
+     * Helper to get capabilities owned by a specific format name.
+     */
+    private Set<Capability> capsForFormat(Map<DataFormat, Set<Capability>> capMap, String formatName) {
+        return capMap.entrySet()
+            .stream()
+            .filter(e -> e.getKey().name().equals(formatName))
+            .map(Map.Entry::getValue)
+            .findFirst()
+            .orElse(Set.of());
+    }
+
+    // ---- Parquet-only tests ----
+
+    public void testKeywordFieldParquetOnly() {
+        String idx = "test-kw-parquet";
+        createAndVerifyIndex(idx, parquetOnlySettings(), "status", "type=keyword");
+
+        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "status");
+
+        // Parquet is the only format — it should own all capabilities it supports for keyword
+        // keyword defaults: isSearchable=true (FULL_TEXT_SEARCH), hasDocValues=true (COLUMNAR_STORAGE)
+        // Parquet declares: COLUMNAR_STORAGE, BLOOM_FILTER for keyword
+        // So Parquet wins COLUMNAR_STORAGE. FULL_TEXT_SEARCH is requested but Parquet doesn't support it — no one gets it.
+        assertEquals("Only parquet should be in the map", Set.of(PARQUET), formatNames(capMap));
+        Set<Capability> parquetCaps = capsForFormat(capMap, PARQUET);
+        assertTrue("Parquet should own COLUMNAR_STORAGE", parquetCaps.contains(Capability.COLUMNAR_STORAGE));
+        assertFalse(
+            "FULL_TEXT_SEARCH should not be assigned (parquet doesn't support it)",
+            parquetCaps.contains(Capability.FULL_TEXT_SEARCH)
+        );
+    }
+
+    public void testIntegerFieldParquetOnly() {
+        String idx = "test-int-parquet";
+        createAndVerifyIndex(idx, parquetOnlySettings(), "count", "type=integer");
+
+        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "count");
+
+        // integer defaults: isSearchable=true (POINT_RANGE via override), hasDocValues=true (COLUMNAR_STORAGE)
+        // Parquet declares: COLUMNAR_STORAGE, BLOOM_FILTER for integer
+        assertEquals(Set.of(PARQUET), formatNames(capMap));
+        Set<Capability> parquetCaps = capsForFormat(capMap, PARQUET);
+        assertTrue("Parquet should own COLUMNAR_STORAGE", parquetCaps.contains(Capability.COLUMNAR_STORAGE));
+        // POINT_RANGE is requested but Parquet doesn't declare it — should not be in the map
+        assertFalse("POINT_RANGE should not be assigned", parquetCaps.contains(Capability.POINT_RANGE));
+    }
+
+    public void testDateFieldParquetOnly() {
+        String idx = "test-date-parquet";
+        createAndVerifyIndex(idx, parquetOnlySettings(), "timestamp", "type=date");
+
+        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "timestamp");
+
+        assertEquals(Set.of(PARQUET), formatNames(capMap));
+        Set<Capability> parquetCaps = capsForFormat(capMap, PARQUET);
+        assertTrue("Parquet should own COLUMNAR_STORAGE", parquetCaps.contains(Capability.COLUMNAR_STORAGE));
+        assertFalse("POINT_RANGE should not be assigned", parquetCaps.contains(Capability.POINT_RANGE));
+    }
+
+    public void testTextFieldParquetOnly() {
+        String idx = "test-text-parquet";
+        createAndVerifyIndex(idx, parquetOnlySettings(), "description", "type=text");
+
+        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "description");
+
+        // text defaults: isSearchable=true (FULL_TEXT_SEARCH), hasDocValues=false, isStored=false
+        // Parquet declares: COLUMNAR_STORAGE, BLOOM_FILTER for text — but FULL_TEXT_SEARCH is not declared
+        // requestedCapabilities = {FULL_TEXT_SEARCH} — Parquet doesn't support it, so map may be empty
+        // or Parquet gets COLUMNAR_STORAGE if it's in requested (it's not — text has no docValues)
+        // Actually: text isSearchable=true, hasDocValues=false → requested = {FULL_TEXT_SEARCH}
+        // Parquet doesn't support FULL_TEXT_SEARCH for text → empty map
+        assertTrue("Text field with parquet-only should have empty capability map (no format supports FULL_TEXT_SEARCH)", capMap.isEmpty());
+    }
+
+    // ---- Parquet + Lucene tests: verify only one format wins each capability ----
+
+    public void testKeywordFieldParquetWithLucene() {
+        String idx = "test-kw-both";
+        createAndVerifyIndex(idx, parquetWithLuceneSettings(), "status", "type=keyword");
+
+        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "status");
+
+        // keyword requested: FULL_TEXT_SEARCH (isSearchable=true), COLUMNAR_STORAGE (hasDocValues=true)
+        // Parquet (priority 0): supports COLUMNAR_STORAGE, BLOOM_FILTER
+        // Lucene (priority 50): supports COLUMNAR_STORAGE, STORED_FIELDS
+        // COLUMNAR_STORAGE: both support it, Parquet wins (lower priority)
+        // FULL_TEXT_SEARCH: only Lucene supports it for keyword? Let's check...
+        // Actually Lucene declares COLUMNAR_STORAGE + STORED_FIELDS for keyword, not FULL_TEXT_SEARCH
+        // So FULL_TEXT_SEARCH is requested but no format supports it → not assigned
+        assertThat("Parquet should be in the map", formatNames(capMap), hasItem(PARQUET));
+        Set<Capability> parquetCaps = capsForFormat(capMap, PARQUET);
+        assertTrue("Parquet should own COLUMNAR_STORAGE (lower priority wins)", parquetCaps.contains(Capability.COLUMNAR_STORAGE));
+
+        // Lucene should NOT get COLUMNAR_STORAGE since Parquet won it
+        Set<Capability> luceneCaps = capsForFormat(capMap, LUCENE);
+        assertFalse("Lucene should NOT own COLUMNAR_STORAGE (Parquet won it)", luceneCaps.contains(Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testTextFieldParquetWithLucene() {
+        String idx = "test-text-both";
+        createAndVerifyIndex(idx, parquetWithLuceneSettings(), "description", "type=text");
+
+        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "description");
+
+        // text requested: FULL_TEXT_SEARCH (isSearchable=true)
+        // Parquet: supports COLUMNAR_STORAGE, BLOOM_FILTER for text — not FULL_TEXT_SEARCH
+        // Lucene: supports FULL_TEXT_SEARCH, STORED_FIELDS for text
+        // FULL_TEXT_SEARCH → Lucene wins (only supporter)
+        assertThat("Lucene should be in the map", formatNames(capMap), hasItem(LUCENE));
+        Set<Capability> luceneCaps = capsForFormat(capMap, LUCENE);
+        assertTrue("Lucene should own FULL_TEXT_SEARCH", luceneCaps.contains(Capability.FULL_TEXT_SEARCH));
+
+        // Parquet should NOT be in the map — text doesn't request COLUMNAR_STORAGE (no docValues)
+        assertFalse("Parquet should not be in the map for text", formatNames(capMap).contains(PARQUET));
+    }
+
+    public void testIntegerFieldParquetWithLucene() {
+        String idx = "test-int-both";
+        createAndVerifyIndex(idx, parquetWithLuceneSettings(), "count", "type=integer");
+
+        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "count");
+
+        // integer requested: POINT_RANGE (isSearchable=true, override), COLUMNAR_STORAGE (hasDocValues=true)
+        // Parquet: supports COLUMNAR_STORAGE, BLOOM_FILTER for integer
+        // Lucene: does NOT declare support for integer at all
+        // COLUMNAR_STORAGE → Parquet wins
+        // POINT_RANGE → no format supports it → not assigned
+        assertEquals(Set.of(PARQUET), formatNames(capMap));
+        assertTrue("Parquet should own COLUMNAR_STORAGE", capsForFormat(capMap, PARQUET).contains(Capability.COLUMNAR_STORAGE));
+    }
+
+    // ---- Verify only one format wins when both support the same capability ----
+
+    public void testOnlyOneFormatWinsSharedCapability() {
+        String idx = "test-one-winner";
+        createAndVerifyIndex(idx, parquetWithLuceneSettings(), "tag", "type=keyword");
+
+        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "tag");
+
+        // Both Parquet and Lucene support COLUMNAR_STORAGE for keyword
+        // Parquet (priority 0) should win — verify Lucene does NOT also get it
+        for (Map.Entry<DataFormat, Set<Capability>> entry : capMap.entrySet()) {
+            if (entry.getKey().name().equals(LUCENE)) {
+                assertFalse(
+                    "Lucene should NOT own COLUMNAR_STORAGE when Parquet has higher priority",
+                    entry.getValue().contains(Capability.COLUMNAR_STORAGE)
+                );
+            }
+        }
+    }
+
+    // ---- Negative: field with index:false should NOT get FULL_TEXT_SEARCH ----
+
+    public void testFieldWithIndexFalseNoSearchCapability() {
+        String idx = "test-no-index";
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(idx)
+            .setSettings(parquetWithLuceneSettings())
+            .setMapping("tag", "type=keyword,index=false")
+            .get();
+        assertTrue(response.isAcknowledged());
+        ensureGreen(idx);
+
+        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "tag");
+
+        // keyword with index:false → requestedCapabilities = {COLUMNAR_STORAGE} (no FULL_TEXT_SEARCH)
+        for (Map.Entry<DataFormat, Set<Capability>> entry : capMap.entrySet()) {
+            assertFalse("No format should own FULL_TEXT_SEARCH when index=false", entry.getValue().contains(Capability.FULL_TEXT_SEARCH));
+        }
+        // COLUMNAR_STORAGE should still be assigned (hasDocValues defaults to true)
+        assertTrue("COLUMNAR_STORAGE should be assigned", capsForFormat(capMap, PARQUET).contains(Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testFieldWithDocValuesFalseNoColumnarCapability() {
+        String idx = "test-no-dv";
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(idx)
+            .setSettings(parquetWithLuceneSettings())
+            .setMapping("tag", "type=keyword,doc_values=false")
+            .get();
+        assertTrue(response.isAcknowledged());
+        ensureGreen(idx);
+
+        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "tag");
+
+        // keyword with doc_values:false → no COLUMNAR_STORAGE requested
+        for (Map.Entry<DataFormat, Set<Capability>> entry : capMap.entrySet()) {
+            assertFalse(
+                "No format should own COLUMNAR_STORAGE when doc_values=false",
+                entry.getValue().contains(Capability.COLUMNAR_STORAGE)
+            );
+        }
+    }
+
+    // ---- Non-composite index: capability map should be empty ----
+
+    public void testNonCompositeIndexHasEmptyCapabilityMap() {
+        String idx = "test-standard";
+        Settings standardSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .build();
+
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(idx)
+            .setSettings(standardSettings)
+            .setMapping("name", "type=keyword")
+            .get();
+        assertTrue(response.isAcknowledged());
+        ensureGreen(idx);
+
+        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "name");
+        assertTrue("Non-composite index should have empty capability map", capMap.isEmpty());
+    }
+
+    private void createAndVerifyIndex(String indexName, Settings settings, String... mapping) {
+        CreateIndexResponse response = client().admin().indices().prepareCreate(indexName).setSettings(settings).setMapping(mapping).get();
+        assertTrue("Index creation should be acknowledged", response.isAcknowledged());
+        ensureGreen(indexName);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CapabilityBasedFieldRoutingIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CapabilityBasedFieldRoutingIT.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.composite;
 
-import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.be.datafusion.DataFusionPlugin;
 import org.opensearch.be.lucene.LucenePlugin;
@@ -28,18 +27,25 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-
-import static org.hamcrest.Matchers.hasItem;
 
 /**
- * Integration tests verifying that capability maps are correctly assigned to field types
- * when creating composite indices with pluggable data formats.
+ * Integration tests verifying capability-based field routing for composite indices.
  * <p>
- * Each test creates an index, then inspects the actual {@link MappedFieldType#getCapabilityMap()}
- * to verify that the right data format owns the right capabilities for each field.
+ * Validation rule: a field's full set of requested capabilities must be served by exactly one
+ * configured data format. The system walks the index's configured formats in priority-walk order
+ * (primary first, then secondaries by priority ascending) and selects the first format whose
+ * {@code supportedFields()} declares support for every requested capability for the field's type.
+ * If no single configured format covers the full set, {@link MapperParsingException} is thrown
+ * at index creation time.
+ * <p>
+ * Each test creates an index, then either
+ * <ul>
+ *   <li>Asserts on the {@link MappedFieldType#getCapabilityMap()} structure for the covering
+ *       format, or
+ *   <li>Asserts that index creation fails with the expected message when no single format covers
+ *       the field's requested capabilities.
+ * </ul>
  */
-@AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/issues/TBD - DataFormatRegistry not wired to DocumentMapper.Builder in composite path")
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 1)
 public class CapabilityBasedFieldRoutingIT extends OpenSearchIntegTestCase {
 
@@ -85,7 +91,6 @@ public class CapabilityBasedFieldRoutingIT extends OpenSearchIntegTestCase {
      * Helper to get the capability map for a field from the index's MapperService.
      */
     private Map<DataFormat, Set<Capability>> getCapabilityMap(String indexName, String fieldName) {
-        // Get a data node that holds the index
         Set<String> dataNodes = internalCluster().getDataNodeNames();
         assertFalse("Should have at least one data node", dataNodes.isEmpty());
         String node = dataNodes.iterator().next();
@@ -97,207 +102,187 @@ public class CapabilityBasedFieldRoutingIT extends OpenSearchIntegTestCase {
     }
 
     /**
-     * Helper to extract format names from a capability map.
+     * Asserts that the capability map contains exactly one entry, owned by the named format,
+     * and that the owned capability set equals the expected set.
      */
-    private Set<String> formatNames(Map<DataFormat, Set<Capability>> capMap) {
-        return capMap.keySet().stream().map(DataFormat::name).collect(Collectors.toSet());
+    private void assertSingleFormatOwns(Map<DataFormat, Set<Capability>> capMap, String expectedFormatName, Set<Capability> expectedCaps) {
+        assertEquals("Capability map should contain exactly one format entry", 1, capMap.size());
+        DataFormat owner = capMap.keySet().iterator().next();
+        assertEquals("Capability map should be owned by [" + expectedFormatName + "]", expectedFormatName, owner.name());
+        assertEquals("Owned capabilities should match requested", expectedCaps, capMap.get(owner));
     }
+
+    // ---- Parquet-only configured: full default mapping rejected for unsupported capabilities ----
 
     /**
-     * Helper to get capabilities owned by a specific format name.
+     * Parquet supports {@code COLUMNAR_STORAGE, BLOOM_FILTER} for keyword. With default mapping
+     * ({@code index:true, doc_values:true}) the field requests {@code FULL_TEXT_SEARCH +
+     * COLUMNAR_STORAGE}. Parquet doesn't cover {@code FULL_TEXT_SEARCH} and Lucene isn't a
+     * configured secondary, so index creation must fail.
      */
-    private Set<Capability> capsForFormat(Map<DataFormat, Set<Capability>> capMap, String formatName) {
-        return capMap.entrySet()
-            .stream()
-            .filter(e -> e.getKey().name().equals(formatName))
-            .map(Map.Entry::getValue)
-            .findFirst()
-            .orElse(Set.of());
-    }
-
-    // ---- Parquet-only tests ----
-
-    public void testKeywordFieldParquetOnly() {
-        String idx = "test-kw-parquet";
-        createAndVerifyIndex(idx, parquetOnlySettings(), "status", "type=keyword");
-
-        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "status");
-
-        // Parquet is the only format — it should own all capabilities it supports for keyword
-        // keyword defaults: isSearchable=true (FULL_TEXT_SEARCH), hasDocValues=true (COLUMNAR_STORAGE)
-        // Parquet declares: COLUMNAR_STORAGE, BLOOM_FILTER for keyword
-        // So Parquet wins COLUMNAR_STORAGE. FULL_TEXT_SEARCH is requested but Parquet doesn't support it — no one gets it.
-        assertEquals("Only parquet should be in the map", Set.of(PARQUET), formatNames(capMap));
-        Set<Capability> parquetCaps = capsForFormat(capMap, PARQUET);
-        assertTrue("Parquet should own COLUMNAR_STORAGE", parquetCaps.contains(Capability.COLUMNAR_STORAGE));
-        assertFalse(
-            "FULL_TEXT_SEARCH should not be assigned (parquet doesn't support it)",
-            parquetCaps.contains(Capability.FULL_TEXT_SEARCH)
+    public void testKeywordFieldRejectedOnParquetOnly() {
+        String idx = "test-kw-parquet-rejected";
+        Exception ex = expectThrows(
+            Exception.class,
+            () -> client().admin()
+                .indices()
+                .prepareCreate(idx)
+                .setSettings(parquetOnlySettings())
+                .setMapping("status", "type=keyword")
+                .get()
+        );
+        assertTrue(
+            "expected coverage error mentioning the field, got: " + ex.getMessage(),
+            ex.getMessage().contains("status") && ex.getMessage().contains("no single configured data format")
         );
     }
 
-    public void testIntegerFieldParquetOnly() {
-        String idx = "test-int-parquet";
-        createAndVerifyIndex(idx, parquetOnlySettings(), "count", "type=integer");
-
-        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "count");
-
-        // integer defaults: isSearchable=true (POINT_RANGE via override), hasDocValues=true (COLUMNAR_STORAGE)
-        // Parquet declares: COLUMNAR_STORAGE, BLOOM_FILTER for integer
-        assertEquals(Set.of(PARQUET), formatNames(capMap));
-        Set<Capability> parquetCaps = capsForFormat(capMap, PARQUET);
-        assertTrue("Parquet should own COLUMNAR_STORAGE", parquetCaps.contains(Capability.COLUMNAR_STORAGE));
-        // POINT_RANGE is requested but Parquet doesn't declare it — should not be in the map
-        assertFalse("POINT_RANGE should not be assigned", parquetCaps.contains(Capability.POINT_RANGE));
+    /**
+     * Parquet doesn't support {@code POINT_RANGE} for integer, and Lucene isn't configured.
+     * Default integer mapping requests {@code POINT_RANGE + COLUMNAR_STORAGE}, so index creation
+     * must fail.
+     */
+    public void testIntegerFieldRejectedOnParquetOnly() {
+        String idx = "test-int-parquet-rejected";
+        Exception ex = expectThrows(
+            Exception.class,
+            () -> client().admin().indices().prepareCreate(idx).setSettings(parquetOnlySettings()).setMapping("count", "type=integer").get()
+        );
+        assertTrue(
+            "expected coverage error mentioning the field, got: " + ex.getMessage(),
+            ex.getMessage().contains("count") && ex.getMessage().contains("no single configured data format")
+        );
     }
 
-    public void testDateFieldParquetOnly() {
-        String idx = "test-date-parquet";
-        createAndVerifyIndex(idx, parquetOnlySettings(), "timestamp", "type=date");
-
-        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "timestamp");
-
-        assertEquals(Set.of(PARQUET), formatNames(capMap));
-        Set<Capability> parquetCaps = capsForFormat(capMap, PARQUET);
-        assertTrue("Parquet should own COLUMNAR_STORAGE", parquetCaps.contains(Capability.COLUMNAR_STORAGE));
-        assertFalse("POINT_RANGE should not be assigned", parquetCaps.contains(Capability.POINT_RANGE));
+    /**
+     * Parquet doesn't support {@code FULL_TEXT_SEARCH} for text. Default text mapping requests
+     * {@code FULL_TEXT_SEARCH}, so index creation must fail when only Parquet is configured.
+     */
+    public void testTextFieldRejectedOnParquetOnly() {
+        String idx = "test-text-parquet-rejected";
+        Exception ex = expectThrows(
+            Exception.class,
+            () -> client().admin()
+                .indices()
+                .prepareCreate(idx)
+                .setSettings(parquetOnlySettings())
+                .setMapping("description", "type=text")
+                .get()
+        );
+        assertTrue(
+            "expected coverage error mentioning the field, got: " + ex.getMessage(),
+            ex.getMessage().contains("description") && ex.getMessage().contains("no single configured data format")
+        );
     }
 
-    public void testTextFieldParquetOnly() {
-        String idx = "test-text-parquet";
-        createAndVerifyIndex(idx, parquetOnlySettings(), "description", "type=text");
+    // ---- Parquet-only configured: doc_values-only mappings should pass and route to Parquet ----
 
-        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "description");
+    public void testKeywordDocValuesOnlyOnParquetOnly() {
+        String idx = "test-kw-dv-parquet";
+        createAndVerifyIndex(idx, parquetOnlySettings(), "status", "type=keyword,index=false,doc_values=true");
 
-        // text defaults: isSearchable=true (FULL_TEXT_SEARCH), hasDocValues=false, isStored=false
-        // Parquet declares: COLUMNAR_STORAGE, BLOOM_FILTER for text — but FULL_TEXT_SEARCH is not declared
-        // requestedCapabilities = {FULL_TEXT_SEARCH} — Parquet doesn't support it, so map may be empty
-        // or Parquet gets COLUMNAR_STORAGE if it's in requested (it's not — text has no docValues)
-        // Actually: text isSearchable=true, hasDocValues=false → requested = {FULL_TEXT_SEARCH}
-        // Parquet doesn't support FULL_TEXT_SEARCH for text → empty map
-        assertTrue("Text field with parquet-only should have empty capability map (no format supports FULL_TEXT_SEARCH)", capMap.isEmpty());
+        assertSingleFormatOwns(getCapabilityMap(idx, "status"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
     }
 
-    // ---- Parquet + Lucene tests: verify only one format wins each capability ----
+    public void testIntegerDocValuesOnlyOnParquetOnly() {
+        String idx = "test-int-dv-parquet";
+        createAndVerifyIndex(idx, parquetOnlySettings(), "count", "type=integer,index=false,doc_values=true");
 
-    public void testKeywordFieldParquetWithLucene() {
-        String idx = "test-kw-both";
+        assertSingleFormatOwns(getCapabilityMap(idx, "count"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testDateDocValuesOnlyOnParquetOnly() {
+        String idx = "test-date-dv-parquet";
+        createAndVerifyIndex(idx, parquetOnlySettings(), "timestamp", "type=date,index=false,doc_values=true");
+
+        assertSingleFormatOwns(getCapabilityMap(idx, "timestamp"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
+    }
+
+    // ---- Parquet + Lucene configured: full mapping passes, routes to single covering format ----
+
+    /**
+     * Both formats are configured. {@code keyword} with defaults requests
+     * {@code FULL_TEXT_SEARCH + COLUMNAR_STORAGE}. Walk: Parquet (primary) doesn't cover
+     * {@code FULL_TEXT_SEARCH} → reject; Lucene covers both → wins. Single-format coverage
+     * means Lucene owns both capabilities.
+     */
+    public void testKeywordRoutedToLuceneOnParquetWithLucene() {
+        String idx = "test-kw-routed-lucene";
         createAndVerifyIndex(idx, parquetWithLuceneSettings(), "status", "type=keyword");
 
-        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "status");
-
-        // keyword requested: FULL_TEXT_SEARCH (isSearchable=true), COLUMNAR_STORAGE (hasDocValues=true)
-        // Parquet (priority 0): supports COLUMNAR_STORAGE, BLOOM_FILTER
-        // Lucene (priority 50): supports COLUMNAR_STORAGE, STORED_FIELDS
-        // COLUMNAR_STORAGE: both support it, Parquet wins (lower priority)
-        // FULL_TEXT_SEARCH: only Lucene supports it for keyword? Let's check...
-        // Actually Lucene declares COLUMNAR_STORAGE + STORED_FIELDS for keyword, not FULL_TEXT_SEARCH
-        // So FULL_TEXT_SEARCH is requested but no format supports it → not assigned
-        assertThat("Parquet should be in the map", formatNames(capMap), hasItem(PARQUET));
-        Set<Capability> parquetCaps = capsForFormat(capMap, PARQUET);
-        assertTrue("Parquet should own COLUMNAR_STORAGE (lower priority wins)", parquetCaps.contains(Capability.COLUMNAR_STORAGE));
-
-        // Lucene should NOT get COLUMNAR_STORAGE since Parquet won it
-        Set<Capability> luceneCaps = capsForFormat(capMap, LUCENE);
-        assertFalse("Lucene should NOT own COLUMNAR_STORAGE (Parquet won it)", luceneCaps.contains(Capability.COLUMNAR_STORAGE));
+        assertSingleFormatOwns(getCapabilityMap(idx, "status"), LUCENE, Set.of(Capability.FULL_TEXT_SEARCH, Capability.COLUMNAR_STORAGE));
     }
 
-    public void testTextFieldParquetWithLucene() {
-        String idx = "test-text-both";
+    /**
+     * {@code text} with defaults requests {@code FULL_TEXT_SEARCH}. Parquet doesn't cover it;
+     * Lucene does. Lucene wins.
+     */
+    public void testTextRoutedToLuceneOnParquetWithLucene() {
+        String idx = "test-text-routed-lucene";
         createAndVerifyIndex(idx, parquetWithLuceneSettings(), "description", "type=text");
 
-        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "description");
-
-        // text requested: FULL_TEXT_SEARCH (isSearchable=true)
-        // Parquet: supports COLUMNAR_STORAGE, BLOOM_FILTER for text — not FULL_TEXT_SEARCH
-        // Lucene: supports FULL_TEXT_SEARCH, STORED_FIELDS for text
-        // FULL_TEXT_SEARCH → Lucene wins (only supporter)
-        assertThat("Lucene should be in the map", formatNames(capMap), hasItem(LUCENE));
-        Set<Capability> luceneCaps = capsForFormat(capMap, LUCENE);
-        assertTrue("Lucene should own FULL_TEXT_SEARCH", luceneCaps.contains(Capability.FULL_TEXT_SEARCH));
-
-        // Parquet should NOT be in the map — text doesn't request COLUMNAR_STORAGE (no docValues)
-        assertFalse("Parquet should not be in the map for text", formatNames(capMap).contains(PARQUET));
+        assertSingleFormatOwns(getCapabilityMap(idx, "description"), LUCENE, Set.of(Capability.FULL_TEXT_SEARCH));
     }
 
-    public void testIntegerFieldParquetWithLucene() {
-        String idx = "test-int-both";
+    /**
+     * {@code integer} with defaults requests {@code POINT_RANGE + COLUMNAR_STORAGE}. Parquet
+     * doesn't cover {@code POINT_RANGE}; Lucene covers both. Lucene wins.
+     */
+    public void testIntegerRoutedToLuceneOnParquetWithLucene() {
+        String idx = "test-int-routed-lucene";
         createAndVerifyIndex(idx, parquetWithLuceneSettings(), "count", "type=integer");
 
-        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "count");
-
-        // integer requested: POINT_RANGE (isSearchable=true, override), COLUMNAR_STORAGE (hasDocValues=true)
-        // Parquet: supports COLUMNAR_STORAGE, BLOOM_FILTER for integer
-        // Lucene: does NOT declare support for integer at all
-        // COLUMNAR_STORAGE → Parquet wins
-        // POINT_RANGE → no format supports it → not assigned
-        assertEquals(Set.of(PARQUET), formatNames(capMap));
-        assertTrue("Parquet should own COLUMNAR_STORAGE", capsForFormat(capMap, PARQUET).contains(Capability.COLUMNAR_STORAGE));
+        assertSingleFormatOwns(getCapabilityMap(idx, "count"), LUCENE, Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE));
     }
 
-    // ---- Verify only one format wins when both support the same capability ----
+    // ---- Different fields can pick different formats in the same index ----
 
-    public void testOnlyOneFormatWinsSharedCapability() {
-        String idx = "test-one-winner";
-        createAndVerifyIndex(idx, parquetWithLuceneSettings(), "tag", "type=keyword");
-
-        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "tag");
-
-        // Both Parquet and Lucene support COLUMNAR_STORAGE for keyword
-        // Parquet (priority 0) should win — verify Lucene does NOT also get it
-        for (Map.Entry<DataFormat, Set<Capability>> entry : capMap.entrySet()) {
-            if (entry.getKey().name().equals(LUCENE)) {
-                assertFalse(
-                    "Lucene should NOT own COLUMNAR_STORAGE when Parquet has higher priority",
-                    entry.getValue().contains(Capability.COLUMNAR_STORAGE)
-                );
-            }
-        }
-    }
-
-    // ---- Negative: field with index:false should NOT get FULL_TEXT_SEARCH ----
-
-    public void testFieldWithIndexFalseNoSearchCapability() {
-        String idx = "test-no-index";
+    /**
+     * Verifies that within a single composite index, fields with different capability needs
+     * route to different formats: a doc_values-only field stays on Parquet (primary, lower
+     * priority), while a fully-indexed field falls through to Lucene.
+     */
+    public void testDifferentFieldsPickDifferentFormats() {
+        String idx = "test-mixed-routing";
         CreateIndexResponse response = client().admin()
             .indices()
             .prepareCreate(idx)
             .setSettings(parquetWithLuceneSettings())
-            .setMapping("tag", "type=keyword,index=false")
+            .setMapping("tag", "type=keyword,index=false,doc_values=true", "title", "type=keyword,index=true,doc_values=true")
             .get();
         assertTrue(response.isAcknowledged());
         ensureGreen(idx);
 
-        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "tag");
+        // tag → only COLUMNAR_STORAGE requested → Parquet (primary) covers → Parquet wins.
+        assertSingleFormatOwns(getCapabilityMap(idx, "tag"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
 
-        // keyword with index:false → requestedCapabilities = {COLUMNAR_STORAGE} (no FULL_TEXT_SEARCH)
-        for (Map.Entry<DataFormat, Set<Capability>> entry : capMap.entrySet()) {
-            assertFalse("No format should own FULL_TEXT_SEARCH when index=false", entry.getValue().contains(Capability.FULL_TEXT_SEARCH));
-        }
-        // COLUMNAR_STORAGE should still be assigned (hasDocValues defaults to true)
-        assertTrue("COLUMNAR_STORAGE should be assigned", capsForFormat(capMap, PARQUET).contains(Capability.COLUMNAR_STORAGE));
+        // title → FULL_TEXT_SEARCH + COLUMNAR_STORAGE requested → Parquet rejects → Lucene wins.
+        assertSingleFormatOwns(getCapabilityMap(idx, "title"), LUCENE, Set.of(Capability.FULL_TEXT_SEARCH, Capability.COLUMNAR_STORAGE));
     }
 
-    public void testFieldWithDocValuesFalseNoColumnarCapability() {
-        String idx = "test-no-dv";
-        CreateIndexResponse response = client().admin()
-            .indices()
-            .prepareCreate(idx)
-            .setSettings(parquetWithLuceneSettings())
-            .setMapping("tag", "type=keyword,doc_values=false")
-            .get();
-        assertTrue(response.isAcknowledged());
-        ensureGreen(idx);
+    /**
+     * Doc-values-only keyword on Parquet+Lucene goes to Parquet because Parquet has lower
+     * priority and covers the requested set. A field is never split — Lucene does not also
+     * appear in the capability map.
+     */
+    public void testKeywordDocValuesOnlyPicksPrimary() {
+        String idx = "test-kw-dv-primary";
+        createAndVerifyIndex(idx, parquetWithLuceneSettings(), "tag", "type=keyword,index=false,doc_values=true");
 
-        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "tag");
+        assertSingleFormatOwns(getCapabilityMap(idx, "tag"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
+    }
 
-        // keyword with doc_values:false → no COLUMNAR_STORAGE requested
-        for (Map.Entry<DataFormat, Set<Capability>> entry : capMap.entrySet()) {
-            assertFalse(
-                "No format should own COLUMNAR_STORAGE when doc_values=false",
-                entry.getValue().contains(Capability.COLUMNAR_STORAGE)
-            );
-        }
+    // ---- Negative settings: empty requested capabilities yields empty map ----
+
+    /**
+     * A field with all of {@code index:false, doc_values:false, store:false} requests no
+     * capabilities. Validation is skipped and the capability map is empty.
+     */
+    public void testEmptyRequestedCapabilitiesYieldsEmptyMap() {
+        String idx = "test-empty-caps";
+        createAndVerifyIndex(idx, parquetWithLuceneSettings(), "ignored", "type=keyword,index=false,doc_values=false,store=false");
+
+        assertTrue("Capability map should be empty when no capabilities are requested", getCapabilityMap(idx, "ignored").isEmpty());
     }
 
     // ---- Non-composite index: capability map should be empty ----
@@ -318,8 +303,7 @@ public class CapabilityBasedFieldRoutingIT extends OpenSearchIntegTestCase {
         assertTrue(response.isAcknowledged());
         ensureGreen(idx);
 
-        Map<DataFormat, Set<Capability>> capMap = getCapabilityMap(idx, "name");
-        assertTrue("Non-composite index should have empty capability map", capMap.isEmpty());
+        assertTrue("Non-composite index should have empty capability map", getCapabilityMap(idx, "name").isEmpty());
     }
 
     private void createAndVerifyIndex(String indexName, Settings settings, String... mapping) {

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FieldTypeCapabilityMatrixIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FieldTypeCapabilityMatrixIT.java
@@ -1,0 +1,421 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities.Capability;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Comprehensive matrix coverage for capability-based field routing across every user-facing
+ * field type that Parquet declares support for. Each test fixes a (field type, mapping config,
+ * composite config) cell and asserts either:
+ * <ul>
+ *   <li>The capability map after index creation contains exactly one entry, owned by the expected
+ *       format, with the expected capability set; or</li>
+ *   <li>Index creation fails with {@link org.opensearch.index.mapper.MapperParsingException}
+ *       when no single configured format covers the field's requested capabilities.</li>
+ * </ul>
+ *
+ * <p>Two composite configurations are exercised:
+ * <ul>
+ *   <li><b>Parquet-only</b>: {@code primary=parquet, secondaries=[]}. Parquet supports
+ *       {@code COLUMNAR_STORAGE, BLOOM_FILTER} for every declared field type. Any mapping
+ *       requesting {@code FULL_TEXT_SEARCH}, {@code POINT_RANGE}, or {@code STORED_FIELDS} fails.</li>
+ *   <li><b>Parquet + Lucene</b>: {@code primary=parquet, secondaries=[lucene]}. Walk: parquet first
+ *       (priority 0), then lucene (priority 50). The first format whose {@code supportedFields()}
+ *       covers the field's full requested capability set wins.</li>
+ * </ul>
+ *
+ * <p>Field types covered: text, match_only_text, keyword, integer, long, short, byte, float,
+ * half_float, double, unsigned_long, date, date_nanos, boolean, ip, binary. Skipped:
+ * {@code scaled_float} and {@code token_count} live in the {@code mapper-extras} module which is
+ * not loaded into this composite-engine test cluster.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 1)
+public class FieldTypeCapabilityMatrixIT extends OpenSearchIntegTestCase {
+
+    private static final String PARQUET = "parquet";
+    private static final String LUCENE = "lucene";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(ParquetDataFormatPlugin.class, CompositeDataFormatPlugin.class, LucenePlugin.class, DataFusionPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .build();
+    }
+
+    private Settings parquetOnly() {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", PARQUET)
+            .putList("index.composite.secondary_data_formats")
+            .build();
+    }
+
+    private Settings parquetWithLucene() {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", PARQUET)
+            .putList("index.composite.secondary_data_formats", LUCENE)
+            .build();
+    }
+
+    private Map<DataFormat, Set<Capability>> capMap(String indexName, String fieldName) {
+        Set<String> dataNodes = internalCluster().getDataNodeNames();
+        assertFalse("Should have at least one data node", dataNodes.isEmpty());
+        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, dataNodes.iterator().next());
+        IndexService indexService = indicesService.indexServiceSafe(resolveIndex(indexName));
+        MappedFieldType ft = indexService.mapperService().fieldType(fieldName);
+        assertNotNull("Field [" + fieldName + "] should exist", ft);
+        return ft.getCapabilityMap();
+    }
+
+    private void assertOwnedBy(Map<DataFormat, Set<Capability>> cm, String formatName, Set<Capability> expectedCaps) {
+        assertEquals("Capability map should contain exactly one format entry", 1, cm.size());
+        DataFormat owner = cm.keySet().iterator().next();
+        assertEquals("Capability map owner mismatch", formatName, owner.name());
+        assertEquals("Owned capability set mismatch", expectedCaps, cm.get(owner));
+    }
+
+    private void create(String idx, Settings settings, String fieldName, String typeSpec) {
+        CreateIndexResponse r = client().admin().indices().prepareCreate(idx).setSettings(settings).setMapping(fieldName, typeSpec).get();
+        assertTrue("Index creation should be acknowledged", r.isAcknowledged());
+        ensureGreen(idx);
+    }
+
+    private void expectCoverageFailure(String idx, Settings settings, String fieldName, String typeSpec) {
+        Exception ex = expectThrows(
+            Exception.class,
+            () -> client().admin().indices().prepareCreate(idx).setSettings(settings).setMapping(fieldName, typeSpec).get()
+        );
+        assertTrue(
+            "Expected coverage error mentioning [" + fieldName + "], got: " + ex.getMessage(),
+            ex.getMessage().contains(fieldName) && ex.getMessage().contains("no single configured data format")
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Text family
+    // ---------------------------------------------------------------------
+
+    public void testTextDefaultsParquetOnlyRejected() {
+        // text defaults: index=true → {FTS}. Parquet doesn't cover FTS for text.
+        expectCoverageFailure("t-text-def-po", parquetOnly(), "f", "type=text");
+    }
+
+    public void testTextDefaultsParquetWithLucene() {
+        // text defaults: {FTS}. Parquet rejects, Lucene covers → Lucene wins.
+        create("t-text-def-pwl", parquetWithLucene(), "f", "type=text");
+        assertOwnedBy(capMap("t-text-def-pwl", "f"), LUCENE, Set.of(Capability.FULL_TEXT_SEARCH));
+    }
+
+    public void testTextStoredParquetWithLucene() {
+        // text + store=true: {FTS, SF}. Lucene declares {FTS, SF} for text → covers.
+        create("t-text-st-pwl", parquetWithLucene(), "f", "type=text,store=true");
+        assertOwnedBy(capMap("t-text-st-pwl", "f"), LUCENE, Set.of(Capability.FULL_TEXT_SEARCH, Capability.STORED_FIELDS));
+    }
+
+    public void testMatchOnlyTextDefaultsParquetWithLucene() {
+        // match_only_text: index=true → {FTS}. Lucene declares {FTS} only for this type.
+        create("t-mot-def-pwl", parquetWithLucene(), "f", "type=match_only_text");
+        assertOwnedBy(capMap("t-mot-def-pwl", "f"), LUCENE, Set.of(Capability.FULL_TEXT_SEARCH));
+    }
+
+    public void testMatchOnlyTextStoreNotCovered() {
+        // match_only_text + store=true: requests {FTS, SF}. Lucene declares only {FTS} for this
+        // type (no SF), Parquet has no FTS → no single format covers → reject.
+        expectCoverageFailure("t-mot-st-pwl", parquetWithLucene(), "f", "type=match_only_text,store=true");
+    }
+
+    public void testKeywordDefaultsParquetOnlyRejected() {
+        // keyword defaults: {FTS, CS}. Parquet covers CS but not FTS.
+        expectCoverageFailure("t-kw-def-po", parquetOnly(), "f", "type=keyword");
+    }
+
+    public void testKeywordDefaultsParquetWithLucene() {
+        // keyword defaults: {FTS, CS}. Lucene declares {FTS, CS, SF} → covers.
+        create("t-kw-def-pwl", parquetWithLucene(), "f", "type=keyword");
+        assertOwnedBy(capMap("t-kw-def-pwl", "f"), LUCENE, Set.of(Capability.FULL_TEXT_SEARCH, Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testKeywordDocValuesOnlyParquetOnly() {
+        // keyword + index=false, doc_values=true: {CS}. Parquet covers.
+        create("t-kw-dv-po", parquetOnly(), "f", "type=keyword,index=false");
+        assertOwnedBy(capMap("t-kw-dv-po", "f"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testKeywordDocValuesOnlyParquetWithLucene() {
+        // Same mapping with both formats → Parquet (lower priority) wins.
+        create("t-kw-dv-pwl", parquetWithLucene(), "f", "type=keyword,index=false");
+        assertOwnedBy(capMap("t-kw-dv-pwl", "f"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testKeywordAllParquetWithLucene() {
+        // keyword + index=true, doc_values=true, store=true: {FTS, CS, SF}. Lucene covers.
+        create("t-kw-all-pwl", parquetWithLucene(), "f", "type=keyword,store=true");
+        assertOwnedBy(
+            capMap("t-kw-all-pwl", "f"),
+            LUCENE,
+            Set.of(Capability.FULL_TEXT_SEARCH, Capability.COLUMNAR_STORAGE, Capability.STORED_FIELDS)
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Numeric family — defaults route via POINT_RANGE
+    // ---------------------------------------------------------------------
+
+    public void testIntegerDefaultsParquetOnlyRejected() {
+        expectCoverageFailure("t-int-def-po", parquetOnly(), "f", "type=integer");
+    }
+
+    public void testIntegerDefaultsParquetWithLucene() {
+        create("t-int-def-pwl", parquetWithLucene(), "f", "type=integer");
+        assertOwnedBy(capMap("t-int-def-pwl", "f"), LUCENE, Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testIntegerDocValuesOnlyParquetOnly() {
+        create("t-int-dv-po", parquetOnly(), "f", "type=integer,index=false");
+        assertOwnedBy(capMap("t-int-dv-po", "f"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testLongDefaultsParquetWithLucene() {
+        create("t-long-def-pwl", parquetWithLucene(), "f", "type=long");
+        assertOwnedBy(capMap("t-long-def-pwl", "f"), LUCENE, Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testShortDefaultsParquetWithLucene() {
+        create("t-short-def-pwl", parquetWithLucene(), "f", "type=short");
+        assertOwnedBy(capMap("t-short-def-pwl", "f"), LUCENE, Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testByteDefaultsParquetWithLucene() {
+        create("t-byte-def-pwl", parquetWithLucene(), "f", "type=byte");
+        assertOwnedBy(capMap("t-byte-def-pwl", "f"), LUCENE, Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testFloatDefaultsParquetWithLucene() {
+        create("t-float-def-pwl", parquetWithLucene(), "f", "type=float");
+        assertOwnedBy(capMap("t-float-def-pwl", "f"), LUCENE, Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testHalfFloatDefaultsParquetWithLucene() {
+        create("t-hf-def-pwl", parquetWithLucene(), "f", "type=half_float");
+        assertOwnedBy(capMap("t-hf-def-pwl", "f"), LUCENE, Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testDoubleDefaultsParquetWithLucene() {
+        create("t-dbl-def-pwl", parquetWithLucene(), "f", "type=double");
+        assertOwnedBy(capMap("t-dbl-def-pwl", "f"), LUCENE, Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testUnsignedLongDefaultsParquetWithLucene() {
+        create("t-ul-def-pwl", parquetWithLucene(), "f", "type=unsigned_long");
+        assertOwnedBy(capMap("t-ul-def-pwl", "f"), LUCENE, Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testNumericDocValuesOnlyPicksParquet() {
+        // doc_values=true alone → {CS}. Parquet (primary) covers → wins for every numeric type.
+        create("t-numdv-pwl", parquetWithLucene(), "f", "type=long,index=false");
+        assertOwnedBy(capMap("t-numdv-pwl", "f"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testNumericStoredOnlyPicksLucene() {
+        // long with index=false, doc_values=false, store=true → {SF}. Parquet doesn't have SF
+        // for long; Lucene declares {PR, CS, SF} → covers.
+        create("t-numst-pwl", parquetWithLucene(), "f", "type=long,index=false,doc_values=false,store=true");
+        assertOwnedBy(capMap("t-numst-pwl", "f"), LUCENE, Set.of(Capability.STORED_FIELDS));
+    }
+
+    public void testNumericAllSettingsPicksLucene() {
+        // long with all on: {PR, CS, SF}. Parquet doesn't cover PR; Lucene covers all.
+        create("t-numall-pwl", parquetWithLucene(), "f", "type=long,store=true");
+        assertOwnedBy(
+            capMap("t-numall-pwl", "f"),
+            LUCENE,
+            Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE, Capability.STORED_FIELDS)
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Date family
+    // ---------------------------------------------------------------------
+
+    public void testDateDefaultsParquetOnlyRejected() {
+        expectCoverageFailure("t-date-def-po", parquetOnly(), "f", "type=date");
+    }
+
+    public void testDateDefaultsParquetWithLucene() {
+        create("t-date-def-pwl", parquetWithLucene(), "f", "type=date");
+        assertOwnedBy(capMap("t-date-def-pwl", "f"), LUCENE, Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testDateNanosDefaultsParquetWithLucene() {
+        create("t-dn-def-pwl", parquetWithLucene(), "f", "type=date_nanos");
+        assertOwnedBy(capMap("t-dn-def-pwl", "f"), LUCENE, Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testDateDocValuesOnlyParquetOnly() {
+        create("t-date-dv-po", parquetOnly(), "f", "type=date,index=false");
+        assertOwnedBy(capMap("t-date-dv-po", "f"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
+    }
+
+    // ---------------------------------------------------------------------
+    // Boolean
+    // ---------------------------------------------------------------------
+
+    public void testBooleanDefaultsParquetOnlyRejected() {
+        // Boolean defaults: {FTS, CS}. Parquet has no FTS for boolean.
+        expectCoverageFailure("t-bool-def-po", parquetOnly(), "f", "type=boolean");
+    }
+
+    public void testBooleanDefaultsParquetWithLucene() {
+        create("t-bool-def-pwl", parquetWithLucene(), "f", "type=boolean");
+        assertOwnedBy(capMap("t-bool-def-pwl", "f"), LUCENE, Set.of(Capability.FULL_TEXT_SEARCH, Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testBooleanDocValuesOnlyPicksParquet() {
+        create("t-bool-dv-pwl", parquetWithLucene(), "f", "type=boolean,index=false");
+        assertOwnedBy(capMap("t-bool-dv-pwl", "f"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
+    }
+
+    // ---------------------------------------------------------------------
+    // IP
+    // ---------------------------------------------------------------------
+
+    public void testIpDefaultsParquetOnlyRejected() {
+        expectCoverageFailure("t-ip-def-po", parquetOnly(), "f", "type=ip");
+    }
+
+    public void testIpDefaultsParquetWithLucene() {
+        create("t-ip-def-pwl", parquetWithLucene(), "f", "type=ip");
+        assertOwnedBy(capMap("t-ip-def-pwl", "f"), LUCENE, Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testIpDocValuesOnlyPicksParquet() {
+        create("t-ip-dv-pwl", parquetWithLucene(), "f", "type=ip,index=false");
+        assertOwnedBy(capMap("t-ip-dv-pwl", "f"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
+    }
+
+    // ---------------------------------------------------------------------
+    // Binary — index=false by default; Lucene declares only {SF}
+    // ---------------------------------------------------------------------
+
+    public void testBinaryAllOffEmptyMap() {
+        // binary defaults: index=false (forced), doc_values=false, store=false → {} requested.
+        // No validation runs; cap map stays empty.
+        create("t-bin-off-pwl", parquetWithLucene(), "f", "type=binary");
+        assertTrue("Capability map should be empty for binary with no caps", capMap("t-bin-off-pwl", "f").isEmpty());
+    }
+
+    public void testBinaryDocValuesPicksParquet() {
+        // binary + doc_values=true: {CS}. Parquet covers; Lucene declares only {SF} for binary.
+        create("t-bin-dv-pwl", parquetWithLucene(), "f", "type=binary,doc_values=true");
+        assertOwnedBy(capMap("t-bin-dv-pwl", "f"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testBinaryStorePicksLucene() {
+        // binary + store=true: {SF}. Parquet has no SF; Lucene covers.
+        create("t-bin-st-pwl", parquetWithLucene(), "f", "type=binary,store=true");
+        assertOwnedBy(capMap("t-bin-st-pwl", "f"), LUCENE, Set.of(Capability.STORED_FIELDS));
+    }
+
+    public void testBinaryDocValuesAndStoreNotCovered() {
+        // binary + doc_values=true, store=true: {CS, SF}. Parquet covers CS but not SF for binary;
+        // Lucene covers SF but not CS for binary. No single format covers both → reject.
+        expectCoverageFailure("t-bin-dvst-pwl", parquetWithLucene(), "f", "type=binary,doc_values=true,store=true");
+    }
+
+    // ---------------------------------------------------------------------
+    // Multi-field index — different fields can pick different formats
+    // ---------------------------------------------------------------------
+
+    public void testMultiFieldRoutingMixed() {
+        String idx = "t-multi-pwl";
+        CreateIndexResponse r = client().admin()
+            .indices()
+            .prepareCreate(idx)
+            .setSettings(parquetWithLucene())
+            .setMapping(
+                "tag",
+                "type=keyword,index=false,doc_values=true",
+                "title",
+                "type=keyword,index=true,doc_values=true",
+                "ts",
+                "type=date,index=true,doc_values=true",
+                "tag_dv",
+                "type=long,index=false,doc_values=true"
+            )
+            .get();
+        assertTrue(r.isAcknowledged());
+        ensureGreen(idx);
+
+        // tag → {CS} → Parquet wins.
+        assertOwnedBy(capMap(idx, "tag"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
+        // title → {FTS, CS} → Lucene wins.
+        assertOwnedBy(capMap(idx, "title"), LUCENE, Set.of(Capability.FULL_TEXT_SEARCH, Capability.COLUMNAR_STORAGE));
+        // ts → {PR, CS} → Lucene wins.
+        assertOwnedBy(capMap(idx, "ts"), LUCENE, Set.of(Capability.POINT_RANGE, Capability.COLUMNAR_STORAGE));
+        // tag_dv → {CS} on long → Parquet wins.
+        assertOwnedBy(capMap(idx, "tag_dv"), PARQUET, Set.of(Capability.COLUMNAR_STORAGE));
+    }
+
+    // ---------------------------------------------------------------------
+    // Empty requested capabilities — no validation, empty map regardless of config
+    // ---------------------------------------------------------------------
+
+    public void testKeywordAllOffEmptyMap() {
+        create("t-kw-off-pwl", parquetWithLucene(), "f", "type=keyword,index=false,doc_values=false");
+        assertTrue("Capability map should be empty when no capabilities requested", capMap("t-kw-off-pwl", "f").isEmpty());
+    }
+
+    // ---------------------------------------------------------------------
+    // Non-composite index — capability map remains empty
+    // ---------------------------------------------------------------------
+
+    public void testNonCompositeIndexEmptyMap() {
+        String idx = "t-nc";
+        Settings s = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .build();
+        CreateIndexResponse r = client().admin().indices().prepareCreate(idx).setSettings(s).setMapping("f", "type=keyword").get();
+        assertTrue(r.isAcknowledged());
+        ensureGreen(idx);
+        assertTrue("Non-composite index should have empty capability map", capMap(idx, "f").isEmpty());
+    }
+}

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -43,6 +43,7 @@ import org.opensearch.watcher.ResourceWatcherService;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -297,6 +298,41 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
             }
         }
         return Map.copyOf(descriptors);
+    }
+
+    /**
+     * Returns the data formats configured for this composite index in priority-walk order:
+     * the primary format first (regardless of its priority value), followed by secondaries sorted
+     * by {@link DataFormat#priority()} ascending. Used by capability coverage validation in
+     * {@link org.opensearch.index.mapper.Mapper.BuilderContext#assignCapabilities}.
+     *
+     * <p>Skips any format names that are missing from the registry — those are reported by
+     * other validation paths and would only confuse a coverage error here.
+     */
+    @Override
+    public List<DataFormat> getConfiguredFormats(IndexSettings indexSettings, DataFormatRegistry dataFormatRegistry) {
+        Settings settings = indexSettings.getSettings();
+        String primaryFormatName = PRIMARY_DATA_FORMAT.get(settings);
+        List<String> secondaryFormatNames = SECONDARY_DATA_FORMATS.get(settings);
+
+        List<DataFormat> configured = new ArrayList<>();
+        if (primaryFormatName != null && primaryFormatName.isEmpty() == false) {
+            DataFormat primary = dataFormatRegistry.getRegisteredFormats()
+                .stream()
+                .filter(f -> f.name().equals(primaryFormatName))
+                .findFirst()
+                .orElse(null);
+            if (primary != null) {
+                configured.add(primary);
+            }
+        }
+        secondaryFormatNames.stream()
+            .filter(name -> name != null && name.isEmpty() == false)
+            .map(name -> dataFormatRegistry.getRegisteredFormats().stream().filter(f -> f.name().equals(name)).findFirst().orElse(null))
+            .filter(f -> f != null)
+            .sorted(Comparator.comparingLong(DataFormat::priority))
+            .forEach(configured::add);
+        return List.copyOf(configured);
     }
 
     /**

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeIndexingExecutionEngine.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeIndexingExecutionEngine.java
@@ -16,7 +16,6 @@ import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.composite.merge.CompositeMerger;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.DataFormat;
-import org.opensearch.index.engine.dataformat.DataFormatPlugin;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
@@ -75,8 +74,8 @@ public class CompositeIndexingExecutionEngine implements IndexingExecutionEngine
     /**
      * Constructs a CompositeIndexingExecutionEngine by reading index settings to
      * determine the primary and secondary data formats, validating that all configured
-     * formats are registered, and creating per-format engines via the discovered
-     * {@link DataFormatPlugin} instances.
+     * formats are registered, and creating per-format engines via the data format
+     * plugin instances.
      * <p>
      * The primary engine is the authoritative format used for merge operations and
      * commit coordination. Secondary engines receive writes alongside the primary but

--- a/sandbox/plugins/parquet-data-format/benchmarks/src/main/java/org/opensearch/parquet/benchmark/VSRRotationBenchmark.java
+++ b/sandbox/plugins/parquet-data-format/benchmarks/src/main/java/org/opensearch/parquet/benchmark/VSRRotationBenchmark.java
@@ -19,6 +19,7 @@ import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.parquet.engine.ParquetDataFormat;
 import org.opensearch.parquet.fields.ArrowFieldRegistry;
 import org.opensearch.parquet.fields.ParquetField;
 import org.opensearch.parquet.memory.ArrowBufferPool;
@@ -136,7 +137,7 @@ public class VSRRotationBenchmark {
     @Benchmark
     public void benchmarkDocumentIngestion() throws IOException {
         for (int i = 0; i < totalDocuments; i++) {
-            ParquetDocumentInput doc = new ParquetDocumentInput();
+            ParquetDocumentInput doc = new ParquetDocumentInput(new ParquetDataFormat());
             for (int f = 0; f < fieldTypes.size(); f++) {
                 MappedFieldType ft = fieldTypes.get(f);
                 switch (f % 3) {

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetDataFormat.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetDataFormat.java
@@ -13,7 +13,6 @@ import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.parquet.fields.ArrowFieldRegistry;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Data format descriptor for the Parquet format.
@@ -40,18 +39,14 @@ public class ParquetDataFormat extends DataFormat {
         return 0;
     }
 
+    /**
+     * Returns the set of field type capabilities supported by the Parquet data format.
+     * Delegates to {@link ArrowFieldRegistry#getSupportedFieldCapabilities()}.
+     *
+     * @return unmodifiable set of {@link FieldTypeCapabilities}
+     */
     @Override
     public Set<FieldTypeCapabilities> supportedFields() {
-        // TODO - Override FieldRegistry to return capability for each field
-        return ArrowFieldRegistry.getRegisteredFields()
-            .keySet()
-            .stream()
-            .map(
-                type -> new FieldTypeCapabilities(
-                    type,
-                    Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER)
-                )
-            )
-            .collect(Collectors.toUnmodifiableSet());
+        return ArrowFieldRegistry.getSupportedFieldCapabilities();
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
@@ -265,7 +265,7 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
 
     @Override
     public ParquetDocumentInput newDocumentInput() {
-        return new ParquetDocumentInput();
+        return new ParquetDocumentInput(this.dataFormat);
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ArrowFieldRegistry.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ArrowFieldRegistry.java
@@ -8,13 +8,16 @@
 
 package org.opensearch.parquet.fields;
 
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.parquet.fields.plugins.CoreDataFieldPlugin;
 import org.opensearch.parquet.fields.plugins.MetadataFieldPlugin;
 import org.opensearch.parquet.fields.plugins.ParquetFieldPlugin;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * Registry mapping OpenSearch field types to their corresponding Parquet field implementations.
@@ -73,5 +76,18 @@ public final class ArrowFieldRegistry {
      */
     public static Map<String, ParquetField> getRegisteredFields() {
         return Collections.unmodifiableMap(FIELD_REGISTRY);
+    }
+
+    /**
+     * Returns the supported field type capabilities for all registered fields,
+     * querying each {@link ParquetField} for its supported capabilities.
+     *
+     * @return unmodifiable set of {@link FieldTypeCapabilities} for all registered field types
+     */
+    public static Set<FieldTypeCapabilities> getSupportedFieldCapabilities() {
+        return FIELD_REGISTRY.entrySet()
+            .stream()
+            .map(e -> new FieldTypeCapabilities(e.getKey(), e.getValue().supportedCapabilities()))
+            .collect(Collectors.toUnmodifiableSet());
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ParquetField.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/fields/ParquetField.java
@@ -10,8 +10,12 @@ package org.opensearch.parquet.fields;
 
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.parquet.vsr.ManagedVSR;
+
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * Abstract base class for Parquet field implementations that handle conversion
@@ -40,6 +44,16 @@ public abstract class ParquetField {
         assert fieldType != null : "MappedFieldType cannot be null";
         assert managedVSR != null : "ManagedVSR cannot be null";
         addToGroup(fieldType, managedVSR, parseValue);
+    }
+
+    /**
+     * Returns the set of capabilities supported by this field type.
+     * Subclasses may override to declare different capabilities.
+     *
+     * @return set of supported {@link FieldTypeCapabilities.Capability}
+     */
+    public Set<FieldTypeCapabilities.Capability> supportedCapabilities() {
+        return Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER);
     }
 
     /** Returns the Arrow type for this field. */

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetDocumentInput.java
@@ -8,7 +8,9 @@
 
 package org.opensearch.parquet.writer;
 
+import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.IdFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.SeqNoFieldMapper;
@@ -16,6 +18,9 @@ import org.opensearch.index.mapper.VersionFieldMapper;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * Document input for the Parquet data format.
@@ -29,17 +34,35 @@ import java.util.List;
  */
 public class ParquetDocumentInput implements DocumentInput<List<FieldValuePair>> {
 
+    private final DataFormat owningFormat;
     private final List<FieldValuePair> collectedFields = new ArrayList<>();
     private long rowId = -1;
     private boolean isClosed = false;
 
-    /** Creates a new ParquetDocumentInput. */
-    public ParquetDocumentInput() {}
+    /**
+     * Creates a new ParquetDocumentInput with the owning data format for capability filtering.
+     *
+     * @param owningFormat the DataFormat instance that owns this document input
+     */
+    public ParquetDocumentInput(DataFormat owningFormat) {
+        this.owningFormat = Objects.requireNonNull(owningFormat, "owningFormat must not be null");
+    }
 
     @Override
     public void addField(MappedFieldType fieldType, Object value) {
         ensureOpen();
-        collectedFields.add(new FieldValuePair(fieldType, value));
+        // Check capability map — accept only if this format owns capabilities for this field type
+        Map<DataFormat, Set<FieldTypeCapabilities.Capability>> capMap = fieldType.getCapabilityMap();
+        if (capMap.isEmpty()) {
+            // No capability map set — no format declared support for this field type, skip it
+            return;
+        }
+
+        Set<FieldTypeCapabilities.Capability> ownedCaps = capMap.get(owningFormat);
+        if (ownedCaps != null && ownedCaps.isEmpty() == false) {
+            collectedFields.add(new FieldValuePair(fieldType, value));
+        }
+        // else: silently skip — this format has no capabilities for this field type
     }
 
     @Override

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
@@ -23,6 +23,7 @@ import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.parquet.bridge.ParquetFileMetadata;
 import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.parquet.engine.ParquetDataFormat;
 import org.opensearch.parquet.memory.ArrowBufferPool;
 import org.opensearch.parquet.writer.ParquetDocumentInput;
 import org.opensearch.test.OpenSearchTestCase;
@@ -118,7 +119,7 @@ public class VSRManagerTests extends OpenSearchTestCase {
         VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 0L);
 
         NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
-        ParquetDocumentInput doc = new ParquetDocumentInput();
+        ParquetDocumentInput doc = new ParquetDocumentInput(new ParquetDataFormat());
         populateMetadataFields(doc);
         doc.addField(valField, 42);
         doc.setRowId("__row_id__", 0);

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetDocumentInputTests.java
@@ -8,20 +8,36 @@
 
 package org.opensearch.parquet.writer;
 
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.parquet.engine.ParquetDataFormat;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.opensearch.parquet.engine.ParquetIndexingEngineTests.populateMetadataFields;
 
 public class ParquetDocumentInputTests extends OpenSearchTestCase {
 
+    private static final ParquetDataFormat PARQUET_FORMAT = new ParquetDataFormat();
+
+    /**
+     * Helper to set a capability map on a field type indicating the Parquet format owns capabilities for it.
+     */
+    private static void assignParquetCapabilities(MappedFieldType ft) {
+        ft.setCapabilityMap(
+            Map.of(PARQUET_FORMAT, Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER))
+        );
+    }
+
     public void testAddFieldAndGetFinalInput() {
-        ParquetDocumentInput input = new ParquetDocumentInput();
+        ParquetDocumentInput input = new ParquetDocumentInput(PARQUET_FORMAT);
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("age", NumberFieldMapper.NumberType.INTEGER);
+        assignParquetCapabilities(ft);
         input.addField(ft, 25);
         input.setRowId("__row_id__", 0L);
         populateMetadataFields(input);
@@ -32,9 +48,11 @@ public class ParquetDocumentInputTests extends OpenSearchTestCase {
     }
 
     public void testMultipleFields() {
-        ParquetDocumentInput input = new ParquetDocumentInput();
+        ParquetDocumentInput input = new ParquetDocumentInput(PARQUET_FORMAT);
         MappedFieldType ft1 = new NumberFieldMapper.NumberFieldType("a", NumberFieldMapper.NumberType.INTEGER);
         MappedFieldType ft2 = new KeywordFieldMapper.KeywordFieldType("b");
+        assignParquetCapabilities(ft1);
+        assignParquetCapabilities(ft2);
         input.addField(ft1, 1);
         input.addField(ft2, "val");
         input.setRowId("__row_id__", 0L);
@@ -43,7 +61,7 @@ public class ParquetDocumentInputTests extends OpenSearchTestCase {
     }
 
     public void testEmptyInput() {
-        ParquetDocumentInput input = new ParquetDocumentInput();
+        ParquetDocumentInput input = new ParquetDocumentInput(PARQUET_FORMAT);
         populateMetadataFields(input);
         input.setRowId("__row_id__", 0L);
         assertEquals(4, input.getFinalInput().size());
@@ -52,25 +70,48 @@ public class ParquetDocumentInputTests extends OpenSearchTestCase {
     public void testSetRowId() {
         ParquetDocumentInput input = new ParquetDocumentInput();
         populateMetadataFields(input);
+        ParquetDocumentInput input = new ParquetDocumentInput(PARQUET_FORMAT);
         input.setRowId("_row_id", 42L);
         assertEquals(42L, input.getRowId());
     }
 
     public void testAddFieldRejectsNullFieldType() {
-        ParquetDocumentInput input = new ParquetDocumentInput();
+        ParquetDocumentInput input = new ParquetDocumentInput(PARQUET_FORMAT);
         populateMetadataFields(input);
         expectThrows(IllegalArgumentException.class, () -> input.addField(null, "ignored"));
     }
 
     public void testCloseClearsState() {
-        ParquetDocumentInput input = new ParquetDocumentInput();
+        ParquetDocumentInput input = new ParquetDocumentInput(PARQUET_FORMAT);
         populateMetadataFields(input);
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("age", NumberFieldMapper.NumberType.INTEGER);
+        assignParquetCapabilities(ft);
         input.addField(ft, 25);
         input.setRowId("__row_id__", 0L);
         assertEquals(5, input.getFinalInput().size());
 
         input.close();
         assertTrue(input.getFinalInput().isEmpty());
+    }
+
+    public void testFieldWithEmptyCapabilityMapIsSkipped() {
+        ParquetDocumentInput input = new ParquetDocumentInput(PARQUET_FORMAT);
+        populateMetadataFields(input);
+        input.setRowId("_row_id", 42L);
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("age", NumberFieldMapper.NumberType.INTEGER);
+        // No capability map set — default is empty
+        input.addField(ft, 25);
+        assertTrue("Field with empty capability map should be skipped", input.getFinalInput().isEmpty());
+    }
+
+    public void testFieldWithNoCapabilitiesForOwningFormatIsSkipped() {
+        ParquetDocumentInput input = new ParquetDocumentInput(PARQUET_FORMAT);
+        populateMetadataFields(input);
+        input.setRowId("_row_id", 42L);
+        MappedFieldType ft = new KeywordFieldMapper.KeywordFieldType("name");
+        // Set capability map that does NOT include the Parquet format
+        ft.setCapabilityMap(Map.of());
+        input.addField(ft, "value");
+        assertTrue("Field with no capabilities for owning format should be skipped", input.getFinalInput().isEmpty());
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetWriterTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetWriterTests.java
@@ -151,8 +151,55 @@ public class ParquetWriterTests extends OpenSearchTestCase {
             null
         );
 
+        ParquetDocumentInput doc = new ParquetDocumentInput(new ParquetDataFormat());
+        doc.addField(idField, 1);
+        doc.addField(nameField, "alice");
+        doc.addField(scoreField, 100L);
+        WriteResult result = writer.addDoc(doc);
+        assertTrue(result instanceof WriteResult.Success);
+        doc.close();
+        writer.flush();
+    }
+
+    public void testSingleDocumentFlush() throws Exception {
+        String filePath = createTempDir().resolve("single.parquet").toString();
+        ParquetWriter writer = new ParquetWriter(
+            filePath,
+            1L,
+            new ParquetDataFormat(),
+            schema,
+            bufferPool,
+            indexSettings,
+            threadPool,
+            null
+        );
+
+        ParquetDocumentInput doc = new ParquetDocumentInput(new ParquetDataFormat());
+        doc.addField(idField, 42);
+        doc.addField(nameField, "bob");
+        doc.addField(scoreField, 500L);
+        writer.addDoc(doc);
+        doc.close();
+
+        writer.flush();
+        assertEquals(1, RustBridge.getFileMetadata(filePath).numRows());
+    }
+
+    public void testMultipleDocumentsFlush() throws Exception {
+        String filePath = createTempDir().resolve("multi.parquet").toString();
+        ParquetWriter writer = new ParquetWriter(
+            filePath,
+            1L,
+            new ParquetDataFormat(),
+            schema,
+            bufferPool,
+            indexSettings,
+            threadPool,
+            null
+        );
+
         for (int i = 0; i < 10; i++) {
-            ParquetDocumentInput doc = new ParquetDocumentInput();
+            ParquetDocumentInput doc = new ParquetDocumentInput(new ParquetDataFormat());
             populateMetadataFields(doc);
             doc.addField(idField, i);
             doc.addField(nameField, "user_" + i);
@@ -198,7 +245,7 @@ public class ParquetWriterTests extends OpenSearchTestCase {
             null
         );
 
-        ParquetDocumentInput doc = new ParquetDocumentInput();
+        ParquetDocumentInput doc = new ParquetDocumentInput(new ParquetDataFormat());
         populateMetadataFields(doc);
         doc.addField(idField, 1);
         doc.addField(nameField, "alice");

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -297,7 +297,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 // we parse all percolator queries as they would be parsed on shard 0
                 () -> newQueryShardContext(0, null, System::currentTimeMillis, null),
                 idFieldDataEnabled,
-                scriptService
+                scriptService,
+                dataFormatRegistry
             );
             this.indexFieldData = new IndexFieldDataService(
                 indexSettings,

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatPlugin.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatPlugin.java
@@ -12,6 +12,7 @@ import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.exec.commit.Committer;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -62,6 +63,23 @@ public interface DataFormatPlugin {
         DataFormatRegistry dataFormatRegistry
     ) {
         return Map.of();
+    }
+
+    /**
+     * Returns the data formats configured for use by the given index, in priority-walk order:
+     * the primary format first (the format the index designates as authoritative), followed by
+     * any secondary formats sorted by {@link DataFormat#priority()} ascending. Used by capability
+     * coverage validation to scope checks to formats that actually participate in this index.
+     *
+     * <p>Single-format plugins return a singleton list containing their own format. Composite
+     * plugins override this to return primary + secondaries in declared/priority order.
+     *
+     * @param indexSettings      the index settings
+     * @param dataFormatRegistry the registry, used by composite plugins to resolve sub-format plugins
+     * @return ordered list of configured formats; never {@code null}
+     */
+    default List<DataFormat> getConfiguredFormats(IndexSettings indexSettings, DataFormatRegistry dataFormatRegistry) {
+        return List.of(getDataFormat());
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatRegistry.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatRegistry.java
@@ -164,6 +164,20 @@ public class DataFormatRegistry {
     }
 
     /**
+     * Returns all registered data formats sorted by {@link DataFormat#priority()} ascending
+     * (lowest priority value = highest preference). Used by capability coverage validation
+     * to walk formats in primary-first order.
+     *
+     * @return list of data formats sorted by priority ascending
+     */
+    public List<DataFormat> getRegisteredFormatsByPriority() {
+        return dataFormatPluginRegistry.keySet()
+            .stream()
+            .sorted(Comparator.comparingLong(DataFormat::priority))
+            .collect(Collectors.toList());
+    }
+
+    /**
      * Computes the capability map for a given field type name across all registered data formats.
      * Convenience overload that passes no default or requested capabilities.
      *
@@ -281,6 +295,38 @@ public class DataFormatRegistry {
             }
         }
         return Map.of();
+    }
+
+    /**
+     * Returns the data formats configured for use by the given index, in priority-walk order
+     * (primary first, then secondaries by priority ascending). Resolves the active data format
+     * plugin from index settings via the {@code pluggable_dataformat} setting and delegates to
+     * {@link DataFormatPlugin#getConfiguredFormats(IndexSettings, DataFormatRegistry)}.
+     *
+     * <p>Used by capability coverage validation in
+     * {@link org.opensearch.index.mapper.Mapper.BuilderContext#assignCapabilities} to scope
+     * checks to formats that actually participate in this index, not every format registered
+     * on the node.
+     *
+     * @param indexSettings the index settings used to determine the active data format plugin
+     * @return ordered list of configured formats, or an empty list if no pluggable data format
+     *         is configured
+     */
+    public List<DataFormat> getConfiguredFormats(IndexSettings indexSettings) {
+        String dataformatName = indexSettings.pluggableDataFormat();
+        if (dataformatName == null || dataformatName.isEmpty()) {
+            return List.of();
+        }
+        DataFormat format = dataFormats.get(dataformatName);
+        if (format == null) {
+            return List.of();
+        }
+        DataFormatPlugin plugin = dataFormatPluginRegistry.get(format);
+        if (plugin == null) {
+            return List.of();
+        }
+        List<DataFormat> configured = plugin.getConfiguredFormats(indexSettings, this);
+        return configured == null ? List.of() : List.copyOf(configured);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatRegistry.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatRegistry.java
@@ -23,12 +23,16 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import static java.util.Collections.unmodifiableSet;
 
 /**
  * Registry that holds the mapping from {@link DataFormat} to the {@link DataFormatPlugin} that provides it.
@@ -48,6 +52,11 @@ public class DataFormatRegistry {
     private final Map<String, DataFormat> dataFormats;
 
     private static final Logger logger = LogManager.getLogger(DataFormatRegistry.class);
+
+    /** All capability values, cached to avoid repeated array allocation from {@code Capability.values()}. */
+    private static final Set<FieldTypeCapabilities.Capability> ALL_CAPABILITIES = unmodifiableSet(
+        EnumSet.allOf(FieldTypeCapabilities.Capability.class)
+    );
 
     /**
      * Creates a registry by discovering all {@link DataFormatPlugin} and {@link SearchBackEndPlugin} implementations
@@ -126,11 +135,12 @@ public class DataFormatRegistry {
     }
 
     /**
-     * Returns all registered data formats that support a specific capability for a field type.
+     * Returns all registered data formats that support a specific capability for a field type,
+     * sorted by priority ascending (lowest priority value = highest preference).
      *
-     * @param fieldType the field type name
+     * @param fieldType  the field type name
      * @param capability the capability to check
-     * @return list of data formats supporting the capability for the field type
+     * @return list of data formats supporting the capability, sorted by priority
      */
     public List<DataFormat> supportsCapability(String fieldType, FieldTypeCapabilities.Capability capability) {
         return dataFormatPluginRegistry.keySet()
@@ -151,6 +161,97 @@ public class DataFormatRegistry {
      */
     public Set<DataFormat> getRegisteredFormats() {
         return Set.copyOf(dataFormatPluginRegistry.keySet());
+    }
+
+    /**
+     * Computes the capability map for a given field type name across all registered data formats.
+     * Convenience overload that passes no default or requested capabilities.
+     *
+     * @param fieldTypeName the field type name (e.g., "keyword", "long")
+     * @return an immutable capability map for this field type
+     * @see #computeCapabilityMap(String, Set, Set)
+     */
+    public Map<DataFormat, Set<FieldTypeCapabilities.Capability>> computeCapabilityMap(String fieldTypeName) {
+        return computeCapabilityMap(fieldTypeName, Set.of(), ALL_CAPABILITIES);
+    }
+
+    /**
+     * Computes the capability map for a given field type name, using the provided default
+     * capabilities as a fallback when no registered data format declares support for a capability.
+     * Considers all capabilities (no filtering by user request).
+     *
+     * @param fieldTypeName       the field type name (e.g., "keyword", "long", "_id")
+     * @param defaultCapabilities fallback capabilities for metadata fields not declared by any format
+     * @return an immutable capability map for this field type
+     * @see #computeCapabilityMap(String, Set, Set)
+     */
+    public Map<DataFormat, Set<FieldTypeCapabilities.Capability>> computeCapabilityMap(
+        String fieldTypeName,
+        Set<FieldTypeCapabilities.Capability> defaultCapabilities
+    ) {
+        // Pass all capabilities as requested — the 2-arg overload means "consider everything, with defaults as fallback"
+        return computeCapabilityMap(fieldTypeName, defaultCapabilities, ALL_CAPABILITIES);
+    }
+
+    /**
+     * Computes the capability map for a given field type name, filtered to only the capabilities
+     * that the user's mapping configuration actually requests.
+     * <p>
+     * The algorithm determines which capabilities to consider:
+     * <ul>
+     *   <li>If {@code requestedCapabilities} is non-empty, only those capabilities are considered</li>
+     *   <li>If {@code requestedCapabilities} is empty (metadata fields), {@code defaultCapabilities} are used</li>
+     *   <li>If both are empty, no capabilities are assigned</li>
+     * </ul>
+     * For each considered capability:
+     * <ol>
+     *   <li>Queries all registered formats for support via {@link #supportsCapability}</li>
+     *   <li>If at least one format supports it, the highest-priority format (lowest priority value) wins</li>
+     *   <li>If no format declares support but the capability is in {@code defaultCapabilities},
+     *       it is assigned to the highest-priority registered format (primary)</li>
+     * </ol>
+     *
+     * @param fieldTypeName         the field type name (e.g., "keyword", "long", "_id")
+     * @param defaultCapabilities   fallback capabilities for metadata fields not declared by any format
+     * @param requestedCapabilities capabilities the user's mapping requests; empty means use defaultCapabilities
+     * @return an immutable capability map for this field type
+     */
+    public Map<DataFormat, Set<FieldTypeCapabilities.Capability>> computeCapabilityMap(
+        String fieldTypeName,
+        Set<FieldTypeCapabilities.Capability> defaultCapabilities,
+        Set<FieldTypeCapabilities.Capability> requestedCapabilities
+    ) {
+        // Determine which capabilities to consider:
+        // - Callers pass the specific set of capabilities to evaluate
+        // - The 1-arg and 2-arg overloads pass all Capability.values()
+        // - The 3-arg call from assignCapabilities passes requestedCapabilities from the field type
+        // - If requestedCapabilities is empty, no capabilities are assigned (field doesn't need any)
+        if (requestedCapabilities.isEmpty()) {
+            return Map.of();
+        }
+        Set<FieldTypeCapabilities.Capability> capabilitiesToConsider = requestedCapabilities;
+
+        Map<DataFormat, Set<FieldTypeCapabilities.Capability>> result = new HashMap<>();
+
+        for (FieldTypeCapabilities.Capability capability : capabilitiesToConsider) {
+            List<DataFormat> supporters = supportsCapability(fieldTypeName, capability);
+            if (supporters.isEmpty() == false) {
+                // First match wins — list is sorted by priority ascending (lowest = highest priority)
+                result.computeIfAbsent(supporters.get(0), k -> new HashSet<>()).add(capability);
+            } else if (defaultCapabilities.contains(capability)) {
+                // No format declares support, but the field type itself declares this as a default
+                // capability. Assign to the highest-priority registered format.
+                DataFormat primary = dataFormatPluginRegistry.keySet()
+                    .stream()
+                    .min(Comparator.comparingLong(DataFormat::priority))
+                    .orElse(null);
+                if (primary != null) {
+                    result.computeIfAbsent(primary, k -> new HashSet<>()).add(capability);
+                }
+            }
+        }
+
+        return result.isEmpty() ? Map.of() : Map.copyOf(result);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DateFieldMapper.java
@@ -60,6 +60,7 @@ import org.opensearch.common.util.LocaleUtils;
 import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.index.IndexSortConfig;
 import org.opensearch.index.compositeindex.datacube.DimensionType;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.opensearch.index.fielddata.plain.SortedNumericIndexFieldData;
@@ -79,10 +80,12 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -448,6 +451,25 @@ public final class DateFieldMapper extends ParametrizedFieldMapper {
         @Override
         public String typeName() {
             return resolution.type();
+        }
+
+        /**
+         * Date fields use {@link FieldTypeCapabilities.Capability#POINT_RANGE} for indexing
+         * instead of {@link FieldTypeCapabilities.Capability#FULL_TEXT_SEARCH}.
+         */
+        @Override
+        public Set<FieldTypeCapabilities.Capability> requestedCapabilities() {
+            Set<FieldTypeCapabilities.Capability> caps = new HashSet<>();
+            if (isSearchable()) {
+                caps.add(FieldTypeCapabilities.Capability.POINT_RANGE);
+            }
+            if (hasDocValues()) {
+                caps.add(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE);
+            }
+            if (isStored()) {
+                caps.add(FieldTypeCapabilities.Capability.STORED_FIELDS);
+            }
+            return caps.isEmpty() ? Set.of() : Set.copyOf(caps);
         }
 
         public DateFormatter dateTimeFormatter() {

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
@@ -52,6 +52,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.IndexSortConfig;
 import org.opensearch.index.analysis.IndexAnalyzers;
+import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.mapper.MapperService.MergeReason;
@@ -97,8 +98,13 @@ public class DocumentMapper implements ToXContentFragment {
         }
 
         public Builder(RootObjectMapper.Builder builder, MapperService mapperService, @Nullable DataFormatRegistry dataFormatRegistry) {
-            final Settings indexSettings = mapperService.getIndexSettings().getSettings();
-            this.builderContext = new Mapper.BuilderContext(indexSettings, new ContentPath(1), dataFormatRegistry);
+            final IndexSettings is = mapperService.getIndexSettings();
+            final Settings indexSettings = is.getSettings();
+            // Resolve the index's configured data formats once at mapping build time. The list is
+            // empty when the index has no pluggable data format configured; in that case validation
+            // and capability map assignment are skipped downstream.
+            final List<DataFormat> configuredFormats = dataFormatRegistry == null ? List.of() : dataFormatRegistry.getConfiguredFormats(is);
+            this.builderContext = new Mapper.BuilderContext(indexSettings, new ContentPath(1), dataFormatRegistry, configuredFormats);
             this.rootObjectMapper = builder.build(builderContext);
 
             final DocumentMapper existingMapper = mapperService.documentMapper();
@@ -119,22 +125,23 @@ public class DocumentMapper implements ToXContentFragment {
             }
 
             // Assign capability maps to all field types during mapper building.
-            // Each field type (including metadata) participates in capability-based routing:
-            // the registry assigns each capability to the highest-priority format that supports it.
+            // Each field type (including metadata) participates in capability-based routing.
+            // Non-metadata fields go through single-format coverage validation; metadata fields
+            // use the existing per-capability priority-winner algorithm with defaults.
             if (dataFormatRegistry != null) {
                 assignCapabilitiesRecursive(rootObjectMapper, builderContext);
                 for (MetadataFieldMapper metadataMapper : metadataMappers.values()) {
-                    builderContext.assignCapabilities(metadataMapper.fieldType());
+                    builderContext.assignCapabilities(metadataMapper.fieldType(), /* isMetadataField */ true);
                 }
             }
         }
 
         /**
-         * Recursively walks the mapper tree and assigns capability maps to all field types.
+         * Recursively walks the mapper tree and assigns capability maps to all non-metadata field types.
          */
         private static void assignCapabilitiesRecursive(Mapper mapper, Mapper.BuilderContext context) {
             if (mapper instanceof FieldMapper) {
-                context.assignCapabilities(((FieldMapper) mapper).fieldType());
+                context.assignCapabilities(((FieldMapper) mapper).fieldType(), /* isMetadataField */ false);
             }
             for (Mapper child : mapper) {
                 assignCapabilitiesRecursive(child, context);

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
@@ -39,6 +39,7 @@ import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.OpenSearchGenerationException;
 import org.opensearch.Version;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.settings.Settings;
@@ -51,6 +52,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.IndexSortConfig;
 import org.opensearch.index.analysis.IndexAnalyzers;
+import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.mapper.MapperService.MergeReason;
 import org.opensearch.index.mapper.MetadataFieldMapper.TypeParser;
@@ -91,8 +93,12 @@ public class DocumentMapper implements ToXContentFragment {
         private final Mapper.BuilderContext builderContext;
 
         public Builder(RootObjectMapper.Builder builder, MapperService mapperService) {
+            this(builder, mapperService, null);
+        }
+
+        public Builder(RootObjectMapper.Builder builder, MapperService mapperService, @Nullable DataFormatRegistry dataFormatRegistry) {
             final Settings indexSettings = mapperService.getIndexSettings().getSettings();
-            this.builderContext = new Mapper.BuilderContext(indexSettings, new ContentPath(1));
+            this.builderContext = new Mapper.BuilderContext(indexSettings, new ContentPath(1), dataFormatRegistry);
             this.rootObjectMapper = builder.build(builderContext);
 
             final DocumentMapper existingMapper = mapperService.documentMapper();
@@ -110,6 +116,28 @@ public class DocumentMapper implements ToXContentFragment {
                     metadataMapper = existingMetadataMapper;
                 }
                 metadataMappers.put(metadataMapper.getClass(), metadataMapper);
+            }
+
+            // Assign capability maps to all field types during mapper building.
+            // Each field type (including metadata) participates in capability-based routing:
+            // the registry assigns each capability to the highest-priority format that supports it.
+            if (dataFormatRegistry != null) {
+                assignCapabilitiesRecursive(rootObjectMapper, builderContext);
+                for (MetadataFieldMapper metadataMapper : metadataMappers.values()) {
+                    builderContext.assignCapabilities(metadataMapper.fieldType());
+                }
+            }
+        }
+
+        /**
+         * Recursively walks the mapper tree and assigns capability maps to all field types.
+         */
+        private static void assignCapabilitiesRecursive(Mapper mapper, Mapper.BuilderContext context) {
+            if (mapper instanceof FieldMapper) {
+                context.assignCapabilities(((FieldMapper) mapper).fieldType());
+            }
+            for (Mapper child : mapper) {
+                assignCapabilitiesRecursive(child, context);
             }
         }
 

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapperParser.java
@@ -128,7 +128,7 @@ public class DocumentMapperParser {
             queryShardContextSupplier,
             null,
             scriptService,
-            dataFormatRegistry
+            Mapper.isPluggableDataFormatEnabled(mapperService.getIndexSettings().getSettings()) ? dataFormatRegistry : null
         );
     }
 
@@ -141,7 +141,7 @@ public class DocumentMapperParser {
             queryShardContextSupplier,
             dateFormatter,
             scriptService,
-            dataFormatRegistry
+            Mapper.isPluggableDataFormatEnabled(mapperService.getIndexSettings().getSettings()) ? dataFormatRegistry : null
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapperParser.java
@@ -42,6 +42,7 @@ import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.similarity.SimilarityService;
 import org.opensearch.indices.mapper.MapperRegistry;
@@ -74,6 +75,7 @@ public class DocumentMapperParser {
     private final Map<String, Mapper.TypeParser> typeParsers;
     private final Map<String, MetadataFieldMapper.TypeParser> rootTypeParsers;
     private final ScriptService scriptService;
+    private final DataFormatRegistry dataFormatRegistry;
 
     public DocumentMapperParser(
         IndexSettings indexSettings,
@@ -84,6 +86,28 @@ public class DocumentMapperParser {
         Supplier<QueryShardContext> queryShardContextSupplier,
         ScriptService scriptService
     ) {
+        this(
+            indexSettings,
+            mapperService,
+            xContentRegistry,
+            similarityService,
+            mapperRegistry,
+            queryShardContextSupplier,
+            scriptService,
+            null
+        );
+    }
+
+    public DocumentMapperParser(
+        IndexSettings indexSettings,
+        MapperService mapperService,
+        NamedXContentRegistry xContentRegistry,
+        SimilarityService similarityService,
+        MapperRegistry mapperRegistry,
+        Supplier<QueryShardContext> queryShardContextSupplier,
+        ScriptService scriptService,
+        @Nullable DataFormatRegistry dataFormatRegistry
+    ) {
         this.mapperService = mapperService;
         this.xContentRegistry = xContentRegistry;
         this.similarityService = similarityService;
@@ -92,6 +116,7 @@ public class DocumentMapperParser {
         this.typeParsers = mapperRegistry.getMapperParsers();
         this.indexVersionCreated = indexSettings.getIndexVersionCreated();
         this.rootTypeParsers = mapperRegistry.getMetadataMapperParsers();
+        this.dataFormatRegistry = dataFormatRegistry;
     }
 
     public Mapper.TypeParser.ParserContext parserContext() {
@@ -102,7 +127,8 @@ public class DocumentMapperParser {
             indexVersionCreated,
             queryShardContextSupplier,
             null,
-            scriptService
+            scriptService,
+            dataFormatRegistry
         );
     }
 
@@ -114,7 +140,8 @@ public class DocumentMapperParser {
             indexVersionCreated,
             queryShardContextSupplier,
             dateFormatter,
-            scriptService
+            scriptService,
+            dataFormatRegistry
         );
     }
 
@@ -141,7 +168,8 @@ public class DocumentMapperParser {
         // parse RootObjectMapper
         DocumentMapper.Builder docBuilder = new DocumentMapper.Builder(
             (RootObjectMapper.Builder) rootObjectTypeParser.parse(type, mapping, parserContext),
-            mapperService
+            mapperService,
+            Mapper.isPluggableDataFormatEnabled(mapperService.getIndexSettings().getSettings()) ? dataFormatRegistry : null
         );
         Iterator<Map.Entry<String, Object>> iterator = mapping.entrySet().iterator();
         // parse DocumentMapper

--- a/server/src/main/java/org/opensearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IdFieldMapper.java
@@ -47,6 +47,7 @@ import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.core.indices.breaker.CircuitBreakerService;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.opensearch.index.fielddata.IndexFieldDataCache;
@@ -69,6 +70,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -138,6 +140,11 @@ public class IdFieldMapper extends MetadataFieldMapper {
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        @Override
+        public Set<FieldTypeCapabilities.Capability> defaultCapabilities() {
+            return Set.of(FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH, FieldTypeCapabilities.Capability.STORED_FIELDS);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/IpFieldMapper.java
@@ -58,6 +58,7 @@ import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.network.InetAddresses;
 import org.opensearch.common.network.NetworkAddress;
 import org.opensearch.index.compositeindex.datacube.DimensionType;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.ScriptDocValues;
 import org.opensearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
@@ -72,9 +73,11 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -235,6 +238,25 @@ public class IpFieldMapper extends ParametrizedFieldMapper {
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        /**
+         * IP fields use {@link FieldTypeCapabilities.Capability#POINT_RANGE} for indexing
+         * (via InetAddressPoint) instead of {@link FieldTypeCapabilities.Capability#FULL_TEXT_SEARCH}.
+         */
+        @Override
+        public Set<FieldTypeCapabilities.Capability> requestedCapabilities() {
+            Set<FieldTypeCapabilities.Capability> caps = new HashSet<>();
+            if (isSearchable()) {
+                caps.add(FieldTypeCapabilities.Capability.POINT_RANGE);
+            }
+            if (hasDocValues()) {
+                caps.add(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE);
+            }
+            if (isStored()) {
+                caps.add(FieldTypeCapabilities.Capability.STORED_FIELDS);
+            }
+            return caps.isEmpty() ? Set.of() : Set.copyOf(caps);
         }
 
         private static InetAddress parse(Object value) {

--- a/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MappedFieldType.java
@@ -57,6 +57,8 @@ import org.opensearch.common.geo.ShapeRelation;
 import org.opensearch.common.time.DateMathParser;
 import org.opensearch.common.unit.Fuzziness;
 import org.opensearch.index.analysis.NamedAnalyzer;
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.query.DistanceFeatureQueryBuilder;
 import org.opensearch.index.query.IntervalMode;
@@ -69,9 +71,11 @@ import org.opensearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -92,6 +96,12 @@ public abstract class MappedFieldType {
     private float boost;
     private NamedAnalyzer indexAnalyzer;
     private boolean eagerGlobalOrdinals;
+
+    /**
+     * Capability map assigning each registered {@link DataFormat} to the set of capabilities it owns for this field type.
+     * Set once at mapping creation time, read at indexing time. Volatile for cross-thread visibility.
+     */
+    private volatile Map<DataFormat, Set<FieldTypeCapabilities.Capability>> capabilityMap = Map.of();
 
     public MappedFieldType(
         String name,
@@ -464,6 +474,71 @@ public abstract class MappedFieldType {
 
     public void setEagerGlobalOrdinals(boolean eagerGlobalOrdinals) {
         this.eagerGlobalOrdinals = eagerGlobalOrdinals;
+    }
+
+    /**
+     * Returns an unmodifiable view of the capability map for this field type.
+     * The map assigns each registered {@link DataFormat} to the set of capabilities it owns for this field type.
+     * Returns an empty map if no capability map has been set.
+     *
+     * @return an unmodifiable capability map
+     */
+    public Map<DataFormat, Set<FieldTypeCapabilities.Capability>> getCapabilityMap() {
+        return capabilityMap;
+    }
+
+    /**
+     * Sets the capability map for this field type. Stores a defensive immutable copy.
+     * Called at mapping creation time by the composite engine.
+     *
+     * @param capabilityMap the capability map to set
+     */
+    public void setCapabilityMap(Map<DataFormat, Set<FieldTypeCapabilities.Capability>> capabilityMap) {
+        this.capabilityMap = Map.copyOf(capabilityMap);
+    }
+
+    /**
+     * Returns the default set of capabilities that this field type requires.
+     * Used by the capability assignment algorithm for metadata fields whose type names
+     * are not declared in any {@link DataFormat#supportedFields()}.
+     * <p>
+     * The default implementation returns an empty set. Metadata field types should override
+     * this to declare their intrinsic storage and query needs (e.g., {@code STORED_FIELDS},
+     * {@code POINT_RANGE}).
+     *
+     * @return the default capabilities for this field type
+     */
+    public Set<FieldTypeCapabilities.Capability> defaultCapabilities() {
+        return Set.of();
+    }
+
+    /**
+     * Returns the set of capabilities that the user's mapping configuration requests for this field.
+     * Derived from the field's indexing, storage, and doc-values settings.
+     * <p>
+     * The base implementation maps:
+     * <ul>
+     *   <li>{@code isSearchable() == true} → {@link FieldTypeCapabilities.Capability#FULL_TEXT_SEARCH}</li>
+     *   <li>{@code hasDocValues() == true} → {@link FieldTypeCapabilities.Capability#COLUMNAR_STORAGE}</li>
+     *   <li>{@code isStored() == true} → {@link FieldTypeCapabilities.Capability#STORED_FIELDS}</li>
+     * </ul>
+     * Subclasses should override when the mapping between settings and capabilities differs
+     * (e.g., numeric types use {@code POINT_RANGE} instead of {@code FULL_TEXT_SEARCH} for indexing).
+     *
+     * @return the set of capabilities requested by the user's mapping configuration
+     */
+    public Set<FieldTypeCapabilities.Capability> requestedCapabilities() {
+        Set<FieldTypeCapabilities.Capability> caps = new HashSet<>();
+        if (isSearchable()) {
+            caps.add(FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH);
+        }
+        if (hasDocValues()) {
+            caps.add(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE);
+        }
+        if (isStored()) {
+            caps.add(FieldTypeCapabilities.Capability.STORED_FIELDS);
+        }
+        return caps.isEmpty() ? Set.of() : Set.copyOf(caps);
     }
 
     /** Return a {@link DocValueFormat} that can be used to display and parse

--- a/server/src/main/java/org/opensearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/Mapper.java
@@ -43,16 +43,21 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.analysis.IndexAnalyzers;
+import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.similarity.SimilarityProvider;
 import org.opensearch.script.ScriptService;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static org.opensearch.index.IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING;
 
@@ -75,16 +80,32 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
         private final ContentPath contentPath;
         @Nullable
         private final DataFormatRegistry dataFormatRegistry;
+        /**
+         * Configured data formats for this index in priority-walk order (primary first, then
+         * secondaries by priority ascending). Empty when {@link #dataFormatRegistry} is null
+         * or the index does not configure a pluggable data format.
+         */
+        private final List<DataFormat> configuredFormats;
 
         public BuilderContext(Settings indexSettings, ContentPath contentPath) {
-            this(indexSettings, contentPath, null);
+            this(indexSettings, contentPath, null, List.of());
         }
 
         public BuilderContext(Settings indexSettings, ContentPath contentPath, @Nullable DataFormatRegistry dataFormatRegistry) {
+            this(indexSettings, contentPath, dataFormatRegistry, List.of());
+        }
+
+        public BuilderContext(
+            Settings indexSettings,
+            ContentPath contentPath,
+            @Nullable DataFormatRegistry dataFormatRegistry,
+            List<DataFormat> configuredFormats
+        ) {
             Objects.requireNonNull(indexSettings, "indexSettings is required");
             this.contentPath = contentPath;
             this.indexSettings = indexSettings;
             this.dataFormatRegistry = dataFormatRegistry;
+            this.configuredFormats = configuredFormats == null ? List.of() : List.copyOf(configuredFormats);
         }
 
         public ContentPath path() {
@@ -104,25 +125,87 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
         }
 
         /**
-         * Computes and assigns the capability map on the given {@link MappedFieldType} using the
-         * {@link DataFormatRegistry}. No-op if the registry is not available (non-composite path).
-         * <p>
-         * Passes the field type's {@link MappedFieldType#defaultCapabilities()} as fallback for
-         * metadata fields, and {@link MappedFieldType#requestedCapabilities()} to filter the map
-         * to only capabilities the user's mapping configuration actually needs.
+         * Validates capability coverage and assigns the capability map on the given
+         * {@link MappedFieldType}. No-op when the {@link DataFormatRegistry} is unavailable
+         * (non-composite path).
          *
-         * @param fieldType the field type to assign capabilities to
+         * <p>For non-metadata fields with a non-empty {@link MappedFieldType#requestedCapabilities()},
+         * walks the {@link #configuredFormats} (primary first, then secondaries by priority
+         * ascending — supplied at construction time from
+         * {@link DataFormatRegistry#getConfiguredFormats(org.opensearch.index.IndexSettings)})
+         * and selects the first format whose {@code supportedFields()} declares support for every
+         * requested capability for the field's type. Throws {@link MapperParsingException} when
+         * no single configured format can cover the full set. The capability map is set to
+         * {@code { coveringFormat -> requestedCapabilities }}.
+         *
+         * <p>For metadata fields, falls back to
+         * {@link DataFormatRegistry#computeCapabilityMap(String, Set, Set)} so the existing
+         * metadata routing behavior (per-capability priority winner with defaults) is preserved.
+         *
+         * <p>For non-metadata fields with an empty requested capability set, sets an empty map
+         * without running coverage validation.
+         *
+         * @param fieldType       the field type to validate and assign
+         * @param isMetadataField whether the field is a metadata field; metadata bypasses
+         *                        coverage validation
          */
-        public void assignCapabilities(MappedFieldType fieldType) {
-            if (dataFormatRegistry != null) {
-                fieldType.setCapabilityMap(
-                    dataFormatRegistry.computeCapabilityMap(
-                        fieldType.typeName(),
-                        fieldType.defaultCapabilities(),
-                        fieldType.requestedCapabilities()
-                    )
-                );
+        public void assignCapabilities(MappedFieldType fieldType, boolean isMetadataField) {
+            if (dataFormatRegistry == null) {
+                return;
             }
+            Set<FieldTypeCapabilities.Capability> requested = fieldType.requestedCapabilities();
+
+            if (isMetadataField) {
+                fieldType.setCapabilityMap(
+                    dataFormatRegistry.computeCapabilityMap(fieldType.typeName(), fieldType.defaultCapabilities(), requested)
+                );
+                return;
+            }
+
+            if (requested.isEmpty()) {
+                fieldType.setCapabilityMap(Map.of());
+                return;
+            }
+
+            if (configuredFormats.isEmpty()) {
+                // Registry is available but no formats are configured for this index (e.g.,
+                // pluggable data format flag enabled but no plugin name set). Treat as no-op
+                // so misconfigurations surface elsewhere rather than as a per-field validation
+                // error.
+                fieldType.setCapabilityMap(Map.of());
+                return;
+            }
+
+            for (DataFormat format : configuredFormats) {
+                if (formatCovers(format, fieldType.typeName(), requested)) {
+                    fieldType.setCapabilityMap(Map.of(format, Set.copyOf(requested)));
+                    return;
+                }
+            }
+
+            throw new MapperParsingException(
+                "Field ["
+                    + fieldType.name()
+                    + "] of type ["
+                    + fieldType.typeName()
+                    + "] requires capabilities "
+                    + requested
+                    + " but no single configured data format covers all of them. Configured formats: "
+                    + configuredFormats.stream().map(DataFormat::name).collect(Collectors.toList())
+            );
+        }
+
+        /**
+         * Returns whether the given format declares support for every required capability for
+         * the given field type name.
+         */
+        private static boolean formatCovers(DataFormat format, String typeName, Set<FieldTypeCapabilities.Capability> required) {
+            return format.supportedFields()
+                .stream()
+                .filter(ftc -> ftc.fieldType().equals(typeName))
+                .findFirst()
+                .map(ftc -> ftc.capabilities().containsAll(required))
+                .orElse(false);
         }
 
         public Version indexCreatedVersion() {

--- a/server/src/main/java/org/opensearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/Mapper.java
@@ -43,6 +43,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.analysis.IndexAnalyzers;
+import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.similarity.SimilarityProvider;
 import org.opensearch.script.ScriptService;
@@ -72,11 +73,18 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
     public static class BuilderContext {
         private final Settings indexSettings;
         private final ContentPath contentPath;
+        @Nullable
+        private final DataFormatRegistry dataFormatRegistry;
 
         public BuilderContext(Settings indexSettings, ContentPath contentPath) {
+            this(indexSettings, contentPath, null);
+        }
+
+        public BuilderContext(Settings indexSettings, ContentPath contentPath, @Nullable DataFormatRegistry dataFormatRegistry) {
             Objects.requireNonNull(indexSettings, "indexSettings is required");
             this.contentPath = contentPath;
             this.indexSettings = indexSettings;
+            this.dataFormatRegistry = dataFormatRegistry;
         }
 
         public ContentPath path() {
@@ -85,6 +93,36 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
         public Settings indexSettings() {
             return this.indexSettings;
+        }
+
+        /**
+         * Returns the data format registry, or {@code null} if pluggable data formats are not enabled.
+         */
+        @Nullable
+        public DataFormatRegistry dataFormatRegistry() {
+            return dataFormatRegistry;
+        }
+
+        /**
+         * Computes and assigns the capability map on the given {@link MappedFieldType} using the
+         * {@link DataFormatRegistry}. No-op if the registry is not available (non-composite path).
+         * <p>
+         * Passes the field type's {@link MappedFieldType#defaultCapabilities()} as fallback for
+         * metadata fields, and {@link MappedFieldType#requestedCapabilities()} to filter the map
+         * to only capabilities the user's mapping configuration actually needs.
+         *
+         * @param fieldType the field type to assign capabilities to
+         */
+        public void assignCapabilities(MappedFieldType fieldType) {
+            if (dataFormatRegistry != null) {
+                fieldType.setCapabilityMap(
+                    dataFormatRegistry.computeCapabilityMap(
+                        fieldType.typeName(),
+                        fieldType.defaultCapabilities(),
+                        fieldType.requestedCapabilities()
+                    )
+                );
+            }
         }
 
         public Version indexCreatedVersion() {
@@ -154,6 +192,8 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
             private final ScriptService scriptService;
 
+            private final DataFormatRegistry dataFormatRegistry;
+
             public ParserContext(
                 Function<String, SimilarityProvider> similarityLookupService,
                 MapperService mapperService,
@@ -163,6 +203,28 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 DateFormatter dateFormatter,
                 ScriptService scriptService
             ) {
+                this(
+                    similarityLookupService,
+                    mapperService,
+                    typeParsers,
+                    indexVersionCreated,
+                    queryShardContextSupplier,
+                    dateFormatter,
+                    scriptService,
+                    null
+                );
+            }
+
+            public ParserContext(
+                Function<String, SimilarityProvider> similarityLookupService,
+                MapperService mapperService,
+                Function<String, TypeParser> typeParsers,
+                Version indexVersionCreated,
+                Supplier<QueryShardContext> queryShardContextSupplier,
+                DateFormatter dateFormatter,
+                ScriptService scriptService,
+                @Nullable DataFormatRegistry dataFormatRegistry
+            ) {
                 this.similarityLookupService = similarityLookupService;
                 this.mapperService = mapperService;
                 this.typeParsers = typeParsers;
@@ -170,6 +232,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 this.queryShardContextSupplier = queryShardContextSupplier;
                 this.dateFormatter = dateFormatter;
                 this.scriptService = scriptService;
+                this.dataFormatRegistry = dataFormatRegistry;
             }
 
             public IndexAnalyzers getIndexAnalyzers() {
@@ -228,6 +291,15 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                 return scriptService;
             }
 
+            /**
+             * Returns the DataFormatRegistry, or null if not available.
+             * Only non-null when pluggable data format is enabled.
+             */
+            @Nullable
+            public DataFormatRegistry dataFormatRegistry() {
+                return dataFormatRegistry;
+            }
+
             public ParserContext createMultiFieldContext(ParserContext in) {
                 return new MultiFieldParserContext(in);
             }
@@ -246,7 +318,8 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
                         in.indexVersionCreated(),
                         in.queryShardContextSupplier(),
                         in.getDateFormatter(),
-                        in.scriptService()
+                        in.scriptService(),
+                        in.dataFormatRegistry()
                     );
                 }
 

--- a/server/src/main/java/org/opensearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MapperService.java
@@ -38,6 +38,7 @@ import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.logging.DeprecationLogger;
@@ -63,6 +64,7 @@ import org.opensearch.index.analysis.NamedAnalyzer;
 import org.opensearch.index.analysis.ReloadableCustomAnalyzer;
 import org.opensearch.index.analysis.TokenFilterFactory;
 import org.opensearch.index.analysis.TokenizerFactory;
+import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.mapper.Mapper.BuilderContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.similarity.SimilarityService;
@@ -262,6 +264,30 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         BooleanSupplier idFieldDataEnabled,
         ScriptService scriptService
     ) {
+        this(
+            indexSettings,
+            indexAnalyzers,
+            xContentRegistry,
+            similarityService,
+            mapperRegistry,
+            queryShardContextSupplier,
+            idFieldDataEnabled,
+            scriptService,
+            null
+        );
+    }
+
+    public MapperService(
+        IndexSettings indexSettings,
+        IndexAnalyzers indexAnalyzers,
+        NamedXContentRegistry xContentRegistry,
+        SimilarityService similarityService,
+        MapperRegistry mapperRegistry,
+        Supplier<QueryShardContext> queryShardContextSupplier,
+        BooleanSupplier idFieldDataEnabled,
+        ScriptService scriptService,
+        @Nullable DataFormatRegistry dataFormatRegistry
+    ) {
         super(indexSettings);
 
         this.indexVersionCreated = indexSettings.getIndexVersionCreated();
@@ -273,7 +299,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             similarityService,
             mapperRegistry,
             queryShardContextSupplier,
-            scriptService
+            scriptService,
+            dataFormatRegistry
         );
         this.indexAnalyzer = new MapperAnalyzerWrapper(indexAnalyzers.getDefaultIndexAnalyzer(), MappedFieldType::indexAnalyzer);
         this.searchAnalyzer = new MapperAnalyzerWrapper(

--- a/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java
@@ -63,6 +63,7 @@ import org.opensearch.core.xcontent.XContentParser.Token;
 import org.opensearch.index.compositeindex.datacube.DimensionType;
 import org.opensearch.index.document.SortedUnsignedLongDocValuesRangeQuery;
 import org.opensearch.index.document.SortedUnsignedLongDocValuesSetQuery;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.opensearch.index.fielddata.plain.SortedNumericIndexFieldData;
@@ -86,10 +87,12 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -1974,6 +1977,25 @@ public class NumberFieldMapper extends ParametrizedFieldMapper {
 
         public NumberType numberType() {
             return type;
+        }
+
+        /**
+         * Numeric fields use {@link FieldTypeCapabilities.Capability#POINT_RANGE} for indexing
+         * instead of {@link FieldTypeCapabilities.Capability#FULL_TEXT_SEARCH}.
+         */
+        @Override
+        public Set<FieldTypeCapabilities.Capability> requestedCapabilities() {
+            Set<FieldTypeCapabilities.Capability> caps = new HashSet<>();
+            if (isSearchable()) {
+                caps.add(FieldTypeCapabilities.Capability.POINT_RANGE);
+            }
+            if (hasDocValues()) {
+                caps.add(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE);
+            }
+            if (isStored()) {
+                caps.add(FieldTypeCapabilities.Capability.STORED_FIELDS);
+            }
+            return caps.isEmpty() ? Set.of() : Set.copyOf(caps);
         }
 
         public NumericType numericType() {

--- a/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
@@ -47,6 +47,9 @@ import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeIndexSettings;
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DataFormatRegistry;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MapperService.MergeReason;
 
 import java.io.IOException;
@@ -59,6 +62,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Field mapper for object field types
@@ -634,6 +638,8 @@ public class ObjectMapper extends Mapper implements Cloneable {
                     if (Boolean.TRUE.equals(objBuilder.disableObjects.value())) {
                         // Use the full field name as-is without splitting
                         Mapper.Builder<?> fieldBuilder = typeParser.parse(fieldName, propNode, parserContext);
+                        // Validate field type is supported by at least one registered data format
+                        validateFieldTypeSupported(type, fieldName, propNode, parserContext);
                         objBuilder.add(fieldBuilder);
                     } else {
                         // Standard behavior: split dotted names and create intermediate object mappers
@@ -644,6 +650,8 @@ public class ObjectMapper extends Mapper implements Cloneable {
                         }
                         String realFieldName = fieldNameParts[fieldNameParts.length - 1];
                         Mapper.Builder<?> fieldBuilder = typeParser.parse(realFieldName, propNode, parserContext);
+                        // Validate field type is supported by at least one registered data format
+                        validateFieldTypeSupported(type, fieldName, propNode, parserContext);
                         for (int i = fieldNameParts.length - 2; i >= 0; --i) {
                             ObjectMapper.Builder<?> intermediate = new ObjectMapper.Builder<>(fieldNameParts[i]);
                             intermediate.add(fieldBuilder);
@@ -669,6 +677,126 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 "DocType mapping definition has unsupported parameters: "
             );
 
+        }
+
+        /**
+         * Validates that the given field type's requested capabilities are supported by at least one
+         * registered data format when pluggable data format is enabled. Derives the required capabilities
+         * from the raw property map and verifies each is supported by at least one format.
+         * <p>
+         * Capability mapping from field configuration:
+         * <ul>
+         *   <li>{@code index: true} → requires {@code FULL_TEXT_SEARCH} or {@code POINT_RANGE}</li>
+         *   <li>{@code doc_values: true} → requires {@code COLUMNAR_STORAGE}</li>
+         *   <li>{@code store: true} → requires {@code STORED_FIELDS}</li>
+         * </ul>
+         * Skips validation when pluggable data format is not enabled.
+         */
+        private static void validateFieldTypeSupported(
+            String type,
+            String fieldName,
+            Map<String, Object> propNode,
+            ParserContext parserContext
+        ) {
+            DataFormatRegistry registry = parserContext.dataFormatRegistry();
+            if (registry == null) {
+                return;
+            }
+
+            // First check: at least one format must support this field type at all
+            boolean typeSupported = registry.getRegisteredFormats()
+                .stream()
+                .anyMatch(format -> format.supportedFields().stream().anyMatch(ftc -> ftc.fieldType().equals(type)));
+            if (typeSupported == false) {
+                throw new MapperParsingException(
+                    "Field ["
+                        + fieldName
+                        + "] of type ["
+                        + type
+                        + "] is not supported by any registered data format "
+                        + registry.getRegisteredFormats().stream().map(DataFormat::name).collect(Collectors.toList())
+                );
+            }
+
+            // Second check: validate each requested capability is supported.
+            // For index/doc_values/store, check both explicit settings and defaults.
+            // Most field types default to index:true and doc_values:true, so we must
+            // validate even when the property is not explicitly set.
+            boolean isIndexed = isPropertyTrueOrAbsent(propNode, "index", true);
+            boolean hasDocValues = isPropertyTrueOrAbsent(propNode, "doc_values", true);
+            boolean isStored = isPropertyTrue(propNode, "store");
+
+            if (isIndexed) {
+                boolean hasIndexSupport = registry.supportsCapability(type, FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH)
+                    .isEmpty() == false
+                    || registry.supportsCapability(type, FieldTypeCapabilities.Capability.POINT_RANGE).isEmpty() == false;
+                if (hasIndexSupport == false) {
+                    throw new MapperParsingException(
+                        "Field ["
+                            + fieldName
+                            + "] of type ["
+                            + type
+                            + "] has [index: true] but no registered data format supports "
+                            + "FULL_TEXT_SEARCH or POINT_RANGE for this type"
+                    );
+                }
+            }
+
+            if (hasDocValues) {
+                if (registry.supportsCapability(type, FieldTypeCapabilities.Capability.COLUMNAR_STORAGE).isEmpty()) {
+                    throw new MapperParsingException(
+                        "Field ["
+                            + fieldName
+                            + "] of type ["
+                            + type
+                            + "] has [doc_values: true] but no registered data format supports "
+                            + "COLUMNAR_STORAGE for this type"
+                    );
+                }
+            }
+
+            if (isStored) {
+                if (registry.supportsCapability(type, FieldTypeCapabilities.Capability.STORED_FIELDS).isEmpty()) {
+                    throw new MapperParsingException(
+                        "Field ["
+                            + fieldName
+                            + "] of type ["
+                            + type
+                            + "] has [store: true] but no registered data format supports "
+                            + "STORED_FIELDS for this type"
+                    );
+                }
+            }
+        }
+
+        /**
+         * Returns true if the given property is explicitly set to true in the property map.
+         * Returns false if the property is absent, null, or set to false.
+         */
+        private static boolean isPropertyTrue(Map<String, Object> propNode, String property) {
+            Object value = propNode.get(property);
+            if (value == null) {
+                return false;
+            }
+            if (value instanceof Boolean) {
+                return (Boolean) value;
+            }
+            return Boolean.parseBoolean(value.toString());
+        }
+
+        /**
+         * Returns true if the given property is explicitly set to true, or if absent, returns the default.
+         * This handles the common case where field types default to index:true / doc_values:true.
+         */
+        private static boolean isPropertyTrueOrAbsent(Map<String, Object> propNode, String property, boolean defaultValue) {
+            Object value = propNode.get(property);
+            if (value == null) {
+                return defaultValue;
+            }
+            if (value instanceof Boolean) {
+                return (Boolean) value;
+            }
+            return Boolean.parseBoolean(value.toString());
         }
 
     }

--- a/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
@@ -47,9 +47,6 @@ import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.compositeindex.datacube.startree.StarTreeIndexSettings;
-import org.opensearch.index.engine.dataformat.DataFormat;
-import org.opensearch.index.engine.dataformat.DataFormatRegistry;
-import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.MapperService.MergeReason;
 
 import java.io.IOException;
@@ -62,7 +59,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Field mapper for object field types
@@ -638,8 +634,6 @@ public class ObjectMapper extends Mapper implements Cloneable {
                     if (Boolean.TRUE.equals(objBuilder.disableObjects.value())) {
                         // Use the full field name as-is without splitting
                         Mapper.Builder<?> fieldBuilder = typeParser.parse(fieldName, propNode, parserContext);
-                        // Validate field type is supported by at least one registered data format
-                        validateFieldTypeSupported(type, fieldName, propNode, parserContext);
                         objBuilder.add(fieldBuilder);
                     } else {
                         // Standard behavior: split dotted names and create intermediate object mappers
@@ -650,8 +644,6 @@ public class ObjectMapper extends Mapper implements Cloneable {
                         }
                         String realFieldName = fieldNameParts[fieldNameParts.length - 1];
                         Mapper.Builder<?> fieldBuilder = typeParser.parse(realFieldName, propNode, parserContext);
-                        // Validate field type is supported by at least one registered data format
-                        validateFieldTypeSupported(type, fieldName, propNode, parserContext);
                         for (int i = fieldNameParts.length - 2; i >= 0; --i) {
                             ObjectMapper.Builder<?> intermediate = new ObjectMapper.Builder<>(fieldNameParts[i]);
                             intermediate.add(fieldBuilder);
@@ -677,126 +669,6 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 "DocType mapping definition has unsupported parameters: "
             );
 
-        }
-
-        /**
-         * Validates that the given field type's requested capabilities are supported by at least one
-         * registered data format when pluggable data format is enabled. Derives the required capabilities
-         * from the raw property map and verifies each is supported by at least one format.
-         * <p>
-         * Capability mapping from field configuration:
-         * <ul>
-         *   <li>{@code index: true} → requires {@code FULL_TEXT_SEARCH} or {@code POINT_RANGE}</li>
-         *   <li>{@code doc_values: true} → requires {@code COLUMNAR_STORAGE}</li>
-         *   <li>{@code store: true} → requires {@code STORED_FIELDS}</li>
-         * </ul>
-         * Skips validation when pluggable data format is not enabled.
-         */
-        private static void validateFieldTypeSupported(
-            String type,
-            String fieldName,
-            Map<String, Object> propNode,
-            ParserContext parserContext
-        ) {
-            DataFormatRegistry registry = parserContext.dataFormatRegistry();
-            if (registry == null) {
-                return;
-            }
-
-            // First check: at least one format must support this field type at all
-            boolean typeSupported = registry.getRegisteredFormats()
-                .stream()
-                .anyMatch(format -> format.supportedFields().stream().anyMatch(ftc -> ftc.fieldType().equals(type)));
-            if (typeSupported == false) {
-                throw new MapperParsingException(
-                    "Field ["
-                        + fieldName
-                        + "] of type ["
-                        + type
-                        + "] is not supported by any registered data format "
-                        + registry.getRegisteredFormats().stream().map(DataFormat::name).collect(Collectors.toList())
-                );
-            }
-
-            // Second check: validate each requested capability is supported.
-            // For index/doc_values/store, check both explicit settings and defaults.
-            // Most field types default to index:true and doc_values:true, so we must
-            // validate even when the property is not explicitly set.
-            boolean isIndexed = isPropertyTrueOrAbsent(propNode, "index", true);
-            boolean hasDocValues = isPropertyTrueOrAbsent(propNode, "doc_values", true);
-            boolean isStored = isPropertyTrue(propNode, "store");
-
-            if (isIndexed) {
-                boolean hasIndexSupport = registry.supportsCapability(type, FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH)
-                    .isEmpty() == false
-                    || registry.supportsCapability(type, FieldTypeCapabilities.Capability.POINT_RANGE).isEmpty() == false;
-                if (hasIndexSupport == false) {
-                    throw new MapperParsingException(
-                        "Field ["
-                            + fieldName
-                            + "] of type ["
-                            + type
-                            + "] has [index: true] but no registered data format supports "
-                            + "FULL_TEXT_SEARCH or POINT_RANGE for this type"
-                    );
-                }
-            }
-
-            if (hasDocValues) {
-                if (registry.supportsCapability(type, FieldTypeCapabilities.Capability.COLUMNAR_STORAGE).isEmpty()) {
-                    throw new MapperParsingException(
-                        "Field ["
-                            + fieldName
-                            + "] of type ["
-                            + type
-                            + "] has [doc_values: true] but no registered data format supports "
-                            + "COLUMNAR_STORAGE for this type"
-                    );
-                }
-            }
-
-            if (isStored) {
-                if (registry.supportsCapability(type, FieldTypeCapabilities.Capability.STORED_FIELDS).isEmpty()) {
-                    throw new MapperParsingException(
-                        "Field ["
-                            + fieldName
-                            + "] of type ["
-                            + type
-                            + "] has [store: true] but no registered data format supports "
-                            + "STORED_FIELDS for this type"
-                    );
-                }
-            }
-        }
-
-        /**
-         * Returns true if the given property is explicitly set to true in the property map.
-         * Returns false if the property is absent, null, or set to false.
-         */
-        private static boolean isPropertyTrue(Map<String, Object> propNode, String property) {
-            Object value = propNode.get(property);
-            if (value == null) {
-                return false;
-            }
-            if (value instanceof Boolean) {
-                return (Boolean) value;
-            }
-            return Boolean.parseBoolean(value.toString());
-        }
-
-        /**
-         * Returns true if the given property is explicitly set to true, or if absent, returns the default.
-         * This handles the common case where field types default to index:true / doc_values:true.
-         */
-        private static boolean isPropertyTrueOrAbsent(Map<String, Object> propNode, String property, boolean defaultValue) {
-            Object value = propNode.get(property);
-            if (value == null) {
-                return defaultValue;
-            }
-            if (value instanceof Boolean) {
-                return (Boolean) value;
-            }
-            return Boolean.parseBoolean(value.toString());
         }
 
     }

--- a/server/src/main/java/org/opensearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RangeFieldMapper.java
@@ -51,6 +51,7 @@ import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.time.DateMathParser;
 import org.opensearch.common.util.LocaleUtils;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.plain.BinaryIndexFieldData;
 import org.opensearch.index.query.QueryShardContext;
@@ -343,6 +344,25 @@ public class RangeFieldMapper extends ParametrizedFieldMapper {
         @Override
         public String typeName() {
             return rangeType.name;
+        }
+
+        /**
+         * Range fields use {@link FieldTypeCapabilities.Capability#POINT_RANGE} for indexing
+         * instead of {@link FieldTypeCapabilities.Capability#FULL_TEXT_SEARCH}.
+         */
+        @Override
+        public Set<FieldTypeCapabilities.Capability> requestedCapabilities() {
+            Set<FieldTypeCapabilities.Capability> caps = new HashSet<>();
+            if (isSearchable()) {
+                caps.add(FieldTypeCapabilities.Capability.POINT_RANGE);
+            }
+            if (hasDocValues()) {
+                caps.add(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE);
+            }
+            if (isStored()) {
+                caps.add(FieldTypeCapabilities.Capability.STORED_FIELDS);
+            }
+            return caps.isEmpty() ? Set.of() : Set.copyOf(caps);
         }
 
         public DateFormatter dateTimeFormatter() {

--- a/server/src/main/java/org/opensearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/RoutingFieldMapper.java
@@ -37,11 +37,13 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lucene.Lucene;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.lookup.SearchLookup;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Internal field mapper for _routing fields
@@ -125,6 +127,11 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        @Override
+        public Set<FieldTypeCapabilities.Capability> defaultCapabilities() {
+            return Set.of(FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH, FieldTypeCapabilities.Capability.STORED_FIELDS);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/SeqNoFieldMapper.java
@@ -40,6 +40,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.opensearch.index.fielddata.plain.SortedNumericIndexFieldData;
@@ -52,6 +53,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -128,6 +130,11 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        @Override
+        public Set<FieldTypeCapabilities.Capability> defaultCapabilities() {
+            return Set.of(FieldTypeCapabilities.Capability.POINT_RANGE, FieldTypeCapabilities.Capability.COLUMNAR_STORAGE);
         }
 
         private long parse(Object value) {

--- a/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java
@@ -51,6 +51,7 @@ import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryShardException;
 import org.opensearch.search.lookup.SearchLookup;
@@ -61,6 +62,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -216,6 +218,11 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        @Override
+        public Set<FieldTypeCapabilities.Capability> defaultCapabilities() {
+            return Set.of(FieldTypeCapabilities.Capability.STORED_FIELDS);
         }
 
         @Override

--- a/server/src/main/java/org/opensearch/index/mapper/VersionFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/VersionFieldMapper.java
@@ -35,12 +35,14 @@ package org.opensearch.index.mapper;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.search.Query;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
 import org.opensearch.index.mapper.ParseContext.Document;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryShardException;
 import org.opensearch.search.lookup.SearchLookup;
 
 import java.util.Collections;
+import java.util.Set;
 
 /**
  * Mapper for the _version field.
@@ -70,6 +72,11 @@ public class VersionFieldMapper extends MetadataFieldMapper {
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        @Override
+        public Set<FieldTypeCapabilities.Capability> defaultCapabilities() {
+            return Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE);
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatRegistryTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatRegistryTests.java
@@ -457,4 +457,281 @@ public class DataFormatRegistryTests extends OpenSearchTestCase {
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> registry.getDeleteExecutionEngine(mock(Committer.class)));
         assertTrue(e.getMessage().contains("No DataFormatPlugin provides a DeleteExecutionEngine"));
     }
+
+    // --- computeCapabilityMap tests ---
+
+    private DataFormatRegistry createRegistryWith(MockDataFormat... formats) {
+        List<DataFormatPlugin> plugins = new java.util.ArrayList<>();
+        List<String> formatNames = new java.util.ArrayList<>();
+        for (MockDataFormat f : formats) {
+            plugins.add(MockDataFormatPlugin.of(f));
+            formatNames.add(f.name());
+        }
+        when(pluginsService.filterPlugins(DataFormatPlugin.class)).thenReturn(plugins);
+        when(pluginsService.filterPlugins(SearchBackEndPlugin.class)).thenReturn(List.of(new MockSearchBackEndPlugin(formatNames)));
+        return new DataFormatRegistry(pluginsService);
+    }
+
+    public void testComputeCapabilityMapSingleFormat() {
+        MockDataFormat parquet = new MockDataFormat(
+            "parquet",
+            0L,
+            Set.of(
+                new FieldTypeCapabilities(
+                    "keyword",
+                    Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER)
+                )
+            )
+        );
+        DataFormatRegistry registry = createRegistryWith(parquet);
+
+        Map<DataFormat, Set<FieldTypeCapabilities.Capability>> capMap = registry.computeCapabilityMap("keyword");
+
+        assertEquals(1, capMap.size());
+        assertTrue(capMap.containsKey(parquet));
+        assertEquals(
+            Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER),
+            capMap.get(parquet)
+        );
+    }
+
+    public void testComputeCapabilityMapHighestPriorityWins() {
+        MockDataFormat parquet = new MockDataFormat(
+            "parquet",
+            0L,
+            Set.of(new FieldTypeCapabilities("keyword", Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE)))
+        );
+        MockDataFormat lucene = new MockDataFormat(
+            "lucene",
+            50L,
+            Set.of(new FieldTypeCapabilities("keyword", Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE)))
+        );
+        DataFormatRegistry registry = createRegistryWith(parquet, lucene);
+
+        Map<DataFormat, Set<FieldTypeCapabilities.Capability>> capMap = registry.computeCapabilityMap("keyword");
+
+        assertTrue(capMap.containsKey(parquet));
+        assertTrue(capMap.get(parquet).contains(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE));
+        assertFalse(capMap.containsKey(lucene));
+    }
+
+    public void testComputeCapabilityMapSplitAcrossFormats() {
+        MockDataFormat parquet = new MockDataFormat(
+            "parquet",
+            0L,
+            Set.of(new FieldTypeCapabilities("keyword", Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE)))
+        );
+        MockDataFormat lucene = new MockDataFormat(
+            "lucene",
+            50L,
+            Set.of(new FieldTypeCapabilities("keyword", Set.of(FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH)))
+        );
+        DataFormatRegistry registry = createRegistryWith(parquet, lucene);
+
+        Map<DataFormat, Set<FieldTypeCapabilities.Capability>> capMap = registry.computeCapabilityMap("keyword");
+
+        assertEquals(2, capMap.size());
+        assertEquals(Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE), capMap.get(parquet));
+        assertEquals(Set.of(FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH), capMap.get(lucene));
+    }
+
+    public void testComputeCapabilityMapUnknownFieldTypeReturnsEmpty() {
+        MockDataFormat parquet = new MockDataFormat(
+            "parquet",
+            0L,
+            Set.of(new FieldTypeCapabilities("keyword", Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE)))
+        );
+        DataFormatRegistry registry = createRegistryWith(parquet);
+
+        assertTrue(registry.computeCapabilityMap("unknown_type").isEmpty());
+    }
+
+    public void testComputeCapabilityMapEmptyRegistryReturnsEmpty() {
+        DataFormatRegistry registry = createRegistryWith();
+        assertTrue(registry.computeCapabilityMap("keyword").isEmpty());
+    }
+
+    public void testComputeCapabilityMapDefaultCapabilitiesFallback() {
+        MockDataFormat parquet = new MockDataFormat(
+            "parquet",
+            0L,
+            Set.of(new FieldTypeCapabilities("keyword", Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE)))
+        );
+        MockDataFormat lucene = new MockDataFormat(
+            "lucene",
+            50L,
+            Set.of(new FieldTypeCapabilities("text", Set.of(FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH)))
+        );
+        DataFormatRegistry registry = createRegistryWith(parquet, lucene);
+
+        // No format declares support for "_id", but defaults include FULL_TEXT_SEARCH + STORED_FIELDS
+        Set<FieldTypeCapabilities.Capability> defaults = Set.of(
+            FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH,
+            FieldTypeCapabilities.Capability.STORED_FIELDS
+        );
+        Map<DataFormat, Set<FieldTypeCapabilities.Capability>> capMap = registry.computeCapabilityMap("_id", defaults);
+
+        // Both default capabilities assigned to highest-priority format (parquet, priority 0)
+        assertEquals(1, capMap.size());
+        assertTrue(capMap.containsKey(parquet));
+        assertEquals(defaults, capMap.get(parquet));
+    }
+
+    public void testComputeCapabilityMapFormatDeclarationTakesPrecedenceOverDefaults() {
+        MockDataFormat parquet = new MockDataFormat(
+            "parquet",
+            0L,
+            Set.of(new FieldTypeCapabilities("keyword", Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE)))
+        );
+        MockDataFormat lucene = new MockDataFormat(
+            "lucene",
+            50L,
+            Set.of(new FieldTypeCapabilities("keyword", Set.of(FieldTypeCapabilities.Capability.STORED_FIELDS)))
+        );
+        DataFormatRegistry registry = createRegistryWith(parquet, lucene);
+
+        Set<FieldTypeCapabilities.Capability> defaults = Set.of(
+            FieldTypeCapabilities.Capability.COLUMNAR_STORAGE,
+            FieldTypeCapabilities.Capability.STORED_FIELDS
+        );
+        Map<DataFormat, Set<FieldTypeCapabilities.Capability>> capMap = registry.computeCapabilityMap("keyword", defaults);
+
+        // Format declarations win: COLUMNAR_STORAGE → parquet, STORED_FIELDS → lucene
+        assertEquals(2, capMap.size());
+        assertEquals(Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE), capMap.get(parquet));
+        assertEquals(Set.of(FieldTypeCapabilities.Capability.STORED_FIELDS), capMap.get(lucene));
+    }
+
+    public void testComputeCapabilityMapPartialDefaultFallback() {
+        MockDataFormat parquet = new MockDataFormat(
+            "parquet",
+            0L,
+            Set.of(new FieldTypeCapabilities("keyword", Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE)))
+        );
+        DataFormatRegistry registry = createRegistryWith(parquet);
+
+        // STORED_FIELDS not declared by any format, but is in defaults
+        Set<FieldTypeCapabilities.Capability> defaults = Set.of(FieldTypeCapabilities.Capability.STORED_FIELDS);
+        Map<DataFormat, Set<FieldTypeCapabilities.Capability>> capMap = registry.computeCapabilityMap("keyword", defaults);
+
+        // COLUMNAR_STORAGE from format + STORED_FIELDS from default, both on parquet
+        assertEquals(1, capMap.size());
+        assertTrue(capMap.get(parquet).contains(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE));
+        assertTrue(capMap.get(parquet).contains(FieldTypeCapabilities.Capability.STORED_FIELDS));
+    }
+
+    public void testComputeCapabilityMapEmptyDefaultsNoFallback() {
+        MockDataFormat parquet = new MockDataFormat(
+            "parquet",
+            0L,
+            Set.of(new FieldTypeCapabilities("keyword", Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE)))
+        );
+        DataFormatRegistry registry = createRegistryWith(parquet);
+
+        assertTrue(registry.computeCapabilityMap("_id", Set.of()).isEmpty());
+    }
+
+    public void testComputeCapabilityMapResultIsImmutable() {
+        MockDataFormat parquet = new MockDataFormat(
+            "parquet",
+            0L,
+            Set.of(new FieldTypeCapabilities("keyword", Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE)))
+        );
+        DataFormatRegistry registry = createRegistryWith(parquet);
+
+        Map<DataFormat, Set<FieldTypeCapabilities.Capability>> capMap = registry.computeCapabilityMap("keyword");
+        expectThrows(UnsupportedOperationException.class, () -> capMap.put(parquet, Set.of()));
+    }
+
+    // --- MappedFieldType capability map tests ---
+
+    public void testMappedFieldTypeCapabilityMapDefaultsToEmpty() {
+        org.opensearch.index.mapper.MappedFieldType ft = new org.opensearch.index.mapper.KeywordFieldMapper.KeywordFieldType("test");
+        assertTrue(ft.getCapabilityMap().isEmpty());
+    }
+
+    public void testMappedFieldTypeSetAndGetCapabilityMap() {
+        org.opensearch.index.mapper.MappedFieldType ft = new org.opensearch.index.mapper.KeywordFieldMapper.KeywordFieldType("test");
+        MockDataFormat parquet = new MockDataFormat("parquet", 0L, Set.of());
+
+        ft.setCapabilityMap(
+            Map.of(parquet, Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER))
+        );
+
+        Map<DataFormat, Set<FieldTypeCapabilities.Capability>> result = ft.getCapabilityMap();
+        assertEquals(1, result.size());
+        assertEquals(
+            Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.BLOOM_FILTER),
+            result.get(parquet)
+        );
+    }
+
+    public void testMappedFieldTypeCapabilityMapIsUnmodifiable() {
+        org.opensearch.index.mapper.MappedFieldType ft = new org.opensearch.index.mapper.KeywordFieldMapper.KeywordFieldType("test");
+        MockDataFormat parquet = new MockDataFormat("parquet", 0L, Set.of());
+
+        ft.setCapabilityMap(Map.of(parquet, Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE)));
+
+        Map<DataFormat, Set<FieldTypeCapabilities.Capability>> result = ft.getCapabilityMap();
+        expectThrows(UnsupportedOperationException.class, () -> result.put(parquet, Set.of()));
+    }
+
+    public void testMappedFieldTypeDefaultCapabilitiesIsEmpty() {
+        org.opensearch.index.mapper.MappedFieldType ft = new org.opensearch.index.mapper.KeywordFieldMapper.KeywordFieldType("test");
+        assertTrue(ft.defaultCapabilities().isEmpty());
+    }
+
+    // --- requestedCapabilities tests ---
+
+    public void testKeywordFieldTypeRequestedCapabilities() {
+        org.opensearch.index.mapper.KeywordFieldMapper.KeywordFieldType ft =
+            new org.opensearch.index.mapper.KeywordFieldMapper.KeywordFieldType("test");
+        Set<FieldTypeCapabilities.Capability> caps = ft.requestedCapabilities();
+        // keyword defaults: indexed=true, docValues=true, stored=false
+        assertTrue(caps.contains(FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH));
+        assertTrue(caps.contains(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE));
+        assertFalse(caps.contains(FieldTypeCapabilities.Capability.STORED_FIELDS));
+    }
+
+    public void testNumberFieldTypeRequestedCapabilities() {
+        org.opensearch.index.mapper.NumberFieldMapper.NumberFieldType ft =
+            new org.opensearch.index.mapper.NumberFieldMapper.NumberFieldType(
+                "test",
+                org.opensearch.index.mapper.NumberFieldMapper.NumberType.LONG
+            );
+        Set<FieldTypeCapabilities.Capability> caps = ft.requestedCapabilities();
+        // numeric fields use POINT_RANGE instead of FULL_TEXT_SEARCH
+        assertTrue(caps.contains(FieldTypeCapabilities.Capability.POINT_RANGE));
+        assertTrue(caps.contains(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE));
+        assertFalse(caps.contains(FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH));
+    }
+
+    public void testDateFieldTypeRequestedCapabilities() {
+        org.opensearch.index.mapper.DateFieldMapper.DateFieldType ft = new org.opensearch.index.mapper.DateFieldMapper.DateFieldType(
+            "test"
+        );
+        Set<FieldTypeCapabilities.Capability> caps = ft.requestedCapabilities();
+        // date fields use POINT_RANGE instead of FULL_TEXT_SEARCH
+        assertTrue(caps.contains(FieldTypeCapabilities.Capability.POINT_RANGE));
+        assertTrue(caps.contains(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE));
+        assertFalse(caps.contains(FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH));
+    }
+
+    // --- metadata field defaultCapabilities tests ---
+
+    public void testSeqNoFieldTypeDefaultCapabilities() {
+        org.opensearch.index.mapper.MappedFieldType ft = new org.opensearch.index.mapper.SeqNoFieldMapper().fieldType();
+        Set<FieldTypeCapabilities.Capability> caps = ft.defaultCapabilities();
+        assertEquals(2, caps.size());
+        assertTrue(caps.contains(FieldTypeCapabilities.Capability.POINT_RANGE));
+        assertTrue(caps.contains(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE));
+    }
+
+    public void testVersionFieldTypeDefaultCapabilitiesBase() {
+        // VersionFieldType is package-private; the override is tested in
+        // VersionFieldMapperTests in the mapper package. Here we verify the
+        // base MappedFieldType returns empty defaults.
+        org.opensearch.index.mapper.MappedFieldType ft = new org.opensearch.index.mapper.KeywordFieldMapper.KeywordFieldType("test");
+        assertTrue(ft.defaultCapabilities().isEmpty());
+    }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/IdFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/IdFieldMapperTests.java
@@ -127,4 +127,12 @@ public class IdFieldMapperTests extends OpenSearchSingleNodeTestCase {
                 .get();
         }
     }
+
+    public void testDefaultCapabilities() {
+        IdFieldMapper.IdFieldType ft = new IdFieldMapper.IdFieldType(() -> false);
+        java.util.Set<org.opensearch.index.engine.dataformat.FieldTypeCapabilities.Capability> caps = ft.defaultCapabilities();
+        assertEquals(2, caps.size());
+        assertTrue(caps.contains(org.opensearch.index.engine.dataformat.FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH));
+        assertTrue(caps.contains(org.opensearch.index.engine.dataformat.FieldTypeCapabilities.Capability.STORED_FIELDS));
+    }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/RoutingFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/RoutingFieldMapperTests.java
@@ -113,4 +113,12 @@ public class RoutingFieldMapperTests extends OpenSearchSingleNodeTestCase {
         );
         assertThat(ex.getMessage(), containsString("metadata field and cannot be added inside a document"));
     }
+
+    public void testDefaultCapabilities() {
+        java.util.Set<org.opensearch.index.engine.dataformat.FieldTypeCapabilities.Capability> caps =
+            RoutingFieldMapper.RoutingFieldType.INSTANCE.defaultCapabilities();
+        assertEquals(2, caps.size());
+        assertTrue(caps.contains(org.opensearch.index.engine.dataformat.FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH));
+        assertTrue(caps.contains(org.opensearch.index.engine.dataformat.FieldTypeCapabilities.Capability.STORED_FIELDS));
+    }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/SeqNoFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/SeqNoFieldMapperTests.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Set;
+
+public class SeqNoFieldMapperTests extends OpenSearchTestCase {
+
+    public void testDefaultCapabilities() {
+        SeqNoFieldMapper mapper = new SeqNoFieldMapper();
+        Set<FieldTypeCapabilities.Capability> caps = mapper.fieldType().defaultCapabilities();
+        assertEquals(2, caps.size());
+        assertTrue(caps.contains(FieldTypeCapabilities.Capability.POINT_RANGE));
+        assertTrue(caps.contains(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE));
+    }
+}

--- a/server/src/test/java/org/opensearch/index/mapper/SourceFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/SourceFieldMapperTests.java
@@ -572,4 +572,16 @@ public class SourceFieldMapperTests extends OpenSearchSingleNodeTestCase {
         documentMapper = parser3.parse("type", new CompressedXContent(mapping3));
         assertTrue(documentMapper.sourceMapper().enabled());
     }
+
+    public void testDefaultCapabilities() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type").endObject().endObject().toString();
+        DocumentMapper docMapper = createIndex("test_caps").mapperService()
+            .documentMapperParser()
+            .parse("type", new CompressedXContent(mapping));
+        SourceFieldMapper sourceMapper = docMapper.sourceMapper();
+        java.util.Set<org.opensearch.index.engine.dataformat.FieldTypeCapabilities.Capability> caps = sourceMapper.fieldType()
+            .defaultCapabilities();
+        assertEquals(1, caps.size());
+        assertTrue(caps.contains(org.opensearch.index.engine.dataformat.FieldTypeCapabilities.Capability.STORED_FIELDS));
+    }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/VersionFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/VersionFieldMapperTests.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.mapper;
+
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Set;
+
+public class VersionFieldMapperTests extends OpenSearchTestCase {
+
+    public void testDefaultCapabilities() {
+        Set<FieldTypeCapabilities.Capability> caps = VersionFieldMapper.VersionFieldType.INSTANCE.defaultCapabilities();
+        assertEquals(1, caps.size());
+        assertTrue(caps.contains(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE));
+    }
+}


### PR DESCRIPTION
# Add FieldTypeCapabilities-based routing for pluggable data formats

## Description

This PR introduces a capability-based field routing mechanism that allows the composite indexing engine to determine which data format (e.g., Parquet, Lucene) is responsible for storing each field's data. At mapping creation time, each `MappedFieldType` is assigned an immutable capability map (`Map<DataFormat, Set<Capability>>`) that records which format owns which capabilities (e.g., `COLUMNAR_STORAGE`, `FULL_TEXT_SEARCH`, `POINT_RANGE`) for that field. At indexing time, each format's `DocumentInput` uses this map to accept only the fields it owns.

## Problem

Previously, when multiple data formats were registered in a composite engine, there was no mechanism to decide which format should handle which aspect of a field. Every format received every field, leading to redundant storage and no clear ownership of capabilities like full-text search vs. columnar storage.

## Solution

### Capability assignment algorithm

For each field type, the `DataFormatRegistry.computeCapabilityMap()` method:

1. Determines which capabilities the field requests (from its mapping configuration: `index`, `doc_values`, `store`)
2. For each requested capability, finds all formats that declare support for it
3. The highest-priority format (lowest priority value) wins ownership of that capability
4. For metadata fields (e.g., `_id`, `_source`) whose type names aren't declared by any format, `defaultCapabilities()` provides a fallback assigned to the primary format

### Key changes

- **`MappedFieldType`**: Added `capabilityMap`, `requestedCapabilities()`, and `defaultCapabilities()` methods
- **`DataFormatRegistry`**: Added `computeCapabilityMap()` with 1-arg, 2-arg, and 3-arg overloads
- **`Mapper.BuilderContext`**: Carries `DataFormatRegistry` and provides `assignCapabilities()` helper
- **`DocumentMapper.Builder`**: Recursively assigns capability maps to all field types (user fields + metadata) at mapping build time
- **`ObjectMapper`**: Validates at parse time that each field type is supported by at least one registered format
- **Field type overrides**: `NumberFieldType`, `DateFieldType`, `IpFieldType`, `RangeFieldType`, `ScaledFloatFieldType` override `requestedCapabilities()` to use `POINT_RANGE` instead of `FULL_TEXT_SEARCH`
- **Metadata field overrides**: `_id`, `_routing`, `_seq_no`, `_source`, `_version` override `defaultCapabilities()` to declare their intrinsic storage needs
- **`ParquetDocumentInput`**: Uses the capability map to filter fields — only accepts fields where the owning format has capabilities assigned
- **`ParquetField`**: Each field declares its own `supportedCapabilities()` instead of a blanket default

### Wiring path

`MapperService` → `DocumentMapperParser` → `Mapper.ParserContext` → `DocumentMapper.Builder` → `BuilderContext.assignCapabilities()` — the `DataFormatRegistry` is threaded through the entire mapping creation pipeline when pluggable data format is enabled.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant MapperService
    participant DocumentMapperParser
    participant ObjectMapper
    participant DocumentMapper.Builder
    participant BuilderContext
    participant DataFormatRegistry
    participant MappedFieldType
    participant ParquetDocumentInput

    Note over User,ParquetDocumentInput: === Mapping Creation Time ===

    User->>MapperService: createMapping(mappingSource)
    MapperService->>DocumentMapperParser: parse(type, mappingSource)

    Note right of DocumentMapperParser: ParserContext carries<br/>DataFormatRegistry

    DocumentMapperParser->>ObjectMapper: parseProperties(mapping, parserContext)

    loop For each field in mapping
        ObjectMapper->>ObjectMapper: validateFieldTypeSupported(type, fieldName, propNode, parserContext)
        Note right of ObjectMapper: Checks:<br/>1. Field type supported by ≥1 format<br/>2. index:true → FULL_TEXT_SEARCH or POINT_RANGE supported<br/>3. doc_values:true → COLUMNAR_STORAGE supported<br/>4. store:true → STORED_FIELDS supported
        ObjectMapper-->>ObjectMapper: Throws MapperParsingException if unsupported
    end

    DocumentMapperParser->>DocumentMapper.Builder: new Builder(rootMapper, mapperService, dataFormatRegistry)

    Note right of DocumentMapper.Builder: Recursively assign capabilities<br/>to all field types

    loop For each FieldMapper (recursive tree walk)
        DocumentMapper.Builder->>BuilderContext: assignCapabilities(fieldType)
        BuilderContext->>MappedFieldType: typeName()
        BuilderContext->>MappedFieldType: defaultCapabilities()
        BuilderContext->>MappedFieldType: requestedCapabilities()

        Note right of MappedFieldType: Base: isSearchable→FULL_TEXT_SEARCH<br/>Numeric/Date/IP/Range: isSearchable→POINT_RANGE<br/>hasDocValues→COLUMNAR_STORAGE<br/>isStored→STORED_FIELDS

        BuilderContext->>DataFormatRegistry: computeCapabilityMap(typeName, defaults, requested)

        Note right of DataFormatRegistry: For each requested capability:<br/>1. Find formats supporting it<br/>2. Sort by priority (ascending)<br/>3. Highest-priority format wins<br/>4. Fallback to defaults for metadata fields

        DataFormatRegistry-->>BuilderContext: Map<DataFormat, Set<Capability>>
        BuilderContext->>MappedFieldType: setCapabilityMap(capMap)
    end

    loop For each MetadataFieldMapper (_id, _source, _routing, etc.)
        DocumentMapper.Builder->>BuilderContext: assignCapabilities(metadataFieldType)
        BuilderContext->>DataFormatRegistry: computeCapabilityMap(typeName, defaults, requested)
        DataFormatRegistry-->>BuilderContext: Map<DataFormat, Set<Capability>>
        BuilderContext->>MappedFieldType: setCapabilityMap(capMap)
    end

    Note over User,ParquetDocumentInput: === Indexing Time ===

    User->>ParquetDocumentInput: addField(fieldType, value)
    ParquetDocumentInput->>MappedFieldType: getCapabilityMap()
    MappedFieldType-->>ParquetDocumentInput: Map<DataFormat, Set<Capability>>

    alt capMap is empty
        ParquetDocumentInput-->>ParquetDocumentInput: Skip field (no format declared support)
    else owningFormat has capabilities
        ParquetDocumentInput->>ParquetDocumentInput: Accept field → collectedFields.add(...)
    else owningFormat not in map
        ParquetDocumentInput-->>ParquetDocumentInput: Skip field (not owned by this format)
    end
```

### Example: Parquet (priority=0) + Lucene (priority=50)

For a `keyword` field with `index: true, doc_values: true`:

| Capability | Declared by | Winner |
|---|---|---|
| `FULL_TEXT_SEARCH` | Lucene only | **Lucene** |
| `COLUMNAR_STORAGE` | Parquet, Lucene | **Parquet** (priority 0 < 50) |
| `BLOOM_FILTER` | Parquet only | **Parquet** |

Result: `{parquet: [COLUMNAR_STORAGE, BLOOM_FILTER], lucene: [FULL_TEXT_SEARCH]}`

For a `long` field with `index: true, doc_values: true`:

| Capability | Declared by | Winner |
|---|---|---|
| `POINT_RANGE` | Lucene only | **Lucene** |
| `COLUMNAR_STORAGE` | Parquet, Lucene | **Parquet** (priority 0 < 50) |

Result: `{parquet: [COLUMNAR_STORAGE], lucene: [POINT_RANGE]}`

For `_source` (metadata, `defaultCapabilities = [STORED_FIELDS]`):

| Capability | Declared by | Winner |
|---|---|---|
| `STORED_FIELDS` | No format declares | **Parquet** (primary, via default fallback) |

## Testing

- Unit tests for `DataFormatRegistry.computeCapabilityMap()` covering single format, multi-format priority, split capabilities, default fallback, immutability
- Unit tests for `MappedFieldType.getCapabilityMap()` / `setCapabilityMap()`
- Unit tests for metadata field `defaultCapabilities()` (`_id`, `_routing`, `_seq_no`, `_source`, `_version`)
- Integration test `CapabilityBasedFieldRoutingIT` validating end-to-end capability assignment on composite indices

## Files Changed (34 files)

**Server core (mapper framework):**
- `MappedFieldType.java` — capability map storage, `requestedCapabilities()`, `defaultCapabilities()`
- `Mapper.java` — `BuilderContext` and `ParserContext` carry `DataFormatRegistry`
- `DocumentMapper.java` — recursive capability assignment during build
- `DocumentMapperParser.java` — threads `DataFormatRegistry` through parsing
- `MapperService.java` — accepts optional `DataFormatRegistry`
- `ObjectMapper.java` — field type validation at parse time

**Server core (data format):**
- `DataFormatRegistry.java` — `computeCapabilityMap()` algorithm

**Field type overrides (POINT_RANGE instead of FULL_TEXT_SEARCH):**
- `NumberFieldMapper.java`, `DateFieldMapper.java`, `IpFieldMapper.java`, `RangeFieldMapper.java`, `ScaledFloatFieldMapper.java`

**Metadata field overrides (defaultCapabilities):**
- `IdFieldMapper.java`, `RoutingFieldMapper.java`, `SeqNoFieldMapper.java`, `SourceFieldMapper.java`, `VersionFieldMapper.java`

**Parquet plugin:**
- `ParquetDocumentInput.java` — capability-based field filtering
- `ParquetDataFormat.java` — delegates to `ArrowFieldRegistry`
- `ArrowFieldRegistry.java` — `getSupportedFieldCapabilities()`
- `ParquetField.java` — per-field `supportedCapabilities()`

**Composite engine:**
- `CompositeIndexingExecutionEngine.java` — minor cleanup
- `CapabilityBasedFieldRoutingIT.java` — integration test
