### PR TITLE
Omit repository-s3 default ACL and storage headers

### DIFF
--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
@@ -52,7 +52,9 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectAttributes;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
@@ -586,10 +588,17 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             .bucket(blobStore.bucket())
             .key(blobName)
             .contentLength(blobSize)
-            .storageClass(blobStore.getStorageClass())
-            .acl(blobStore.getCannedACL())
             .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().putObjectMetricPublisher))
             .expectedBucketOwner(blobStore.expectedBucketOwner());
+
+        StorageClass storageClass = blobStore.getStorageClass();
+        if (storageClass != null) {
+            putObjectRequestBuilder.storageClass(storageClass);
+        }
+        ObjectCannedACL cannedACL = blobStore.getCannedACL();
+        if (cannedACL != null) {
+            putObjectRequestBuilder.acl(cannedACL);
+        }
 
         if (CollectionUtils.isNotEmpty(metadata)) {
             putObjectRequestBuilder = putObjectRequestBuilder.metadata(metadata);
@@ -644,10 +653,17 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
         CreateMultipartUploadRequest.Builder createMultipartUploadRequestBuilder = CreateMultipartUploadRequest.builder()
             .bucket(bucketName)
             .key(blobName)
-            .storageClass(blobStore.getStorageClass())
-            .acl(blobStore.getCannedACL())
             .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector))
             .expectedBucketOwner(blobStore.expectedBucketOwner());
+
+        StorageClass storageClass = blobStore.getStorageClass();
+        if (storageClass != null) {
+            createMultipartUploadRequestBuilder.storageClass(storageClass);
+        }
+        ObjectCannedACL cannedACL = blobStore.getCannedACL();
+        if (cannedACL != null) {
+            createMultipartUploadRequestBuilder.acl(cannedACL);
+        }
 
         if (CollectionUtils.isNotEmpty(metadata)) {
             createMultipartUploadRequestBuilder.metadata(metadata);

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobStore.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobStore.java
@@ -38,6 +38,7 @@ import software.amazon.awssdk.services.s3.model.StorageClass;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobPath;
 import org.opensearch.common.blobstore.BlobStore;
@@ -93,8 +94,10 @@ public class S3BlobStore implements BlobStore {
     private volatile String serverSideEncryptionEncryptionContext;
     private volatile String expectedBucketOwner;
 
+    @Nullable
     private volatile ObjectCannedACL cannedACL;
 
+    @Nullable
     private volatile StorageClass storageClass;
 
     private volatile int bulkDeletesSize;
@@ -296,10 +299,12 @@ public class S3BlobStore implements BlobStore {
         return true;
     }
 
+    @Nullable
     public ObjectCannedACL getCannedACL() {
         return cannedACL;
     }
 
+    @Nullable
     public StorageClass getStorageClass() {
         return storageClass;
     }
@@ -308,9 +313,10 @@ public class S3BlobStore implements BlobStore {
         return statsMetricPublisher;
     }
 
+    @Nullable
     public static StorageClass initStorageClass(String storageClassStringValue) {
         if ((storageClassStringValue == null) || storageClassStringValue.equals("")) {
-            return StorageClass.STANDARD;
+            return null;
         }
 
         final StorageClass storageClass = StorageClass.fromValue(storageClassStringValue.toUpperCase(Locale.ENGLISH));
@@ -328,9 +334,10 @@ public class S3BlobStore implements BlobStore {
     /**
      * Constructs canned acl from string
      */
+    @Nullable
     public static ObjectCannedACL initCannedACL(String cannedACL) {
         if ((cannedACL == null) || cannedACL.equals("")) {
-            return ObjectCannedACL.PRIVATE;
+            return null;
         }
 
         for (final ObjectCannedACL cur : ObjectCannedACL.values()) {

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
@@ -312,13 +312,15 @@ class S3Repository extends MeteredBlobStoreRepository {
 
     /**
      * Sets the S3 storage class type for the backup files. Values may be standard, reduced_redundancy,
-     * standard_ia, onezone_ia and intelligent_tiering. Defaults to standard.
+     * standard_ia, onezone_ia and intelligent_tiering. When unset, the request omits the storage class header and
+     * S3 applies its default.
      */
     static final Setting<String> STORAGE_CLASS_SETTING = Setting.simpleString("storage_class");
 
     /**
      * The S3 repository supports all S3 canned ACLs : private, public-read, public-read-write,
-     * authenticated-read, log-delivery-write, bucket-owner-read, bucket-owner-full-control. Defaults to private.
+     * authenticated-read, log-delivery-write, bucket-owner-read, bucket-owner-full-control. When unset, the request
+     * omits the ACL header and S3 applies its default.
      */
     static final Setting<String> CANNED_ACL_SETTING = Setting.simpleString("canned_acl");
 

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -655,13 +655,11 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         }
         when(blobStore.expectedBucketOwner()).thenReturn(randomAlphaOfLength(12));
 
-        final StorageClass storageClass = randomFrom(StorageClass.values());
+        final StorageClass storageClass = randomBoolean() ? randomFrom(StorageClass.values()) : null;
         when(blobStore.getStorageClass()).thenReturn(storageClass);
 
         final ObjectCannedACL cannedAccessControlList = randomBoolean() ? randomFrom(ObjectCannedACL.values()) : null;
-        if (cannedAccessControlList != null) {
-            when(blobStore.getCannedACL()).thenReturn(cannedAccessControlList);
-        }
+        when(blobStore.getCannedACL()).thenReturn(cannedAccessControlList);
 
         final S3Client client = mock(S3Client.class);
         final AmazonS3Reference clientReference = new AmazonS3Reference(client);
@@ -701,6 +699,40 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         } else {
             assertEquals(ServerSideEncryption.AES256, request.serverSideEncryption());
         }
+    }
+
+    public void testExecuteSingleUploadOmitsUnsetAclAndStorageClass() throws IOException {
+        final String bucketName = randomAlphaOfLengthBetween(1, 10);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+        final byte[] payload = randomByteArrayOfLength(randomIntBetween(0, 1024));
+
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+        when(blobStore.bucket()).thenReturn(bucketName);
+        when(blobStore.bufferSizeInBytes()).thenReturn(2048L);
+        when(blobStore.getStorageClass()).thenReturn(null);
+        when(blobStore.getCannedACL()).thenReturn(null);
+        when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
+        when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AES256.toString());
+        when(blobStore.expectedBucketOwner()).thenReturn(randomAlphaOfLength(12));
+
+        final S3Client client = mock(S3Client.class);
+        when(blobStore.clientReference()).thenReturn(new AmazonS3Reference(client));
+
+        final ArgumentCaptor<PutObjectRequest> putReqCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        when(client.putObject(putReqCaptor.capture(), any(RequestBody.class))).thenReturn(PutObjectResponse.builder().build());
+
+        new S3BlobContainer(new BlobPath(), blobStore).executeSingleUpload(
+            blobStore,
+            blobName,
+            new ByteArrayInputStream(payload),
+            payload.length,
+            null,
+            null
+        );
+
+        final PutObjectRequest request = putReqCaptor.getValue();
+        assertNull(request.storageClass());
+        assertNull(request.acl());
     }
 
     public void testExecuteMultipartUploadBlobSizeTooLarge() {
@@ -768,13 +800,11 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         }
         when(blobStore.expectedBucketOwner()).thenReturn(randomAlphaOfLength(12));
 
-        final StorageClass storageClass = randomFrom(StorageClass.values());
+        final StorageClass storageClass = randomBoolean() ? randomFrom(StorageClass.values()) : null;
         when(blobStore.getStorageClass()).thenReturn(storageClass);
 
         final ObjectCannedACL cannedAccessControlList = randomBoolean() ? randomFrom(ObjectCannedACL.values()) : null;
-        if (cannedAccessControlList != null) {
-            when(blobStore.getCannedACL()).thenReturn(cannedAccessControlList);
-        }
+        when(blobStore.getCannedACL()).thenReturn(cannedAccessControlList);
 
         final S3Client client = mock(S3Client.class);
         final AmazonS3Reference clientReference = new AmazonS3Reference(client);
@@ -866,6 +896,49 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
             .map(CompletedPart::eTag)
             .collect(Collectors.toList());
         assertEquals(expectedEtags, actualETags);
+    }
+
+    public void testExecuteMultipartUploadOmitsUnsetAclAndStorageClass() throws IOException {
+        final String bucketName = randomAlphaOfLengthBetween(1, 10);
+        final String blobName = randomAlphaOfLengthBetween(1, 10);
+        final long blobSize = ByteSizeUnit.MB.toBytes(6);
+        final long bufferSize = ByteSizeUnit.MB.toBytes(5);
+
+        final S3BlobStore blobStore = mock(S3BlobStore.class);
+        when(blobStore.bucket()).thenReturn(bucketName);
+        when(blobStore.bufferSizeInBytes()).thenReturn(bufferSize);
+        when(blobStore.getStorageClass()).thenReturn(null);
+        when(blobStore.getCannedACL()).thenReturn(null);
+        when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
+        when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AES256.toString());
+        when(blobStore.expectedBucketOwner()).thenReturn(randomAlphaOfLength(12));
+
+        final S3Client client = mock(S3Client.class);
+        when(blobStore.clientReference()).thenReturn(new AmazonS3Reference(client));
+
+        final ArgumentCaptor<CreateMultipartUploadRequest> createCaptor = ArgumentCaptor.forClass(CreateMultipartUploadRequest.class);
+        when(client.createMultipartUpload(createCaptor.capture())).thenReturn(
+            CreateMultipartUploadResponse.builder().uploadId("upload-id").build()
+        );
+        when(client.uploadPart(any(UploadPartRequest.class), any(RequestBody.class))).thenReturn(
+            UploadPartResponse.builder().eTag("etag").build()
+        );
+        when(client.completeMultipartUpload(any(CompleteMultipartUploadRequest.class))).thenReturn(
+            CompleteMultipartUploadResponse.builder().build()
+        );
+
+        new S3BlobContainer(new BlobPath(), blobStore).executeMultipartUpload(
+            blobStore,
+            blobName,
+            new ByteArrayInputStream(new byte[(int) blobSize]),
+            blobSize,
+            null,
+            null
+        );
+
+        final CreateMultipartUploadRequest request = createCaptor.getValue();
+        assertNull(request.storageClass());
+        assertNull(request.acl());
     }
 
     public void testExecuteMultipartUploadAborted() {
@@ -1016,9 +1089,9 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
             "bucket-owner-read",
             "bucket-owner-full-control" };
 
-        // empty acl
-        assertThat(S3BlobStore.initCannedACL(null), equalTo(ObjectCannedACL.PRIVATE));
-        assertThat(S3BlobStore.initCannedACL(""), equalTo(ObjectCannedACL.PRIVATE));
+        // empty acl omits the header and lets S3 apply its default
+        assertNull(S3BlobStore.initCannedACL(null));
+        assertNull(S3BlobStore.initCannedACL(""));
 
         // it should init cannedACL correctly
         for (String aclString : aclList) {
@@ -1039,9 +1112,9 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
     }
 
     public void testInitStorageClass() {
-        // it should default to `standard`
-        assertThat(S3BlobStore.initStorageClass(null), equalTo(StorageClass.STANDARD));
-        assertThat(S3BlobStore.initStorageClass(""), equalTo(StorageClass.STANDARD));
+        // empty storage class omits the header and lets S3 apply its default
+        assertNull(S3BlobStore.initStorageClass(null));
+        assertNull(S3BlobStore.initStorageClass(""));
 
         // it should accept [standard, standard_ia, onezone_ia, reduced_redundancy, intelligent_tiering]
         assertThat(S3BlobStore.initStorageClass("standard"), equalTo(StorageClass.STANDARD));


### PR DESCRIPTION
### Description
repository-s3 currently materializes unset `canned_acl` and `storage_class` settings into explicit `x-amz-acl` and `x-amz-storage-class` headers on sync upload requests. That is fine for standard S3, but it breaks S3 Outposts because the repository is sending default headers even when those settings were never configured.

This change stops forcing those defaults into the request. When `canned_acl` or `storage_class` is unset, repository-s3 now omits the corresponding header and lets S3 apply its default behavior. Explicit repository overrides still continue to populate the request as before.

The fix covers both single-part uploads and multipart upload initialization, and adds focused repository-s3 tests for omitted default headers as well as explicit overrides.

### Related Issues
Resolves #21190

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

### Validation
- `JAVA_HOME=/Users/abishekkumargiri/Library/Java/JavaVirtualMachines/openjdk-21.0.1/Contents/Home ./gradlew :plugins:repository-s3:spotlessJavaCheck`
- `JAVA_HOME=/Users/abishekkumargiri/Library/Java/JavaVirtualMachines/openjdk-21.0.1/Contents/Home ./gradlew :plugins:repository-s3:compileTestJava :plugins:repository-s3:test --tests "org.opensearch.repositories.s3.S3BlobStoreContainerTests" -x :test:fixtures:s3-fixture:composeBuild -x :test:fixtures:minio-fixture:composeBuild -x :test:fixtures:s3-fixture:composeUp -x :test:fixtures:minio-fixture:composeUp -x :test:fixtures:s3-fixture:buildFixture -x :test:fixtures:minio-fixture:buildFixture`
