### PR TITLE
Fix flaky testThreeZoneOneReplicaWithForceZoneValueAndLoadAwareness

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/AwarenessAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/allocation/AwarenessAllocationIT.java
@@ -46,6 +46,7 @@ import org.opensearch.cluster.routing.allocation.AwarenessReplicaBalance;
 import org.opensearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
 import org.opensearch.common.Priority;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.OpenSearchIntegTestCase.ClusterScope;
@@ -495,6 +496,7 @@ public class AwarenessAllocationIT extends OpenSearchIntegTestCase {
             .setWaitForActiveShards(2 * numOfShards * (numOfReplica + 1))
             .setWaitForNoRelocatingShards(true)
             .setWaitForNoInitializingShards(true)
+            .setTimeout(TimeValue.timeValueMinutes(2))
             .execute()
             .actionGet();
         clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();


### PR DESCRIPTION
### Description

Fixes the long-standing flakiness of `AwarenessAllocationIT.testThreeZoneOneReplicaWithForceZoneValueAndLoadAwareness` by bumping the timeout on its final cluster health check from the default 30s to 2 minutes.

The test stops two of the five nodes in zone-a, creates a second 30-shard/1-replica index while the cluster is short those nodes, then restarts the zone-a nodes and asserts that the cluster returns to green with all 120 shards started. Under CI load, the allocator frequently needs more than 30s to finish rebalancing — the load-aware decider (`skew_factor=0.0`, `provisioned_capacity=15`, default `flat_skew=2`) limits each node to 10 shards, so restarting the zone-a nodes triggers substantial movement to rebalance test-1 replicas while assigning the newly-created test-2 shards.

The metrics cluster shows 149 occurrences of this failure across 149 unique builds (~10–18/month) since the prior `@AwaitsFix(#5908)` annotation was inadvertently removed as part of #17652 in March 2025.

Bumping the timeout matches the approach already used by similarly rebalancing-heavy tests like `RelocationIT` and `ShrinkIndexIT`.

### Related Issues

Addresses #3603 and the autocut report #17930.

### Testing

- `./gradlew :server:spotlessJavaCheck` passes
- Reproducer from a recent failure (build [74782](https://build.ci.opensearch.org/job/gradle-check/74782/)) passes:
  ```
  ./gradlew ':server:internalClusterTest' --tests 'org.opensearch.cluster.allocation.AwarenessAllocationIT.testThreeZoneOneReplicaWithForceZoneValueAndLoadAwareness' -Dtests.seed=D5DDEBBD8A7C1C89 -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=zh-Hant-TW -Dtests.timezone=Africa/Luanda
  ```
- 5 iterations with random seeds all pass

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
