### PR TITLE
Add slow logs, per-query metrics, and TierActionMetrics for WritableWarm tiered storage

### DIFF
--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -61,6 +61,7 @@ import org.opensearch.index.store.Store;
 import org.opensearch.indices.IndicesBitsetFilterCache;
 import org.opensearch.indices.IndicesRequestCache;
 import org.opensearch.search.streaming.FlushModeResolver;
+import org.opensearch.storage.slowlogs.TieredStorageSearchSlowLog;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -312,6 +313,18 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexModule.INDEX_STORE_LOCALITY_SETTING,
                 IndexModule.INDEX_TIERING_STATE,
                 IndexModule.IS_WARM_INDEX_SETTING,
+
+                // Tiered storage search slow log settings
+                TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_ENABLED,
+                TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING,
+                TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_INFO_SETTING,
+                TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_DEBUG_SETTING,
+                TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_TRACE_SETTING,
+                TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING,
+                TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO_SETTING,
+                TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING,
+                TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_TRACE_SETTING,
+                TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_LEVEL,
 
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {

--- a/server/src/main/java/org/opensearch/storage/indexinput/OnDemandPrefetchBlockSnapshotIndexInput.java
+++ b/server/src/main/java/org/opensearch/storage/indexinput/OnDemandPrefetchBlockSnapshotIndexInput.java
@@ -19,6 +19,8 @@ import org.opensearch.index.store.remote.filecache.FileCache;
 import org.opensearch.index.store.remote.utils.BlobFetchRequest;
 import org.opensearch.index.store.remote.utils.TransferManager;
 import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
+import org.opensearch.storage.slowlogs.TieredStoragePerQueryMetric;
+import org.opensearch.storage.slowlogs.TieredStorageQueryMetricService;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -60,7 +62,12 @@ public class OnDemandPrefetchBlockSnapshotIndexInput extends OnDemandBlockSnapsh
 
     @Override
     protected IndexInput fetchBlock(int blockId) throws IOException {
-        // TODO: Metric recording will be added when TieredStorageQueryMetricService is available
+        // Record cache access attempt and track hit/miss
+        String blockFileName = fileName + "_block_" + blockId;
+        boolean cacheHit = checkCacheHit(blockId);
+        final TieredStoragePerQueryMetric metricCollector = TieredStorageQueryMetricService.getInstance()
+            .getMetricCollector(Thread.currentThread().threadId());
+        metricCollector.recordFileAccess(blockFileName, cacheHit);
         fetchNextNBlocks(blockId);
         return super.fetchBlock(blockId);
     }
@@ -114,7 +121,7 @@ public class OnDemandPrefetchBlockSnapshotIndexInput extends OnDemandBlockSnapsh
         }
         logger.trace("Prefetching Read Ahead Block Count: {} from Block ID: {} for File: {}", readAheadBlockCount, blockId, fileName);
         downloadBlocksAsync(blockId + 1, blockId + readAheadBlockCount, true);
-        // TODO: Metric recording will be added when TieredStorageQueryMetricService is available
+        TieredStorageQueryMetricService.getInstance().recordDocValuesPrefetch(true);
     }
 
     @Override
@@ -134,6 +141,8 @@ public class OnDemandPrefetchBlockSnapshotIndexInput extends OnDemandBlockSnapsh
     }
 
     protected void downloadBlocksAsync(int startBlock, int endBlock, boolean isReadAhead) {
+        final TieredStoragePerQueryMetric metricCollector = TieredStorageQueryMetricService.getInstance()
+            .getMetricCollector(Thread.currentThread().threadId());
         for (int nextBlockId = startBlock; nextBlockId <= endBlock; nextBlockId++) {
             String blockFileName = fileName + "_block_" + nextBlockId;
             long blockStart = getBlockStart(nextBlockId);
@@ -146,7 +155,11 @@ public class OnDemandPrefetchBlockSnapshotIndexInput extends OnDemandBlockSnapsh
                 blockEnd,
                 originalFileSize
             );
-            // TODO: Metric recording will be added when TieredStorageQueryMetricService is available
+            if (isReadAhead) {
+                metricCollector.recordReadAhead(fileName, nextBlockId);
+            } else {
+                metricCollector.recordPrefetch(fileName, nextBlockId);
+            }
             // Block may be present on multiple chunks of a file, so we need
             // to fetch each chunk/blob part separately to fetch an entire block.
             BlobFetchRequest blobFetchRequest = BlobFetchRequest.builder()
@@ -204,7 +217,6 @@ public class OnDemandPrefetchBlockSnapshotIndexInput extends OnDemandBlockSnapsh
     /**
      * Checks if a block file exists in the file cache.
      * This method determines cache hit/miss status for transfer manager operations.
-     * TODO: Will be used by TieredStorageQueryMetricService for recording per-query cache metrics.
      *
      * @param blockId the id of the block to check
      * @return true if the block exists in cache (cache hit), false otherwise (cache miss)

--- a/server/src/main/java/org/opensearch/storage/metrics/TierActionMetrics.java
+++ b/server/src/main/java/org/opensearch/storage/metrics/TierActionMetrics.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.metrics;
+
+import org.opensearch.telemetry.metrics.Counter;
+import org.opensearch.telemetry.metrics.Histogram;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
+import org.opensearch.telemetry.metrics.tags.Tags;
+
+/**
+ * Metrics for tracking tier migration operations including successful migrations,
+ * rejections, and latency.
+ *
+ * @opensearch.experimental
+ */
+public final class TierActionMetrics {
+
+    private static final String LATENCY_METRIC_UNIT_MS = "ms";
+    private static final String COUNTER_METRICS_UNIT = "1";
+
+    /** Tag key for node ID. */
+    public static final String NODE_ID = "node_id";
+    /** Tag key for index name. */
+    public static final String INDEX_NAME = "index_name";
+    /** Tag key for tier type. */
+    public static final String TIER_TYPE = "tier_type";
+    /** Tag key for rejection reason. */
+    public static final String REJECTION_REASON = "rejection_reason";
+
+    /** Counter for successful tier migrations. */
+    public final Counter successfulMigrations;
+    /** Counter for rejected tier migrations. */
+    public final Counter rejectionReason;
+    /** Histogram for tracking end-to-end migration time. */
+    public final Histogram migrationLatency;
+
+    /**
+     * Creates a new TierActionMetrics instance.
+     * @param metricsRegistry the metrics registry to create counters and histograms
+     */
+    public TierActionMetrics(MetricsRegistry metricsRegistry) {
+        successfulMigrations = metricsRegistry.createCounter(
+            "migration_successful",
+            "Counter for successful tier migrations",
+            COUNTER_METRICS_UNIT
+        );
+
+        rejectionReason = metricsRegistry.createCounter(
+            "migration_rejection_reason",
+            "Counter for rejected tier migrations with their reasons",
+            COUNTER_METRICS_UNIT
+        );
+
+        migrationLatency = metricsRegistry.createHistogram(
+            "migration_latency",
+            "Histogram for tracking end-to-end migration time",
+            LATENCY_METRIC_UNIT_MS
+        );
+    }
+
+    /**
+     * Records migration latency.
+     * @param value the latency value in milliseconds
+     * @param nodeId the node ID
+     * @param indexName the index name
+     * @param tierType the tier type
+     */
+    public void recordMigrationLatency(Double value, String nodeId, String indexName, String tierType) {
+        Tags tags = createBaseTags(nodeId, indexName, tierType);
+        migrationLatency.record(value, tags);
+    }
+
+    /**
+     * Records a successful migration.
+     * @param nodeId the node ID
+     * @param indexName the index name
+     * @param tierType the tier type
+     */
+    public void recordSuccessfulMigration(String nodeId, String indexName, String tierType) {
+        Tags tags = createBaseTags(nodeId, indexName, tierType);
+        successfulMigrations.add(1.0, tags);
+    }
+
+    /**
+     * Records a rejected migration.
+     * @param nodeId the node ID
+     * @param indexName the index name
+     * @param tierType the tier type
+     * @param reason the rejection reason
+     */
+    public void recordRejectedMigration(String nodeId, String indexName, String tierType, String reason) {
+        Tags tags = createBaseTags(nodeId, indexName, tierType).addTag(REJECTION_REASON, reason);
+        rejectionReason.add(1.0, tags);
+    }
+
+    private Tags createBaseTags(String nodeId, String indexName, String tierType) {
+        return Tags.create().addTag(NODE_ID, nodeId).addTag(INDEX_NAME, indexName).addTag(TIER_TYPE, tierType);
+    }
+}

--- a/server/src/main/java/org/opensearch/storage/metrics/package-info.java
+++ b/server/src/main/java/org/opensearch/storage/metrics/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Metrics for tiered storage operations including migration tracking.
+ */
+package org.opensearch.storage.metrics;

--- a/server/src/main/java/org/opensearch/storage/prefetch/StoredFieldsPrefetch.java
+++ b/server/src/main/java/org/opensearch/storage/prefetch/StoredFieldsPrefetch.java
@@ -21,6 +21,7 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.common.lucene.search.Queries;
 import org.opensearch.index.shard.SearchOperationListener;
 import org.opensearch.search.internal.SearchContext;
+import org.opensearch.storage.slowlogs.TieredStorageQueryMetricService;
 
 import java.io.IOException;
 import java.util.function.Supplier;
@@ -50,7 +51,7 @@ public class StoredFieldsPrefetch implements SearchOperationListener {
         // Based on cluster settings
         if (checkIfStoredFieldsPrefetchEnabled()) {
             executePrefetch(searchContext);
-            // TODO: Metric recording will be added when TieredStorageQueryMetricService is available
+            TieredStorageQueryMetricService.getInstance().recordStoredFieldsPrefetch(true);
         }
     }
 

--- a/server/src/main/java/org/opensearch/storage/slowlogs/PrefetchStats.java
+++ b/server/src/main/java/org/opensearch/storage/slowlogs/PrefetchStats.java
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.slowlogs;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Stats for prefetch operations on tiered storage.
+ *
+ * @opensearch.experimental
+ */
+public class PrefetchStats implements Writeable, ToXContentFragment {
+
+    private final long storedFieldsPrefetchSuccess;
+    private final long storedFieldsPrefetchFailure;
+    private final long docValuesPrefetchSuccess;
+    private final long docValuesPrefetchFailure;
+
+    /**
+     * Creates a new PrefetchStats instance.
+     * @param storedFieldsPrefetchSuccess count of successful stored fields prefetches
+     * @param storedFieldsPrefetchFailure count of failed stored fields prefetches
+     * @param docValuesPrefetchSuccess count of successful doc values prefetches
+     * @param docValuesPrefetchFailure count of failed doc values prefetches
+     */
+    public PrefetchStats(
+        long storedFieldsPrefetchSuccess,
+        long storedFieldsPrefetchFailure,
+        long docValuesPrefetchSuccess,
+        long docValuesPrefetchFailure
+    ) {
+        this.storedFieldsPrefetchSuccess = storedFieldsPrefetchSuccess;
+        this.storedFieldsPrefetchFailure = storedFieldsPrefetchFailure;
+        this.docValuesPrefetchSuccess = docValuesPrefetchSuccess;
+        this.docValuesPrefetchFailure = docValuesPrefetchFailure;
+    }
+
+    /**
+     * Creates a new PrefetchStats instance from a stream.
+     * @param in the stream input
+     * @throws IOException if an I/O error occurs
+     */
+    public PrefetchStats(StreamInput in) throws IOException {
+        storedFieldsPrefetchSuccess = in.readVLong();
+        storedFieldsPrefetchFailure = in.readVLong();
+        docValuesPrefetchSuccess = in.readVLong();
+        docValuesPrefetchFailure = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(storedFieldsPrefetchSuccess);
+        out.writeVLong(storedFieldsPrefetchFailure);
+        out.writeVLong(docValuesPrefetchSuccess);
+        out.writeVLong(docValuesPrefetchFailure);
+    }
+
+    /**
+     * Returns the count of successful stored fields prefetches.
+     * @return the success count
+     */
+    public long getStoredFieldsPrefetchSuccess() {
+        return storedFieldsPrefetchSuccess;
+    }
+
+    /**
+     * Returns the count of failed stored fields prefetches.
+     * @return the failure count
+     */
+    public long getStoredFieldsPrefetchFailure() {
+        return storedFieldsPrefetchFailure;
+    }
+
+    /**
+     * Returns the count of successful doc values prefetches.
+     * @return the success count
+     */
+    public long getDocValuesPrefetchSuccess() {
+        return docValuesPrefetchSuccess;
+    }
+
+    /**
+     * Returns the count of failed doc values prefetches.
+     * @return the failure count
+     */
+    public long getDocValuesPrefetchFailure() {
+        return docValuesPrefetchFailure;
+    }
+
+    /**
+     * Field names for XContent serialization.
+     *
+     * @opensearch.experimental
+     */
+    static final class Fields {
+        static final String PREFETCH_STATS = "prefetch_stats";
+        static final String STORED_FIELDS_PREFETCH_SUCCESS = "stored_fields_prefetch_success_count";
+        static final String STORED_FIELDS_PREFETCH_FAILURE = "stored_fields_prefetch_failure_count";
+        static final String DOC_VALUES_PREFETCH_SUCCESS = "doc_values_prefetch_success_count";
+        static final String DOC_VALUES_PREFETCH_FAILURE = "doc_values_prefetch_failure_count";
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(Fields.PREFETCH_STATS);
+        builder.field(Fields.STORED_FIELDS_PREFETCH_SUCCESS, getStoredFieldsPrefetchSuccess());
+        builder.field(Fields.STORED_FIELDS_PREFETCH_FAILURE, getStoredFieldsPrefetchFailure());
+        builder.field(Fields.DOC_VALUES_PREFETCH_SUCCESS, getDocValuesPrefetchSuccess());
+        builder.field(Fields.DOC_VALUES_PREFETCH_FAILURE, getDocValuesPrefetchFailure());
+        builder.endObject();
+        return builder;
+    }
+}

--- a/server/src/main/java/org/opensearch/storage/slowlogs/TieredStoragePerQueryMetric.java
+++ b/server/src/main/java/org/opensearch/storage/slowlogs/TieredStoragePerQueryMetric.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.slowlogs;
+
+import org.apache.lucene.util.Accountable;
+
+/**
+ * Interface that needs to be implemented by any per query metric collector.
+ *
+ * @opensearch.experimental
+ */
+public interface TieredStoragePerQueryMetric extends Accountable {
+
+    /**
+     * Records a file access event.
+     * @param blockFileName the block file name
+     * @param hit whether the access was a cache hit
+     */
+    void recordFileAccess(String blockFileName, boolean hit);
+
+    /**
+     * Records a prefetch event.
+     * @param fileName the file name
+     * @param blockId the block id
+     */
+    void recordPrefetch(String fileName, int blockId);
+
+    /**
+     * Records a read-ahead event.
+     * @param fileName the file name
+     * @param blockId the block id
+     */
+    void recordReadAhead(String fileName, int blockId);
+
+    /** Records the end time of the metric collection. */
+    void recordEndTime();
+
+    /**
+     * Returns the parent task id.
+     * @return the parent task id
+     */
+    String getParentTaskId();
+
+    /**
+     * Returns the shard id.
+     * @return the shard id
+     */
+    String getShardId();
+}

--- a/server/src/main/java/org/opensearch/storage/slowlogs/TieredStoragePerQueryMetricImpl.java
+++ b/server/src/main/java/org/opensearch/storage/slowlogs/TieredStoragePerQueryMetricImpl.java
@@ -1,0 +1,379 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.slowlogs;
+
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implementation for collecting tiered storage metrics at per query level.
+ * Tracks cache hits/misses, prefetch operations, and read-ahead operations
+ * for each file accessed during a query.
+ *
+ * @opensearch.experimental
+ */
+public class TieredStoragePerQueryMetricImpl implements TieredStoragePerQueryMetric, ToXContentObject {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(TieredStoragePerQueryMetricImpl.class);
+    private static final long FC_BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FileCacheStat.class);
+    private static final long PREFETCH_BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(PrefetchStat.class);
+    private static final long READ_AHEAD_BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ReadAheadStat.class);
+
+    // File Cache stats will include hit/miss for both block and full file
+    protected final Map<String, FileCacheStat> fileCacheStats;
+
+    /** Prefetch stats per file. */
+    protected final Map<String, PrefetchStat> prefetchStats;
+    /** Prefetch file timestamps. */
+    protected final Map<String, Long> prefetchFiles;
+    /** Read-ahead stats per file. */
+    protected final Map<String, ReadAheadStat> readAheadStats;
+    /** Read-ahead file timestamps. */
+    protected final Map<String, Long> readAheadFiles;
+
+    /** Effective bytes transferred. */
+    protected long effectiveBytes;
+    /** Total cache hits. */
+    protected long hits;
+    /** Total cache misses. */
+    protected long miss;
+    private final String parentTaskId;
+    private final String shardId;
+    private final long startTime;
+    private long endTime;
+
+    /**
+     * Creates a new per-query metric collector.
+     * @param parentTaskId the parent task id
+     * @param shardId the shard id
+     */
+    public TieredStoragePerQueryMetricImpl(String parentTaskId, String shardId) {
+        this.parentTaskId = parentTaskId;
+        this.shardId = shardId;
+        this.fileCacheStats = new HashMap<>();
+        this.prefetchStats = new HashMap<>();
+        this.prefetchFiles = new HashMap<>();
+        this.readAheadStats = new HashMap<>();
+        this.readAheadFiles = new HashMap<>();
+        this.effectiveBytes = 0L;
+        this.hits = 0L;
+        this.miss = 0L;
+        this.startTime = System.currentTimeMillis();
+        this.endTime = 0L;
+    }
+
+    private FileBlock getFileBlock(String blockFileName) {
+        String[] fileParts = blockFileName.split("[.]", -1);
+        String fileName = fileParts[0];
+        String[] blocks = fileParts[1].split("_", -1);
+        fileName = fileName + blocks[0];
+        if (fileParts.length == 2 && blocks.length == 3) {
+            // ignore the 4th part which is the block extension
+            return new FileBlock(fileName, Integer.parseInt(blocks[2]));
+        } else {
+            assert false : "getFileBlock called with invalid block name, possibly without the extension";
+            return new FileBlock(blockFileName, -1);
+        }
+    }
+
+    @Override
+    public void recordFileAccess(String blockFileName, boolean hit) {
+        final FileBlock fileBlock = getFileBlock(blockFileName);
+        FileCacheStat fileCacheStat = this.fileCacheStats.get(fileBlock.fileName);
+        if (fileCacheStat == null) {
+            fileCacheStat = new FileCacheStat();
+            this.fileCacheStats.put(fileBlock.fileName, fileCacheStat);
+        }
+        if (hit) {
+            fileCacheStat.hits++;
+            this.hits++;
+            fileCacheStat.hitBlocks.add(fileBlock.blockId);
+        } else {
+            fileCacheStat.miss++;
+            this.miss++;
+            fileCacheStat.missBlocks.add(fileBlock.blockId);
+        }
+    }
+
+    @Override
+    public void recordPrefetch(String fileName, int blockId) {
+        if (!this.prefetchFiles.containsKey(fileName)) {
+            this.prefetchFiles.put(fileName, System.currentTimeMillis());
+            this.prefetchStats.put(fileName, new PrefetchStat());
+        }
+        this.prefetchStats.get(fileName).prefetchBlocks.add(blockId);
+    }
+
+    @Override
+    public void recordReadAhead(String fileName, int blockId) {
+        if (!this.readAheadFiles.containsKey(fileName)) {
+            this.readAheadFiles.put(fileName, System.currentTimeMillis());
+            this.readAheadStats.put(fileName, new ReadAheadStat());
+        }
+        this.readAheadStats.get(fileName).readAheadBlocks.add(blockId);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        long size = BASE_RAM_BYTES_USED;
+        // While this is not completely accurate, it serves as
+        // good approximation for tracking any memory leaks
+        size += RamUsageEstimator.sizeOf(fileCacheStats.values().toArray(new FileCacheStat[0]));
+        return size;
+    }
+
+    @Override
+    public void recordEndTime() {
+        this.endTime = System.currentTimeMillis();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("parentTask", parentTaskId);
+        builder.field("shardId", shardId);
+
+        // Summary section
+        builder.startObject("summary");
+        builder.field("fileCache", String.format(Locale.ROOT, "%d hits out of %d total", this.hits, this.hits + this.miss));
+        builder.field("prefetchFiles", this.prefetchFiles);
+        builder.field("readAheadFiles", this.readAheadFiles);
+        builder.endObject();
+
+        // Details section
+        builder.startObject("details");
+
+        // File cache details
+        builder.startObject("fileCache");
+        for (Map.Entry<String, FileCacheStat> entry : this.fileCacheStats.entrySet()) {
+            builder.startObject(entry.getKey());
+            entry.getValue().toXContent(builder, params);
+            builder.endObject();
+        }
+        builder.endObject();
+
+        // Prefetch details
+        // Prefetch details
+        builder.startObject("prefetch");
+        for (Map.Entry<String, PrefetchStat> entry : this.prefetchStats.entrySet()) {
+            builder.startObject(entry.getKey());
+            entry.getValue().toXContent(builder, params);
+            builder.endObject();
+        }
+        builder.endObject();
+
+        // ReadAhead details
+        builder.startObject("readAhead");
+        for (Map.Entry<String, ReadAheadStat> entry : this.readAheadStats.entrySet()) {
+            builder.startObject(entry.getKey());
+            entry.getValue().toXContent(builder, params);
+            builder.endObject();
+        }
+        builder.endObject();
+
+        builder.endObject(); // end details
+
+        // Timestamps section
+        builder.startObject("timestamps");
+        builder.field("startTime", this.startTime);
+        builder.field("endTime", this.endTime);
+        builder.endObject();
+
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            toXContent(builder, ToXContent.EMPTY_PARAMS);
+            return builder.toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String getParentTaskId() {
+        return parentTaskId;
+    }
+
+    @Override
+    public String getShardId() {
+        return shardId;
+    }
+
+    private long getSetSize(Set<Integer> set) {
+        // While this is not completely accurate, it serves as
+        // good approximation for tracking any memory leaks
+        long size = RamUsageEstimator.shallowSizeOf(set);
+        size += set.size() * RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        size += set.size() * Integer.BYTES;
+        return size;
+    }
+
+    private class FileBlock {
+        final String fileName;
+        final int blockId;
+
+        FileBlock(String fileName, int blockId) {
+            this.fileName = fileName;
+            this.blockId = blockId;
+        }
+    }
+
+    /**
+     * Tracks file cache hit/miss statistics per file.
+     *
+     * @opensearch.experimental
+     */
+    protected class FileCacheStat implements Accountable, ToXContent {
+        /** Number of cache hits. */
+        public long hits;
+        /** Number of cache misses. */
+        public long miss;
+        /** Set of block IDs that were cache hits. */
+        public Set<Integer> hitBlocks;
+        /** Set of block IDs that were cache misses. */
+        public Set<Integer> missBlocks;
+
+        /** Creates a new FileCacheStat instance. */
+        public FileCacheStat() {
+            this.hits = 0L;
+            this.miss = 0L;
+            this.hitBlocks = new HashSet<>();
+            this.missBlocks = new HashSet<>();
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.field("hits", this.hits);
+            builder.field("miss", this.miss);
+            builder.field("total", this.hits + this.miss);
+
+            if (!hitBlocks.isEmpty() || !missBlocks.isEmpty()) {
+                builder.startObject("blockDetails");
+                builder.field("hitBlockCount", this.hitBlocks.size());
+                builder.field("hitBlocks", this.hitBlocks);
+                builder.field("missBlockCount", this.missBlocks.size());
+                builder.field("missBlocks", this.missBlocks);
+                builder.endObject();
+            }
+
+            return builder;
+        }
+
+        @Override
+        public String toString() {
+            // Full file case
+            if (hitBlocks.isEmpty() && missBlocks.isEmpty()) {
+                return String.format(Locale.ROOT, "%d hits out of %d total", this.hits, this.hits + this.miss);
+            } else {
+                return String.format(
+                    Locale.ROOT,
+                    "%d hits out of %d total, %d distinct hit blocks - %s, %d distinct miss blocks - %s",
+                    this.hits,
+                    this.hits + this.miss,
+                    this.hitBlocks.size(),
+                    this.hitBlocks,
+                    this.missBlocks.size(),
+                    this.missBlocks
+                );
+            }
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            long size = FC_BASE_RAM_BYTES_USED;
+            size += getSetSize(hitBlocks);
+            size += getSetSize(missBlocks);
+            return size;
+        }
+    }
+
+    /**
+     * Tracks read-ahead statistics per file.
+     *
+     * @opensearch.experimental
+     */
+    protected class ReadAheadStat implements Accountable, ToXContent {
+        /** Set of block IDs that were read ahead. */
+        public Set<Integer> readAheadBlocks;
+
+        /** Creates a new ReadAheadStat instance. */
+        public ReadAheadStat() {
+            this.readAheadBlocks = new HashSet<>();
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.field("blockCount", this.readAheadBlocks.size());
+            builder.field("blocks", this.readAheadBlocks);
+            return builder;
+        }
+
+        @Override
+        public String toString() {
+            return String.format(Locale.ROOT, "%d distinct submitted blocks - %s,", this.readAheadBlocks.size(), this.readAheadBlocks);
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            long size = READ_AHEAD_BASE_RAM_BYTES_USED;
+            size += getSetSize(readAheadBlocks);
+            return size;
+        }
+    }
+
+    /**
+     * Tracks prefetch statistics per file.
+     *
+     * @opensearch.experimental
+     */
+    protected class PrefetchStat implements Accountable, ToXContent {
+        /** Set of block IDs that were prefetched. */
+        public Set<Integer> prefetchBlocks;
+
+        /** Creates a new PrefetchStat instance. */
+        public PrefetchStat() {
+            this.prefetchBlocks = new HashSet<>();
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.field("blockCount", this.prefetchBlocks.size());
+            builder.field("blocks", this.prefetchBlocks);
+            return builder;
+        }
+
+        @Override
+        public String toString() {
+            return String.format(Locale.ROOT, "%d distinct submitted blocks - %s", this.prefetchBlocks.size(), this.prefetchBlocks);
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            long size = PREFETCH_BASE_RAM_BYTES_USED;
+            size += getSetSize(prefetchBlocks);
+            return size;
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/storage/slowlogs/TieredStorageQueryMetricService.java
+++ b/server/src/main/java/org/opensearch/storage/slowlogs/TieredStorageQueryMetricService.java
@@ -1,0 +1,303 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.slowlogs;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.opensearch.common.metrics.CounterMetric;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Singleton service for maintaining per-query metric collectors across threads.
+ * Provides thread-safe access to metric collectors during query and fetch phases.
+ *
+ * @opensearch.experimental
+ */
+public class TieredStorageQueryMetricService {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(TieredStorageQueryMetricService.class);
+
+    private static final Logger logger = LogManager.getLogger(TieredStorageQueryMetricService.class);
+
+    private static final TieredStorageQueryMetricService INSTANCE = new TieredStorageQueryMetricService();
+
+    /**
+     * Map of thread ID to active collector. Only one collector is active per thread at a time.
+     */
+    protected final ConcurrentMap<Long, TieredStoragePerQueryMetric> metricCollectors = new ConcurrentHashMap<>();
+
+    /**
+     * Map of task id + shard id to set of collectors for query phase.
+     * Multiple threads can work on the same shard concurrently during concurrent segment search.
+     */
+    protected final ConcurrentMap<String, Set<TieredStoragePerQueryMetric>> taskIdToQueryPhaseCollectorMap = new ConcurrentHashMap<>();
+
+    /**
+     * Map of task id + shard id to set of collectors for fetch phase.
+     */
+    protected final ConcurrentMap<String, Set<TieredStoragePerQueryMetric>> taskIdToFetchPhaseCollectorMap = new ConcurrentHashMap<>();
+
+    private final PrefetchStatsHolder prefetchStats = new PrefetchStatsHolder();
+
+    private static final int MAX_PER_QUERY_COLLECTOR_SIZE = 1000;
+
+    private TieredStorageQueryMetricService() {}
+
+    /**
+     * Returns the singleton instance.
+     * @return the singleton instance
+     */
+    public static TieredStorageQueryMetricService getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Returns the per-query metric collector for the given thread.
+     * Returns a no-op dummy collector if none exists.
+     * @param threadId the thread id
+     * @return the metric collector for the thread
+     */
+    public TieredStoragePerQueryMetric getMetricCollector(final long threadId) {
+        return metricCollectors.getOrDefault(threadId, TieredStoragePerQueryMetricDummy.getInstance());
+    }
+
+    /**
+     * Adds a metric collector for the given thread. Enforces a hard limit on the
+     * number of collectors to prevent excessive memory consumption.
+     * @param threadId the thread id
+     * @param metricCollector the metric collector
+     * @param isQueryPhase true if this is for the query phase, false for fetch phase
+     */
+    public void addMetricCollector(final long threadId, final TieredStoragePerQueryMetric metricCollector, boolean isQueryPhase) {
+        // TODO if possible add thread id in collector
+        if (metricCollectors.size() >= MAX_PER_QUERY_COLLECTOR_SIZE
+            || taskIdToQueryPhaseCollectorMap.values().stream().mapToInt(Set::size).sum() >= MAX_PER_QUERY_COLLECTOR_SIZE
+            || taskIdToFetchPhaseCollectorMap.values().stream().mapToInt(Set::size).sum() >= MAX_PER_QUERY_COLLECTOR_SIZE) {
+            logger.error(
+                "Number of metric collectors already equals maximum size of "
+                    + MAX_PER_QUERY_COLLECTOR_SIZE
+                    + ". Skipping. Current sizes - metricCollectors: "
+                    + metricCollectors.size()
+                    + ", queryPhaseCollectors: "
+                    + taskIdToQueryPhaseCollectorMap.values().stream().mapToInt(Set::size).sum()
+                    + ", fetchPhaseCollectors: "
+                    + taskIdToFetchPhaseCollectorMap.values().stream().mapToInt(Set::size).sum()
+            );
+        } else {
+            // The same threadId will not be used concurrently, so below is safe
+            metricCollectors.put(threadId, metricCollector);
+            // Multiple threads can be working on the same shard at the same time though, so below needs to be atomic
+            if (isQueryPhase) {
+                taskIdToQueryPhaseCollectorMap.compute(
+                    metricCollector.getParentTaskId() + metricCollector.getShardId(),
+                    (id, collectors) -> {
+                        Set<TieredStoragePerQueryMetric> newCollectors = (collectors == null) ? new HashSet<>() : collectors;
+                        newCollectors.add(metricCollector);
+                        return newCollectors;
+                    }
+                );
+            } else {
+                taskIdToFetchPhaseCollectorMap.compute(
+                    metricCollector.getParentTaskId() + metricCollector.getShardId(),
+                    (id, collectors) -> {
+                        Set<TieredStoragePerQueryMetric> newCollectors = (collectors == null) ? new HashSet<>() : collectors;
+                        newCollectors.add(metricCollector);
+                        return newCollectors;
+                    }
+                );
+            }
+        }
+    }
+
+    /**
+     * Removes the metric collector for the given thread and records its end time.
+     * @param threadId the thread id
+     * @return the removed metric collector, or null if none existed
+     */
+    public TieredStoragePerQueryMetric removeMetricCollector(final long threadId) {
+        // Do not update taskIdToCollectorMap here as the query may not be complete
+        // For safety, use getOrDefault here
+        metricCollectors.getOrDefault(threadId, TieredStoragePerQueryMetricDummy.getInstance()).recordEndTime();
+        return metricCollectors.remove(threadId);
+    }
+
+    /**
+     * Removes all metric collectors for the given task and shard combination.
+     * @param parentTaskId the parent task id
+     * @param shardId the shard id
+     * @param isQueryPhase true for query phase collectors, false for fetch phase
+     * @return the set of removed collectors
+     */
+    public Set<TieredStoragePerQueryMetric> removeMetricCollectors(String parentTaskId, String shardId, boolean isQueryPhase) {
+        final Set<TieredStoragePerQueryMetric> collectors;
+        if (isQueryPhase) {
+            collectors = taskIdToQueryPhaseCollectorMap.remove(parentTaskId + shardId);
+        } else {
+            collectors = taskIdToFetchPhaseCollectorMap.remove(parentTaskId + shardId);
+        }
+        if (collectors == null) {
+            // Slice Execution hooks will not be triggered in the case of a cache hit, however query phase hooks will always be triggered
+            return Collections.emptySet();
+        }
+        return collectors;
+    }
+
+    /**
+     * Returns the task-to-collector map for testing.
+     * @param isQueryPhase true for query phase map, false for fetch phase
+     * @return the task-to-collector map
+     */
+    Map<String, Set<TieredStoragePerQueryMetric>> getTaskIdToCollectorMap(boolean isQueryPhase) {
+        return isQueryPhase ? taskIdToQueryPhaseCollectorMap : taskIdToFetchPhaseCollectorMap;
+    }
+
+    /**
+     * Returns the metric collectors map for testing.
+     * @return the metric collectors map
+     */
+    Map<Long, TieredStoragePerQueryMetric> getMetricCollectors() {
+        return metricCollectors;
+    }
+
+    /**
+     * Returns estimated memory consumption of the metric service.
+     * @return ram bytes usage
+     */
+    public long ramBytesUsed() {
+        long size = BASE_RAM_BYTES_USED;
+        // While this is not completely accurate, it serves as good approximation for tracking any memory leaks
+        // Each collector in metricCollectors will also be referenced in taskIdToCollectorMap, however the opposite is not true.
+        // Therefore, we use taskIdToCollectorMap to estimate ram usage.
+        for (Set<TieredStoragePerQueryMetric> collectors : taskIdToQueryPhaseCollectorMap.values()) {
+            size += RamUsageEstimator.sizeOf(collectors.toArray(new TieredStoragePerQueryMetric[0]));
+        }
+        for (Set<TieredStoragePerQueryMetric> collectors : taskIdToFetchPhaseCollectorMap.values()) {
+            size += RamUsageEstimator.sizeOf(collectors.toArray(new TieredStoragePerQueryMetric[0]));
+        }
+        return size;
+    }
+
+    /**
+     * Records a stored fields prefetch event.
+     * @param success true if the prefetch was successful
+     */
+    public void recordStoredFieldsPrefetch(boolean success) {
+        if (success) {
+            prefetchStats.storedFieldsPrefetchSuccess.inc();
+        } else {
+            prefetchStats.storedFieldsPrefetchFailure.inc();
+        }
+    }
+
+    /**
+     * Records a doc values prefetch event.
+     * @param success true if the prefetch was successful
+     */
+    public void recordDocValuesPrefetch(boolean success) {
+        if (success) {
+            prefetchStats.docValuesPrefetchSuccess.inc();
+        } else {
+            prefetchStats.docValuesPrefetchFailure.inc();
+        }
+    }
+
+    /**
+     * Returns the current prefetch stats.
+     * @return the prefetch stats
+     */
+    // TODO has to emit as part of node stats
+    public PrefetchStats getPrefetchStats() {
+        return this.prefetchStats.getStats();
+    }
+
+    /**
+     * No-op dummy metric collector to avoid null checks throughout the codebase.
+     *
+     * @opensearch.experimental
+     */
+    static class TieredStoragePerQueryMetricDummy implements TieredStoragePerQueryMetric {
+        private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(TieredStoragePerQueryMetricDummy.class);
+        private static final TieredStoragePerQueryMetricDummy INSTANCE = new TieredStoragePerQueryMetricDummy();
+
+        /**
+         * Returns the singleton dummy instance.
+         * @return the dummy instance
+         */
+        public static TieredStoragePerQueryMetricDummy getInstance() {
+            return INSTANCE;
+        }
+
+        private TieredStoragePerQueryMetricDummy() {}
+
+        @Override
+        public void recordFileAccess(String blockFileName, boolean hit) {
+            // Do nothing
+        }
+
+        @Override
+        public void recordEndTime() {}
+
+        @Override
+        public void recordPrefetch(String fileName, int blockId) {}
+
+        @Override
+        public void recordReadAhead(String fileName, int blockId) {}
+
+        @Override
+        public String getParentTaskId() {
+            return "DummyParentTaskId";
+        }
+
+        @Override
+        public String getShardId() {
+            return "DummyShardId";
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return BASE_RAM_BYTES_USED;
+        }
+    }
+
+    /**
+     * Holder for prefetch statistics counters.
+     *
+     * @opensearch.experimental
+     */
+    public static final class PrefetchStatsHolder {
+        /** Counter for successful stored fields prefetches. */
+        final CounterMetric storedFieldsPrefetchSuccess = new CounterMetric();
+        /** Counter for failed stored fields prefetches. */
+        final CounterMetric storedFieldsPrefetchFailure = new CounterMetric();
+        /** Counter for successful doc values prefetches. */
+        final CounterMetric docValuesPrefetchSuccess = new CounterMetric();
+        /** Counter for failed doc values prefetches. */
+        final CounterMetric docValuesPrefetchFailure = new CounterMetric();
+
+        /**
+         * Returns the current prefetch stats snapshot.
+         * @return the prefetch stats
+         */
+        PrefetchStats getStats() {
+            return new PrefetchStats(
+                storedFieldsPrefetchSuccess.count(),
+                storedFieldsPrefetchFailure.count(),
+                docValuesPrefetchSuccess.count(),
+                docValuesPrefetchFailure.count()
+            );
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/storage/slowlogs/TieredStorageSearchSlowLog.java
+++ b/server/src/main/java/org/opensearch/storage/slowlogs/TieredStorageSearchSlowLog.java
@@ -1,0 +1,577 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.slowlogs;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.logging.SlowLogLevel;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Setting.Property;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.shard.SearchOperationListener;
+import org.opensearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Search slow log implementation for tiered storage (warm data).
+ * Logs slow queries and fetches with per-query cache and prefetch metrics.
+ *
+ * @opensearch.experimental
+ */
+public final class TieredStorageSearchSlowLog implements SearchOperationListener {
+
+    private volatile boolean tieredStorageSlowlogEnabled;
+    private volatile long queryWarnThreshold;
+    private volatile long queryInfoThreshold;
+    private volatile long queryDebugThreshold;
+    private volatile long queryTraceThreshold;
+
+    private volatile long fetchWarnThreshold;
+    private volatile long fetchInfoThreshold;
+    private volatile long fetchDebugThreshold;
+    private volatile long fetchTraceThreshold;
+
+    private SlowLogLevel level;
+
+    private final Logger queryLogger;
+    private final Logger fetchLogger;
+
+    /** Settings prefix for tiered storage search slow log. */
+    public static final String TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX = "index.tiered.storage.slowlog";
+
+    /** Setting to enable or disable tiered storage search slow log. */
+    public static final Setting<Boolean> TIERED_STORAGE_SEARCH_SLOWLOG_ENABLED = Setting.boolSetting(
+        TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".enabled",
+        false,
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /** Query warn threshold setting. */
+    public static final Setting<TimeValue> INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING = Setting.timeSetting(
+        TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".threshold.query.warn",
+        TimeValue.timeValueMillis(10000),
+        TimeValue.timeValueMillis(-1),
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /** Query info threshold setting. */
+    public static final Setting<TimeValue> INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_INFO_SETTING = Setting.timeSetting(
+        TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".threshold.query.info",
+        TimeValue.timeValueMillis(5000),
+        TimeValue.timeValueMillis(-1),
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /** Query debug threshold setting. */
+    public static final Setting<TimeValue> INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_DEBUG_SETTING = Setting.timeSetting(
+        TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".threshold.query.debug",
+        TimeValue.timeValueMillis(2000),
+        TimeValue.timeValueMillis(-1),
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /** Query trace threshold setting. */
+    public static final Setting<TimeValue> INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_TRACE_SETTING = Setting.timeSetting(
+        TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".threshold.query.trace",
+        TimeValue.timeValueMillis(500),
+        TimeValue.timeValueMillis(-1),
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /** Fetch warn threshold setting. */
+    public static final Setting<TimeValue> INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING = Setting.timeSetting(
+        TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".threshold.fetch.warn",
+        TimeValue.timeValueMillis(10000),
+        TimeValue.timeValueMillis(-1),
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /** Fetch info threshold setting. */
+    public static final Setting<TimeValue> INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO_SETTING = Setting.timeSetting(
+        TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".threshold.fetch.info",
+        TimeValue.timeValueMillis(5000),
+        TimeValue.timeValueMillis(-1),
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /** Fetch debug threshold setting. */
+    public static final Setting<TimeValue> INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING = Setting.timeSetting(
+        TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".threshold.fetch.debug",
+        TimeValue.timeValueMillis(2000),
+        TimeValue.timeValueMillis(-1),
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /** Fetch trace threshold setting. */
+    public static final Setting<TimeValue> INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_TRACE_SETTING = Setting.timeSetting(
+        TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".threshold.fetch.trace",
+        TimeValue.timeValueMillis(500),
+        TimeValue.timeValueMillis(-1),
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /** Slow log level setting. */
+    public static final Setting<SlowLogLevel> INDEX_SEARCH_SLOWLOG_LEVEL = new Setting<>(
+        TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".level",
+        SlowLogLevel.TRACE.name(),
+        SlowLogLevel::parse,
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
+    /** Map of all tiered storage search slow log settings keyed by setting name. */
+    public static final Map<String, Setting<?>> TIERED_STORAGE_SEARCH_SLOWLOG_SETTINGS_MAP = Collections.unmodifiableMap(new HashMap<>() {
+        {
+            put(TIERED_STORAGE_SEARCH_SLOWLOG_ENABLED.getKey(), TIERED_STORAGE_SEARCH_SLOWLOG_ENABLED);
+            put(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING.getKey(), INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING);
+            put(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_INFO_SETTING.getKey(), INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_INFO_SETTING);
+            put(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_DEBUG_SETTING.getKey(), INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_DEBUG_SETTING);
+            put(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_TRACE_SETTING.getKey(), INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_TRACE_SETTING);
+            put(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING.getKey(), INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING);
+            put(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO_SETTING.getKey(), INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO_SETTING);
+            put(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING.getKey(), INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING);
+            put(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_TRACE_SETTING.getKey(), INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_TRACE_SETTING);
+            put(INDEX_SEARCH_SLOWLOG_LEVEL.getKey(), INDEX_SEARCH_SLOWLOG_LEVEL);
+        }
+    });
+
+    /** Set of all tiered storage search slow log settings. */
+    public static final Set<Setting<?>> TIERED_STORAGE_SEARCH_SLOWLOG_SETTINGS = Collections.unmodifiableSet(
+        new HashSet<>(TIERED_STORAGE_SEARCH_SLOWLOG_SETTINGS_MAP.values())
+    );
+
+    private static final ToXContent.Params FORMAT_PARAMS = new ToXContent.MapParams(Collections.singletonMap("pretty", "false"));
+
+    /**
+     * Creates a new TieredStorageSearchSlowLog instance.
+     * @param indexSettings the index settings
+     */
+    public TieredStorageSearchSlowLog(IndexSettings indexSettings) {
+        this.queryLogger = LogManager.getLogger(TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".query");
+        this.fetchLogger = LogManager.getLogger(TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".fetch");
+
+        indexSettings.getScopedSettings()
+            .addSettingsUpdateConsumer(TIERED_STORAGE_SEARCH_SLOWLOG_ENABLED, this::setTieredStorageSlowlogEnabled);
+        setTieredStorageSlowlogEnabled(indexSettings.getValue(TIERED_STORAGE_SEARCH_SLOWLOG_ENABLED));
+
+        indexSettings.getScopedSettings()
+            .addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING, this::setQueryWarnThreshold);
+        setQueryWarnThreshold(indexSettings.getValue(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING));
+        indexSettings.getScopedSettings()
+            .addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_INFO_SETTING, this::setQueryInfoThreshold);
+        setQueryInfoThreshold(indexSettings.getValue(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_INFO_SETTING));
+        indexSettings.getScopedSettings()
+            .addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_DEBUG_SETTING, this::setQueryDebugThreshold);
+        setQueryDebugThreshold(indexSettings.getValue(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_DEBUG_SETTING));
+        indexSettings.getScopedSettings()
+            .addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_TRACE_SETTING, this::setQueryTraceThreshold);
+        setQueryTraceThreshold(indexSettings.getValue(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_TRACE_SETTING));
+
+        indexSettings.getScopedSettings()
+            .addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING, this::setFetchWarnThreshold);
+        setFetchWarnThreshold(indexSettings.getValue(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING));
+        indexSettings.getScopedSettings()
+            .addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO_SETTING, this::setFetchInfoThreshold);
+        setFetchInfoThreshold(indexSettings.getValue(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO_SETTING));
+        indexSettings.getScopedSettings()
+            .addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING, this::setFetchDebugThreshold);
+        setFetchDebugThreshold(indexSettings.getValue(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING));
+        indexSettings.getScopedSettings()
+            .addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_TRACE_SETTING, this::setFetchTraceThreshold);
+        setFetchTraceThreshold(indexSettings.getValue(INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_TRACE_SETTING));
+
+        indexSettings.getScopedSettings().addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_LEVEL, this::setLevel);
+        setLevel(indexSettings.getValue(INDEX_SEARCH_SLOWLOG_LEVEL));
+    }
+
+    private void setLevel(SlowLogLevel level) {
+        this.level = level;
+        Loggers.setLevel(queryLogger, level.name());
+        Loggers.setLevel(fetchLogger, level.name());
+    }
+
+    private TieredStoragePerQueryMetric removeMetricCollector() {
+        return TieredStorageQueryMetricService.getInstance().removeMetricCollector(Thread.currentThread().threadId());
+    }
+
+    private Set<TieredStoragePerQueryMetric> removeMetricCollectors(String parentTaskId, String shardId, boolean isQueryPhase) {
+        return TieredStorageQueryMetricService.getInstance().removeMetricCollectors(parentTaskId, shardId, isQueryPhase);
+    }
+
+    private void setMetricCollector(SearchContext searchContext, boolean isQueryPhase) {
+        final SearchShardTask searchTask = searchContext.getTask();
+        final Logger log = isQueryPhase ? queryLogger : fetchLogger;
+        if (searchTask == null) {
+            log.error("Warm Slow Log: Search Task not expected to be null");
+        }
+        TieredStorageQueryMetricService.getInstance()
+            .addMetricCollector(
+                Thread.currentThread().threadId(),
+                new TieredStoragePerQueryMetricImpl(
+                    searchTask == null ? null : searchTask.getParentTaskId().toString(),
+                    searchContext.shardTarget().getShardId().toString()
+                ),
+                isQueryPhase
+            );
+    }
+
+    @Override
+    public void onPreQueryPhase(SearchContext searchContext) {
+        // The same search thread can pick up multiple slice executions post https://github.com/apache/lucene/pull/13472
+        // so we initialize collectors only in onPreSliceExecution
+    }
+
+    @Override
+    public void onFailedQueryPhase(SearchContext searchContext) {
+        // Only clean up if we were collecting metrics
+        if (tieredStorageSlowlogEnabled) {
+            removeMetricCollector();
+            removeMetricCollectors(
+                searchContext.getTask().getParentTaskId().toString(),
+                searchContext.shardTarget().getShardId().toString(),
+                true
+            );
+        }
+    }
+
+    @Override
+    public void onQueryPhase(SearchContext context, long tookInNanos) {
+        // Get all collectors associated with the task/shard
+        final List<TieredStoragePerQueryMetric> metricCollectors = new ArrayList<>(
+            removeMetricCollectors(context.getTask().getParentTaskId().toString(), context.shardTarget().getShardId().toString(), true)
+        );
+
+        // No need to call removeMetricCollector() here as that will be handled in onSliceExecution in both
+        // concurrent search and non-concurrent search cases
+
+        // Only log if tiered storage slow log is enabled
+        if (tieredStorageSlowlogEnabled) {
+            printSlowLog(
+                context,
+                tookInNanos,
+                metricCollectors,
+                queryWarnThreshold,
+                queryLogger,
+                queryInfoThreshold,
+                queryDebugThreshold,
+                queryTraceThreshold
+            );
+        }
+    }
+
+    private void printSlowLog(
+        SearchContext context,
+        long tookInNanos,
+        List<TieredStoragePerQueryMetric> metricCollectors,
+        long warnThreshold,
+        Logger log,
+        long infoThreshold,
+        long debugThreshold,
+        long traceThreshold
+    ) {
+        if (warnThreshold >= 0 && tookInNanos > warnThreshold) {
+            log.warn("{}", new TieredStorageSlowLogPrinter(context, tookInNanos, metricCollectors));
+        } else if (infoThreshold >= 0 && tookInNanos > infoThreshold) {
+            log.info("{}", new TieredStorageSlowLogPrinter(context, tookInNanos, metricCollectors));
+        } else if (debugThreshold >= 0 && tookInNanos > debugThreshold) {
+            log.debug("{}", new TieredStorageSlowLogPrinter(context, tookInNanos, metricCollectors));
+        } else if (traceThreshold >= 0 && tookInNanos > traceThreshold) {
+            log.trace("{}", new TieredStorageSlowLogPrinter(context, tookInNanos, metricCollectors));
+        }
+    }
+
+    @Override
+    public void onPreSliceExecution(SearchContext searchContext) {
+        // Only collect metrics if tiered storage slow log is enabled
+        if (tieredStorageSlowlogEnabled) {
+            setMetricCollector(searchContext, true);
+        }
+    }
+
+    @Override
+    public void onFailedSliceExecution(SearchContext searchContext) {
+        // Only clean up if we were collecting metrics
+        if (tieredStorageSlowlogEnabled) {
+            removeMetricCollector();
+        }
+    }
+
+    @Override
+    public void onSliceExecution(SearchContext searchContext) {
+        // Only clean up if we were collecting metrics
+        if (tieredStorageSlowlogEnabled) {
+            removeMetricCollector();
+        }
+    }
+
+    @Override
+    public void onPreFetchPhase(SearchContext searchContext) {
+        // Fetch phase execution is starting. Add new metric collector only if enabled
+        if (tieredStorageSlowlogEnabled) {
+            setMetricCollector(searchContext, false);
+        }
+    }
+
+    @Override
+    public void onFailedFetchPhase(SearchContext searchContext) {
+        // Only clean up if we were collecting metrics
+        if (tieredStorageSlowlogEnabled) {
+            removeMetricCollector();
+            removeMetricCollectors(
+                searchContext.getTask().getParentTaskId().toString(),
+                searchContext.shardTarget().getShardId().toString(),
+                false
+            );
+        }
+    }
+
+    @Override
+    public void onFetchPhase(SearchContext context, long tookInNanos) {
+        // Only clean up and log if we were collecting metrics
+        if (tieredStorageSlowlogEnabled) {
+            removeMetricCollector();
+            // Although fetch phase is single threaded today, we will use the same map implementation for posterity.
+            // It's also much cleaner than propagating the fetch boolean to TieredStorageQueryMetricService
+            final List<TieredStoragePerQueryMetric> metricCollectors = new ArrayList<>(
+                removeMetricCollectors(context.getTask().getParentTaskId().toString(), context.shardTarget().getShardId().toString(), false)
+            );
+            assert metricCollectors.size() == 1 : "Fetch phase is expected to be single threaded, so we should only have 1 collector";
+
+            printSlowLog(
+                context,
+                tookInNanos,
+                metricCollectors,
+                fetchWarnThreshold,
+                fetchLogger,
+                fetchInfoThreshold,
+                fetchDebugThreshold,
+                fetchTraceThreshold
+            );
+        }
+    }
+
+    /**
+     * Formats slow log output as JSON with warm storage metrics.
+     *
+     * @opensearch.experimental
+     */
+    static final class TieredStorageSlowLogPrinter {
+        private final SearchContext context;
+        private final long tookInNanos;
+        private final List<TieredStoragePerQueryMetric> metricCollectors;
+        private final Logger logger = LogManager.getLogger(TieredStorageSlowLogPrinter.class);
+
+        /**
+         * Creates a new slow log printer.
+         * @param context the search context
+         * @param tookInNanos the time taken in nanoseconds
+         * @param metricCollectors the per-query metric collectors
+         */
+        TieredStorageSlowLogPrinter(SearchContext context, long tookInNanos, List<TieredStoragePerQueryMetric> metricCollectors) {
+            this.context = context;
+            this.tookInNanos = tookInNanos;
+            this.metricCollectors = metricCollectors;
+        }
+
+        @Override
+        public String toString() {
+            try {
+                XContentBuilder builder = XContentFactory.jsonBuilder();
+                toXContent(builder, FORMAT_PARAMS);
+                return builder.toString();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+            builder.startObject();
+
+            // warm_stats array
+            builder.startArray("warm_stats");
+            if (metricCollectors != null && !metricCollectors.isEmpty()) {
+                for (TieredStoragePerQueryMetric collector : metricCollectors) {
+                    builder.value(collector.toString());
+                }
+            }
+            builder.endArray();
+
+            // took and took_millis
+            builder.field("took", TimeValue.timeValueNanos(tookInNanos).toString());
+            builder.field("took_millis", TimeUnit.NANOSECONDS.toMillis(tookInNanos));
+
+            // stats array
+            builder.startArray("stats");
+            List<Object> stats = new ArrayList<>();
+            if (context.groupStats() != null) {
+                if (metricCollectors != null) {
+                    stats.addAll(metricCollectors);
+                }
+                stats.addAll(Objects.requireNonNull(context.groupStats()));
+            }
+            if (!stats.isEmpty()) {
+                for (Object stat : stats) {
+                    builder.value(stat.toString());
+                }
+            }
+            builder.endArray();
+
+            // search_type, total_shards, and source
+            builder.field("search_type", context.searchType().toString());
+            builder.field("total_shards", context.numberOfShards());
+
+            if (context.request().source() != null) {
+                builder.field("source", context.request().source().toString(params));
+            } else {
+                builder.nullField("source");
+            }
+
+            builder.endObject();
+            return builder;
+        }
+    }
+
+    /**
+     * Sets whether tiered storage slow log is enabled.
+     * @param tieredStorageSlowlogEnabled true to enable
+     */
+    public void setTieredStorageSlowlogEnabled(boolean tieredStorageSlowlogEnabled) {
+        this.tieredStorageSlowlogEnabled = tieredStorageSlowlogEnabled;
+    }
+
+    private void setQueryWarnThreshold(TimeValue warnThreshold) {
+        this.queryWarnThreshold = warnThreshold.nanos();
+    }
+
+    private void setQueryInfoThreshold(TimeValue infoThreshold) {
+        this.queryInfoThreshold = infoThreshold.nanos();
+    }
+
+    private void setQueryDebugThreshold(TimeValue debugThreshold) {
+        this.queryDebugThreshold = debugThreshold.nanos();
+    }
+
+    private void setQueryTraceThreshold(TimeValue traceThreshold) {
+        this.queryTraceThreshold = traceThreshold.nanos();
+    }
+
+    private void setFetchWarnThreshold(TimeValue warnThreshold) {
+        this.fetchWarnThreshold = warnThreshold.nanos();
+    }
+
+    private void setFetchInfoThreshold(TimeValue infoThreshold) {
+        this.fetchInfoThreshold = infoThreshold.nanos();
+    }
+
+    private void setFetchDebugThreshold(TimeValue debugThreshold) {
+        this.fetchDebugThreshold = debugThreshold.nanos();
+    }
+
+    private void setFetchTraceThreshold(TimeValue traceThreshold) {
+        this.fetchTraceThreshold = traceThreshold.nanos();
+    }
+
+    /**
+     * Returns the query warn threshold in nanoseconds.
+     * @return the threshold
+     */
+    long getQueryWarnThreshold() {
+        return queryWarnThreshold;
+    }
+
+    /**
+     * Returns the query info threshold in nanoseconds.
+     * @return the threshold
+     */
+    long getQueryInfoThreshold() {
+        return queryInfoThreshold;
+    }
+
+    /**
+     * Returns the query debug threshold in nanoseconds.
+     * @return the threshold
+     */
+    long getQueryDebugThreshold() {
+        return queryDebugThreshold;
+    }
+
+    /**
+     * Returns the query trace threshold in nanoseconds.
+     * @return the threshold
+     */
+    long getQueryTraceThreshold() {
+        return queryTraceThreshold;
+    }
+
+    /**
+     * Returns the fetch warn threshold in nanoseconds.
+     * @return the threshold
+     */
+    long getFetchWarnThreshold() {
+        return fetchWarnThreshold;
+    }
+
+    /**
+     * Returns the fetch info threshold in nanoseconds.
+     * @return the threshold
+     */
+    long getFetchInfoThreshold() {
+        return fetchInfoThreshold;
+    }
+
+    /**
+     * Returns the fetch debug threshold in nanoseconds.
+     * @return the threshold
+     */
+    long getFetchDebugThreshold() {
+        return fetchDebugThreshold;
+    }
+
+    /**
+     * Returns the fetch trace threshold in nanoseconds.
+     * @return the threshold
+     */
+    long getFetchTraceThreshold() {
+        return fetchTraceThreshold;
+    }
+
+    /**
+     * Returns the current slow log level.
+     * @return the slow log level
+     */
+    // TODO check this level
+    SlowLogLevel getLevel() {
+        return level;
+    }
+}

--- a/server/src/main/java/org/opensearch/storage/slowlogs/package-info.java
+++ b/server/src/main/java/org/opensearch/storage/slowlogs/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Slow logs and per-query metrics for tiered storage search operations.
+ */
+package org.opensearch.storage.slowlogs;

--- a/server/src/test/java/org/opensearch/storage/slowlogs/TieredStoragePerQueryMetricImplJsonTests.java
+++ b/server/src/test/java/org/opensearch/storage/slowlogs/TieredStoragePerQueryMetricImplJsonTests.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.slowlogs;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+/**
+ * Test class to verify JSON serialization of TieredStoragePerQueryMetricImpl.
+ */
+public class TieredStoragePerQueryMetricImplJsonTests extends OpenSearchTestCase {
+
+    public void testToXContentBasic() throws IOException {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-123", "shard-0");
+
+        // Record some sample data
+        metric.recordFileAccess("file1.block_0_1", true);  // hit
+        metric.recordFileAccess("file1.block_0_2", false); // miss
+        metric.recordPrefetch("file2", 1);
+        metric.recordReadAhead("file3", 2);
+        metric.recordEndTime();
+
+        // Test XContentBuilder serialization
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        metric.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = builder.toString();
+
+        // Verify JSON contains expected fields
+        assertNotNull(json);
+        assertTrue(json.contains("\"parentTask\":\"task-123\""));
+        assertTrue(json.contains("\"shardId\":\"shard-0\""));
+        assertTrue(json.contains("\"summary\""));
+        assertTrue(json.contains("\"details\""));
+        assertTrue(json.contains("\"timestamps\""));
+        assertTrue(json.contains("\"fileCache\""));
+        assertTrue(json.contains("\"prefetch\""));
+        assertTrue(json.contains("\"readAhead\""));
+    }
+
+    public void testToStringUsesXContentBuilder() throws IOException {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-456", "shard-1");
+
+        // Record some sample data
+        metric.recordFileAccess("test.block_0_5", true);
+        metric.recordPrefetch("prefetch-file", 10);
+        metric.recordEndTime();
+
+        // Test toString method (which should use XContentBuilder internally)
+        String jsonString = metric.toString();
+
+        // Verify the toString output is valid JSON
+        assertNotNull(jsonString);
+        assertTrue(jsonString.contains("\"parentTask\":\"task-456\""));
+        assertTrue(jsonString.contains("\"shardId\":\"shard-1\""));
+    }
+
+    public void testEmptyMetricSerialization() throws IOException {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("empty-task", "empty-shard");
+        metric.recordEndTime();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        metric.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = builder.toString();
+
+        // Should still contain basic structure even with no data
+        assertTrue(json.contains("\"parentTask\":\"empty-task\""));
+        assertTrue(json.contains("\"shardId\":\"empty-shard\""));
+        assertTrue(json.contains("\"summary\""));
+        assertTrue(json.contains("\"details\""));
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/slowlogs/TieredStoragePerQueryMetricImplTests.java
+++ b/server/src/test/java/org/opensearch/storage/slowlogs/TieredStoragePerQueryMetricImplTests.java
@@ -1,0 +1,330 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.slowlogs;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+/**
+ * Comprehensive unit tests for TieredStoragePerQueryMetricImpl.
+ */
+public class TieredStoragePerQueryMetricImplTests extends OpenSearchTestCase {
+
+    public void testConstructor() {
+        String parentTaskId = "task-123";
+        String shardId = "shard-0";
+
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl(parentTaskId, shardId);
+
+        assertEquals(parentTaskId, metric.getParentTaskId());
+        assertEquals(shardId, metric.getShardId());
+        assertTrue(metric.ramBytesUsed() > 0);
+    }
+
+    public void testRecordFileAccessHit() {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // Test block file access hit
+        metric.recordFileAccess("file1.block_0_1", true);
+
+        // Verify internal state through XContent
+        String json = metric.toString();
+        assertTrue(json.contains("\"hits\":1"));
+        assertTrue(json.contains("\"miss\":0"));
+        assertTrue(json.contains("\"total\":1"));
+    }
+
+    public void testRecordFileAccessMiss() {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // Test block file access miss
+        metric.recordFileAccess("file1.block_0_1", false);
+
+        // Verify internal state through XContent
+        String json = metric.toString();
+        assertTrue(json.contains("\"hits\":0"));
+        assertTrue(json.contains("\"miss\":1"));
+        assertTrue(json.contains("\"total\":1"));
+    }
+
+    public void testRecordFileAccessMultipleFiles() {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // Test multiple files with different blocks
+        metric.recordFileAccess("file1.block_0_1", true);   // file1 hit
+        metric.recordFileAccess("file1.block_0_2", false);  // file1 miss
+        metric.recordFileAccess("file2.block_0_1", true);   // file2 hit
+        metric.recordFileAccess("file2.block_0_3", true);   // file2 hit
+
+        String json = metric.toString();
+
+        // Should have entries for both files
+        assertTrue(json.contains("file1block"));
+        assertTrue(json.contains("file2block"));
+
+        // Overall stats should be aggregated
+        assertTrue(json.contains("\"fileCache\":\"3 hits out of 4 total\""));
+    }
+
+    public void testRecordFileAccessSameBlockMultipleTimes() {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // Record same block multiple times
+        metric.recordFileAccess("file1.block_0_1", true);
+        metric.recordFileAccess("file1.block_0_1", true);
+        metric.recordFileAccess("file1.block_0_1", false);
+
+        String json = metric.toString();
+
+        // Should have 2 hits and 1 miss for total of 3
+        assertTrue(json.contains("\"hits\":2"));
+        assertTrue(json.contains("\"miss\":1"));
+        assertTrue(json.contains("\"total\":3"));
+
+        // But only 1 unique hit block and 1 unique miss block
+        assertTrue(json.contains("\"hitBlockCount\":1"));
+        assertTrue(json.contains("\"missBlockCount\":1"));
+    }
+
+    public void testRecordPrefetch() {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // Test prefetch recording
+        metric.recordPrefetch("file1", 1);
+        metric.recordPrefetch("file1", 2);
+        metric.recordPrefetch("file2", 5);
+
+        String json = metric.toString();
+
+        // Should have prefetch entries
+        assertTrue(json.contains("\"prefetch\""));
+        assertTrue(json.contains("file1"));
+        assertTrue(json.contains("file2"));
+        assertTrue(json.contains("\"blockCount\":2")); // file1 has 2 blocks
+        assertTrue(json.contains("\"blockCount\":1")); // file2 has 1 block
+    }
+
+    public void testRecordPrefetchSameBlockMultipleTimes() {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // Record same block multiple times - should only count once
+        metric.recordPrefetch("file1", 1);
+        metric.recordPrefetch("file1", 1);
+        metric.recordPrefetch("file1", 1);
+
+        String json = metric.toString();
+
+        // Should only have 1 unique block
+        assertTrue(json.contains("\"blockCount\":1"));
+        assertTrue(json.contains("[1]"));
+    }
+
+    public void testRecordReadAhead() {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // Test read ahead recording
+        metric.recordReadAhead("file1", 10);
+        metric.recordReadAhead("file1", 11);
+        metric.recordReadAhead("file2", 20);
+
+        String json = metric.toString();
+
+        // Should have read ahead entries
+        assertTrue(json.contains("\"readAhead\""));
+        assertTrue(json.contains("file1"));
+        assertTrue(json.contains("file2"));
+        assertTrue(json.contains("\"blockCount\":2")); // file1 has 2 blocks
+        assertTrue(json.contains("\"blockCount\":1")); // file2 has 1 block
+    }
+
+    public void testRecordReadAheadSameBlockMultipleTimes() {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // Record same block multiple times - should only count once
+        metric.recordReadAhead("file1", 5);
+        metric.recordReadAhead("file1", 5);
+        metric.recordReadAhead("file1", 5);
+
+        String json = metric.toString();
+
+        // Should only have 1 unique block
+        assertTrue(json.contains("\"blockCount\":1"));
+        assertTrue(json.contains("[5]"));
+    }
+
+    public void testRecordEndTime() {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        long startTime = System.currentTimeMillis();
+        metric.recordEndTime();
+        long endTime = System.currentTimeMillis();
+
+        String json = metric.toString();
+
+        // Should have timestamps
+        assertTrue(json.contains("\"timestamps\""));
+        assertTrue(json.contains("\"startTime\""));
+        assertTrue(json.contains("\"endTime\""));
+
+        // End time should be after start time and before current time
+        assertTrue(json.contains("\"endTime\":") && !json.contains("\"endTime\":0"));
+    }
+
+    public void testGetFileBlockParsing() {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // Test various block file name formats - use proper format: filename.extension_blockId_blockNumber
+        // Format: filename.extension_blockId_blockNumber where blockNumber is numeric
+        metric.recordFileAccess("segments_1.block_0_123", true);
+        metric.recordFileAccess("_0.cfs_456_789", false);
+        metric.recordFileAccess("test.dat_0_999", true);
+
+        String json = metric.toString();
+
+        // Should parse file names correctly - filename + first part of extension
+        assertTrue(json.contains("segments_1block"));
+        assertTrue(json.contains("_0cfs"));
+        assertTrue(json.contains("testdat"));
+    }
+
+    public void testRamBytesUsed() {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        long initialRam = metric.ramBytesUsed();
+        assertTrue(initialRam > 0);
+
+        // Add some data and verify RAM usage increases
+        metric.recordFileAccess("file1.block_0_1", true);
+        metric.recordFileAccess("file1.block_0_2", false);
+        metric.recordPrefetch("file2", 1);
+        metric.recordReadAhead("file3", 1);
+
+        long finalRam = metric.ramBytesUsed();
+        assertTrue(finalRam >= initialRam);
+    }
+
+    public void testToXContentStructure() throws IOException {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-123", "shard-456");
+
+        // Add comprehensive test data
+        metric.recordFileAccess("file1.block_0_1", true);
+        metric.recordFileAccess("file1.block_0_2", false);
+        metric.recordPrefetch("prefetch-file", 10);
+        metric.recordReadAhead("readahead-file", 20);
+        metric.recordEndTime();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        metric.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = builder.toString();
+
+        // Verify complete structure
+        assertTrue(json.contains("\"parentTask\":\"task-123\""));
+        assertTrue(json.contains("\"shardId\":\"shard-456\""));
+
+        // Summary section
+        assertTrue(json.contains("\"summary\""));
+        assertTrue(json.contains("\"fileCache\":\"1 hits out of 2 total\""));
+        assertTrue(json.contains("\"prefetchFiles\""));
+        assertTrue(json.contains("\"readAheadFiles\""));
+
+        // Details section
+        assertTrue(json.contains("\"details\""));
+        assertTrue(json.contains("\"fileCache\""));
+        assertTrue(json.contains("\"prefetch\""));
+        assertTrue(json.contains("\"readAhead\""));
+
+        // Timestamps section
+        assertTrue(json.contains("\"timestamps\""));
+        assertTrue(json.contains("\"startTime\""));
+        assertTrue(json.contains("\"endTime\""));
+    }
+
+    public void testToStringHandlesIOException() {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // toString should not throw exception even if there are issues
+        String result = metric.toString();
+        assertNotNull(result);
+        assertTrue(result.length() > 0);
+    }
+
+    public void testFileCacheStatToXContent() throws IOException {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // Record data to create FileCacheStat
+        metric.recordFileAccess("file1.block_0_1", true);
+        metric.recordFileAccess("file1.block_0_2", false);
+        metric.recordFileAccess("file1.block_0_3", true);
+
+        String json = metric.toString();
+
+        // Verify FileCacheStat XContent structure
+        assertTrue(json.contains("\"hits\":2"));
+        assertTrue(json.contains("\"miss\":1"));
+        assertTrue(json.contains("\"total\":3"));
+        assertTrue(json.contains("\"blockDetails\""));
+        assertTrue(json.contains("\"hitBlockCount\":2"));
+        assertTrue(json.contains("\"hitBlocks\":[1,3]"));
+        assertTrue(json.contains("\"missBlockCount\":1"));
+        assertTrue(json.contains("\"missBlocks\":[2]"));
+    }
+
+    public void testPrefetchStatToXContent() throws IOException {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // Record prefetch data
+        metric.recordPrefetch("file1", 5);
+        metric.recordPrefetch("file1", 10);
+        metric.recordPrefetch("file1", 15);
+
+        String json = metric.toString();
+
+        // Verify PrefetchStat XContent structure
+        assertTrue(json.contains("\"blockCount\":3"));
+        assertTrue(json.contains("\"blocks\":[5,10,15]"));
+    }
+
+    public void testReadAheadStatToXContent() throws IOException {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // Record read ahead data
+        metric.recordReadAhead("file1", 25);
+        metric.recordReadAhead("file1", 30);
+
+        String json = metric.toString();
+
+        // Verify ReadAheadStat XContent structure
+        assertTrue(json.contains("\"blockCount\":2"));
+        assertTrue(json.contains("\"blocks\":[25,30]"));
+    }
+
+    public void testInnerClassRamBytesUsed() {
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        // Add data to create inner class instances
+        metric.recordFileAccess("file1.block_0_1", true);
+        metric.recordPrefetch("file2", 1);
+        metric.recordReadAhead("file3", 1);
+
+        // Verify RAM usage calculation includes inner classes
+        long ramUsage = metric.ramBytesUsed();
+        assertTrue(ramUsage > 0);
+
+        // Add more data and verify RAM increases
+        metric.recordFileAccess("file1.block_0_2", false);
+        metric.recordFileAccess("file1.block_0_3", true);
+
+        long newRamUsage = metric.ramBytesUsed();
+        assertTrue(newRamUsage >= ramUsage);
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/slowlogs/TieredStorageQueryMetricServiceTests.java
+++ b/server/src/test/java/org/opensearch/storage/slowlogs/TieredStorageQueryMetricServiceTests.java
@@ -1,0 +1,362 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.slowlogs;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Comprehensive unit tests for TieredStorageQueryMetricService
+ */
+public class TieredStorageQueryMetricServiceTests extends OpenSearchTestCase {
+
+    private TieredStorageQueryMetricService service;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        service = TieredStorageQueryMetricService.getInstance();
+
+        // Clear any existing state
+        service.getMetricCollectors().clear();
+        service.getTaskIdToCollectorMap(true).clear();
+        service.getTaskIdToCollectorMap(false).clear();
+    }
+
+    public void testGetInstance() {
+        TieredStorageQueryMetricService instance1 = TieredStorageQueryMetricService.getInstance();
+        TieredStorageQueryMetricService instance2 = TieredStorageQueryMetricService.getInstance();
+
+        // Should return the same singleton instance
+        assertSame(instance1, instance2);
+    }
+
+    public void testGetMetricCollectorWhenNotExists() {
+        long threadId = Thread.currentThread().threadId();
+
+        TieredStoragePerQueryMetric collector = service.getMetricCollector(threadId);
+
+        // Should return dummy collector when no collector exists
+        assertNotNull(collector);
+        assertTrue(collector instanceof TieredStorageQueryMetricService.TieredStoragePerQueryMetricDummy);
+        assertEquals("DummyParentTaskId", collector.getParentTaskId());
+        assertEquals("DummyShardId", collector.getShardId());
+    }
+
+    public void testAddAndGetMetricCollectorQueryPhase() {
+        long threadId = Thread.currentThread().threadId();
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        service.addMetricCollector(threadId, metric, true);
+
+        TieredStoragePerQueryMetric retrieved = service.getMetricCollector(threadId);
+        assertSame(metric, retrieved);
+
+        // Verify it's added to query phase map
+        Map<String, Set<TieredStoragePerQueryMetric>> queryMap = service.getTaskIdToCollectorMap(true);
+        assertTrue(queryMap.containsKey("task-1shard-1"));
+        assertTrue(queryMap.get("task-1shard-1").contains(metric));
+
+        // Should not be in fetch phase map
+        Map<String, Set<TieredStoragePerQueryMetric>> fetchMap = service.getTaskIdToCollectorMap(false);
+        assertFalse(fetchMap.containsKey("task-1shard-1"));
+    }
+
+    public void testAddAndGetMetricCollectorFetchPhase() {
+        long threadId = Thread.currentThread().threadId();
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-2", "shard-2");
+
+        service.addMetricCollector(threadId, metric, false);
+
+        TieredStoragePerQueryMetric retrieved = service.getMetricCollector(threadId);
+        assertSame(metric, retrieved);
+
+        // Verify it's added to fetch phase map
+        Map<String, Set<TieredStoragePerQueryMetric>> fetchMap = service.getTaskIdToCollectorMap(false);
+        assertTrue(fetchMap.containsKey("task-2shard-2"));
+        assertTrue(fetchMap.get("task-2shard-2").contains(metric));
+
+        // Should not be in query phase map
+        Map<String, Set<TieredStoragePerQueryMetric>> queryMap = service.getTaskIdToCollectorMap(true);
+        assertFalse(queryMap.containsKey("task-2shard-2"));
+    }
+
+    public void testAddMultipleCollectorsForSameTaskShard() {
+        long threadId1 = Thread.currentThread().threadId();
+        long threadId2 = threadId1 + 1; // Simulate different thread
+
+        TieredStoragePerQueryMetricImpl metric1 = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+        TieredStoragePerQueryMetricImpl metric2 = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        service.addMetricCollector(threadId1, metric1, true);
+        service.addMetricCollector(threadId2, metric2, true);
+
+        // Both should be in the task-shard map
+        Map<String, Set<TieredStoragePerQueryMetric>> queryMap = service.getTaskIdToCollectorMap(true);
+        Set<TieredStoragePerQueryMetric> collectors = queryMap.get("task-1shard-1");
+        assertEquals(2, collectors.size());
+        assertTrue(collectors.contains(metric1));
+        assertTrue(collectors.contains(metric2));
+    }
+
+    public void testRemoveMetricCollector() {
+        long threadId = Thread.currentThread().threadId();
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        service.addMetricCollector(threadId, metric, true);
+
+        TieredStoragePerQueryMetric removed = service.removeMetricCollector(threadId);
+        assertSame(metric, removed);
+
+        // Should return dummy collector after removal
+        TieredStoragePerQueryMetric afterRemoval = service.getMetricCollector(threadId);
+        assertTrue(afterRemoval instanceof TieredStorageQueryMetricService.TieredStoragePerQueryMetricDummy);
+
+        // Should still be in task-shard map (not removed by removeMetricCollector)
+        Map<String, Set<TieredStoragePerQueryMetric>> queryMap = service.getTaskIdToCollectorMap(true);
+        assertTrue(queryMap.containsKey("task-1shard-1"));
+    }
+
+    public void testRemoveMetricCollectorWhenNotExists() {
+        long threadId = Thread.currentThread().threadId();
+
+        TieredStoragePerQueryMetric removed = service.removeMetricCollector(threadId);
+
+        // Should return null when no collector exists
+        assertNull(removed);
+    }
+
+    public void testRemoveMetricCollectorsQueryPhase() {
+        long threadId1 = Thread.currentThread().threadId();
+        long threadId2 = threadId1 + 1;
+
+        TieredStoragePerQueryMetricImpl metric1 = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+        TieredStoragePerQueryMetricImpl metric2 = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+
+        service.addMetricCollector(threadId1, metric1, true);
+        service.addMetricCollector(threadId2, metric2, true);
+
+        Set<TieredStoragePerQueryMetric> removed = service.removeMetricCollectors("task-1", "shard-1", true);
+
+        assertEquals(2, removed.size());
+        assertTrue(removed.contains(metric1));
+        assertTrue(removed.contains(metric2));
+
+        // Should be removed from task-shard map
+        Map<String, Set<TieredStoragePerQueryMetric>> queryMap = service.getTaskIdToCollectorMap(true);
+        assertFalse(queryMap.containsKey("task-1shard-1"));
+    }
+
+    public void testRemoveMetricCollectorsFetchPhase() {
+        long threadId = Thread.currentThread().threadId();
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-2", "shard-2");
+
+        service.addMetricCollector(threadId, metric, false);
+
+        Set<TieredStoragePerQueryMetric> removed = service.removeMetricCollectors("task-2", "shard-2", false);
+
+        assertEquals(1, removed.size());
+        assertTrue(removed.contains(metric));
+
+        // Should be removed from task-shard map
+        Map<String, Set<TieredStoragePerQueryMetric>> fetchMap = service.getTaskIdToCollectorMap(false);
+        assertFalse(fetchMap.containsKey("task-2shard-2"));
+    }
+
+    public void testRemoveMetricCollectorsWhenNotExists() {
+        Set<TieredStoragePerQueryMetric> removed = service.removeMetricCollectors("nonexistent", "shard", true);
+
+        assertTrue(removed.isEmpty());
+    }
+
+    public void testRamBytesUsed() {
+        long initialRam = service.ramBytesUsed();
+        assertTrue(initialRam > 0);
+
+        // Add some collectors
+        TieredStoragePerQueryMetricImpl metric1 = new TieredStoragePerQueryMetricImpl("task-1", "shard-1");
+        TieredStoragePerQueryMetricImpl metric2 = new TieredStoragePerQueryMetricImpl("task-2", "shard-2");
+
+        service.addMetricCollector(1L, metric1, true);
+        service.addMetricCollector(2L, metric2, false);
+
+        long finalRam = service.ramBytesUsed();
+        assertTrue(finalRam >= initialRam);
+    }
+
+    public void testRecordStoredFieldsPrefetchSuccess() {
+        PrefetchStats initialStats = service.getPrefetchStats();
+        long initialSuccess = initialStats.getStoredFieldsPrefetchSuccess();
+
+        service.recordStoredFieldsPrefetch(true);
+
+        PrefetchStats finalStats = service.getPrefetchStats();
+        assertEquals(initialSuccess + 1, finalStats.getStoredFieldsPrefetchSuccess());
+    }
+
+    public void testRecordStoredFieldsPrefetchFailure() {
+        PrefetchStats initialStats = service.getPrefetchStats();
+        long initialFailure = initialStats.getStoredFieldsPrefetchFailure();
+
+        service.recordStoredFieldsPrefetch(false);
+
+        PrefetchStats finalStats = service.getPrefetchStats();
+        assertEquals(initialFailure + 1, finalStats.getStoredFieldsPrefetchFailure());
+    }
+
+    public void testRecordDocValuesPrefetchSuccess() {
+        PrefetchStats initialStats = service.getPrefetchStats();
+        long initialSuccess = initialStats.getDocValuesPrefetchSuccess();
+
+        service.recordDocValuesPrefetch(true);
+
+        PrefetchStats finalStats = service.getPrefetchStats();
+        assertEquals(initialSuccess + 1, finalStats.getDocValuesPrefetchSuccess());
+    }
+
+    public void testRecordDocValuesPrefetchFailure() {
+        PrefetchStats initialStats = service.getPrefetchStats();
+        long initialFailure = initialStats.getDocValuesPrefetchFailure();
+
+        service.recordDocValuesPrefetch(false);
+
+        PrefetchStats finalStats = service.getPrefetchStats();
+        assertEquals(initialFailure + 1, finalStats.getDocValuesPrefetchFailure());
+    }
+
+    public void testGetPrefetchStats() {
+        PrefetchStats stats = service.getPrefetchStats();
+
+        assertNotNull(stats);
+        assertTrue(stats.getStoredFieldsPrefetchSuccess() >= 0);
+        assertTrue(stats.getStoredFieldsPrefetchFailure() >= 0);
+        assertTrue(stats.getDocValuesPrefetchSuccess() >= 0);
+        assertTrue(stats.getDocValuesPrefetchFailure() >= 0);
+    }
+
+    public void testTieredStoragePerQueryMetricDummyGetInstance() {
+        TieredStorageQueryMetricService.TieredStoragePerQueryMetricDummy dummy1 =
+            TieredStorageQueryMetricService.TieredStoragePerQueryMetricDummy.getInstance();
+        TieredStorageQueryMetricService.TieredStoragePerQueryMetricDummy dummy2 =
+            TieredStorageQueryMetricService.TieredStoragePerQueryMetricDummy.getInstance();
+
+        // Should return the same singleton instance
+        assertSame(dummy1, dummy2);
+    }
+
+    public void testTieredStoragePerQueryMetricDummyMethods() {
+        TieredStorageQueryMetricService.TieredStoragePerQueryMetricDummy dummy =
+            TieredStorageQueryMetricService.TieredStoragePerQueryMetricDummy.getInstance();
+
+        // All methods should be no-op and not throw exceptions
+        dummy.recordFileAccess("test.block_0_1", true);
+        dummy.recordPrefetch("test", 1);
+        dummy.recordReadAhead("test", 1);
+        dummy.recordEndTime();
+
+        assertEquals("DummyParentTaskId", dummy.getParentTaskId());
+        assertEquals("DummyShardId", dummy.getShardId());
+        assertTrue(dummy.ramBytesUsed() > 0);
+    }
+
+    public void testMaxCollectorSizeLimit() {
+        // This test would be difficult to run in practice due to the high limit (1000)
+        // but we can verify the logic by checking that the service handles the limit gracefully
+
+        // Add a reasonable number of collectors to verify normal operation
+        for (int i = 0; i < 10; i++) {
+            TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-" + i, "shard-" + i);
+            service.addMetricCollector((long) i, metric, true);
+        }
+
+        // Verify all were added
+        assertEquals(10, service.getMetricCollectors().size());
+        assertEquals(10, service.getTaskIdToCollectorMap(true).size());
+    }
+
+    public void testConcurrentAccess() {
+        // Test that the service can handle concurrent access
+        String taskId = "concurrent-task";
+        String shardId = "concurrent-shard";
+
+        TieredStoragePerQueryMetricImpl metric1 = new TieredStoragePerQueryMetricImpl(taskId, shardId);
+        TieredStoragePerQueryMetricImpl metric2 = new TieredStoragePerQueryMetricImpl(taskId, shardId);
+
+        // Add collectors for the same task-shard from different threads
+        service.addMetricCollector(100L, metric1, true);
+        service.addMetricCollector(200L, metric2, true);
+
+        // Both should be in the same task-shard set
+        Set<TieredStoragePerQueryMetric> collectors = service.getTaskIdToCollectorMap(true).get(taskId + shardId);
+        assertEquals(2, collectors.size());
+        assertTrue(collectors.contains(metric1));
+        assertTrue(collectors.contains(metric2));
+    }
+
+    public void testPrefetchStatsHolder() {
+        TieredStorageQueryMetricService.PrefetchStatsHolder holder = new TieredStorageQueryMetricService.PrefetchStatsHolder();
+
+        // Initial stats should be zero
+        PrefetchStats initialStats = holder.getStats();
+        assertEquals(0, initialStats.getStoredFieldsPrefetchSuccess());
+        assertEquals(0, initialStats.getStoredFieldsPrefetchFailure());
+        assertEquals(0, initialStats.getDocValuesPrefetchSuccess());
+        assertEquals(0, initialStats.getDocValuesPrefetchFailure());
+
+        // Increment counters
+        holder.storedFieldsPrefetchSuccess.inc();
+        holder.storedFieldsPrefetchFailure.inc();
+        holder.docValuesPrefetchSuccess.inc();
+        holder.docValuesPrefetchFailure.inc();
+
+        // Verify increments
+        PrefetchStats finalStats = holder.getStats();
+        assertEquals(1, finalStats.getStoredFieldsPrefetchSuccess());
+        assertEquals(1, finalStats.getStoredFieldsPrefetchFailure());
+        assertEquals(1, finalStats.getDocValuesPrefetchSuccess());
+        assertEquals(1, finalStats.getDocValuesPrefetchFailure());
+    }
+
+    public void testMixedQueryAndFetchPhaseCollectors() {
+        String taskId = "mixed-task";
+        String shardId = "mixed-shard";
+
+        TieredStoragePerQueryMetricImpl queryMetric = new TieredStoragePerQueryMetricImpl(taskId, shardId);
+        TieredStoragePerQueryMetricImpl fetchMetric = new TieredStoragePerQueryMetricImpl(taskId, shardId);
+
+        service.addMetricCollector(100L, queryMetric, true);
+        service.addMetricCollector(200L, fetchMetric, false);
+
+        // Should be in separate maps
+        assertTrue(service.getTaskIdToCollectorMap(true).containsKey(taskId + shardId));
+        assertTrue(service.getTaskIdToCollectorMap(false).containsKey(taskId + shardId));
+
+        assertEquals(1, service.getTaskIdToCollectorMap(true).get(taskId + shardId).size());
+        assertEquals(1, service.getTaskIdToCollectorMap(false).get(taskId + shardId).size());
+
+        // Remove query phase collectors
+        Set<TieredStoragePerQueryMetric> queryCollectors = service.removeMetricCollectors(taskId, shardId, true);
+        assertEquals(1, queryCollectors.size());
+        assertTrue(queryCollectors.contains(queryMetric));
+
+        // Fetch phase collectors should still be there
+        assertTrue(service.getTaskIdToCollectorMap(false).containsKey(taskId + shardId));
+
+        // Remove fetch phase collectors
+        Set<TieredStoragePerQueryMetric> fetchCollectors = service.removeMetricCollectors(taskId, shardId, false);
+        assertEquals(1, fetchCollectors.size());
+        assertTrue(fetchCollectors.contains(fetchMetric));
+
+        // Both maps should be empty for this task-shard now
+        assertFalse(service.getTaskIdToCollectorMap(true).containsKey(taskId + shardId));
+        assertFalse(service.getTaskIdToCollectorMap(false).containsKey(taskId + shardId));
+    }
+}

--- a/server/src/test/java/org/opensearch/storage/slowlogs/TieredStorageSearchSlowLogTests.java
+++ b/server/src/test/java/org/opensearch/storage/slowlogs/TieredStorageSearchSlowLogTests.java
@@ -1,0 +1,510 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.slowlogs;
+
+import org.opensearch.Version;
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.logging.SlowLogLevel;
+import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.tasks.TaskId;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.search.SearchShardTarget;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.internal.ShardSearchRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Comprehensive unit tests for TieredStorageSearchSlowLog
+ */
+public class TieredStorageSearchSlowLogTests extends OpenSearchTestCase {
+
+    private TieredStorageSearchSlowLog slowLog;
+    private IndexSettings indexSettings;
+    private SearchContext searchContext;
+    private SearchShardTask searchTask;
+    private TieredStorageQueryMetricService metricService;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // Create mock objects
+        indexSettings = createMockIndexSettings();
+        searchContext = mock(SearchContext.class);
+        searchTask = mock(SearchShardTask.class);
+
+        // Mock search context setup
+        when(searchContext.getTask()).thenReturn(searchTask);
+        SearchShardTarget shardTarget = new SearchShardTarget("testNode", mock(ShardId.class), null, null);
+        when(searchContext.shardTarget()).thenReturn(shardTarget);
+        when(searchContext.numberOfShards()).thenReturn(1);
+        when(searchContext.searchType()).thenReturn(org.opensearch.action.search.SearchType.QUERY_THEN_FETCH);
+        when(searchContext.request()).thenReturn(mock(ShardSearchRequest.class));
+        when(searchContext.request().source()).thenReturn(null);
+
+        // Mock search task - use string directly to avoid TaskId class issues
+        when(searchTask.getParentTaskId()).thenReturn(TaskId.EMPTY_TASK_ID);
+
+        // Create slow log instance
+        slowLog = new TieredStorageSearchSlowLog(indexSettings);
+
+        // Mock metric service
+        metricService = mock(TieredStorageQueryMetricService.class);
+    }
+
+    private IndexSettings createMockIndexSettings() {
+        Set<Setting<?>> settingSet = new HashSet<>(IndexScopedSettings.BUILT_IN_INDEX_SETTINGS);
+        settingSet.add(TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_ENABLED);
+        settingSet.add(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_LEVEL);
+        settingSet.add(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING);
+        settingSet.add(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO_SETTING);
+        settingSet.add(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING);
+        settingSet.add(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_TRACE_SETTING);
+        settingSet.add(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_DEBUG_SETTING);
+        settingSet.add(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_INFO_SETTING);
+        settingSet.add(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING);
+        settingSet.add(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_TRACE_SETTING);
+
+        Settings settings = Settings.builder()
+            .put(TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_ENABLED.getKey(), true)
+            .put(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING.getKey(), "1s")
+            .put(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_INFO_SETTING.getKey(), "500ms")
+            .put(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_DEBUG_SETTING.getKey(), "100ms")
+            .put(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_TRACE_SETTING.getKey(), "10ms")
+            .put(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING.getKey(), "1s")
+            .put(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO_SETTING.getKey(), "500ms")
+            .put(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING.getKey(), "100ms")
+            .put(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_TRACE_SETTING.getKey(), "10ms")
+            .put(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_LEVEL.getKey(), "TRACE")
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, "uuid")
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+            .build();
+
+        IndexMetadata metadata = IndexMetadata.builder("Index").settings(settings).build();
+        return new IndexSettings(metadata, settings, new IndexScopedSettings(settings, settingSet));
+    }
+
+    public void testConstructorInitializesSettings() {
+        // Verify that constructor properly initializes all settings
+        assertTrue(slowLog.getQueryWarnThreshold() > 0);
+        assertTrue(slowLog.getQueryInfoThreshold() > 0);
+        assertTrue(slowLog.getQueryDebugThreshold() > 0);
+        assertTrue(slowLog.getQueryTraceThreshold() > 0);
+
+        assertTrue(slowLog.getFetchWarnThreshold() > 0);
+        assertTrue(slowLog.getFetchInfoThreshold() > 0);
+        assertTrue(slowLog.getFetchDebugThreshold() > 0);
+        assertTrue(slowLog.getFetchTraceThreshold() > 0);
+
+        assertEquals(SlowLogLevel.TRACE, slowLog.getLevel());
+    }
+
+    public void testSetTieredStorageSlowlogEnabled() {
+        // Test enabling/disabling slow log
+        slowLog.setTieredStorageSlowlogEnabled(true);
+        // No direct way to verify, but should not throw exception
+
+        slowLog.setTieredStorageSlowlogEnabled(false);
+        // No direct way to verify, but should not throw exception
+    }
+
+    public void testOnPreQueryPhase() {
+        // onPreQueryPhase should not do anything as per the implementation
+        // Just verify it doesn't throw exception
+        slowLog.onPreQueryPhase(searchContext);
+    }
+
+    public void testOnPreSliceExecutionWhenEnabled() {
+        // Enable slow log
+        slowLog.setTieredStorageSlowlogEnabled(true);
+
+        // Should call setMetricCollector when enabled
+        slowLog.onPreSliceExecution(searchContext);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnPreSliceExecutionWhenDisabled() {
+        // Disable slow log
+        slowLog.setTieredStorageSlowlogEnabled(false);
+
+        // Should not call setMetricCollector when disabled
+        slowLog.onPreSliceExecution(searchContext);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnSliceExecutionWhenEnabled() {
+        // Enable slow log
+        slowLog.setTieredStorageSlowlogEnabled(true);
+
+        // Should call removeMetricCollector when enabled
+        slowLog.onSliceExecution(searchContext);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnSliceExecutionWhenDisabled() {
+        // Disable slow log
+        slowLog.setTieredStorageSlowlogEnabled(false);
+
+        // Should not call removeMetricCollector when disabled
+        slowLog.onSliceExecution(searchContext);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnFailedSliceExecutionWhenEnabled() {
+        // Enable slow log
+        slowLog.setTieredStorageSlowlogEnabled(true);
+
+        // Should call removeMetricCollector when enabled
+        slowLog.onFailedSliceExecution(searchContext);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnFailedSliceExecutionWhenDisabled() {
+        // Disable slow log
+        slowLog.setTieredStorageSlowlogEnabled(false);
+
+        // Should not call removeMetricCollector when disabled
+        slowLog.onFailedSliceExecution(searchContext);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnQueryPhaseWhenEnabled() {
+        // Enable slow log
+        slowLog.setTieredStorageSlowlogEnabled(true);
+
+        // Test with time above trace threshold
+        long tookInNanos = TimeUnit.MILLISECONDS.toNanos(50); // Above 10ms trace threshold
+
+        slowLog.onQueryPhase(searchContext, tookInNanos);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnQueryPhaseWhenDisabled() {
+        // Disable slow log
+        slowLog.setTieredStorageSlowlogEnabled(false);
+
+        long tookInNanos = TimeUnit.MILLISECONDS.toNanos(50);
+
+        slowLog.onQueryPhase(searchContext, tookInNanos);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnFailedQueryPhaseWhenEnabled() {
+        // Enable slow log
+        slowLog.setTieredStorageSlowlogEnabled(true);
+
+        slowLog.onFailedQueryPhase(searchContext);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnFailedQueryPhaseWhenDisabled() {
+        // Disable slow log
+        slowLog.setTieredStorageSlowlogEnabled(false);
+
+        slowLog.onFailedQueryPhase(searchContext);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnPreFetchPhaseWhenEnabled() {
+        // Enable slow log
+        slowLog.setTieredStorageSlowlogEnabled(true);
+
+        slowLog.onPreFetchPhase(searchContext);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnPreFetchPhaseWhenDisabled() {
+        // Disable slow log
+        slowLog.setTieredStorageSlowlogEnabled(false);
+
+        slowLog.onPreFetchPhase(searchContext);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnFetchPhaseWhenEnabled() {
+        // Enable slow log
+        slowLog.setTieredStorageSlowlogEnabled(true);
+
+        slowLog.onPreFetchPhase(searchContext);
+
+        long tookInNanos = TimeUnit.MILLISECONDS.toNanos(50);
+
+        slowLog.onFetchPhase(searchContext, tookInNanos);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnFetchPhaseWhenDisabled() {
+        // Disable slow log
+        slowLog.setTieredStorageSlowlogEnabled(false);
+
+        long tookInNanos = TimeUnit.MILLISECONDS.toNanos(50);
+
+        slowLog.onFetchPhase(searchContext, tookInNanos);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnFailedFetchPhaseWhenEnabled() {
+        // Enable slow log
+        slowLog.setTieredStorageSlowlogEnabled(true);
+
+        slowLog.onFailedFetchPhase(searchContext);
+
+        // Verify no exception is thrown
+    }
+
+    public void testOnFailedFetchPhaseWhenDisabled() {
+        // Disable slow log
+        slowLog.setTieredStorageSlowlogEnabled(false);
+
+        slowLog.onFailedFetchPhase(searchContext);
+
+        // Verify no exception is thrown
+    }
+
+    public void testThresholdGetters() {
+        // Test all threshold getters return expected values
+        assertTrue(slowLog.getQueryWarnThreshold() >= 0);
+        assertTrue(slowLog.getQueryInfoThreshold() >= 0);
+        assertTrue(slowLog.getQueryDebugThreshold() >= 0);
+        assertTrue(slowLog.getQueryTraceThreshold() >= 0);
+
+        assertTrue(slowLog.getFetchWarnThreshold() >= 0);
+        assertTrue(slowLog.getFetchInfoThreshold() >= 0);
+        assertTrue(slowLog.getFetchDebugThreshold() >= 0);
+        assertTrue(slowLog.getFetchTraceThreshold() >= 0);
+    }
+
+    public void testSlowLogSettings() {
+        // Test that all settings are properly defined
+        assertNotNull(TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_ENABLED);
+        assertNotNull(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING);
+        assertNotNull(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_INFO_SETTING);
+        assertNotNull(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_DEBUG_SETTING);
+        assertNotNull(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_TRACE_SETTING);
+
+        assertNotNull(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_WARN_SETTING);
+        assertNotNull(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_INFO_SETTING);
+        assertNotNull(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING);
+        assertNotNull(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_TRACE_SETTING);
+
+        assertNotNull(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_LEVEL);
+    }
+
+    public void testSlowLogSettingsMap() {
+        // Test that settings map contains all expected settings
+        assertFalse(TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_SETTINGS_MAP.isEmpty());
+        assertTrue(
+            TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_SETTINGS_MAP.containsKey(
+                TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".enabled"
+            )
+        );
+        assertTrue(
+            TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_SETTINGS_MAP.containsKey(
+                TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".threshold.query.warn"
+            )
+        );
+        assertTrue(
+            TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_SETTINGS_MAP.containsKey(
+                TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX + ".level"
+            )
+        );
+    }
+
+    public void testSlowLogSettingsSet() {
+        // Test that settings set contains all expected settings
+        assertFalse(TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_SETTINGS.isEmpty());
+        assertEquals(10, TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_SETTINGS.size());
+    }
+
+    public void testTieredStorageSlowLogPrinterConstructor() {
+        TieredStorageSearchSlowLog.TieredStorageSlowLogPrinter printer = new TieredStorageSearchSlowLog.TieredStorageSlowLogPrinter(
+            searchContext,
+            TimeUnit.MILLISECONDS.toNanos(100),
+            java.util.Collections.emptyList()
+        );
+
+        assertNotNull(printer);
+    }
+
+    public void testTieredStorageSlowLogPrinterToString() {
+        TieredStorageSearchSlowLog.TieredStorageSlowLogPrinter printer = new TieredStorageSearchSlowLog.TieredStorageSlowLogPrinter(
+            searchContext,
+            TimeUnit.MILLISECONDS.toNanos(100),
+            java.util.Collections.emptyList()
+        );
+
+        String result = printer.toString();
+        assertNotNull(result);
+        assertTrue(result.length() > 0);
+
+        // Should contain expected JSON structure
+        assertTrue(result.contains("warm_stats"));
+        assertTrue(result.contains("took"));
+        assertTrue(result.contains("took_millis"));
+        assertTrue(result.contains("stats"));
+        assertTrue(result.contains("search_type"));
+        assertTrue(result.contains("total_shards"));
+    }
+
+    public void testTieredStorageSlowLogPrinterWithMetrics() {
+        // Create a metric collector
+        TieredStoragePerQueryMetricImpl metric = new TieredStoragePerQueryMetricImpl("task-1", "shard-0");
+        metric.recordFileAccess("file1.block_0_1", true);
+        metric.recordPrefetch("file2", 1);
+        metric.recordEndTime();
+
+        java.util.List<TieredStoragePerQueryMetric> metrics = java.util.Arrays.asList(metric);
+
+        TieredStorageSearchSlowLog.TieredStorageSlowLogPrinter printer = new TieredStorageSearchSlowLog.TieredStorageSlowLogPrinter(
+            searchContext,
+            TimeUnit.MILLISECONDS.toNanos(100),
+            metrics
+        );
+
+        String result = printer.toString();
+        assertNotNull(result);
+        assertTrue(result.length() > 0);
+
+        // Should contain metric data in warm_stats
+        assertTrue(result.contains("warm_stats"));
+        assertTrue(result.contains("parentTask"));
+        assertTrue(result.contains("task-1"));
+    }
+
+    public void testSearchContextWithNullTask() {
+        // Test behavior when search task is null
+        when(searchContext.getTask()).thenReturn(null);
+
+        slowLog.setTieredStorageSlowlogEnabled(true);
+
+        // Should handle null task gracefully
+        slowLog.onPreSliceExecution(searchContext);
+        slowLog.onSliceExecution(searchContext);
+        slowLog.onPreFetchPhase(searchContext);
+
+        // Verify no exceptions are thrown
+    }
+
+    public void testDifferentLogLevels() {
+        slowLog.setTieredStorageSlowlogEnabled(true);
+
+        // Test different time thresholds for different log levels
+
+        // Test TRACE level (10ms threshold)
+        long traceTime = TimeUnit.MILLISECONDS.toNanos(15);
+        slowLog.onQueryPhase(searchContext, traceTime);
+
+        // Test DEBUG level (100ms threshold)
+        long debugTime = TimeUnit.MILLISECONDS.toNanos(150);
+        slowLog.onQueryPhase(searchContext, debugTime);
+
+        // Test INFO level (500ms threshold)
+        long infoTime = TimeUnit.MILLISECONDS.toNanos(600);
+        slowLog.onQueryPhase(searchContext, infoTime);
+
+        // Test WARN level (1s threshold)
+        long warnTime = TimeUnit.MILLISECONDS.toNanos(1100);
+        slowLog.onQueryPhase(searchContext, warnTime);
+
+        // All should complete without exceptions
+    }
+
+    public void testFetchPhaseLogging() {
+        slowLog.setTieredStorageSlowlogEnabled(true);
+
+        slowLog.onPreFetchPhase(searchContext);
+        // Test fetch phase with different thresholds
+        long fetchTime = TimeUnit.MILLISECONDS.toNanos(600); // Above info threshold
+
+        slowLog.onFetchPhase(searchContext, fetchTime);
+
+        // Should complete without exceptions
+    }
+
+    public void testSettingsPrefix() {
+        // Verify the settings prefix is correct
+        String expectedPrefix = TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_PREFIX;
+
+        assertTrue(TieredStorageSearchSlowLog.TIERED_STORAGE_SEARCH_SLOWLOG_ENABLED.getKey().startsWith(expectedPrefix));
+        assertTrue(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING.getKey().startsWith(expectedPrefix));
+        assertTrue(TieredStorageSearchSlowLog.INDEX_SEARCH_SLOWLOG_LEVEL.getKey().startsWith(expectedPrefix));
+    }
+
+    public void testTimeValueConversion() {
+        // Test that time values are properly converted to nanoseconds
+        assertTrue(slowLog.getQueryWarnThreshold() > 0);
+        assertTrue(slowLog.getQueryInfoThreshold() > 0);
+        assertTrue(slowLog.getQueryDebugThreshold() > 0);
+        assertTrue(slowLog.getQueryTraceThreshold() > 0);
+
+        // Verify hierarchy: warn > info > debug > trace
+        assertTrue(slowLog.getQueryWarnThreshold() >= slowLog.getQueryInfoThreshold());
+        assertTrue(slowLog.getQueryInfoThreshold() >= slowLog.getQueryDebugThreshold());
+        assertTrue(slowLog.getQueryDebugThreshold() >= slowLog.getQueryTraceThreshold());
+    }
+
+    public void testSlowLogPrinterWithNullSource() {
+        // Test printer when search request source is null
+        when(searchContext.request().source()).thenReturn(null);
+
+        TieredStorageSearchSlowLog.TieredStorageSlowLogPrinter printer = new TieredStorageSearchSlowLog.TieredStorageSlowLogPrinter(
+            searchContext,
+            TimeUnit.MILLISECONDS.toNanos(100),
+            java.util.Collections.emptyList()
+        );
+
+        String result = printer.toString();
+        assertNotNull(result);
+        assertTrue(result.contains("\"source\":null"));
+    }
+
+    public void testSlowLogPrinterWithGroupStats() {
+        // Mock group stats - use List<String> to match expected type
+        java.util.List<String> groupStats = java.util.Arrays.asList("stat1", "stat2");
+        when(searchContext.groupStats()).thenReturn(groupStats);
+
+        TieredStorageSearchSlowLog.TieredStorageSlowLogPrinter printer = new TieredStorageSearchSlowLog.TieredStorageSlowLogPrinter(
+            searchContext,
+            TimeUnit.MILLISECONDS.toNanos(100),
+            java.util.Collections.emptyList()
+        );
+
+        String result = printer.toString();
+        assertNotNull(result);
+        assertTrue(result.contains("stats"));
+    }
+}


### PR DESCRIPTION
### Description

Adds search slow log support, per-query metric collection, and migration metrics for WritableWarm tiered storage.

**New files:**
- `TieredStorageSearchSlowLog`: `SearchOperationListener` that logs slow queries and fetches on warm data with configurable index-scoped thresholds (enabled, query/fetch warn/info/debug/trace, level)
- `TieredStoragePerQueryMetricImpl`: Per-query metric collector tracking file cache hits/misses, prefetch blocks, and read-ahead blocks per file with JSON serialization
- `TieredStorageQueryMetricService`: Singleton service managing per-query metric collectors across threads for both query and fetch phases
- `PrefetchStats`: Completed with `StreamInput` constructor, `writeTo`, getters, `toXContent`, and inner `Fields` class
- `TierActionMetrics`: Migration success/rejection/latency metrics using `MetricsRegistry`

**Modified files:**
- `OnDemandPrefetchBlockSnapshotIndexInput`: Replaced metric TODOs with actual cache hit/miss, read-ahead, and prefetch recording via `TieredStorageQueryMetricService`
- `StoredFieldsPrefetch`: Added `recordStoredFieldsPrefetch(true/false)` calls in `onPreFetchPhase`
- `IndexScopedSettings`: Registered all 10 slow log index-scoped settings in `BUILT_IN_INDEX_SETTINGS`

**Tests:** — `TieredStoragePerQueryMetricImplTests`, `TieredStoragePerQueryMetricImplJsonTests`, `TieredStorageQueryMetricServiceTests`, `TieredStorageSearchSlowLogTests`

### Related Issues
Resolves #21101

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
