### PR TITLE
Fix BlockTransferManagerTests to extend OpenSearchTestCase instead of LuceneTestCase

### DIFF
--- a/server/src/test/java/org/opensearch/storage/common/BlockTransferManagerTests.java
+++ b/server/src/test/java/org/opensearch/storage/common/BlockTransferManagerTests.java
@@ -12,7 +12,6 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.IOContext;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.UUIDs;
@@ -23,6 +22,7 @@ import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
 import org.opensearch.index.store.remote.utils.TransferManager;
 import org.opensearch.node.Node;
 import org.opensearch.storage.indexinput.BlockFetchRequest;
+import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Assert;
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.when;
  * Tests cover single block downloads, failure scenarios, duplicate handling, and concurrent operations.
  */
 @ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
-public class BlockTransferManagerTests extends LuceneTestCase {
+public class BlockTransferManagerTests extends OpenSearchTestCase {
 
     // Node and index configuration constants
     private static final String TEST_NODE_NAME = "test-node";


### PR DESCRIPTION
### Description

`BlockTransferManagerTests` was extending `LuceneTestCase` directly, which causes sysout check failures in CI since the test uses loggers that print to console during execution. Changed the base class to `OpenSearchTestCase` which already includes `@SuppressSysoutChecks` and follows the project convention for all tests in the `server/` module.

### Related Issues

Related to #21355

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

