### PR TITLE
[DataFormatAwareEngine] Make flush idempotent of CatalogSnapshot

### DIFF
--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeCommitDeletionIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeCommitDeletionIT.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -113,7 +114,13 @@ public class CompositeCommitDeletionIT extends OpenSearchIntegTestCase {
 
     private int commitCount(IndexShard shard) throws IOException {
         List<IndexCommit> commits = DirectoryReader.listCommits(shard.store().directory());
-        return commits.size();
+        return (int) commits.stream().map(c -> {
+            try {
+                return c.getUserData().get(CatalogSnapshot.CATALOG_SNAPSHOT_ID);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }).filter(Objects::nonNull).distinct().count();
     }
 
     // ---- Test 1: Old commit files deleted after flush ----

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -550,10 +550,6 @@ public class DataFormatAwareEngine implements Indexer {
 
     @Override
     public void refresh(String source) throws EngineException {
-        refresh(source, false);
-    }
-
-    private void refresh(String source, boolean force) throws EngineException {
         final long localCheckpointBeforeRefresh = localCheckpointTracker.getProcessedCheckpoint();
         boolean refreshed = false;
         try (ReleasableLock ignored = readLock.acquire()) {
@@ -589,7 +585,7 @@ public class DataFormatAwareEngine implements Indexer {
                         logger.debug("Produced {} new segments from flush", newSegments.size());
 
                         // refresh only if new segments have been created or force param is true
-                        if (force || refreshed) {
+                        if (refreshed) {
                             RefreshInput refreshInput = new RefreshInput(existingSegments, newSegments);
                             RefreshResult result = indexingExecutionEngine.refresh(refreshInput);
                             catalogSnapshotManager.commitNewSnapshot(result.refreshedSegments());
@@ -644,7 +640,7 @@ public class DataFormatAwareEngine implements Indexer {
             }
             try {
                 // Refresh first to flush buffered data to segments
-                refresh("flush", force);
+                refresh("flush");
                 // Persist the latest catalog snapshot so it survives restart
                 try (GatedConditionalCloseable<CatalogSnapshot> snapshotRef = catalogSnapshotManager.acquireSnapshotForCommit()) {
                     CatalogSnapshot snapshot = snapshotRef.get();

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -550,6 +550,10 @@ public class DataFormatAwareEngine implements Indexer {
 
     @Override
     public void refresh(String source) throws EngineException {
+        refresh(source, false);
+    }
+
+    private void refresh(String source, boolean force) throws EngineException {
         final long localCheckpointBeforeRefresh = localCheckpointTracker.getProcessedCheckpoint();
         boolean refreshed = false;
         try (ReleasableLock ignored = readLock.acquire()) {
@@ -584,20 +588,21 @@ public class DataFormatAwareEngine implements Indexer {
                         }
                         logger.debug("Produced {} new segments from flush", newSegments.size());
 
-                        RefreshInput refreshInput = new RefreshInput(existingSegments, newSegments);
-                        RefreshResult result = indexingExecutionEngine.refresh(refreshInput);
-                        catalogSnapshotManager.commitNewSnapshot(result.refreshedSegments());
+                        // refresh only if new segments have been created or force param is true
+                        if (force || refreshed) {
+                            RefreshInput refreshInput = new RefreshInput(existingSegments, newSegments);
+                            RefreshResult result = indexingExecutionEngine.refresh(refreshInput);
+                            catalogSnapshotManager.commitNewSnapshot(result.refreshedSegments());
 
-                        // TODO: Add other Refresh listeners
-                        // Notify reader managers so they can create readers for the new snapshot
-                        try (GatedCloseable<CatalogSnapshot> newSnapshotRef = catalogSnapshotManager.acquireSnapshot()) {
-                            CatalogSnapshot newSnapshot = newSnapshotRef.get();
-                            for (EngineReaderManager<?> rm : readerManagers.values()) {
-                                rm.afterRefresh(refreshed, newSnapshot);
+                            // TODO: Add other Refresh listeners
+                            // Notify reader managers so they can create readers for the new snapshot
+                            try (GatedCloseable<CatalogSnapshot> newSnapshotRef = catalogSnapshotManager.acquireSnapshot()) {
+                                CatalogSnapshot newSnapshot = newSnapshotRef.get();
+                                for (EngineReaderManager<?> rm : readerManagers.values()) {
+                                    rm.afterRefresh(refreshed, newSnapshot);
+                                }
                             }
                         }
-
-                        refreshed = true;
                     } finally {
                         store.decRef();
                     }
@@ -639,30 +644,38 @@ public class DataFormatAwareEngine implements Indexer {
             }
             try {
                 // Refresh first to flush buffered data to segments
-                refresh("flush");
-                // Sync translog before commit so the global checkpoint is persisted
-                // and available to the deletion policy when onCommit is triggered.
-                translogManager.ensureCanFlush();
-                translogManager.syncTranslog();
+                refresh("flush", force);
                 // Persist the latest catalog snapshot so it survives restart
                 try (GatedConditionalCloseable<CatalogSnapshot> snapshotRef = catalogSnapshotManager.acquireSnapshotForCommit()) {
                     CatalogSnapshot snapshot = snapshotRef.get();
-                    Map<String, String> commitData = new HashMap<>();
-                    commitData.put(CatalogSnapshot.CATALOG_SNAPSHOT_KEY, snapshot.serializeToString());
-                    commitData.put(CatalogSnapshot.LAST_COMPOSITE_WRITER_GEN_KEY, Long.toString(snapshot.getLastWriterGeneration()));
-                    commitData.put(CatalogSnapshot.CATALOG_SNAPSHOT_ID, Long.toString(snapshot.getId()));
-                    commitData.put(Translog.TRANSLOG_UUID_KEY, translogManager.getTranslogUUID());
-                    commitData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, Long.toString(localCheckpointTracker.getProcessedCheckpoint()));
-                    commitData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(localCheckpointTracker.getMaxSeqNo()));
-                    commitData.put(MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID, Long.toString(maxUnsafeAutoIdTimestamp.get()));
-                    commitData.put(Engine.HISTORY_UUID_KEY, historyUUID);
-                    // Update snapshot userData so deletion policy can read max_seq_no
-                    snapshot.setUserData(commitData, true);
-                    committer.commit(commitData);
-                    snapshotRef.markSuccess();
+                    Map<String, String> lastCommitData = committer.getLastCommittedData();
+                    String lastCommittedSnapshotId = lastCommitData.get(CatalogSnapshot.CATALOG_SNAPSHOT_ID);
+                    // commit only if last committed CS id is different from the one we are about to commit or if force param is true
+                    if (force || lastCommittedSnapshotId == null || snapshot.getId() != Long.parseLong(lastCommittedSnapshotId)) {
+                        // Sync translog before commit so the global checkpoint is persisted
+                        // and available to the deletion policy when onCommit is triggered.
+                        translogManager.ensureCanFlush();
+                        translogManager.syncTranslog();
+                        Map<String, String> commitData = new HashMap<>();
+                        commitData.put(CatalogSnapshot.CATALOG_SNAPSHOT_KEY, snapshot.serializeToString());
+                        commitData.put(CatalogSnapshot.LAST_COMPOSITE_WRITER_GEN_KEY, Long.toString(snapshot.getLastWriterGeneration()));
+                        commitData.put(CatalogSnapshot.CATALOG_SNAPSHOT_ID, Long.toString(snapshot.getId()));
+                        commitData.put(Translog.TRANSLOG_UUID_KEY, translogManager.getTranslogUUID());
+                        commitData.put(
+                            SequenceNumbers.LOCAL_CHECKPOINT_KEY,
+                            Long.toString(localCheckpointTracker.getProcessedCheckpoint())
+                        );
+                        commitData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(localCheckpointTracker.getMaxSeqNo()));
+                        commitData.put(MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID, Long.toString(maxUnsafeAutoIdTimestamp.get()));
+                        commitData.put(Engine.HISTORY_UUID_KEY, historyUUID);
+                        // Update snapshot userData so deletion policy can read max_seq_no
+                        snapshot.setUserData(commitData, true);
+                        committer.commit(commitData);
+                        snapshotRef.markSuccess();
+                        translogManager.rollTranslogGeneration();
+                        translogManager.trimUnreferencedReaders();
+                    }
                 }
-                translogManager.rollTranslogGeneration();
-                translogManager.trimUnreferencedReaders();
                 logger.trace("flush completed");
             } catch (AlreadyClosedException e) {
                 failOnTragicEvent(e);

--- a/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
@@ -460,7 +460,7 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
                 assertThat(snapshot, notNullValue());
                 // Flush calls refresh internally, producing 1 segment
                 assertThat(snapshot.getSegments().size(), equalTo(1));
-                assertThat(snapshot.getGeneration(), equalTo(2L));
+                assertThat(snapshot.getGeneration(), equalTo(1L));
             }
             assertThat(engine.getProcessedLocalCheckpoint(), equalTo((long) numDocs - 1));
             assertThat(engine.lastRefreshedCheckpoint(), equalTo((long) numDocs - 1));
@@ -737,7 +737,7 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
             assertThat(engine.lastRefreshedCheckpoint(), equalTo((long) numDocs - 1));
             try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
                 CatalogSnapshot snapshot = ref.get();
-                assertThat(snapshot.getGeneration(), equalTo(2L));
+                assertThat(snapshot.getGeneration(), equalTo(1L));
                 assertThat(snapshot.getSegments().size(), equalTo(1));
                 assertThat(snapshot.getSegments().get(0).dfGroupedSearchableFiles().containsKey(mockDataFormat.name()), equalTo(true));
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Added check to prevent flushing if previously committed and current catalog snapshot are same.
Having multiple commits associated with the same catalog snapshot will cause issues with our custom file deletion logic and would cause multiple commits to remain alive, when ideally we would want only one.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
