### PR TITLE
Clean up temporary scale-down block on shard sync failure

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/scale/searchonly/ScaleIndexIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/indices/scale/searchonly/ScaleIndexIT.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.action.admin.indices.scale.searchonly;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchResponse;
@@ -20,10 +21,14 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.plugins.Plugin;
 import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
 import org.opensearch.test.InternalTestCluster;
 import org.opensearch.test.OpenSearchIntegTestCase;
+import org.opensearch.test.transport.MockTransportService;
+import org.opensearch.transport.TransportService;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -42,6 +47,13 @@ public class ScaleIndexIT extends RemoteStoreBaseIntegTestCase {
 
     public Settings indexSettings() {
         return Settings.builder().put(SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        Collection<Class<? extends Plugin>> plugins = new HashSet<>(super.nodePlugins());
+        plugins.add(MockTransportService.TestPlugin.class);
+        return plugins;
     }
 
     public void testFullLifecycleWithSearchReplica() throws Exception {
@@ -203,6 +215,53 @@ public class ScaleIndexIT extends RemoteStoreBaseIntegTestCase {
             assertHitCount(finalResponse, 11);
             assertSearchNodeDocCounts(11, TEST_INDEX);
         });
+    }
+
+    public void testScaleDownShardSyncFailureAllowsWrites() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        String dataNode = internalCluster().startDataOnlyNode();
+        internalCluster().startSearchOnlyNode();
+
+        Settings specificSettings = Settings.builder()
+            .put(indexSettings())
+            .put(SETTING_NUMBER_OF_SHARDS, 1)
+            .put(SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(SETTING_NUMBER_OF_SEARCH_REPLICAS, 1)
+            .build();
+
+        createIndex(TEST_INDEX, specificSettings);
+        ensureGreen(TEST_INDEX);
+
+        IndexResponse firstIndexResponse = client().prepareIndex(TEST_INDEX)
+            .setId("before-scale-down")
+            .setSource("field1", "value-before")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .get();
+        assertEquals(RestStatus.CREATED, firstIndexResponse.status());
+
+        MockTransportService dataNodeTransportService = (MockTransportService) internalCluster().getInstance(
+            TransportService.class,
+            dataNode
+        );
+        dataNodeTransportService.addRequestHandlingBehavior(TransportScaleIndexAction.NAME, (handler, request, channel, task) -> {
+            throw new OpenSearchException("simulated shard sync failure");
+        });
+
+        try {
+            expectThrows(OpenSearchException.class, () -> client().admin().indices().prepareScaleSearchOnly(TEST_INDEX, true).get());
+        } finally {
+            dataNodeTransportService.clearAllRules();
+        }
+
+        GetSettingsResponse settingsResponse = client().admin().indices().prepareGetSettings(TEST_INDEX).get();
+        assertFalse(Boolean.parseBoolean(settingsResponse.getSetting(TEST_INDEX, IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING.getKey())));
+
+        IndexResponse indexResponse = client().prepareIndex(TEST_INDEX)
+            .setId("after-failed-scale-down")
+            .setSource("field1", "value-after")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .get();
+        assertEquals(RestStatus.CREATED, indexResponse.status());
     }
 
     /**

--- a/server/src/main/java/org/opensearch/action/admin/indices/scale/searchonly/ScaleIndexClusterStateBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/scale/searchonly/ScaleIndexClusterStateBuilder.java
@@ -129,6 +129,22 @@ class ScaleIndexClusterStateBuilder {
     }
 
     /**
+     * Removes the temporary block created while preparing a scale-down operation.
+     *
+     * @param currentState the current cluster state
+     * @param index        the name of the index whose temporary block should be removed
+     * @param scaleBlock   the exact temporary block added for this operation
+     * @return the modified cluster state with the temporary block removed
+     */
+    ClusterState buildScaleDownFailureState(ClusterState currentState, String index, ClusterBlock scaleBlock) {
+        ClusterBlocks.Builder blocksBuilder = ClusterBlocks.builder().blocks(currentState.blocks());
+
+        blocksBuilder.removeIndexBlock(index, scaleBlock);
+
+        return ClusterState.builder(currentState).blocks(blocksBuilder).build();
+    }
+
+    /**
      * Updates the routing table for a scale-down operation, removing non-search-only shards.
      * <p>
      * This method preserves only the search-only replica shards in the routing table,

--- a/server/src/main/java/org/opensearch/action/admin/indices/scale/searchonly/TransportScaleIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/scale/searchonly/TransportScaleIndexAction.java
@@ -224,6 +224,24 @@ public class TransportScaleIndexAction extends TransportClusterManagerNodeAction
         clusterService.submitStateUpdateTask("finalize-scale-down", new FinalizeScaleDownTask(index, listener));
     }
 
+    private void removeScaleDownBlockOnFailure(
+        String index,
+        ClusterBlock scaleBlock,
+        Exception failure,
+        ActionListener<AcknowledgedResponse> listener
+    ) {
+        logger.warn("Scale-down failed for index [{}], removing temporary block", index, failure);
+        try {
+            clusterService.submitStateUpdateTask(
+                "remove-block-index-after-scale-down-failure " + index,
+                new RemoveBlockAfterScaleDownFailureTask(index, scaleBlock, failure, listener)
+            );
+        } catch (Exception cleanupSubmissionFailure) {
+            failure.addSuppressed(cleanupSubmissionFailure);
+            listener.onFailure(failure);
+        }
+    }
+
     /**
      * Handles an incoming shard sync request from another node.
      */
@@ -373,7 +391,12 @@ public class TransportScaleIndexAction extends TransportClusterManagerNodeAction
             IndexMetadata indexMetadata = newState.metadata().index(index);
             if (indexMetadata != null) {
                 Map<ShardId, String> primaryShardsNodes = scaleIndexShardSyncManager.getPrimaryShardAssignments(indexMetadata, newState);
-                proceedWithScaleDown(index, primaryShardsNodes, listener);
+                ClusterBlock scaleBlock = blockedIndices.get(indexMetadata.getIndex());
+                ActionListener<AcknowledgedResponse> cleanupOnFailureListener = ActionListener.delegateResponse(
+                    listener,
+                    (delegate, e) -> removeScaleDownBlockOnFailure(index, scaleBlock, e, delegate)
+                );
+                proceedWithScaleDown(index, primaryShardsNodes, cleanupOnFailureListener);
             }
         }
 
@@ -381,6 +404,46 @@ public class TransportScaleIndexAction extends TransportClusterManagerNodeAction
         public void onFailure(String source, Exception e) {
             logger.error("Failed to process cluster state update for scale down", e);
             listener.onFailure(e);
+        }
+    }
+
+    /**
+     * Cluster state update task for cleaning up the temporary scale-down block when shard synchronization fails.
+     */
+    class RemoveBlockAfterScaleDownFailureTask extends ClusterStateUpdateTask {
+        private final String index;
+        private final ClusterBlock scaleBlock;
+        private final Exception failure;
+        private final ActionListener<AcknowledgedResponse> listener;
+
+        RemoveBlockAfterScaleDownFailureTask(
+            String index,
+            ClusterBlock scaleBlock,
+            Exception failure,
+            ActionListener<AcknowledgedResponse> listener
+        ) {
+            super(Priority.URGENT);
+            this.index = index;
+            this.scaleBlock = scaleBlock;
+            this.failure = failure;
+            this.listener = listener;
+        }
+
+        @Override
+        public ClusterState execute(ClusterState currentState) {
+            return scaleIndexClusterStateBuilder.buildScaleDownFailureState(currentState, index, scaleBlock);
+        }
+
+        @Override
+        public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+            listener.onFailure(failure);
+        }
+
+        @Override
+        public void onFailure(String source, Exception e) {
+            logger.error("Failed to remove temporary scale-down block", e);
+            failure.addSuppressed(e);
+            listener.onFailure(failure);
         }
     }
 

--- a/server/src/main/java/org/opensearch/action/admin/indices/scale/searchonly/TransportScaleIndexAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/indices/scale/searchonly/TransportScaleIndexAction.java
@@ -10,6 +10,7 @@ package org.opensearch.action.admin.indices.scale.searchonly;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.action.admin.indices.flush.FlushRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.ChannelActionListener;
@@ -230,7 +231,7 @@ public class TransportScaleIndexAction extends TransportClusterManagerNodeAction
         Exception failure,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        logger.warn("Scale-down failed for index [{}], removing temporary block", index, failure);
+        logger.warn(() -> new ParameterizedMessage("Scale-down failed for index [{}], removing temporary block", index), failure);
         try {
             clusterService.submitStateUpdateTask(
                 "remove-block-index-after-scale-down-failure " + index,


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

During search-only scale down, OpenSearch first adds a temporary index block to stop writes while primary shards are synced. If shard sync fails before the final scale-down cluster state update, the request returns a failure but the temporary block remains in cluster state. This leaves the index with `index.blocks.search_only=false` while writes are still rejected by the leaked temporary block.

This change cleans up the temporary scale-down block when any downstream scale-down step fails after the block has been applied.

### Related Issues
Resolves #21188
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
