### PR TITLE
Fix YAML parser corrupting string values that resemble booleans

### DIFF
--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/OpenSearchYamlFactory.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/OpenSearchYamlFactory.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.xcontent.yaml;
+
+import java.io.InputStream;
+import java.io.Reader;
+
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.io.IOContext;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLFactoryBuilder;
+import tools.jackson.dataformat.yaml.YAMLParser;
+
+/**
+ * Custom {@link YAMLFactory} that creates {@link OpenSearchYamlParser} instances
+ * to restore YAML 1.1 boolean handling lost in the Jackson 3.x migration.
+ */
+class OpenSearchYamlFactory extends YAMLFactory {
+
+    OpenSearchYamlFactory(YAMLFactoryBuilder builder) {
+        super(builder);
+    }
+
+    @Override
+    protected YAMLParser _createParser(ObjectReadContext readCtxt, IOContext ioCtxt, Reader r) {
+        return new OpenSearchYamlParser(
+            readCtxt,
+            ioCtxt,
+            _getBufferRecycler(),
+            readCtxt.getStreamReadFeatures(_streamReadFeatures),
+            readCtxt.getFormatReadFeatures(_formatReadFeatures),
+            _loadSettings,
+            r
+        );
+    }
+
+    @Override
+    protected YAMLParser _createParser(ObjectReadContext readCtxt, IOContext ioCtxt, InputStream is) {
+        return _createParser(readCtxt, ioCtxt, _createReader(is, null, ioCtxt));
+    }
+}

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/OpenSearchYamlParser.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/OpenSearchYamlParser.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.xcontent.yaml;
+
+import java.io.Reader;
+import java.util.Set;
+
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.events.ScalarEvent;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.io.IOContext;
+import tools.jackson.core.util.BufferRecycler;
+import tools.jackson.dataformat.yaml.YAMLParser;
+
+/**
+ * Extends Jackson 3.x's {@link YAMLParser} to restore YAML 1.1 boolean handling
+ * that was present in Jackson 2.x (via SnakeYAML 1.x).
+ *
+ * <p>Jackson 3.x only recognizes lowercase {@code true}/{@code false} as boolean tokens.
+ * The other forms from SnakeYAML's {@code Resolver.BOOL} regex
+ * ({@code yes/Yes/YES, no/No/NO, True/TRUE, False/FALSE, on/On/ON, off/Off/OFF})
+ * are emitted as {@code VALUE_STRING}. This subclass checks whether the scalar is
+ * unquoted (plain) and matches one of these forms, and if so, returns the appropriate
+ * boolean token — matching the behavior of Jackson 2.x.
+ *
+ * <p>Quoted scalars (e.g. {@code "no"}) are left as {@code VALUE_STRING}, preserving
+ * the YAML convention that quoting forces a string interpretation.
+ */
+class OpenSearchYamlParser extends YAMLParser {
+
+    private static final Set<String> YAML_BOOLEAN_TRUE = Set.of("True", "TRUE", "yes", "Yes", "YES", "on", "On", "ON");
+    private static final Set<String> YAML_BOOLEAN_FALSE = Set.of("False", "FALSE", "no", "No", "NO", "off", "Off", "OFF");
+
+    OpenSearchYamlParser(
+        ObjectReadContext readCtxt,
+        IOContext ioCtxt,
+        BufferRecycler br,
+        int stdFeatures,
+        int formatFeatures,
+        LoadSettings loadSettings,
+        Reader reader
+    ) {
+        super(readCtxt, ioCtxt, br, stdFeatures, formatFeatures, loadSettings, reader);
+    }
+
+    @Override
+    protected JsonToken _decodeScalar(ScalarEvent scalar) throws JacksonException {
+        JsonToken token = super._decodeScalar(scalar);
+        if (token == JsonToken.VALUE_STRING && scalar.isPlain()) {
+            String value = scalar.getValue();
+            if (YAML_BOOLEAN_TRUE.contains(value)) {
+                return JsonToken.VALUE_TRUE;
+            } else if (YAML_BOOLEAN_FALSE.contains(value)) {
+                return JsonToken.VALUE_FALSE;
+            }
+        }
+        return token;
+    }
+}

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/YamlXContent.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/YamlXContent.java
@@ -87,7 +87,7 @@ public class YamlXContent implements XContent, XContentConstraints {
         );
         builder.configure(StreamReadFeature.USE_FAST_DOUBLE_PARSER, true);
 
-        yamlFactory = builder.build();
+        yamlFactory = new OpenSearchYamlFactory(builder);
         yamlXContent = new YamlXContent();
     }
 

--- a/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/YamlXContentParser.java
+++ b/libs/x-content/src/main/java/org/opensearch/common/xcontent/yaml/YamlXContentParser.java
@@ -37,11 +37,7 @@ import org.opensearch.common.xcontent.json.JsonXContentParser;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 
-import java.io.IOException;
-
-import org.snakeyaml.engine.v2.resolver.ScalarResolver;
 import tools.jackson.core.JsonParser;
-import tools.jackson.dataformat.yaml.YAMLParser;
 
 public class YamlXContentParser extends JsonXContentParser {
 
@@ -52,32 +48,5 @@ public class YamlXContentParser extends JsonXContentParser {
     @Override
     public XContentType contentType() {
         return XContentType.YAML;
-    }
-
-    /**
-     * Normalizes YAML boolean variants (e.g. {@code True}, {@code False}, {@code TRUE}, {@code FALSE})
-     * to lowercase {@code "true"} / {@code "false"}.
-     *
-     * The underlying Jackson YAML parser uses {@code JsonScalarResolver} which only recognizes
-     * lowercase {@code true}/{@code false} as boolean tokens. Mixed-case variants allowed by the
-     * YAML 1.1/1.2 core schema (e.g. {@code True}, {@code FALSE}) are therefore emitted as
-     * {@code VALUE_STRING} tokens with their original casing preserved, this we normalize
-     * such values at parse time.
-     *
-     * The better way to deal with that would be be to provide own dedicated {@link ScalarResolver}
-     * implementation but unfortunately {@link YAMLParser} does not provide a way to set or override it
-     * currently.
-     */
-    @Override
-    public String text() throws IOException {
-        String text = super.text();
-        if (currentToken() == Token.VALUE_STRING) {
-            if ("true".equalsIgnoreCase(text)) {
-                return "true";
-            } else if ("false".equalsIgnoreCase(text)) {
-                return "false";
-            }
-        }
-        return text;
     }
 }

--- a/libs/x-content/src/test/java/org/opensearch/common/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/opensearch/common/xcontent/XContentParserTests.java
@@ -925,4 +925,53 @@ public class XContentParserTests extends OpenSearchTestCase {
         return tokens;
     }
 
+    public void testYamlBooleanParsing() throws IOException {
+        // YAML 1.1 boolean true values per SnakeYAML's Resolver.BOOL regex
+        String[] truthyValues = { "true", "True", "TRUE", "yes", "Yes", "YES", "on", "On", "ON" };
+        // YAML 1.1 boolean false values per SnakeYAML's Resolver.BOOL regex
+        String[] falsyValues = { "false", "False", "FALSE", "no", "No", "NO", "off", "Off", "OFF" };
+
+        for (String value : truthyValues) {
+            String yaml = "---\nfield: " + value + "\n";
+            try (XContentParser parser = createParser(YamlXContent.yamlXContent, yaml)) {
+                assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+                assertEquals("field", parser.currentName());
+                XContentParser.Token token = parser.nextToken();
+                assertEquals("Expected VALUE_BOOLEAN token for '" + value + "'", XContentParser.Token.VALUE_BOOLEAN, token);
+                assertTrue("Expected '" + value + "' to be a boolean value", parser.isBooleanValue());
+                assertTrue("Expected '" + value + "' to parse as true", parser.booleanValue());
+                assertEquals("Expected text() to preserve original value", value, parser.text());
+            }
+        }
+
+        for (String value : falsyValues) {
+            String yaml = "---\nfield: " + value + "\n";
+            try (XContentParser parser = createParser(YamlXContent.yamlXContent, yaml)) {
+                assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+                assertEquals("field", parser.currentName());
+                XContentParser.Token token = parser.nextToken();
+                assertEquals("Expected VALUE_BOOLEAN token for '" + value + "'", XContentParser.Token.VALUE_BOOLEAN, token);
+                assertTrue("Expected '" + value + "' to be a boolean value", parser.isBooleanValue());
+                assertFalse("Expected '" + value + "' to parse as false", parser.booleanValue());
+                assertEquals("Expected text() to preserve original value", value, parser.text());
+            }
+        }
+
+        // Values that should NOT be treated as booleans
+        String[] nonBooleans = { "truthy", "nope", "yep", "often", "None", "NOTICE", "trUe", "fAlse", "TruE", "y", "Y", "n", "N" };
+        for (String value : nonBooleans) {
+            String yaml = "---\nfield: " + value + "\n";
+            try (XContentParser parser = createParser(YamlXContent.yamlXContent, yaml)) {
+                assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+                assertEquals("field", parser.currentName());
+                parser.nextToken();
+                assertFalse("Expected '" + value + "' to NOT be a boolean value", parser.isBooleanValue());
+                assertEquals(value, parser.text());
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Jackson 2.x (via SnakeYAML 1.x) recognized 18 YAML 1.1 boolean
forms as VALUE_BOOLEAN tokens: yes/Yes/YES, no/No/NO, true/True/
TRUE, false/False/FALSE, on/On/ON, off/Off/OFF. It only did this
for unquoted (plain) scalars — quoted strings like "no" stayed as
VALUE_STRING.

Jackson 3.x only recognizes lowercase true/false as VALUE_BOOLEAN.
The other 16 forms are emitted as VALUE_STRING regardless of
quoting. The migration (https://github.com/opensearch-project/OpenSearch/pull/21029) added a text() override in
YamlXContentParser using equalsIgnoreCase to normalize these, but
this matched all 48 case permutations of true/false rather than the
specific 16 forms, and could not distinguish quoted from unquoted
scalars, corrupting strings like document IDs.

Fix by subclassing Jackson's YAMLParser (OpenSearchYamlParser) to
override _decodeScalar, which has access to the ScalarEvent and its
isPlain() method. For unquoted scalars matching the 16 SnakeYAML
boolean forms, we return VALUE_TRUE/VALUE_FALSE — exactly restoring
Jackson 2.x behavior. Quoted scalars are unaffected. This requires
no overrides in YamlXContentParser and no changes to any caller.

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
