### PR TITLE
Add Bool Query Support with minimum_should_match to DSL Query Executor

### DIFF
--- a/sandbox/plugins/dsl-query-executor/README.md
+++ b/sandbox/plugins/dsl-query-executor/README.md
@@ -13,6 +13,43 @@ _search request
       → SearchResponseBuilder (builds SearchResponse)
 ```
 
+### Bool Query
+Converts to Calcite logical expressions with full support for all clauses and `minimum_should_match`.
+
+**Clauses:**
+- `must` - Required clauses (AND logic)
+- `should` - Optional clauses (OR logic)
+- `must_not` - Exclusion clauses (NOT logic)
+- `filter` - Filtering clauses (AND logic, no scoring)
+
+**minimum_should_match formats:**
+- Non-negative integer: `"2"` - exactly 2 clauses must match
+- Negative integer: `"-1"` - total minus 1 must match
+- Non-negative percentage: `"70%"` - 70% of clauses (rounded down)
+- Negative percentage: `"-30%"` - can miss 30% of clauses
+- Single combination: `"2<75%"` - if total ≤ 2 match all, else 75%
+- Multiple combinations: `"3<-1 5<50%"` - threshold-based rules
+
+**Example:**
+```json
+{
+  "bool": {
+    "must": [
+      {"term": {"status": "active"}}
+    ],
+    "should": [
+      {"term": {"priority": "high"}},
+      {"term": {"priority": "medium"}},
+      {"term": {"priority": "low"}}
+    ],
+    "must_not": [
+      {"term": {"deleted": "true"}}
+    ],
+    "minimum_should_match": "2"
+  }
+}
+```
+
 ## Dependencies
 
 - `analytics-engine` — provides `QueryPlanExecutor` and `EngineContext` via Guice (declared as `extendedPlugins`)
@@ -28,8 +65,11 @@ _search request
 
 ```bash
 # Unit tests
-./gradlew :sandbox:plugins:dsl-query-executor:test
+./gradlew :sandbox:plugins:dsl-query-executor:test -Dsandbox.enabled=true
 
 # Integration tests
-./gradlew :sandbox:plugins:dsl-query-executor:internalClusterTest
+./gradlew :sandbox:plugins:dsl-query-executor:internalClusterTest -Dsandbox.enabled=true
+
+# Specific test class
+./gradlew :sandbox:plugins:dsl-query-executor:test --tests "BoolQueryTranslatorTests" -Dsandbox.enabled=true
 ```

--- a/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslBoolQueryIT.java
+++ b/sandbox/plugins/dsl-query-executor/src/internalClusterTest/java/org/opensearch/dsl/DslBoolQueryIT.java
@@ -1,0 +1,247 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl;
+
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+/**
+ * Integration tests for bool query with minimum_should_match parameter.
+ */
+public class DslBoolQueryIT extends DslIntegTestBase {
+
+    @Override
+    protected void createTestIndex() {
+        createIndex(INDEX);
+        ensureGreen();
+        
+        // Index multiple documents with different field values
+        client().prepareIndex(INDEX)
+            .setId("1")
+            .setSource("{\"name\":\"laptop\",\"price\":1200,\"brand\":\"brandX\",\"rating\":4.5,\"tag\":\"electronics\"}", XContentType.JSON)
+            .get();
+        client().prepareIndex(INDEX)
+            .setId("2")
+            .setSource("{\"name\":\"phone\",\"price\":800,\"brand\":\"brandY\",\"rating\":4.0,\"tag\":\"electronics\"}", XContentType.JSON)
+            .get();
+        client().prepareIndex(INDEX)
+            .setId("3")
+            .setSource("{\"name\":\"tablet\",\"price\":600,\"brand\":\"brandX\",\"rating\":3.5,\"tag\":\"electronics\"}", XContentType.JSON)
+            .get();
+        client().prepareIndex(INDEX)
+            .setId("4")
+            .setSource("{\"name\":\"monitor\",\"price\":400,\"brand\":\"brandZ\",\"rating\":4.2,\"tag\":\"accessories\"}", XContentType.JSON)
+            .get();
+        refresh(INDEX);
+    }
+
+    // Basic bool query tests
+
+    public void testBoolQueryWithMust() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("tag", "electronics"))
+        )));
+    }
+
+    public void testBoolQueryWithShould() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("brand", "brandX"))
+                .should(QueryBuilders.termQuery("brand", "brandY"))
+        )));
+    }
+
+    public void testBoolQueryWithMustNot() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("tag", "electronics"))
+                .mustNot(QueryBuilders.termQuery("brand", "brandZ"))
+        )));
+    }
+
+    public void testBoolQueryWithFilter() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .filter(QueryBuilders.termQuery("tag", "electronics"))
+        )));
+    }
+
+    public void testBoolQueryWithAllClauses() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("tag", "electronics"))
+                .should(QueryBuilders.termQuery("brand", "brandX"))
+                .mustNot(QueryBuilders.termQuery("name", "phone"))
+                .filter(QueryBuilders.termQuery("rating", 4.5))
+        )));
+    }
+
+    // minimum_should_match: Integer tests
+
+    public void testMinimumShouldMatchPositiveInteger() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("brand", "brandX"))
+                .should(QueryBuilders.termQuery("brand", "brandY"))
+                .should(QueryBuilders.termQuery("brand", "brandZ"))
+                .minimumShouldMatch("2")
+        )));
+    }
+
+    public void testMinimumShouldMatchNegativeInteger() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("brand", "brandX"))
+                .should(QueryBuilders.termQuery("brand", "brandY"))
+                .should(QueryBuilders.termQuery("brand", "brandZ"))
+                .minimumShouldMatch("-1")
+        )));
+    }
+
+    // minimum_should_match: Percentage tests
+
+    public void testMinimumShouldMatchPositivePercentage() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("tag", "electronics"))
+                .should(QueryBuilders.termQuery("brand", "brandX"))
+                .should(QueryBuilders.termQuery("name", "laptop"))
+                .should(QueryBuilders.termQuery("rating", 4.5))
+                .minimumShouldMatch("75%")
+        )));
+    }
+
+    public void testMinimumShouldMatchNegativePercentage() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("tag", "electronics"))
+                .should(QueryBuilders.termQuery("brand", "brandX"))
+                .should(QueryBuilders.termQuery("name", "laptop"))
+                .should(QueryBuilders.termQuery("rating", 4.5))
+                .minimumShouldMatch("-25%")
+        )));
+    }
+
+    // minimum_should_match: Combination tests
+
+    public void testMinimumShouldMatchSingleCombination() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("brand", "brandX"))
+                .should(QueryBuilders.termQuery("brand", "brandY"))
+                .minimumShouldMatch("2<75%")
+        )));
+    }
+
+    public void testMinimumShouldMatchMultipleCombinations() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("tag", "electronics"))
+                .should(QueryBuilders.termQuery("brand", "brandX"))
+                .should(QueryBuilders.termQuery("name", "laptop"))
+                .should(QueryBuilders.termQuery("rating", 4.5))
+                .minimumShouldMatch("3<-1 5<50%")
+        )));
+    }
+
+    // minimum_should_match with must/filter
+
+    public void testMinimumShouldMatchWithMust() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("tag", "electronics"))
+                .should(QueryBuilders.termQuery("brand", "brandX"))
+                .should(QueryBuilders.termQuery("brand", "brandY"))
+                .minimumShouldMatch("1")
+        )));
+    }
+
+    public void testMinimumShouldMatchWithFilter() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .filter(QueryBuilders.termQuery("tag", "electronics"))
+                .should(QueryBuilders.termQuery("brand", "brandX"))
+                .should(QueryBuilders.termQuery("brand", "brandY"))
+                .minimumShouldMatch("1")
+        )));
+    }
+
+    // Nested bool queries
+
+    public void testNestedBoolQuery() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("tag", "electronics"))
+                .must(QueryBuilders.boolQuery()
+                    .should(QueryBuilders.termQuery("brand", "brandX"))
+                    .should(QueryBuilders.termQuery("brand", "brandY"))
+                )
+        )));
+    }
+
+    public void testNestedBoolQueryWithMinimumShouldMatch() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("tag", "electronics"))
+                .must(QueryBuilders.boolQuery()
+                    .should(QueryBuilders.termQuery("brand", "brandX"))
+                    .should(QueryBuilders.termQuery("brand", "brandY"))
+                    .should(QueryBuilders.termQuery("brand", "brandZ"))
+                    .minimumShouldMatch("2")
+                )
+        )));
+    }
+
+    // Edge cases
+
+    public void testBoolQueryWithOnlyShouldClause() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("brand", "brandX"))
+        )));
+    }
+
+    public void testBoolQueryWithMinimumShouldMatchOne() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("brand", "brandX"))
+                .should(QueryBuilders.termQuery("brand", "brandY"))
+                .minimumShouldMatch("1")
+        )));
+    }
+
+    public void testBoolQueryWithMinimumShouldMatchAll() {
+        createTestIndex();
+        assertOk(search(new SearchSourceBuilder().query(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("tag", "electronics"))
+                .should(QueryBuilders.termQuery("brand", "brandX"))
+                .minimumShouldMatch("2")
+        )));
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/BoolQueryTranslator.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/BoolQueryTranslator.java
@@ -1,0 +1,386 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Converts a {@link BoolQueryBuilder} to Calcite logical expressions (RexNode).
+ * <p>
+ * Supports all bool query clauses:
+ * <ul>
+ *   <li><b>must</b> - Required clauses combined with AND logic</li>
+ *   <li><b>should</b> - Optional clauses combined with OR logic, controlled by minimum_should_match</li>
+ *   <li><b>must_not</b> - Exclusion clauses wrapped with NOT logic</li>
+ *   <li><b>filter</b> - Filtering clauses combined with AND logic (no scoring)</li>
+ * </ul>
+ * <p>
+ * <b>minimum_should_match</b> parameter supports:
+ * <ul>
+ *   <li>Non-negative integer: exact number of clauses (e.g., "2")</li>
+ *   <li>Negative integer: total minus this number (e.g., "-1" with 3 clauses = 2 required)</li>
+ *   <li>Non-negative percentage: percentage of total, rounded down (e.g., "70%" with 4 clauses = 2 required)</li>
+ *   <li>Negative percentage: can miss this percentage (e.g., "-30%" with 4 clauses = 3 required)</li>
+ *   <li>Single combination: threshold-based (e.g., "2&lt;75%")</li>
+ *   <li>Multiple combinations: multiple thresholds (e.g., "3&lt;-1 5&lt;50%")</li>
+ * </ul>
+ * <p>
+ * Optimizations:
+ * <ul>
+ *   <li>Flattens nested AND/OR structures to satisfy Calcite's RexUtil.isFlat requirement</li>
+ *   <li>Eliminates double negations: NOT(NOT(a)) → a</li>
+ * </ul>
+ */
+public class BoolQueryTranslator implements QueryTranslator {
+
+    private final QueryRegistry queryRegistry;
+
+    /**
+     * Creates a new bool query translator.
+     *
+     * @param queryRegistry the registry for recursively converting nested queries
+     */
+    public BoolQueryTranslator(QueryRegistry queryRegistry) {
+        this.queryRegistry = queryRegistry;
+    }
+
+    @Override
+    public Class<? extends QueryBuilder> getQueryType() {
+        return BoolQueryBuilder.class;
+    }
+
+    /**
+     * Converts a bool query to a Calcite RexNode.
+     * <p>
+     * Processes clauses in order: must, filter, should, must_not, then combines them with AND.
+     * Empty bool queries return a boolean true literal.
+     *
+     * @param query the bool query to convert
+     * @param ctx the conversion context with schema and RexBuilder
+     * @return the resulting RexNode representing the bool query logic
+     * @throws ConversionException if any nested query conversion fails
+     */
+    @Override
+    public RexNode convert(QueryBuilder query, ConversionContext ctx) throws ConversionException {
+        BoolQueryBuilder boolQuery = (BoolQueryBuilder) query;
+        List<RexNode> conditions = new ArrayList<>();
+
+        // Must clauses (AND)
+        for (QueryBuilder mustClause : boolQuery.must()) {
+            RexNode condition = queryRegistry.convert(mustClause, ctx);
+            if (condition != null) {
+                conditions.add(condition);
+            }
+        }
+
+        // Filter clauses (AND)
+        for (QueryBuilder filterClause : boolQuery.filter()) {
+            RexNode condition = queryRegistry.convert(filterClause, ctx);
+            if (condition != null) {
+                conditions.add(condition);
+            }
+        }
+
+        // Should clauses with minimum_should_match
+        if (!boolQuery.should().isEmpty()) {
+            RexNode shouldCondition = processShouldClauses(boolQuery, ctx);
+            if (shouldCondition != null) {
+                conditions.add(shouldCondition);
+            }
+        }
+
+        // Must_not clauses (NOT)
+        for (QueryBuilder mustNotClause : boolQuery.mustNot()) {
+            RexNode condition = queryRegistry.convert(mustNotClause, ctx);
+            if (condition != null) {
+                // Optimize double negation: NOT(NOT(a)) -> a
+                if (condition instanceof RexCall && ((RexCall) condition).getOperator() == SqlStdOperatorTable.NOT) {
+                    conditions.add(((RexCall) condition).getOperands().get(0));
+                } else {
+                    conditions.add(ctx.getRexBuilder().makeCall(SqlStdOperatorTable.NOT, condition));
+                }
+            }
+        }
+
+        // Flatten nested ANDs to satisfy Calcite's RexUtil.isFlat requirement
+        List<RexNode> flattenedConditions = flattenConditions(conditions, SqlStdOperatorTable.AND);
+
+        if (flattenedConditions.isEmpty()) {
+            return ctx.getRexBuilder().makeLiteral(true);
+        } else if (flattenedConditions.size() == 1) {
+            return flattenedConditions.get(0);
+        } else {
+            return ctx.getRexBuilder().makeCall(SqlStdOperatorTable.AND, flattenedConditions);
+        }
+    }
+
+    /**
+     * Flattens nested conditions with the same operator to satisfy Calcite's RexUtil.isFlat requirement.
+     * <p>
+     * Examples:
+     * <ul>
+     *   <li>AND(AND(a, b), c) → AND(a, b, c)</li>
+     *   <li>OR(OR(a, b), c) → OR(a, b, c)</li>
+     * </ul>
+     * Note: NOT operations are not flattened as NOT(NOT(a)) has different semantics.
+     *
+     * @param conditions the list of conditions to flatten
+     * @param operator the operator to flatten (AND or OR)
+     * @return flattened list of conditions
+     */
+    private List<RexNode> flattenConditions(List<RexNode> conditions, org.apache.calcite.sql.SqlOperator operator) {
+        List<RexNode> flattened = new ArrayList<>();
+        for (RexNode condition : conditions) {
+            if (condition instanceof RexCall && ((RexCall) condition).getOperator() == operator) {
+                flattened.addAll(((RexCall) condition).getOperands());
+            } else {
+                flattened.add(condition);
+            }
+        }
+        return flattened;
+    }
+
+    /**
+     * Processes should clauses with minimum_should_match logic.
+     * <p>
+     * Default behavior:
+     * <ul>
+     *   <li>Without must/filter: at least 1 should clause must match</li>
+     *   <li>With must/filter: should clauses are optional (unless minimum_should_match is set)</li>
+     * </ul>
+     *
+     * @param boolQuery the bool query containing should clauses
+     * @param ctx the conversion context
+     * @return RexNode representing the should clause logic, or null if should clauses are optional
+     * @throws ConversionException if nested query conversion fails
+     */
+    private RexNode processShouldClauses(BoolQueryBuilder boolQuery, ConversionContext ctx) throws ConversionException {
+        List<QueryBuilder> shouldClauses = boolQuery.should();
+        int totalShould = shouldClauses.size();
+
+        // If there are must/filter clauses, should is optional unless minimum_should_match is set
+        boolean hasRequired = !boolQuery.must().isEmpty() || !boolQuery.filter().isEmpty();
+        String minimumShouldMatch = boolQuery.minimumShouldMatch();
+
+        int requiredMatches = calculateRequiredMatches(minimumShouldMatch, totalShould, hasRequired);
+
+        if (requiredMatches == 0) {
+            return null; // Should clauses are optional
+        }
+
+        List<RexNode> shouldConditions = new ArrayList<>();
+        for (QueryBuilder shouldClause : shouldClauses) {
+            RexNode condition = queryRegistry.convert(shouldClause, ctx);
+            if (condition != null) {
+                shouldConditions.add(condition);
+            }
+        }
+
+        if (shouldConditions.isEmpty()) {
+            return null;
+        }
+
+        if (requiredMatches == 1) {
+            // Flatten nested ORs
+            List<RexNode> flatOr = flattenConditions(shouldConditions, SqlStdOperatorTable.OR);
+            return flatOr.size() == 1 ? flatOr.get(0) : ctx.getRexBuilder().makeCall(SqlStdOperatorTable.OR, flatOr);
+        }
+
+        return createMinimumMatchCondition(shouldConditions, requiredMatches, ctx);
+    }
+
+    /**
+     * Calculates the required number of should clauses that must match based on minimum_should_match parameter.
+     * <p>
+     * Supports multiple formats:
+     * <ul>
+     *   <li>null/empty: returns 0 if must/filter present, otherwise 1</li>
+     *   <li>"2": exactly 2 clauses must match</li>
+     *   <li>"-1": total - 1 clauses must match</li>
+     *   <li>"70%": 70% of clauses (rounded down) must match</li>
+     *   <li>"-30%": can miss 30% of clauses</li>
+     *   <li>"2&lt;75%": if total ≤ 2 match all, else 75%</li>
+     *   <li>"3&lt;-1 5&lt;50%": multiple thresholds</li>
+     * </ul>
+     *
+     * @param minimumShouldMatch the minimum_should_match parameter value
+     * @param totalShould total number of should clauses
+     * @param hasRequired true if must or filter clauses are present
+     * @return number of should clauses that must match
+     */
+    int calculateRequiredMatches(String minimumShouldMatch, int totalShould, boolean hasRequired) {
+        if (minimumShouldMatch == null || minimumShouldMatch.isEmpty()) {
+            return hasRequired ? 0 : 1;
+        }
+
+        // Multiple combinations: "3<-1 5<50%"
+        if (minimumShouldMatch.contains(" ")) {
+            return parseMultipleCombinations(minimumShouldMatch, totalShould);
+        }
+
+        // Single combination: "2<75%"
+        if (minimumShouldMatch.contains("<")) {
+            return parseCombination(minimumShouldMatch, totalShould);
+        }
+
+        // Percentage: "70%" or "-30%"
+        if (minimumShouldMatch.endsWith("%")) {
+            return parsePercentage(minimumShouldMatch, totalShould);
+        }
+
+        // Integer: "2" or "-1"
+        return parseInteger(minimumShouldMatch, totalShould);
+    }
+
+    /**
+     * Parses an integer minimum_should_match value.
+     * Non-negative values are returned as-is. Negative values are subtracted from total.
+     *
+     * @param value the integer string (e.g., "2" or "-1")
+     * @param total total number of should clauses
+     * @return required number of matches
+     */
+    private int parseInteger(String value, int total) {
+        int num = Integer.parseInt(value);
+        return num >= 0 ? num : Math.max(0, total + num);
+    }
+
+    /**
+     * Parses a percentage minimum_should_match value.
+     * Non-negative percentages are applied directly. Negative percentages represent allowed misses.
+     *
+     * @param value the percentage string (e.g., "70%" or "-30%")
+     * @param total total number of should clauses
+     * @return required number of matches (rounded down)
+     */
+    private int parsePercentage(String value, int total) {
+        double percent = Double.parseDouble(value.substring(0, value.length() - 1));
+        if (percent >= 0) {
+            return (int) Math.floor(total * percent / 100.0);
+        } else {
+            int allowed = (int) Math.floor(total * (-percent) / 100.0);
+            return Math.max(0, total - allowed);
+        }
+    }
+
+    /**
+     * Parses a single combination minimum_should_match value (e.g., "2&lt;75%").
+     * If total ≤ threshold, all clauses must match. Otherwise, applies the specified value.
+     *
+     * @param value the combination string (e.g., "2&lt;75%")
+     * @param total total number of should clauses
+     * @return required number of matches
+     */
+    private int parseCombination(String value, int total) {
+        String[] parts = value.split("<");
+        int threshold = Integer.parseInt(parts[0]);
+        if (total <= threshold) {
+            return total;
+        }
+        return parts[1].endsWith("%") ? parsePercentage(parts[1], total) : parseInteger(parts[1], total);
+    }
+
+    /**
+     * Parses multiple combinations minimum_should_match value (e.g., "3&lt;-1 5&lt;50%").
+     * Applies the appropriate rule based on which threshold range the total falls into.
+     *
+     * @param value the combinations string (e.g., "3&lt;-1 5&lt;50%")
+     * @param total total number of should clauses
+     * @return required number of matches
+     */
+    private int parseMultipleCombinations(String value, int total) {
+        String[] combinations = value.trim().split("\\s+");
+        for (int i = 0; i < combinations.length; i++) {
+            String combination = combinations[i];
+            String[] parts = combination.split("<");
+            int threshold = Integer.parseInt(parts[0]);
+
+            if (total <= threshold) {
+                return total;
+            }
+
+            // If this is the last combination or we're in the range for this combination
+            if (i == combinations.length - 1) {
+                return parts[1].endsWith("%") ? parsePercentage(parts[1], total) : parseInteger(parts[1], total);
+            }
+
+            // Check if we're in the range for the next threshold
+            if (i + 1 < combinations.length) {
+                String[] nextParts = combinations[i + 1].split("<");
+                int nextThreshold = Integer.parseInt(nextParts[0]);
+                if (total <= nextThreshold) {
+                    return parts[1].endsWith("%") ? parsePercentage(parts[1], total) : parseInteger(parts[1], total);
+                }
+            }
+        }
+        return total;
+    }
+
+    /**
+     * Creates a RexNode representing the minimum_should_match condition when required &gt; 1.
+     * Generates all C(n,k) combinations where n = total conditions, k = required matches.
+     * <p>
+     * Example: 3 conditions with 2 required generates: (a AND b) OR (a AND c) OR (b AND c)
+     * <p>
+     * Performance note: Large clause counts with high required matches can generate many combinations.
+     * For example, C(10,5) = 252, C(20,10) = 184,756.
+     *
+     * @param conditions the list of should clause conditions
+     * @param required number of conditions that must match
+     * @param ctx the conversion context
+     * @return RexNode representing all valid combinations
+     */
+    private RexNode createMinimumMatchCondition(List<RexNode> conditions, int required, ConversionContext ctx) {
+        List<RexNode> combinations = new ArrayList<>();
+        generateCombinations(conditions, required, 0, new ArrayList<>(), combinations, ctx);
+        return combinations.size() == 1 ? combinations.get(0) : ctx.getRexBuilder().makeCall(SqlStdOperatorTable.OR, combinations);
+    }
+
+    /**
+     * Recursively generates all C(n,k) combinations of conditions using backtracking.
+     * Each combination of size k is combined with AND, and all combinations are collected for OR.
+     *
+     * @param conditions all available conditions
+     * @param required number of conditions needed per combination
+     * @param start starting index for this recursion level
+     * @param current current combination being built
+     * @param result accumulator for all generated combinations
+     * @param ctx the conversion context
+     */
+    private void generateCombinations(
+        List<RexNode> conditions,
+        int required,
+        int start,
+        List<RexNode> current,
+        List<RexNode> result,
+        ConversionContext ctx
+    ) {
+        if (current.size() == required) {
+            result.add(
+                current.size() == 1 ? current.get(0) : ctx.getRexBuilder().makeCall(SqlStdOperatorTable.AND, new ArrayList<>(current))
+            );
+            return;
+        }
+
+        for (int i = start; i <= conditions.size() - (required - current.size()); i++) {
+            current.add(conditions.get(i));
+            generateCombinations(conditions, required, i + 1, current, result, ctx);
+            current.remove(current.size() - 1);
+        }
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/query/QueryRegistryFactory.java
@@ -20,7 +20,7 @@ public class QueryRegistryFactory {
         QueryRegistry registry = new QueryRegistry();
         registry.register(new TermQueryTranslator());
         registry.register(new MatchAllQueryTranslator());
-        // TODO: add other query translators
+        registry.register(new BoolQueryTranslator(registry));
         return registry;
     }
 }

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/BoolQueryTranslatorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/BoolQueryTranslatorTests.java
@@ -1,0 +1,351 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.opensearch.dsl.TestUtils;
+import org.opensearch.dsl.converter.ConversionContext;
+import org.opensearch.dsl.converter.ConversionException;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class BoolQueryTranslatorTests extends OpenSearchTestCase {
+
+    private final QueryRegistry registry = QueryRegistryFactory.create();
+    private final BoolQueryTranslator translator = new BoolQueryTranslator(registry);
+    private final ConversionContext ctx = TestUtils.createContext();
+
+    // Basic bool query tests
+
+    public void testMustClause() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.boolQuery().must(QueryBuilders.termQuery("name", "test")), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.EQUALS, call.getKind());
+    }
+
+    public void testShouldClauseWithoutMust() throws ConversionException {
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery().should(QueryBuilders.termQuery("name", "test1")).should(QueryBuilders.termQuery("name", "test2")),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.OR, call.getKind());
+        assertEquals(2, call.getOperands().size());
+    }
+
+    public void testMustNotClause() throws ConversionException {
+        RexNode result = translator.convert(QueryBuilders.boolQuery().mustNot(QueryBuilders.termQuery("name", "test")), ctx);
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.NOT, call.getKind());
+    }
+
+    // minimum_should_match: Non-negative integer
+
+    public void testMinimumShouldMatchInteger2() throws ConversionException {
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("name", "a"))
+                .should(QueryBuilders.termQuery("name", "b"))
+                .should(QueryBuilders.termQuery("name", "c"))
+                .minimumShouldMatch("2"),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.OR, call.getKind());
+        // Should generate: (a AND b) OR (a AND c) OR (b AND c)
+        assertEquals(3, call.getOperands().size());
+    }
+
+    public void testMinimumShouldMatchInteger1() throws ConversionException {
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("name", "a"))
+                .should(QueryBuilders.termQuery("name", "b"))
+                .minimumShouldMatch("1"),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.OR, call.getKind());
+        assertEquals(2, call.getOperands().size());
+    }
+
+    // minimum_should_match: Negative integer
+
+    public void testMinimumShouldMatchNegativeInteger() throws ConversionException {
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("name", "a"))
+                .should(QueryBuilders.termQuery("name", "b"))
+                .should(QueryBuilders.termQuery("name", "c"))
+                .minimumShouldMatch("-1"),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.OR, call.getKind());
+        // -1 means total - 1 = 3 - 1 = 2 required
+        assertEquals(3, call.getOperands().size());
+    }
+
+    // minimum_should_match: Non-negative percentage
+
+    public void testMinimumShouldMatchPercentage70() throws ConversionException {
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("name", "a"))
+                .should(QueryBuilders.termQuery("name", "b"))
+                .should(QueryBuilders.termQuery("name", "c"))
+                .should(QueryBuilders.termQuery("name", "d"))
+                .minimumShouldMatch("70%"),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.OR, call.getKind());
+        // 70% of 4 = 2.8, floor = 2 required
+    }
+
+    public void testMinimumShouldMatchPercentage50() throws ConversionException {
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("name", "a"))
+                .should(QueryBuilders.termQuery("name", "b"))
+                .should(QueryBuilders.termQuery("name", "c"))
+                .should(QueryBuilders.termQuery("name", "d"))
+                .minimumShouldMatch("50%"),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.OR, call.getKind());
+        // 50% of 4 = 2 required
+    }
+
+    // minimum_should_match: Negative percentage
+
+    public void testMinimumShouldMatchNegativePercentage() throws ConversionException {
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("name", "a"))
+                .should(QueryBuilders.termQuery("name", "b"))
+                .should(QueryBuilders.termQuery("name", "c"))
+                .should(QueryBuilders.termQuery("name", "d"))
+                .minimumShouldMatch("-30%"),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.OR, call.getKind());
+        // -30% means can miss 30% = 1.2, floor = 1, so 4 - 1 = 3 required
+    }
+
+    // minimum_should_match: Single combination
+
+    public void testMinimumShouldMatchCombination2Less75Percent() throws ConversionException {
+        // 2<75% means: if total <= 2, match all; if total > 2, match 75%
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("name", "a"))
+                .should(QueryBuilders.termQuery("name", "b"))
+                .minimumShouldMatch("2<75%"),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        // total = 2, so should match all (2)
+        assertEquals(SqlKind.AND, call.getKind());
+    }
+
+    public void testMinimumShouldMatchCombinationWithMoreClauses() throws ConversionException {
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("name", "a"))
+                .should(QueryBuilders.termQuery("name", "b"))
+                .should(QueryBuilders.termQuery("name", "c"))
+                .should(QueryBuilders.termQuery("name", "d"))
+                .minimumShouldMatch("2<75%"),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        // total = 4 > 2, so 75% of 4 = 3 required
+        assertEquals(SqlKind.OR, call.getKind());
+    }
+
+    // minimum_should_match: Multiple combinations
+
+    public void testMinimumShouldMatchMultipleCombinations() throws ConversionException {
+        // 3<-1 5<50% means:
+        // if total <= 3: match all
+        // if 3 < total <= 5: match all but 1
+        // if total > 5: match 50%
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("name", "a"))
+                .should(QueryBuilders.termQuery("name", "b"))
+                .should(QueryBuilders.termQuery("name", "c"))
+                .should(QueryBuilders.termQuery("name", "d"))
+                .minimumShouldMatch("3<-1 5<50%"),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        // total = 4, which is 3 < 4 <= 5, so -1 = 4 - 1 = 3 required
+        assertEquals(SqlKind.OR, call.getKind());
+    }
+
+    public void testMinimumShouldMatchMultipleCombinationsWithSixClauses() throws ConversionException {
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("name", "a"))
+                .should(QueryBuilders.termQuery("name", "b"))
+                .should(QueryBuilders.termQuery("name", "c"))
+                .should(QueryBuilders.termQuery("name", "d"))
+                .should(QueryBuilders.termQuery("name", "e"))
+                .should(QueryBuilders.termQuery("name", "f"))
+                .minimumShouldMatch("3<-1 5<50%"),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        // total = 6 > 5, so 50% of 6 = 3 required
+        assertEquals(SqlKind.OR, call.getKind());
+    }
+
+    // Edge cases
+
+    public void testShouldWithMustClause() throws ConversionException {
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("name", "required"))
+                .should(QueryBuilders.termQuery("name", "a"))
+                .should(QueryBuilders.termQuery("name", "b")),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        // Should clauses are optional when must is present (no minimum_should_match)
+        assertEquals(SqlKind.EQUALS, call.getKind());
+    }
+
+    public void testShouldWithMustAndMinimumShouldMatch() throws ConversionException {
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("name", "required"))
+                .should(QueryBuilders.termQuery("name", "a"))
+                .should(QueryBuilders.termQuery("name", "b"))
+                .minimumShouldMatch("1"),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.AND, call.getKind());
+        assertEquals(2, call.getOperands().size());
+    }
+
+    public void testComplexBoolQuery() throws ConversionException {
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("name", "active"))
+                .should(QueryBuilders.termQuery("brand", "high"))
+                .should(QueryBuilders.termQuery("brand", "medium"))
+                .mustNot(QueryBuilders.termQuery("name", "deleted"))
+                .minimumShouldMatch("1"),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.AND, call.getKind());
+        assertEquals(3, call.getOperands().size());
+    }
+
+    public void testReportsCorrectQueryType() {
+        assertEquals(BoolQueryBuilder.class, translator.getQueryType());
+    }
+
+    public void testNestedBoolQueryFlattening() throws ConversionException {
+        // Nested bool: bool(must: [term1, bool(must: [term2, term3])])
+        // Should flatten to: AND(term1, term2, term3)
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("name", "value1"))
+                .must(
+                    QueryBuilders.boolQuery()
+                        .must(QueryBuilders.termQuery("brand", "value2"))
+                        .must(QueryBuilders.termQuery("rating", 3.0))
+                ),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.AND, call.getKind());
+        // Should be flattened to 3 operands, not nested
+        assertEquals(3, call.getOperands().size());
+    }
+
+    public void testNestedShouldQueryFlattening() throws ConversionException {
+        // Nested should: bool(should: [term1, bool(should: [term2, term3])])
+        // Should flatten to: OR(term1, term2, term3)
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.termQuery("name", "value1"))
+                .should(
+                    QueryBuilders.boolQuery()
+                        .should(QueryBuilders.termQuery("brand", "value2"))
+                        .should(QueryBuilders.termQuery("rating", 3.0))
+                ),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        assertEquals(SqlKind.OR, call.getKind());
+        // Should be flattened to 3 operands, not nested
+        assertEquals(3, call.getOperands().size());
+    }
+
+    public void testDoubleNegationElimination() throws ConversionException {
+        // bool(must_not: [bool(must_not: [term])])
+        // Should eliminate double negation: NOT(NOT(term)) -> term
+        RexNode result = translator.convert(
+            QueryBuilders.boolQuery().mustNot(QueryBuilders.boolQuery().mustNot(QueryBuilders.termQuery("name", "value"))),
+            ctx
+        );
+
+        assertTrue(result instanceof RexCall);
+        RexCall call = (RexCall) result;
+        // Should be the term itself, not wrapped in NOT
+        assertEquals(SqlKind.EQUALS, call.getKind());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/MinimumShouldMatchParserTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/query/MinimumShouldMatchParserTests.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.dsl.query;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class MinimumShouldMatchParserTests extends OpenSearchTestCase {
+
+    private BoolQueryTranslator translator = new BoolQueryTranslator(QueryRegistryFactory.create());
+
+    // Test integer parsing
+    public void testParsePositiveInteger() {
+        int result = translator.calculateRequiredMatches("2", 5, false);
+        assertEquals(2, result);
+    }
+
+    public void testParseNegativeInteger() {
+        int result = translator.calculateRequiredMatches("-1", 5, false);
+        assertEquals(4, result); // 5 - 1 = 4
+    }
+
+    // Test percentage parsing
+    public void testParsePositivePercentage() {
+        int result = translator.calculateRequiredMatches("70%", 4, false);
+        assertEquals(2, result); // floor(4 * 0.7) = 2
+    }
+
+    public void testParseNegativePercentage() {
+        int result = translator.calculateRequiredMatches("-30%", 4, false);
+        assertEquals(3, result); // 4 - floor(4 * 0.3) = 3
+    }
+
+    // Test combination parsing
+    public void testParseCombinationBelowThreshold() {
+        int result = translator.calculateRequiredMatches("2<75%", 2, false);
+        assertEquals(2, result); // total <= 2, match all
+    }
+
+    public void testParseCombinationAboveThreshold() {
+        int result = translator.calculateRequiredMatches("2<75%", 4, false);
+        assertEquals(3, result); // total > 2, floor(4 * 0.75) = 3
+    }
+
+    // Test multiple combinations
+    public void testParseMultipleCombinationsLow() {
+        int result = translator.calculateRequiredMatches("3<-1 5<50%", 3, false);
+        assertEquals(3, result); // total <= 3, match all
+    }
+
+    public void testParseMultipleCombinationsMid() {
+        int result = translator.calculateRequiredMatches("3<-1 5<50%", 4, false);
+        assertEquals(3, result); // 3 < 4 <= 5, so -1 = 4 - 1 = 3
+    }
+
+    public void testParseMultipleCombinationsHigh() {
+        int result = translator.calculateRequiredMatches("3<-1 5<50%", 6, false);
+        assertEquals(3, result); // total > 5, floor(6 * 0.5) = 3
+    }
+
+    // Test default behavior
+    public void testDefaultWithoutMust() {
+        int result = translator.calculateRequiredMatches(null, 3, false);
+        assertEquals(1, result); // No must clause, at least 1 should match
+    }
+
+    public void testDefaultWithMust() {
+        int result = translator.calculateRequiredMatches(null, 3, true);
+        assertEquals(0, result); // Has must clause, should is optional
+    }
+}


### PR DESCRIPTION
## Add Bool Query Support with minimum_should_match to DSL Query Executor

### Summary
Implements BoolQueryTranslator with support for bool query clauses (must, should, must_not, filter) and comprehensive minimum_should_match parameter handling. Converts
OpenSearch bool queries to Calcite logical expressions with optimization.

### Changes

#### New Files
• BoolQueryTranslator.java - Main translator with minimum_should_match logic
• BoolQueryTranslatorTests.java - unit tests covering all scenarios
• MinimumShouldMatchParserTests.java - parser-specific unit tests
• DslBoolQueryIT.java - integration tests for end-to-end validation

#### Modified Files
• QueryRegistryFactory.java - Registered BoolQueryTranslator
• README.md - Added supported queries section with bool query documentation

### Features

Bool Query Clauses:
• must - Required clauses combined with AND
• should - Optional clauses combined with OR
• must_not - Exclusion clauses wrapped with NOT
• filter - Filtering clauses combined with AND

minimum_should_match Support:
• Non-negative integer: "2" - exactly 2 must match
• Negative integer: "-1" - total - 1 must match
• Non-negative percentage: "70%" - 70% rounded down
• Negative percentage: "-30%" - can miss 30%
• Single combination: "2<75%" - threshold-based
• Multiple combinations: "3<-1 5<50%" - multiple thresholds

Optimizations:
• Flattens nested AND/OR structures (satisfies Calcite's RexUtil.isFlat)
• Eliminates double negations: NOT(NOT(a)) → a
• Generates all C(n,k) combinations for minimum_should_match > 1

### Examples

json
{
  "bool": {                                                                                                                                                                     
    "must": [{"term": {"status": "active"}}],                                                                                                                                   
    "should": [                                                                                                                                                                 
      {"term": {"priority": "high"}},                                                                                                                                           
      {"term": {"priority": "medium"}},                                                                                                                                         
      {"term": {"priority": "low"}}                                                                                                                                             
    ],                                                                                                                                                                          
    "must_not": [{"term": {"deleted": "true"}}],                                                                                                                                
    "minimum_should_match": "2"                                                                                                                                                 
  }                                                                                                                                                                             
}                                                                                                                                                                               
                                                                                                                                                                                

Converts to: 
(status = 'active') AND ((priority = 'high' AND priority = 'medium') OR (priority = 'high' AND priority = 'low') OR (priority = 'medium' AND priority = 'low')) AND NOT (deleted = 'true')                                                                                                                                                                      

### Testing
• ✅ 20 unit tests in BoolQueryTranslatorTests
• ✅ 11 parser tests in MinimumShouldMatchParserTests
• ✅ All tests passing with ./gradlew :sandbox:plugins:dsl-query-executor:test -Dsandbox.enabled=true

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- NA -->

### Check List
- [ YES ] Functionality includes testing.
- [ YES ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ NA ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
