### PR TITLE
Reject DSL search on indices with pluggable dataformat enabled

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
@@ -26,7 +26,6 @@ import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
-import org.opensearch.transport.client.node.NodeClient;
 import org.opensearch.watcher.ResourceWatcherService;
 
 import java.util.Collection;
@@ -59,7 +58,7 @@ public class DslQueryExecutorPlugin extends Plugin implements ActionPlugin {
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        this.searchActionFilter = new SearchActionFilter((NodeClient) client);
+        this.searchActionFilter = new SearchActionFilter(clusterService, indexNameExpressionResolver);
         return Collections.emptyList();
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
@@ -8,36 +8,41 @@
 
 package org.opensearch.dsl.action;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.action.support.ActionRequestMetadata;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.tasks.Task;
-import org.opensearch.transport.client.node.NodeClient;
 
 /**
- * Intercepts all {@code _search} requests and dispatches them to {@link DslExecuteAction}
- * for execution through the Calcite pipeline. Non-search actions pass through unchanged.
+ * Intercepts {@code _search} requests targeting indices with {@code index.pluggable.dataformat.enabled}
+ * and rejects them with an error directing users to PPL instead.
  */
 public class SearchActionFilter implements ActionFilter {
+
+    private static final Logger logger = LogManager.getLogger(SearchActionFilter.class);
 
     /** Runs after the Security plugin's authorization filter (order 0). */
     static final int FILTER_ORDER = 1;
 
-    private final NodeClient client;
+    private final ClusterService clusterService;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
 
-    /**
-     * Creates a filter that dispatches intercepted searches via the given client.
-     *
-     * @param client node client for dispatching to {@link DslExecuteAction}
-     */
-    public SearchActionFilter(NodeClient client) {
-        this.client = client;
+    public SearchActionFilter(ClusterService clusterService, IndexNameExpressionResolver indexNameExpressionResolver) {
+        this.clusterService = clusterService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
     }
 
     @Override
@@ -46,7 +51,6 @@ public class SearchActionFilter implements ActionFilter {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <Request extends ActionRequest, Response extends ActionResponse> void apply(
         Task task,
         String action,
@@ -55,13 +59,33 @@ public class SearchActionFilter implements ActionFilter {
         ActionListener<Response> listener,
         ActionFilterChain<Request, Response> chain
     ) {
-        // TODO: add support for other search-related APIs (_msearch, _count, _search_shards, etc.).
+        // TODO: Add support for other search-related APIs (_msearch, _count, _search_shards, etc.).
         // Consider two categories: APIs that execute search vs APIs that only explain/validate.
         if (SearchAction.NAME.equals(action)) {
             SearchRequest searchRequest = (SearchRequest) request;
-            client.execute(DslExecuteAction.INSTANCE, searchRequest, (ActionListener<SearchResponse>) listener);
-        } else {
-            chain.proceed(task, action, request, listener);
+            ClusterState state = clusterService.state();
+            Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, searchRequest);
+
+            if (hasPluggableDataFormatIndex(state, concreteIndices)) {
+                logger.debug("Rejecting DSL search: at least one target index has pluggable dataformat enabled");
+                // TODO: Route to DSL/Calcite engine once supported:
+                // client.execute(DslExecuteAction.INSTANCE, searchRequest, (ActionListener<SearchResponse>) listener);
+                listener.onFailure(
+                    new UnsupportedOperationException("DSL is not supported with Optimized Engine currently. Please use PPL or SQL for search.")
+                );
+                return;
+            }
         }
+        chain.proceed(task, action, request, listener);
+    }
+
+    private boolean hasPluggableDataFormatIndex(ClusterState state, Index[] concreteIndices) {
+        for (Index index : concreteIndices) {
+            IndexMetadata indexMetadata = state.metadata().index(index);
+            if (indexMetadata != null && IndexSettings.isPluggableDataFormatEnabled(indexMetadata.getSettings())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
@@ -15,27 +15,38 @@ import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.action.support.ActionRequestMetadata;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.index.Index;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.transport.client.node.NodeClient;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 public class SearchActionFilterTests extends OpenSearchTestCase {
 
-    private final NodeClient client = mock(NodeClient.class);
+    private final ClusterService clusterService = mock(ClusterService.class);
+    private final IndexNameExpressionResolver indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
     private final Task task = mock(Task.class);
     private final ActionListener<ActionResponse> listener = mock(ActionListener.class);
     private final ActionFilterChain<ActionRequest, ActionResponse> chain = mock(ActionFilterChain.class);
     private final ActionRequestMetadata<ActionRequest, ActionResponse> metadata = mock(ActionRequestMetadata.class);
-    private final SearchActionFilter filter = new SearchActionFilter(client);
+    private final SearchActionFilter filter = new SearchActionFilter(clusterService, indexNameExpressionResolver);
+
+    private static final Settings PLUGGABLE_SETTINGS = Settings.builder().put("index.pluggable.dataformat.enabled", true).build();
 
     public void testOrderRunsAfterSecurityFilter() {
         assertEquals(SearchActionFilter.FILTER_ORDER, filter.order());
@@ -47,17 +58,73 @@ public class SearchActionFilterTests extends OpenSearchTestCase {
         filter.apply(task, BulkAction.NAME, request, metadata, listener, chain);
 
         verify(chain).proceed(task, BulkAction.NAME, request, listener);
-        verify(client, never()).execute(any(), any(), any());
+        verify(listener, never()).onFailure(any());
     }
 
-    // TODO: add tests to verify reroute only happens when the target index has the setting enabled
-
-    public void testReroutesSearchAction() {
+    public void testPassesThroughWhenNoPluggableDataFormat() {
         SearchRequest request = new SearchRequest("test-index");
+        mockIndices(request, new IndexEntry(new Index("test-index", "uuid"), Settings.EMPTY));
 
-        filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
+        filter.apply(task, SearchAction.NAME, request, this.metadata, listener, chain);
 
-        verify(client).execute(eq(DslExecuteAction.INSTANCE), eq(request), any());
+        verify(chain).proceed(task, SearchAction.NAME, request, listener);
+        verify(listener, never()).onFailure(any());
+    }
+
+    public void testPassesThroughWhenConcreteIndicesEmpty() {
+        SearchRequest request = new SearchRequest("no-match-*");
+        ClusterState state = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(state);
+        when(indexNameExpressionResolver.concreteIndices(state, request)).thenReturn(new Index[0]);
+
+        filter.apply(task, SearchAction.NAME, request, this.metadata, listener, chain);
+
+        verify(chain).proceed(task, SearchAction.NAME, request, listener);
+        verify(listener, never()).onFailure(any());
+    }
+
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testRejectsWhenAllIndicesHavePluggableDataFormat() {
+        SearchRequest request = new SearchRequest("idx1", "idx2");
+        mockIndices(request, indexEntry("idx1", PLUGGABLE_SETTINGS), indexEntry("idx2", PLUGGABLE_SETTINGS));
+
+        filter.apply(task, SearchAction.NAME, request, this.metadata, listener, chain);
+
+        verify(listener).onFailure(argThat(e -> e instanceof UnsupportedOperationException));
         verify(chain, never()).proceed(any(), any(), any(), any());
+    }
+
+    @LockFeatureFlag(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testRejectsWhenMixedIndices() {
+        SearchRequest request = new SearchRequest("idx1", "idx2");
+        mockIndices(request, indexEntry("idx1", PLUGGABLE_SETTINGS), indexEntry("idx2", Settings.EMPTY));
+
+        filter.apply(task, SearchAction.NAME, request, this.metadata, listener, chain);
+
+        verify(listener).onFailure(argThat(e -> e instanceof UnsupportedOperationException));
+        verify(chain, never()).proceed(any(), any(), any(), any());
+    }
+
+    private IndexEntry indexEntry(String name, Settings settings) {
+        return new IndexEntry(new Index(name, name + "-uuid"), settings);
+    }
+
+    private void mockIndices(SearchRequest request, IndexEntry... entries) {
+        ClusterState state = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        when(clusterService.state()).thenReturn(state);
+        when(state.metadata()).thenReturn(metadata);
+
+        Index[] indices = new Index[entries.length];
+        for (int i = 0; i < entries.length; i++) {
+            indices[i] = entries[i].index;
+            IndexMetadata indexMetadata = mock(IndexMetadata.class);
+            when(indexMetadata.getSettings()).thenReturn(entries[i].settings);
+            when(metadata.index(entries[i].index)).thenReturn(indexMetadata);
+        }
+        when(indexNameExpressionResolver.concreteIndices(state, request)).thenReturn(indices);
+    }
+
+    private record IndexEntry(Index index, Settings settings) {
     }
 }

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -1240,8 +1240,7 @@ public final class IndexSettings {
         checkPendingFlushEnabled = scopedSettings.get(INDEX_CHECK_PENDING_FLUSH_ENABLED);
         defaultSearchPipeline = scopedSettings.get(DEFAULT_SEARCH_PIPELINE);
         derivedSourceEnabled = scopedSettings.get(INDEX_DERIVED_SOURCE_SETTING);
-        pluggableDataFormatEnabled = FeatureFlags.isEnabled(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
-            && scopedSettings.get(PLUGGABLE_DATAFORMAT_ENABLED_SETTING);
+        pluggableDataFormatEnabled = isPluggableDataFormatEnabled(settings);
         pluggedDataFormat = scopedSettings.get(PLUGGABLE_DATAFORMAT_VALUE_SETTING);
         derivedSourceEnabledForTranslog = scopedSettings.get(INDEX_DERIVED_SOURCE_TRANSLOG_ENABLED_SETTING);
         scopedSettings.addSettingsUpdateConsumer(INDEX_DERIVED_SOURCE_TRANSLOG_ENABLED_SETTING, this::setDerivedSourceEnabledForTranslog);
@@ -2398,6 +2397,16 @@ public final class IndexSettings {
     /**
      * Returns whether the pluggable data format feature is enabled for this index.
      * Requires both the experimental feature flag and the index-level setting.
+     *
+     * @return {@code true} if pluggable data format is enabled
+     */
+    public static boolean isPluggableDataFormatEnabled(Settings settings) {
+        return FeatureFlags.isEnabled(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+            && PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(settings);
+    }
+
+    /**
+     * Returns whether pluggable data format is enabled for this index (cached at construction time).
      *
      * @return {@code true} if pluggable data format is enabled
      */


### PR DESCRIPTION
### Description
Modifies `SearchActionFilter` to check `index.pluggable.dataformat.enabled` on target indices. Indices not using pluggable dataformat should go through the normal Lucene search path while DSL search on indices using pluggable dataformat should be rejected.

Notes on `pluggable.dataformat.enabled`:
- `pluggable.dataformat.enabled` is immutable and cannot be changed once set
- If index level `pluggable.dataformat.enabled` is not set, cluster level pluggable.dataformat.enabled will be added on the index by default

Reference PR - https://github.com/opensearch-project/OpenSearch/pull/21435

**Behavior:**                                                                                                  
  - No target indices have the setting `pluggable.dataformat.enabled = true` →  Use normal search path
  - If any index have `pluggable.dataformat.enabled = true` → Reject request

### Changes
  - `SearchActionFilter`: Added `ClusterService` and `IndexNameExpressionResolver` to resolve concrete indices   
  and check their settings before deciding the execution path. 
  - `DslQueryExecutorPlugin`: Pass new dependencies to `SearchActionFilter`. 
  - `SearchActionFilterTests`: Added tests for all-pluggable bypass, mixed-index rejection, and refactored       
  existing tests to use shared mock helpers.  

### Check List
- [Done] Functionality includes testing.
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [NA] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
