### PR TITLE
Add infrastructure to convert analytics engine execution results to OpenSearch aggregation r…

### DIFF
--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -78,13 +78,21 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
         try {
             String indexName = resolveToSingleIndex(request);
+            long startTime = System.currentTimeMillis();
 
-            long convertStart = System.nanoTime();
             SearchSourceConverter converter = new SearchSourceConverter(engineContext.getSchema());
             QueryPlans plans = converter.convert(request.source(), indexName);
-            long convertTime = System.nanoTime() - convertStart;
+
             List<ExecutionResult> results = planExecutor.execute(plans);
-            SearchResponse response = SearchResponseBuilder.build(results, convertTime);
+
+            long tookInMillis = System.currentTimeMillis() - startTime;
+            SearchResponse response = SearchResponseBuilder.build(
+                results,
+                request,
+                converter.getAggregationRegistry(),
+                tookInMillis
+            );
+
             listener.onResponse(response);
         } catch (Exception e) {
             logger.error("DSL execution failed", e);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/converter/SearchSourceConverter.java
@@ -23,6 +23,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.opensearch.dsl.aggregation.AggregationMetadata;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
 import org.opensearch.dsl.aggregation.AggregationRegistryFactory;
 import org.opensearch.dsl.aggregation.AggregationTreeWalker;
 import org.opensearch.dsl.executor.QueryPlans;
@@ -50,6 +51,7 @@ public class SearchSourceConverter {
     private final AggregateConverter aggConverter;
     private final PostAggregateConverter postAggConverter;
     private final AggregationTreeWalker treeWalker;
+    private final AggregationRegistry aggRegistry;
 
     /**
      * Initializes planning infrastructure from the given schema.
@@ -77,8 +79,13 @@ public class SearchSourceConverter {
         this.aggConverter = new AggregateConverter();
         this.postAggConverter = new PostAggregateConverter();
 
-        var aggRegistry = AggregationRegistryFactory.create();
+        this.aggRegistry = AggregationRegistryFactory.create();
         this.treeWalker = new AggregationTreeWalker(aggRegistry);
+    }
+
+    /** Returns the aggregation registry used by this converter. */
+    public AggregationRegistry getAggregationRegistry() {
+        return aggRegistry;
     }
 
     /**

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/AggregationResponseBuilder.java
@@ -1,0 +1,291 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.result;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.aggregation.AggregationTranslator;
+import org.opensearch.dsl.aggregation.GroupingInfo;
+import org.opensearch.dsl.aggregation.bucket.BucketTranslator;
+import org.opensearch.dsl.aggregation.metric.MetricTranslator;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.util.ComparisonUtils;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Converts execution results into OpenSearch InternalAggregations format.
+ * Uses granularity-based matching to map flat tabular results to hierarchical aggregation structures.
+ */
+public final class AggregationResponseBuilder {
+
+    private static final String NO_GROUPING_KEY = "";
+    private static final String AGGREGATION_LEVEL_SEPARATOR = ",";
+
+    private final AggregationRegistry registry;
+    private final Map<String, ExecutionResult> granularityMap;
+
+    public AggregationResponseBuilder(AggregationRegistry registry, List<ExecutionResult> aggResults) {
+        this.registry = registry;
+        this.granularityMap = new HashMap<>();
+        for (ExecutionResult result : aggResults) {
+            String key = computeGranularityKey(result);
+            granularityMap.put(key, result);
+        }
+    }
+
+    /**
+     * Builds InternalAggregations from the original aggregation builders.
+     */
+    public InternalAggregations build(List<AggregationBuilder> originalAggs) throws ConversionException {
+        List<InternalAggregation> aggs = buildLevel(originalAggs, new ArrayList<>(), Map.of());
+        return InternalAggregations.from(aggs);
+    }
+
+    /**
+     * Recursively builds aggregations at a specific nesting level.
+     * Routes to buildMetric or buildBucket based on aggregation type.
+     */
+    private List<InternalAggregation> buildLevel(
+            List<AggregationBuilder> aggs,
+            List<String> accumulatedGroupFields,
+            Map<String, Object> parentKeyFilter) throws ConversionException {
+
+        List<InternalAggregation> result = new ArrayList<>();
+
+        for (AggregationBuilder agg : aggs) {
+            @SuppressWarnings("unchecked")
+            AggregationTranslator<AggregationBuilder> type = (AggregationTranslator<AggregationBuilder>) registry.get(agg.getClass());
+
+            if (type instanceof MetricTranslator) {
+                result.add(buildMetric((MetricTranslator<AggregationBuilder>) type, agg,
+                    accumulatedGroupFields, parentKeyFilter));
+            } else if (type instanceof BucketTranslator) {
+                result.add(buildBucket((BucketTranslator<AggregationBuilder>) type, agg,
+                    accumulatedGroupFields, parentKeyFilter));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Builds a metric aggregation by extracting the computed value from execution results.
+     * Finds the matching row using granularity key and parent filters.
+     */
+    private InternalAggregation buildMetric(
+            MetricTranslator<AggregationBuilder> translator,
+            AggregationBuilder agg,
+            List<String> accumulatedGroupFields,
+            Map<String, Object> parentKeyFilter) {
+
+        String granularityKey = String.join(AGGREGATION_LEVEL_SEPARATOR, accumulatedGroupFields);
+        ExecutionResult result = granularityMap.get(granularityKey);
+
+        if (result == null) {
+            return buildEmptyMetric(translator, agg);
+        }
+
+        List<Object[]> rows = StreamSupport.stream(result.getRows().spliterator(), false)
+            .collect(Collectors.toList());
+
+        if (rows.isEmpty()) {
+            return buildEmptyMetric(translator, agg);
+        }
+
+        Map<String, Integer> colIndex = buildColumnIndex(result);
+        Integer colIdx = colIndex.get(agg.getName());
+
+        if (colIdx == null) {
+            return buildEmptyMetric(translator, agg);
+        }
+
+        Object[] matchingRow = findMatchingRow(rows, colIndex, parentKeyFilter);
+        Object value = (matchingRow != null) ? matchingRow[colIdx] : null;
+        return translator.toInternalAggregation(agg.getName(), value);
+    }
+
+    /**
+     * Builds an empty metric aggregation with no computed value.
+     */
+    private static InternalAggregation buildEmptyMetric(
+            MetricTranslator<AggregationBuilder> translator,
+            AggregationBuilder agg) {
+        return translator.toInternalAggregation(agg.getName(), null);
+    }
+
+    /**
+     * Builds an empty bucket aggregation with no buckets.
+     */
+    private static InternalAggregation buildEmptyBucket(
+            BucketTranslator<AggregationBuilder> translator,
+            AggregationBuilder agg) {
+        return translator.toBucketAggregation(agg, List.of());
+    }
+
+    /**
+     * Builds a bucket aggregation by grouping rows and recursively building sub-aggregations.
+     * Groups rows by bucket keys and recursively processes nested aggregations for each bucket.
+     */
+    private InternalAggregation buildBucket(
+            BucketTranslator<AggregationBuilder> translator,
+            AggregationBuilder agg,
+            List<String> accumulatedGroupFields,
+            Map<String, Object> parentKeyFilter) throws ConversionException {
+
+        GroupingInfo grouping = translator.getGrouping(agg);
+        List<String> newGroupFields = new ArrayList<>(accumulatedGroupFields);
+        newGroupFields.addAll(grouping.getFieldNames());
+
+        String granularityKey = String.join(AGGREGATION_LEVEL_SEPARATOR, newGroupFields);
+        ExecutionResult result = granularityMap.get(granularityKey);
+
+        if (result == null) {
+            return buildEmptyBucket(translator, agg);
+        }
+
+        List<Object[]> rows = StreamSupport.stream(result.getRows().spliterator(), false)
+            .collect(Collectors.toList());
+
+        if (rows.isEmpty()) {
+            return buildEmptyBucket(translator, agg);
+        }
+
+        Map<String, Integer> colIndex = buildColumnIndex(result);
+        List<Object[]> filteredRows = filterRows(rows, colIndex, parentKeyFilter);
+
+        List<String> currentGroupColumns = new ArrayList<>(grouping.getFieldNames());
+
+        Map<List<Object>, List<Object[]>> grouped = groupRowsByKeys(filteredRows, currentGroupColumns.size(), colIndex);
+
+        List<BucketEntry> buckets = new ArrayList<>();
+        List<AggregationBuilder> subAggs = new ArrayList<>(translator.getSubAggregations(agg));
+
+        for (Map.Entry<List<Object>, List<Object[]>> entry : grouped.entrySet()) {
+            Map<String, Object> childFilter = new HashMap<>(parentKeyFilter);
+            for (int i = 0; i < currentGroupColumns.size(); i++) {
+                childFilter.put(currentGroupColumns.get(i), entry.getKey().get(i));
+            }
+
+            Integer countIdx = colIndex.get("_count");
+            if (countIdx == null) {
+                throw new ConversionException("Missing _count column in aggregation result");
+            }
+            Object[] firstRowInGroup = entry.getValue().get(0);
+            long docCount = ((Number) firstRowInGroup[countIdx]).longValue();
+
+            InternalAggregations subAggregations = subAggs.isEmpty()
+                ? InternalAggregations.EMPTY
+                : InternalAggregations.from(buildLevel(subAggs, newGroupFields, childFilter));
+
+            buckets.add(new BucketEntry(entry.getKey(), docCount, subAggregations));
+        }
+
+        return translator.toBucketAggregation(agg, buckets);
+    }
+
+    /**
+     * Builds a map from column names to their indices.
+     * Enables efficient column lookup by name during row processing.
+     */
+    private static Map<String, Integer> buildColumnIndex(ExecutionResult result) {
+        Map<String, Integer> index = new HashMap<>();
+        List<String> fieldNames = result.getFieldNames();
+        for (int i = 0; i < fieldNames.size(); i++) {
+            index.put(fieldNames.get(i), i);
+        }
+        return index;
+    }
+
+    /**
+     * Finds the first row matching all filter criteria.
+     * Used to locate the specific row for nested metric aggregations.
+     */
+    private static Object[] findMatchingRow(List<Object[]> rows, Map<String, Integer> colIndex,
+            Map<String, Object> filter) {
+        for (Object[] row : rows) {
+            if (matchesFilter(row, colIndex, filter)) {
+                return row;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Filters rows to only those matching all filter criteria.
+     * Ensures nested aggregations only process rows belonging to their parent bucket.
+     */
+    private static List<Object[]> filterRows(List<Object[]> rows, Map<String, Integer> colIndex,
+            Map<String, Object> filter) {
+        if (filter.isEmpty()) {
+            return rows;
+        }
+        return rows.stream()
+            .filter(row -> matchesFilter(row, colIndex, filter))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Checks if a row matches all filter criteria.
+     * Uses type-coercion comparison to handle numeric type differences from execution engine.
+     */
+    private static boolean matchesFilter(Object[] row, Map<String, Integer> colIndex,
+            Map<String, Object> filter) {
+        for (Map.Entry<String, Object> entry : filter.entrySet()) {
+            Integer idx = colIndex.get(entry.getKey());
+            if (idx == null || !ComparisonUtils.valuesEqual(row[idx], entry.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Groups rows by their grouping column values (the bucket keys).
+     * Creates buckets where each unique combination of grouping values becomes a separate bucket.
+     */
+    private static Map<List<Object>, List<Object[]>> groupRowsByKeys(
+            List<Object[]> rows, int groupColumnCount, Map<String, Integer> colIndex) {
+        Map<List<Object>, List<Object[]>> grouped = new LinkedHashMap<>();
+
+        for (Object[] row : rows) {
+            List<Object> key = new ArrayList<>(groupColumnCount);
+            for (int i = 0; i < groupColumnCount; i++) {
+                key.add(row[i]);
+            }
+            grouped.computeIfAbsent(key, k -> new ArrayList<>()).add(row);
+        }
+
+        return grouped;
+    }
+
+    /**
+     * Computes the aggregation level key (comma-separated group field names) for an execution result.
+     * Used to match execution results with the appropriate aggregation nesting level.
+     */
+    private static String computeGranularityKey(ExecutionResult result) {
+        RelNode relNode = result.getPlan().relNode();
+        if (relNode instanceof LogicalAggregate agg) {
+            int groupCount = agg.getGroupCount();
+            return result.getFieldNames().stream()
+                .limit(groupCount)
+                .collect(Collectors.joining(AGGREGATION_LEVEL_SEPARATOR));
+        }
+        return NO_GROUPING_KEY;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/SearchResponseBuilder.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/result/SearchResponseBuilder.java
@@ -8,38 +8,87 @@
 
 package org.opensearch.dsl.result;
 
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchResponseSections;
 import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.dsl.executor.QueryPlans;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.InternalAggregations;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Builds a {@link SearchResponse} from execution results.
+ * Handles conversion of flat execution results into OpenSearch response format.
  */
 public class SearchResponseBuilder {
 
     private SearchResponseBuilder() {}
 
     /**
-     * Builds a SearchResponse from the given results and timing.
+     * Builds a SearchResponse from execution results.
      *
-     * @param results execution results from the plan executor
-     * @param convertTimeNanos time spent in DSL-to-RelNode conversion, in nanoseconds
+     * @param results execution results from the query executor
+     * @param request the original search request
+     * @param registry aggregation registry for building aggregations
+     * @param tookInMillis total execution time in milliseconds
      * @return a SearchResponse
      */
-    // TODO: Analytics plugin should return execution metadata alongside Iterable<Object[]> rows:
-    // - executionTimeNanos: query execution time
-    // - totalDocCount: total matching documents for hits.total
-    // - terminatedEarly: whether execution was terminated early
-    // - timedOut: whether execution timed out
-    // - shardInfo: total/successful/skipped/failed shard counts
-    public static SearchResponse build(List<ExecutionResult> results, long convertTimeNanos) {
-        // TODO: populate HITS and AGGREGATION plan types from results
-        long tookInMillis = convertTimeNanos / 1_000_000;
-        SearchHits hits = SearchHits.empty(true);
-        SearchResponseSections sections = new SearchResponseSections(hits, null, null, false, null, null, 0);
-        return new SearchResponse(sections, null, 0, 0, 0, tookInMillis, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
+    public static SearchResponse build(
+            List<ExecutionResult> results,
+            SearchRequest request,
+            AggregationRegistry registry,
+            long tookInMillis) throws ConversionException {
+
+        SearchHits hits = buildHits(results);
+        InternalAggregations aggregations = buildAggregations(results, request, registry);
+
+        SearchResponseSections sections = new SearchResponseSections(
+            hits,
+            aggregations,
+            null,
+            false,
+            null,
+            null,
+            0
+        );
+
+        return new SearchResponse(
+            sections,
+            null,
+            aggregations != null ? 1 : 0,
+            aggregations != null ? 1 : 0,
+            0,
+            tookInMillis,
+            ShardSearchFailure.EMPTY_ARRAY,
+            SearchResponse.Clusters.EMPTY
+        );
+    }
+
+    private static SearchHits buildHits(List<ExecutionResult> results) {
+        // TODO: Build hits from HITS results
+        return SearchHits.empty(true);
+    }
+
+    private static InternalAggregations buildAggregations(
+            List<ExecutionResult> results,
+            SearchRequest request,
+            AggregationRegistry registry) throws ConversionException {
+
+        List<ExecutionResult> aggResults = results.stream()
+            .filter(r -> r.getType() == QueryPlans.Type.AGGREGATION)
+            .collect(Collectors.toList());
+
+        if (aggResults.isEmpty() || request.source() == null || request.source().aggregations() == null) {
+            return null;
+        }
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, aggResults);
+        return builder.build(new ArrayList<>(request.source().aggregations().getAggregatorFactories()));
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/util/ComparisonUtils.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/util/ComparisonUtils.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.util;
+
+import java.util.Objects;
+
+/**
+ * Utility methods for comparing values.
+ */
+public final class ComparisonUtils {
+
+    private ComparisonUtils() {}
+
+    /**
+     * Compares two values for equality, handling type coercion for numbers and strings.
+     */
+    public static boolean valuesEqual(Object a, Object b) {
+        if (Objects.equals(a, b)) return true;
+
+        if (a == null || b == null) return false;
+
+        if (a instanceof Number && b instanceof Number) {
+            return ((Number) a).doubleValue() == ((Number) b).doubleValue();
+        }
+
+        return a.toString().equals(b.toString());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/AggregationResponseBuilderTests.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.result;
+
+import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.dsl.aggregation.GroupingInfo;
+import org.opensearch.dsl.aggregation.bucket.BucketTranslator;
+import org.opensearch.dsl.aggregation.metric.MetricTranslator;
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregations;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AggregationResponseBuilderTests extends OpenSearchTestCase {
+
+    public void testBuildEmptyAggregations() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+
+        InternalAggregations aggs = builder.build(List.of());
+        assertNotNull(aggs);
+        assertEquals(0, aggs.asList().size());
+    }
+
+    public void testBuildMetricWithNoResults() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        registry.register(createMetricTranslator(AvgAggregationBuilder.class));
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+        AvgAggregationBuilder avgAgg = new AvgAggregationBuilder("avg_price").field("price");
+
+        InternalAggregations aggs = builder.build(List.of(avgAgg));
+        assertEquals(1, aggs.asList().size());
+        assertEquals("avg_price", aggs.asList().get(0).getName());
+    }
+
+    public void testBuildBucketWithNoResults() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        registry.register(createBucketTranslator(TermsAggregationBuilder.class, "brand"));
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+        TermsAggregationBuilder termsAgg = new TermsAggregationBuilder("by_brand").field("brand");
+
+        InternalAggregations aggs = builder.build(List.of(termsAgg));
+        assertEquals(1, aggs.asList().size());
+        assertEquals("by_brand", aggs.asList().get(0).getName());
+    }
+
+    public void testBuildMultipleAggregations() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        registry.register(createMetricTranslator(AvgAggregationBuilder.class));
+        registry.register(createBucketTranslator(TermsAggregationBuilder.class, "brand"));
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+
+        AvgAggregationBuilder avgAgg = new AvgAggregationBuilder("avg_price").field("price");
+        TermsAggregationBuilder termsAgg = new TermsAggregationBuilder("by_brand").field("brand");
+
+        InternalAggregations aggs = builder.build(List.of(avgAgg, termsAgg));
+        assertEquals(2, aggs.asList().size());
+    }
+
+    public void testBuildNestedAggregation() throws Exception {
+        AggregationRegistry registry = new AggregationRegistry();
+        registry.register(createBucketTranslator(TermsAggregationBuilder.class, "brand"));
+        registry.register(createMetricTranslator(AvgAggregationBuilder.class));
+
+        AggregationResponseBuilder builder = new AggregationResponseBuilder(registry, List.of());
+
+        TermsAggregationBuilder termsAgg = new TermsAggregationBuilder("by_brand")
+            .field("brand")
+            .subAggregation(new AvgAggregationBuilder("avg_price").field("price"));
+
+        InternalAggregations aggs = builder.build(List.of(termsAgg));
+        assertEquals(1, aggs.asList().size());
+        assertEquals("by_brand", aggs.asList().get(0).getName());
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends AggregationBuilder> MetricTranslator<T> createMetricTranslator(Class<T> aggClass) {
+        MetricTranslator<T> translator = mock(MetricTranslator.class);
+        when(translator.getAggregationType()).thenReturn(aggClass);
+        when(translator.toInternalAggregation(any(), any())).thenAnswer(inv -> {
+            InternalAggregation agg = mock(InternalAggregation.class);
+            when(agg.getName()).thenReturn(inv.getArgument(0));
+            return agg;
+        });
+        return translator;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends AggregationBuilder> BucketTranslator<T> createBucketTranslator(Class<T> aggClass, String fieldName) {
+        BucketTranslator<T> translator = mock(BucketTranslator.class);
+        when(translator.getAggregationType()).thenReturn(aggClass);
+
+        GroupingInfo grouping = mock(GroupingInfo.class);
+        when(grouping.getFieldNames()).thenReturn(List.of(fieldName));
+        when(translator.getGrouping(any())).thenReturn(grouping);
+        when(translator.getSubAggregations(any())).thenReturn(List.of());
+
+        when(translator.toBucketAggregation(any(), any())).thenAnswer(inv -> {
+            InternalAggregation agg = mock(InternalAggregation.class);
+            when(agg.getName()).thenReturn(((AggregationBuilder) inv.getArgument(0)).getName());
+            return agg;
+        });
+        return translator;
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/result/SearchResponseBuilderTests.java
@@ -8,19 +8,104 @@
 
 package org.opensearch.dsl.result;
 
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.dsl.aggregation.AggregationRegistry;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.List;
 
 public class SearchResponseBuilderTests extends OpenSearchTestCase {
 
-    public void testBuildReturnsEmptyResponse() {
-        SearchResponse response = SearchResponseBuilder.build(List.of(), 42L * 1_000_000);
+    public void testBuildWithNoResults() throws Exception {
+        SearchRequest request = new SearchRequest();
+        request.source(new SearchSourceBuilder());
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 42L);
 
         assertNotNull(response);
         assertEquals(200, response.status().getStatus());
         assertEquals(0, response.getHits().getHits().length);
         assertEquals(42L, response.getTook().millis());
+        assertNull(response.getAggregations());
+        assertEquals(0, response.getTotalShards());
+        assertEquals(0, response.getSuccessfulShards());
+    }
+
+    public void testBuildWithEmptyRequest() throws Exception {
+        SearchRequest request = new SearchRequest();
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 100L);
+
+        assertNotNull(response);
+        assertEquals(200, response.status().getStatus());
+        assertEquals(100L, response.getTook().millis());
+        assertNull(response.getAggregations());
+    }
+
+    public void testBuildWithNullSource() throws Exception {
+        SearchRequest request = new SearchRequest();
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 50L);
+
+        assertNotNull(response);
+        assertEquals(200, response.status().getStatus());
+        assertNull(response.getAggregations());
+        assertEquals(0, response.getTotalShards());
+    }
+
+    public void testBuildWithAggregationsButNoResults() throws Exception {
+        SearchRequest request = new SearchRequest();
+        SearchSourceBuilder source = new SearchSourceBuilder();
+        source.aggregation(AggregationBuilders.avg("avg_price").field("price"));
+        request.source(source);
+        
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 75L);
+
+        assertNotNull(response);
+        assertEquals(75L, response.getTook().millis());
+        assertNull(response.getAggregations());
+    }
+
+    public void testShardCountsWithNoAggregations() throws Exception {
+        SearchRequest request = new SearchRequest();
+        request.source(new SearchSourceBuilder());
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 10L);
+
+        assertEquals(0, response.getTotalShards());
+        assertEquals(0, response.getSuccessfulShards());
+        assertEquals(0, response.getSkippedShards());
+        assertEquals(0, response.getFailedShards());
+    }
+
+    public void testTimingPreserved() throws Exception {
+        SearchRequest request = new SearchRequest();
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response1 = SearchResponseBuilder.build(List.of(), request, registry, 0L);
+        assertEquals(0L, response1.getTook().millis());
+
+        SearchResponse response2 = SearchResponseBuilder.build(List.of(), request, registry, 999L);
+        assertEquals(999L, response2.getTook().millis());
+    }
+
+    public void testEmptyHitsAlwaysReturned() throws Exception {
+        SearchRequest request = new SearchRequest();
+        AggregationRegistry registry = new AggregationRegistry();
+
+        SearchResponse response = SearchResponseBuilder.build(List.of(), request, registry, 10L);
+
+        assertNotNull(response.getHits());
+        assertEquals(0, response.getHits().getHits().length);
+        assertNotNull(response.getHits().getTotalHits());
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/util/ComparisonUtilsTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/util/ComparisonUtilsTests.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.util;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ComparisonUtilsTests extends OpenSearchTestCase {
+
+    public void testBothNull() {
+        assertTrue(ComparisonUtils.valuesEqual(null, null));
+    }
+
+    public void testFirstNull() {
+        assertFalse(ComparisonUtils.valuesEqual(null, "value"));
+    }
+
+    public void testSecondNull() {
+        assertFalse(ComparisonUtils.valuesEqual("value", null));
+    }
+
+    public void testEqualStrings() {
+        assertTrue(ComparisonUtils.valuesEqual("test", "test"));
+    }
+
+    public void testDifferentValues() {
+        assertFalse(ComparisonUtils.valuesEqual("foo", "bar"));
+    }
+
+    public void testIntegerAndLong() {
+        assertTrue(ComparisonUtils.valuesEqual(42, 42L));
+    }
+
+    public void testIntegerAndDouble() {
+        assertTrue(ComparisonUtils.valuesEqual(42, 42.0));
+    }
+
+    public void testDoubleAndFloat() {
+        assertTrue(ComparisonUtils.valuesEqual(42.0, 42.0f));
+    }
+
+    public void testDifferentNumbers() {
+        assertFalse(ComparisonUtils.valuesEqual(42, 43));
+    }
+
+    public void testNumberAndString() {
+        assertTrue(ComparisonUtils.valuesEqual(42, "42"));
+    }
+
+    public void testBooleanComparison() {
+        assertTrue(ComparisonUtils.valuesEqual(true, true));
+        assertFalse(ComparisonUtils.valuesEqual(true, false));
+    }
+}


### PR DESCRIPTION
## Description

Adds infrastructure to convert analytics engine execution results into OpenSearch `InternalAggregations` format, enabling proper aggregation responses in the DSL query executor.

## Changes

- **AggregationResponseBuilder**: Converts flat execution results to nested aggregation structure using granularity-based matching
- **ComparisonUtils**: Handles type coercion for numeric comparisons (Integer vs Double)
- **TransportDslExecuteAction**: Integrates response builder to construct aggregations from execution results
- **SearchResponseBuilder**: Updated to accept pre-built aggregations instead of raw results