### PR TITLE
Fix map_unmapped_fields_as_text lost after dynamic mapping update

### DIFF
--- a/modules/percolator/src/main/java/org/opensearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/opensearch/percolator/PercolatorFieldMapper.java
@@ -125,7 +125,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
 
     @Override
     public ParametrizedFieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), queryShardContext).init(this);
+        return new Builder(simpleName(), queryShardContext, mapUnmappedFieldsAsText).init(this);
     }
 
     static class Builder extends ParametrizedFieldMapper.Builder {
@@ -133,10 +133,16 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
         private final Supplier<QueryShardContext> queryShardContext;
+        private final boolean mapUnmappedFieldsAsText;
 
         Builder(String fieldName, Supplier<QueryShardContext> queryShardContext) {
+            this(fieldName, queryShardContext, false);
+        }
+
+        Builder(String fieldName, Supplier<QueryShardContext> queryShardContext, boolean mapUnmappedFieldsAsText) {
             super(fieldName);
             this.queryShardContext = queryShardContext;
+            this.mapUnmappedFieldsAsText = mapUnmappedFieldsAsText;
         }
 
         @Override
@@ -146,6 +152,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public PercolatorFieldMapper build(BuilderContext context) {
+            boolean mapUnmapped = getMapUnmappedFieldAsText(context.indexSettings());
             PercolatorFieldType fieldType = new PercolatorFieldType(buildFullName(context), meta.getValue());
             context.path().add(name());
             KeywordFieldMapper extractedTermsField = createExtractQueryFieldBuilder(EXTRACTED_TERMS_FIELD_NAME, context);
@@ -160,7 +167,7 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
             fieldType.rangeField = rangeFieldMapper.fieldType();
             NumberFieldMapper minimumShouldMatchFieldMapper = createMinimumShouldMatchField(context);
             fieldType.minimumShouldMatchField = minimumShouldMatchFieldMapper.fieldType();
-            fieldType.mapUnmappedFieldsAsText = getMapUnmappedFieldAsText(context.indexSettings());
+            fieldType.mapUnmappedFieldsAsText = mapUnmapped;
 
             context.path().remove();
             return new PercolatorFieldMapper(
@@ -174,12 +181,15 @@ public class PercolatorFieldMapper extends ParametrizedFieldMapper {
                 queryBuilderField,
                 rangeFieldMapper,
                 minimumShouldMatchFieldMapper,
-                getMapUnmappedFieldAsText(context.indexSettings())
+                mapUnmapped
             );
         }
 
-        private static boolean getMapUnmappedFieldAsText(Settings indexSettings) {
-            return INDEX_MAP_UNMAPPED_FIELDS_AS_TEXT_SETTING.get(indexSettings);
+        private boolean getMapUnmappedFieldAsText(Settings indexSettings) {
+            if (INDEX_MAP_UNMAPPED_FIELDS_AS_TEXT_SETTING.exists(indexSettings)) {
+                return INDEX_MAP_UNMAPPED_FIELDS_AS_TEXT_SETTING.get(indexSettings);
+            }
+            return mapUnmappedFieldsAsText;
         }
 
         static KeywordFieldMapper createExtractQueryFieldBuilder(String name, BuilderContext context) {

--- a/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorQuerySearchTests.java
+++ b/modules/percolator/src/test/java/org/opensearch/percolator/PercolatorQuerySearchTests.java
@@ -303,6 +303,39 @@ public class PercolatorQuerySearchTests extends OpenSearchSingleNodeTestCase {
         assertSearchHits(response, "1");
     }
 
+    public void testMapUnmappedFieldAsTextAfterDynamicMappingUpdate() throws IOException {
+        Settings.Builder settings = Settings.builder().put("index.percolator.map_unmapped_fields_as_text", true);
+        createIndexWithSimpleMappings("test", settings.build(), "query", "type=percolator", "title", "type=text");
+
+        // Index a document that triggers a dynamic mapping update
+        client().prepareIndex("test")
+            .setId("doc1")
+            .setSource(
+                jsonBuilder().startObject().field("title", "some document").field("new_dynamic_field", "triggers mapping").endObject()
+            )
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .get();
+
+        // Now index a percolator query referencing an unmapped field — this should still work
+        client().prepareIndex("test")
+            .setId("1")
+            .setSource(jsonBuilder().startObject().field("query", matchQuery("unmapped_field", "value")).endObject())
+            .get();
+        client().admin().indices().prepareRefresh().get();
+
+        SearchResponse response = client().prepareSearch("test")
+            .setQuery(
+                new PercolateQueryBuilder(
+                    "query",
+                    BytesReference.bytes(jsonBuilder().startObject().field("unmapped_field", "value").endObject()),
+                    MediaTypeRegistry.JSON
+                )
+            )
+            .get();
+        assertHitCount(response, 1);
+        assertSearchHits(response, "1");
+    }
+
     public void testRangeQueriesWithNow() throws Exception {
         IndexService indexService = createIndexWithSimpleMappings(
             "test",


### PR DESCRIPTION
When a dynamic mapping update triggers a mapping merge, the PercolatorFieldMapper is rebuilt via ParametrizedFieldMapper.merge() which passes Settings.EMPTY to BuilderContext. The Builder read map_unmapped_fields_as_text from these empty settings, reverting it to the default value of false.

Preserve the setting value through merges by passing it from the existing mapper into the new Builder instance.

### Related Issues
Closes #21072

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
