### PR TITLE
Add delete Index engine abstraction

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LucenePlugin.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LucenePlugin.java
@@ -11,11 +11,13 @@ package org.opensearch.be.lucene;
 import org.apache.lucene.index.DirectoryReader;
 import org.opensearch.be.lucene.index.LuceneCommitter;
 import org.opensearch.be.lucene.index.LuceneCommitterFactory;
+import org.opensearch.be.lucene.index.LuceneDeleteExecutionEngine;
 import org.opensearch.be.lucene.index.LuceneIndexingExecutionEngine;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatPlugin;
+import org.opensearch.index.engine.dataformat.DeleteExecutionEngine;
 import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
 import org.opensearch.index.engine.dataformat.ReaderManagerConfig;
@@ -123,5 +125,10 @@ public class LucenePlugin extends Plugin implements DataFormatPlugin, SearchBack
     @Override
     public Optional<CommitterFactory> getCommitterFactory(IndexSettings indexSettings) {
         return Optional.of(new LuceneCommitterFactory());
+    }
+
+    @Override
+    public DeleteExecutionEngine<?> getDeleteExecutionEngine(Committer committer) {
+        return new LuceneDeleteExecutionEngine(DATA_FORMAT, committer);
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngine.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngine.java
@@ -1,0 +1,84 @@
+package org.opensearch.be.lucene.index;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.Term;
+import org.opensearch.be.lucene.LuceneDataFormat;
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DeleteExecutionEngine;
+import org.opensearch.index.engine.dataformat.DeleteInput;
+import org.opensearch.index.engine.dataformat.DeleteResult;
+import org.opensearch.index.engine.dataformat.Deleter;
+import org.opensearch.index.engine.dataformat.DeleterImpl;
+import org.opensearch.index.engine.dataformat.RefreshInput;
+import org.opensearch.index.engine.dataformat.RefreshResult;
+import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.exec.commit.Committer;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Lucene-based implementation of {@link DeleteExecutionEngine} that tracks per-generation
+ * deleters paired with their corresponding writers. Each deleter delegates document
+ * deletion to the underlying {@link LuceneWriter}.
+ *
+ * @opensearch.experimental
+ */
+public class LuceneDeleteExecutionEngine implements DeleteExecutionEngine<DataFormat> {
+
+    private static final Logger logger = LogManager.getLogger(LuceneDeleteExecutionEngine.class);
+
+    private final Map<Long, Deleter> generationToDeleterMap;
+    private final DataFormat dataFormat;
+    private final LuceneCommitter committer;
+
+    public LuceneDeleteExecutionEngine(DataFormat dataFormat, Committer committer) {
+        this.generationToDeleterMap = new ConcurrentHashMap<>();
+        this.dataFormat = dataFormat;
+        this.committer = (LuceneCommitter) committer;
+    }
+
+    @Override
+    public Deleter createDeleter(Writer<?> writer) {
+        LuceneWriter luceneWriter = writer.getWriterForFormat(LuceneDataFormat.LUCENE_FORMAT_NAME)
+            .map(w -> (LuceneWriter) w)
+            .orElseThrow(
+                () -> new IllegalArgumentException("Cannot create deleter: no Lucene writer found for generation=" + writer.generation())
+            );
+        Deleter deleter = new DeleterImpl<>(luceneWriter);
+        generationToDeleterMap.put(writer.generation(), deleter);
+        return deleter;
+    }
+
+    @Override
+    public RefreshResult refresh(RefreshInput refreshInput) throws IOException {
+        return null;
+    }
+
+    @Override
+    public DeleteResult deleteDocument(DeleteInput deleteInput) throws IOException {
+        Deleter deleter = generationToDeleterMap.get(deleteInput.generation());
+        if (deleter != null) {
+            return deleter.deleteDoc(deleteInput);
+        } else {
+            Term uid = new Term(deleteInput.fieldName(), deleteInput.value());
+            this.committer.getIndexWriter().deleteDocuments(uid);
+            return new DeleteResult.Success(1L, 1L, 1L);
+        }
+    }
+
+    @Override
+    public DataFormat getDataFormat() {
+        return this.dataFormat;
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (Deleter deleter : generationToDeleterMap.values()) {
+            deleter.close();
+        }
+        generationToDeleterMap.clear();
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
@@ -17,12 +17,15 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MMapDirectory;
 import org.opensearch.be.lucene.LuceneDataFormat;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.index.engine.dataformat.DeleteInput;
+import org.opensearch.index.engine.dataformat.DeleteResult;
 import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.WriteResult;
 import org.opensearch.index.engine.dataformat.Writer;
@@ -32,6 +35,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * Per-generation Lucene writer that creates segments in an isolated temporary directory.
@@ -247,5 +251,27 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
             logger.warn("Failed to close directory for generation[{}]: {}", writerGeneration, e);
         }
         IOUtils.rm(tempDirectory);
+    }
+
+    /**
+     * Deletes all documents containing the given term from this writer's {@link IndexWriter}.
+     *
+     * @param deleteInput the {@code _id} term identifying the document(s) to delete
+     * @return the result of the delete operation
+     * @throws IOException if a low-level I/O error occurs
+     */
+    @Override
+    public DeleteResult deleteDocument(DeleteInput deleteInput) throws IOException {
+        Term uid = new Term(deleteInput.fieldName(), deleteInput.value());
+        indexWriter.deleteDocuments(uid);
+        return new DeleteResult.Success(1L, 1L, 1L);
+    }
+
+    @Override
+    public Optional<Writer<?>> getWriterForFormat(String formatName) {
+        if (LuceneDataFormat.LUCENE_FORMAT_NAME.equals(formatName)) {
+            return Optional.of(this);
+        }
+        return Optional.empty();
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/DeleterImplTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/DeleterImplTests.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.index;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.be.lucene.LuceneDataFormat;
+import org.opensearch.index.engine.dataformat.DeleteInput;
+import org.opensearch.index.engine.dataformat.DeleteResult;
+import org.opensearch.index.engine.dataformat.DeleterImpl;
+import org.opensearch.index.engine.dataformat.FileInfos;
+import org.opensearch.index.engine.exec.WriterFileSet;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link DeleterImpl}.
+ */
+public class DeleterImplTests extends OpenSearchTestCase {
+
+    private LuceneDataFormat dataFormat;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        dataFormat = new LuceneDataFormat();
+    }
+
+    private LuceneWriter createWriter(Path baseDir, long generation) throws IOException {
+        return new LuceneWriter(generation, 0L, dataFormat, baseDir, null, Codec.getDefault(), null);
+    }
+
+    private void addDoc(LuceneWriter writer, String id) throws IOException {
+        MappedFieldType keywordField = mock(MappedFieldType.class);
+        when(keywordField.typeName()).thenReturn("keyword");
+        when(keywordField.name()).thenReturn("_id");
+        when(keywordField.hasDocValues()).thenReturn(false);
+
+        LuceneDocumentInput input = new LuceneDocumentInput();
+        input.addField(keywordField, id);
+        input.setRowId(LuceneDocumentInput.ROW_ID_FIELD, 0);
+        writer.addDoc(input);
+    }
+
+    private LuceneWriter createWriterWithDoc(Path baseDir, long generation, String id) throws IOException {
+        LuceneWriter writer = createWriter(baseDir, generation);
+        addDoc(writer, id);
+        return writer;
+    }
+
+    public void testGenerationMatchesWriter() throws IOException {
+        Path baseDir = createTempDir();
+        long gen = randomLongBetween(1, 100);
+        try (LuceneWriter writer = new LuceneWriter(gen, 0L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
+            DeleterImpl<?> deleter = new DeleterImpl<>(writer);
+            assertEquals("Deleter generation should match writer generation", gen, deleter.generation());
+        }
+    }
+
+    public void testDeleteDocRemovesDocument() throws IOException {
+        Path baseDir = createTempDir();
+        try (LuceneWriter writer = createWriterWithDoc(baseDir, 1L, "doc-to-delete")) {
+            DeleterImpl<?> deleter = new DeleterImpl<>(writer);
+
+            DeleteInput deleteInput = new DeleteInput("_id", new BytesRef("doc-to-delete"), 1L);
+            DeleteResult result = deleter.deleteDoc(deleteInput);
+
+            assertTrue("deleteDoc should return Success", result instanceof DeleteResult.Success);
+        }
+    }
+
+    public void testDeleteDocReturnsSuccessForNonExistentDoc() throws IOException {
+        Path baseDir = createTempDir();
+        try (LuceneWriter writer = createWriterWithDoc(baseDir, 1L, "existing-doc")) {
+            DeleterImpl<?> deleter = new DeleterImpl<>(writer);
+
+            // Delete a doc that doesn't exist — Lucene doesn't error, just no-ops
+            DeleteInput deleteInput = new DeleteInput("_id", new BytesRef("non-existent"), 1L);
+            DeleteResult result = deleter.deleteDoc(deleteInput);
+
+            assertTrue("deleteDoc should return Success even for non-existent doc", result instanceof DeleteResult.Success);
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngineTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneDeleteExecutionEngineTests.java
@@ -1,0 +1,218 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.lucene.index;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.Version;
+import org.opensearch.be.lucene.LuceneDataFormat;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.codec.CodecService;
+import org.opensearch.index.engine.EngineConfig;
+import org.opensearch.index.engine.dataformat.DeleteInput;
+import org.opensearch.index.engine.dataformat.DeleteResult;
+import org.opensearch.index.engine.dataformat.Deleter;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.exec.commit.CommitterConfig;
+import org.opensearch.index.seqno.RetentionLeases;
+import org.opensearch.index.store.Store;
+import org.opensearch.index.translog.TranslogConfig;
+import org.opensearch.test.DummyShardLock;
+import org.opensearch.test.IndexSettingsModule;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link LuceneDeleteExecutionEngine}.
+ */
+public class LuceneDeleteExecutionEngineTests extends OpenSearchTestCase {
+
+    private LuceneCommitter committer;
+    private LuceneDataFormat dataFormat;
+    private Store store;
+    private LuceneDeleteExecutionEngine deleteEngine;
+    private Path baseDir;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        baseDir = createTempDir();
+        ShardId shardId = new ShardId("test", "_na_", 0);
+        Path dataPath = baseDir.resolve(shardId.getIndex().getUUID()).resolve(Integer.toString(shardId.id()));
+        Files.createDirectories(dataPath);
+        Path translogPath = dataPath.resolve("translog");
+        Files.createDirectories(translogPath);
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", Settings.EMPTY);
+        store = new Store(shardId, indexSettings, new NIOFSDirectory(dataPath), new DummyShardLock(shardId));
+        store.createEmpty(Version.LATEST);
+
+        EngineConfig engineConfig = new EngineConfig.Builder().indexSettings(indexSettings)
+            .store(store)
+            .codecService(new CodecService(null, indexSettings, LogManager.getLogger(getClass()), List.of()))
+            .translogConfig(new TranslogConfig(shardId, translogPath, indexSettings, BigArrays.NON_RECYCLING_INSTANCE, "", false))
+            .retentionLeasesSupplier(() -> new RetentionLeases(0, 0, Collections.emptyList()))
+            .build();
+
+        committer = (LuceneCommitter) new LuceneCommitterFactory().getCommitter(new CommitterConfig(engineConfig, () -> {}));
+        deleteEngine = new LuceneDeleteExecutionEngine(new LuceneDataFormat(), committer);
+        dataFormat = new LuceneDataFormat();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        if (deleteEngine != null) {
+            deleteEngine.close();
+        }
+        if (committer != null) {
+            committer.close();
+        }
+        if (store != null) {
+            store.close();
+        }
+        super.tearDown();
+    }
+
+    private LuceneWriter createLuceneWriter(long generation) throws IOException {
+        Path writerDir = baseDir.resolve("writers");
+        Files.createDirectories(writerDir);
+        return new LuceneWriter(generation, 0L, dataFormat, baseDir, null, Codec.getDefault(), null);
+    }
+
+    private Writer<?> createMockCompositeWriter(long generation, boolean hasLucene, boolean hasParquet) {
+        Writer<?> compositeWriter = mock(Writer.class);
+        when(compositeWriter.generation()).thenReturn(generation);
+
+        if (hasLucene) {
+            LuceneWriter mockLuceneWriter = mock(LuceneWriter.class);
+            when(mockLuceneWriter.generation()).thenReturn(generation);
+            when(compositeWriter.getWriterForFormat("lucene")).thenReturn(Optional.of(mockLuceneWriter));
+        } else {
+            when(compositeWriter.getWriterForFormat("lucene")).thenReturn(Optional.empty());
+        }
+
+        if (hasParquet) {
+            Writer<?> mockParquetWriter = mock(Writer.class);
+            when(mockParquetWriter.generation()).thenReturn(generation);
+            when(compositeWriter.getWriterForFormat("parquet")).thenReturn(Optional.of(mockParquetWriter));
+        } else {
+            when(compositeWriter.getWriterForFormat("parquet")).thenReturn(Optional.empty());
+        }
+
+        return compositeWriter;
+    }
+
+    private void addDoc(LuceneWriter writer, String id, int rowId) throws IOException {
+        LuceneDocumentInput input = new LuceneDocumentInput();
+        org.opensearch.index.mapper.MappedFieldType keywordField = mock(org.opensearch.index.mapper.MappedFieldType.class);
+        when(keywordField.typeName()).thenReturn("keyword");
+        when(keywordField.name()).thenReturn("_id");
+        when(keywordField.hasDocValues()).thenReturn(false);
+        input.addField(keywordField, id);
+        input.setRowId(DocumentInput.ROW_ID_FIELD, rowId);
+        writer.addDoc(input);
+    }
+
+    public void testGetDataFormatReturnsLucene() {
+        assertEquals("lucene", deleteEngine.getDataFormat().name());
+    }
+
+    public void testCreateDeleterReturnsPairedDeleter() throws IOException {
+        try (LuceneWriter writer = createLuceneWriter(1L)) {
+            Deleter deleter = deleteEngine.createDeleter(writer);
+
+            assertNotNull("createDeleter should return non-null", deleter);
+            assertEquals("Deleter generation should match writer", 1L, deleter.generation());
+        }
+    }
+
+    public void testGetDeleterReturnsCreatedDeleter() throws IOException {
+        try (LuceneWriter writer = createLuceneWriter(5L)) {
+            Deleter created = deleteEngine.createDeleter(writer);
+
+            assertNotNull("retrieved deleter should not be null", created);
+        }
+    }
+
+    public void testCreateDeleterWithCompositeWriterUsesGetWriterForFormat() {
+        Writer<?> compositeWriter = createMockCompositeWriter(10L, true, false);
+
+        Deleter deleter = deleteEngine.createDeleter(compositeWriter);
+
+        assertNotNull(deleter);
+        assertEquals(10L, deleter.generation());
+    }
+
+    public void testCreateDeleterWithCompositeWriterHavingParquetPrimaryAndLuceneSecondary() {
+        // Composite writer: parquet is primary, lucene is secondary
+        Writer<?> compositeWriter = createMockCompositeWriter(5L, true, true);
+
+        Deleter deleter = deleteEngine.createDeleter(compositeWriter);
+
+        assertNotNull("Deleter should be created from the lucene secondary writer", deleter);
+        assertEquals(5L, deleter.generation());
+    }
+
+    public void testCreateDeleterWithCompositeWriterHavingLucenePrimaryAndParquetSecondary() {
+        // Composite writer: lucene is primary, parquet is secondary
+        Writer<?> compositeWriter = createMockCompositeWriter(8L, true, true);
+
+        Deleter deleter = deleteEngine.createDeleter(compositeWriter);
+
+        assertNotNull("Deleter should be created from the lucene primary writer", deleter);
+        assertEquals(8L, deleter.generation());
+    }
+
+    public void testCreateDeleterThrowsWhenNoLuceneWriterFound() {
+        // Composite writer with only parquet, no lucene
+        Writer<?> writerWithoutLucene = createMockCompositeWriter(7L, false, true);
+
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> deleteEngine.createDeleter(writerWithoutLucene));
+        assertTrue(ex.getMessage().contains("no Lucene writer found"));
+    }
+
+    public void testDeleteDocumentFallsBackToCommitterWhenNoDeleter() throws IOException {
+        // Index a doc via the committer's IndexWriter so we can delete it
+        committer.getIndexWriter().addDocument(new org.apache.lucene.document.Document());
+        committer.getIndexWriter().commit();
+
+        DeleteInput deleteInput = new DeleteInput("_id", new BytesRef("test-doc"), 999L);
+        DeleteResult result = deleteEngine.deleteDocument(deleteInput);
+
+        assertTrue("Should return success even via fallback", result instanceof DeleteResult.Success);
+    }
+
+    public void testDeleteDocumentDelegatesToDeleterWhenPresent() throws IOException {
+        try (LuceneWriter writer = createLuceneWriter(1L)) {
+            addDoc(writer, "doc1", 0);
+
+            Deleter deleter = deleteEngine.createDeleter(writer);
+            assertNotNull("Deleter should be created", deleter);
+
+            DeleteInput deleteInput = new DeleteInput("_id", new BytesRef("doc1"), 1L);
+            DeleteResult result = deleteEngine.deleteDocument(deleteInput);
+
+            assertTrue("Should return success via deleter", result instanceof DeleteResult.Success);
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
@@ -21,9 +21,12 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.be.lucene.LuceneDataFormat;
+import org.opensearch.index.engine.dataformat.DeleteInput;
 import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.WriteResult;
+import org.opensearch.index.engine.dataformat.Writer;
 import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.mapper.KeywordFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
@@ -32,6 +35,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
@@ -314,5 +318,41 @@ public class LuceneWriterTests extends OpenSearchTestCase {
             writer1.close();
             writer2.close();
         }
+    }
+
+    public void testGetWriterForFormatReturnsItselfForLucene() throws IOException {
+        Path baseDir = createTempDir();
+        try (LuceneWriter writer = new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
+            Optional<Writer<?>> result = writer.getWriterForFormat("lucene");
+
+            assertTrue("Should return present for 'lucene'", result.isPresent());
+            assertSame("Should return itself", writer, result.get());
+        }
+    }
+
+    public void testGetWriterForFormatReturnsEmptyForOtherFormats() throws IOException {
+        Path baseDir = createTempDir();
+        try (LuceneWriter writer = new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), null)) {
+            Optional<Writer<?>> parquetResult = writer.getWriterForFormat("parquet");
+            Optional<Writer<?>> nullResult = writer.getWriterForFormat(null);
+
+            assertFalse("Should return empty for non-lucene format", parquetResult.isPresent());
+            assertFalse("Should return empty for null format", nullResult.isPresent());
+        }
+    }
+
+    public void testWriterDefaultGetWriterForFormatReturnsEmpty() {
+        Writer<?> writer = mock(Writer.class, org.mockito.Mockito.CALLS_REAL_METHODS);
+        Optional<Writer<?>> result = writer.getWriterForFormat("any");
+        assertFalse(result.isPresent());
+    }
+
+    public void testWriterDefaultDeleteDocumentThrowsUnsupported() {
+        Writer<?> writer = mock(Writer.class, org.mockito.Mockito.CALLS_REAL_METHODS);
+        UnsupportedOperationException e = expectThrows(
+            UnsupportedOperationException.class,
+            () -> writer.deleteDocument(new DeleteInput("_id", new BytesRef("1"), 1L))
+        );
+        assertTrue(e.getMessage().contains("deleteDocument is not supported"));
     }
 }

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
@@ -221,6 +221,19 @@ class CompositeWriter implements Writer<CompositeDocumentInput> {
     }
 
     /**
+     * Searches primary and secondary formats by {@link DataFormat#name()}.
+     */
+    @Override
+    public Optional<Writer<?>> getWriterForFormat(String formatName) {
+        if (primaryFormat.name().equals(formatName)) return Optional.of(primaryWriter);
+        return secondaryWritersByFormat.entrySet()
+            .stream()
+            .filter(e -> e.getKey().name().equals(formatName))
+            .<Writer<?>>map(Map.Entry::getValue)
+            .findFirst();
+    }
+
+    /**
      * Returns the writer generation number.
      *
      * @return the writer generation

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterTests.java
@@ -9,10 +9,12 @@
 package org.opensearch.composite;
 
 import org.opensearch.index.engine.dataformat.FileInfos;
+import org.opensearch.index.engine.dataformat.Writer;
 import org.opensearch.index.engine.dataformat.WriterConfig;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Tests for {@link CompositeWriter}.
@@ -128,4 +130,27 @@ public class CompositeWriterTests extends OpenSearchTestCase {
         writer.close();
     }
 
+    public void testGetWriterForFormatReturnsLuceneWriter() throws IOException {
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(1L));
+        Optional<Writer<?>> result = writer.getWriterForFormat("lucene");
+
+        assertTrue("Should return present for 'lucene'", result.isPresent());
+        assertEquals("Returned writer generation should match", 1L, result.get().generation());
+    }
+
+    public void testGetWriterForFormatReturnsParquetWriter() throws IOException {
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(1L));
+        Optional<Writer<?>> result = writer.getWriterForFormat("parquet");
+
+        assertTrue("Should return present for 'parquet'", result.isPresent());
+        assertEquals("Returned writer generation should match", 1L, result.get().generation());
+    }
+
+    public void testGetWriterForFormatReturnsEmptyForUnknownFormat() throws IOException {
+        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(1L));
+        Optional<Writer<?>> result = writer.getWriterForFormat("unknown");
+
+        assertFalse("Should return empty for unknown format", result.isPresent());
+        assertEquals("Writer generation should still be accessible", 1L, writer.generation());
+    }
 }

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -34,6 +34,7 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
+import org.opensearch.index.engine.dataformat.DeleteExecutionEngine;
 import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
@@ -139,6 +140,7 @@ public class DataFormatAwareEngine implements Indexer {
     private final Store store;
 
     private final IndexingExecutionEngine indexingExecutionEngine;
+    private final DeleteExecutionEngine<?> deleteExecutionEngine;
     private final IndexingStrategyPlanner indexingStrategyPlanner;
     private final LockablePool<DefaultLockableHolder<Writer<?>>> writerPool;
     private final AtomicLong writerGenerationCounter;
@@ -276,6 +278,9 @@ public class DataFormatAwareEngine implements Indexer {
                 ),
                 registry.format(config().getIndexSettings().pluggableDataFormat())
             );
+
+            this.deleteExecutionEngine = registry.getDeleteExecutionEngine(committer);
+
             long maxGenFromCommit = 0L;
             try {
                 List<CatalogSnapshot> initSnapshots = committer.listCommittedSnapshots();
@@ -291,7 +296,9 @@ public class DataFormatAwareEngine implements Indexer {
             this.writerPool = new LockablePool<>(() -> {
                 long gen = writerGenerationCounter.incrementAndGet();
                 assert gen > 0 : "writer generation must be positive but was: " + gen;
-                return DefaultLockableHolder.of(new RowIdAwareWriter<>(indexingExecutionEngine.createWriter(new WriterConfig(gen))));
+                Writer<?> writer = indexingExecutionEngine.createWriter(new WriterConfig(gen));
+                deleteExecutionEngine.createDeleter(writer);
+                return DefaultLockableHolder.of(new RowIdAwareWriter<>(writer));
             }, LinkedList::new, Runtime.getRuntime().availableProcessors());
             // Create Reader managers
             // We will pass IndexStoreProvider to this, which would contain store

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatPlugin.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatPlugin.java
@@ -10,6 +10,7 @@ package org.opensearch.index.engine.dataformat;
 
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.exec.commit.Committer;
 
 import java.util.Map;
 import java.util.function.Supplier;
@@ -81,5 +82,16 @@ public interface DataFormatPlugin {
      */
     default Map<DataFormat, StoreStrategy> getStoreStrategies(IndexSettings indexSettings, DataFormatRegistry dataFormatRegistry) {
         return Map.of();
+    }
+
+    /**
+     * Returns the delete execution engine for this data format, or {@code null} if this
+     * plugin does not support delete operations.
+     *
+     * @param committer the committer for durable delete tracking
+     * @return the delete execution engine, or {@code null}
+     */
+    default DeleteExecutionEngine<?> getDeleteExecutionEngine(Committer committer) {
+        return null;
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatRegistry.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatRegistry.java
@@ -14,11 +14,13 @@ import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.exec.EngineReaderManager;
+import org.opensearch.index.engine.exec.commit.Committer;
 import org.opensearch.index.store.FormatChecksumStrategy;
 import org.opensearch.plugins.PluginsService;
 import org.opensearch.plugins.SearchBackEndPlugin;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -278,5 +280,33 @@ public class DataFormatRegistry {
             );
         }
         return Map.of(readerManagerConfig.format(), readerManagerBuilders.get(readerManagerConfig.format()).apply(readerManagerConfig));
+    }
+
+    /**
+     * Returns the {@link DeleteExecutionEngine} by finding the single registered plugin that provides one.
+     * Iterates over all registered data format plugins and validates that exactly one returns a non-null
+     * result from {@link DataFormatPlugin#getDeleteExecutionEngine(Committer)}.
+     *
+     * @param committer the committer for durable delete tracking
+     * @return the delete execution engine
+     * @throws IllegalStateException if no plugin or multiple plugins provide a delete execution engine
+     */
+    public DeleteExecutionEngine<?> getDeleteExecutionEngine(Committer committer) {
+        List<DeleteExecutionEngine<?>> engines = new ArrayList<>();
+        for (DataFormatPlugin plugin : dataFormatPluginRegistry.values()) {
+            DeleteExecutionEngine<?> engine = plugin.getDeleteExecutionEngine(committer);
+            if (engine != null) {
+                engines.add(engine);
+            }
+        }
+        if (engines.size() > 1) {
+            throw new IllegalStateException(
+                "Multiple DataFormatPlugins provide a DeleteExecutionEngine, expected exactly one but found [" + engines.size() + "]"
+            );
+        }
+        if (engines.isEmpty()) {
+            throw new IllegalStateException("No DataFormatPlugin provides a DeleteExecutionEngine");
+        }
+        return engines.getFirst();
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteExecutionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteExecutionEngine.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Engine for executing delete operations for a specific data format.
+ * Each deleter is paired with a writer and shares its generation, enabling
+ * format-specific delete tracking (e.g., live-doc bitsets for Parquet files).
+ *
+ * <p>A single universal implementation handles all data formats by internally
+ * using a {@code LuceneIndexingExecutionEngine} + {@code LuceneCommitter} for
+ * durable delete tracking. The engine decides at runtime whether to create its
+ * own Lucene infrastructure (Parquet-only) or reuse an existing one (composite/Lucene).
+ *
+ * @param <T> the data format type
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public interface DeleteExecutionEngine<T extends DataFormat> extends Closeable {
+
+    /**
+     * Creates a new deleter paired with the given writer.
+     * The deleter tracks deletes for documents managed by this writer.
+     *
+     * @param writer the writer this deleter is paired with
+     * @return a new deleter instance
+     */
+    Deleter createDeleter(Writer<?> writer);
+
+    /**
+     * Refreshes delete state, making buffered deletes visible to readers.
+     * For Parquet-only format, this incorporates per-gen Lucene segments into
+     * the parent writer and builds delete bitmaps.
+     *
+     * @param refreshInput the refresh configuration
+     * @return the result of the refresh operation
+     * @throws IOException if an I/O error occurs during refresh
+     */
+    RefreshResult refresh(RefreshInput refreshInput) throws IOException;
+
+    /**
+     * Returns the data format this engine handles deletes for.
+     *
+     * @return the data format
+     */
+    T getDataFormat();
+
+    /**
+     * Deletes a document by looking up the deleter for the generation specified
+     * in the input and delegating the delete operation.
+     *
+     * @param deleteInput the input containing field name, value, and generation
+     * @return the result of the delete operation
+     * @throws IOException if an I/O error occurs during deletion
+     */
+    DeleteResult deleteDocument(DeleteInput deleteInput) throws IOException;
+}

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteInput.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteInput.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.annotation.ExperimentalApi;
+
+/**
+ * Immutable input data for a delete operation, containing the field name, value,
+ * and writer generation needed to identify and delete a document.
+ *
+ * <p>The {@link org.apache.lucene.index.Term} uid is constructed by the deleter
+ * implementation from the field name and value provided here.
+ *
+ * @param fieldName the name of the field used to identify the document (e.g. "_id")
+ * @param value the field value identifying the document to delete
+ * @param generation the writer generation whose deleter should handle to delete
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public record DeleteInput(String fieldName, BytesRef value, long generation) {
+
+    /**
+     * Creates a new DeleteInput.
+     *
+     * @param fieldName the field name (must not be null)
+     * @param value the bytes ref value (must not be null)
+     * @param generation the writer generation
+     */
+    public DeleteInput {
+        if (fieldName == null) {
+            throw new IllegalArgumentException("fieldName must not be null");
+        }
+        if (value == null) {
+            throw new IllegalArgumentException("value must not be null");
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteResult.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteResult.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+/**
+ * Result of a delete operation. Sealed hierarchy with {@link Success} and {@link Failure} variants.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public sealed interface DeleteResult permits DeleteResult.Success, DeleteResult.Failure {
+
+    /**
+     * Successful delete result.
+     *
+     * @param version the version after to delete
+     * @param primaryTerm the primary term
+     * @param seqNo the sequence number
+     */
+    record Success(long version, long primaryTerm, long seqNo) implements DeleteResult {
+    }
+
+    /**
+     * Failed delete result.
+     *
+     * @param cause the exception that caused the failure
+     */
+    record Failure(Exception cause) implements DeleteResult {
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/Deleter.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/Deleter.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.queue.Lockable;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Handles document deletion for a specific data format. Each deleter is paired with a
+ * {@link Writer} and shares its generation. Implements {@link Lockable} for thread-safe
+ * pooling via {@link org.opensearch.common.queue.LockablePool}.
+ *
+ * <p>For Parquet-only format, the deleter holds a per-generation Lucene writer for
+ * indexing identity documents. For Lucene-only format, the deleter is a no-op wrapper
+ * since Lucene natively tracks live docs.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public interface Deleter extends Closeable, Lockable {
+
+    /**
+     * Returns the generation number of this deleter, matching its paired writer.
+     *
+     * @return the generation number
+     */
+    long generation();
+
+    /**
+     * Deletes a document from the underlying format-specific storage.
+     *
+     * @param deleteInput the input containing field name, value, and generation to identify the document
+     * @return the result of the delete operation
+     * @throws IOException if an I/O error occurs
+     */
+    DeleteResult deleteDoc(DeleteInput deleteInput) throws IOException;
+}

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DeleterImpl.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DeleterImpl.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.apache.lucene.index.Term;
+
+import java.io.IOException;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Lucene-based implementation of {@link Deleter} that delegates document deletion
+ * to the paired {@link Writer}. Each instance shares the generation number
+ * of its associated writer. Constructs the {@link Term} uid from the field name
+ * and value provided in the {@link DeleteInput}.
+ *
+ * @opensearch.experimental
+ */
+public class DeleterImpl<T extends Writer<?>> implements Deleter {
+
+    private final Writer<?> writer;
+    private final long deleterGeneration;
+    private final ReentrantLock lock;
+
+    public DeleterImpl(T writer) {
+        this.writer = writer;
+        this.deleterGeneration = writer.generation();
+        this.lock = new ReentrantLock();
+    }
+
+    @Override
+    public long generation() {
+        return this.deleterGeneration;
+    }
+
+    @Override
+    public DeleteResult deleteDoc(DeleteInput deleteInput) throws IOException {
+        return writer.deleteDocument(deleteInput);
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    @Override
+    public void lock() {
+        lock.lock();
+    }
+
+    @Override
+    public boolean tryLock() {
+        return lock.tryLock();
+    }
+
+    @Override
+    public void unlock() {
+        lock.unlock();
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/Writer.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/Writer.java
@@ -12,6 +12,7 @@ import org.opensearch.common.annotation.ExperimentalApi;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Interface for writing documents to a data format.
@@ -76,4 +77,28 @@ public interface Writer<P extends DocumentInput<?>> extends Closeable {
      * @param newVersion the new mapping version
      */
     void updateMappingVersion(long newVersion);
+
+    /**
+     * Returns the underlying writer for the specified data format name.
+     * Composite writers override this to return the format-specific delegate.
+     * Simple writers return themselves if the format matches.
+     *
+     * @param formatName the name of the data format to look up
+     * @return an optional containing the writer for the given format, or empty if not found
+     */
+    default Optional<Writer<?>> getWriterForFormat(String formatName) {
+        return Optional.empty();
+    }
+
+    /**
+     * Deletes a document identified by the given delete input.
+     * Implementations that support direct deletion should override this method.
+     *
+     * @param deleteInput the input containing field name, value, and generation to identify the document
+     * @return the result of the delete operation
+     * @throws IOException if an I/O error occurs during deletion
+     */
+    default DeleteResult deleteDocument(DeleteInput deleteInput) throws IOException {
+        throw new UnsupportedOperationException("deleteDocument is not supported by this writer");
+    }
 }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatPluginTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatPluginTests.java
@@ -455,4 +455,20 @@ public class DataFormatPluginTests extends OpenSearchTestCase {
         assertEquals(1, rm.deletedFiles.size());
         assertTrue(rm.deletedFiles.contains("a.parquet"));
     }
+
+    public void testGetDeleteExecutionEngineDefaultReturnsNull() {
+        DataFormatPlugin plugin = new DataFormatPlugin() {
+            @Override
+            public DataFormat getDataFormat() {
+                return new MockDataFormat("test", 1L, Set.of());
+            }
+
+            @Override
+            public IndexingExecutionEngine<?, ?> indexingEngine(IndexingEngineConfig settings) {
+                return null;
+            }
+        };
+
+        assertNull(plugin.getDeleteExecutionEngine(mock(org.opensearch.index.engine.exec.commit.Committer.class)));
+    }
 }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatRegistryTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatRegistryTests.java
@@ -17,6 +17,7 @@ import org.opensearch.index.engine.dataformat.stub.MockDataFormat;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormatPlugin;
 import org.opensearch.index.engine.dataformat.stub.MockSearchBackEndPlugin;
 import org.opensearch.index.engine.exec.EngineReaderManager;
+import org.opensearch.index.engine.exec.commit.Committer;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.plugins.PluginsService;
@@ -412,5 +413,48 @@ public class DataFormatRegistryTests extends OpenSearchTestCase {
         DataFormatRegistry registry = new DataFormatRegistry(pluginsService);
 
         assertNull("Should return empty map for null name", registry.getPlugin(null));
+    }
+
+    public void testGetDeleteExecutionEngineThrowsWhenMultiplePluginsProvide() {
+        MockDataFormat format1 = new MockDataFormat("format1", 100L, Set.of());
+        MockDataFormat format2 = new MockDataFormat("format2", 50L, Set.of());
+        MockSearchBackEndPlugin backEnd = new MockSearchBackEndPlugin(List.of(format1.name(), format2.name()));
+
+        when(pluginsService.filterPlugins(DataFormatPlugin.class)).thenReturn(
+            List.of(MockDataFormatPlugin.of(format1), MockDataFormatPlugin.of(format2))
+        );
+        when(pluginsService.filterPlugins(SearchBackEndPlugin.class)).thenReturn(List.of(backEnd));
+
+        DataFormatRegistry registry = new DataFormatRegistry(pluginsService);
+
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> registry.getDeleteExecutionEngine(mock(Committer.class)));
+        assertTrue(e.getMessage().contains("Multiple DataFormatPlugins provide a DeleteExecutionEngine"));
+    }
+
+    public void testGetDeleteExecutionEngineThrowsWhenNoPluginProvides() {
+        when(pluginsService.filterPlugins(DataFormatPlugin.class)).thenReturn(List.of());
+        when(pluginsService.filterPlugins(SearchBackEndPlugin.class)).thenReturn(List.of());
+
+        DataFormatRegistry registry = new DataFormatRegistry(pluginsService);
+
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> registry.getDeleteExecutionEngine(mock(Committer.class)));
+        assertTrue(e.getMessage().contains("No DataFormatPlugin provides a DeleteExecutionEngine"));
+    }
+
+    public void testGetDeleteExecutionEngineSkipsPluginReturningNull() {
+        MockDataFormat format = new MockDataFormat("columnar", 100L, Set.of());
+        MockSearchBackEndPlugin backEnd = new MockSearchBackEndPlugin(List.of(format.name()));
+
+        DataFormatPlugin nullDeletePlugin = mock(DataFormatPlugin.class);
+        when(nullDeletePlugin.getDataFormat()).thenReturn(format);
+        when(nullDeletePlugin.getDeleteExecutionEngine(org.mockito.ArgumentMatchers.any())).thenReturn(null);
+
+        when(pluginsService.filterPlugins(DataFormatPlugin.class)).thenReturn(List.of(nullDeletePlugin));
+        when(pluginsService.filterPlugins(SearchBackEndPlugin.class)).thenReturn(List.of(backEnd));
+
+        DataFormatRegistry registry = new DataFormatRegistry(pluginsService);
+
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> registry.getDeleteExecutionEngine(mock(Committer.class)));
+        assertTrue(e.getMessage().contains("No DataFormatPlugin provides a DeleteExecutionEngine"));
     }
 }

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDataFormatPlugin.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDataFormatPlugin.java
@@ -10,8 +10,10 @@ package org.opensearch.index.engine.dataformat.stub;
 
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatPlugin;
+import org.opensearch.index.engine.dataformat.DeleteExecutionEngine;
 import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
+import org.opensearch.index.engine.exec.commit.Committer;
 import org.opensearch.plugins.Plugin;
 
 import java.util.Set;
@@ -42,5 +44,10 @@ public class MockDataFormatPlugin extends Plugin implements DataFormatPlugin {
     @Override
     public IndexingExecutionEngine<?, ?> indexingEngine(IndexingEngineConfig settings) {
         return new MockIndexingExecutionEngine(dataFormat);
+    }
+
+    @Override
+    public DeleteExecutionEngine<?> getDeleteExecutionEngine(Committer committer) {
+        return new MockDeleteExecutionEngine(dataFormat);
     }
 }

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDeleteExecutionEngine.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDeleteExecutionEngine.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat.stub;
+
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DeleteExecutionEngine;
+import org.opensearch.index.engine.dataformat.DeleteInput;
+import org.opensearch.index.engine.dataformat.DeleteResult;
+import org.opensearch.index.engine.dataformat.Deleter;
+import org.opensearch.index.engine.dataformat.RefreshInput;
+import org.opensearch.index.engine.dataformat.RefreshResult;
+import org.opensearch.index.engine.dataformat.Writer;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A mock {@link DeleteExecutionEngine} for testing purposes.
+ */
+public class MockDeleteExecutionEngine implements DeleteExecutionEngine<DataFormat> {
+
+    private final DataFormat dataFormat;
+    private final Map<Long, Deleter> deleters = new ConcurrentHashMap<>();
+
+    public MockDeleteExecutionEngine(DataFormat dataFormat) {
+        this.dataFormat = dataFormat;
+    }
+
+    @Override
+    public Deleter createDeleter(Writer<?> writer) {
+        Deleter deleter = new MockDeleter(writer.generation());
+        deleters.put(writer.generation(), deleter);
+        return deleter;
+    }
+
+    @Override
+    public RefreshResult refresh(RefreshInput refreshInput) throws IOException {
+        return null;
+    }
+
+    @Override
+    public DataFormat getDataFormat() {
+        return dataFormat;
+    }
+
+    @Override
+    public DeleteResult deleteDocument(DeleteInput deleteInput) throws IOException {
+        Deleter deleter = deleters.get(deleteInput.generation());
+        if (deleter != null) {
+            return deleter.deleteDoc(deleteInput);
+        }
+        return new DeleteResult.Success(1L, 1L, 1L);
+    }
+
+    @Override
+    public void close() throws IOException {
+        deleters.clear();
+    }
+
+    private static class MockDeleter implements Deleter {
+        private final long generation;
+
+        MockDeleter(long generation) {
+            this.generation = generation;
+        }
+
+        @Override
+        public long generation() {
+            return generation;
+        }
+
+        @Override
+        public DeleteResult deleteDoc(DeleteInput deleteInput) throws IOException {
+            return new DeleteResult.Success(1L, 1L, 1L);
+        }
+
+        @Override
+        public void lock() {}
+
+        @Override
+        public boolean tryLock() {
+            return true;
+        }
+
+        @Override
+        public void unlock() {}
+
+        @Override
+        public void close() throws IOException {}
+    }
+}


### PR DESCRIPTION
### Description

Introduces the delete execution engine abstraction for `DataFormatAwareEngine` — enabling pluggable, format-specific delete handling in OpenSearch's multi-format engine. This builds on the `DataFormatAwareEngine` introduced in #21181, adding the delete-side counterpart to the existing `IndexingExecutionEngine`.

`DeleteExecutionEngine` follows the same plugin discovery and factory pattern as `CommitterFactory`. Each engine plugin provides a `DeleteExecutionEngineFactory` that is collected during index creation and stored on `EngineConfig`. When the shard initializes, `DataFormatAwareEngine` calls the factory with the already-created `Committer`, allowing the delete engine to be constructed with all required dependencies at the right time.

Each `Deleter` is paired 1:1 with a `Writer` sharing the same generation — enabling format-specific delete tracking (e.g., live-doc bitsets for Parquet files).

**Key additions:**

- `DeleteExecutionEngine<T>` — format-specific engine interface for delete operations, paired with writers via shared generation
- `DeleteExecutionEngineFactory` — factory interface (mirrors `CommitterFactory`) allowing deferred construction with the `Committer`
- `LuceneDeleteExecutionEngine` — Lucene-based implementation that tracks per-generation deleters and delegates to the committer's IndexWriter
- `LuceneDeleteExecutionEngineFactory` — concrete factory registered by `LucenePlugin` (mirrors `LuceneCommitterFactory`)
- `Deleter` — per-writer delete handler implementing `Lockable` for thread-safe pooling, mirrors `Writer` interface pattern
- `DeleterImpl` — Lucene-based deleter that delegates to `LuceneWriter.deleteDocument()`
- `DeleteResult` — sealed result type (Success/Failure) for delete operations, mirrors `WriteResult`
- `Writer.getWriterForFormat(String)` — default method on the `Writer` interface enabling format-specific writer resolution across plugin boundaries
- `EnginePlugin.getDeleteExecutionEngineFactory()` — SPI method for plugins to provide their delete engine factory

**Design decisions:**

1. **`Writer.getWriterForFormat(String)`** — Added because `CompositeWriter` (in the composite-engine plugin) wraps per-format writers including `LuceneWriter` (in the analytics-backend-lucene plugin). Since these reside in different plugin classloaders, `DeleterImpl` cannot directly cast or import `CompositeWriter`. The `getWriterForFormat` method on the `Writer` interface provides a plugin-boundary-safe way to resolve the underlying Lucene writer without cross-plugin dependencies. `CompositeWriter` overrides it to delegate to its internal format map; `LuceneWriter` returns itself for `"lucene"`.

2. **`LuceneDeleteExecutionEngine` naming** — Named to match the established convention where the Lucene plugin provides the single concrete implementation (same pattern as `LuceneCommitter`, `LuceneCommitterFactory`, `LuceneIndexingExecutionEngine`). All delete operations ultimately go through Lucene's IndexWriter for durable tracking, regardless of the indexing data format.

### Related Issues

Resolves #[Issue number to be closed when this PR is merged]

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
