### PR TITLE
Handle negative field data stats during serialization

### DIFF
--- a/server/src/main/java/org/opensearch/index/fielddata/FieldDataStats.java
+++ b/server/src/main/java/org/opensearch/index/fielddata/FieldDataStats.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.index.fielddata;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.FieldMemoryStats;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.PublicApi;
@@ -52,6 +54,8 @@ import java.util.Objects;
  */
 @PublicApi(since = "1.0.0")
 public class FieldDataStats implements Writeable, ToXContentFragment {
+
+    private static final Logger logger = LogManager.getLogger(FieldDataStats.class);
 
     private static final String FIELDDATA = "fielddata";
     private static final String MEMORY_SIZE = "memory_size";
@@ -164,8 +168,18 @@ public class FieldDataStats implements Writeable, ToXContentFragment {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVLong(memorySize);
-        out.writeVLong(evictions);
+        if (memorySize < 0) {
+            logger.warn("FieldDataStats 'memorySize' is negative: {}, writing 0 instead", memorySize);
+            out.writeVLong(0);
+        } else {
+            out.writeVLong(memorySize);
+        }
+        if (evictions < 0) {
+            logger.warn("FieldDataStats 'evictions' is negative: {}, writing 0 instead", evictions);
+            out.writeVLong(0);
+        } else {
+            out.writeVLong(evictions);
+        }
         out.writeOptionalWriteable(fields);
     }
 

--- a/server/src/test/java/org/opensearch/index/fielddata/FieldDataStatsTests.java
+++ b/server/src/test/java/org/opensearch/index/fielddata/FieldDataStatsTests.java
@@ -56,4 +56,22 @@ public class FieldDataStatsTests extends OpenSearchTestCase {
         assertEquals(stats.getMemorySize(), read.getMemorySize());
         assertEquals(stats.getFields(), read.getFields());
     }
+
+    public void testNegativeMemorySizeWriteTo() throws IOException {
+        FieldDataStats stats = new FieldDataStats(-2895512, randomNonNegativeLong(), null);
+        BytesStreamOutput out = new BytesStreamOutput();
+        stats.writeTo(out);
+        StreamInput input = out.bytes().streamInput();
+        FieldDataStats read = new FieldDataStats(input);
+        assertEquals(0, read.getMemorySizeInBytes());
+    }
+
+    public void testNegativeEvictionsWriteTo() throws IOException {
+        FieldDataStats stats = new FieldDataStats(randomNonNegativeLong(), -100, null);
+        BytesStreamOutput out = new BytesStreamOutput();
+        stats.writeTo(out);
+        StreamInput input = out.bytes().streamInput();
+        FieldDataStats read = new FieldDataStats(input);
+        assertEquals(0, read.getEvictions());
+    }
 }


### PR DESCRIPTION
### Description

`FieldDataStats.writeTo()` crashes with `IllegalStateException: Negative longs unsupported` when `memorySize` goes negative due to race conditions in stats aggregation across shards. This causes the `indices:monitor/stats` transport action to fail.

### Solution

Check for negative values before calling `writeVLong()` in `FieldDataStats.writeTo()`. If negative, log a warning and write `0` instead. This matches the pattern used for `SearchStats` in #19340.

### Related Issues

Similar to #16598

```
[2026-04-22T02:10:59,550][DEBUG][o.o.a.a.i.s.TransportIndicesStatsAction] [abc] #[org.opensearch.transport.RemoteTransportException,java.lang.IllegalStateException]#failed to execute [indices:monitor/stats] on node [def]
RemoteTransportException[[xyz][1.1.1.1:9300][indices:monitor/stats[n]]]; nested: IllegalStateException[Negative longs unsupported, use writeLong or writeZLong for negative numbers [-2895512]];
Caused by: java.lang.IllegalStateException: Negative longs unsupported, use writeLong or writeZLong for negative numbers [-2895512]
    at org.opensearch.core.common.io.stream.StreamOutput.writeVLong(StreamOutput.java:310)
    at org.opensearch.index.fielddata.FieldDataStats.writeTo(FieldDataStats.java:116)
    at org.opensearch.core.common.io.stream.StreamOutput.lambda$writeOptionalWriteable$29(StreamOutput.java:974)
    at org.opensearch.core.common.io.stream.StreamOutput.writeOptionalWriteable(StreamOutput.java:980)
    at org.opensearch.core.common.io.stream.StreamOutput.writeOptionalWriteable(StreamOutput.java:974)
    at org.opensearch.action.admin.indices.stats.CommonStats.writeTo(CommonStats.java:281)
    at org.opensearch.action.admin.indices.stats.ShardStats.writeTo(ShardStats.java:146)
    at org.opensearch.core.common.io.stream.StreamOutput.lambda$writeOptionalWriteable$29(StreamOutput.java:974)
    at org.opensearch.core.common.io.stream.StreamOutput.writeOptionalWriteable(StreamOutput.java:980)
    at org.opensearch.core.common.io.stream.StreamOutput.writeOptionalWriteable(StreamOutput.java:974)
    at org.opensearch.action.support.broadcast.node.TransportBroadcastByNodeAction$NodeResponse.writeTo(TransportBroadcastByNodeAction.java:651)
    at org.opensearch.transport.nativeprotocol.NativeOutboundMessage.writeMessage(NativeOutboundMessage.java:108)
    at org.opensearch.transport.nativeprotocol.NativeOutboundMessage.serialize(NativeOutboundMessage.java:85)
    at org.opensearch.transport.nativeprotocol.NativeOutboundHandler$MessageSerializer.get(NativeOutboundHandler.java:216)
    at org.opensearch.transport.nativeprotocol.NativeOutboundHandler$MessageSerializer.get(NativeOutboundHandler.java:202)
    at org.opensearch.transport.OutboundHandler$SendContext.get(OutboundHandler.java:130)
    at org.opensearch.transport.OutboundHandler.sendBytes(OutboundHandler.java:80)
    at org.opensearch.transport.nativeprotocol.NativeOutboundHandler.sendMessage(NativeOutboundHandler.java:186)
    at org.opensearch.transport.nativeprotocol.NativeOutboundHandler.sendResponse(NativeOutboundHandler.java:152)
    at org.opensearch.transport.TcpTransportChannel.sendResponse(TcpTransportChannel.java:96)
    at org.opensearch.transport.TaskTransportChannel.sendResponse(TaskTransportChannel.java:72)
    at org.opensearch.action.support.broadcast.node.TransportBroadcastByNodeAction$BroadcastByNodeTransportRequestHandler.messageReceived(TransportBroadcastByNodeAction.java:482)
    at org.opensearch.action.support.broadcast.node.TransportBroadcastByNodeAction$BroadcastByNodeTransportRequestHandler.messageReceived(TransportBroadcastByNodeAction.java:456)
    at org.opensearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:108)
    at org.opensearch.transport.NativeMessageHandler$RequestHandler.doRun(NativeMessageHandler.java:487)
    at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1023)
    at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    at java.lang.Thread.run(Thread.java:1583)
```



### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).