### PR TITLE
Update logic in FipsBuildParams.isInFipsApprovedOnlyMode to check for env param instead of org.bouncycastle.fips.approved_only

### DIFF
--- a/buildSrc/src/main/java/org/opensearch/gradle/info/FipsBuildParams.java
+++ b/buildSrc/src/main/java/org/opensearch/gradle/info/FipsBuildParams.java
@@ -9,6 +9,7 @@
 package org.opensearch.gradle.info;
 
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class FipsBuildParams {
 
@@ -18,6 +19,7 @@ public class FipsBuildParams {
     public static final String DEFAULT_FIPS_MODE = "FIPS-140-3";
 
     private static String fipsMode;
+    static Supplier<String> fipsModeEnvSupplier = () -> System.getenv("OPENSEARCH_FIPS_MODE");
 
     public static void init(Function<String, Object> fipsValue) {
         var fipsBuildParamForTests = Boolean.parseBoolean((String) fipsValue.apply(FIPS_BUILD_PARAM_FOR_TESTS));
@@ -37,7 +39,7 @@ public class FipsBuildParams {
     }
 
     public static boolean isInFipsApprovedOnlyMode() {
-        return isInFipsMode() && "true".equals(System.getProperty("org.bouncycastle.fips.approved_only"));
+        return isInFipsMode() && "true".equalsIgnoreCase(fipsModeEnvSupplier.get());
     }
 
     public static String getFipsMode() {

--- a/buildSrc/src/test/java/org/opensearch/gradle/info/FipsBuildParamsTests.java
+++ b/buildSrc/src/test/java/org/opensearch/gradle/info/FipsBuildParamsTests.java
@@ -14,6 +14,30 @@ import java.util.function.Function;
 
 public class FipsBuildParamsTests extends GradleUnitTestCase {
 
+    public void testIsInFipsApprovedOnlyMode() {
+        FipsBuildParams.init(cryptoEntryFnWithStringParam);
+
+        FipsBuildParams.fipsModeEnvSupplier = () -> "true";
+        assertTrue(FipsBuildParams.isInFipsApprovedOnlyMode());
+
+        FipsBuildParams.fipsModeEnvSupplier = () -> "TRUE";
+        assertTrue(FipsBuildParams.isInFipsApprovedOnlyMode());
+
+        FipsBuildParams.fipsModeEnvSupplier = () -> "false";
+        assertFalse(FipsBuildParams.isInFipsApprovedOnlyMode());
+
+        FipsBuildParams.fipsModeEnvSupplier = () -> null;
+        assertFalse(FipsBuildParams.isInFipsApprovedOnlyMode());
+
+        // Not in FIPS mode — should always be false regardless of env var
+        FipsBuildParams.init(param -> null);
+        FipsBuildParams.fipsModeEnvSupplier = () -> "true";
+        assertFalse(FipsBuildParams.isInFipsApprovedOnlyMode());
+
+        // Reset
+        FipsBuildParams.fipsModeEnvSupplier = () -> System.getenv("OPENSEARCH_FIPS_MODE");
+    }
+
     public void testIsInFipsMode() {
         FipsBuildParams.init(cryptoEntryFnWithStringParam);
         assertTrue(FipsBuildParams.isInFipsMode());


### PR DESCRIPTION
### Description

Currently, FipsBuildParam looks for the system prop (`org.bouncycastle.fips.approved_only`) to determine if FIPS is enforced at runtime. This system prop is specific to the bouncycastle library and implicitly set [here in opensearch-env](https://github.com/opensearch-project/OpenSearch/blob/main/distribution/src/bin/opensearch-env#L115-L128). This PR makes configuring FIPS more intentional by the cluster operator by looking for an OpenSearch env var instead of the bouncycastle system prop to determine if FIPS should be enforced at runtime.

### Related Issues

Related to https://github.com/opensearch-project/OpenSearch/issues/20738

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
