### PR TITLE
Add count-based translog flush threshold

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -190,6 +190,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 EnableAllocationDecider.INDEX_ROUTING_ALLOCATION_ENABLE_SETTING,
                 IndexSettings.INDEX_FLUSH_AFTER_MERGE_THRESHOLD_SIZE_SETTING,
                 IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING,
+                IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_OPS_SETTING,
                 IndexSettings.INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING,
                 IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING,
                 IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING,

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -444,8 +444,12 @@ public final class IndexSettings {
     /**
      * Number of operations in the translog that will trigger a flush in addition to the size based threshold
      * configured via {@link #INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING}. A flush is triggered when either
-     * threshold is crossed. Default is {@link Integer#MAX_VALUE} which effectively disables the count based
-     * trigger and preserves the existing size only behaviour.
+     * threshold is crossed.
+     *
+     * <p>The default value is {@link Integer#MAX_VALUE}, which effectively disables the operation count based
+     * trigger and preserves the legacy size only behaviour. The same {@link Integer#MAX_VALUE} is also the
+     * accepted upper bound: the setting is intentionally capped at the largest representable {@code int} and
+     * any value at or near the ceiling should be interpreted as "disabled".</p>
      */
     public static final Setting<Integer> INDEX_TRANSLOG_FLUSH_THRESHOLD_OPS_SETTING = Setting.intSetting(
         "index.translog.flush_threshold_ops",

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -442,6 +442,21 @@ public final class IndexSettings {
     );
 
     /**
+     * Number of operations in the translog that will trigger a flush in addition to the size based threshold
+     * configured via {@link #INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING}. A flush is triggered when either
+     * threshold is crossed. Default is {@link Integer#MAX_VALUE} which effectively disables the count based
+     * trigger and preserves the existing size only behaviour.
+     */
+    public static final Setting<Integer> INDEX_TRANSLOG_FLUSH_THRESHOLD_OPS_SETTING = Setting.intSetting(
+        "index.translog.flush_threshold_ops",
+        Integer.MAX_VALUE,
+        100,
+        Integer.MAX_VALUE,
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /**
      * The minimum size of a merge that triggers a flush in order to free resources
      */
     public static final Setting<ByteSizeValue> INDEX_FLUSH_AFTER_MERGE_THRESHOLD_SIZE_SETTING = Setting.byteSizeSetting(
@@ -964,6 +979,7 @@ public final class IndexSettings {
     private volatile TimeValue refreshInterval;
     private volatile TimeValue periodicFlushInterval;
     private volatile ByteSizeValue flushThresholdSize;
+    private volatile int flushThresholdOps;
     private volatile TimeValue translogRetentionAge;
     private volatile ByteSizeValue translogRetentionSize;
     private volatile ByteSizeValue generationThresholdSize;
@@ -1193,6 +1209,7 @@ public final class IndexSettings {
         refreshInterval = scopedSettings.get(INDEX_REFRESH_INTERVAL_SETTING);
         periodicFlushInterval = scopedSettings.get(INDEX_PERIODIC_FLUSH_INTERVAL_SETTING);
         flushThresholdSize = scopedSettings.get(INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING);
+        flushThresholdOps = scopedSettings.get(INDEX_TRANSLOG_FLUSH_THRESHOLD_OPS_SETTING);
         generationThresholdSize = scopedSettings.get(INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING);
         flushAfterMergeThresholdSize = scopedSettings.get(INDEX_FLUSH_AFTER_MERGE_THRESHOLD_SIZE_SETTING);
         mergeSchedulerConfig = new MergeSchedulerConfig(this);
@@ -1342,6 +1359,7 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(INDEX_WARMER_ENABLED_SETTING, this::setEnableWarmer);
         scopedSettings.addSettingsUpdateConsumer(INDEX_GC_DELETES_SETTING, this::setGCDeletes);
         scopedSettings.addSettingsUpdateConsumer(INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING, this::setTranslogFlushThresholdSize);
+        scopedSettings.addSettingsUpdateConsumer(INDEX_TRANSLOG_FLUSH_THRESHOLD_OPS_SETTING, this::setTranslogFlushThresholdOps);
         scopedSettings.addSettingsUpdateConsumer(INDEX_FLUSH_AFTER_MERGE_THRESHOLD_SIZE_SETTING, this::setFlushAfterMergeThresholdSize);
         scopedSettings.addSettingsUpdateConsumer(INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING, this::setGenerationThresholdSize);
         scopedSettings.addSettingsUpdateConsumer(INDEX_TRANSLOG_RETENTION_AGE_SETTING, this::setTranslogRetentionAge);
@@ -1421,6 +1439,10 @@ public final class IndexSettings {
 
     private void setTranslogFlushThresholdSize(ByteSizeValue byteSizeValue) {
         this.flushThresholdSize = byteSizeValue;
+    }
+
+    private void setTranslogFlushThresholdOps(int ops) {
+        this.flushThresholdOps = ops;
     }
 
     private void setFlushAfterMergeThresholdSize(ByteSizeValue byteSizeValue) {
@@ -1815,6 +1837,14 @@ public final class IndexSettings {
      */
     public ByteSizeValue getFlushThresholdSize() {
         return flushThresholdSize;
+    }
+
+    /**
+     * Returns the transaction log operation count threshold when to forcefully flush the index and clear the
+     * transaction log. A flush is triggered when either this or {@link #getFlushThresholdSize()} is crossed.
+     */
+    public int getFlushThresholdOps() {
+        return flushThresholdOps;
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -695,7 +695,8 @@ public class DataFormatAwareEngine implements Indexer {
         final long localCheckpointOfLastCommit = localCheckpointTracker.getPersistedCheckpoint();
         return translogManager.shouldPeriodicallyFlush(
             localCheckpointOfLastCommit,
-            engineConfig.getIndexSettings().getFlushThresholdSize().getBytes()
+            engineConfig.getIndexSettings().getFlushThresholdSize().getBytes(),
+            engineConfig.getIndexSettings().getFlushThresholdOps()
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -1545,7 +1545,8 @@ public class InternalEngine extends Engine {
         );
         return translogManager.shouldPeriodicallyFlush(
             localCheckpointOfLastCommit,
-            config().getIndexSettings().getFlushThresholdSize().getBytes()
+            config().getIndexSettings().getFlushThresholdSize().getBytes(),
+            config().getIndexSettings().getFlushThresholdOps()
         );
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/InternalTranslogManager.java
@@ -435,10 +435,12 @@ public class InternalTranslogManager implements TranslogManager {
     /**
      *
      * @param localCheckpointOfLastCommit local checkpoint reference of last commit to translog
-     * @param flushThreshold threshold to flush to translog
+     * @param flushThreshold size based threshold to flush the translog (bytes)
+     * @param flushThresholdOps operation count based threshold to flush the translog; a flush is triggered when
+     *                          either the size or the operation count threshold is crossed
      * @return if the translog should be flushed
      */
-    public boolean shouldPeriodicallyFlush(long localCheckpointOfLastCommit, long flushThreshold) {
+    public boolean shouldPeriodicallyFlush(long localCheckpointOfLastCommit, long flushThreshold, int flushThresholdOps) {
         /*
          * This can trigger flush depending upon translog's implementation
          */
@@ -448,7 +450,9 @@ public class InternalTranslogManager implements TranslogManager {
         // This is the minimum seqNo that is referred in translog and considered for calculating translog size
         long minTranslogRefSeqNo = translog.getMinUnreferencedSeqNoInSegments(localCheckpointOfLastCommit + 1);
         final long minReferencedTranslogGeneration = translog.getMinGenerationForSeqNo(minTranslogRefSeqNo).translogFileGeneration;
-        if (translog.sizeInBytesByMinGen(minReferencedTranslogGeneration) < flushThreshold) {
+        final boolean sizeExceeded = translog.sizeInBytesByMinGen(minReferencedTranslogGeneration) >= flushThreshold;
+        final boolean opsExceeded = translog.totalOperationsByMinGen(minReferencedTranslogGeneration) >= flushThresholdOps;
+        if (sizeExceeded == false && opsExceeded == false) {
             return false;
         }
         /*
@@ -458,8 +462,9 @@ public class InternalTranslogManager implements TranslogManager {
          * commit points to the later generation the last commit's(eg. gen-of-last-commit < gen-of-new-commit)[1].
          *
          * When the local checkpoint equals to max_seqno, and translog-gen of the last commit equals to translog-gen of
-         * the new commit, we know that the last generation must contain operations because its size is above the flush
-         * threshold and the flush-threshold is guaranteed to be higher than an empty translog by the setting validation.
+         * the new commit, we know that the last generation must contain operations because its size (or operation
+         * count) is above the corresponding flush-threshold; the size threshold is guaranteed to be higher than an
+         * empty translog by setting validation, and the ops threshold has a minimum bound enforced by the setting.
          * This guarantees that the new commit will point to the newly rolled generation. In fact, this scenario only
          * happens when the generation-threshold is close to or above the flush-threshold; otherwise we have rolled
          * generations as the generation-threshold was reached, then the first condition (eg. [1]) is already satisfied.

--- a/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/NoOpTranslogManager.java
@@ -173,7 +173,7 @@ public class NoOpTranslogManager implements TranslogManager {
     public void trimUnreferencedReaders() throws IOException {}
 
     @Override
-    public boolean shouldPeriodicallyFlush(long localCheckpointOfLastCommit, long flushThreshold) {
+    public boolean shouldPeriodicallyFlush(long localCheckpointOfLastCommit, long flushThreshold, int flushThresholdOps) {
         return false;
     }
 

--- a/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
@@ -161,6 +161,18 @@ public interface TranslogManager extends Closeable {
     void trimUnreferencedReaders() throws IOException;
 
     /**
+     * Backwards compatible overload that keeps the count-based threshold disabled by delegating to
+     * {@link #shouldPeriodicallyFlush(long, long, int)} with {@link Integer#MAX_VALUE} for the ops threshold.
+     *
+     * @param localCheckpointOfLastCommit local checkpoint reference of last commit to translog
+     * @param flushThreshold size based threshold to flush the translog (bytes)
+     * @return if the translog should be flushed
+     */
+    default boolean shouldPeriodicallyFlush(long localCheckpointOfLastCommit, long flushThreshold) {
+        return shouldPeriodicallyFlush(localCheckpointOfLastCommit, flushThreshold, Integer.MAX_VALUE);
+    }
+
+    /**
      *
      * @param localCheckpointOfLastCommit local checkpoint reference of last commit to translog
      * @param flushThreshold size based threshold to flush the translog (bytes)

--- a/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
+++ b/server/src/main/java/org/opensearch/index/translog/TranslogManager.java
@@ -163,10 +163,12 @@ public interface TranslogManager extends Closeable {
     /**
      *
      * @param localCheckpointOfLastCommit local checkpoint reference of last commit to translog
-     * @param flushThreshold threshold to flush to translog
+     * @param flushThreshold size based threshold to flush the translog (bytes)
+     * @param flushThresholdOps operation count based threshold to flush the translog; a flush is triggered when
+     *                          either the size or the operation count threshold is crossed
      * @return if the translog should be flushed
      */
-    boolean shouldPeriodicallyFlush(long localCheckpointOfLastCommit, long flushThreshold);
+    boolean shouldPeriodicallyFlush(long localCheckpointOfLastCommit, long flushThreshold, int flushThresholdOps);
 
     /**
      * Retrieves the underlying translog tragic exception

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -615,19 +615,14 @@ public class IndexSettingsTests extends OpenSearchTestCase {
 
         // dynamic update
         int newOps = randomIntBetween(100, 1_000_000);
-        settings.updateIndexMetadata(
-            newIndexMeta("index", Settings.builder().put(key, newOps).build())
-        );
+        settings.updateIndexMetadata(newIndexMeta("index", Settings.builder().put(key, newOps).build()));
         assertEquals(newOps, settings.getFlushThresholdOps());
 
         // minimum bound is enforced (must be >= 100)
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> new IndexSettings(
-                newIndexMeta(
-                    "index",
-                    Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).put(key, 99).build()
-                ),
+                newIndexMeta("index", Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).put(key, 99).build()),
                 Settings.EMPTY
             )
         );

--- a/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexSettingsTests.java
@@ -593,6 +593,54 @@ public class IndexSettingsTests extends OpenSearchTestCase {
         assertEquals(actualNewTranslogFlushThresholdSize, settings.getFlushThresholdSize());
     }
 
+    public void testTranslogFlushOpsThreshold() {
+        final String key = IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_OPS_SETTING.getKey();
+
+        // default
+        IndexMetadata defaultMeta = newIndexMeta(
+            "index",
+            Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).build()
+        );
+        IndexSettings defaultSettings = new IndexSettings(defaultMeta, Settings.EMPTY);
+        assertEquals(Integer.MAX_VALUE, defaultSettings.getFlushThresholdOps());
+
+        // custom value
+        int ops = randomIntBetween(100, 1_000_000);
+        IndexMetadata metadata = newIndexMeta(
+            "index",
+            Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).put(key, ops).build()
+        );
+        IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
+        assertEquals(ops, settings.getFlushThresholdOps());
+
+        // dynamic update
+        int newOps = randomIntBetween(100, 1_000_000);
+        settings.updateIndexMetadata(
+            newIndexMeta("index", Settings.builder().put(key, newOps).build())
+        );
+        assertEquals(newOps, settings.getFlushThresholdOps());
+
+        // minimum bound is enforced (must be >= 100)
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new IndexSettings(
+                newIndexMeta(
+                    "index",
+                    Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT).put(key, 99).build()
+                ),
+                Settings.EMPTY
+            )
+        );
+        assertThat(e.getMessage(), containsString(key));
+
+        // minimum bound is also enforced on dynamic updates
+        IllegalArgumentException dynamicErr = expectThrows(
+            IllegalArgumentException.class,
+            () -> settings.updateIndexMetadata(newIndexMeta("index", Settings.builder().put(key, 50).build()))
+        );
+        assertThat(dynamicErr.getMessage(), containsString(key));
+    }
+
     public void testTranslogGenerationSizeThreshold() {
         final ByteSizeValue size = new ByteSizeValue(Math.abs(randomInt()));
         final String key = IndexSettings.INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING.getKey();

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -6763,6 +6763,49 @@ public class InternalEngineTests extends EngineTestCase {
         }
     }
 
+    public void testShouldPeriodicallyFlushOnOpsThreshold() throws Exception {
+        assertThat("Empty engine does not need flushing", engine.shouldPeriodicallyFlush(), equalTo(false));
+        // Index a handful of operations below the default ops threshold (Integer.MAX_VALUE)
+        final int numDocs = between(5, 20);
+        for (int id = 0; id < numDocs; id++) {
+            final ParsedDocument doc = testParsedDocument(Integer.toString(id), null, testDocumentWithTextField(), SOURCE, null);
+            engine.index(indexForDoc(doc));
+        }
+        assertThat("Default ops threshold not crossed", engine.shouldPeriodicallyFlush(), equalTo(false));
+
+        // Lower the ops threshold below the number of uncommitted ops; size threshold stays at default so
+        // the flush must be triggered by the ops check (OR logic).
+        final IndexSettings indexSettings = engine.config().getIndexSettings();
+        final int opsThreshold = Math.max(100, numDocs / 2 + 100);
+        // Re-index enough ops to exceed the threshold
+        for (int id = numDocs; id < opsThreshold + numDocs; id++) {
+            final ParsedDocument doc = testParsedDocument(Integer.toString(id), null, testDocumentWithTextField(), SOURCE, null);
+            engine.index(indexForDoc(doc));
+        }
+        final IndexMetadata indexMetadata = IndexMetadata.builder(indexSettings.getIndexMetadata())
+            .settings(
+                Settings.builder()
+                    .put(indexSettings.getSettings())
+                    .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_OPS_SETTING.getKey(), opsThreshold)
+            )
+            .build();
+        indexSettings.updateIndexMetadata(indexMetadata);
+        engine.onSettingsChanged(
+            indexSettings.getTranslogRetentionAge(),
+            indexSettings.getTranslogRetentionSize(),
+            indexSettings.getSoftDeleteRetentionOperations()
+        );
+        assertThat(indexSettings.getFlushThresholdOps(), equalTo(opsThreshold));
+        assertThat(
+            "Ops threshold crossed, flush expected",
+            engine.translogManager().getTranslogStats().getUncommittedOperations(),
+            greaterThanOrEqualTo(opsThreshold)
+        );
+        assertThat(engine.shouldPeriodicallyFlush(), equalTo(true));
+        engine.flush();
+        assertThat("After flush, ops threshold no longer crossed", engine.shouldPeriodicallyFlush(), equalTo(false));
+    }
+
     public void testShouldPeriodicallyFlushAfterMerge() throws Exception {
         engine.close();
         // Do not use MockRandomMergePolicy as it can cause a force merge performing two merges.

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -6773,11 +6773,7 @@ public class InternalEngineTests extends EngineTestCase {
             engine.index(indexForDoc(doc));
         }
         // Default ops threshold is Integer.MAX_VALUE so the feature is disabled and no flush should be scheduled.
-        assertThat(
-            "Default ops threshold is disabled, flush should not be scheduled",
-            engine.shouldPeriodicallyFlush(),
-            equalTo(false)
-        );
+        assertThat("Default ops threshold is disabled, flush should not be scheduled", engine.shouldPeriodicallyFlush(), equalTo(false));
         assertThat(engine.translogManager().getTranslogStats().getUncommittedOperations(), equalTo(numDocs));
 
         // Lower the ops threshold below the number of uncommitted ops so the count-based condition triggers.
@@ -6803,8 +6799,7 @@ public class InternalEngineTests extends EngineTestCase {
         assertThat("Ops threshold crossed, flush expected", engine.shouldPeriodicallyFlush(), equalTo(true));
 
         engine.flush();
-        assertThat("After flush, no uncommitted operations remain above the threshold",
-            engine.shouldPeriodicallyFlush(), equalTo(false));
+        assertThat("After flush, no uncommitted operations remain above the threshold", engine.shouldPeriodicallyFlush(), equalTo(false));
     }
 
     public void testShouldPeriodicallyFlushAfterMerge() throws Exception {

--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -6765,23 +6765,26 @@ public class InternalEngineTests extends EngineTestCase {
 
     public void testShouldPeriodicallyFlushOnOpsThreshold() throws Exception {
         assertThat("Empty engine does not need flushing", engine.shouldPeriodicallyFlush(), equalTo(false));
-        // Index a handful of operations below the default ops threshold (Integer.MAX_VALUE)
-        final int numDocs = between(5, 20);
+
+        // Index enough operations that we can later set a threshold both equal to and below the count.
+        final int numDocs = between(150, 300);
         for (int id = 0; id < numDocs; id++) {
             final ParsedDocument doc = testParsedDocument(Integer.toString(id), null, testDocumentWithTextField(), SOURCE, null);
             engine.index(indexForDoc(doc));
         }
-        assertThat("Default ops threshold not crossed", engine.shouldPeriodicallyFlush(), equalTo(false));
+        // Default ops threshold is Integer.MAX_VALUE so the feature is disabled and no flush should be scheduled.
+        assertThat(
+            "Default ops threshold is disabled, flush should not be scheduled",
+            engine.shouldPeriodicallyFlush(),
+            equalTo(false)
+        );
+        assertThat(engine.translogManager().getTranslogStats().getUncommittedOperations(), equalTo(numDocs));
 
-        // Lower the ops threshold below the number of uncommitted ops; size threshold stays at default so
-        // the flush must be triggered by the ops check (OR logic).
+        // Lower the ops threshold below the number of uncommitted ops so the count-based condition triggers.
+        // The size threshold is left at its default (512 MB) and is far from being crossed, proving the flush
+        // is driven by the new ops check via the OR logic.
+        final int opsThreshold = numDocs - 1;
         final IndexSettings indexSettings = engine.config().getIndexSettings();
-        final int opsThreshold = Math.max(100, numDocs / 2 + 100);
-        // Re-index enough ops to exceed the threshold
-        for (int id = numDocs; id < opsThreshold + numDocs; id++) {
-            final ParsedDocument doc = testParsedDocument(Integer.toString(id), null, testDocumentWithTextField(), SOURCE, null);
-            engine.index(indexForDoc(doc));
-        }
         final IndexMetadata indexMetadata = IndexMetadata.builder(indexSettings.getIndexMetadata())
             .settings(
                 Settings.builder()
@@ -6796,14 +6799,12 @@ public class InternalEngineTests extends EngineTestCase {
             indexSettings.getSoftDeleteRetentionOperations()
         );
         assertThat(indexSettings.getFlushThresholdOps(), equalTo(opsThreshold));
-        assertThat(
-            "Ops threshold crossed, flush expected",
-            engine.translogManager().getTranslogStats().getUncommittedOperations(),
-            greaterThanOrEqualTo(opsThreshold)
-        );
-        assertThat(engine.shouldPeriodicallyFlush(), equalTo(true));
+        assertThat(engine.translogManager().getTranslogStats().getUncommittedOperations(), greaterThanOrEqualTo(opsThreshold));
+        assertThat("Ops threshold crossed, flush expected", engine.shouldPeriodicallyFlush(), equalTo(true));
+
         engine.flush();
-        assertThat("After flush, ops threshold no longer crossed", engine.shouldPeriodicallyFlush(), equalTo(false));
+        assertThat("After flush, no uncommitted operations remain above the threshold",
+            engine.shouldPeriodicallyFlush(), equalTo(false));
     }
 
     public void testShouldPeriodicallyFlushAfterMerge() throws Exception {


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Introduce a new index setting `index.translog.flush_threshold_ops` that triggers a Lucene commit when the number of operations in the translog crosses the configured threshold, in addition to the existing size-based threshold `index.translog.flush_threshold_size`. A flush is triggered when either threshold is crossed.

This is useful for workloads with small documents or heavy deletes, where reaching the default 512 MB size threshold takes a long time and leaves a large number of uncommitted operations in the translog.

The setting is dynamic, index-scoped, defaults to Integer.MAX_VALUE (effectively disabled, preserving existing behavior), and enforces a minimum value of 100 to avoid pathologically frequent flushes.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->
https://github.com/opensearch-project/OpenSearch/issues/15561


### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
