### PR TITLE
Use atomic writes in FsBlobContainer

### DIFF
--- a/server/src/main/java/org/opensearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/opensearch/common/blobstore/fs/FsBlobContainer.java
@@ -193,17 +193,8 @@ public class FsBlobContainer extends AbstractBlobContainer {
 
     @Override
     public void writeBlob(String blobName, InputStream inputStream, long blobSize, boolean failIfAlreadyExists) throws IOException {
-        final Path file = path.resolve(blobName);
-        try {
-            writeToPath(inputStream, file, blobSize);
-        } catch (FileAlreadyExistsException faee) {
-            if (failIfAlreadyExists) {
-                throw faee;
-            }
-            deleteBlobsIgnoringIfNotExists(Collections.singletonList(blobName));
-            writeToPath(inputStream, file, blobSize);
-        }
-        IOUtils.fsync(path, true);
+        // Delegate to the atomic variant to match the behavior of real object stores
+        writeBlobAtomic(blobName, inputStream, blobSize, failIfAlreadyExists);
     }
 
     @Override


### PR DESCRIPTION
I believe non-atomic writes are the causes of test failures [like this][1]. We could fix the logic to be resilient to non-atomic writes, but I don't believe the code will ever see a non-atomic write in real life. I think it's better just to make the FS repo always use atomic writes.

[1]: https://build.ci.opensearch.org/job/gradle-check/74598/testReport/org.opensearch.indices.replication/WarmIndexSegmentReplicationIT/testScrollCreatedOnReplica/

### Check List
- [x] Functionality includes testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
