### PR TITLE
[Backport 2.17] Add SSE-KMS encryption context and bucket owner verification to S3 repository plugin (re-submission)

### DIFF
--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
@@ -58,7 +58,6 @@ import software.amazon.awssdk.services.s3.model.ObjectAttributes;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Error;
-import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
@@ -112,6 +111,7 @@ import java.util.stream.Collectors;
 import static org.opensearch.repositories.s3.S3Repository.MAX_FILE_SIZE;
 import static org.opensearch.repositories.s3.S3Repository.MAX_FILE_SIZE_USING_MULTIPART;
 import static org.opensearch.repositories.s3.S3Repository.MIN_PART_SIZE_USING_MULTIPART;
+import static org.opensearch.repositories.s3.utils.SseKmsUtil.configureEncryptionSettings;
 
 class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamBlobContainer {
 
@@ -131,7 +131,13 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
             SocketAccess.doPrivileged(
                 () -> clientReference.get()
-                    .headObject(HeadObjectRequest.builder().bucket(blobStore.bucket()).key(buildKey(blobName)).build())
+                    .headObject(
+                        HeadObjectRequest.builder()
+                            .bucket(blobStore.bucket())
+                            .key(buildKey(blobName))
+                            .expectedBucketOwner(blobStore.expectedBucketOwner())
+                            .build()
+                    )
             );
             return true;
         } catch (NoSuchKeyException e) {
@@ -216,7 +222,12 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             writeContext.doRemoteDataIntegrityCheck(),
             writeContext.getExpectedChecksum(),
             blobStore.isUploadRetryEnabled(),
-            writeContext.getMetadata()
+            writeContext.getMetadata(),
+            blobStore.serverSideEncryptionType(),
+            blobStore.serverSideEncryptionKmsKey(),
+            blobStore.serverSideEncryptionBucketKey(),
+            blobStore.serverSideEncryptionEncryptionContext(),
+            blobStore.expectedBucketOwner()
         );
         try {
             // If file size is greater than the queue capacity than SizeBasedBlockingQ will always reject the upload.
@@ -594,6 +605,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             .prefix(keyPath)
             .delimiter("/")
             .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().listObjectsMetricPublisher))
+            .expectedBucketOwner(blobStore.expectedBucketOwner())
             .build();
     }
 
@@ -630,14 +642,13 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             .contentLength(blobSize)
             .storageClass(blobStore.getStorageClass())
             .acl(blobStore.getCannedACL())
-            .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().putObjectMetricPublisher));
+            .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().putObjectMetricPublisher))
+            .expectedBucketOwner(blobStore.expectedBucketOwner());
 
         if (CollectionUtils.isNotEmpty(metadata)) {
             putObjectRequestBuilder = putObjectRequestBuilder.metadata(metadata);
         }
-        if (blobStore.serverSideEncryption()) {
-            putObjectRequestBuilder.serverSideEncryption(ServerSideEncryption.AES256);
-        }
+        configureEncryptionSettings(putObjectRequestBuilder, blobStore);
 
         PutObjectRequest putObjectRequest = putObjectRequestBuilder.build();
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
@@ -687,15 +698,14 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             .key(blobName)
             .storageClass(blobStore.getStorageClass())
             .acl(blobStore.getCannedACL())
-            .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector));
+            .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector))
+            .expectedBucketOwner(blobStore.expectedBucketOwner());
 
         if (CollectionUtils.isNotEmpty(metadata)) {
             createMultipartUploadRequestBuilder.metadata(metadata);
         }
 
-        if (blobStore.serverSideEncryption()) {
-            createMultipartUploadRequestBuilder.serverSideEncryption(ServerSideEncryption.AES256);
-        }
+        configureEncryptionSettings(createMultipartUploadRequestBuilder, blobStore);
 
         final InputStream requestInputStream;
         if (blobStore.isUploadRetryEnabled()) {
@@ -724,6 +734,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
                     .partNumber(i)
                     .contentLength((i < nbParts) ? partSize : lastPartSize)
                     .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector))
+                    .expectedBucketOwner(blobStore.expectedBucketOwner())
                     .build();
 
                 bytesCount += uploadPartRequest.contentLength();
@@ -746,6 +757,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
                 .uploadId(uploadId.get())
                 .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build())
                 .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector))
+                .expectedBucketOwner(blobStore.expectedBucketOwner())
                 .build();
 
             SocketAccess.doPrivilegedVoid(() -> clientReference.get().completeMultipartUpload(completeMultipartUploadRequest));
@@ -759,6 +771,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
                     .bucket(bucketName)
                     .key(blobName)
                     .uploadId(uploadId.get())
+                    .expectedBucketOwner(blobStore.expectedBucketOwner())
                     .build();
                 try (AmazonS3Reference clientReference = blobStore.clientReference()) {
                     SocketAccess.doPrivilegedVoid(() -> clientReference.get().abortMultipartUpload(abortRequest));
@@ -825,12 +838,14 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
         @Nullable Integer partNumber
     ) {
         final boolean isMultipartObject = partNumber != null;
-        final GetObjectRequest.Builder getObjectRequestBuilder = GetObjectRequest.builder().bucket(bucketName).key(blobKey);
+        final GetObjectRequest.Builder getObjectRequestBuilder = GetObjectRequest.builder()
+            .bucket(bucketName)
+            .key(blobKey)
+            .expectedBucketOwner(blobStore.expectedBucketOwner());
 
         if (isMultipartObject) {
             getObjectRequestBuilder.partNumber(partNumber);
         }
-
         return SocketAccess.doPrivileged(
             () -> s3AsyncClient.getObject(getObjectRequestBuilder.build(), AsyncResponseTransformer.toBlockingInputStream())
                 .thenApply(response -> transformResponseToInputStreamContainer(response, isMultipartObject))
@@ -871,6 +886,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             .bucket(bucketName)
             .key(blobName)
             .objectAttributes(ObjectAttributes.CHECKSUM, ObjectAttributes.OBJECT_SIZE, ObjectAttributes.OBJECT_PARTS)
+            .expectedBucketOwner(blobStore.expectedBucketOwner())
             .build();
 
         return SocketAccess.doPrivileged(() -> s3AsyncClient.getObjectAttributes(getObjectAttributesRequest));

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobStore.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobStore.java
@@ -48,6 +48,8 @@ import org.opensearch.repositories.s3.async.AsyncTransferManager;
 import org.opensearch.repositories.s3.async.SizeBasedBlockingQ;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
@@ -57,13 +59,17 @@ import static org.opensearch.repositories.s3.S3Repository.BUCKET_SETTING;
 import static org.opensearch.repositories.s3.S3Repository.BUFFER_SIZE_SETTING;
 import static org.opensearch.repositories.s3.S3Repository.BULK_DELETE_SIZE;
 import static org.opensearch.repositories.s3.S3Repository.CANNED_ACL_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.EXPECTED_BUCKET_OWNER_SETTING;
 import static org.opensearch.repositories.s3.S3Repository.PERMIT_BACKED_TRANSFER_ENABLED;
 import static org.opensearch.repositories.s3.S3Repository.REDIRECT_LARGE_S3_UPLOAD;
-import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_ENCRYPTION_CONTEXT_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_KMS_KEY_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_TYPE_SETTING;
 import static org.opensearch.repositories.s3.S3Repository.STORAGE_CLASS_SETTING;
 import static org.opensearch.repositories.s3.S3Repository.UPLOAD_RETRY_ENABLED;
 
-class S3BlobStore implements BlobStore {
+public class S3BlobStore implements BlobStore {
 
     private static final Logger logger = LogManager.getLogger(S3BlobStore.class);
 
@@ -81,7 +87,11 @@ class S3BlobStore implements BlobStore {
 
     private volatile boolean permitBackedTransferEnabled;
 
-    private volatile boolean serverSideEncryption;
+    private volatile String serverSideEncryptionType;
+    private volatile String serverSideEncryptionKmsKey;
+    private volatile boolean serverSideEncryptionBucketKey;
+    private volatile String serverSideEncryptionEncryptionContext;
+    private volatile String expectedBucketOwner;
 
     private volatile ObjectCannedACL cannedACL;
 
@@ -107,7 +117,6 @@ class S3BlobStore implements BlobStore {
         S3AsyncService s3AsyncService,
         boolean multipartUploadEnabled,
         String bucket,
-        boolean serverSideEncryption,
         ByteSizeValue bufferSize,
         String cannedACL,
         String storageClass,
@@ -119,13 +128,17 @@ class S3BlobStore implements BlobStore {
         AsyncExecutorContainer normalExecutorBuilder,
         SizeBasedBlockingQ normalPrioritySizeBasedBlockingQ,
         SizeBasedBlockingQ lowPrioritySizeBasedBlockingQ,
-        GenericStatsMetricPublisher genericStatsMetricPublisher
+        GenericStatsMetricPublisher genericStatsMetricPublisher,
+        String serverSideEncryptionType,
+        String serverSideEncryptionKmsKey,
+        boolean serverSideEncryptionBucketKey,
+        String serverSideEncryptionEncryptionContext,
+        String expectedBucketOwner
     ) {
         this.service = service;
         this.s3AsyncService = s3AsyncService;
         this.multipartUploadEnabled = multipartUploadEnabled;
         this.bucket = bucket;
-        this.serverSideEncryption = serverSideEncryption;
         this.bufferSize = bufferSize;
         this.cannedACL = initCannedACL(cannedACL);
         this.storageClass = initStorageClass(storageClass);
@@ -142,13 +155,17 @@ class S3BlobStore implements BlobStore {
         this.lowPrioritySizeBasedBlockingQ = lowPrioritySizeBasedBlockingQ;
         this.genericStatsMetricPublisher = genericStatsMetricPublisher;
         this.permitBackedTransferEnabled = PERMIT_BACKED_TRANSFER_ENABLED.get(repositoryMetadata.settings());
+        this.serverSideEncryptionType = serverSideEncryptionType;
+        this.serverSideEncryptionKmsKey = serverSideEncryptionKmsKey;
+        this.serverSideEncryptionBucketKey = serverSideEncryptionBucketKey;
+        this.serverSideEncryptionEncryptionContext = serverSideEncryptionEncryptionContext;
+        this.expectedBucketOwner = expectedBucketOwner;
     }
 
     @Override
     public void reload(RepositoryMetadata repositoryMetadata) {
         this.repositoryMetadata = repositoryMetadata;
         this.bucket = BUCKET_SETTING.get(repositoryMetadata.settings());
-        this.serverSideEncryption = SERVER_SIDE_ENCRYPTION_SETTING.get(repositoryMetadata.settings());
         this.bufferSize = BUFFER_SIZE_SETTING.get(repositoryMetadata.settings());
         this.cannedACL = initCannedACL(CANNED_ACL_SETTING.get(repositoryMetadata.settings()));
         this.storageClass = initStorageClass(STORAGE_CLASS_SETTING.get(repositoryMetadata.settings()));
@@ -156,6 +173,11 @@ class S3BlobStore implements BlobStore {
         this.redirectLargeUploads = REDIRECT_LARGE_S3_UPLOAD.get(repositoryMetadata.settings());
         this.uploadRetryEnabled = UPLOAD_RETRY_ENABLED.get(repositoryMetadata.settings());
         this.permitBackedTransferEnabled = PERMIT_BACKED_TRANSFER_ENABLED.get(repositoryMetadata.settings());
+        this.serverSideEncryptionType = SERVER_SIDE_ENCRYPTION_TYPE_SETTING.get(repositoryMetadata.settings());
+        this.serverSideEncryptionKmsKey = SERVER_SIDE_ENCRYPTION_KMS_KEY_SETTING.get(repositoryMetadata.settings());
+        this.serverSideEncryptionBucketKey = SERVER_SIDE_ENCRYPTION_BUCKET_KEY_SETTING.get(repositoryMetadata.settings());
+        this.serverSideEncryptionEncryptionContext = SERVER_SIDE_ENCRYPTION_ENCRYPTION_CONTEXT_SETTING.get(repositoryMetadata.settings());
+        this.expectedBucketOwner = EXPECTED_BUCKET_OWNER_SETTING.get(repositoryMetadata.settings());
     }
 
     @Override
@@ -191,8 +213,33 @@ class S3BlobStore implements BlobStore {
         return bucket;
     }
 
-    public boolean serverSideEncryption() {
-        return serverSideEncryption;
+    public String serverSideEncryptionType() {
+        return serverSideEncryptionType;
+    }
+
+    public String serverSideEncryptionKmsKey() {
+        return serverSideEncryptionKmsKey;
+    }
+
+    public boolean serverSideEncryptionBucketKey() {
+        return serverSideEncryptionBucketKey;
+    }
+
+    /**
+     * Returns the SSE encryption context base64 UTF8 encoded, as required by S3 SDK. If the encryption context is empty return
+     * null as the S3 client ignores null header values
+     */
+    public String serverSideEncryptionEncryptionContext() {
+        return serverSideEncryptionEncryptionContext.isEmpty()
+            ? null
+            : Base64.getEncoder().encodeToString(serverSideEncryptionEncryptionContext.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Returns the expected bucket owner if set, else null as the S3 client ignores null header values
+     */
+    public String expectedBucketOwner() {
+        return expectedBucketOwner.isEmpty() ? null : expectedBucketOwner;
     }
 
     public long bufferSizeInBytes() {

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Repository.java
@@ -33,6 +33,7 @@
 package org.opensearch.repositories.s3;
 
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 
 import org.apache.logging.log4j.LogManager;
@@ -128,11 +129,53 @@ class S3Repository extends MeteredBlobStoreRepository {
 
     static final Setting<String> BUCKET_SETTING = Setting.simpleString("bucket");
 
+    static final String BUCKET_DEFAULT_ENCRYPTION_TYPE = "bucket_default";
     /**
-     * When set to true files are encrypted on server side using AES256 algorithm.
-     * Defaults to false.
+     * The type of S3 Server Side Encryption to use.
+     * Defaults to AES256.
+     * Supports: AES256, aws:kms
      */
-    static final Setting<Boolean> SERVER_SIDE_ENCRYPTION_SETTING = Setting.boolSetting("server_side_encryption", false);
+    static final Setting<String> SERVER_SIDE_ENCRYPTION_TYPE_SETTING = Setting.simpleString(
+        "server_side_encryption_type",
+        BUCKET_DEFAULT_ENCRYPTION_TYPE,
+        value -> {
+            if (!(value.equals(ServerSideEncryption.AES256.toString())
+                || value.equals(ServerSideEncryption.AWS_KMS.toString())
+                || value.equals(BUCKET_DEFAULT_ENCRYPTION_TYPE))) {
+                throw new IllegalArgumentException("server_side_encryption_type must be one of [AES256, aws:kms, bucket_default]");
+            }
+        }
+    );
+
+    /**
+     * The KMS key id to be used for SSE-KMS. Must be used when server_side_encryption_type setting is set to aws:kms.
+     */
+    static final Setting<String> SERVER_SIDE_ENCRYPTION_KMS_KEY_SETTING = Setting.simpleString("server_side_encryption_kms_key_id");
+
+    /**
+     * Whether to use S3 Bucket Keys along with SSE-KMS.
+     * Defaults to true.
+     */
+    static final Setting<Boolean> SERVER_SIDE_ENCRYPTION_BUCKET_KEY_SETTING = Setting.boolSetting(
+        "server_side_encryption_bucket_key_enabled",
+        true
+    );
+
+    /**
+     * Optional additional encryption context passed to S3 for use in KMS crypto operations. The setting value must be formatted as a key-value pair JSON object.
+     */
+    static final Setting<String> SERVER_SIDE_ENCRYPTION_ENCRYPTION_CONTEXT_SETTING = Setting.simpleString(
+        "server_side_encryption_encryption_context"
+    );
+
+    /**
+     * Optional setting to specify the expected S3 bucket owner. This is used to verify S3 bucket ownership before reading/writing data from/to a bucket.
+     */
+    static final Setting<String> EXPECTED_BUCKET_OWNER_SETTING = Setting.simpleString("expected_bucket_owner", value -> {
+        if (!(value.matches("\\d{12}") || value.isEmpty())) {
+            throw new IllegalArgumentException("expected_bucket_owner must be a 12 digit AWS account id");
+        }
+    });
 
     /**
      * Maximum size of files that can be uploaded using a single upload request.
@@ -307,7 +350,11 @@ class S3Repository extends MeteredBlobStoreRepository {
 
     private volatile BlobPath basePath;
 
-    private volatile boolean serverSideEncryption;
+    private volatile String serverSideEncryptionType;
+    private volatile String serverSideEncryptionKmsKey;
+    private volatile boolean serverSideEncryptionBucketKey;
+    private volatile String serverSideEncryptionEncryptionContext;
+    private volatile String expectedBucketOwner;
 
     private volatile String storageClass;
 
@@ -510,7 +557,6 @@ class S3Repository extends MeteredBlobStoreRepository {
             s3AsyncService,
             multipartUploadEnabled,
             bucket,
-            serverSideEncryption,
             bufferSize,
             cannedACL,
             storageClass,
@@ -522,7 +568,12 @@ class S3Repository extends MeteredBlobStoreRepository {
             normalExecutorBuilder,
             normalPrioritySizeBasedBlockingQ,
             lowPrioritySizeBasedBlockingQ,
-            genericStatsMetricPublisher
+            genericStatsMetricPublisher,
+            serverSideEncryptionType,
+            serverSideEncryptionKmsKey,
+            serverSideEncryptionBucketKey,
+            serverSideEncryptionEncryptionContext,
+            expectedBucketOwner
         );
     }
 
@@ -577,7 +628,11 @@ class S3Repository extends MeteredBlobStoreRepository {
             this.basePath = BlobPath.cleanPath();
         }
 
-        this.serverSideEncryption = SERVER_SIDE_ENCRYPTION_SETTING.get(metadata.settings());
+        this.serverSideEncryptionType = SERVER_SIDE_ENCRYPTION_TYPE_SETTING.get(metadata.settings());
+        this.serverSideEncryptionKmsKey = SERVER_SIDE_ENCRYPTION_KMS_KEY_SETTING.get(metadata.settings());
+        this.serverSideEncryptionBucketKey = SERVER_SIDE_ENCRYPTION_BUCKET_KEY_SETTING.get(metadata.settings());
+        this.serverSideEncryptionEncryptionContext = SERVER_SIDE_ENCRYPTION_ENCRYPTION_CONTEXT_SETTING.get(metadata.settings());
+        this.expectedBucketOwner = EXPECTED_BUCKET_OWNER_SETTING.get(metadata.settings());
         this.storageClass = STORAGE_CLASS_SETTING.get(metadata.settings());
         this.cannedACL = CANNED_ACL_SETTING.get(metadata.settings());
         this.bulkDeletesSize = BULK_DELETE_SIZE.get(metadata.settings());
@@ -591,13 +646,18 @@ class S3Repository extends MeteredBlobStoreRepository {
         }
 
         logger.debug(
-            "using bucket [{}], chunk_size [{}], server_side_encryption [{}], buffer_size [{}], cannedACL [{}], storageClass [{}]",
+            "using bucket [{}], chunk_size [{}], buffer_size [{}], cannedACL [{}], storageClass [{}], "
+                + "server_side_encryption_type [{}], server_side_encryption_kms_key_id [{}], server_side_encryption_bucket_key_enabled [{}], server_side_encryption_encryption_context [{}], expected_bucket_owner [{}], ",
             bucket,
             chunkSize,
-            serverSideEncryption,
             bufferSize,
             cannedACL,
-            storageClass
+            storageClass,
+            serverSideEncryptionType,
+            serverSideEncryptionKmsKey,
+            serverSideEncryptionBucketKey,
+            serverSideEncryptionEncryptionContext,
+            expectedBucketOwner
         );
     }
 

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RetryingInputStream.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RetryingInputStream.java
@@ -106,7 +106,8 @@ class S3RetryingInputStream extends InputStream {
             final GetObjectRequest.Builder getObjectRequest = GetObjectRequest.builder()
                 .bucket(blobStore.bucket())
                 .key(blobKey)
-                .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().getObjectMetricPublisher));
+                .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().getObjectMetricPublisher))
+                .expectedBucketOwner(blobStore.expectedBucketOwner());
             if (currentOffset > 0 || start > 0 || end < Long.MAX_VALUE - 1) {
                 assert start + currentOffset <= end : "requesting beyond end, start = "
                     + start

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/AsyncPartsHandler.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/AsyncPartsHandler.java
@@ -95,7 +95,8 @@ public class AsyncPartsHandler {
                     .key(uploadRequest.getKey())
                     .uploadId(uploadId)
                     .overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector))
-                    .contentLength(inputStreamContainer.getContentLength());
+                    .contentLength(inputStreamContainer.getContentLength())
+                    .expectedBucketOwner(uploadRequest.getExpectedBucketOwner());
                 if (uploadRequest.doRemoteDataIntegrityCheck()) {
                     uploadPartRequestBuilder.checksumAlgorithm(ChecksumAlgorithm.CRC32);
                 }
@@ -136,6 +137,7 @@ public class AsyncPartsHandler {
             .bucket(uploadRequest.getBucket())
             .key(uploadRequest.getKey())
             .uploadId(uploadId)
+            .expectedBucketOwner(uploadRequest.getExpectedBucketOwner())
             .build();
         SocketAccess.doPrivileged(() -> s3AsyncClient.abortMultipartUpload(abortMultipartUploadRequest).exceptionally(throwable -> {
             log.warn(

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/UploadRequest.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/UploadRequest.java
@@ -28,6 +28,11 @@ public class UploadRequest {
     private final Long expectedChecksum;
     private final boolean uploadRetryEnabled;
     private final Map<String, String> metadata;
+    private volatile String serverSideEncryptionType;
+    private volatile String serverSideEncryptionKmsKey;
+    private volatile boolean serverSideEncryptionBucketKey;
+    private volatile String serverSideEncryptionEncryptionContext;
+    private final String expectedBucketOwner;
 
     /**
      * Construct a new UploadRequest object
@@ -50,7 +55,12 @@ public class UploadRequest {
         boolean doRemoteDataIntegrityCheck,
         Long expectedChecksum,
         boolean uploadRetryEnabled,
-        @Nullable Map<String, String> metadata
+        @Nullable Map<String, String> metadata,
+        String serverSideEncryptionType,
+        String serverSideEncryptionKmsKey,
+        boolean serverSideEncryptionBucketKey,
+        @Nullable String serverSideEncryptionEncryptionContext,
+        @Nullable String expectedBucketOwner
     ) {
         this.bucket = bucket;
         this.key = key;
@@ -61,6 +71,11 @@ public class UploadRequest {
         this.expectedChecksum = expectedChecksum;
         this.uploadRetryEnabled = uploadRetryEnabled;
         this.metadata = metadata;
+        this.serverSideEncryptionType = serverSideEncryptionType;
+        this.serverSideEncryptionKmsKey = serverSideEncryptionKmsKey;
+        this.serverSideEncryptionBucketKey = serverSideEncryptionBucketKey;
+        this.serverSideEncryptionEncryptionContext = serverSideEncryptionEncryptionContext;
+        this.expectedBucketOwner = expectedBucketOwner;
     }
 
     public String getBucket() {
@@ -100,5 +115,25 @@ public class UploadRequest {
      */
     public Map<String, String> getMetadata() {
         return metadata;
+    }
+
+    public String getServerSideEncryptionType() {
+        return serverSideEncryptionType;
+    }
+
+    public String getServerSideEncryptionKmsKey() {
+        return serverSideEncryptionKmsKey;
+    }
+
+    public boolean getServerSideEncryptionBucketKey() {
+        return serverSideEncryptionBucketKey;
+    }
+
+    public String getServerSideEncryptionEncryptionContext() {
+        return serverSideEncryptionEncryptionContext;
+    }
+
+    public String getExpectedBucketOwner() {
+        return expectedBucketOwner;
     }
 }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/utils/SseKmsUtil.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/utils/SseKmsUtil.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.repositories.s3.utils;
+
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+
+import org.opensearch.repositories.s3.S3BlobStore;
+import org.opensearch.repositories.s3.async.UploadRequest;
+
+public class SseKmsUtil {
+
+    public static void configureEncryptionSettings(CreateMultipartUploadRequest.Builder builder, S3BlobStore blobStore) {
+        if (blobStore.serverSideEncryptionType().equals(ServerSideEncryption.AES256.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AES256);
+        } else if (blobStore.serverSideEncryptionType().equals(ServerSideEncryption.AWS_KMS.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AWS_KMS);
+            builder.ssekmsKeyId(blobStore.serverSideEncryptionKmsKey());
+            builder.bucketKeyEnabled(blobStore.serverSideEncryptionBucketKey());
+            builder.ssekmsEncryptionContext(blobStore.serverSideEncryptionEncryptionContext());
+        }
+    }
+
+    public static void configureEncryptionSettings(PutObjectRequest.Builder builder, S3BlobStore blobStore) {
+        if (blobStore.serverSideEncryptionType().equals(ServerSideEncryption.AES256.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AES256);
+        } else if (blobStore.serverSideEncryptionType().equals(ServerSideEncryption.AWS_KMS.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AWS_KMS);
+            builder.ssekmsKeyId(blobStore.serverSideEncryptionKmsKey());
+            builder.bucketKeyEnabled(blobStore.serverSideEncryptionBucketKey());
+            builder.ssekmsEncryptionContext(blobStore.serverSideEncryptionEncryptionContext());
+        }
+    }
+
+    public static void configureEncryptionSettings(CreateMultipartUploadRequest.Builder builder, UploadRequest uploadRequest) {
+        if (uploadRequest.getServerSideEncryptionType().equals(ServerSideEncryption.AES256.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AES256);
+        } else if (uploadRequest.getServerSideEncryptionType().equals(ServerSideEncryption.AWS_KMS.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AWS_KMS);
+            builder.ssekmsKeyId(uploadRequest.getServerSideEncryptionKmsKey());
+            builder.bucketKeyEnabled(uploadRequest.getServerSideEncryptionBucketKey());
+            builder.ssekmsEncryptionContext(uploadRequest.getServerSideEncryptionEncryptionContext());
+        }
+    }
+
+    public static void configureEncryptionSettings(PutObjectRequest.Builder builder, UploadRequest uploadRequest) {
+        if (uploadRequest.getServerSideEncryptionType().equals(ServerSideEncryption.AES256.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AES256);
+        } else if (uploadRequest.getServerSideEncryptionType().equals(ServerSideEncryption.AWS_KMS.toString())) {
+            builder.serverSideEncryption(ServerSideEncryption.AWS_KMS);
+            builder.ssekmsKeyId(uploadRequest.getServerSideEncryptionKmsKey());
+            builder.bucketKeyEnabled(uploadRequest.getServerSideEncryptionBucketKey());
+            builder.ssekmsEncryptionContext(uploadRequest.getServerSideEncryptionEncryptionContext());
+        }
+    }
+}

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -101,6 +101,11 @@ import static org.opensearch.repositories.s3.S3ClientSettings.MAX_RETRIES_SETTIN
 import static org.opensearch.repositories.s3.S3ClientSettings.READ_TIMEOUT_SETTING;
 import static org.opensearch.repositories.s3.S3ClientSettings.REGION;
 import static org.opensearch.repositories.s3.S3Repository.BULK_DELETE_SIZE;
+import static org.opensearch.repositories.s3.S3Repository.EXPECTED_BUCKET_OWNER_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_ENCRYPTION_CONTEXT_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_KMS_KEY_SETTING;
+import static org.opensearch.repositories.s3.S3Repository.SERVER_SIDE_ENCRYPTION_TYPE_SETTING;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -246,7 +251,6 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
                 asyncService,
                 true,
                 "bucket",
-                S3Repository.SERVER_SIDE_ENCRYPTION_SETTING.getDefault(Settings.EMPTY),
                 bufferSize == null ? S3Repository.BUFFER_SIZE_SETTING.getDefault(Settings.EMPTY) : bufferSize,
                 S3Repository.CANNED_ACL_SETTING.getDefault(Settings.EMPTY),
                 S3Repository.STORAGE_CLASS_SETTING.getDefault(Settings.EMPTY),
@@ -270,7 +274,12 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
                 asyncExecutorContainer,
                 normalPrioritySizeBasedBlockingQ,
                 lowPrioritySizeBasedBlockingQ,
-                genericStatsMetricPublisher
+                genericStatsMetricPublisher,
+                SERVER_SIDE_ENCRYPTION_TYPE_SETTING.getDefault(Settings.EMPTY),
+                SERVER_SIDE_ENCRYPTION_KMS_KEY_SETTING.getDefault(Settings.EMPTY),
+                SERVER_SIDE_ENCRYPTION_BUCKET_KEY_SETTING.getDefault(Settings.EMPTY),
+                SERVER_SIDE_ENCRYPTION_ENCRYPTION_CONTEXT_SETTING.getDefault(Settings.EMPTY),
+                EXPECTED_BUCKET_OWNER_SETTING.getDefault(Settings.EMPTY)
             )
         ) {
             @Override

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -456,8 +456,19 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
 
         final S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
 
-        final boolean serverSideEncryption = randomBoolean();
-        when(blobStore.serverSideEncryption()).thenReturn(serverSideEncryption);
+        final boolean useSseKms = randomBoolean();
+        final String kmsKeyId = randomAlphaOfLength(10);
+        final String kmsContext = randomAlphaOfLength(10);
+        final boolean useBucketKey = randomBoolean();
+        if (useSseKms) {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AWS_KMS.toString());
+            when(blobStore.serverSideEncryptionKmsKey()).thenReturn(kmsKeyId);
+            when(blobStore.serverSideEncryptionBucketKey()).thenReturn(useBucketKey);
+            when(blobStore.serverSideEncryptionEncryptionContext()).thenReturn(kmsContext);
+        } else {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AES256.toString());
+        }
+        when(blobStore.expectedBucketOwner()).thenReturn(randomAlphaOfLength(12));
 
         final StorageClass storageClass = randomFrom(StorageClass.values());
         when(blobStore.getStorageClass()).thenReturn(storageClass);
@@ -492,7 +503,12 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         assertEquals(storageClass, request.storageClass());
         assertEquals(cannedAccessControlList, request.acl());
         assertEquals(metadata, request.metadata());
-        if (serverSideEncryption) {
+        if (useSseKms) {
+            assertEquals(ServerSideEncryption.AWS_KMS, request.serverSideEncryption());
+            assertEquals(kmsKeyId, request.ssekmsKeyId());
+            assertEquals(kmsContext, request.ssekmsEncryptionContext());
+            assertEquals(useBucketKey, request.bucketKeyEnabled());
+        } else {
             assertEquals(ServerSideEncryption.AES256, request.serverSideEncryption());
         }
     }
@@ -542,8 +558,19 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
         when(blobStore.bufferSizeInBytes()).thenReturn(bufferSize);
 
-        final boolean serverSideEncryption = randomBoolean();
-        when(blobStore.serverSideEncryption()).thenReturn(serverSideEncryption);
+        final boolean useSseKms = randomBoolean();
+        final String kmsKeyId = randomAlphaOfLength(10);
+        final String kmsContext = randomAlphaOfLength(10);
+        final boolean useBucketKey = randomBoolean();
+        if (useSseKms) {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AWS_KMS.toString());
+            when(blobStore.serverSideEncryptionKmsKey()).thenReturn(kmsKeyId);
+            when(blobStore.serverSideEncryptionBucketKey()).thenReturn(useBucketKey);
+            when(blobStore.serverSideEncryptionEncryptionContext()).thenReturn(kmsContext);
+        } else {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AES256.toString());
+        }
+        when(blobStore.expectedBucketOwner()).thenReturn(randomAlphaOfLength(12));
 
         final StorageClass storageClass = randomFrom(StorageClass.values());
         when(blobStore.getStorageClass()).thenReturn(storageClass);
@@ -602,7 +629,12 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         assertEquals(cannedAccessControlList, initRequest.acl());
         assertEquals(metadata, initRequest.metadata());
 
-        if (serverSideEncryption) {
+        if (useSseKms) {
+            assertEquals(ServerSideEncryption.AWS_KMS, initRequest.serverSideEncryption());
+            assertEquals(kmsKeyId, initRequest.ssekmsKeyId());
+            assertEquals(kmsContext, initRequest.ssekmsEncryptionContext());
+            assertEquals(useBucketKey, initRequest.bucketKeyEnabled());
+        } else {
             assertEquals(ServerSideEncryption.AES256, initRequest.serverSideEncryption());
         }
 
@@ -653,6 +685,20 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         when(blobStore.bufferSizeInBytes()).thenReturn(bufferSize);
         when(blobStore.getStorageClass()).thenReturn(randomFrom(StorageClass.values()));
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
+
+        final boolean useSseKms = randomBoolean();
+        final String kmsKeyId = randomAlphaOfLength(10);
+        final String kmsContext = randomAlphaOfLength(10);
+        final boolean useBucketKey = randomBoolean();
+        if (useSseKms) {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AWS_KMS.toString());
+            when(blobStore.serverSideEncryptionKmsKey()).thenReturn(kmsKeyId);
+            when(blobStore.serverSideEncryptionBucketKey()).thenReturn(useBucketKey);
+            when(blobStore.serverSideEncryptionEncryptionContext()).thenReturn(kmsContext);
+        } else {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AES256.toString());
+        }
+        when(blobStore.expectedBucketOwner()).thenReturn(randomAlphaOfLength(12));
 
         final S3Client client = mock(S3Client.class);
         final AmazonS3Reference clientReference = new AmazonS3Reference(client);
@@ -970,8 +1016,21 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
 
         when(blobStore.bucket()).thenReturn(bucketName);
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
-        when(blobStore.serverSideEncryption()).thenReturn(false);
         when(blobStore.asyncClientReference()).thenReturn(amazonAsyncS3Reference);
+
+        final boolean useSseKms = randomBoolean();
+        final String kmsKeyId = randomAlphaOfLength(10);
+        final String kmsContext = randomAlphaOfLength(10);
+        final boolean useBucketKey = randomBoolean();
+        if (useSseKms) {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AWS_KMS.toString());
+            when(blobStore.serverSideEncryptionKmsKey()).thenReturn(kmsKeyId);
+            when(blobStore.serverSideEncryptionBucketKey()).thenReturn(useBucketKey);
+            when(blobStore.serverSideEncryptionEncryptionContext()).thenReturn(kmsContext);
+        } else {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AES256.toString());
+        }
+        when(blobStore.expectedBucketOwner()).thenReturn(null);
 
         CompletableFuture<GetObjectAttributesResponse> getObjectAttributesResponseCompletableFuture = new CompletableFuture<>();
         getObjectAttributesResponseCompletableFuture.complete(
@@ -1027,8 +1086,21 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
 
         when(blobStore.bucket()).thenReturn(bucketName);
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
-        when(blobStore.serverSideEncryption()).thenReturn(false);
         when(blobStore.asyncClientReference()).thenReturn(amazonAsyncS3Reference);
+
+        final boolean useSseKms = randomBoolean();
+        final String kmsKeyId = randomAlphaOfLength(10);
+        final String kmsContext = randomAlphaOfLength(10);
+        final boolean useBucketKey = randomBoolean();
+        if (useSseKms) {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AWS_KMS.toString());
+            when(blobStore.serverSideEncryptionKmsKey()).thenReturn(kmsKeyId);
+            when(blobStore.serverSideEncryptionBucketKey()).thenReturn(useBucketKey);
+            when(blobStore.serverSideEncryptionEncryptionContext()).thenReturn(kmsContext);
+        } else {
+            when(blobStore.serverSideEncryptionType()).thenReturn(ServerSideEncryption.AES256.toString());
+        }
+        when(blobStore.expectedBucketOwner()).thenReturn(null);
 
         CompletableFuture<GetObjectAttributesResponse> getObjectAttributesResponseCompletableFuture = new CompletableFuture<>();
         getObjectAttributesResponseCompletableFuture.complete(
@@ -1083,7 +1155,6 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
 
         when(blobStore.bucket()).thenReturn(bucketName);
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
-        when(blobStore.serverSideEncryption()).thenReturn(false);
         when(blobStore.asyncClientReference()).thenReturn(amazonAsyncS3Reference);
 
         CompletableFuture<GetObjectAttributesResponse> getObjectAttributesResponseCompletableFuture = new CompletableFuture<>();
@@ -1126,7 +1197,6 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
 
         when(blobStore.bucket()).thenReturn(bucketName);
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
-        when(blobStore.serverSideEncryption()).thenReturn(false);
         when(blobStore.asyncClientReference()).thenReturn(amazonAsyncS3Reference);
 
         CompletableFuture<GetObjectAttributesResponse> getObjectAttributesResponseCompletableFuture = new CompletableFuture<>();
@@ -1165,7 +1235,6 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         final BlobPath blobPath = new BlobPath();
         when(blobStore.bucket()).thenReturn(bucketName);
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
-        when(blobStore.serverSideEncryption()).thenReturn(false);
         final S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
 
         CompletableFuture<GetObjectAttributesResponse> getObjectAttributesResponseCompletableFuture = new CompletableFuture<>();
@@ -1200,7 +1269,6 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
         final BlobPath blobPath = new BlobPath();
         when(blobStore.bucket()).thenReturn(bucketName);
         when(blobStore.getStatsMetricPublisher()).thenReturn(new StatsMetricPublisher());
-        when(blobStore.serverSideEncryption()).thenReturn(false);
         final S3BlobContainer blobContainer = new S3BlobContainer(blobPath, blobStore);
 
         GetObjectResponse getObjectResponse = GetObjectResponse.builder().contentLength(contentLength).contentRange(contentRange).build();
@@ -1215,6 +1283,8 @@ public class S3BlobStoreContainerTests extends OpenSearchTestCase {
                 ArgumentMatchers.<AsyncResponseTransformer<GetObjectResponse, ResponseInputStream<GetObjectResponse>>>any()
             )
         ).thenReturn(getObjectPartResponse);
+
+        when(blobStore.expectedBucketOwner()).thenReturn(randomAlphaOfLength(12));
 
         // Header based offset in case of a multi part object request
         InputStreamContainer inputStreamContainer = blobContainer.getBlobPartInputStreamContainer(s3AsyncClient, bucketName, blobName, 0)

--- a/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/async/AsyncTransferManagerTests.java
+++ b/plugins/repository-s3/src/test/java/org/opensearch/repositories/s3/async/AsyncTransferManagerTests.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
@@ -97,7 +98,7 @@ public class AsyncTransferManagerTests extends OpenSearchTestCase {
             s3AsyncClient,
             new UploadRequest("bucket", "key", ByteSizeUnit.MB.toBytes(1), WritePriority.HIGH, uploadSuccess -> {
                 // do nothing
-            }, false, null, true, metadata),
+            }, false, null, true, metadata, ServerSideEncryption.AWS_KMS.toString(), randomAlphaOfLength(10), true, null, null),
             new StreamContext((partIdx, partSize, position) -> {
                 streamRef.set(new ZeroInputStream(partSize));
                 return new InputStreamContainer(streamRef.get(), partSize, position);
@@ -146,7 +147,7 @@ public class AsyncTransferManagerTests extends OpenSearchTestCase {
             s3AsyncClient,
             new UploadRequest("bucket", "key", ByteSizeUnit.MB.toBytes(1), WritePriority.HIGH, uploadSuccess -> {
                 // do nothing
-            }, false, null, true, metadata),
+            }, false, null, true, metadata, ServerSideEncryption.AWS_KMS.toString(), randomAlphaOfLength(10), true, null, null),
             new StreamContext(
                 (partIdx, partSize, position) -> new InputStreamContainer(new ZeroInputStream(partSize), partSize, position),
                 ByteSizeUnit.MB.toBytes(1),
@@ -203,7 +204,7 @@ public class AsyncTransferManagerTests extends OpenSearchTestCase {
             s3AsyncClient,
             new UploadRequest("bucket", "key", ByteSizeUnit.MB.toBytes(5), WritePriority.HIGH, uploadSuccess -> {
                 // do nothing
-            }, true, 3376132981L, true, metadata),
+            }, true, 3376132981L, true, metadata, ServerSideEncryption.AWS_KMS.toString(), randomAlphaOfLength(10), true, null, null),
             new StreamContext((partIdx, partSize, position) -> {
                 InputStream stream = new ZeroInputStream(partSize);
                 streams.add(stream);
@@ -267,7 +268,7 @@ public class AsyncTransferManagerTests extends OpenSearchTestCase {
             s3AsyncClient,
             new UploadRequest("bucket", "key", ByteSizeUnit.MB.toBytes(5), WritePriority.HIGH, uploadSuccess -> {
                 // do nothing
-            }, true, 0L, true, metadata),
+            }, true, 0L, true, metadata, ServerSideEncryption.AWS_KMS.toString(), randomAlphaOfLength(10), true, null, null),
             new StreamContext(
                 (partIdx, partSize, position) -> new InputStreamContainer(new ZeroInputStream(partSize), partSize, position),
                 ByteSizeUnit.MB.toBytes(1),


### PR DESCRIPTION
## Summary

Backport of opensearch-project/OpenSearch#18312 to `branch-2.17`.

> Note: This PR is a re-submission of #21276 from a personal fork to debug a `gradle-check` failure on the original PR. Same commit, same changes.

Adds support for:
- SSE-KMS encryption context in the S3 repository plugin
- Typed encryption settings (`AES256`, `aws:kms`, `bucket_default`) replacing the previous boolean `server_side_encryption` flag
- KMS key ID and encryption context configuration
- S3 Bucket Key support for performance optimization
- Expected bucket owner verification for all S3 operations

## Changes

- New `SseKmsUtil.java` utility class centralizing encryption configuration for S3 request builders
- Updated `S3Repository` with new typed settings definitions
- Updated `S3BlobStore`, `S3BlobContainer`, `UploadRequest`
- Updated async operations: `AsyncTransferManager`, `AsyncPartsHandler`
- Updated test files to cover new SSE-KMS configuration paths

## Conflict Resolutions (2.17-specific)

- Preserved `metadata` field in `UploadRequest.java` (added in 2.17.1, not present in `main`)
- Kept `S3Error` import in `S3BlobContainer.java` (used in 2.17.1)
- Skipped `S3AsyncDeleteHelper.java` change (file does not exist in 2.17.1)

## Testing

- All existing S3 repository unit tests pass locally

Related: #18312, #21276

Signed-off-by: yzhang5 <yzhang5@atlassian.com>
