### PR TITLE
Honor includes/excludes with derived source

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/get/GetActionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/get/GetActionIT.java
@@ -1078,6 +1078,50 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         assertEquals("2025-07-30T00:00:00.000Z", source.get("date_field"));
     }
 
+    public void testDerivedSourceHonorsMappingSourceFiltersOnGet() throws Exception {
+        String index = "test_derive_filtered";
+        assertAcked(
+            prepareCreate(index).setSettings(
+                Settings.builder()
+                    .put("index.number_of_shards", 1)
+                    .put("index.number_of_replicas", 0)
+                    .put("index.refresh_interval", -1)
+                    .put("index.derived_source.enabled", true)
+            ).setMapping("""
+                {
+                  "_source": {
+                    "includes": ["name", "city", "age"],
+                    "excludes": ["age"]
+                  },
+                  "properties": {
+                    "name": { "type": "keyword" },
+                    "age": { "type": "integer" },
+                    "city": { "type": "keyword" },
+                    "country": { "type": "keyword" }
+                  }
+                }""")
+        );
+        ensureGreen();
+
+        client().prepareIndex(index)
+            .setId("1")
+            .setSource(
+                jsonBuilder().startObject()
+                    .field("name", "test")
+                    .field("age", 25)
+                    .field("city", "seattle")
+                    .field("country", "usa")
+                    .endObject()
+            )
+            .get();
+
+        assertDerivedSourceFilteredGet(index);
+        refresh();
+        assertDerivedSourceFilteredGet(index);
+        flush();
+        assertDerivedSourceFilteredGet(index);
+    }
+
     void validateDeriveSource(Map<String, Object> source) {
         Map<String, Object> latLon = (Map<String, Object>) source.get("geopoint_field");
         assertEquals(75.98, (Double) latLon.get("lat"), 0.001);
@@ -1088,6 +1132,23 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         assertEquals(true, source.get("bool_field"));
         assertEquals("test text", source.get("text_field"));
         assertEquals("1.2.3.4", source.get("ip_field"));
+    }
+
+    void assertDerivedSourceFilteredGet(String index) {
+        GetResponse getResponse = client().prepareGet(index, "1").get();
+        assertTrue(getResponse.isExists());
+        Map<String, Object> source = getResponse.getSourceAsMap();
+        assertThat(source.size(), equalTo(2));
+        assertThat(source.get("name"), equalTo("test"));
+        assertThat(source.get("city"), equalTo("seattle"));
+        assertThat(source, not(hasKey("age")));
+        assertThat(source, not(hasKey("country")));
+
+        getResponse = client().prepareGet(index, "1").setFetchSource(new String[] { "city" }, null).get();
+        assertTrue(getResponse.isExists());
+        source = getResponse.getSourceAsMap();
+        assertThat(source.size(), equalTo(1));
+        assertThat(source.get("city"), equalTo("seattle"));
     }
 
     void indexSingleDocumentWithStringFieldsGeneratedFromText(boolean stored, boolean sourceEnabled) {

--- a/server/src/internalClusterTest/java/org/opensearch/search/source/SourceFetchingIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/source/SourceFetchingIT.java
@@ -40,8 +40,12 @@ import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
 
 import static org.opensearch.search.SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -130,5 +134,46 @@ public class SourceFetchingIT extends ParameterizedStaticSettingsOpenSearchInteg
         assertThat(response.getHits().getAt(0).getSourceAsString(), notNullValue());
         assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
         assertThat((String) response.getHits().getAt(0).getSourceAsMap().get("field"), equalTo("value"));
+    }
+
+    public void testDerivedSourceHonorsMappingSourceFilters() throws InterruptedException {
+        assertAcked(
+            prepareCreate("test").setSettings(
+                Settings.builder()
+                    .put("index.number_of_shards", 1)
+                    .put("index.number_of_replicas", 0)
+                    .put("index.derived_source.enabled", true)
+            ).setMapping("""
+                {
+                  "_source": {
+                    "includes": ["name", "city", "age"],
+                    "excludes": ["age"]
+                  },
+                  "properties": {
+                    "name": { "type": "keyword" },
+                    "age": { "type": "integer" },
+                    "city": { "type": "keyword" },
+                    "country": { "type": "keyword" }
+                  }
+                }""")
+        );
+        ensureGreen();
+
+        client().prepareIndex("test").setId("1").setSource("name", "test", "age", 25, "city", "seattle", "country", "usa").get();
+        refresh();
+        indexRandomForConcurrentSearch("test");
+
+        SearchResponse response = client().prepareSearch("test").get();
+        Map<String, Object> source = response.getHits().getAt(0).getSourceAsMap();
+        assertThat(source.size(), equalTo(2));
+        assertThat(source.get("name"), equalTo("test"));
+        assertThat(source.get("city"), equalTo("seattle"));
+        assertThat(source, not(hasKey("age")));
+        assertThat(source, not(hasKey("country")));
+
+        response = client().prepareSearch("test").setFetchSource(new String[] { "city" }, null).get();
+        source = response.getHits().getAt(0).getSourceAsMap();
+        assertThat(source.size(), equalTo(1));
+        assertThat(source.get("city"), equalTo("seattle"));
     }
 }

--- a/server/src/main/java/org/opensearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/opensearch/index/get/ShardGetService.java
@@ -370,49 +370,11 @@ public final class ShardGetService extends AbstractIndexShardComponent {
         }
 
         if (source != null) {
-            // apply request-level source filtering
             if (fetchSourceContext.fetchSource() == false) {
                 source = null;
-            } else if (fetchSourceContext.includes().length > 0 || fetchSourceContext.excludes().length > 0) {
-                Map<String, Object> sourceAsMap;
-                // TODO: The source might be parsed and available in the sourceLookup but that one uses unordered maps so different.
-                // Do we care?
-                Tuple<XContentType, Map<String, Object>> typeMapTuple = XContentHelper.convertToMap(source, true);
-                XContentType sourceContentType = typeMapTuple.v1();
-                sourceAsMap = typeMapTuple.v2();
-                sourceAsMap = XContentMapValues.filter(sourceAsMap, fetchSourceContext.includes(), fetchSourceContext.excludes());
-                try {
-                    source = BytesReference.bytes(MediaTypeRegistry.contentBuilder(sourceContentType).map(sourceAsMap));
-                } catch (IOException e) {
-                    throw new OpenSearchException("Failed to get id [" + id + "] with includes/excludes set", e);
-                }
-            }
-        }
-
-        if (!fetchSourceContext.fetchSource()) {
-            source = null;
-        }
-
-        if (source != null && get.isFromTranslog()) {
-            // reapply source filters from mapping (possibly also nulling the source)
-            try {
-                source = docMapper.sourceMapper().applyFilters(source, null);
-            } catch (IOException e) {
-                throw new OpenSearchException("Failed to reapply filters for [" + id + "] after reading from translog", e);
-            }
-        }
-
-        if (source != null && (fetchSourceContext.includes().length > 0 || fetchSourceContext.excludes().length > 0)) {
-            Map<String, Object> sourceAsMap;
-            // TODO: The source might parsed and available in the sourceLookup but that one uses unordered maps so different. Do we care?
-            Tuple<XContentType, Map<String, Object>> typeMapTuple = XContentHelper.convertToMap(source, true);
-            XContentType sourceContentType = typeMapTuple.v1();
-            sourceAsMap = typeMapTuple.v2();
-            sourceAsMap = XContentMapValues.filter(sourceAsMap, fetchSourceContext.includes(), fetchSourceContext.excludes());
-            try {
-                source = BytesReference.bytes(MediaTypeRegistry.contentBuilder(sourceContentType).map(sourceAsMap));
-            } catch (IOException e) {
-                throw new OpenSearchException("Failed to get id [" + id + "] with includes/excludes set", e);
+            } else {
+                source = applyMappingSourceFilters(docMapper, source, id);
+                source = applyRequestSourceFilters(source, fetchSourceContext, id);
             }
         }
 
@@ -427,6 +389,37 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             documentFields,
             metadataFields
         );
+    }
+
+    private BytesReference applyMappingSourceFilters(DocumentMapper docMapper, BytesReference source, String id) {
+        SourceFieldMapper sourceMapper = docMapper.sourceMapper();
+        if (sourceMapper.isComplete()) {
+            return source;
+        }
+        try {
+            return sourceMapper.applyFilters(source, null);
+        } catch (IOException e) {
+            throw new OpenSearchException("Failed to reapply mapping source filters for [" + id + "]", e);
+        }
+    }
+
+    private BytesReference applyRequestSourceFilters(BytesReference source, FetchSourceContext fetchSourceContext, String id) {
+        if (fetchSourceContext.includes().length == 0 && fetchSourceContext.excludes().length == 0) {
+            return source;
+        }
+
+        Map<String, Object> sourceAsMap;
+        // TODO: The source might be parsed and available in the sourceLookup but that one uses unordered maps so different.
+        // Do we care?
+        Tuple<XContentType, Map<String, Object>> typeMapTuple = XContentHelper.convertToMap(source, true);
+        XContentType sourceContentType = typeMapTuple.v1();
+        sourceAsMap = typeMapTuple.v2();
+        sourceAsMap = XContentMapValues.filter(sourceAsMap, fetchSourceContext.includes(), fetchSourceContext.excludes());
+        try {
+            return BytesReference.bytes(MediaTypeRegistry.contentBuilder(sourceContentType).map(sourceAsMap));
+        } catch (IOException e) {
+            throw new OpenSearchException("Failed to get id [" + id + "] with includes/excludes set", e);
+        }
     }
 
     private static FieldsVisitor buildFieldsVisitors(String[] fields, FetchSourceContext fetchSourceContext) {

--- a/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java
@@ -51,6 +51,7 @@ import org.opensearch.common.lucene.search.Queries;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.support.XContentMapValues;
+import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.tasks.TaskCancelledException;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.index.fieldvisitor.CustomFieldsVisitor;
@@ -441,7 +442,7 @@ public class FetchPhase {
             HitContext hitContext = new HitContext(hit, subReaderContext, subDocId, lookup.source());
             if (fieldsVisitor.source() != null) {
                 profile(breakdown, FetchTimingType.LOAD_SOURCE, () -> {
-                    hitContext.sourceLookup().setSource(fieldsVisitor.source());
+                    hitContext.sourceLookup().setSource(applyMappingSourceFilters(context, fieldsVisitor.source()));
                     return null;
                 });
             }
@@ -497,7 +498,10 @@ public class FetchPhase {
 
             if (needSource) {
                 if (rootFieldsVisitor.source() != null) {
-                    Tuple<XContentType, Map<String, Object>> tuple = XContentHelper.convertToMap(rootFieldsVisitor.source(), false);
+                    Tuple<XContentType, Map<String, Object>> tuple = XContentHelper.convertToMap(
+                        applyMappingSourceFilters(context, rootFieldsVisitor.source()),
+                        false
+                    );
                     rootSourceAsMap = tuple.v2();
                     rootSourceContentType = tuple.v1();
                 } else {
@@ -587,6 +591,14 @@ public class FetchPhase {
             hitContext.sourceLookup().setSourceContentType(rootSourceContentType);
         }
         return hitContext;
+    }
+
+    private BytesReference applyMappingSourceFilters(SearchContext context, BytesReference source) throws IOException {
+        SourceFieldMapper sourceMapper = context.mapperService().documentMapper().sourceMapper();
+        if (sourceMapper.isComplete()) {
+            return source;
+        }
+        return sourceMapper.applyFilters(source, null);
     }
 
     private SearchHit.NestedIdentity getInternalNestedIdentity(


### PR DESCRIPTION
### Description
This change fixes source filtering for indices with `index.derived_source.enabled=true`.

When `_source` is reconstructed from derived source, the get and search fetch paths were returning the reconstructed content without reapplying mapping-level `_source.includes` / `_source.excludes`. As a result, responses could include fields that should have been filtered out.

This PR:
- reapplies mapping-level source filters in the get path after derived source reconstruction
- reapplies mapping-level source filters in the search fetch path, including nested fetch handling
- adds integration coverage for derived-source source filtering in both get and search flows
- verifies request-level fetch-source filtering still works on top of mapping-level filters

### Related Issues
Resolves #21197

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

### Validation
- `JAVA_HOME=/Users/abishekkumargiri/Library/Java/JavaVirtualMachines/openjdk-21.0.1/Contents/Home ./gradlew :server:precommit :server:internalClusterTest --tests "org.opensearch.get.GetActionIT.testDerivedSourceHonorsMappingSourceFiltersOnGet" --tests "org.opensearch.search.source.SourceFetchingIT.testDerivedSourceHonorsMappingSourceFilters"`
