### PR TITLE
Added queryTimeout to the IndexSearcher to ensure that queries that uses this timeout during search exit when queries times out

### DIFF
--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.QueryTimeout;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.CollectionStatistics;
@@ -69,6 +70,7 @@ import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
+import org.opensearch.core.tasks.TaskCancelledException;
 import org.opensearch.lucene.util.CombinedBitSet;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchHits;
@@ -157,6 +159,13 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         setQueryCachingPolicy(queryCachingPolicy);
         this.cancellable = cancellable;
         this.searchContext = searchContext;
+        // Set the timeout on the IndexSearcher so that Lucene-native timeout-aware components
+        // (e.g. TimeLimitingKnnCollectorManager used by AbstractKnnVectorQuery) can enforce
+        // the query timeout. Without this, searcher.getTimeout() returns null and KNN vector
+        // searches ignore the configured query timeout entirely.
+        if (cancellable != null) {
+            setTimeout(cancellable);
+        }
     }
 
     public void setProfiler(QueryProfiler profiler) {
@@ -604,7 +613,23 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         return (DirectoryReader) reader;
     }
 
-    private static class MutableQueryTimeout implements ExitableDirectoryReader.QueryCancellation {
+    /**
+     * A mutable timeout implementation that bridges OpenSearch's cancellation mechanism with Lucene's
+     * {@link QueryTimeout} interface.
+     * <p>
+     * This class implements both {@link ExitableDirectoryReader.QueryCancellation} (used by OpenSearch's
+     * {@link ExitableDirectoryReader} to check for cancellation while iterating terms, points, and stored fields)
+     * and {@link QueryTimeout} (used by Lucene's {@link org.apache.lucene.search.IndexSearcher} to enforce
+     * timeouts in components like {@link org.apache.lucene.search.TimeLimitingKnnCollectorManager} for KNN
+     * vector queries).
+     * <p>
+     * Cancellation runnables are added/removed dynamically via {@link #add} and {@link #remove}. When any
+     * runnable throws a {@link RuntimeException} (e.g. {@link org.opensearch.search.query.QueryPhase.TimeExceededException}),
+     * it signals that the query should be terminated.
+     *
+     * @opensearch.internal
+     */
+    private static class MutableQueryTimeout implements ExitableDirectoryReader.QueryCancellation, QueryTimeout {
 
         private final Set<Runnable> runnables = new HashSet<>();
 
@@ -630,6 +655,26 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         @Override
         public boolean isEnabled() {
             return runnables.isEmpty() == false;
+        }
+
+        /**
+         * Implements {@link QueryTimeout#shouldExit()} by delegating to {@link #checkCancelled()}.
+         * Returns {@code true} if a registered cancellation runnable throws a
+         * {@link org.opensearch.search.query.QueryPhase.TimeExceededException} (timeout) or
+         * {@link org.opensearch.core.tasks.TaskCancelledException} (task cancellation),
+         * indicating that the query should be terminated early.
+         * <p>
+         * This is called by Lucene's {@link org.apache.lucene.search.TimeLimitingKnnCollectorManager}
+         * during KNN vector search to check whether the search should be terminated early.
+         */
+        @Override
+        public boolean shouldExit() {
+            try {
+                checkCancelled();
+            } catch (QueryPhase.TimeExceededException | TaskCancelledException e) {
+                return true;
+            }
+            return false;
         }
 
         public void clear() {

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -46,6 +46,7 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.QueryTimeout;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.BoostQuery;
@@ -72,11 +73,13 @@ import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.SparseFixedBitSet;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.support.StreamSearchChannelListener;
+import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
 import org.opensearch.common.lucene.index.SequentialStoredFieldsLeafReader;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.tasks.TaskCancelledException;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.cache.bitset.BitsetFilterCache;
 import org.opensearch.index.shard.IndexShard;
@@ -88,6 +91,7 @@ import org.opensearch.search.aggregations.LeafBucketCollector;
 import org.opensearch.search.aggregations.metrics.InternalSum;
 import org.opensearch.search.fetch.FetchSearchResult;
 import org.opensearch.search.fetch.QueryFetchSearchResult;
+import org.opensearch.search.query.QueryPhase;
 import org.opensearch.search.query.QuerySearchResult;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
@@ -583,6 +587,92 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
         @Override
         public void visit(QueryVisitor visitor) {
             visitor.visitLeaf(this);
+        }
+    }
+
+    public void testTimeoutIsSetOnSearcher() throws Exception {
+        withContextIndexSearcher(searcher -> {
+            QueryTimeout timeout = searcher.getTimeout();
+            assertNotNull("setTimeout should have been called with MutableQueryTimeout", timeout);
+        });
+    }
+
+    public void testTimeoutShouldExitReturnsFalseWhenNoCancellations() throws Exception {
+        withContextIndexSearcher(searcher -> {
+            assertFalse("shouldExit should return false when no cancellations are registered", searcher.getTimeout().shouldExit());
+        });
+    }
+
+    public void testTimeoutShouldExitReturnsFalseWhenCancellationDoesNotThrow() throws Exception {
+        withContextIndexSearcher(searcher -> {
+            searcher.addQueryCancellation(() -> {});
+            assertFalse("shouldExit should return false when cancellation does not throw", searcher.getTimeout().shouldExit());
+        });
+    }
+
+    public void testTimeoutShouldExitReturnsTrueWhenTimeoutExceeded() throws Exception {
+        withContextIndexSearcher(searcher -> {
+            searcher.addQueryCancellation(() -> { throw new QueryPhase.TimeExceededException(); });
+            assertTrue("shouldExit should return true on TimeExceededException", searcher.getTimeout().shouldExit());
+        });
+    }
+
+    public void testTimeoutShouldExitReturnsTrueWhenTaskCancelled() throws Exception {
+        withContextIndexSearcher(searcher -> {
+            searcher.addQueryCancellation(() -> { throw new TaskCancelledException("cancelled"); });
+            assertTrue("shouldExit should return true on TaskCancelledException", searcher.getTimeout().shouldExit());
+        });
+    }
+
+    public void testTimeoutShouldExitDoesNotCatchUnrelatedExceptions() throws Exception {
+        withContextIndexSearcher(searcher -> {
+            searcher.addQueryCancellation(() -> { throw new NullPointerException("unrelated"); });
+            expectThrows(NullPointerException.class, () -> searcher.getTimeout().shouldExit());
+        });
+    }
+
+    public void testTimeoutShouldExitReflectsRemoval() throws Exception {
+        withContextIndexSearcher(searcher -> {
+            Runnable cancellation = searcher.addQueryCancellation(() -> { throw new QueryPhase.TimeExceededException(); });
+            assertTrue("shouldExit should return true while cancellation is active", searcher.getTimeout().shouldExit());
+
+            searcher.removeQueryCancellation(cancellation);
+            assertFalse("shouldExit should return false after cancellation is removed", searcher.getTimeout().shouldExit());
+        });
+    }
+
+    /**
+     * Helper that creates a {@link ContextIndexSearcher} backed by a single-doc index and a mocked
+     * {@link SearchContext}, then passes it to the provided consumer. All resources are closed
+     * automatically.
+     */
+    private void withContextIndexSearcher(CheckedConsumer<ContextIndexSearcher, Exception> test) throws Exception {
+        try (
+            Directory directory = newDirectory();
+            IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()))
+        ) {
+            Document doc = new Document();
+            doc.add(new StringField("field", "value", Field.Store.NO));
+            writer.addDocument(doc);
+            writer.commit();
+
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                SearchContext searchContext = mock(SearchContext.class);
+                IndexShard indexShard = mock(IndexShard.class);
+                when(searchContext.indexShard()).thenReturn(indexShard);
+                when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+
+                ContextIndexSearcher searcher = new ContextIndexSearcher(
+                    reader,
+                    IndexSearcher.getDefaultSimilarity(),
+                    IndexSearcher.getDefaultQueryCache(),
+                    IndexSearcher.getDefaultQueryCachingPolicy(),
+                    true,
+                    null,
+                    searchContext
+                );
+                test.accept(searcher);
+            }
         }
     }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Added queryTimeout to the IndexSearcher to ensure that queries that uses this timeout during search exit when queries times out

### Problem

OpenSearch implements its own query timeout/cancellation mechanism via `MutableQueryTimeout` and `ExitableDirectoryReader`, which hooks into Lucene at the reader level (terms, points, bulk scoring). However, it never calls `IndexSearcher.setTimeout()` to set the timeout on Lucene's `IndexSearcher`.

This is a problem because Lucene's `AbstractKnnVectorQuery` relies on `IndexSearcher.getTimeout()` to enforce timeouts during KNN vector search. Specifically, in `AbstractKnnVectorQuery.rewrite()`:

```java
KnnCollectorManager manager = getKnnCollectorManager(k, searcher);
manager = new TimeLimitingKnnCollectorManager(manager, searcher.getTimeout());
```

Since `searcher.getTimeout()` returns `null`, `TimeLimitingKnnCollectorManager` gets a null `QueryTimeout`, and **KNN vector searches completely ignore the query timeout**. This means a slow KNN query can run indefinitely even when a user has set a `timeout` on their search request or the cluster has `search.default_search_timeout` configured.

Additionally, `ExitableDirectoryReader.ExitableLeafReader` does not wrap `FloatVectorValues`, `ByteVectorValues`, or any vector-related APIs, so there are no cancellation checks during HNSW graph traversal either.

### What's NOT covered by the existing timeout mechanism

| Lucene API | Wrapped by ExitableLeafReader? | Timeout enforced? |
|---|---|---|
| `Terms` / `TermsEnum` | ✅ Yes (`ExitableTerms`, `ExitableTermsEnum`) | ✅ Yes |
| `PointValues` / `PointTree` | ✅ Yes (`ExitablePointValues`, `ExitablePointTree`) | ✅ Yes |
| HNSW graph traversal (KNN search) | ❌ No | ❌ No |
| `TimeLimitingKnnCollectorManager` | N/A (uses `IndexSearcher.getTimeout()`) | ❌ No — `getTimeout()` returns `null` |

### Fix

Two changes in `ContextIndexSearcher.java`:

1. **`MutableQueryTimeout` now implements both interfaces:**
   - `ExitableDirectoryReader.QueryCancellation` (OpenSearch's interface — existing)
   - `org.apache.lucene.index.QueryTimeout` (Lucene's interface — new)

   The new `shouldExit()` method delegates to `checkCancelled()` — if any cancellation runnable throws, it returns `true`.

2. **`setTimeout(cancellable)` is called in the `ContextIndexSearcher` constructor** so that `searcher.getTimeout()` returns the `MutableQueryTimeout` instance instead of `null`.

## Impact

- **KNN vector queries** now respect the query timeout via Lucene's `TimeLimitingKnnCollectorManager`.
- **Any future Lucene feature** that uses `IndexSearcher.getTimeout()` will automatically work.
- **Zero impact on existing behavior** — the existing `ExitableDirectoryReader` + `addQueryCancellation` mechanism continues to work exactly as before for terms, points, and bulk scoring.

## Testing

Added 5 unit tests in `ContextIndexSearcherTests`:

| Test | What it verifies |
|---|---|
| `testTimeoutIsSetOnSearcher` | `getTimeout()` returns non-null after construction — confirms `setTimeout(cancellable)` is called |
| `testTimeoutShouldExitReturnsFalseWhenNoCancellations` | `shouldExit()` returns `false` when no cancellation runnables are registered |
| `testTimeoutShouldExitReturnsFalseWhenCancellationDoesNotThrow` | `shouldExit()` returns `false` when a no-op cancellation is registered (query still within time) |
| `testTimeoutShouldExitReturnsTrueWhenCancellationThrows` | `shouldExit()` returns `true` when a cancellation runnable throws (timeout exceeded) |
| `testTimeoutShouldExitReflectsRemoval` | `shouldExit()` transitions from `true` → `false` after the throwing cancellation is removed via `removeQueryCancellation()` |


### Related Issues
NA

### Check List
- [X] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
