### PR TITLE
Optimize multi_terms aggregation with packed ordinal bucket keys

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregationFactory.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregationFactory.java
@@ -24,6 +24,7 @@ import org.opensearch.search.aggregations.support.ValuesSource;
 import org.opensearch.search.aggregations.support.ValuesSourceConfig;
 import org.opensearch.search.aggregations.support.ValuesSourceRegistry;
 import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.startree.StarTreeQueryHelper;
 
 import java.io.IOException;
 import java.util.List;
@@ -142,11 +143,13 @@ public class MultiTermsAggregationFactory extends AggregatorFactory {
         }
         // TODO: Optimize passing too many value source config derived objects to aggregator
         bucketCountThresholds.ensureValidity();
+        List<ValuesSource> rawValuesSources = configs.stream().map(config -> config.v1().getValuesSource()).toList();
+        MultiTermsBucketOrds ordinalBucketOrds = selectOrdinalStrategy(rawValuesSources, searchContext, cardinality);
         return new MultiTermsAggregator(
             name,
             factories,
             showTermDocCountError,
-            configs.stream().map(config -> config.v1().getValuesSource()).toList(),
+            rawValuesSources,
             configs.stream()
                 .map(config -> queryShardContext.getValuesSourceRegistry().getAggregator(REGISTRY_KEY, config.v1()).build(config))
                 .collect(Collectors.toList()),
@@ -158,12 +161,53 @@ public class MultiTermsAggregationFactory extends AggregatorFactory {
             searchContext,
             parent,
             cardinality,
-            metadata
+            metadata,
+            ordinalBucketOrds
         );
     }
 
     public List<String> getRequestFields() {
         return requestFields;
+    }
+
+    /**
+     * Selects the optimal {@link MultiTermsBucketOrds} strategy based on field types.
+     * Returns {@code null} when the ordinal optimization cannot be applied (mixed types or overflow).
+     */
+    private static MultiTermsBucketOrds selectOrdinalStrategy(
+        List<ValuesSource> rawValuesSources,
+        SearchContext searchContext,
+        CardinalityUpperBound cardinality
+    ) throws IOException {
+        // Star-tree precomputation writes to the bytes-based bucketOrds, so the ordinal
+        // optimization must be disabled when a star-tree index is available to avoid
+        // splitting buckets across two different storage structures.
+        if (StarTreeQueryHelper.getSupportedStarTree(searchContext.getQueryShardContext()) != null) {
+            return null;
+        }
+        for (ValuesSource vs : rawValuesSources) {
+            if ((vs instanceof ValuesSource.Bytes.WithOrdinals) == false) {
+                return null;
+            }
+        }
+        int numFields = rawValuesSources.size();
+        long[] maxOrds = new long[numFields];
+        for (int i = 0; i < numFields; i++) {
+            maxOrds[i] = ((ValuesSource.Bytes.WithOrdinals) rawValuesSources.get(i)).globalMaxOrd(searchContext.searcher());
+        }
+        if (PackedOrdinalBucketOrds.fitsInSingleLong(maxOrds)) {
+            // Single-long path supports any cardinality via LongKeyedBucketOrds
+            return new PackedOrdinalBucketOrds(searchContext.bigArrays(), cardinality, maxOrds);
+        }
+        if (PackedOrdinalBucketOrds.fitsInTwoLongs(maxOrds)) {
+            // Two-long path uses LongLongHash directly, which does not support
+            // multiple owning bucket ordinals. Only use it for top-level aggregations.
+            if (cardinality == CardinalityUpperBound.ONE) {
+                return new PackedOrdinalBucketOrds(searchContext.bigArrays(), cardinality, maxOrds);
+            }
+        }
+        // Ordinals don't fit, or multi-owning-bucket with >63 bits — fall back to existing bytes-based path
+        return null;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
@@ -200,8 +200,142 @@ public class MultiTermsAggregator extends DeferableBucketAggregator implements S
     /**
      * Build top buckets from the ordinal-based path by resolving packed ordinals
      * back to term values via {@code lookupOrd()}.
+     * <p>
+     * When ordering by doc count descending (the default), uses a two-pass approach:
+     * first finds the top-K bucket ordinals by doc count without resolving any ordinals,
+     * then resolves ordinals only for the top-K winners. This avoids O(total_buckets)
+     * lookupOrd calls and BytesRef allocations.
      */
     private InternalMultiTerms.Bucket[] buildOrdinalBuckets(
+        long owningBucketOrd,
+        LocalBucketCountThresholds localBucketCountThresholds,
+        long[] otherDocCounts,
+        int ordIdx,
+        SortedSetDocValues[] globalOrdsForLookup
+    ) throws IOException {
+        if (InternalOrder.isCountDesc(order)) {
+            return buildOrdinalBucketsTwoPass(owningBucketOrd, localBucketCountThresholds, otherDocCounts, ordIdx, globalOrdsForLookup);
+        }
+        return buildOrdinalBucketsSinglePass(owningBucketOrd, localBucketCountThresholds, otherDocCounts, ordIdx, globalOrdsForLookup);
+    }
+
+    /**
+     * Two-pass build for count-descending order. Pass 1 finds top-K by doc count
+     * using only bucket ordinals (no term resolution). Pass 2 resolves ordinals
+     * only for the top-K buckets.
+     */
+    private InternalMultiTerms.Bucket[] buildOrdinalBucketsTwoPass(
+        long owningBucketOrd,
+        LocalBucketCountThresholds localBucketCountThresholds,
+        long[] otherDocCounts,
+        int ordIdx,
+        SortedSetDocValues[] globalOrdsForLookup
+    ) throws IOException {
+        long bucketsInOrd = ordinalBucketOrds.bucketsInOrd(owningBucketOrd);
+        int requiredSize = (int) Math.min(bucketsInOrd, localBucketCountThresholds.getRequiredSize());
+        long minDocCount = localBucketCountThresholds.getMinDocCount();
+
+        // Pass 1: find top-K bucket ords by doc count — no ordinal resolution
+        // Use a min-heap of size requiredSize: the smallest doc count is at the top.
+        // When a new bucket has a higher doc count than the min, it replaces it.
+        long[] topBucketOrds = new long[requiredSize];
+        long[] topDocCounts = new long[requiredSize];
+        int topCount = 0;
+        long totalOtherDocCount = 0;
+
+        MultiTermsBucketOrds.BucketOrdsEnum ordsEnum = ordinalBucketOrds.ordsEnum(owningBucketOrd);
+        while (ordsEnum.next()) {
+            long bucketOrd = ordsEnum.ord();
+            long docCount = bucketDocCount(bucketOrd);
+            totalOtherDocCount += docCount;
+            if (docCount < minDocCount) {
+                continue;
+            }
+            if (topCount < requiredSize) {
+                // Heap not full yet — just add
+                topBucketOrds[topCount] = bucketOrd;
+                topDocCounts[topCount] = docCount;
+                topCount++;
+                if (topCount == requiredSize) {
+                    // Heapify once full
+                    buildMinHeap(topBucketOrds, topDocCounts, topCount);
+                }
+            } else if (docCount > topDocCounts[0]) {
+                // Replace the min element
+                topBucketOrds[0] = bucketOrd;
+                topDocCounts[0] = docCount;
+                siftDown(topBucketOrds, topDocCounts, 0, topCount);
+            }
+        }
+
+        otherDocCounts[ordIdx] += totalOtherDocCount;
+
+        // Pass 2: resolve ordinals only for the top-K buckets
+        CheckedSupplier<InternalMultiTerms.Bucket, IOException> emptyBucketBuilder = () -> InternalMultiTerms.Bucket.EMPTY(
+            showTermDocCountError,
+            formats
+        );
+        InternalMultiTerms.Bucket[] bucketsForOrd = new InternalMultiTerms.Bucket[topCount];
+        for (int i = 0; i < topCount; i++) {
+            long bucketOrd = topBucketOrds[i];
+            long docCount = topDocCounts[i];
+
+            // Resolve ordinals for this bucket
+            long[] ordinals = ordinalBucketOrds.getOrdinals(bucketOrd);
+            List<Object> termValues = new ArrayList<>(ordinals.length);
+            for (int f = 0; f < ordinals.length; f++) {
+                termValues.add(BytesRef.deepCopyOf(globalOrdsForLookup[f].lookupOrd(ordinals[f])));
+            }
+
+            InternalMultiTerms.Bucket bucket = emptyBucketBuilder.get();
+            bucket.termValues = termValues;
+            bucket.docCount = docCount;
+            bucket.bucketOrd = bucketOrd;
+            bucketsForOrd[i] = bucket;
+            otherDocCounts[ordIdx] -= docCount;
+        }
+
+        // Sort by doc count descending (the heap doesn't guarantee order)
+        Arrays.sort(bucketsForOrd, (a, b) -> Long.compare(b.getDocCount(), a.getDocCount()));
+        return bucketsForOrd;
+    }
+
+    /** Build a min-heap on docCounts (parallel arrays). */
+    private static void buildMinHeap(long[] ords, long[] counts, int size) {
+        for (int i = size / 2 - 1; i >= 0; i--) {
+            siftDown(ords, counts, i, size);
+        }
+    }
+
+    /** Sift down element at index i in a min-heap on counts. */
+    private static void siftDown(long[] ords, long[] counts, int i, int size) {
+        long ord = ords[i];
+        long count = counts[i];
+        int half = size >>> 1;
+        while (i < half) {
+            int child = (i << 1) + 1;
+            long childCount = counts[child];
+            int right = child + 1;
+            if (right < size && counts[right] < childCount) {
+                child = right;
+                childCount = counts[right];
+            }
+            if (count <= childCount) {
+                break;
+            }
+            ords[i] = ords[child];
+            counts[i] = counts[child];
+            i = child;
+        }
+        ords[i] = ord;
+        counts[i] = count;
+    }
+
+    /**
+     * Original single-pass build for non-count-descending orders (key order, sub-agg order).
+     * Resolves ordinals for every bucket and uses the full comparator.
+     */
+    private InternalMultiTerms.Bucket[] buildOrdinalBucketsSinglePass(
         long owningBucketOrd,
         LocalBucketCountThresholds localBucketCountThresholds,
         long[] otherDocCounts,

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregator.java
@@ -8,8 +8,10 @@
 
 package org.opensearch.search.aggregations.bucket.terms;
 
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.PriorityQueue;
@@ -74,6 +76,8 @@ import static org.opensearch.search.startree.StarTreeQueryHelper.getSupportedSta
 public class MultiTermsAggregator extends DeferableBucketAggregator implements StarTreePreComputeCollector {
 
     private final BytesKeyedBucketOrds bucketOrds;
+    private final MultiTermsBucketOrds ordinalBucketOrds;
+    private final List<ValuesSource.Bytes.WithOrdinals> ordinalSources;
     private final MultiTermsValuesSource multiTermsValue;
     private final boolean showTermDocCountError;
     private final List<DocValueFormat> formats;
@@ -99,9 +103,20 @@ public class MultiTermsAggregator extends DeferableBucketAggregator implements S
         SearchContext context,
         Aggregator parent,
         CardinalityUpperBound cardinality,
-        Map<String, Object> metadata
+        Map<String, Object> metadata,
+        MultiTermsBucketOrds ordinalBucketOrds
     ) throws IOException {
         super(name, factories, context, parent, metadata);
+        this.ordinalBucketOrds = ordinalBucketOrds;
+        if (ordinalBucketOrds != null) {
+            List<ValuesSource.Bytes.WithOrdinals> ordSources = new ArrayList<>(rawValuesSources.size());
+            for (ValuesSource vs : rawValuesSources) {
+                ordSources.add((ValuesSource.Bytes.WithOrdinals) vs);
+            }
+            this.ordinalSources = ordSources;
+        } else {
+            this.ordinalSources = null;
+        }
         this.bucketOrds = BytesKeyedBucketOrds.build(context.bigArrays(), cardinality);
         this.multiTermsValue = new MultiTermsValuesSource(rawValuesSources, internalValuesSources);
         this.showTermDocCountError = showTermDocCountError;
@@ -140,45 +155,36 @@ public class MultiTermsAggregator extends DeferableBucketAggregator implements S
         LocalBucketCountThresholds localBucketCountThresholds = context.asLocalBucketCountThresholds(bucketCountThresholds);
         InternalMultiTerms.Bucket[][] topBucketsPerOrd = new InternalMultiTerms.Bucket[owningBucketOrds.length][];
         long[] otherDocCounts = new long[owningBucketOrds.length];
+
+        // Resolve SortedSetDocValues for ordinal lookup if using ordinal path.
+        // Because these sources are WithOrdinals, calling lookupOrd(globalOrd) on the
+        // SortedSetDocValues obtained from any leaf returns the correct BytesRef for that
+        // global ordinal (the global-ord -> term mapping is shared across the whole index).
+        // Same pattern used in GlobalOrdinalsStringTermsAggregator.
+        SortedSetDocValues[] globalOrdsForLookup = null;
+        if (ordinalBucketOrds != null) {
+            globalOrdsForLookup = new SortedSetDocValues[ordinalSources.size()];
+            List<LeafReaderContext> leaves = context.searcher().getTopReaderContext().leaves();
+            LeafReaderContext leafCtx = leaves.isEmpty() ? null : leaves.get(0);
+            for (int i = 0; i < ordinalSources.size(); i++) {
+                globalOrdsForLookup[i] = leafCtx == null ? DocValues.emptySortedSet() : ordinalSources.get(i).globalOrdinalsValues(leafCtx);
+            }
+        }
+
         for (int ordIdx = 0; ordIdx < owningBucketOrds.length; ordIdx++) {
             checkCancelled();
             collectZeroDocEntriesIfNeeded(owningBucketOrds[ordIdx]);
-            long bucketsInOrd = bucketOrds.bucketsInOrd(owningBucketOrds[ordIdx]);
 
-            int size = (int) Math.min(bucketsInOrd, localBucketCountThresholds.getRequiredSize());
-            PriorityQueue<InternalMultiTerms.Bucket> ordered = new BucketPriorityQueue<>(size, partiallyBuiltBucketComparator);
-            InternalMultiTerms.Bucket spare = null;
-            BytesRef dest = null;
-            BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum = bucketOrds.ordsEnum(owningBucketOrds[ordIdx]);
-            CheckedSupplier<InternalMultiTerms.Bucket, IOException> emptyBucketBuilder = () -> InternalMultiTerms.Bucket.EMPTY(
-                showTermDocCountError,
-                formats
-            );
-            while (ordsEnum.next()) {
-                long docCount = bucketDocCount(ordsEnum.ord());
-                otherDocCounts[ordIdx] += docCount;
-                if (docCount < localBucketCountThresholds.getMinDocCount()) {
-                    continue;
-                }
-                if (spare == null) {
-                    spare = emptyBucketBuilder.get();
-                    dest = new BytesRef();
-                }
-
-                ordsEnum.readValue(dest);
-
-                spare.termValues = decode(dest);
-                spare.docCount = docCount;
-                spare.bucketOrd = ordsEnum.ord();
-                spare = ordered.insertWithOverflow(spare);
-            }
-
-            // Get the top buckets
-            InternalMultiTerms.Bucket[] bucketsForOrd = new InternalMultiTerms.Bucket[ordered.size()];
-            topBucketsPerOrd[ordIdx] = bucketsForOrd;
-            for (int b = ordered.size() - 1; b >= 0; --b) {
-                topBucketsPerOrd[ordIdx][b] = ordered.pop();
-                otherDocCounts[ordIdx] -= topBucketsPerOrd[ordIdx][b].getDocCount();
+            if (ordinalBucketOrds != null) {
+                topBucketsPerOrd[ordIdx] = buildOrdinalBuckets(
+                    owningBucketOrds[ordIdx],
+                    localBucketCountThresholds,
+                    otherDocCounts,
+                    ordIdx,
+                    globalOrdsForLookup
+                );
+            } else {
+                topBucketsPerOrd[ordIdx] = buildBytesBuckets(owningBucketOrds[ordIdx], localBucketCountThresholds, otherDocCounts, ordIdx);
             }
         }
 
@@ -189,6 +195,102 @@ public class MultiTermsAggregator extends DeferableBucketAggregator implements S
             result[ordIdx] = buildResult(owningBucketOrds[ordIdx], otherDocCounts[ordIdx], topBucketsPerOrd[ordIdx]);
         }
         return result;
+    }
+
+    /**
+     * Build top buckets from the ordinal-based path by resolving packed ordinals
+     * back to term values via {@code lookupOrd()}.
+     */
+    private InternalMultiTerms.Bucket[] buildOrdinalBuckets(
+        long owningBucketOrd,
+        LocalBucketCountThresholds localBucketCountThresholds,
+        long[] otherDocCounts,
+        int ordIdx,
+        SortedSetDocValues[] globalOrdsForLookup
+    ) throws IOException {
+        long bucketsInOrd = ordinalBucketOrds.bucketsInOrd(owningBucketOrd);
+        int size = (int) Math.min(bucketsInOrd, localBucketCountThresholds.getRequiredSize());
+        PriorityQueue<InternalMultiTerms.Bucket> ordered = new BucketPriorityQueue<>(size, partiallyBuiltBucketComparator);
+        InternalMultiTerms.Bucket spare = null;
+        CheckedSupplier<InternalMultiTerms.Bucket, IOException> emptyBucketBuilder = () -> InternalMultiTerms.Bucket.EMPTY(
+            showTermDocCountError,
+            formats
+        );
+        MultiTermsBucketOrds.BucketOrdsEnum ordsEnum = ordinalBucketOrds.ordsEnum(owningBucketOrd);
+        while (ordsEnum.next()) {
+            long docCount = bucketDocCount(ordsEnum.ord());
+            otherDocCounts[ordIdx] += docCount;
+            if (docCount < localBucketCountThresholds.getMinDocCount()) {
+                continue;
+            }
+            if (spare == null) {
+                spare = emptyBucketBuilder.get();
+            }
+
+            long[] ordinals = ordsEnum.ordinals();
+            List<Object> termValues = new ArrayList<>(ordinals.length);
+            for (int i = 0; i < ordinals.length; i++) {
+                termValues.add(BytesRef.deepCopyOf(globalOrdsForLookup[i].lookupOrd(ordinals[i])));
+            }
+
+            spare.termValues = termValues;
+            spare.docCount = docCount;
+            spare.bucketOrd = ordsEnum.ord();
+            spare = ordered.insertWithOverflow(spare);
+        }
+
+        InternalMultiTerms.Bucket[] bucketsForOrd = new InternalMultiTerms.Bucket[ordered.size()];
+        for (int b = ordered.size() - 1; b >= 0; --b) {
+            bucketsForOrd[b] = ordered.pop();
+            otherDocCounts[ordIdx] -= bucketsForOrd[b].getDocCount();
+        }
+        return bucketsForOrd;
+    }
+
+    /**
+     * Build top buckets from the existing bytes-based path.
+     */
+    private InternalMultiTerms.Bucket[] buildBytesBuckets(
+        long owningBucketOrd,
+        LocalBucketCountThresholds localBucketCountThresholds,
+        long[] otherDocCounts,
+        int ordIdx
+    ) throws IOException {
+        long bucketsInOrd = bucketOrds.bucketsInOrd(owningBucketOrd);
+        int size = (int) Math.min(bucketsInOrd, localBucketCountThresholds.getRequiredSize());
+        PriorityQueue<InternalMultiTerms.Bucket> ordered = new BucketPriorityQueue<>(size, partiallyBuiltBucketComparator);
+        InternalMultiTerms.Bucket spare = null;
+        BytesRef dest = null;
+        BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum = bucketOrds.ordsEnum(owningBucketOrd);
+        CheckedSupplier<InternalMultiTerms.Bucket, IOException> emptyBucketBuilder = () -> InternalMultiTerms.Bucket.EMPTY(
+            showTermDocCountError,
+            formats
+        );
+        while (ordsEnum.next()) {
+            long docCount = bucketDocCount(ordsEnum.ord());
+            otherDocCounts[ordIdx] += docCount;
+            if (docCount < localBucketCountThresholds.getMinDocCount()) {
+                continue;
+            }
+            if (spare == null) {
+                spare = emptyBucketBuilder.get();
+                dest = new BytesRef();
+            }
+
+            ordsEnum.readValue(dest);
+
+            spare.termValues = decode(dest);
+            spare.docCount = docCount;
+            spare.bucketOrd = ordsEnum.ord();
+            spare = ordered.insertWithOverflow(spare);
+        }
+
+        InternalMultiTerms.Bucket[] bucketsForOrd = new InternalMultiTerms.Bucket[ordered.size()];
+        for (int b = ordered.size() - 1; b >= 0; --b) {
+            bucketsForOrd[b] = ordered.pop();
+            otherDocCounts[ordIdx] -= bucketsForOrd[b].getDocCount();
+        }
+        return bucketsForOrd;
     }
 
     InternalMultiTerms buildResult(long owningBucketOrd, long otherDocCount, InternalMultiTerms.Bucket[] topBuckets) {
@@ -233,11 +335,70 @@ public class MultiTermsAggregator extends DeferableBucketAggregator implements S
 
     @Override
     protected LeafBucketCollector getLeafCollector(LeafReaderContext ctx, LeafBucketCollector sub) throws IOException {
+        if (ordinalBucketOrds != null) {
+            return getOrdinalLeafCollector(ctx, sub);
+        }
         MultiTermsValuesSourceCollector collector = multiTermsValue.getValues(ctx, bucketOrds, this, sub);
         return new LeafBucketCollector() {
             @Override
             public void collect(int doc, long owningBucketOrd) throws IOException {
                 collector.apply(doc, owningBucketOrd);
+            }
+        };
+    }
+
+    /**
+     * Creates a leaf collector that collects global ordinals directly instead of
+     * serialized term values. Generates the cartesian product of ordinal tuples
+     * across all fields for each document.
+     */
+    private LeafBucketCollector getOrdinalLeafCollector(LeafReaderContext ctx, LeafBucketCollector sub) throws IOException {
+        int numFields = ordinalSources.size();
+        SortedSetDocValues[] globalOrds = new SortedSetDocValues[numFields];
+        for (int i = 0; i < numFields; i++) {
+            globalOrds[i] = ordinalSources.get(i).globalOrdinalsValues(ctx);
+        }
+        return new LeafBucketCollector() {
+            private final long[] ordTuple = new long[numFields];
+            // Reusable scratch buffer: one long[] per field, grown on demand.
+            private final long[][] ordinalSets = new long[numFields][];
+            // Per-field valid-element counts for the current doc.
+            private final int[] counts = new int[numFields];
+
+            @Override
+            public void collect(int doc, long owningBucketOrd) throws IOException {
+                for (int i = 0; i < numFields; i++) {
+                    if (globalOrds[i].advanceExact(doc) == false) {
+                        return; // missing value in any field → skip doc
+                    }
+                    int count = globalOrds[i].docValueCount();
+                    if (ordinalSets[i] == null || ordinalSets[i].length < count) {
+                        ordinalSets[i] = new long[count];
+                    }
+                    for (int j = 0; j < count; j++) {
+                        ordinalSets[i][j] = globalOrds[i].nextOrd();
+                    }
+                    counts[i] = count;
+                }
+                generateOrdinalCombinations(0, owningBucketOrd, doc, sub);
+            }
+
+            private void generateOrdinalCombinations(int depth, long owningBucketOrd, int doc, LeafBucketCollector sub) throws IOException {
+                if (depth == numFields) {
+                    long bucketOrd = ordinalBucketOrds.add(owningBucketOrd, ordTuple);
+                    if (bucketOrd < 0) {
+                        collectExistingBucket(sub, doc, -1 - bucketOrd);
+                    } else {
+                        collectBucket(sub, doc, bucketOrd);
+                    }
+                    return;
+                }
+                long[] fieldOrds = ordinalSets[depth];
+                int count = counts[depth];
+                for (int k = 0; k < count; k++) {
+                    ordTuple[depth] = fieldOrds[k];
+                    generateOrdinalCombinations(depth + 1, owningBucketOrd, doc, sub);
+                }
             }
         };
     }
@@ -378,9 +539,17 @@ public class MultiTermsAggregator extends DeferableBucketAggregator implements S
         );
     }
 
+    /**
+     * Returns the ordinal-based bucket ords, or {@code null} if the bytes-based path is active.
+     * Package-private for testing.
+     */
+    MultiTermsBucketOrds getOrdinalBucketOrds() {
+        return ordinalBucketOrds;
+    }
+
     @Override
     protected void doClose() {
-        Releasables.close(bucketOrds, multiTermsValue);
+        Releasables.close(bucketOrds, ordinalBucketOrds, multiTermsValue);
     }
 
     private static List<Object> decode(BytesRef bytesRef) {
@@ -409,16 +578,77 @@ public class MultiTermsAggregator extends DeferableBucketAggregator implements S
         if (bucketCountThresholds.getMinDocCount() != 0) {
             return;
         }
-        if (InternalOrder.isCountDesc(order) && bucketOrds.bucketsInOrd(owningBucketOrd) >= bucketCountThresholds.getRequiredSize()) {
+        if (ordinalBucketOrds != null) {
+            if (InternalOrder.isCountDesc(order)
+                && ordinalBucketOrds.bucketsInOrd(owningBucketOrd) >= bucketCountThresholds.getRequiredSize()) {
+                return;
+            }
+            for (LeafReaderContext ctx : context.searcher().getTopReaderContext().leaves()) {
+                collectZeroDocOrdinals(ctx, owningBucketOrd);
+            }
+        } else {
+            if (InternalOrder.isCountDesc(order) && bucketOrds.bucketsInOrd(owningBucketOrd) >= bucketCountThresholds.getRequiredSize()) {
+                return;
+            }
+            // we need to fill-in the blanks
+            for (LeafReaderContext ctx : context.searcher().getTopReaderContext().leaves()) {
+                // brute force
+                MultiTermsValuesSourceCollector collector = multiTermsValue.getValues(ctx, bucketOrds, null, null);
+                for (int docId = 0; docId < ctx.reader().maxDoc(); ++docId) {
+                    collector.apply(docId, owningBucketOrd);
+                }
+            }
+        }
+    }
+
+    /**
+     * Adds all ordinal tuples from a leaf to the ordinal bucket ords without
+     * collecting sub-aggregators or incrementing doc counts. Used for zero-doc
+     * entry filling when minDocCount is 0.
+     */
+    private void collectZeroDocOrdinals(LeafReaderContext ctx, long owningBucketOrd) throws IOException {
+        int numFields = ordinalSources.size();
+        SortedSetDocValues[] globalOrds = new SortedSetDocValues[numFields];
+        for (int i = 0; i < numFields; i++) {
+            globalOrds[i] = ordinalSources.get(i).globalOrdinalsValues(ctx);
+        }
+        long[] ordTuple = new long[numFields];
+        long[][] ordinalSets = new long[numFields][];
+        int[] counts = new int[numFields];
+        int maxDoc = ctx.reader().maxDoc();
+        for (int docId = 0; docId < maxDoc; ++docId) {
+            boolean skip = false;
+            for (int i = 0; i < numFields; i++) {
+                if (globalOrds[i].advanceExact(docId) == false) {
+                    skip = true;
+                    break;
+                }
+                int count = globalOrds[i].docValueCount();
+                if (ordinalSets[i] == null || ordinalSets[i].length < count) {
+                    ordinalSets[i] = new long[count];
+                }
+                for (int j = 0; j < count; j++) {
+                    ordinalSets[i][j] = globalOrds[i].nextOrd();
+                }
+                counts[i] = count;
+            }
+            if (skip) {
+                continue;
+            }
+            addOrdinalCombinations(ordinalSets, counts, 0, ordTuple, owningBucketOrd);
+        }
+    }
+
+    private void addOrdinalCombinations(long[][] ordinalSets, int[] counts, int depth, long[] current, long owningBucketOrd) {
+        if (depth == ordinalSets.length) {
+            ordinalBucketOrds.add(owningBucketOrd, current);
             return;
         }
-        // we need to fill-in the blanks
-        for (LeafReaderContext ctx : context.searcher().getTopReaderContext().leaves()) {
-            // brute force
-            MultiTermsValuesSourceCollector collector = multiTermsValue.getValues(ctx, bucketOrds, null, null);
-            for (int docId = 0; docId < ctx.reader().maxDoc(); ++docId) {
-                collector.apply(docId, owningBucketOrd);
-            }
+        long[] fieldOrds = ordinalSets[depth];
+        int count = counts[depth];
+        for (int k = 0; k < count; k++) {
+            current[depth] = fieldOrds[k];
+            addOrdinalCombinations(ordinalSets, counts, depth + 1, current, owningBucketOrd);
         }
     }
 

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsBucketOrds.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsBucketOrds.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.terms;
+
+import org.opensearch.common.lease.Releasable;
+
+/**
+ * Maps composite ordinal tuples to bucket ordinals for multi-terms aggregation.
+ * Used when all fields in the aggregation support global ordinals, enabling
+ * packed ordinal storage instead of serialized BytesRef composite keys.
+ *
+ * @opensearch.internal
+ */
+public interface MultiTermsBucketOrds extends Releasable {
+
+    /**
+     * Add the {@code owningBucketOrd, ordinals} tuple. Return the ord for
+     * their bucket if they have yet to be added, or {@code -1-ord}
+     * if they were already present.
+     */
+    long add(long owningBucketOrd, long[] ordinals);
+
+    /**
+     * Count the buckets in {@code owningBucketOrd}.
+     */
+    long bucketsInOrd(long owningBucketOrd);
+
+    /**
+     * The number of collected buckets.
+     */
+    long size();
+
+    /**
+     * Build an iterator for buckets inside {@code owningBucketOrd} in order
+     * of increasing ord.
+     * <p>
+     * When first returned it is "unpositioned" and you must call
+     * {@link BucketOrdsEnum#next()} to move it to the first value.
+     */
+    BucketOrdsEnum ordsEnum(long owningBucketOrd);
+
+    /**
+     * An iterator for buckets inside a particular {@code owningBucketOrd}.
+     *
+     * @opensearch.internal
+     */
+    interface BucketOrdsEnum {
+        /**
+         * Advance to the next value.
+         * @return {@code true} if there *is* a next value,
+         *         {@code false} if there isn't
+         */
+        boolean next();
+
+        /**
+         * The ordinal of the current bucket.
+         */
+        long ord();
+
+        /**
+         * Read the ordinal tuple for the current bucket.
+         */
+        long[] ordinals();
+
+        /**
+         * An {@linkplain BucketOrdsEnum} that is empty.
+         */
+        BucketOrdsEnum EMPTY = new BucketOrdsEnum() {
+            @Override
+            public boolean next() {
+                return false;
+            }
+
+            @Override
+            public long ord() {
+                return 0;
+            }
+
+            @Override
+            public long[] ordinals() {
+                return new long[0];
+            }
+        };
+    }
+}

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsBucketOrds.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsBucketOrds.java
@@ -46,6 +46,13 @@ public interface MultiTermsBucketOrds extends Releasable {
     BucketOrdsEnum ordsEnum(long owningBucketOrd);
 
     /**
+     * Look up the ordinal tuple for a specific bucket ordinal.
+     * Used by the two-pass build optimization to resolve ordinals
+     * only for top-K buckets without iterating all buckets.
+     */
+    long[] getOrdinals(long bucketOrd);
+
+    /**
      * An iterator for buckets inside a particular {@code owningBucketOrd}.
      *
      * @opensearch.internal

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/PackedOrdinalBucketOrds.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/PackedOrdinalBucketOrds.java
@@ -307,6 +307,15 @@ public class PackedOrdinalBucketOrds implements MultiTermsBucketOrds {
     }
 
     @Override
+    public long[] getOrdinals(long bucketOrd) {
+        if (singleLongDelegate != null) {
+            return unpackSingleLong(singleLongDelegate.get(bucketOrd));
+        } else {
+            return unpackTwoLongs(twoLongDelegate.getKey1(bucketOrd), twoLongDelegate.getKey2(bucketOrd));
+        }
+    }
+
+    @Override
     public void close() {
         Releasables.close(singleLongDelegate, twoLongDelegate);
     }

--- a/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/PackedOrdinalBucketOrds.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/bucket/terms/PackedOrdinalBucketOrds.java
@@ -1,0 +1,329 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.terms;
+
+import org.opensearch.common.lease.Releasables;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.common.util.LongLongHash;
+import org.opensearch.search.aggregations.CardinalityUpperBound;
+
+/**
+ * {@link MultiTermsBucketOrds} that packs N field ordinals into one or two {@code long}
+ * values and stores them in a native long-based hash structure, avoiding
+ * {@link org.apache.lucene.util.BytesRef} serialization entirely.
+ * <p>
+ * When the total bits required for all fields fit in 63 bits, a single {@code long}
+ * is used via {@link LongKeyedBucketOrds}. When the total exceeds 63 bits but fits
+ * in 126 bits (two longs), a {@link LongLongHash} is used directly.
+ * <p>
+ * Each field is assigned a bit width based on its global ordinal value count.
+ * Fields are packed contiguously: field 0 occupies the lowest bits, field 1 the
+ * next bits, and so on.
+ *
+ * @opensearch.internal
+ */
+public class PackedOrdinalBucketOrds implements MultiTermsBucketOrds {
+
+    private final int numFields;
+    /** Number of bits required for each field. */
+    private final int[] bitsPerField;
+    /** Bit offset of each field within the packed representation. */
+    private final int[] bitOffsets;
+    /** Bit mask for each field (applied after right-shifting to offset). */
+    private final long[] fieldMasks;
+    /** Total bits needed across all fields. */
+    private final int totalBits;
+
+    /**
+     * Delegate for the single-long path (totalBits &lt;= 63).
+     * Null when using the two-long path.
+     */
+    private final LongKeyedBucketOrds singleLongDelegate;
+
+    /**
+     * Delegate for the two-long path (64 &lt;= totalBits &lt;= 126).
+     * Null when using the single-long path.
+     */
+    private final LongLongHash twoLongDelegate;
+
+    /**
+     * The bit offset that separates the first long from the second long
+     * in the two-long path. Fields with {@code bitOffsets[i] < splitOffset}
+     * go into long1; the rest go into long2.
+     * Only meaningful when {@code twoLongDelegate != null}.
+     */
+    private final int splitOffset;
+
+    /**
+     * Create a new instance.
+     *
+     * @param bigArrays   for memory allocation
+     * @param cardinality upper bound on owning bucket cardinality
+     * @param maxOrds     the value count (exclusive upper bound) for each field's ordinals
+     */
+    public PackedOrdinalBucketOrds(BigArrays bigArrays, CardinalityUpperBound cardinality, long[] maxOrds) {
+        this.numFields = maxOrds.length;
+        this.bitsPerField = new int[numFields];
+        this.bitOffsets = new int[numFields];
+        this.fieldMasks = new long[numFields];
+
+        int total = 0;
+        for (int i = 0; i < numFields; i++) {
+            bitsPerField[i] = bitsRequired(maxOrds[i]);
+            bitOffsets[i] = total;
+            fieldMasks[i] = bitsPerField[i] == 64 ? -1L : (1L << bitsPerField[i]) - 1;
+            total += bitsPerField[i];
+        }
+        this.totalBits = total;
+        assert totalBits <= 126 : "total bits " + totalBits + " exceeds 126";
+
+        if (totalBits <= 63) {
+            this.singleLongDelegate = LongKeyedBucketOrds.build(bigArrays, cardinality);
+            this.twoLongDelegate = null;
+            this.splitOffset = 0;
+        } else {
+            this.singleLongDelegate = null;
+            this.twoLongDelegate = new LongLongHash(2, bigArrays);
+            // splitOffset = 63: pack as much as possible into the first long
+            this.splitOffset = 63;
+        }
+    }
+
+    /**
+     * Returns the minimum number of bits needed to represent values in {@code [0, maxOrd)}.
+     * Returns 0 when {@code maxOrd} is 0 or negative.
+     */
+    static int bitsRequired(long maxOrd) {
+        if (maxOrd <= 0) {
+            return 0;
+        }
+        return Long.SIZE - Long.numberOfLeadingZeros(maxOrd - 1);
+    }
+
+    /**
+     * Check whether the given max ordinal counts can be packed into a single long
+     * (63 usable bits, reserving the sign bit).
+     */
+    public static boolean fitsInSingleLong(long[] maxOrds) {
+        int total = 0;
+        for (long maxOrd : maxOrds) {
+            total += bitsRequired(maxOrd);
+            if (total > 63) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Check whether the given max ordinal counts can be packed into two longs
+     * (126 usable bits total).
+     */
+    public static boolean fitsInTwoLongs(long[] maxOrds) {
+        int total = 0;
+        for (long maxOrd : maxOrds) {
+            total += bitsRequired(maxOrd);
+            if (total > 126) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Pack ordinals into a single long. Only valid when {@code totalBits <= 63}.
+     */
+    long packSingleLong(long[] ordinals) {
+        assert ordinals.length == numFields;
+        long packed = 0;
+        for (int i = 0; i < numFields; i++) {
+            packed |= (ordinals[i] << bitOffsets[i]);
+        }
+        return packed;
+    }
+
+    /**
+     * Unpack ordinals from a single long.
+     */
+    long[] unpackSingleLong(long packed) {
+        long[] ordinals = new long[numFields];
+        for (int i = 0; i < numFields; i++) {
+            ordinals[i] = (packed >>> bitOffsets[i]) & fieldMasks[i];
+        }
+        return ordinals;
+    }
+
+    /**
+     * Pack ordinals into two longs. Fields whose bit offset is below
+     * {@code splitOffset} go into long1; the rest go into long2.
+     * Only valid when {@code 64 <= totalBits <= 126}.
+     */
+    long packLong1(long[] ordinals) {
+        long packed = 0;
+        for (int i = 0; i < numFields; i++) {
+            if (bitOffsets[i] + bitsPerField[i] <= splitOffset) {
+                // field fits entirely in long1
+                packed |= (ordinals[i] << bitOffsets[i]);
+            } else if (bitOffsets[i] < splitOffset) {
+                // field straddles the boundary — put low bits in long1
+                int bitsInLong1 = splitOffset - bitOffsets[i];
+                long mask = (1L << bitsInLong1) - 1;
+                packed |= ((ordinals[i] & mask) << bitOffsets[i]);
+            }
+            // else: field is entirely in long2
+        }
+        return packed;
+    }
+
+    long packLong2(long[] ordinals) {
+        long packed = 0;
+        for (int i = 0; i < numFields; i++) {
+            if (bitOffsets[i] >= splitOffset) {
+                // field is entirely in long2
+                packed |= (ordinals[i] << (bitOffsets[i] - splitOffset));
+            } else if (bitOffsets[i] + bitsPerField[i] > splitOffset) {
+                // field straddles the boundary — put high bits in long2
+                int bitsInLong1 = splitOffset - bitOffsets[i];
+                packed |= (ordinals[i] >>> bitsInLong1);
+            }
+            // else: field is entirely in long1
+        }
+        return packed;
+    }
+
+    long[] unpackTwoLongs(long long1, long long2) {
+        long[] ordinals = new long[numFields];
+        for (int i = 0; i < numFields; i++) {
+            if (bitOffsets[i] + bitsPerField[i] <= splitOffset) {
+                // field is entirely in long1
+                ordinals[i] = (long1 >>> bitOffsets[i]) & fieldMasks[i];
+            } else if (bitOffsets[i] >= splitOffset) {
+                // field is entirely in long2
+                ordinals[i] = (long2 >>> (bitOffsets[i] - splitOffset)) & fieldMasks[i];
+            } else {
+                // field straddles the boundary
+                int bitsInLong1 = splitOffset - bitOffsets[i];
+                long lowMask = (1L << bitsInLong1) - 1;
+                long lowBits = (long1 >>> bitOffsets[i]) & lowMask;
+                int bitsInLong2 = bitsPerField[i] - bitsInLong1;
+                long highMask = (1L << bitsInLong2) - 1;
+                long highBits = long2 & highMask;
+                ordinals[i] = (highBits << bitsInLong1) | lowBits;
+            }
+        }
+        return ordinals;
+    }
+
+    @Override
+    public long add(long owningBucketOrd, long[] ordinals) {
+        assert ordinals.length == numFields;
+        if (singleLongDelegate != null) {
+            return singleLongDelegate.add(owningBucketOrd, packSingleLong(ordinals));
+        } else {
+            checkSingleOwningBucket(owningBucketOrd);
+            return twoLongDelegate.add(packLong1(ordinals), packLong2(ordinals));
+        }
+    }
+
+    @Override
+    public long bucketsInOrd(long owningBucketOrd) {
+        if (singleLongDelegate != null) {
+            return singleLongDelegate.bucketsInOrd(owningBucketOrd);
+        } else {
+            checkSingleOwningBucket(owningBucketOrd);
+            return twoLongDelegate.size();
+        }
+    }
+
+    /**
+     * The two-long path delegates to {@link LongLongHash}, which does not encode
+     * {@code owningBucketOrd} in its key space. The factory guards against this by
+     * only choosing the two-long path when {@code CardinalityUpperBound.ONE} holds,
+     * but we fail loudly here if that invariant is ever violated.
+     */
+    private static void checkSingleOwningBucket(long owningBucketOrd) {
+        if (owningBucketOrd != 0) {
+            throw new IllegalStateException("two-long path only supports a single owning bucket (owningBucketOrd=" + owningBucketOrd + ")");
+        }
+    }
+
+    @Override
+    public long size() {
+        if (singleLongDelegate != null) {
+            return singleLongDelegate.size();
+        } else {
+            return twoLongDelegate.size();
+        }
+    }
+
+    @Override
+    public BucketOrdsEnum ordsEnum(long owningBucketOrd) {
+        if (singleLongDelegate != null) {
+            LongKeyedBucketOrds.BucketOrdsEnum inner = singleLongDelegate.ordsEnum(owningBucketOrd);
+            return new BucketOrdsEnum() {
+                @Override
+                public boolean next() {
+                    return inner.next();
+                }
+
+                @Override
+                public long ord() {
+                    return inner.ord();
+                }
+
+                @Override
+                public long[] ordinals() {
+                    return unpackSingleLong(inner.value());
+                }
+            };
+        } else {
+            checkSingleOwningBucket(owningBucketOrd);
+            return new BucketOrdsEnum() {
+                private long ord = -1;
+
+                @Override
+                public boolean next() {
+                    ord++;
+                    return ord < twoLongDelegate.size();
+                }
+
+                @Override
+                public long ord() {
+                    return ord;
+                }
+
+                @Override
+                public long[] ordinals() {
+                    return unpackTwoLongs(twoLongDelegate.getKey1(ord), twoLongDelegate.getKey2(ord));
+                }
+            };
+        }
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(singleLongDelegate, twoLongDelegate);
+    }
+
+    /**
+     * Returns the total number of bits used for packing.
+     * Package-private for testing.
+     */
+    int totalBits() {
+        return totalBits;
+    }
+
+    /**
+     * Returns whether this instance uses the single-long path.
+     * Package-private for testing.
+     */
+    boolean isSingleLongPath() {
+        return singleLongDelegate != null;
+    }
+}

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregatorTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsAggregatorTests.java
@@ -958,7 +958,8 @@ public class MultiTermsAggregatorTests extends AggregatorTestCase {
             context,
             parent,
             cardinality,
-            metadata
+            metadata,
+            null
         );
         InternalAggregation emptyAgg = mAgg.buildEmptyAggregation();
 

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsOrdinalOptimizationTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/MultiTermsOrdinalOptimizationTests.java
@@ -1,0 +1,797 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.terms;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.index.mapper.HllFieldMapper;
+import org.opensearch.index.mapper.KeywordFieldMapper;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.search.aggregations.AggregatorTestCase;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.metrics.InternalSum;
+import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.opensearch.search.aggregations.support.CoreValuesSourceType;
+import org.opensearch.search.aggregations.support.MultiTermsValuesSourceConfig;
+import org.opensearch.search.aggregations.support.ValuesSourceType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+
+/**
+ * End-to-end equivalence tests verifying that the ordinal-based path and the
+ * bytes-based path produce identical aggregation results for the same data.
+ */
+public class MultiTermsOrdinalOptimizationTests extends AggregatorTestCase {
+
+    private static final String KW_FIELD_1 = "kw1";
+    private static final String KW_FIELD_2 = "kw2";
+    private static final String KW_FIELD_3 = "kw3";
+    private static final String INT_FIELD = "int_val";
+
+    private MappedFieldType[] allFieldTypes() {
+        return new MappedFieldType[] {
+            new KeywordFieldMapper.KeywordFieldType(KW_FIELD_1),
+            new KeywordFieldMapper.KeywordFieldType(KW_FIELD_2),
+            new KeywordFieldMapper.KeywordFieldType(KW_FIELD_3),
+            new NumberFieldMapper.NumberFieldType(INT_FIELD, NumberFieldMapper.NumberType.INTEGER) };
+    }
+
+    private MultiTermsValuesSourceConfig kwConfig(String field) {
+        return new MultiTermsValuesSourceConfig.Builder().setFieldName(field).build();
+    }
+
+    private MultiTermsValuesSourceConfig intConfig() {
+        return new MultiTermsValuesSourceConfig.Builder().setFieldName(INT_FIELD).build();
+    }
+
+    /**
+     * Test with 2 keyword fields — exercises the PackedOrdinalBucketOrds (single-long) path.
+     * Indexes random documents with 2 keyword fields, runs multi_terms aggregation,
+     * and verifies results match expected bucket keys and doc counts.
+     */
+    public void testTwoKeywordFieldsPairPackingPath() throws IOException {
+        int numDistinctValues = randomIntBetween(3, 15);
+        String[] values = new String[numDistinctValues];
+        for (int i = 0; i < numDistinctValues; i++) {
+            values[i] = randomAlphaOfLength(randomIntBetween(3, 10));
+        }
+
+        int numDocs = randomIntBetween(20, 100);
+        Map<String, Long> expectedCounts = new HashMap<>();
+
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int i = 0; i < numDocs; i++) {
+                String v1 = values[randomIntBetween(0, numDistinctValues - 1)];
+                String v2 = values[randomIntBetween(0, numDistinctValues - 1)];
+                Document doc = new Document();
+                doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef(v1)));
+                doc.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef(v2)));
+                iw.addDocument(doc);
+                expectedCounts.merge(v1 + "|" + v2, 1L, Long::sum);
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2))
+                ).size(numDistinctValues * numDistinctValues + 10);
+
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+
+                // Verify every bucket matches expected counts
+                Map<String, Long> actualCounts = new HashMap<>();
+                for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+                    List<Object> key = bucket.getKey();
+                    assertEquals("Each bucket key should have 2 elements", 2, key.size());
+                    String compositeKey = key.get(0) + "|" + key.get(1);
+                    actualCounts.put(compositeKey, bucket.getDocCount());
+                }
+
+                assertEquals("Bucket count mismatch", expectedCounts.size(), actualCounts.size());
+                for (Map.Entry<String, Long> entry : expectedCounts.entrySet()) {
+                    assertEquals("Doc count mismatch for key " + entry.getKey(), entry.getValue(), actualCounts.get(entry.getKey()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Test with 3 keyword fields — exercises the PackedOrdinalBucketOrds (single-long) path.
+     * Indexes random documents with 3 keyword fields, runs multi_terms aggregation,
+     * and verifies results match expected bucket keys and doc counts.
+     */
+    public void testThreeKeywordFieldsPackedOrdinalsPath() throws IOException {
+        int numDistinctValues = randomIntBetween(2, 8);
+        String[] values = new String[numDistinctValues];
+        for (int i = 0; i < numDistinctValues; i++) {
+            values[i] = randomAlphaOfLength(randomIntBetween(3, 10));
+        }
+
+        int numDocs = randomIntBetween(20, 80);
+        Map<String, Long> expectedCounts = new HashMap<>();
+
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int i = 0; i < numDocs; i++) {
+                String v1 = values[randomIntBetween(0, numDistinctValues - 1)];
+                String v2 = values[randomIntBetween(0, numDistinctValues - 1)];
+                String v3 = values[randomIntBetween(0, numDistinctValues - 1)];
+                Document doc = new Document();
+                doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef(v1)));
+                doc.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef(v2)));
+                doc.add(new SortedDocValuesField(KW_FIELD_3, new BytesRef(v3)));
+                iw.addDocument(doc);
+                expectedCounts.merge(v1 + "|" + v2 + "|" + v3, 1L, Long::sum);
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2), kwConfig(KW_FIELD_3))
+                ).size(numDistinctValues * numDistinctValues * numDistinctValues + 10);
+
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+
+                Map<String, Long> actualCounts = new HashMap<>();
+                for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+                    List<Object> key = bucket.getKey();
+                    assertEquals("Each bucket key should have 3 elements", 3, key.size());
+                    String compositeKey = key.get(0) + "|" + key.get(1) + "|" + key.get(2);
+                    actualCounts.put(compositeKey, bucket.getDocCount());
+                }
+
+                assertEquals("Bucket count mismatch", expectedCounts.size(), actualCounts.size());
+                for (Map.Entry<String, Long> entry : expectedCounts.entrySet()) {
+                    assertEquals("Doc count mismatch for key " + entry.getKey(), entry.getValue(), actualCounts.get(entry.getKey()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Test with mixed keyword + numeric fields — exercises the BytesKeyedBucketOrds fallback path.
+     * Verifies that when not all fields are WithOrdinals, the aggregation still produces correct results.
+     */
+    public void testMixedKeywordAndNumericFallbackPath() throws IOException {
+        int numDistinctKw = randomIntBetween(3, 10);
+        String[] kwValues = new String[numDistinctKw];
+        for (int i = 0; i < numDistinctKw; i++) {
+            kwValues[i] = randomAlphaOfLength(randomIntBetween(3, 8));
+        }
+
+        int numDocs = randomIntBetween(20, 80);
+        Map<String, Long> expectedCounts = new HashMap<>();
+
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int i = 0; i < numDocs; i++) {
+                String kw1 = kwValues[randomIntBetween(0, numDistinctKw - 1)];
+                int intVal = randomIntBetween(1, 5);
+                Document doc = new Document();
+                doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef(kw1)));
+                doc.add(new NumericDocValuesField(INT_FIELD, intVal));
+                iw.addDocument(doc);
+                expectedCounts.merge(kw1 + "|" + intVal, 1L, Long::sum);
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), intConfig())
+                ).size(numDistinctKw * 5 + 10);
+
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+
+                Map<String, Long> actualCounts = new HashMap<>();
+                for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+                    List<Object> key = bucket.getKey();
+                    assertEquals("Each bucket key should have 2 elements", 2, key.size());
+                    String compositeKey = key.get(0) + "|" + key.get(1);
+                    actualCounts.put(compositeKey, bucket.getDocCount());
+                }
+
+                assertEquals("Bucket count mismatch", expectedCounts.size(), actualCounts.size());
+                for (Map.Entry<String, Long> entry : expectedCounts.entrySet()) {
+                    assertEquals("Doc count mismatch for key " + entry.getKey(), entry.getValue(), actualCounts.get(entry.getKey()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Test equivalence between ordinal path (2 keyword fields) and fallback path (keyword + int)
+     * using the same underlying data. Indexes documents with both keyword and numeric representations,
+     * then compares the sorted bucket results from both paths.
+     */
+    public void testOrdinalPathEquivalentToFallbackPath() throws IOException {
+        // Use deterministic values so we can compare across paths
+        String[] kw1Values = { "alpha", "beta", "gamma" };
+        String[] kw2Values = { "one", "two", "three" };
+        // Map kw2 values to integers for the fallback path
+        Map<String, Integer> kw2ToInt = new HashMap<>();
+        kw2ToInt.put("one", 1);
+        kw2ToInt.put("two", 2);
+        kw2ToInt.put("three", 3);
+
+        int numDocs = randomIntBetween(30, 100);
+        List<int[]> docChoices = new ArrayList<>();
+        for (int i = 0; i < numDocs; i++) {
+            docChoices.add(new int[] { randomIntBetween(0, 2), randomIntBetween(0, 2) });
+        }
+
+        // Run ordinal path: 2 keyword fields
+        List<String> ordinalBuckets;
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int[] choice : docChoices) {
+                Document doc = new Document();
+                doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef(kw1Values[choice[0]])));
+                doc.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef(kw2Values[choice[1]])));
+                iw.addDocument(doc);
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2))
+                ).size(100);
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+                ordinalBuckets = bucketsToSortedStrings(result);
+            }
+        }
+
+        // Run fallback path: keyword + int (forces BytesKeyedBucketOrds)
+        List<String> fallbackBuckets;
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int[] choice : docChoices) {
+                Document doc = new Document();
+                doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef(kw1Values[choice[0]])));
+                doc.add(new NumericDocValuesField(INT_FIELD, kw2ToInt.get(kw2Values[choice[1]])));
+                iw.addDocument(doc);
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), intConfig())
+                ).size(100);
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+                // Convert int keys to the kw2 equivalent for comparison
+                fallbackBuckets = new ArrayList<>();
+                Map<Long, String> intToKw2 = new HashMap<>();
+                intToKw2.put(1L, "one");
+                intToKw2.put(2L, "two");
+                intToKw2.put(3L, "three");
+                for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+                    String kw = (String) bucket.getKey().get(0);
+                    String mapped = intToKw2.get(bucket.getKey().get(1));
+                    fallbackBuckets.add(kw + "|" + mapped + "=" + bucket.getDocCount());
+                }
+                fallbackBuckets.sort(Comparator.naturalOrder());
+            }
+        }
+
+        assertEquals("Ordinal and fallback paths should produce equivalent results", ordinalBuckets, fallbackBuckets);
+    }
+
+    /**
+     * Test with high-cardinality fields to exercise the ordinal path with many distinct values.
+     * Verifies correct results regardless of which internal packing path is used.
+     */
+    public void testHighCardinalityKeywordFields() throws IOException {
+        // Generate enough distinct values to exercise the ordinal path with higher cardinality
+        int numDistinct = randomIntBetween(50, 200);
+        String[] values = new String[numDistinct];
+        for (int i = 0; i < numDistinct; i++) {
+            values[i] = String.format(Locale.ROOT, "%05d_%s", i, randomAlphaOfLength(5));
+        }
+
+        int numDocs = randomIntBetween(100, 300);
+        Map<String, Long> expectedCounts = new HashMap<>();
+
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int i = 0; i < numDocs; i++) {
+                String v1 = values[randomIntBetween(0, numDistinct - 1)];
+                String v2 = values[randomIntBetween(0, numDistinct - 1)];
+                Document doc = new Document();
+                doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef(v1)));
+                doc.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef(v2)));
+                iw.addDocument(doc);
+                expectedCounts.merge(v1 + "|" + v2, 1L, Long::sum);
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+
+                // Use a large size to capture all buckets
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2))
+                ).size(expectedCounts.size() + 10);
+
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+
+                Map<String, Long> actualCounts = new HashMap<>();
+                for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+                    List<Object> key = bucket.getKey();
+                    assertEquals(2, key.size());
+                    String compositeKey = key.get(0) + "|" + key.get(1);
+                    actualCounts.put(compositeKey, bucket.getDocCount());
+                }
+
+                assertEquals("Bucket count mismatch for high-cardinality test", expectedCounts.size(), actualCounts.size());
+                for (Map.Entry<String, Long> entry : expectedCounts.entrySet()) {
+                    assertEquals("Doc count mismatch for key " + entry.getKey(), entry.getValue(), actualCounts.get(entry.getKey()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Test with multi-valued keyword fields (SortedSetDocValuesField) to verify
+     * the cartesian product is correctly generated in the ordinal path.
+     */
+    public void testMultiValuedKeywordFieldsOrdinalPath() throws IOException {
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+
+            // Doc 1: kw1=[a,b], kw2=[x] → buckets: (a,x), (b,x)
+            Document doc1 = new Document();
+            doc1.add(new SortedSetDocValuesField(KW_FIELD_1, new BytesRef("a")));
+            doc1.add(new SortedSetDocValuesField(KW_FIELD_1, new BytesRef("b")));
+            doc1.add(new SortedSetDocValuesField(KW_FIELD_2, new BytesRef("x")));
+            iw.addDocument(doc1);
+
+            // Doc 2: kw1=[a], kw2=[x,y] → buckets: (a,x), (a,y)
+            Document doc2 = new Document();
+            doc2.add(new SortedSetDocValuesField(KW_FIELD_1, new BytesRef("a")));
+            doc2.add(new SortedSetDocValuesField(KW_FIELD_2, new BytesRef("x")));
+            doc2.add(new SortedSetDocValuesField(KW_FIELD_2, new BytesRef("y")));
+            iw.addDocument(doc2);
+
+            // Doc 3: kw1=[b], kw2=[y] → buckets: (b,y)
+            Document doc3 = new Document();
+            doc3.add(new SortedSetDocValuesField(KW_FIELD_1, new BytesRef("b")));
+            doc3.add(new SortedSetDocValuesField(KW_FIELD_2, new BytesRef("y")));
+            iw.addDocument(doc3);
+
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2))
+                ).size(100);
+
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+
+                Map<String, Long> actualCounts = new HashMap<>();
+                for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+                    String compositeKey = bucket.getKey().get(0) + "|" + bucket.getKey().get(1);
+                    actualCounts.put(compositeKey, bucket.getDocCount());
+                }
+
+                // Expected: (a,x)=2, (a,y)=1, (b,x)=1, (b,y)=1
+                assertEquals(Long.valueOf(2), actualCounts.get("a|x"));
+                assertEquals(Long.valueOf(1), actualCounts.get("a|y"));
+                assertEquals(Long.valueOf(1), actualCounts.get("b|x"));
+                assertEquals(Long.valueOf(1), actualCounts.get("b|y"));
+                assertEquals(4, actualCounts.size());
+            }
+        }
+    }
+
+    /**
+     * Verify that 2 keyword fields select the PackedOrdinalBucketOrds strategy (single-long path).
+     */
+    public void testStrategySelectionTwoKeywordFields() throws IOException {
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            Document doc = new Document();
+            doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef("a")));
+            doc.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef("b")));
+            iw.addDocument(doc);
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2))
+                );
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+                // Verify the ordinal path produced correct results (1 bucket with count 1)
+                assertEquals(1, result.getBuckets().size());
+                InternalMultiTerms.Bucket bucket = result.getBuckets().get(0);
+                assertEquals("a", bucket.getKey().get(0));
+                assertEquals("b", bucket.getKey().get(1));
+                assertEquals(1, bucket.getDocCount());
+            }
+        }
+    }
+
+    /**
+     * Verify that 3 keyword fields select the PackedOrdinalBucketOrds strategy (single-long path for low cardinality).
+     */
+    public void testStrategySelectionThreeKeywordFields() throws IOException {
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            Document doc = new Document();
+            doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef("a")));
+            doc.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef("b")));
+            doc.add(new SortedDocValuesField(KW_FIELD_3, new BytesRef("c")));
+            iw.addDocument(doc);
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2), kwConfig(KW_FIELD_3))
+                );
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+                assertEquals(1, result.getBuckets().size());
+                InternalMultiTerms.Bucket bucket = result.getBuckets().get(0);
+                assertEquals("a", bucket.getKey().get(0));
+                assertEquals("b", bucket.getKey().get(1));
+                assertEquals("c", bucket.getKey().get(2));
+                assertEquals(1, bucket.getDocCount());
+            }
+        }
+    }
+
+    /**
+     * Verify that mixed keyword + numeric fields fall back to the bytes-based path and still produce correct results.
+     */
+    public void testStrategySelectionMixedFieldsFallback() throws IOException {
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            Document doc = new Document();
+            doc.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef("a")));
+            doc.add(new NumericDocValuesField(INT_FIELD, 42));
+            iw.addDocument(doc);
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), intConfig())
+                );
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, allFieldTypes());
+                assertEquals(1, result.getBuckets().size());
+                InternalMultiTerms.Bucket bucket = result.getBuckets().get(0);
+                assertEquals("a", bucket.getKey().get(0));
+                assertEquals(42L, bucket.getKey().get(1));
+                assertEquals(1, bucket.getDocCount());
+            }
+        }
+    }
+
+    /**
+     * Exercises the PackedOrdinalBucketOrds two-long path end-to-end via searchAndReduce.
+     * Uses 8 keyword fields each with 300 distinct values: bitsRequired(300)=9, total=72 bits,
+     * which exceeds 63 and forces the LongLongHash-backed path.
+     */
+    public void testTwoLongPathEndToEnd() throws IOException {
+        final int numFields = 8;
+        final int numDistinct = 300;
+        // Sanity-check that this shape actually forces the two-long path.
+        long[] maxOrds = new long[numFields];
+        Arrays.fill(maxOrds, numDistinct);
+        assertFalse("shape should not fit in a single long", PackedOrdinalBucketOrds.fitsInSingleLong(maxOrds));
+        assertTrue("shape should fit in two longs", PackedOrdinalBucketOrds.fitsInTwoLongs(maxOrds));
+
+        String[] fieldNames = new String[numFields];
+        MappedFieldType[] fieldTypes = new MappedFieldType[numFields];
+        List<MultiTermsValuesSourceConfig> configs = new ArrayList<>(numFields);
+        for (int f = 0; f < numFields; f++) {
+            fieldNames[f] = "f" + f;
+            fieldTypes[f] = new KeywordFieldMapper.KeywordFieldType(fieldNames[f]);
+            configs.add(kwConfig(fieldNames[f]));
+        }
+
+        int numDocs = randomIntBetween(numDistinct, numDistinct + 200);
+        Map<String, Long> expectedCounts = new HashMap<>();
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int i = 0; i < numDocs; i++) {
+                Document doc = new Document();
+                StringBuilder keyBuilder = new StringBuilder();
+                for (int f = 0; f < numFields; f++) {
+                    // Ensure all numDistinct ordinals are realized so globalMaxOrd reaches numDistinct.
+                    int ordIdx = i < numDistinct ? i : randomIntBetween(0, numDistinct - 1);
+                    String value = String.format(Locale.ROOT, "%s_v%03d", fieldNames[f], ordIdx);
+                    doc.add(new SortedDocValuesField(fieldNames[f], new BytesRef(value)));
+                    if (f > 0) keyBuilder.append("|");
+                    keyBuilder.append(value);
+                }
+                iw.addDocument(doc);
+                expectedCounts.merge(keyBuilder.toString(), 1L, Long::sum);
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(configs)
+                    .size(expectedCounts.size() + 10);
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, fieldTypes);
+
+                Map<String, Long> actualCounts = new HashMap<>();
+                for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+                    assertEquals(numFields, bucket.getKey().size());
+                    StringBuilder sb = new StringBuilder();
+                    for (int f = 0; f < numFields; f++) {
+                        if (f > 0) sb.append("|");
+                        sb.append(bucket.getKey().get(f));
+                    }
+                    actualCounts.put(sb.toString(), bucket.getDocCount());
+                }
+                assertEquals("Bucket count mismatch on two-long path", expectedCounts.size(), actualCounts.size());
+                for (Map.Entry<String, Long> entry : expectedCounts.entrySet()) {
+                    assertEquals("Doc count mismatch for " + entry.getKey(), entry.getValue(), actualCounts.get(entry.getKey()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Exercises the ordinal path's zero-doc-filling branch (collectZeroDocOrdinals) with
+     * min_doc_count=0 and a filtered query. The filter excludes some docs from bucket
+     * collection; with min_doc_count=0 those unmatched tuples still appear as 0-count buckets.
+     */
+    public void testOrdinalPathMinDocCountZeroFillsBuckets() throws IOException {
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            // Doc 0: kw1=a, kw2=x — matches the filter
+            Document d0 = new Document();
+            d0.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef("a")));
+            d0.add(new StringField(KW_FIELD_1, "a", Field.Store.NO));
+            d0.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef("x")));
+            iw.addDocument(d0);
+            // Doc 1: kw1=b, kw2=y — excluded by filter; should still surface with 0 count.
+            Document d1 = new Document();
+            d1.add(new SortedDocValuesField(KW_FIELD_1, new BytesRef("b")));
+            d1.add(new StringField(KW_FIELD_1, "b", Field.Store.NO));
+            d1.add(new SortedDocValuesField(KW_FIELD_2, new BytesRef("y")));
+            iw.addDocument(d1);
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2))
+                ).size(50).minDocCount(0);
+                // Filter to just doc 0; zero-doc-fill should still add the (b,y) tuple.
+                InternalMultiTerms result = searchAndReduce(searcher, new TermQuery(new Term(KW_FIELD_1, "a")), builder, allFieldTypes());
+
+                Map<String, Long> actual = new HashMap<>();
+                for (InternalMultiTerms.Bucket b : result.getBuckets()) {
+                    actual.put(b.getKey().get(0) + "|" + b.getKey().get(1), b.getDocCount());
+                }
+                assertEquals("Expected 2 buckets (1 matched + 1 zero-filled), got: " + actual, 2, actual.size());
+                assertEquals(Long.valueOf(1), actual.get("a|x"));
+                assertEquals(Long.valueOf(0), actual.get("b|y"));
+            }
+        }
+    }
+
+    /**
+     * Verifies that for multi-valued docs, sub-aggregations are correctly accumulated across
+     * all cartesian-product tuples via the {@code collectExistingBucket} branch in the
+     * ordinal-path leaf collector.
+     */
+    public void testOrdinalPathMultiValuedWithSubAggAccumulation() throws IOException {
+        final String NUM_FIELD = "n";
+        MappedFieldType[] fieldTypes = {
+            new KeywordFieldMapper.KeywordFieldType(KW_FIELD_1),
+            new KeywordFieldMapper.KeywordFieldType(KW_FIELD_2),
+            new NumberFieldMapper.NumberFieldType(NUM_FIELD, NumberFieldMapper.NumberType.INTEGER) };
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            // Doc 0: kw1=[a,b], kw2=[x], n=10 → tuples (a,x) and (b,x)
+            Document d0 = new Document();
+            d0.add(new SortedSetDocValuesField(KW_FIELD_1, new BytesRef("a")));
+            d0.add(new SortedSetDocValuesField(KW_FIELD_1, new BytesRef("b")));
+            d0.add(new SortedSetDocValuesField(KW_FIELD_2, new BytesRef("x")));
+            d0.add(new NumericDocValuesField(NUM_FIELD, 10));
+            iw.addDocument(d0);
+            // Doc 1: kw1=[a], kw2=[x,y], n=20 → tuples (a,x) and (a,y)
+            Document d1 = new Document();
+            d1.add(new SortedSetDocValuesField(KW_FIELD_1, new BytesRef("a")));
+            d1.add(new SortedSetDocValuesField(KW_FIELD_2, new BytesRef("x")));
+            d1.add(new SortedSetDocValuesField(KW_FIELD_2, new BytesRef("y")));
+            d1.add(new NumericDocValuesField(NUM_FIELD, 20));
+            iw.addDocument(d1);
+            // Doc 2: kw1=[b], kw2=[y], n=5 → (b,y)
+            Document d2 = new Document();
+            d2.add(new SortedSetDocValuesField(KW_FIELD_1, new BytesRef("b")));
+            d2.add(new SortedSetDocValuesField(KW_FIELD_2, new BytesRef("y")));
+            d2.add(new NumericDocValuesField(NUM_FIELD, 5));
+            iw.addDocument(d2);
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("test_agg").terms(
+                    asList(kwConfig(KW_FIELD_1), kwConfig(KW_FIELD_2))
+                ).size(100).subAggregation(new SumAggregationBuilder("sum_n").field(NUM_FIELD));
+
+                InternalMultiTerms result = searchAndReduce(searcher, new MatchAllDocsQuery(), builder, fieldTypes);
+
+                Map<String, long[]> actual = new HashMap<>(); // key -> [docCount, sum]
+                for (InternalMultiTerms.Bucket b : result.getBuckets()) {
+                    double sum = ((InternalSum) b.getAggregations().get("sum_n")).value();
+                    actual.put(b.getKey().get(0) + "|" + b.getKey().get(1), new long[] { b.getDocCount(), (long) sum });
+                }
+                // Expected: (a,x) count=2 sum=30, (a,y) count=1 sum=20, (b,x) count=1 sum=10, (b,y) count=1 sum=5
+                assertEquals(4, actual.size());
+                assertArrayEquals("a|x", new long[] { 2, 30 }, actual.get("a|x"));
+                assertArrayEquals("a|y", new long[] { 1, 20 }, actual.get("a|y"));
+                assertArrayEquals("b|x", new long[] { 1, 10 }, actual.get("b|x"));
+                assertArrayEquals("b|y", new long[] { 1, 5 }, actual.get("b|y"));
+            }
+        }
+    }
+
+    /**
+     * When a multi_terms whose ordinal shape would require the two-long path is nested under
+     * a parent bucket aggregation (so {@code CardinalityUpperBound > ONE}), the factory must
+     * fall back to the bytes path because {@link org.opensearch.common.util.LongLongHash} does
+     * not carry an owningBucketOrd dimension. Result correctness must be preserved.
+     */
+    public void testNestedMultiTermsTwoLongShapeFallsBackToBytes() throws IOException {
+        // Parent field for the outer terms agg.
+        final String PARENT_FIELD = "parent";
+        final int numInnerFields = 8;
+        final int numDistinct = 300; // 9 bits per field × 8 fields = 72 bits → two-long shape
+        String[] innerFieldNames = new String[numInnerFields];
+        MappedFieldType[] fieldTypes = new MappedFieldType[numInnerFields + 1];
+        fieldTypes[0] = new KeywordFieldMapper.KeywordFieldType(PARENT_FIELD);
+        List<MultiTermsValuesSourceConfig> innerConfigs = new ArrayList<>(numInnerFields);
+        for (int f = 0; f < numInnerFields; f++) {
+            innerFieldNames[f] = "f" + f;
+            fieldTypes[f + 1] = new KeywordFieldMapper.KeywordFieldType(innerFieldNames[f]);
+            innerConfigs.add(kwConfig(innerFieldNames[f]));
+        }
+        // Sanity-check the shape requires the two-long path.
+        long[] maxOrds = new long[numInnerFields];
+        Arrays.fill(maxOrds, numDistinct);
+        assertFalse(PackedOrdinalBucketOrds.fitsInSingleLong(maxOrds));
+        assertTrue(PackedOrdinalBucketOrds.fitsInTwoLongs(maxOrds));
+
+        // 2 parent buckets × numDistinct inner ordinals per field; realize every ordinal.
+        String[] parents = { "p1", "p2" };
+        Map<String, Map<String, Long>> expected = new HashMap<>(); // parent -> tuple -> count
+        expected.put(parents[0], new HashMap<>());
+        expected.put(parents[1], new HashMap<>());
+
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int i = 0; i < numDistinct; i++) {
+                for (String parent : parents) {
+                    Document doc = new Document();
+                    doc.add(new SortedDocValuesField(PARENT_FIELD, new BytesRef(parent)));
+                    StringBuilder sb = new StringBuilder();
+                    for (int f = 0; f < numInnerFields; f++) {
+                        String v = String.format(Locale.ROOT, "%s_v%03d", innerFieldNames[f], i);
+                        doc.add(new SortedDocValuesField(innerFieldNames[f], new BytesRef(v)));
+                        if (f > 0) sb.append("|");
+                        sb.append(v);
+                    }
+                    iw.addDocument(doc);
+                    expected.get(parent).merge(sb.toString(), 1L, Long::sum);
+                }
+            }
+            iw.close();
+
+            try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader reader = wrapDirectoryReader(unwrapped)) {
+                IndexSearcher searcher = newIndexSearcher(reader);
+                TermsAggregationBuilder outer = new TermsAggregationBuilder("by_parent").field(PARENT_FIELD).size(10);
+                outer.subAggregation(new MultiTermsAggregationBuilder("inner").terms(innerConfigs).size(numDistinct + 5));
+                InternalAggregation result = searchAndReduce(searcher, new MatchAllDocsQuery(), outer, fieldTypes);
+                StringTerms outerTerms = (StringTerms) result;
+                assertEquals(2, outerTerms.getBuckets().size());
+                for (StringTerms.Bucket pb : outerTerms.getBuckets()) {
+                    String parent = pb.getKeyAsString();
+                    InternalMultiTerms inner = pb.getAggregations().get("inner");
+                    Map<String, Long> actual = new HashMap<>();
+                    for (InternalMultiTerms.Bucket b : inner.getBuckets()) {
+                        StringBuilder sb = new StringBuilder();
+                        for (int f = 0; f < numInnerFields; f++) {
+                            if (f > 0) sb.append("|");
+                            sb.append(b.getKey().get(f));
+                        }
+                        actual.put(sb.toString(), b.getDocCount());
+                    }
+                    assertEquals("bucket count mismatch for parent=" + parent, expected.get(parent).size(), actual.size());
+                    for (Map.Entry<String, Long> e : expected.get(parent).entrySet()) {
+                        assertEquals("doc count mismatch for " + parent + "/" + e.getKey(), e.getValue(), actual.get(e.getKey()));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Convert InternalMultiTerms buckets to a sorted list of "key=count" strings for comparison.
+     */
+    private List<String> bucketsToSortedStrings(InternalMultiTerms result) {
+        List<String> bucketStrings = new ArrayList<>();
+        for (InternalMultiTerms.Bucket bucket : result.getBuckets()) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < bucket.getKey().size(); i++) {
+                if (i > 0) {
+                    sb.append("|");
+                }
+                sb.append(bucket.getKey().get(i));
+            }
+            sb.append("=").append(bucket.getDocCount());
+            bucketStrings.add(sb.toString());
+        }
+        bucketStrings.sort(Comparator.naturalOrder());
+        return bucketStrings;
+    }
+
+    @Override
+    protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
+        return List.of(
+            CoreValuesSourceType.NUMERIC,
+            CoreValuesSourceType.BYTES,
+            CoreValuesSourceType.IP,
+            CoreValuesSourceType.DATE,
+            CoreValuesSourceType.BOOLEAN
+        );
+    }
+
+    @Override
+    protected List<String> unsupportedMappedFieldTypes() {
+        return List.of(HllFieldMapper.CONTENT_TYPE);
+    }
+
+    @Override
+    protected org.opensearch.search.aggregations.AggregationBuilder createAggBuilderForTypeTest(
+        MappedFieldType fieldType,
+        String fieldName
+    ) {
+        return new MultiTermsAggregationBuilder("_name").terms(asList(kwConfig(fieldName), kwConfig(fieldName)));
+    }
+}

--- a/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/PackedOrdinalBucketOrdsTests.java
+++ b/server/src/test/java/org/opensearch/search/aggregations/bucket/terms/PackedOrdinalBucketOrdsTests.java
@@ -1,0 +1,281 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.aggregations.bucket.terms;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.common.util.MockBigArrays;
+import org.opensearch.common.util.MockPageCacheRecycler;
+import org.opensearch.core.indices.breaker.NoneCircuitBreakerService;
+import org.opensearch.search.aggregations.CardinalityUpperBound;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PackedOrdinalBucketOrdsTests extends OpenSearchTestCase {
+
+    private BigArrays bigArrays;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        bigArrays = new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService());
+    }
+
+    public void testBitsRequired() {
+        assertEquals(0, PackedOrdinalBucketOrds.bitsRequired(0));
+        assertEquals(0, PackedOrdinalBucketOrds.bitsRequired(-1));
+        assertEquals(0, PackedOrdinalBucketOrds.bitsRequired(1)); // [0,1) = {0} needs 0 bits
+        assertEquals(1, PackedOrdinalBucketOrds.bitsRequired(2)); // [0,2) = {0,1} needs 1 bit
+        assertEquals(2, PackedOrdinalBucketOrds.bitsRequired(3)); // [0,3) needs 2 bits
+        assertEquals(2, PackedOrdinalBucketOrds.bitsRequired(4)); // [0,4) needs 2 bits
+        assertEquals(3, PackedOrdinalBucketOrds.bitsRequired(5)); // [0,5) needs 3 bits
+        assertEquals(3, PackedOrdinalBucketOrds.bitsRequired(8)); // [0,8) needs 3 bits
+        assertEquals(20, PackedOrdinalBucketOrds.bitsRequired(1_000_000));
+        assertEquals(30, PackedOrdinalBucketOrds.bitsRequired(1L << 30));
+    }
+
+    public void testFitsInSingleLong() {
+        assertTrue(PackedOrdinalBucketOrds.fitsInSingleLong(new long[] { 1000, 1000 }));
+        // 31 + 32 = 63 bits — exactly fits
+        assertTrue(PackedOrdinalBucketOrds.fitsInSingleLong(new long[] { 1L << 31, 1L << 32 }));
+        // 32 + 32 = 64 bits — does not fit
+        assertFalse(PackedOrdinalBucketOrds.fitsInSingleLong(new long[] { 1L << 32, 1L << 32 }));
+    }
+
+    public void testFitsInTwoLongs() {
+        assertTrue(PackedOrdinalBucketOrds.fitsInTwoLongs(new long[] { 1000, 1000 }));
+        // 3 fields at 42 bits each = 126 — exactly fits
+        assertTrue(PackedOrdinalBucketOrds.fitsInTwoLongs(new long[] { 1L << 42, 1L << 42, 1L << 42 }));
+        // 3 fields at 43 bits each = 129 — does not fit
+        assertFalse(PackedOrdinalBucketOrds.fitsInTwoLongs(new long[] { 1L << 43, 1L << 43, 1L << 43 }));
+    }
+
+    public void testSingleLongPathRoundTrip() {
+        long[] maxOrds = { 1000, 1000 };
+        try (PackedOrdinalBucketOrds ords = new PackedOrdinalBucketOrds(bigArrays, CardinalityUpperBound.ONE, maxOrds)) {
+            assertTrue(ords.isSingleLongPath());
+
+            long[] ordinals = { 500, 300 };
+            long packed = ords.packSingleLong(ordinals);
+            long[] unpacked = ords.unpackSingleLong(packed);
+            assertArrayEquals(ordinals, unpacked);
+        }
+    }
+
+    public void testTwoLongPathRoundTrip() {
+        // 40 bits each × 3 = 120 bits total — needs two longs
+        long[] maxOrds = { 1L << 40, 1L << 40, 1L << 40 };
+        try (PackedOrdinalBucketOrds ords = new PackedOrdinalBucketOrds(bigArrays, CardinalityUpperBound.ONE, maxOrds)) {
+            assertFalse(ords.isSingleLongPath());
+            assertTrue(ords.totalBits() > 63);
+
+            long[] ordinals = { (1L << 39), (1L << 39), (1L << 39) };
+            long long1 = ords.packLong1(ordinals);
+            long long2 = ords.packLong2(ordinals);
+            long[] unpacked = ords.unpackTwoLongs(long1, long2);
+            assertArrayEquals(ordinals, unpacked);
+        }
+    }
+
+    public void testBoundaryCaseSingleLong63Bits() {
+        // 31 + 31 + 1 = 63 bits — exactly at the boundary
+        long[] maxOrds = { 1L << 31, 1L << 31, 1L << 1 };
+        try (PackedOrdinalBucketOrds ords = new PackedOrdinalBucketOrds(bigArrays, CardinalityUpperBound.ONE, maxOrds)) {
+            assertTrue(ords.isSingleLongPath());
+            assertEquals(63, ords.totalBits());
+
+            long[] ordinals = { (1L << 31) - 1, (1L << 31) - 1, 1 };
+            long packed = ords.packSingleLong(ordinals);
+            long[] unpacked = ords.unpackSingleLong(packed);
+            assertArrayEquals(ordinals, unpacked);
+        }
+    }
+
+    public void testStraddlingFieldsTwoLongs() {
+        // 50 + 50 = 100 bits — second field straddles the 63-bit boundary
+        long[] maxOrds = { 1L << 50, 1L << 50 };
+        try (PackedOrdinalBucketOrds ords = new PackedOrdinalBucketOrds(bigArrays, CardinalityUpperBound.ONE, maxOrds)) {
+            assertFalse(ords.isSingleLongPath());
+
+            long[] ordinals = { (1L << 49), (1L << 49) };
+            long long1 = ords.packLong1(ordinals);
+            long long2 = ords.packLong2(ordinals);
+            long[] unpacked = ords.unpackTwoLongs(long1, long2);
+            assertArrayEquals(ordinals, unpacked);
+        }
+    }
+
+    public void testAddAndRetrieveSingleLong() {
+        long[] maxOrds = { 1000, 1000 };
+        try (PackedOrdinalBucketOrds ords = new PackedOrdinalBucketOrds(bigArrays, CardinalityUpperBound.ONE, maxOrds)) {
+            long[] ordinals1 = { 100, 200 };
+            long[] ordinals2 = { 300, 400 };
+
+            long bucketOrd1 = ords.add(0, ordinals1);
+            long bucketOrd2 = ords.add(0, ordinals2);
+            long bucketOrd3 = ords.add(0, ordinals1); // duplicate
+
+            assertTrue(bucketOrd1 >= 0);
+            assertTrue(bucketOrd2 >= 0);
+            assertEquals(-1 - bucketOrd1, bucketOrd3);
+
+            assertEquals(2, ords.size());
+            assertEquals(2, ords.bucketsInOrd(0));
+
+            MultiTermsBucketOrds.BucketOrdsEnum ordsEnum = ords.ordsEnum(0);
+            List<long[]> retrieved = new ArrayList<>();
+            while (ordsEnum.next()) {
+                retrieved.add(ordsEnum.ordinals());
+            }
+            assertEquals(2, retrieved.size());
+            assertTrue(containsArray(retrieved, ordinals1));
+            assertTrue(containsArray(retrieved, ordinals2));
+        }
+    }
+
+    public void testAddAndRetrieveTwoLongs() {
+        long[] maxOrds = { 1L << 40, 1L << 40, 1L << 40 };
+        try (PackedOrdinalBucketOrds ords = new PackedOrdinalBucketOrds(bigArrays, CardinalityUpperBound.ONE, maxOrds)) {
+            long[] ordinals1 = { 1L << 39, 1L << 39, 1L << 39 };
+            long[] ordinals2 = { 100, 200, 300 };
+
+            long bucketOrd1 = ords.add(0, ordinals1);
+            long bucketOrd2 = ords.add(0, ordinals2);
+            long bucketOrd3 = ords.add(0, ordinals1); // duplicate
+
+            assertTrue(bucketOrd1 >= 0);
+            assertTrue(bucketOrd2 >= 0);
+            assertEquals(-1 - bucketOrd1, bucketOrd3);
+
+            assertEquals(2, ords.size());
+            assertEquals(2, ords.bucketsInOrd(0));
+
+            MultiTermsBucketOrds.BucketOrdsEnum ordsEnum = ords.ordsEnum(0);
+            List<long[]> retrieved = new ArrayList<>();
+            while (ordsEnum.next()) {
+                retrieved.add(ordsEnum.ordinals());
+            }
+            assertEquals(2, retrieved.size());
+            assertTrue(containsArray(retrieved, ordinals1));
+            assertTrue(containsArray(retrieved, ordinals2));
+        }
+    }
+
+    public void testManyFieldsSingleLong() {
+        // 6 fields at 4 bits each = 24 bits total
+        long[] maxOrds = { 10, 10, 10, 10, 10, 10 };
+        try (PackedOrdinalBucketOrds ords = new PackedOrdinalBucketOrds(bigArrays, CardinalityUpperBound.ONE, maxOrds)) {
+            assertTrue(ords.isSingleLongPath());
+
+            long[] ordinals = { 5, 5, 5, 5, 5, 5 };
+            long packed = ords.packSingleLong(ordinals);
+            long[] unpacked = ords.unpackSingleLong(packed);
+            assertArrayEquals(ordinals, unpacked);
+        }
+    }
+
+    public void testTwoLongPathRandomRoundTrips() {
+        // 3 fields at 40 bits each = 120 bits — field 1 straddles the 63-bit boundary
+        long[] maxOrds = { 1L << 40, 1L << 40, 1L << 40 };
+        try (PackedOrdinalBucketOrds ords = new PackedOrdinalBucketOrds(bigArrays, CardinalityUpperBound.ONE, maxOrds)) {
+            assertFalse(ords.isSingleLongPath());
+            for (int iter = 0; iter < 100; iter++) {
+                long[] ordinals = {
+                    randomLongBetween(0, (1L << 40) - 1),
+                    randomLongBetween(0, (1L << 40) - 1),
+                    randomLongBetween(0, (1L << 40) - 1) };
+                long long1 = ords.packLong1(ordinals);
+                long long2 = ords.packLong2(ordinals);
+                long[] unpacked = ords.unpackTwoLongs(long1, long2);
+                assertArrayEquals("Round-trip failed for " + Arrays.toString(ordinals), ordinals, unpacked);
+            }
+        }
+    }
+
+    public void testTwoLongPathAddRetrieveWithStraddling() {
+        // 2 fields at 50 bits each = 100 bits — field 1 straddles the 63-bit boundary
+        long[] maxOrds = { 1L << 50, 1L << 50 };
+        try (PackedOrdinalBucketOrds ords = new PackedOrdinalBucketOrds(bigArrays, CardinalityUpperBound.ONE, maxOrds)) {
+            assertFalse(ords.isSingleLongPath());
+
+            int numEntries = randomIntBetween(10, 50);
+            List<long[]> inserted = new ArrayList<>();
+            for (int i = 0; i < numEntries; i++) {
+                long[] ordinals = { randomLongBetween(0, (1L << 50) - 1), randomLongBetween(0, (1L << 50) - 1) };
+                long result = ords.add(0, ordinals);
+                if (result >= 0) {
+                    inserted.add(ordinals);
+                }
+            }
+
+            assertEquals(inserted.size(), ords.size());
+
+            MultiTermsBucketOrds.BucketOrdsEnum ordsEnum = ords.ordsEnum(0);
+            List<long[]> retrieved = new ArrayList<>();
+            while (ordsEnum.next()) {
+                retrieved.add(ordsEnum.ordinals());
+            }
+            assertEquals(inserted.size(), retrieved.size());
+            for (long[] expected : inserted) {
+                assertTrue("Missing ordinals " + Arrays.toString(expected), containsArray(retrieved, expected));
+            }
+        }
+    }
+
+    public void testSingleValueFieldZeroBits() {
+        // Field with maxOrd=1 gets 0 bits — only ordinal 0 is valid
+        long[] maxOrds = { 1000, 1, 1000 };
+        try (PackedOrdinalBucketOrds ords = new PackedOrdinalBucketOrds(bigArrays, CardinalityUpperBound.ONE, maxOrds)) {
+            assertTrue(ords.isSingleLongPath());
+
+            long[] ordinals = { 500, 0, 300 };
+            long bucketOrd = ords.add(0, ordinals);
+            assertTrue(bucketOrd >= 0);
+
+            MultiTermsBucketOrds.BucketOrdsEnum ordsEnum = ords.ordsEnum(0);
+            assertTrue(ordsEnum.next());
+            assertArrayEquals(ordinals, ordsEnum.ordinals());
+            assertFalse(ordsEnum.next());
+        }
+    }
+
+    public void testDuplicateDetectionTwoLongs() {
+        long[] maxOrds = { 1L << 40, 1L << 40, 1L << 40 };
+        try (PackedOrdinalBucketOrds ords = new PackedOrdinalBucketOrds(bigArrays, CardinalityUpperBound.ONE, maxOrds)) {
+            long[] ordinals = { 12345L, 67890L, 11111L };
+
+            long first = ords.add(0, ordinals);
+            assertTrue(first >= 0);
+
+            long second = ords.add(0, ordinals);
+            assertEquals(-1 - first, second);
+
+            // Different ordinals should get a new bucket
+            long[] different = { 12345L, 67890L, 22222L };
+            long third = ords.add(0, different);
+            assertTrue(third >= 0);
+            assertNotEquals(first, third);
+
+            assertEquals(2, ords.size());
+        }
+    }
+
+    /** Helper: check if a list of long[] contains an array with matching content. */
+    private static boolean containsArray(List<long[]> list, long[] target) {
+        for (long[] item : list) {
+            if (Arrays.equals(item, target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
When every field in a multi_terms aggregation is keyword-like
(ValuesSource.Bytes.WithOrdinals), pack each doc's global ordinal
tuple into one or two longs and key the bucket hash on those longs
instead of serializing composite BytesRef keys. Eliminates the
per-doc BytesRef allocation and composite-key hashing that dominated
the hot path.

Path selection (MultiTermsAggregationFactory.selectOrdinalStrategy):
- All sources WithOrdinals, no star-tree index active:
  - total bits <= 63       -> single-long via LongKeyedBucketOrds
                              (any CardinalityUpperBound)
  - 64 <= total bits <= 126 and cardinality == ONE
                           -> two-long via LongLongHash
  - otherwise              -> bytes fallback
- Mixed ordinal + numeric  -> bytes fallback

Speedup on a 50k-doc, single-shard, single-segment shard (median of
30 runs, request_cache=false): 60-69% faster for 2/3/4-keyword
multi_terms queries (with and without sub-aggregations like sum,
stats, cardinality, percentiles); ~25% faster for the two-long path
(8 keyword fields x 300 distinct values); no regression on the
bytes fallback path. Results are byte-identical to the prior
implementation across 37 query shapes.

Signed-off-by: Sandesh Kumar <sandeshkr419@gmail.com><!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
