### PR TITLE
Fix Flaky Test Report for Netty4Http3IT

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/http/netty4/Netty4Http3IT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/opensearch/http/netty4/Netty4Http3IT.java
@@ -18,6 +18,8 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.http.AbstractHttpServerTransport;
+import org.opensearch.http.HttpRequest.HttpVersion;
 import org.opensearch.http.HttpServerTransport;
 import org.opensearch.http.HttpTransportSettings;
 import org.opensearch.http.netty4.http3.Http3Utils;
@@ -32,6 +34,7 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -47,6 +50,7 @@ import io.netty.util.ReferenceCounted;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -81,22 +85,25 @@ public class Netty4Http3IT extends OpenSearchNetty4IntegTestCase {
 
         String[] requests = new String[] { "/", "/_nodes/stats", "/", "/_cluster/state", "/" };
         HttpServerTransport httpServerTransport = internalCluster().getInstance(HttpServerTransport.class);
-        TransportAddress[] boundAddresses = httpServerTransport.boundAddress().boundAddresses();
-        TransportAddress transportAddress = randomFrom(boundAddresses);
+        assertThat(httpServerTransport, instanceOf(Netty4CompositeHttpServerTransport.class));
 
         @SuppressWarnings("unchecked")
-        final Tuple<Netty4HttpClient, String> client = randomFrom(
-            Tuple.tuple(Netty4HttpClient.http3().withLogger(logger), "h2="),
-            Tuple.tuple(Netty4HttpClient.https().withLogger(logger), "h3=")
+        final Tuple<Netty4HttpClient, Tuple<String, HttpVersion>> client = randomFrom(
+            Tuple.tuple(Netty4HttpClient.http3().withLogger(logger), Tuple.tuple("h2=", HttpVersion.HTTP_3_0)),
+            Tuple.tuple(Netty4HttpClient.https().withLogger(logger), Tuple.tuple("h3=", HttpVersion.HTTP_2_0))
         );
 
         try (Netty4HttpClient nettyHttpClient = client.v1()) {
-            Collection<FullHttpResponse> responses = nettyHttpClient.get(transportAddress.address(), randomFrom(requests));
+            final TransportAddress transportAddress = randomFrom(
+                (Netty4CompositeHttpServerTransport) httpServerTransport,
+                client.v2().v2()
+            );
+            final Collection<FullHttpResponse> responses = nettyHttpClient.get(transportAddress.address(), randomFrom(requests));
             try {
                 assertThat(responses, hasSize(1));
 
                 for (HttpResponse response : responses) {
-                    assertThat(response.headers().get("Alt-Svc"), containsString(client.v2()));
+                    assertThat(response.headers().get("Alt-Svc"), containsString(client.v2().v1()));
                 }
 
                 Collection<String> opaqueIds = Netty4HttpClient.returnOpaqueIds(responses);
@@ -115,23 +122,26 @@ public class Netty4Http3IT extends OpenSearchNetty4IntegTestCase {
 
         final List<Tuple<String, CharSequence>> requests = List.of(Tuple.tuple("/_search", "{\"query\":{ \"match_all\":{}}}"));
         HttpServerTransport httpServerTransport = internalCluster().getInstance(HttpServerTransport.class);
-        TransportAddress[] boundAddresses = httpServerTransport.boundAddress().boundAddresses();
-        TransportAddress transportAddress = randomFrom(boundAddresses);
+        assertThat(httpServerTransport, instanceOf(Netty4CompositeHttpServerTransport.class));
 
         @SuppressWarnings("unchecked")
-        final Tuple<Netty4HttpClient, String> client = randomFrom(
-            Tuple.tuple(Netty4HttpClient.http3().withLogger(logger), "h2="),
-            Tuple.tuple(Netty4HttpClient.https().withLogger(logger), "h3=")
+        final Tuple<Netty4HttpClient, Tuple<String, HttpVersion>> client = randomFrom(
+            Tuple.tuple(Netty4HttpClient.http3().withLogger(logger), Tuple.tuple("h2=", HttpVersion.HTTP_3_0)),
+            Tuple.tuple(Netty4HttpClient.https().withLogger(logger), Tuple.tuple("h3=", HttpVersion.HTTP_2_0))
         );
 
         try (Netty4HttpClient nettyHttpClient = client.v1()) {
-            Collection<FullHttpResponse> responses = nettyHttpClient.post(transportAddress.address(), requests);
+            final TransportAddress transportAddress = randomFrom(
+                (Netty4CompositeHttpServerTransport) httpServerTransport,
+                client.v2().v2()
+            );
+            final Collection<FullHttpResponse> responses = nettyHttpClient.post(transportAddress.address(), requests);
             try {
                 assertThat(responses, hasSize(1));
 
                 for (FullHttpResponse response : responses) {
                     assertThat(response.status(), equalTo(HttpResponseStatus.OK));
-                    assertThat(response.headers().get("Alt-Svc"), containsString(client.v2()));
+                    assertThat(response.headers().get("Alt-Svc"), containsString(client.v2().v1()));
                 }
 
                 Collection<String> opaqueIds = Netty4HttpClient.returnOpaqueIds(responses);
@@ -155,6 +165,19 @@ public class Netty4Http3IT extends OpenSearchNetty4IntegTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Stream.concat(super.nodePlugins().stream(), Stream.of(SecureSettingsPlugin.class)).toList();
+    }
+
+    private TransportAddress randomFrom(final Netty4CompositeHttpServerTransport transport, HttpVersion protocol) {
+        final AbstractHttpServerTransport httpServerTransport = Arrays.stream(transport.transports()).filter(t -> {
+            if (protocol == HttpVersion.HTTP_3_0) {
+                return t instanceof Netty4Http3ServerTransport;
+            } else {
+                return t instanceof Netty4HttpServerTransport;
+            }
+        }).findAny().orElseThrow();
+
+        TransportAddress[] boundAddresses = httpServerTransport.boundAddress().boundAddresses();
+        return randomFrom(boundAddresses);
     }
 
     private void assertOpaqueIdsInAnyOrder(int expected, Collection<String> opaqueIds) {

--- a/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4CompositeHttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/opensearch/http/netty4/Netty4CompositeHttpServerTransport.java
@@ -72,4 +72,8 @@ public class Netty4CompositeHttpServerTransport extends AbstractLifecycleCompone
             IOUtils.closeWhileHandlingException(transport);
         }
     }
+
+    AbstractHttpServerTransport[] transports() {
+        return transports;
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The nature of flakyness is understood: under normal conditions, the HTTP/1.1, HTTP/2 and HTTP/3 transports are bound to the same port (but different protocol). At very rare occasion, the HTTP/1.1, HTTP/2 port selection could run into conflict and under `AbstractHttpServerTransport::bindAddress` algorithm, the next free port is going to be taken from the range. HTTP/3 however may not conflict and could pick the first port from the range.

### Related Issues
Closes https://github.com/opensearch-project/OpenSearch/issues/20654

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
