### PR TITLE
Trigger search replica sync when scaling down to search-only

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/scale/searchonly/ScaleIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/scale/searchonly/ScaleIndexIT.java
@@ -16,9 +16,11 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.routing.IndexRoutingTable;
 import org.opensearch.cluster.routing.IndexShardRoutingTable;
+import org.opensearch.cluster.routing.Preference;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
 import org.opensearch.test.InternalTestCluster;
@@ -50,6 +52,61 @@ public class ScaleIndexIT extends RemoteStoreBaseIntegTestCase {
 
     public void testFullLifecycleWithoutSearchReplicas() throws Exception {
         testFullLifecycle(0);
+    }
+
+    public void testScaleDownSearchReplicaCatchesUpWithFinalRemoteStoreState() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+        internalCluster().startSearchOnlyNode();
+
+        Settings specificSettings = Settings.builder()
+            .put(indexSettings())
+            .put(SETTING_NUMBER_OF_SHARDS, 1)
+            .put(SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(SETTING_NUMBER_OF_SEARCH_REPLICAS, 1)
+            .build();
+
+        createIndex(TEST_INDEX, specificSettings);
+        ensureGreen(TEST_INDEX);
+
+        client().prepareIndex(TEST_INDEX)
+            .setId("baseline")
+            .setSource("field1", "baseline")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .get();
+
+        assertBusy(() -> {
+            assertHitCount(client().prepareSearch(TEST_INDEX).setPreference(Preference.PRIMARY.type()).setSize(0).get(), 1);
+            assertHitCount(client().prepareSearch(TEST_INDEX).setPreference(Preference.SEARCH_REPLICA.type()).setSize(0).get(), 1);
+        });
+
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareUpdateSettings(TEST_INDEX)
+                .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "-1"))
+                .get()
+        );
+
+        client().prepareIndex(TEST_INDEX)
+            .setId("latest")
+            .setSource("field1", "latest")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .get();
+
+        assertHitCount(client().prepareSearch(TEST_INDEX).setPreference(Preference.PRIMARY.type()).setSize(0).get(), 2);
+        assertHitCount(client().prepareSearch(TEST_INDEX).setPreference(Preference.SEARCH_REPLICA.type()).setSize(0).get(), 1);
+
+        assertAcked(client().admin().indices().prepareScaleSearchOnly(TEST_INDEX, true).get());
+        ensureGreen(TEST_INDEX);
+
+        assertBusy(
+            () -> {
+                assertHitCount(client().prepareSearch(TEST_INDEX).setPreference(Preference.SEARCH_REPLICA.type()).setSize(0).get(), 2);
+            },
+            10,
+            TimeUnit.SECONDS
+        );
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -1214,6 +1214,10 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
 
     @Override
     public synchronized void updateMetadata(final IndexMetadata currentIndexMetadata, final IndexMetadata newIndexMetadata) {
+        final boolean wasSearchOnly = currentIndexMetadata != null
+            && IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING.get(currentIndexMetadata.getSettings());
+        final boolean isSearchOnly = IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING.get(newIndexMetadata.getSettings());
+        final boolean becameSearchOnly = wasSearchOnly == false && isSearchOnly;
         final boolean updateIndexSettings = indexSettings.updateIndexMetadata(newIndexMetadata);
 
         if (Assertions.ENABLED && currentIndexMetadata != null) {
@@ -1245,18 +1249,21 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             }
             onRefreshIntervalChange();
             updateFsyncTaskIfNecessary();
-            updateReplicationTask();
+            updateReplicationTask(becameSearchOnly);
             updatePublishReferencedSegmentsTask();
         }
 
         metadataListeners.forEach(c -> c.accept(newIndexMetadata));
     }
 
-    private void updateReplicationTask() {
+    private void updateReplicationTask(boolean forceSync) {
         try {
             asyncReplicationTask.close();
         } finally {
             asyncReplicationTask = new AsyncReplicationTask(this);
+            if (forceSync) {
+                asyncReplicationTask.forceSyncSegments();
+            }
         }
     }
 
@@ -1622,6 +1629,25 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             if (shouldRun()) {
                 indexService.maybeSyncSegments(false);
             }
+        }
+
+        void forceSyncSegments() {
+            if (mustReschedule() == false) {
+                return;
+            }
+            threadPool.executor(getThreadPool()).execute(new AbstractRunnable() {
+                @Override
+                public void onFailure(Exception e) {
+                    logger.warn(() -> new ParameterizedMessage("failed to run forced task {}", AsyncReplicationTask.this), e);
+                }
+
+                @Override
+                protected void doRun() {
+                    if (mustReschedule()) {
+                        indexService.maybeSyncSegments(true);
+                    }
+                }
+            });
         }
 
         @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change triggers a final Remote Store segment sync on search-only replicas when an index transitions into search-only mode.

During scale down, primary shards already perform a final sync/flush and wait for Remote Store sync before the final metadata transition. Search-only replicas, however, are not part of checkpoint publishing and normally catch up through `IndexService.AsyncReplicationTask`.

Once `index.blocks.search_only=true` is applied, the regular replication task stops because `AsyncReplicationTask#shouldRun()` returns false. If a search-only replica has not already pulled the latest Remote Store segments before that metadata update, it can continue serving stale results after scale down completes.

This PR fixes that gap by:

  - Detecting the metadata transition from non-search-only to search-only in `IndexService#updateMetadata`.
  - Passing that transition into `updateReplicationTask`.
  - Recreating `AsyncReplicationTask` as before.
  - Triggering a one-time forced segment sync through `AsyncReplicationTask#forceSyncSegments`.
  - Reusing `maybeSyncSegments(true)` so the existing search-only shard filtering and Remote Store sync path are preserved.
  - Checking `mustReschedule()` before enqueueing and again at execution time to respect index lifecycle conditions.

The forced sync is asynchronous and does not add search replica catch-up to the scale-down critical path.

### Related Issues
Resolves #21369
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
