### PR TITLE
Add prefetch settings and stored fields prefetch for WritableWarm tiered storage

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -173,6 +173,7 @@ import org.opensearch.search.streaming.FlushModeResolver;
 import org.opensearch.snapshots.InternalSnapshotsInfoService;
 import org.opensearch.snapshots.SnapshotsService;
 import org.opensearch.storage.common.tiering.TieringUtils;
+import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
 import org.opensearch.tasks.TaskCancellationMonitoringSettings;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.tasks.TaskResourceTrackingService;
@@ -901,7 +902,9 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 ForceMergeManagerSettings.JVM_THRESHOLD_PERCENTAGE_FOR_AUTO_FORCE_MERGE,
                 ForceMergeManagerSettings.CONCURRENCY_MULTIPLIER,
                 StreamTransportService.STREAM_TRANSPORT_REQ_TIMEOUT_SETTING,
-                StreamSearchTransportService.STREAM_SEARCH_ENABLED
+                StreamSearchTransportService.STREAM_SEARCH_ENABLED,
+                TieredStoragePrefetchSettings.READ_AHEAD_BLOCK_COUNT,
+                TieredStoragePrefetchSettings.STORED_FIELDS_PREFETCH_ENABLED_SETTING
             )
         )
     );

--- a/server/src/main/java/org/opensearch/storage/directory/TieredDirectory.java
+++ b/server/src/main/java/org/opensearch/storage/directory/TieredDirectory.java
@@ -23,6 +23,7 @@ import org.opensearch.index.store.remote.utils.FileTypeUtils;
 import org.opensearch.storage.indexinput.CachedSwitchableIndexInput;
 import org.opensearch.storage.indexinput.SwitchableIndexInput;
 import org.opensearch.storage.indexinput.SwitchableIndexInputWrapper;
+import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static org.opensearch.index.store.remote.utils.FileTypeUtils.BLOCK_FILE_IDENTIFIER;
@@ -43,8 +45,17 @@ public class TieredDirectory extends CompositeDirectory {
 
     private static final Logger logger = LogManager.getLogger(TieredDirectory.class);
 
-    public TieredDirectory(Directory localDirectory, Directory remoteDirectory, FileCache fileCache, ThreadPool threadPool) {
+    private final Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier;
+
+    public TieredDirectory(
+        Directory localDirectory,
+        Directory remoteDirectory,
+        FileCache fileCache,
+        ThreadPool threadPool,
+        Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier
+    ) {
         super(localDirectory, remoteDirectory, fileCache, threadPool);
+        this.tieredStoragePrefetchSettingsSupplier = tieredStoragePrefetchSettingsSupplier;
     }
 
     @Override
@@ -222,7 +233,8 @@ public class TieredDirectory extends CompositeDirectory {
                 remoteDirectory,
                 transferManager,
                 cacheFromRemote,
-                threadPool
+                threadPool,
+                tieredStoragePrefetchSettingsSupplier
             )
         );
     }

--- a/server/src/main/java/org/opensearch/storage/directory/TieredDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/storage/directory/TieredDirectoryFactory.java
@@ -14,9 +14,11 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.plugins.IndexStorePlugin;
+import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 /**
  * Factory for creating {@link TieredDirectory} instances that combine local and remote storage.
@@ -25,7 +27,15 @@ public class TieredDirectoryFactory implements IndexStorePlugin.CompositeDirecto
 
     private static final Logger logger = LogManager.getLogger(TieredDirectoryFactory.class);
 
-    public TieredDirectoryFactory() {}
+    private final Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier;
+
+    /**
+     * Creates a new TieredDirectoryFactory.
+     * @param tieredStoragePrefetchSettingsSupplier supplier for prefetch settings
+     */
+    public TieredDirectoryFactory(Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier) {
+        this.tieredStoragePrefetchSettingsSupplier = tieredStoragePrefetchSettingsSupplier;
+    }
 
     @Override
     public Directory newDirectory(
@@ -38,6 +48,6 @@ public class TieredDirectoryFactory implements IndexStorePlugin.CompositeDirecto
     ) throws IOException {
         logger.trace("Creating composite directory from TieredDirectoryFactory");
         Directory localDirectory = localDirectoryFactory.newDirectory(indexSettings, shardPath);
-        return new TieredDirectory(localDirectory, remoteDirectory, fileCache, threadPool);
+        return new TieredDirectory(localDirectory, remoteDirectory, fileCache, threadPool, tieredStoragePrefetchSettingsSupplier);
     }
 }

--- a/server/src/main/java/org/opensearch/storage/indexinput/CachedSwitchableIndexInput.java
+++ b/server/src/main/java/org/opensearch/storage/indexinput/CachedSwitchableIndexInput.java
@@ -15,10 +15,12 @@ import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.remote.filecache.CachedIndexInput;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.index.store.remote.utils.TransferManager;
+import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 import static org.opensearch.storage.utils.DirectoryUtils.getFilePath;
 import static org.opensearch.storage.utils.DirectoryUtils.getFilePathSwitchable;
@@ -38,7 +40,8 @@ public class CachedSwitchableIndexInput implements CachedIndexInput {
         RemoteSegmentStoreDirectory remoteDirectory,
         TransferManager transferManager,
         boolean cacheFromRemote,
-        ThreadPool threadPool
+        ThreadPool threadPool,
+        Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier
     ) throws IOException {
         isClosed = new AtomicBoolean(false);
         String resourceDescription = "SwitchableIndexInput (path=" + getFilePath(localDirectory, fileName) + ")";
@@ -52,7 +55,8 @@ public class CachedSwitchableIndexInput implements CachedIndexInput {
             remoteDirectory,
             transferManager,
             cacheFromRemote,
-            threadPool
+            threadPool,
+            tieredStoragePrefetchSettingsSupplier
         );
     }
 

--- a/server/src/main/java/org/opensearch/storage/indexinput/OnDemandPrefetchBlockSnapshotIndexInput.java
+++ b/server/src/main/java/org/opensearch/storage/indexinput/OnDemandPrefetchBlockSnapshotIndexInput.java
@@ -18,16 +18,22 @@ import org.opensearch.index.store.remote.file.OnDemandBlockSnapshotIndexInput;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.index.store.remote.utils.BlobFetchRequest;
 import org.opensearch.index.store.remote.utils.TransferManager;
+import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.function.Supplier;
+
+import static org.opensearch.storage.prefetch.TieredStoragePrefetchSettings.CFS_FILE_SUFFIX;
 
 /**
  * Block-based index input that prefetches subsequent blocks from remote storage on demand.
  */
 public class OnDemandPrefetchBlockSnapshotIndexInput extends OnDemandBlockSnapshotIndexInput {
 
+    /** Supplier for prefetch settings */
+    public final Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier;
     protected final ThreadPool threadPool;
     protected FileCache fileCache;
     protected final String resourceDescription;
@@ -42,12 +48,14 @@ public class OnDemandPrefetchBlockSnapshotIndexInput extends OnDemandBlockSnapsh
         FSDirectory directory,
         TransferManager transferManager,
         ThreadPool threadPool,
-        FileCache fileCache
+        FileCache fileCache,
+        Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier
     ) {
         super(resourceDescription, fileInfo, offset, length, isClone, directory, transferManager);
         this.threadPool = threadPool;
         this.fileCache = fileCache;
         this.resourceDescription = resourceDescription;
+        this.tieredStoragePrefetchSettingsSupplier = tieredStoragePrefetchSettingsSupplier;
     }
 
     @Override
@@ -64,12 +72,14 @@ public class OnDemandPrefetchBlockSnapshotIndexInput extends OnDemandBlockSnapsh
         FSDirectory directory,
         TransferManager transferManager,
         ThreadPool threadPool,
-        FileCache fileCache
+        FileCache fileCache,
+        Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier
     ) {
         super(builder, fileInfo, directory, transferManager);
         this.threadPool = threadPool;
         this.fileCache = fileCache;
         this.resourceDescription = resourceDescription;
+        this.tieredStoragePrefetchSettingsSupplier = tieredStoragePrefetchSettingsSupplier;
     }
 
     @Override
@@ -86,13 +96,17 @@ public class OnDemandPrefetchBlockSnapshotIndexInput extends OnDemandBlockSnapsh
             directory,
             transferManager,
             threadPool,
-            fileCache
+            fileCache,
+            tieredStoragePrefetchSettingsSupplier
         );
     }
 
     protected void fetchNextNBlocks(int blockId) {
-        // TODO: Read-ahead with configurable block count. TieredStoragePrefetchSettings integration will be added later.
-        int readAheadBlockCount = 4; // DEFAULT_READ_AHEAD_BLOCK_COUNT
+        // check if read ahead was enabled and file type was doc values
+        if (!checkIfFileEnabledReadAhead()) {
+            return;
+        }
+        int readAheadBlockCount = tieredStoragePrefetchSettingsSupplier.get().getReadAheadBlockCount();
         readAheadBlockCount = Math.min(readAheadBlockCount, getTotalBlocks() - 1 - blockId);
         if (readAheadBlockCount <= 0) {
             logger.trace("read ahead block is <=0, for File: {} and Block ID: {}", fileName, blockId);
@@ -100,10 +114,18 @@ public class OnDemandPrefetchBlockSnapshotIndexInput extends OnDemandBlockSnapsh
         }
         logger.trace("Prefetching Read Ahead Block Count: {} from Block ID: {} for File: {}", readAheadBlockCount, blockId, fileName);
         downloadBlocksAsync(blockId + 1, blockId + readAheadBlockCount, true);
+        // TODO: Metric recording will be added when TieredStorageQueryMetricService is available
     }
 
     @Override
     public void prefetch(long offset, long length) throws IOException {
+        // This can trigger by lucene as well internally having validation here will make us to stop async download if needed.
+        if (!checkIfStoredFieldsPrefetchEnabled()) {
+            return;
+        }
+        if (length <= 0) {
+            return;
+        }
         offset = offset + this.offset;
         final int startBlock = getBlock(offset);
         final int endBlock = Math.min(getTotalBlocks() - 1, getBlock(offset + length - 1L));
@@ -146,6 +168,25 @@ public class OnDemandPrefetchBlockSnapshotIndexInput extends OnDemandBlockSnapsh
                 );
             }
         }
+    }
+
+    /**
+     * Checks if read-ahead is enabled for the current file format.
+     * @return true if the file format supports read-ahead
+     */
+    protected boolean checkIfFileEnabledReadAhead() {
+        return tieredStoragePrefetchSettingsSupplier.get()
+            .getReadAheadEnableFileFormats()
+            .stream()
+            .anyMatch(format -> fileName.endsWith(format) || (resourceDescription.endsWith(format) && fileName.endsWith(CFS_FILE_SUFFIX)));
+    }
+
+    /**
+     * Checks if stored fields prefetch is enabled.
+     * @return true if stored fields prefetch is enabled
+     */
+    protected boolean checkIfStoredFieldsPrefetchEnabled() {
+        return tieredStoragePrefetchSettingsSupplier.get().isStoredFieldsPrefetchEnabled();
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/storage/indexinput/SwitchableIndexInput.java
+++ b/server/src/main/java/org/opensearch/storage/indexinput/SwitchableIndexInput.java
@@ -23,6 +23,7 @@ import org.opensearch.index.store.StoreFileMetadata;
 import org.opensearch.index.store.remote.filecache.CachedFullFileIndexInput;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.index.store.remote.utils.TransferManager;
+import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
 
 /**
  * IndexInput that provides a hook for switching from full file based local index input to block based remote index input
@@ -64,6 +66,7 @@ public class SwitchableIndexInput extends IndexInput implements Runnable, Random
     private volatile boolean hasSwitchedToRemote;
     private volatile boolean cachedFromRemote;
     private final ConcurrentMap<SwitchableIndexInput, Boolean> clones;
+    private final Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier;
     private final ThreadPool threadPool;
 
     /*
@@ -100,7 +103,8 @@ public class SwitchableIndexInput extends IndexInput implements Runnable, Random
         RemoteSegmentStoreDirectory remoteDirectory,
         TransferManager transferManager,
         boolean cacheFromRemote,
-        ThreadPool threadPool
+        ThreadPool threadPool,
+        Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier
     ) throws IOException {
         this(
             resourceDescription,
@@ -119,7 +123,8 @@ public class SwitchableIndexInput extends IndexInput implements Runnable, Random
             null,
             null,
             null,
-            threadPool
+            threadPool,
+            tieredStoragePrefetchSettingsSupplier
         );
     }
 
@@ -141,7 +146,8 @@ public class SwitchableIndexInput extends IndexInput implements Runnable, Random
         IndexInput clonedRemoteIndexInput,
         ConcurrentMap<SwitchableIndexInput, Boolean> clones,
         ReadWriteLock sharedLock,
-        ThreadPool threadPool
+        ThreadPool threadPool,
+        Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier
     ) throws IOException {
         super(resourceDescription);
         this.fileCache = fileCache;
@@ -158,6 +164,7 @@ public class SwitchableIndexInput extends IndexInput implements Runnable, Random
         this.hasSwitchedToRemote = cacheFromRemote;
         this.isClosed = false;
         this.threadPool = threadPool;
+        this.tieredStoragePrefetchSettingsSupplier = tieredStoragePrefetchSettingsSupplier;
         this.objectLock = new ReentrantLock();
         if (!isClone) {
             this.sharedLock = new ReentrantReadWriteLock();
@@ -298,7 +305,8 @@ public class SwitchableIndexInput extends IndexInput implements Runnable, Random
                         (hasSwitchedToRemote && remoteIndexInput.get() != null) ? remoteIndexInput.get().clone() : null,
                         clones,
                         sharedLock,
-                        threadPool
+                        threadPool,
+                        tieredStoragePrefetchSettingsSupplier
                     );
                     clonedIndexInput.seek(getFilePointer());
                     clones.put(clonedIndexInput, true);
@@ -340,7 +348,8 @@ public class SwitchableIndexInput extends IndexInput implements Runnable, Random
                             : null,
                         clones,
                         sharedLock,
-                        threadPool
+                        threadPool,
+                        tieredStoragePrefetchSettingsSupplier
                     );
                     slicedIndexInput.seek(0);
                     clones.put(slicedIndexInput, true);
@@ -430,7 +439,8 @@ public class SwitchableIndexInput extends IndexInput implements Runnable, Random
             localDirectory,
             transferManager,
             threadPool,
-            fileCache
+            fileCache,
+            tieredStoragePrefetchSettingsSupplier
         );
     }
 

--- a/server/src/main/java/org/opensearch/storage/prefetch/StoredFieldsPrefetch.java
+++ b/server/src/main/java/org/opensearch/storage/prefetch/StoredFieldsPrefetch.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.prefetch;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.ReaderUtil;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.util.BitSet;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.common.lucene.search.Queries;
+import org.opensearch.index.shard.SearchOperationListener;
+import org.opensearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+/**
+ * Search operation listener that prefetches stored fields before the fetch phase.
+ * This improves search performance on warm data by pre-loading stored field blocks
+ * from remote storage before they are needed.
+ *
+ * @opensearch.experimental
+ */
+public class StoredFieldsPrefetch implements SearchOperationListener {
+
+    private static final Logger log = LogManager.getLogger(StoredFieldsPrefetch.class);
+    private final Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier;
+
+    /**
+     * Creates a new StoredFieldsPrefetch instance.
+     * @param tieredStoragePrefetchSettingsSupplier supplier for prefetch settings
+     */
+    public StoredFieldsPrefetch(Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier) {
+        this.tieredStoragePrefetchSettingsSupplier = tieredStoragePrefetchSettingsSupplier;
+    }
+
+    @Override
+    public void onPreFetchPhase(SearchContext searchContext) {
+        // Based on cluster settings
+        if (checkIfStoredFieldsPrefetchEnabled()) {
+            executePrefetch(searchContext);
+            // TODO: Metric recording will be added when TieredStorageQueryMetricService is available
+        }
+    }
+
+    private void executePrefetch(SearchContext context) {
+        int currentReaderIndex = -1;
+        LeafReaderContext currentReaderContext = null;
+        StoredFields currentReader = null;
+        log.debug("Stored Field Execute prefetch was triggered: {}", context.docIdsToLoadSize());
+        for (int index = 0; index < context.docIdsToLoadSize(); index++) {
+            int docId = context.docIdsToLoad()[context.docIdsToLoadFrom() + index];
+            try {
+                int readerIndex = ReaderUtil.subIndex(docId, context.searcher().getIndexReader().leaves());
+                if (currentReaderIndex != readerIndex) {
+                    currentReaderContext = context.searcher().getIndexReader().leaves().get(readerIndex);
+                    currentReaderIndex = readerIndex;
+
+                    // Unwrap the reader here
+                    LeafReader innerLeafReader = currentReaderContext.reader();
+                    while (innerLeafReader instanceof FilterLeafReader) {
+                        innerLeafReader = ((FilterLeafReader) innerLeafReader).getDelegate();
+                    }
+                    // never be the case, just sanity check
+                    if (!(innerLeafReader instanceof SegmentReader)) {
+                        // disable prefetch on stored fields for this case
+                        return;
+                    }
+                    currentReader = innerLeafReader.storedFields();
+                }
+                assert currentReaderContext != null;
+                log.debug(
+                    "Prefetching stored fields for index shard: "
+                        + context.indexShard().shardId()
+                        + ", docId: "
+                        + docId
+                        + " readerIndex: "
+                        + readerIndex
+                );
+
+                // nested docs logic
+                final int subDocId = docId - currentReaderContext.docBase;
+                final int rootDocId = findRootDocumentIfNested(context, currentReaderContext, subDocId);
+                if (rootDocId != -1) {
+                    currentReader.prefetch(rootDocId);
+                }
+                currentReader.prefetch(subDocId);
+            } catch (Exception e) {
+                throw ExceptionsHelper.convertToOpenSearchException(e);
+            }
+        }
+    }
+
+    private int findRootDocumentIfNested(SearchContext context, LeafReaderContext subReaderContext, int subDocId) throws IOException {
+        if (context.mapperService().hasNested()) {
+            BitSet bits = context.bitsetFilterCache().getBitSetProducer(Queries.newNonNestedFilter()).getBitSet(subReaderContext);
+            if (!bits.get(subDocId)) {
+                return bits.nextSetBit(subDocId);
+            }
+        }
+        return -1;
+    }
+
+    private boolean checkIfStoredFieldsPrefetchEnabled() {
+        return tieredStoragePrefetchSettingsSupplier.get().isStoredFieldsPrefetchEnabled();
+    }
+}

--- a/server/src/main/java/org/opensearch/storage/prefetch/TieredStoragePrefetchSettings.java
+++ b/server/src/main/java/org/opensearch/storage/prefetch/TieredStoragePrefetchSettings.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.prefetch;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+
+import java.util.List;
+
+/**
+ * Settings for tiered storage prefetch behavior including read-ahead block count
+ * and stored fields prefetch configuration.
+ *
+ * @opensearch.experimental
+ */
+public class TieredStoragePrefetchSettings {
+
+    /** Default number of blocks to read ahead */
+    public static final int DEFAULT_READ_AHEAD_BLOCK_COUNT = 4;
+    /** Doc values data file suffix */
+    public static final String DVD_FILE_SUFFIX = "dvd";
+    /** Compound file suffix */
+    public static final String CFS_FILE_SUFFIX = "cfs";
+
+    /** Cluster setting for the number of blocks to read ahead during prefetch */
+    public static final Setting<Integer> READ_AHEAD_BLOCK_COUNT = Setting.intSetting(
+        "tiering.service.prefetch.read_ahead.block_count",
+        DEFAULT_READ_AHEAD_BLOCK_COUNT,
+        0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /** Cluster setting to enable or disable stored fields prefetch */
+    public static final Setting<Boolean> STORED_FIELDS_PREFETCH_ENABLED_SETTING = Setting.boolSetting(
+        "tiering.service.prefetch.stored_fields.enabled",
+        true,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /** File formats for which read-ahead is enabled */
+    public static final List<String> READ_AHEAD_ENABLE_FILE_FORMATS = List.of(DVD_FILE_SUFFIX);
+    private volatile int readAheadBlockCount;
+    private final List<String> readAheadEnableFileFormats;
+    private volatile boolean storedFieldsPrefetchEnabled;
+
+    /**
+     * Creates a new TieredStoragePrefetchSettings instance.
+     * @param clusterSettings the cluster settings
+     */
+    public TieredStoragePrefetchSettings(ClusterSettings clusterSettings) {
+        this.readAheadBlockCount = clusterSettings.get(READ_AHEAD_BLOCK_COUNT);
+        clusterSettings.addSettingsUpdateConsumer(READ_AHEAD_BLOCK_COUNT, this::setReadAheadBlockCount);
+        this.readAheadEnableFileFormats = READ_AHEAD_ENABLE_FILE_FORMATS;
+        this.storedFieldsPrefetchEnabled = clusterSettings.get(STORED_FIELDS_PREFETCH_ENABLED_SETTING);
+        clusterSettings.addSettingsUpdateConsumer(STORED_FIELDS_PREFETCH_ENABLED_SETTING, this::setStoredFieldsPrefetchEnabled);
+    }
+
+    /**
+     * Sets the read-ahead block count.
+     * @param readAheadBlockCount the number of blocks to read ahead
+     */
+    public void setReadAheadBlockCount(int readAheadBlockCount) {
+        this.readAheadBlockCount = readAheadBlockCount;
+    }
+
+    /**
+     * Sets whether stored fields prefetch is enabled.
+     * @param storedFieldsPrefetchEnabled true to enable stored fields prefetch
+     */
+    public void setStoredFieldsPrefetchEnabled(boolean storedFieldsPrefetchEnabled) {
+        this.storedFieldsPrefetchEnabled = storedFieldsPrefetchEnabled;
+    }
+
+    /**
+     * Returns whether stored fields prefetch is enabled.
+     * @return true if stored fields prefetch is enabled
+     */
+    public boolean isStoredFieldsPrefetchEnabled() {
+        return storedFieldsPrefetchEnabled;
+    }
+
+    /**
+     * Returns the read-ahead block count.
+     * @return the number of blocks to read ahead
+     */
+    public int getReadAheadBlockCount() {
+        return this.readAheadBlockCount;
+    }
+
+    /**
+     * Returns the file formats for which read-ahead is enabled.
+     * @return the list of file format suffixes
+     */
+    public List<String> getReadAheadEnableFileFormats() {
+        return this.readAheadEnableFileFormats;
+    }
+}

--- a/server/src/main/java/org/opensearch/storage/prefetch/package-info.java
+++ b/server/src/main/java/org/opensearch/storage/prefetch/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Prefetch settings and utilities for tiered storage.
+ */
+package org.opensearch.storage.prefetch;

--- a/server/src/test/java/org/opensearch/storage/directory/SwitchableIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/storage/directory/SwitchableIndexInputTests.java
@@ -22,6 +22,7 @@ import org.opensearch.index.store.remote.filecache.FullFileCachedIndexInput;
 import org.opensearch.index.store.remote.utils.TransferManager;
 import org.opensearch.storage.indexinput.OnDemandPrefetchBlockSnapshotIndexInput;
 import org.opensearch.storage.indexinput.SwitchableIndexInput;
+import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.Before;
 
@@ -37,10 +38,13 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static org.opensearch.index.store.remote.utils.FileTypeUtils.BLOCK_FILE_IDENTIFIER;
 import static org.opensearch.storage.utils.DirectoryUtils.getFilePath;
 import static org.opensearch.storage.utils.DirectoryUtils.getFilePathSwitchable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link SwitchableIndexInput}.
@@ -53,6 +57,18 @@ public class SwitchableIndexInputTests extends TieredStorageBaseTestCase {
     TransferManager transferManager;
     private static final String FILE_NAME = "_0.si";
     private static final String FILE_NAME_BLOCK = "_0.si_block_0";
+
+    private static final Supplier<TieredStoragePrefetchSettings> MOCK_PREFETCH_SETTINGS_SUPPLIER = () -> {
+        TieredStoragePrefetchSettings settings = mock(TieredStoragePrefetchSettings.class);
+        when(settings.getReadAheadBlockCount()).thenReturn(TieredStoragePrefetchSettings.DEFAULT_READ_AHEAD_BLOCK_COUNT);
+        when(settings.getReadAheadEnableFileFormats()).thenReturn(TieredStoragePrefetchSettings.READ_AHEAD_ENABLE_FILE_FORMATS);
+        when(settings.isStoredFieldsPrefetchEnabled()).thenReturn(true);
+        return settings;
+    };
+
+    private Supplier<TieredStoragePrefetchSettings> getPrefetchSettingsSupplier() {
+        return MOCK_PREFETCH_SETTINGS_SUPPLIER;
+    }
 
     @Before
     public void setup() throws IOException {
@@ -87,7 +103,8 @@ public class SwitchableIndexInputTests extends TieredStorageBaseTestCase {
             remoteSegmentStoreDirectory,
             transferManager,
             false,
-            threadPool
+            threadPool,
+            getPrefetchSettingsSupplier()
         );
 
         CachedIndexInput cachedIndexInput = getFileCacheEntry(FILE_NAME);
@@ -120,7 +137,8 @@ public class SwitchableIndexInputTests extends TieredStorageBaseTestCase {
             remoteSegmentStoreDirectory,
             transferManager,
             true,
-            threadPool
+            threadPool,
+            getPrefetchSettingsSupplier()
         );
 
         CachedIndexInput cachedIndexInput = getFileCacheEntry(FILE_NAME_BLOCK);
@@ -156,7 +174,8 @@ public class SwitchableIndexInputTests extends TieredStorageBaseTestCase {
             remoteSegmentStoreDirectory,
             transferManager,
             false,
-            threadPool
+            threadPool,
+            getPrefetchSettingsSupplier()
         );
 
         SwitchableIndexInput clonedIndexInput = switchableIndexInput.clone();
@@ -193,7 +212,8 @@ public class SwitchableIndexInputTests extends TieredStorageBaseTestCase {
             remoteSegmentStoreDirectory,
             transferManager,
             false,
-            threadPool
+            threadPool,
+            getPrefetchSettingsSupplier()
         );
 
         switchableIndexInput.prefetch(0, 10);
@@ -385,7 +405,8 @@ public class SwitchableIndexInputTests extends TieredStorageBaseTestCase {
                 remoteDirectory,
                 transferManager,
                 cacheFromRemote,
-                threadPool
+                threadPool,
+                MOCK_PREFETCH_SETTINGS_SUPPLIER
             );
             sharedLock = new InjectableReadWriteLock(sharedLock);
             objectLock = new InjectableLock(objectLock);

--- a/server/src/test/java/org/opensearch/storage/directory/TieredDirectoryTests.java
+++ b/server/src/test/java/org/opensearch/storage/directory/TieredDirectoryTests.java
@@ -10,6 +10,7 @@ package org.opensearch.storage.directory;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.FilterIndexInput;
 import org.apache.lucene.store.IOContext;
@@ -19,8 +20,10 @@ import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
 import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.index.store.remote.filecache.FileCacheFactory;
 import org.opensearch.index.store.remote.utils.FileTypeUtils;
+import org.opensearch.plugins.IndexStorePlugin;
 import org.opensearch.storage.indexinput.SwitchableIndexInput;
 import org.opensearch.storage.indexinput.SwitchableIndexInputWrapper;
+import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -29,9 +32,13 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static org.opensearch.storage.utils.DirectoryUtils.getFilePath;
 import static org.opensearch.storage.utils.DirectoryUtils.getFilePathSwitchable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link TieredDirectory}.
@@ -67,8 +74,24 @@ public class TieredDirectoryTests extends TieredStorageBaseTestCase {
         removeExtraFSFiles();
         int concurrencyLevel = randomIntBetween(1, 2);
         fileCache = FileCacheFactory.createConcurrentLRUFileCache(FILE_CACHE_CAPACITY, concurrencyLevel);
-        tieredDirectory = new TieredDirectory(localDirectory, remoteSegmentStoreDirectory, fileCache, threadPool);
+        tieredDirectory = new TieredDirectory(
+            localDirectory,
+            remoteSegmentStoreDirectory,
+            fileCache,
+            threadPool,
+            getMockPrefetchSettingsSupplier()
+        );
         addFilesToDirectory(LOCAL_FILES);
+    }
+
+    private Supplier<TieredStoragePrefetchSettings> getMockPrefetchSettingsSupplier() {
+        return () -> {
+            TieredStoragePrefetchSettings settings = mock(TieredStoragePrefetchSettings.class);
+            when(settings.getReadAheadBlockCount()).thenReturn(TieredStoragePrefetchSettings.DEFAULT_READ_AHEAD_BLOCK_COUNT);
+            when(settings.getReadAheadEnableFileFormats()).thenReturn(TieredStoragePrefetchSettings.READ_AHEAD_ENABLE_FILE_FORMATS);
+            when(settings.isStoredFieldsPrefetchEnabled()).thenReturn(true);
+            return settings;
+        };
     }
 
     public void testListAll() throws IOException {
@@ -220,6 +243,18 @@ public class TieredDirectoryTests extends TieredStorageBaseTestCase {
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    public void testTieredDirectoryFactory() throws IOException {
+        TieredDirectoryFactory factory = new TieredDirectoryFactory(getMockPrefetchSettingsSupplier());
+        FSDirectory factoryLocalDir = FSDirectory.open(createTempDir());
+        IndexStorePlugin.DirectoryFactory localDirFactory = mock(IndexStorePlugin.DirectoryFactory.class);
+        when(localDirFactory.newDirectory(any(), any())).thenReturn(factoryLocalDir);
+        FileCache factoryFileCache = FileCacheFactory.createConcurrentLRUFileCache(FILE_CACHE_CAPACITY, 1);
+
+        Directory result = factory.newDirectory(null, null, localDirFactory, remoteSegmentStoreDirectory, factoryFileCache, threadPool);
+        assertTrue(result instanceof TieredDirectory);
+        result.close();
     }
 
     private void addFilesToDirectory(String[] files) throws IOException {

--- a/server/src/test/java/org/opensearch/storage/indexinput/OnDemandPrefetchBlockSnapshotIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/storage/indexinput/OnDemandPrefetchBlockSnapshotIndexInputTests.java
@@ -28,6 +28,7 @@ import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.index.store.remote.filecache.FileCacheFactory;
 import org.opensearch.index.store.remote.utils.BlobFetchRequest;
 import org.opensearch.index.store.remote.utils.TransferManager;
+import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
@@ -36,6 +37,7 @@ import org.junit.Before;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.function.Supplier;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -65,6 +67,14 @@ public class OnDemandPrefetchBlockSnapshotIndexInputTests extends OpenSearchTest
     private Path path;
     private ThreadPool threadPool;
     private FileCache fileCache;
+
+    private Supplier<TieredStoragePrefetchSettings> getPrefetchSettingsSupplier() {
+        TieredStoragePrefetchSettings settings = mock(TieredStoragePrefetchSettings.class);
+        when(settings.getReadAheadBlockCount()).thenReturn(TieredStoragePrefetchSettings.DEFAULT_READ_AHEAD_BLOCK_COUNT);
+        when(settings.getReadAheadEnableFileFormats()).thenReturn(TieredStoragePrefetchSettings.READ_AHEAD_ENABLE_FILE_FORMATS);
+        when(settings.isStoredFieldsPrefetchEnabled()).thenReturn(true);
+        return () -> settings;
+    }
 
     @Before
     public void init() {
@@ -179,7 +189,8 @@ public class OnDemandPrefetchBlockSnapshotIndexInputTests extends OpenSearchTest
                 directory,
                 transferManager,
                 threadPool,
-                fileCache
+                fileCache,
+                getPrefetchSettingsSupplier()
             )
         ) {
             indexInput.seek(repositoryChunkSize);
@@ -273,7 +284,8 @@ public class OnDemandPrefetchBlockSnapshotIndexInputTests extends OpenSearchTest
             directory,
             transferManager,
             threadPool,
-            fileCache
+            fileCache,
+            getPrefetchSettingsSupplier()
         );
     }
 

--- a/server/src/test/java/org/opensearch/storage/prefetch/OnDemandPrefetchBlockSnapshotIndexInputTests.java
+++ b/server/src/test/java/org/opensearch/storage/prefetch/OnDemandPrefetchBlockSnapshotIndexInputTests.java
@@ -1,0 +1,474 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.prefetch;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.LockFactory;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.SimpleFSLockFactory;
+import org.apache.lucene.util.Constants;
+import org.apache.lucene.util.Version;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.unit.ByteSizeUnit;
+import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
+import org.opensearch.index.store.StoreFileMetadata;
+import org.opensearch.index.store.remote.file.AbstractBlockIndexInput;
+import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
+import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.index.store.remote.filecache.FileCacheFactory;
+import org.opensearch.index.store.remote.utils.BlobFetchRequest;
+import org.opensearch.index.store.remote.utils.TransferManager;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.Before;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static org.opensearch.common.settings.ClusterSettings.BUILT_IN_CLUSTER_SETTINGS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
+public class OnDemandPrefetchBlockSnapshotIndexInputTests extends OpenSearchTestCase {
+
+    private static final String RESOURCE_DESCRIPTION = "Test TestOnDemandPrefetchBlockSnapshotIndexInput Block Size";
+    private static final long BLOCK_SNAPSHOT_FILE_OFFSET = 0;
+    private static final String FILE_NAME = "File_Name";
+    private static final String BLOCK_FILE_PREFIX = FILE_NAME;
+    private static final boolean IS_CLONE = false;
+    private static final int FILE_SIZE = 29360128;
+    protected static final int FILE_CACHE_CAPACITY = 10000000;
+    private TransferManager transferManager;
+    private LockFactory lockFactory;
+    private BlobStoreIndexShardSnapshot.FileInfo fileInfo;
+    private Path path;
+    private ThreadPool threadPool;
+    FileCache fileCache;
+    private TieredStoragePrefetchSettings tieringServicePrefetchSettings;
+
+    @Before
+    public void init() {
+        assumeFalse("Awaiting Windows fix https://github.com/opensearch-project/OpenSearch/issues/5396", Constants.WINDOWS);
+        transferManager = mock(TransferManager.class);
+        lockFactory = SimpleFSLockFactory.INSTANCE;
+        threadPool = new TestThreadPool("PrefetchBlockSnapshotIndexInputTests");
+        path = createTempDir("TestOnDemandPrefetchBlockSnapshotIndexInputTests");
+        int concurrencyLevel = randomIntBetween(1, 2);
+        fileCache = FileCacheFactory.createConcurrentLRUFileCache(FILE_CACHE_CAPACITY, concurrencyLevel);
+        Set<Setting<?>> clusterSettingsToAdd = new HashSet<>(BUILT_IN_CLUSTER_SETTINGS);
+        clusterSettingsToAdd.add(TieredStoragePrefetchSettings.READ_AHEAD_BLOCK_COUNT);
+        clusterSettingsToAdd.add(TieredStoragePrefetchSettings.STORED_FIELDS_PREFETCH_ENABLED_SETTING);
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, clusterSettingsToAdd);
+        this.tieringServicePrefetchSettings = new TieredStoragePrefetchSettings(clusterSettings);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdownNow();
+    }
+
+    public Supplier<TieredStoragePrefetchSettings> getPrefetchSettingsSupplier() {
+        return () -> this.tieringServicePrefetchSettings;
+    }
+
+    public void testPrefetch() throws Exception {
+        final TestOnDemandPrefetchBlockSnapshotIndexInput blockedSnapshotFile = createTestOnDemandPrefetchBlockSnapshotIndexInput(23);
+
+        blockedSnapshotFile.prefetch(0, 10);
+        verify(transferManager, times(1)).fetchBlobAsync(any(BlobFetchRequest.class));
+        blockedSnapshotFile.prefetch(0, 8388670);
+        verify(transferManager, times(3)).fetchBlobAsync(any(BlobFetchRequest.class));
+        blockedSnapshotFile.prefetch(0, 16777350);
+        verify(transferManager, times(6)).fetchBlobAsync(any(BlobFetchRequest.class));
+    }
+
+    public void testSettings() throws Exception {
+        final TestOnDemandPrefetchBlockSnapshotIndexInput blockedSnapshotFile = createTestOnDemandPrefetchBlockSnapshotIndexInput(23);
+        assertFalse(blockedSnapshotFile.checkIfFileEnabledReadAhead());
+        assertTrue(blockedSnapshotFile.checkIfStoredFieldsPrefetchEnabled());
+    }
+
+    public void testReadAheadEnabled() throws Exception {
+        TestOnDemandPrefetchBlockSnapshotIndexInput indexInput = getIndexInput("lucene.dvd", "clone");
+        assertTrue(indexInput.checkIfFileEnabledReadAhead());
+        indexInput = getIndexInput("_1.fdt", "clone");
+        assertFalse(indexInput.checkIfFileEnabledReadAhead());
+        indexInput = getIndexInput("_0.cfs", "lucene9.dvd");
+        assertTrue(indexInput.checkIfFileEnabledReadAhead());
+        indexInput = getIndexInput("_1.cfe", "lucene9.dvd");
+        assertFalse(indexInput.checkIfFileEnabledReadAhead());
+    }
+
+    public void testPrefetchDisabledBySettings() throws Exception {
+        // Disable stored fields prefetch via settings
+        tieringServicePrefetchSettings.setStoredFieldsPrefetchEnabled(false);
+        final TestOnDemandPrefetchBlockSnapshotIndexInput blockedSnapshotFile = createTestOnDemandPrefetchBlockSnapshotIndexInput(23);
+        // prefetch should be a no-op when disabled
+        blockedSnapshotFile.prefetch(0, 10);
+        verify(transferManager, never()).fetchBlobAsync(any(BlobFetchRequest.class));
+    }
+
+    public void testFetchBlockWithCacheTracking() throws Exception {
+        final TestOnDemandPrefetchBlockSnapshotIndexInput blockedSnapshotFile = createTestOnDemandPrefetchBlockSnapshotIndexInput(23);
+
+        // Fetch a block that exists (should be cache hit)
+        IndexInput result = blockedSnapshotFile.fetchBlockPublic(0);
+        assertNotNull("Fetched block should not be null", result);
+    }
+
+    public void testDownloadBlocksAsyncWithCacheOptimization() throws Exception {
+        final TestOnDemandPrefetchBlockSnapshotIndexInput blockedSnapshotFile = createTestOnDemandPrefetchBlockSnapshotIndexInput(23);
+
+        // Test that cached blocks are not re-downloaded
+        blockedSnapshotFile.downloadBlocksAsync(0, 1, false);
+    }
+
+    public void test8MBBlock() throws Exception {
+        runAllTestsFor(23);
+    }
+
+    public void test4KBBlock() throws Exception {
+        runAllTestsFor(12);
+    }
+
+    public void test1MBBlock() throws Exception {
+        runAllTestsFor(20);
+    }
+
+    public void test4MBBlock() throws Exception {
+        runAllTestsFor(22);
+    }
+
+    public void testChunkedRepositoryWithBlockSizeGreaterThanChunkSize() throws IOException {
+        verifyChunkedRepository(
+            new ByteSizeValue(8, ByteSizeUnit.KB).getBytes(),
+            new ByteSizeValue(2, ByteSizeUnit.KB).getBytes(),
+            new ByteSizeValue(15, ByteSizeUnit.KB).getBytes()
+        );
+    }
+
+    public void testChunkedRepositoryWithBlockSizeLessThanChunkSize() throws IOException {
+        verifyChunkedRepository(
+            new ByteSizeValue(1, ByteSizeUnit.KB).getBytes(),
+            new ByteSizeValue(2, ByteSizeUnit.KB).getBytes(),
+            new ByteSizeValue(3, ByteSizeUnit.KB).getBytes()
+        );
+    }
+
+    public void testChunkedRepositoryWithBlockSizeEqualToChunkSize() throws IOException {
+        verifyChunkedRepository(
+            new ByteSizeValue(2, ByteSizeUnit.KB).getBytes(),
+            new ByteSizeValue(2, ByteSizeUnit.KB).getBytes(),
+            new ByteSizeValue(15, ByteSizeUnit.KB).getBytes()
+        );
+    }
+
+    TestOnDemandPrefetchBlockSnapshotIndexInput getIndexInput(String fileName, String resourceDescription) {
+        fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(fileName, new StoreFileMetadata(fileName, FILE_SIZE, "", Version.LATEST), null);
+
+        FSDirectory directory = null;
+        try {
+            directory = new MMapDirectory(path, lockFactory);
+        } catch (IOException e) {
+            fail("fail to create MMapDirectory: " + e.getMessage());
+        }
+
+        return new TestOnDemandPrefetchBlockSnapshotIndexInput(
+            AbstractBlockIndexInput.builder()
+                .resourceDescription(RESOURCE_DESCRIPTION)
+                .offset(BLOCK_SNAPSHOT_FILE_OFFSET)
+                .length(FILE_SIZE)
+                .blockSizeShift(23)
+                .isClone(IS_CLONE),
+            resourceDescription,
+            fileInfo,
+            directory,
+            transferManager,
+            threadPool,
+            fileCache,
+            getPrefetchSettingsSupplier()
+        );
+    }
+
+    private void verifyChunkedRepository(long blockSize, long repositoryChunkSize, long fileSize) throws IOException {
+        when(transferManager.fetchBlob(any())).thenReturn(new ByteArrayIndexInput("test", new byte[(int) blockSize]));
+        try (
+            FSDirectory directory = new MMapDirectory(path, lockFactory);
+            IndexInput indexInput = new TestOnDemandPrefetchBlockSnapshotIndexInput(
+                AbstractBlockIndexInput.builder()
+                    .resourceDescription(RESOURCE_DESCRIPTION)
+                    .offset(BLOCK_SNAPSHOT_FILE_OFFSET)
+                    .length(FILE_SIZE)
+                    .blockSizeShift((int) (Math.log(blockSize) / Math.log(2)))
+                    .isClone(IS_CLONE),
+                RESOURCE_DESCRIPTION,
+                new BlobStoreIndexShardSnapshot.FileInfo(
+                    FILE_NAME,
+                    new StoreFileMetadata(FILE_NAME, fileSize, "", Version.LATEST),
+                    new ByteSizeValue(repositoryChunkSize)
+                ),
+                directory,
+                transferManager,
+                threadPool,
+                fileCache,
+                getPrefetchSettingsSupplier()
+            )
+        ) {
+            indexInput.seek(repositoryChunkSize);
+        }
+        verify(transferManager).fetchBlob(argThat(request -> request.getBlobLength() == blockSize));
+    }
+
+    private TestOnDemandPrefetchBlockSnapshotIndexInput createTestOnDemandPrefetchBlockSnapshotIndexInput(int blockSizeShift)
+        throws IOException {
+        fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(
+            FILE_NAME,
+            new StoreFileMetadata(FILE_NAME, FILE_SIZE, "", Version.LATEST),
+            null
+        );
+
+        int blockSize = 1 << blockSizeShift;
+
+        doAnswer(invocation -> {
+            BlobFetchRequest blobFetchRequest = invocation.getArgument(0);
+            return blobFetchRequest.getDirectory().openInput(blobFetchRequest.getFileName(), IOContext.READONCE);
+        }).when(transferManager).fetchBlob(any());
+
+        FSDirectory directory = null;
+        try {
+            directory = new MMapDirectory(path, lockFactory);
+        } catch (IOException e) {
+            fail("fail to create MMapDirectory: " + e.getMessage());
+        }
+
+        initBlockFiles(blockSize, directory);
+
+        return new TestOnDemandPrefetchBlockSnapshotIndexInput(
+            AbstractBlockIndexInput.builder()
+                .resourceDescription(RESOURCE_DESCRIPTION)
+                .offset(BLOCK_SNAPSHOT_FILE_OFFSET)
+                .length(FILE_SIZE)
+                .blockSizeShift(blockSizeShift)
+                .isClone(IS_CLONE),
+            RESOURCE_DESCRIPTION,
+            fileInfo,
+            directory,
+            transferManager,
+            threadPool,
+            fileCache,
+            getPrefetchSettingsSupplier()
+        );
+    }
+
+    private TestOnDemandPrefetchBlockSnapshotIndexInput createDvdFileIndexInput(int blockSizeShift) throws IOException {
+        String dvdFileName = "_0.dvd";
+        BlobStoreIndexShardSnapshot.FileInfo dvdFileInfo = new BlobStoreIndexShardSnapshot.FileInfo(
+            dvdFileName,
+            new StoreFileMetadata(dvdFileName, FILE_SIZE, "", Version.LATEST),
+            null
+        );
+
+        int blockSize = 1 << blockSizeShift;
+
+        doAnswer(invocation -> {
+            BlobFetchRequest blobFetchRequest = invocation.getArgument(0);
+            return blobFetchRequest.getDirectory().openInput(blobFetchRequest.getFileName(), IOContext.READONCE);
+        }).when(transferManager).fetchBlob(any());
+
+        FSDirectory directory = null;
+        try {
+            directory = new MMapDirectory(path, lockFactory);
+        } catch (IOException e) {
+            fail("fail to create MMapDirectory: " + e.getMessage());
+        }
+
+        // Create block files with the dvd file name prefix
+        int numOfBlocks = FILE_SIZE / blockSize;
+        int sizeOfLastBlock = FILE_SIZE % blockSize;
+        try {
+            for (int i = 0; i < numOfBlocks; i++) {
+                String blockName = dvdFileName + "_block_" + i;
+                IndexOutput output = directory.createOutput(blockName, null);
+                for (int j = 0; j < blockSize / 2; j++) {
+                    output.writeByte((byte) 48);
+                    output.writeByte((byte) -80);
+                }
+                output.close();
+            }
+            if (numOfBlocks > 1 && sizeOfLastBlock != 0) {
+                String lastBlockName = dvdFileName + "_block_" + numOfBlocks;
+                IndexOutput output = directory.createOutput(lastBlockName, null);
+                for (int i = 0; i < sizeOfLastBlock; i++) {
+                    output.writeByte((byte) ((i & 1) == 0 ? 48 : -80));
+                }
+                output.close();
+            }
+        } catch (IOException e) {
+            fail("fail to initialize dvd block files: " + e.getMessage());
+        }
+
+        return new TestOnDemandPrefetchBlockSnapshotIndexInput(
+            AbstractBlockIndexInput.builder()
+                .resourceDescription(RESOURCE_DESCRIPTION)
+                .offset(BLOCK_SNAPSHOT_FILE_OFFSET)
+                .length(FILE_SIZE)
+                .blockSizeShift(blockSizeShift)
+                .isClone(IS_CLONE),
+            RESOURCE_DESCRIPTION,
+            dvdFileInfo,
+            directory,
+            transferManager,
+            threadPool,
+            fileCache,
+            getPrefetchSettingsSupplier()
+        );
+    }
+
+    private void initBlockFiles(int blockSize, FSDirectory fsDirectory) {
+        int numOfBlocks = FILE_SIZE / blockSize;
+        int sizeOfLastBlock = FILE_SIZE % blockSize;
+
+        try {
+            for (int i = 0; i < numOfBlocks; i++) {
+                String blockName = BLOCK_FILE_PREFIX + "_block_" + i;
+                IndexOutput output = fsDirectory.createOutput(blockName, null);
+                for (int j = 0; j < blockSize / 2; j++) {
+                    output.writeByte((byte) 48);
+                    output.writeByte((byte) -80);
+                }
+                output.close();
+            }
+
+            if (numOfBlocks > 1 && sizeOfLastBlock != 0) {
+                String lastBlockName = BLOCK_FILE_PREFIX + "_block_" + numOfBlocks;
+                IndexOutput output = fsDirectory.createOutput(lastBlockName, null);
+                for (int i = 0; i < sizeOfLastBlock; i++) {
+                    if ((i & 1) == 0) {
+                        output.writeByte((byte) 48);
+                    } else {
+                        output.writeByte((byte) -80);
+                    }
+                }
+                output.close();
+            }
+        } catch (IOException e) {
+            fail("fail to initialize block files: " + e.getMessage());
+        }
+    }
+
+    private void runAllTestsFor(int blockSizeShift) throws Exception {
+        final TestOnDemandPrefetchBlockSnapshotIndexInput input = createTestOnDemandPrefetchBlockSnapshotIndexInput(blockSizeShift);
+        final int blockSize = 1 << blockSizeShift;
+
+        // testGetBlock
+        assertEquals(0, input.getBlock(0L));
+        assertEquals(1, input.getBlock(blockSize));
+        assertEquals((FILE_SIZE - 1) / blockSize, input.getBlock(FILE_SIZE - 1));
+
+        // testGetTotalBlocks
+        assertEquals((FILE_SIZE - 1) / blockSize + 1, input.getTotalBlocks());
+
+        // testGetBlockOffset
+        assertEquals(1, input.getBlockOffset(1));
+        assertEquals(0, input.getBlockOffset(blockSize));
+        assertEquals((FILE_SIZE - 1) % blockSize, input.getBlockOffset(FILE_SIZE - 1));
+
+        // testGetBlockStart
+        assertEquals(0L, input.getBlockStart(0));
+        assertEquals(blockSize, input.getBlockStart(1));
+        assertEquals(blockSize * 2, input.getBlockStart(2));
+
+        // testCurrentBlockStart
+        input.seek(blockSize - 1);
+        assertEquals(0L, input.currentBlockStart());
+        input.seek(blockSize * 2 - 1);
+        assertEquals(blockSize, input.currentBlockStart());
+
+        // testCurrentBlockPosition
+        input.seek(blockSize - 1);
+        assertEquals(blockSize - 1, input.currentBlockPosition());
+        input.seek(blockSize + 1);
+        assertEquals(1, input.currentBlockPosition());
+
+        // testClone
+        input.seek(blockSize + 1);
+        TestOnDemandPrefetchBlockSnapshotIndexInput clonedFile = (TestOnDemandPrefetchBlockSnapshotIndexInput) input.clone();
+        assertEquals(clonedFile.currentBlockPosition(), input.currentBlockPosition());
+        assertEquals(clonedFile.getFilePointer(), input.getFilePointer());
+        clonedFile.seek(blockSize + 11);
+        assertNotEquals(clonedFile.currentBlockPosition(), input.currentBlockPosition());
+
+        // testReadByte
+        input.seek(0);
+        assertEquals((byte) 48, input.readByte());
+        input.seek(1);
+        assertEquals((byte) -80, input.readByte());
+        input.seek(blockSize);
+        assertEquals((byte) 48, input.readByte());
+
+        // testReadShort
+        input.seek(0);
+        assertEquals(-20432, input.readShort());
+        input.seek(blockSize - 1);
+        assertEquals(12464, input.readShort());
+
+        // testReadInt
+        input.seek(0);
+        assertEquals(-1338986448, input.readInt());
+        input.seek(blockSize - 1);
+        assertEquals(816853168, input.readInt());
+
+        // testReadLong
+        input.seek(0);
+        assertEquals(-5750903000991223760L, input.readLong());
+
+        // testSeek
+        input.seek(0);
+        assertEquals(0, input.getFilePointer());
+        input.seek(blockSize + 11);
+        assertEquals(blockSize + 11, input.getFilePointer());
+        try {
+            input.seek(FILE_SIZE + 1);
+            fail("Should throw EOFException");
+        } catch (EOFException e) {
+            // expected
+        }
+
+        // testReadBytes
+        input.seek(0);
+        byte[] buf = new byte[4];
+        input.readBytes(buf, 0, 4);
+        assertEquals((byte) 48, buf[0]);
+        assertEquals((byte) -80, buf[1]);
+        assertEquals((byte) 48, buf[2]);
+        assertEquals((byte) -80, buf[3]);
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/prefetch/StoredFieldsPrefetchTests.java
+++ b/server/src/test/java/org/opensearch/storage/prefetch/StoredFieldsPrefetchTests.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.prefetch;
+
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.test.ClusterServiceUtils;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.Before;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static org.opensearch.common.settings.ClusterSettings.BUILT_IN_CLUSTER_SETTINGS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class StoredFieldsPrefetchTests extends OpenSearchTestCase {
+
+    private ClusterService clusterService;
+    private ThreadPool threadPool;
+    private SearchContext searchContext;
+    private TieredStoragePrefetchSettings tieredStoragePrefetchSettings;
+    private StoredFieldsPrefetch storedFieldsPrefetch;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        Set<Setting<?>> clusterSettingsToAdd = new HashSet<>(BUILT_IN_CLUSTER_SETTINGS);
+        clusterSettingsToAdd.add(TieredStoragePrefetchSettings.READ_AHEAD_BLOCK_COUNT);
+        clusterSettingsToAdd.add(TieredStoragePrefetchSettings.STORED_FIELDS_PREFETCH_ENABLED_SETTING);
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, clusterSettingsToAdd);
+        threadPool = new TestThreadPool("StoredFieldsPrefetchTests");
+        clusterService = ClusterServiceUtils.createClusterService(Settings.EMPTY, clusterSettings, threadPool);
+        this.tieredStoragePrefetchSettings = new TieredStoragePrefetchSettings(clusterService.getClusterSettings());
+        searchContext = mock(SearchContext.class);
+        storedFieldsPrefetch = new StoredFieldsPrefetch(getPrefetchSettingsSupplier());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdownNow();
+    }
+
+    public Supplier<TieredStoragePrefetchSettings> getPrefetchSettingsSupplier() {
+        return () -> this.tieredStoragePrefetchSettings;
+    }
+
+    public void testOnPreFetchPhase_WhenPrefetchDisabled() {
+        Settings settings = Settings.builder()
+            .put(TieredStoragePrefetchSettings.STORED_FIELDS_PREFETCH_ENABLED_SETTING.getKey(), false)
+            .build();
+        clusterService.getClusterSettings().applySettings(settings);
+        storedFieldsPrefetch.onPreFetchPhase(searchContext);
+        verify(searchContext, never()).docIdsToLoadSize();
+    }
+
+    public void testOnPreFetchPhase_WhenPrefetchEnabled_ZeroDocs() {
+        // Prefetch is enabled by default, but no docs to load
+        when(searchContext.docIdsToLoadSize()).thenReturn(0);
+        storedFieldsPrefetch.onPreFetchPhase(searchContext);
+        // docIdsToLoadSize is called in the log statement and in the loop condition
+        verify(searchContext, times(2)).docIdsToLoadSize();
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/prefetch/TestOnDemandPrefetchBlockSnapshotIndexInput.java
+++ b/server/src/test/java/org/opensearch/storage/prefetch/TestOnDemandPrefetchBlockSnapshotIndexInput.java
@@ -1,0 +1,175 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.prefetch;
+
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IndexInput;
+import org.opensearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
+import org.opensearch.index.store.remote.file.AbstractBlockIndexInput;
+import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.index.store.remote.utils.BlobFetchRequest;
+import org.opensearch.index.store.remote.utils.TransferManager;
+import org.opensearch.storage.indexinput.OnDemandPrefetchBlockSnapshotIndexInput;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Test helper that exposes protected methods of OnDemandPrefetchBlockSnapshotIndexInput for testing.
+ */
+public class TestOnDemandPrefetchBlockSnapshotIndexInput extends OnDemandPrefetchBlockSnapshotIndexInput {
+
+    public TestOnDemandPrefetchBlockSnapshotIndexInput(
+        Builder<?> builder,
+        String resourceDescription,
+        BlobStoreIndexShardSnapshot.FileInfo fileInfo,
+        FSDirectory directory,
+        TransferManager transferManager,
+        ThreadPool threadPool,
+        FileCache fileCache,
+        Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier
+    ) {
+        super(
+            builder,
+            resourceDescription,
+            fileInfo,
+            directory,
+            transferManager,
+            threadPool,
+            fileCache,
+            tieredStoragePrefetchSettingsSupplier
+        );
+    }
+
+    @Override
+    protected TestOnDemandPrefetchBlockSnapshotIndexInput buildSlice(String sliceDescription, long offset, long length) {
+        return new TestOnDemandPrefetchBlockSnapshotIndexInput(
+            AbstractBlockIndexInput.builder()
+                .blockSizeShift(blockSizeShift)
+                .isClone(true)
+                .offset(this.offset + offset)
+                .length(length)
+                .resourceDescription(sliceDescription),
+            sliceDescription,
+            fileInfo,
+            directory,
+            transferManager,
+            threadPool,
+            fileCache,
+            tieredStoragePrefetchSettingsSupplier
+        );
+    }
+
+    protected Boolean isCloned() {
+        return this.isClone;
+    }
+
+    protected TransferManager getTransferManager() {
+        return this.transferManager;
+    }
+
+    protected String getFileName() {
+        return this.fileName;
+    }
+
+    protected int getBlockMask() {
+        return this.blockMask;
+    }
+
+    protected int getBlockSize() {
+        return this.blockSize;
+    }
+
+    protected int getBlockSizeShift() {
+        return this.blockSizeShift;
+    }
+
+    protected FSDirectory getDirectory() {
+        return this.directory;
+    }
+
+    protected long getOffset() {
+        return this.offset;
+    }
+
+    protected long getLength() {
+        return this.length;
+    }
+
+    @Override
+    protected int getBlock(long pos) {
+        return super.getBlock(pos);
+    }
+
+    @Override
+    protected int getTotalBlocks() {
+        return super.getTotalBlocks();
+    }
+
+    @Override
+    protected int getBlockOffset(long pos) {
+        return super.getBlockOffset(pos);
+    }
+
+    @Override
+    protected long getBlockStart(int blockId) {
+        return super.getBlockStart(blockId);
+    }
+
+    @Override
+    protected List<BlobFetchRequest.BlobPart> getBlobParts(long blockStart, long blockEnd) {
+        return super.getBlobParts(blockStart, blockEnd);
+    }
+
+    protected String getResourceDescription() {
+        return this.resourceDescription;
+    }
+
+    @Override
+    protected boolean checkIfFileEnabledReadAhead() {
+        return super.checkIfFileEnabledReadAhead();
+    }
+
+    @Override
+    protected boolean checkIfStoredFieldsPrefetchEnabled() {
+        return super.checkIfStoredFieldsPrefetchEnabled();
+    }
+
+    @Override
+    protected int currentBlockPosition() {
+        return super.currentBlockPosition();
+    }
+
+    @Override
+    protected long currentBlockStart() {
+        return super.currentBlockStart();
+    }
+
+    @Override
+    public boolean checkCacheHit(int blockId) {
+        return super.checkCacheHit(blockId);
+    }
+
+    @Override
+    public void downloadBlocksAsync(int startBlock, int endBlock, boolean isReadAhead) {
+        super.downloadBlocksAsync(startBlock, endBlock, isReadAhead);
+    }
+
+    /**
+     * Expose fetchBlock for testing.
+     * @param blockId the block id to fetch
+     * @return the fetched IndexInput
+     * @throws IOException if an I/O error occurs
+     */
+    public IndexInput fetchBlockPublic(int blockId) throws IOException {
+        return super.fetchBlock(blockId);
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/prefetch/TieredStoragePrefetchSettingsTests.java
+++ b/server/src/test/java/org/opensearch/storage/prefetch/TieredStoragePrefetchSettingsTests.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.prefetch;
+
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.ClusterServiceUtils;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.junit.Before;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.opensearch.common.settings.ClusterSettings.BUILT_IN_CLUSTER_SETTINGS;
+
+public class TieredStoragePrefetchSettingsTests extends OpenSearchTestCase {
+
+    private ClusterService clusterService;
+    private ThreadPool threadPool;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool("TieredStoragePrefetchSettingsTests");
+        Set<Setting<?>> clusterSettingsToAdd = new HashSet<>(BUILT_IN_CLUSTER_SETTINGS);
+        clusterSettingsToAdd.add(TieredStoragePrefetchSettings.READ_AHEAD_BLOCK_COUNT);
+        clusterSettingsToAdd.add(TieredStoragePrefetchSettings.STORED_FIELDS_PREFETCH_ENABLED_SETTING);
+        clusterService = ClusterServiceUtils.createClusterService(
+            Settings.EMPTY,
+            new ClusterSettings(Settings.EMPTY, clusterSettingsToAdd),
+            threadPool
+        );
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdownNow();
+    }
+
+    public void testDefaultSettings() {
+        TieredStoragePrefetchSettings settings = new TieredStoragePrefetchSettings(clusterService.getClusterSettings());
+        assertEquals(TieredStoragePrefetchSettings.DEFAULT_READ_AHEAD_BLOCK_COUNT, settings.getReadAheadBlockCount());
+        assertEquals(TieredStoragePrefetchSettings.READ_AHEAD_ENABLE_FILE_FORMATS, settings.getReadAheadEnableFileFormats());
+        assertEquals(true, settings.isStoredFieldsPrefetchEnabled());
+    }
+
+    public void testUpdateAfterGetDefaultSettings() {
+        TieredStoragePrefetchSettings tieringServicePrefetchSettings = new TieredStoragePrefetchSettings(
+            clusterService.getClusterSettings()
+        );
+        assertEquals(tieringServicePrefetchSettings.getReadAheadBlockCount(), TieredStoragePrefetchSettings.DEFAULT_READ_AHEAD_BLOCK_COUNT);
+        assertEquals(tieringServicePrefetchSettings.isStoredFieldsPrefetchEnabled(), true);
+        Settings settings = Settings.builder().put(TieredStoragePrefetchSettings.READ_AHEAD_BLOCK_COUNT.getKey(), 10).build();
+        clusterService.getClusterSettings().applySettings(settings);
+        assertEquals(tieringServicePrefetchSettings.getReadAheadBlockCount(), 10);
+    }
+}


### PR DESCRIPTION
### Description

Adds configurable prefetch settings and stored fields prefetch support for WritableWarm tiered storage.

- `TieredStoragePrefetchSettings` — Dynamic cluster settings for read-ahead block count (default 4) and stored fields prefetch toggle (default true), registered in `ClusterSettings.BUILT_IN_CLUSTER_SETTINGS`.
- `StoredFieldsPrefetch` — `SearchOperationListener` that prefetches stored field blocks from remote storage before the fetch phase, with nested document support.
- Updated `OnDemandPrefetchBlockSnapshotIndexInput` to use configurable settings instead of hardcoded values, with read-ahead limited to doc values (`.dvd`) files only.
- Wired `Supplier<TieredStoragePrefetchSettings>` through the full chain: `TieredDirectoryFactory` → `TieredDirectory` → `CachedSwitchableIndexInput` → `SwitchableIndexInput` → `OnDemandPrefetchBlockSnapshotIndexInput`.
- Added tests for settings, prefetch listener, read-ahead file format checks, and chunked repository scenarios.

Note: Metric recording calls (`TieredStorageQueryMetricService`) are left as TODOs — will be added with the slow logs/metrics PR.

### Related Issues

Resolves #21101

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
