### PR TITLE
Add stats, extended_stats, and value_count support to DSL Calcite plugin

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationMetadataBuilder.java
@@ -13,6 +13,7 @@ import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
@@ -113,7 +114,10 @@ public class AggregationMetadataBuilder {
         boolean noGroupBy = groupings.isEmpty();
         List<AggregateCall> allCalls = new ArrayList<>();
         for (AggregateCall call : aggregateCalls) {
-            if (noGroupBy) {
+            // COUNT is always non-nullable (returns 0 for empty sets), while other aggregations
+            // like AVG, MIN, MAX, SUM return null for empty sets when there's no GROUP BY
+            boolean isCount = call.getAggregation().getKind() == SqlKind.COUNT;
+            if (noGroupBy && !isCount) {
                 RelDataType nullableType = typeFactory.createTypeWithNullability(call.getType(), true);
                 allCalls.add(
                     AggregateCall.create(
@@ -144,7 +148,7 @@ public class AggregationMetadataBuilder {
                     List.of(),
                     -1,
                     RelCollations.EMPTY,
-                    typeFactory.createSqlType(SqlTypeName.BIGINT),
+                    typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.BIGINT), false),
                     IMPLICIT_COUNT_NAME
                 )
             );

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationRegistryFactory.java
@@ -10,9 +10,12 @@ package org.opensearch.dsl.aggregation;
 
 import org.opensearch.dsl.aggregation.bucket.TermsBucketTranslator;
 import org.opensearch.dsl.aggregation.metric.AvgMetricTranslator;
+import org.opensearch.dsl.aggregation.metric.ExtendedStatsMetricTranslator;
 import org.opensearch.dsl.aggregation.metric.MaxMetricTranslator;
 import org.opensearch.dsl.aggregation.metric.MinMetricTranslator;
+import org.opensearch.dsl.aggregation.metric.StatsMetricTranslator;
 import org.opensearch.dsl.aggregation.metric.SumMetricTranslator;
+import org.opensearch.dsl.aggregation.metric.ValueCountMetricTranslator;
 
 /**
  * Creates an {@link AggregationRegistry} populated with all supported translators.
@@ -28,8 +31,10 @@ public class AggregationRegistryFactory {
         registry.register(new SumMetricTranslator());
         registry.register(new MinMetricTranslator());
         registry.register(new MaxMetricTranslator());
+        registry.register(new StatsMetricTranslator());
+        registry.register(new ExtendedStatsMetricTranslator());
+        registry.register(new ValueCountMetricTranslator());
         registry.register(new TermsBucketTranslator());
-        // TODO: add other aggregation translators
         return registry;
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/AggregationTreeWalker.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.dsl.aggregation;
 
+import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.opensearch.dsl.aggregation.bucket.BucketTranslator;
@@ -120,7 +121,17 @@ public class AggregationTreeWalker {
         RelDataType rowType
     ) throws ConversionException {
         AggregationMetadataBuilder builder = getOrCreateBuilder(currentGroupings, granularities);
-        builder.addAggregateCall(translator.toAggregateCall(aggBuilder, rowType), translator.getAggregateFieldName(aggBuilder));
+        List<AggregateCall> calls = translator.toAggregateCalls(aggBuilder, rowType);
+        List<String> fieldNames = translator.getAggregateFieldNames(aggBuilder);
+        if (calls.size() != fieldNames.size()) {
+            throw new ConversionException(
+                "Mismatch between aggregate calls (" + calls.size() +
+                ") and field names (" + fieldNames.size() + ") for aggregation: " + aggBuilder.getName()
+            );
+        }
+        for (int i = 0; i < calls.size(); i++) {
+            builder.addAggregateCall(calls.get(i), fieldNames.get(i));
+        }
     }
 
     private AggregationMetadataBuilder getOrCreateBuilder(

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AbstractMetricTranslator.java
@@ -18,11 +18,12 @@ import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.InternalAggregation;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
- * Base class for metric translators. Provides the common {@link #toAggregateCall}
- * logic — subclasses supply the SQL aggregate function, field name, and optionally
- * override the return type.
+ * Base class for simple metric translators (single value: AVG, SUM, MIN, MAX, COUNT).
+ * Provides default implementations for single-value metrics.
  */
 public abstract class AbstractMetricTranslator<T extends AggregationBuilder> implements MetricTranslator<T> {
 
@@ -41,7 +42,7 @@ public abstract class AbstractMetricTranslator<T extends AggregationBuilder> imp
     protected abstract String getFieldName(T agg);
 
     @Override
-    public AggregateCall toAggregateCall(T agg, RelDataType rowType) throws ConversionException {
+    public List<AggregateCall> toAggregateCalls(T agg, RelDataType rowType) throws ConversionException {
         String fieldName = getFieldName(agg);
         RelDataTypeField field = rowType.getField(fieldName, false, false);
         if (field == null) {
@@ -49,7 +50,7 @@ public abstract class AbstractMetricTranslator<T extends AggregationBuilder> imp
         }
 
         // Calcite enforces the return type to be same as input type; eg: AVG int→double coercion happens in response layer.
-        return AggregateCall.create(
+        AggregateCall call = AggregateCall.create(
             getAggFunction(),
             false,
             false,
@@ -60,16 +61,11 @@ public abstract class AbstractMetricTranslator<T extends AggregationBuilder> imp
             field.getType(),
             agg.getName()
         );
+        return Collections.singletonList(call);
     }
 
     @Override
-    public String getAggregateFieldName(T agg) {
-        return agg.getName();
-    }
-
-    // TODO: implement response conversion per metric type (InternalAvg, InternalSum, etc.)
-    @Override
-    public InternalAggregation toInternalAggregation(String name, Object value) {
-        throw new UnsupportedOperationException("toInternalAggregation not yet implemented for " + getClass().getSimpleName());
+    public List<String> getAggregateFieldNames(T agg) {
+        return Collections.singletonList(agg.getName());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AvgMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/AvgMetricTranslator.java
@@ -11,6 +11,8 @@ package org.opensearch.dsl.aggregation.metric;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import java.util.Map;
 
 /** Translates AVG metric aggregation to Calcite. */
 public class AvgMetricTranslator extends AbstractMetricTranslator<AvgAggregationBuilder> {
@@ -31,5 +33,11 @@ public class AvgMetricTranslator extends AbstractMetricTranslator<AvgAggregation
     @Override
     protected String getFieldName(AvgAggregationBuilder agg) {
         return agg.field();
+    }
+
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Map<String, Object> values) {
+        // TODO: Implement conversion from DataFusion result to InternalAvg
+        throw new UnsupportedOperationException("toInternalAggregation not yet implemented for AvgMetricTranslator");
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/ExtendedStatsMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/ExtendedStatsMetricTranslator.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.metric;
+
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.InternalExtendedStats;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Translator for extended_stats aggregation.
+ * Extended stats produces: count, min, max, sum, sum_of_squares, variance, std_deviation, std_deviation_bounds.
+ * Note: avg, stddev are not computed in Calcite - InternalExtendedStats calculates them dynamically.
+ * We compute variance to derive sum_of_squares (Calcite lacks SUM(x²) function).
+ */
+public class ExtendedStatsMetricTranslator implements MetricTranslator<ExtendedStatsAggregationBuilder> {
+
+    private static final int METRIC_COUNT = 5;
+    private static final double DEFAULT_SIGMA = 2.0;
+    private static final String COUNT_SUFFIX = "_count";
+    private static final String MIN_SUFFIX = "_min";
+    private static final String MAX_SUFFIX = "_max";
+    private static final String SUM_SUFFIX = "_sum";
+    private static final String VARIANCE_SUFFIX = "_variance";
+
+    @Override
+    public Class<ExtendedStatsAggregationBuilder> getAggregationType() {
+        return ExtendedStatsAggregationBuilder.class;
+    }
+
+    @Override
+    public List<AggregateCall> toAggregateCalls(ExtendedStatsAggregationBuilder agg, RelDataType rowType)
+            throws ConversionException {
+        String fieldName = agg.field();
+        RelDataTypeField field = rowType.getField(fieldName, true, false);
+        if (field == null) {
+            throw new ConversionException("Field '" + fieldName + "' not found");
+        }
+        int fieldIndex = field.getIndex();
+        String baseName = agg.getName();
+
+        List<AggregateCall> calls = new ArrayList<>(METRIC_COUNT);
+
+        calls.add(createAggregateCall(SqlStdOperatorTable.COUNT, Collections.singletonList(fieldIndex),
+            field.getType(), baseName + COUNT_SUFFIX));
+        calls.add(createAggregateCall(SqlStdOperatorTable.MIN, Collections.singletonList(fieldIndex),
+            field.getType(), baseName + MIN_SUFFIX));
+        calls.add(createAggregateCall(SqlStdOperatorTable.MAX, Collections.singletonList(fieldIndex),
+            field.getType(), baseName + MAX_SUFFIX));
+        calls.add(createAggregateCall(SqlStdOperatorTable.SUM, Collections.singletonList(fieldIndex),
+            field.getType(), baseName + SUM_SUFFIX));
+        calls.add(createAggregateCall(SqlStdOperatorTable.VAR_POP, Collections.singletonList(fieldIndex),
+            field.getType(), baseName + VARIANCE_SUFFIX));
+
+        return calls;
+    }
+
+    private AggregateCall createAggregateCall(SqlAggFunction function, List<Integer> argList,
+            RelDataType type, String name) {
+        return AggregateCall.create(
+            function,
+            false, false, true,
+            argList,
+            -1,
+            RelCollations.EMPTY,
+            type,
+            name
+        );
+    }
+
+    @Override
+    public List<String> getAggregateFieldNames(ExtendedStatsAggregationBuilder agg) {
+        String baseName = agg.getName();
+        return List.of(
+            baseName + COUNT_SUFFIX,
+            baseName + MIN_SUFFIX,
+            baseName + MAX_SUFFIX,
+            baseName + SUM_SUFFIX,
+            baseName + VARIANCE_SUFFIX
+        );
+    }
+
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Map<String, Object> values) {
+        if (values == null) {
+            return new InternalExtendedStats(name, 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0, DEFAULT_SIGMA, DocValueFormat.RAW, Map.of());
+        }
+        String baseName = name;
+        long count = values.get(baseName + COUNT_SUFFIX) != null ? ((Number) values.get(baseName + COUNT_SUFFIX)).longValue() : 0;
+        double min = values.get(baseName + MIN_SUFFIX) != null ? ((Number) values.get(baseName + MIN_SUFFIX)).doubleValue() : Double.POSITIVE_INFINITY;
+        double max = values.get(baseName + MAX_SUFFIX) != null ? ((Number) values.get(baseName + MAX_SUFFIX)).doubleValue() : Double.NEGATIVE_INFINITY;
+        double sum = values.get(baseName + SUM_SUFFIX) != null ? ((Number) values.get(baseName + SUM_SUFFIX)).doubleValue() : 0;
+        double variance = values.get(baseName + VARIANCE_SUFFIX) != null ? ((Number) values.get(baseName + VARIANCE_SUFFIX)).doubleValue() : 0;
+
+        double avg = count > 0 ? sum / count : 0;
+        double sumOfSquares = count > 0 ? (variance * count) + (avg * avg * count) : 0;
+
+        return new InternalExtendedStats(name, count, sum, min, max, sumOfSquares, DEFAULT_SIGMA, DocValueFormat.RAW, Map.of());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MaxMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MaxMetricTranslator.java
@@ -11,6 +11,8 @@ package org.opensearch.dsl.aggregation.metric;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.opensearch.search.aggregations.metrics.MaxAggregationBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import java.util.Map;
 
 /** Translates MAX metric aggregation to Calcite. */
 public class MaxMetricTranslator extends AbstractMetricTranslator<MaxAggregationBuilder> {
@@ -31,5 +33,11 @@ public class MaxMetricTranslator extends AbstractMetricTranslator<MaxAggregation
     @Override
     protected String getFieldName(MaxAggregationBuilder agg) {
         return agg.field();
+    }
+
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Map<String, Object> values) {
+        // TODO: Implement conversion from DataFusion result to InternalMax
+        throw new UnsupportedOperationException("toInternalAggregation not yet implemented for MaxMetricTranslator");
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MetricTranslator.java
@@ -15,39 +15,42 @@ import org.opensearch.dsl.converter.ConversionException;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.InternalAggregation;
 
+import java.util.List;
+import java.util.Map;
+
 /**
- * Translates a metric aggregation (AVG, SUM, MIN, MAX, etc.) to a Calcite AggregateCall,
+ * Translates a metric aggregation to Calcite AggregateCall(s),
  * and converts raw result values back to OpenSearch InternalAggregation for response building.
  */
 public interface MetricTranslator<T extends AggregationBuilder> extends AggregationTranslator<T> {
 
     /**
-     * Converts the metric aggregation to a Calcite AggregateCall.
+     * Converts the metric aggregation to Calcite AggregateCall(s).
      *
      * @param agg the metric aggregation builder
      * @param rowType the index row type for field lookup
-     * @return the Calcite AggregateCall
+     * @return list of Calcite AggregateCalls
      * @throws ConversionException if conversion fails
      */
-    AggregateCall toAggregateCall(T agg, RelDataType rowType) throws ConversionException;
+    List<AggregateCall> toAggregateCalls(T agg, RelDataType rowType) throws ConversionException;
 
     /**
-     * Returns the output field name for this aggregation.
+     * Returns the output field names for this aggregation.
      *
      * @param agg the metric aggregation builder
-     * @return the aggregate field name
+     * @return list of aggregate field names
      */
-    String getAggregateFieldName(T agg);
+    List<String> getAggregateFieldNames(T agg);
 
     // TODO: Revisit signature — accept a stream/iterator of <String,Object> for bulk conversion
     // to avoid per-row virtual dispatch overhead, and use Arrow-native types once Analytics Core
     // exposes them.
     /**
-     * Converts a raw result value from execution into an OpenSearch InternalAggregation.
+     * Converts raw result values from execution into an OpenSearch InternalAggregation.
      *
      * @param name the aggregation name
-     * @param value the raw value (may be null)
+     * @param values map of field names to their computed values
      * @return the corresponding InternalAggregation
      */
-    InternalAggregation toInternalAggregation(String name, Object value);
+    InternalAggregation toInternalAggregation(String name, Map<String, Object> values);
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MinMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/MinMetricTranslator.java
@@ -11,6 +11,8 @@ package org.opensearch.dsl.aggregation.metric;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import java.util.Map;
 
 /** Translates MIN metric aggregation to Calcite. */
 public class MinMetricTranslator extends AbstractMetricTranslator<MinAggregationBuilder> {
@@ -31,5 +33,11 @@ public class MinMetricTranslator extends AbstractMetricTranslator<MinAggregation
     @Override
     protected String getFieldName(MinAggregationBuilder agg) {
         return agg.field();
+    }
+
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Map<String, Object> values) {
+        // TODO: Implement conversion from DataFusion result to InternalMin
+        throw new UnsupportedOperationException("toInternalAggregation not yet implemented for MinMetricTranslator");
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/StatsMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/StatsMetricTranslator.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.metric;
+
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.metrics.InternalStats;
+import org.opensearch.search.aggregations.metrics.StatsAggregationBuilder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Translator for stats aggregation.
+ * Stats produces multiple metrics: count, min, max, sum.
+ * Note: avg is not computed in Calcite - InternalStats calculates it as sum/count.
+ */
+public class StatsMetricTranslator implements MetricTranslator<StatsAggregationBuilder> {
+
+    private static final int METRIC_COUNT = 4;
+    private static final String COUNT_SUFFIX = "_count";
+    private static final String MIN_SUFFIX = "_min";
+    private static final String MAX_SUFFIX = "_max";
+    private static final String SUM_SUFFIX = "_sum";
+
+    @Override
+    public Class<StatsAggregationBuilder> getAggregationType() {
+        return StatsAggregationBuilder.class;
+    }
+
+    @Override
+    public List<AggregateCall> toAggregateCalls(StatsAggregationBuilder agg, RelDataType rowType)
+            throws ConversionException {
+        String fieldName = agg.field();
+        RelDataTypeField field = rowType.getField(fieldName, true, false);
+        if (field == null) {
+            throw new ConversionException("Field '" + fieldName + "' not found");
+        }
+        int fieldIndex = field.getIndex();
+        String baseName = agg.getName();
+
+        List<AggregateCall> calls = new ArrayList<>(METRIC_COUNT);
+
+        calls.add(createAggregateCall(SqlStdOperatorTable.COUNT, Collections.singletonList(fieldIndex),
+            field.getType(), baseName + COUNT_SUFFIX));
+        calls.add(createAggregateCall(SqlStdOperatorTable.MIN, Collections.singletonList(fieldIndex),
+            field.getType(), baseName + MIN_SUFFIX));
+        calls.add(createAggregateCall(SqlStdOperatorTable.MAX, Collections.singletonList(fieldIndex),
+            field.getType(), baseName + MAX_SUFFIX));
+        calls.add(createAggregateCall(SqlStdOperatorTable.SUM, Collections.singletonList(fieldIndex),
+            field.getType(), baseName + SUM_SUFFIX));
+
+        return calls;
+    }
+
+    private AggregateCall createAggregateCall(SqlAggFunction function, List<Integer> argList,
+            RelDataType type, String name) {
+        return AggregateCall.create(
+            function,
+            false, false, true,
+            argList,
+            -1,
+            RelCollations.EMPTY,
+            type,
+            name
+        );
+    }
+
+    @Override
+    public List<String> getAggregateFieldNames(StatsAggregationBuilder agg) {
+        String baseName = agg.getName();
+        return List.of(
+            baseName + COUNT_SUFFIX,
+            baseName + MIN_SUFFIX,
+            baseName + MAX_SUFFIX,
+            baseName + SUM_SUFFIX
+        );
+    }
+
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Map<String, Object> values) {
+        if (values == null) {
+            return new InternalStats(name, 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, DocValueFormat.RAW, Map.of());
+        }
+        String baseName = name;
+        long count = values.get(baseName + COUNT_SUFFIX) != null ? ((Number) values.get(baseName + COUNT_SUFFIX)).longValue() : 0;
+        double min = values.get(baseName + MIN_SUFFIX) != null ? ((Number) values.get(baseName + MIN_SUFFIX)).doubleValue() : Double.POSITIVE_INFINITY;
+        double max = values.get(baseName + MAX_SUFFIX) != null ? ((Number) values.get(baseName + MAX_SUFFIX)).doubleValue() : Double.NEGATIVE_INFINITY;
+        double sum = values.get(baseName + SUM_SUFFIX) != null ? ((Number) values.get(baseName + SUM_SUFFIX)).doubleValue() : 0;
+
+        return new InternalStats(name, count, sum, min, max, DocValueFormat.RAW, Map.of());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/SumMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/SumMetricTranslator.java
@@ -11,6 +11,8 @@ package org.opensearch.dsl.aggregation.metric;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import java.util.Map;
 
 /** Translates SUM metric aggregation to Calcite. */
 public class SumMetricTranslator extends AbstractMetricTranslator<SumAggregationBuilder> {
@@ -31,5 +33,11 @@ public class SumMetricTranslator extends AbstractMetricTranslator<SumAggregation
     @Override
     protected String getFieldName(SumAggregationBuilder agg) {
         return agg.field();
+    }
+
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Map<String, Object> values) {
+        // TODO: Implement conversion from DataFusion result to InternalSum
+        throw new UnsupportedOperationException("toInternalAggregation not yet implemented for SumMetricTranslator");
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/ValueCountMetricTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/aggregation/metric/ValueCountMetricTranslator.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.metric;
+
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.metrics.InternalValueCount;
+import org.opensearch.search.aggregations.metrics.ValueCountAggregationBuilder;
+
+import java.util.Map;
+
+/**
+ * Translator for value_count aggregation.
+ * Counts the number of values for a field.
+ */
+public class ValueCountMetricTranslator extends AbstractMetricTranslator<ValueCountAggregationBuilder> {
+
+    @Override
+    public Class<ValueCountAggregationBuilder> getAggregationType() {
+        return ValueCountAggregationBuilder.class;
+    }
+
+    @Override
+    protected SqlAggFunction getAggFunction() {
+        return SqlStdOperatorTable.COUNT;
+    }
+
+    @Override
+    protected String getFieldName(ValueCountAggregationBuilder agg) {
+        return agg.field();
+    }
+
+    @Override
+    public InternalAggregation toInternalAggregation(String name, Map<String, Object> values) {
+        Object value = values.get(name);
+        long count = value == null ? 0 : ((Number) value).longValue();
+        return new InternalValueCount(name, count, Map.of());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/ExtendedStatsMetricTranslatorTest.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/ExtendedStatsMetricTranslatorTest.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.metric;
+
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.sql.SqlKind;
+import org.opensearch.dsl.TestUtils;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.InternalExtendedStats;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+public class ExtendedStatsMetricTranslatorTest extends OpenSearchTestCase {
+
+    private final ConversionContext ctx = TestUtils.createContext();
+
+    public void testGetAggregationType() {
+        ExtendedStatsMetricTranslator translator = new ExtendedStatsMetricTranslator();
+        assertEquals(ExtendedStatsAggregationBuilder.class, translator.getAggregationType());
+    }
+
+    public void testToAggregateCalls() throws ConversionException {
+        ExtendedStatsMetricTranslator translator = new ExtendedStatsMetricTranslator();
+        ExtendedStatsAggregationBuilder agg = new ExtendedStatsAggregationBuilder("price_stats").field("price");
+
+        List<AggregateCall> calls = translator.toAggregateCalls(agg, ctx.getRowType());
+
+        assertEquals(5, calls.size());
+        assertEquals(SqlKind.COUNT, calls.get(0).getAggregation().getKind());
+        assertEquals(SqlKind.MIN, calls.get(1).getAggregation().getKind());
+        assertEquals(SqlKind.MAX, calls.get(2).getAggregation().getKind());
+        assertEquals(SqlKind.SUM, calls.get(3).getAggregation().getKind());
+        assertEquals("price_stats_variance", calls.get(4).getName());
+    }
+
+    public void testToAggregateCallsInvalidField() {
+        ExtendedStatsMetricTranslator translator = new ExtendedStatsMetricTranslator();
+        ExtendedStatsAggregationBuilder agg = new ExtendedStatsAggregationBuilder("price_stats").field("invalid");
+
+        expectThrows(ConversionException.class, () -> translator.toAggregateCalls(agg, ctx.getRowType()));
+    }
+
+    public void testGetAggregateFieldNames() {
+        ExtendedStatsMetricTranslator translator = new ExtendedStatsMetricTranslator();
+        ExtendedStatsAggregationBuilder agg = new ExtendedStatsAggregationBuilder("price_stats").field("price");
+
+        List<String> names = translator.getAggregateFieldNames(agg);
+
+        assertEquals(5, names.size());
+        assertEquals("price_stats_count", names.get(0));
+        assertEquals("price_stats_min", names.get(1));
+        assertEquals("price_stats_max", names.get(2));
+        assertEquals("price_stats_sum", names.get(3));
+        assertEquals("price_stats_variance", names.get(4));
+    }
+
+    public void testToInternalAggregationWithValidValues() {
+        ExtendedStatsMetricTranslator translator = new ExtendedStatsMetricTranslator();
+        Map<String, Object> values = Map.of(
+            "price_stats_count", 10L,
+            "price_stats_min", 5.0,
+            "price_stats_max", 100.0,
+            "price_stats_sum", 550.0,
+            "price_stats_variance", 900.0
+        );
+
+        InternalAggregation result = translator.toInternalAggregation("price_stats", values);
+
+        assertNotNull(result);
+        assertTrue(result instanceof InternalExtendedStats);
+        InternalExtendedStats stats = (InternalExtendedStats) result;
+        assertEquals(10, stats.getCount());
+        assertEquals(5.0, stats.getMin(), 0.001);
+        assertEquals(100.0, stats.getMax(), 0.001);
+        assertEquals(550.0, stats.getSum(), 0.001);
+        assertEquals(39250.0, stats.getSumOfSquares(), 0.001);
+    }
+
+    public void testToInternalAggregationWithNull() {
+        ExtendedStatsMetricTranslator translator = new ExtendedStatsMetricTranslator();
+
+        InternalAggregation result = translator.toInternalAggregation("price_stats", null);
+
+        assertNotNull(result);
+        assertTrue(result instanceof InternalExtendedStats);
+        InternalExtendedStats stats = (InternalExtendedStats) result;
+        assertEquals(0, stats.getCount());
+        assertEquals(Double.POSITIVE_INFINITY, stats.getMin(), 0.001);
+        assertEquals(Double.NEGATIVE_INFINITY, stats.getMax(), 0.001);
+        assertEquals(0.0, stats.getSum(), 0.001);
+        assertEquals(0.0, stats.getSumOfSquares(), 0.001);
+        assertTrue(Double.isNaN(stats.getVariance()));
+    }
+
+    public void testToInternalAggregationWithPartialNulls() {
+        ExtendedStatsMetricTranslator translator = new ExtendedStatsMetricTranslator();
+        Map<String, Object> values = Map.of(
+            "price_stats_count", 5L,
+            "price_stats_sum", 100.0
+        );
+
+        InternalAggregation result = translator.toInternalAggregation("price_stats", values);
+
+        assertNotNull(result);
+        InternalExtendedStats stats = (InternalExtendedStats) result;
+        assertEquals(5, stats.getCount());
+        assertEquals(Double.POSITIVE_INFINITY, stats.getMin(), 0.001);
+        assertEquals(Double.NEGATIVE_INFINITY, stats.getMax(), 0.001);
+        assertEquals(100.0, stats.getSum(), 0.001);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/MetricTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/MetricTranslatorTests.java
@@ -19,14 +19,18 @@ import org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
 import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.List;
+
 public class MetricTranslatorTests extends OpenSearchTestCase {
 
     private final ConversionContext ctx = TestUtils.createContext();
 
     public void testAvgTranslator() throws ConversionException {
         AvgMetricTranslator translator = new AvgMetricTranslator();
-        AggregateCall call = translator.toAggregateCall(new AvgAggregationBuilder("avg_price").field("price"), ctx.getRowType());
+        List<AggregateCall> calls = translator.toAggregateCalls(new AvgAggregationBuilder("avg_price").field("price"), ctx.getRowType());
 
+        assertEquals(1, calls.size());
+        AggregateCall call = calls.get(0);
         assertEquals(SqlKind.AVG, call.getAggregation().getKind());
         assertEquals("avg_price", call.getName());
         assertEquals(1, call.getArgList().size());
@@ -35,24 +39,30 @@ public class MetricTranslatorTests extends OpenSearchTestCase {
 
     public void testSumTranslator() throws ConversionException {
         SumMetricTranslator translator = new SumMetricTranslator();
-        AggregateCall call = translator.toAggregateCall(new SumAggregationBuilder("total").field("price"), ctx.getRowType());
+        List<AggregateCall> calls = translator.toAggregateCalls(new SumAggregationBuilder("total").field("price"), ctx.getRowType());
 
+        assertEquals(1, calls.size());
+        AggregateCall call = calls.get(0);
         assertEquals(SqlKind.SUM, call.getAggregation().getKind());
         assertEquals("total", call.getName());
     }
 
     public void testMinTranslator() throws ConversionException {
         MinMetricTranslator translator = new MinMetricTranslator();
-        AggregateCall call = translator.toAggregateCall(new MinAggregationBuilder("min_price").field("price"), ctx.getRowType());
+        List<AggregateCall> calls = translator.toAggregateCalls(new MinAggregationBuilder("min_price").field("price"), ctx.getRowType());
 
+        assertEquals(1, calls.size());
+        AggregateCall call = calls.get(0);
         assertEquals(SqlKind.MIN, call.getAggregation().getKind());
         assertEquals("min_price", call.getName());
     }
 
     public void testMaxTranslator() throws ConversionException {
         MaxMetricTranslator translator = new MaxMetricTranslator();
-        AggregateCall call = translator.toAggregateCall(new MaxAggregationBuilder("max_price").field("price"), ctx.getRowType());
+        List<AggregateCall> calls = translator.toAggregateCalls(new MaxAggregationBuilder("max_price").field("price"), ctx.getRowType());
 
+        assertEquals(1, calls.size());
+        AggregateCall call = calls.get(0);
         assertEquals(SqlKind.MAX, call.getAggregation().getKind());
         assertEquals("max_price", call.getName());
     }
@@ -60,14 +70,14 @@ public class MetricTranslatorTests extends OpenSearchTestCase {
     public void testThrowsForUnknownField() {
         AvgMetricTranslator translator = new AvgMetricTranslator();
 
-        expectThrows(
-            ConversionException.class,
-            () -> translator.toAggregateCall(new AvgAggregationBuilder("bad").field("nonexistent"), ctx.getRowType())
-        );
+        expectThrows(ConversionException.class,
+            () -> translator.toAggregateCalls(new AvgAggregationBuilder("bad").field("nonexistent"), ctx.getRowType()));
     }
 
     public void testAggregateFieldName() {
         AvgMetricTranslator translator = new AvgMetricTranslator();
-        assertEquals("avg_price", translator.getAggregateFieldName(new AvgAggregationBuilder("avg_price").field("price")));
+        List<String> names = translator.getAggregateFieldNames(new AvgAggregationBuilder("avg_price").field("price"));
+        assertEquals(1, names.size());
+        assertEquals("avg_price", names.get(0));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/StatsMetricTranslatorTest.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/StatsMetricTranslatorTest.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.metric;
+
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.sql.SqlKind;
+import org.opensearch.dsl.TestUtils;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.metrics.InternalStats;
+import org.opensearch.search.aggregations.metrics.StatsAggregationBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+public class StatsMetricTranslatorTest extends OpenSearchTestCase {
+
+    private final ConversionContext ctx = TestUtils.createContext();
+
+    public void testGetAggregationType() {
+        StatsMetricTranslator translator = new StatsMetricTranslator();
+        assertEquals(StatsAggregationBuilder.class, translator.getAggregationType());
+    }
+
+    public void testToAggregateCalls() throws ConversionException {
+        StatsMetricTranslator translator = new StatsMetricTranslator();
+        StatsAggregationBuilder agg = new StatsAggregationBuilder("price_stats").field("price");
+
+        List<AggregateCall> calls = translator.toAggregateCalls(agg, ctx.getRowType());
+
+        assertEquals(4, calls.size());
+        assertEquals(SqlKind.COUNT, calls.get(0).getAggregation().getKind());
+        assertEquals(SqlKind.MIN, calls.get(1).getAggregation().getKind());
+        assertEquals(SqlKind.MAX, calls.get(2).getAggregation().getKind());
+        assertEquals(SqlKind.SUM, calls.get(3).getAggregation().getKind());
+    }
+
+    public void testToAggregateCallsInvalidField() {
+        StatsMetricTranslator translator = new StatsMetricTranslator();
+        StatsAggregationBuilder agg = new StatsAggregationBuilder("price_stats").field("invalid");
+
+        expectThrows(ConversionException.class, () -> translator.toAggregateCalls(agg, ctx.getRowType()));
+    }
+
+    public void testGetAggregateFieldNames() {
+        StatsMetricTranslator translator = new StatsMetricTranslator();
+        StatsAggregationBuilder agg = new StatsAggregationBuilder("price_stats").field("price");
+
+        List<String> names = translator.getAggregateFieldNames(agg);
+
+        assertEquals(4, names.size());
+        assertEquals("price_stats_count", names.get(0));
+        assertEquals("price_stats_min", names.get(1));
+        assertEquals("price_stats_max", names.get(2));
+        assertEquals("price_stats_sum", names.get(3));
+    }
+
+    public void testToInternalAggregationWithValidValues() {
+        StatsMetricTranslator translator = new StatsMetricTranslator();
+        Map<String, Object> values = Map.of(
+            "price_stats_count", 10L,
+            "price_stats_min", 5.0,
+            "price_stats_max", 100.0,
+            "price_stats_sum", 550.0
+        );
+
+        InternalAggregation result = translator.toInternalAggregation("price_stats", values);
+
+        assertNotNull(result);
+        assertTrue(result instanceof InternalStats);
+        InternalStats stats = (InternalStats) result;
+        assertEquals(10, stats.getCount());
+        assertEquals(5.0, stats.getMin(), 0.001);
+        assertEquals(100.0, stats.getMax(), 0.001);
+        assertEquals(550.0, stats.getSum(), 0.001);
+    }
+
+    public void testToInternalAggregationWithNull() {
+        StatsMetricTranslator translator = new StatsMetricTranslator();
+
+        InternalAggregation result = translator.toInternalAggregation("price_stats", null);
+
+        assertNotNull(result);
+        assertTrue(result instanceof InternalStats);
+        InternalStats stats = (InternalStats) result;
+        assertEquals(0, stats.getCount());
+        assertEquals(Double.POSITIVE_INFINITY, stats.getMin(), 0.001);
+        assertEquals(Double.NEGATIVE_INFINITY, stats.getMax(), 0.001);
+        assertEquals(0.0, stats.getSum(), 0.001);
+    }
+
+    public void testToInternalAggregationWithPartialNulls() {
+        StatsMetricTranslator translator = new StatsMetricTranslator();
+        Map<String, Object> values = Map.of(
+            "price_stats_count", 5L,
+            "price_stats_sum", 100.0
+        );
+
+        InternalAggregation result = translator.toInternalAggregation("price_stats", values);
+
+        assertNotNull(result);
+        InternalStats stats = (InternalStats) result;
+        assertEquals(5, stats.getCount());
+        assertEquals(Double.POSITIVE_INFINITY, stats.getMin(), 0.001);
+        assertEquals(Double.NEGATIVE_INFINITY, stats.getMax(), 0.001);
+        assertEquals(100.0, stats.getSum(), 0.001);
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/ValueCountMetricTranslatorTest.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/aggregation/metric/ValueCountMetricTranslatorTest.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.aggregation.metric;
+
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.sql.SqlKind;
+import org.opensearch.dsl.TestUtils;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.metrics.InternalValueCount;
+import org.opensearch.search.aggregations.metrics.ValueCountAggregationBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+public class ValueCountMetricTranslatorTest extends OpenSearchTestCase {
+
+    private final ConversionContext ctx = TestUtils.createContext();
+
+    public void testGetAggregationType() {
+        ValueCountMetricTranslator translator = new ValueCountMetricTranslator();
+        assertEquals(ValueCountAggregationBuilder.class, translator.getAggregationType());
+    }
+
+    public void testToAggregateCallsReturnsCountFunction() throws ConversionException {
+        ValueCountMetricTranslator translator = new ValueCountMetricTranslator();
+        ValueCountAggregationBuilder agg = new ValueCountAggregationBuilder("price_count").field("price");
+
+        List<AggregateCall> calls = translator.toAggregateCalls(agg, ctx.getRowType());
+
+        assertEquals(1, calls.size());
+        AggregateCall call = calls.get(0);
+        assertEquals(SqlKind.COUNT, call.getAggregation().getKind());
+        assertEquals("price_count", call.getName());
+    }
+
+    public void testToAggregateCallsInvalidField() {
+        ValueCountMetricTranslator translator = new ValueCountMetricTranslator();
+        ValueCountAggregationBuilder agg = new ValueCountAggregationBuilder("count").field("invalid");
+
+        expectThrows(ConversionException.class, () -> translator.toAggregateCalls(agg, ctx.getRowType()));
+    }
+
+    public void testGetAggregateFieldNames() {
+        ValueCountMetricTranslator translator = new ValueCountMetricTranslator();
+        ValueCountAggregationBuilder agg = new ValueCountAggregationBuilder("price_count").field("price");
+
+        List<String> names = translator.getAggregateFieldNames(agg);
+
+        assertEquals(1, names.size());
+        assertEquals("price_count", names.get(0));
+    }
+
+    public void testToInternalAggregationWithValidValue() {
+        ValueCountMetricTranslator translator = new ValueCountMetricTranslator();
+        Map<String, Object> values = Map.of("price_count", 42L);
+
+        InternalAggregation result = translator.toInternalAggregation("price_count", values);
+
+        assertNotNull(result);
+        assertTrue(result instanceof InternalValueCount);
+        InternalValueCount count = (InternalValueCount) result;
+        assertEquals(42L, count.getValue());
+    }
+
+    public void testToInternalAggregationWithZero() {
+        ValueCountMetricTranslator translator = new ValueCountMetricTranslator();
+        Map<String, Object> values = Map.of("price_count", 0L);
+
+        InternalAggregation result = translator.toInternalAggregation("price_count", values);
+
+        assertNotNull(result);
+        InternalValueCount count = (InternalValueCount) result;
+        assertEquals(0L, count.getValue());
+    }
+
+    public void testToInternalAggregationWithNull() {
+        ValueCountMetricTranslator translator = new ValueCountMetricTranslator();
+
+        InternalAggregation result = translator.toInternalAggregation("price_count", null);
+
+        assertNotNull(result);
+        InternalValueCount count = (InternalValueCount) result;
+        assertEquals(0L, count.getValue());
+    }
+
+    public void testToInternalAggregationWithNumberType() {
+        ValueCountMetricTranslator translator = new ValueCountMetricTranslator();
+        Map<String, Object> values = Map.of("price_count", 100);
+
+        InternalAggregation result = translator.toInternalAggregation("price_count", values);
+
+        assertNotNull(result);
+        InternalValueCount count = (InternalValueCount) result;
+        assertEquals(100L, count.getValue());
+    }
+}


### PR DESCRIPTION
## Description

Adds support for stats, extended_stats, and value_count metric aggregations to the DSL Calcite plugin.

Key changes:
• Refactored MetricTranslator interface to support multi-metric aggregations (returns List<AggregateCall> instead of single call)
• Implemented StatsMetricTranslator (count, min, max, sum)
• Implemented ExtendedStatsMetricTranslator (count, min, max, sum, variance)
• Implemented ValueCountMetricTranslator (count on specific field)
• Made COUNT type explicitly non-nullable to match SQL semantics

Note:
Derived metrics like avg and std_deviation are computed by InternalStats/InternalExtendedStats from the base metrics rather than in SQL.

Tests:
Added unit tests for all three new translators covering valid values, null handling, and error cases.