### PR TITLE
Added support for regex, where it will be converted to custom UDF and…

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslQueryIT.java
@@ -39,6 +39,12 @@ public class DslQueryIT extends DslIntegTestBase {
         assertOk(search(new SearchSourceBuilder().query(QueryBuilders.wildcardQuery("name", "lap*"))));
     }
 
+    public void testRegexpQueryWithUnresolvedNode() {
+        createTestIndex();
+        // Regexp query is not converted to standard Rex — wraps in UnresolvedQueryCall.
+        assertOk(search(new SearchSourceBuilder().query(QueryBuilders.regexpQuery("name", "lap.*"))));
+    }
+
     public void testFailsForNonexistentIndex() {
         expectThrows(
             Exception.class,

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
@@ -20,6 +20,7 @@ public class QueryRegistryFactory {
         QueryRegistry registry = new QueryRegistry();
         registry.register(new TermQueryTranslator());
         registry.register(new MatchAllQueryTranslator());
+        registry.register(new RegexpQueryTranslator());
         // TODO: add other query translators
         return registry;
     }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/RegexpQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/RegexpQueryTranslator.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RegexpQueryBuilder;
+
+/**
+ * Converts {@link RegexpQueryBuilder} to {@link UnresolvedQueryCall}.
+ * Translation to SQL SIMILAR TO is lossy — Lucene regex operates on terms in inverted index,
+ * SQL regex operates on full field values. UnresolvedQueryCall preserves Lucene semantics.
+ */
+public class RegexpQueryTranslator implements QueryTranslator {
+
+    @Override
+    public Class<? extends QueryBuilder> getQueryType() {
+        return RegexpQueryBuilder.class;
+    }
+
+    @Override
+    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+        return new UnresolvedQueryCall(ctx.getCluster().getTypeFactory().createSqlType(SqlTypeName.BOOLEAN), query);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/RegexpQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/RegexpQueryTranslatorTests.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.index.query.RegexpQueryBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RegexpQueryTranslatorTests extends OpenSearchTestCase {
+
+    public void testConvertBasicRegexp() throws Exception {
+        RegexpQueryTranslator translator = new RegexpQueryTranslator();
+        RegexpQueryBuilder query = new RegexpQueryBuilder("field", ".*pattern.*");
+
+        ConversionContext ctx = mockContext();
+        RexNode result = translator.convert(query, ctx);
+
+        assertNotNull(result);
+        assertTrue(result instanceof UnresolvedQueryCall);
+        UnresolvedQueryCall call = (UnresolvedQueryCall) result;
+        assertEquals(query, call.getQueryBuilder());
+    }
+
+    public void testConvertWithFlags() throws Exception {
+        RegexpQueryTranslator translator = new RegexpQueryTranslator();
+        RegexpQueryBuilder query = new RegexpQueryBuilder("field", "pattern").flags(1);
+
+        ConversionContext ctx = mockContext();
+        RexNode result = translator.convert(query, ctx);
+
+        assertNotNull(result);
+        assertTrue(result instanceof UnresolvedQueryCall);
+        UnresolvedQueryCall call = (UnresolvedQueryCall) result;
+        assertEquals(query, call.getQueryBuilder());
+        assertEquals(1, ((RegexpQueryBuilder) call.getQueryBuilder()).flags());
+    }
+
+    public void testGetQueryType() {
+        RegexpQueryTranslator translator = new RegexpQueryTranslator();
+        assertEquals(RegexpQueryBuilder.class, translator.getQueryType());
+    }
+
+    private ConversionContext mockContext() {
+        ConversionContext ctx = mock(ConversionContext.class);
+        RelOptCluster cluster = mock(RelOptCluster.class);
+        RelDataTypeFactory typeFactory = mock(RelDataTypeFactory.class);
+        RelDataType boolType = mock(RelDataType.class);
+
+        when(ctx.getCluster()).thenReturn(cluster);
+        when(cluster.getTypeFactory()).thenReturn(typeFactory);
+        when(typeFactory.createSqlType(SqlTypeName.BOOLEAN)).thenReturn(boolType);
+
+        return ctx;
+    }
+}


### PR DESCRIPTION
## PR Summary

### Add regex query support via UnresolvedQueryCall

This PR adds support for RegexpQueryBuilder in the DSL query executor by wrapping it in an UnresolvedQueryCall that preserves Lucene regex semantics.

Changes:
• **New translator**: RegexpQueryTranslator converts RegexpQueryBuilder to UnresolvedQueryCall instead of standard SQL SIMILAR TO
• **Registry update**: Registered the new translator in QueryRegistryFactory
• **Tests**: Added unit tests covering basic regex patterns and flags
• **Integration test**: Added testRegexpQueryWithUnresolvedNode to verify end-to-end functionality

Rationale:
Direct translation to SQL regex is lossy because Lucene regex operates on terms in the inverted index while SQL regex operates on full field values. Using UnresolvedQueryCall 
preserves the correct Lucene semantics and routes execution to Lucene.

### Check List
- [ YES ] Functionality includes testing.
- [ YES ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ NA ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
