### PR TITLE
Fix deadlock between engineMutex and writeLock during index close and engine reset (#11869)

### DIFF
--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -83,7 +83,6 @@ import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.Nullable;
-import org.opensearch.common.SetOnce;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.annotation.InternalApi;
 import org.opensearch.common.annotation.PublicApi;
@@ -5388,13 +5387,20 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         // flush to make sure the latest commit, which will be opened by the read-only engine, includes all operations.
         flush(new FlushRequest().waitIfOngoing(true));
 
-        SetOnce<Indexer> newEngineReference = new SetOnce<>();
+        AtomicReference<Indexer> newEngineReference = new AtomicReference<>();
         final long globalCheckpoint = getLastKnownGlobalCheckpoint();
         assert globalCheckpoint == getLastSyncedGlobalCheckpoint();
         synchronized (engineMutex) {
             verifyNotClosed();
-            // we must create both new read-only engine and new read-write engine under engineMutex to ensure snapshotStoreMetadata,
-            // acquireXXXCommit and close works.
+            // ReadOnlyEngine delegates forward to the new InternalEngine through an
+            // AtomicReference (null = unavailable, non-null = available). Mutations are
+            // serialized by engineMutex; the atomic provides happens-before visibility to
+            // delegate reads that intentionally do not take the monitor. This avoids
+            // synchronizing delegates on engineMutex, which would deadlock: close holds
+            // engineMutex and needs writeLock, recoverFromTranslog holds readLock and a
+            // refresh listener calls a delegate that would need engineMutex. If a delegate
+            // races with Engine.close(), it either completes before teardown or throws
+            // AlreadyClosedException.
             final Engine readOnlyEngine = new ReadOnlyEngine(
                 newEngineConfig(replicationTracker),
                 seqNoStats,
@@ -5405,40 +5411,37 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             ) {
                 @Override
                 public GatedCloseable<IndexCommit> acquireLastIndexCommit(boolean flushFirst) {
-                    synchronized (engineMutex) {
-                        if (newEngineReference.get() == null) {
-                            throw new AlreadyClosedException("engine was closed");
-                        }
-                        // ignore flushFirst since we flushed above and we do not want to interfere with ongoing translog replay
-                        return applyOnEngine(newEngineReference.get(), engine -> engine.acquireLastIndexCommit(false));
+                    Indexer engine = newEngineReference.get();
+                    if (engine == null) {
+                        throw new AlreadyClosedException("engine was closed");
                     }
+                    // ignore flushFirst since we flushed above and we do not want to interfere with ongoing translog replay
+                    return applyOnEngine(engine, e -> e.acquireLastIndexCommit(false));
                 }
 
                 @Override
                 public GatedCloseable<IndexCommit> acquireSafeIndexCommit() {
-                    synchronized (engineMutex) {
-                        if (newEngineReference.get() == null) {
-                            throw new AlreadyClosedException("engine was closed");
-                        }
-                        return applyOnEngine(newEngineReference.get(), Engine::acquireSafeIndexCommit);
+                    Indexer engine = newEngineReference.get();
+                    if (engine == null) {
+                        throw new AlreadyClosedException("engine was closed");
                     }
+                    return applyOnEngine(engine, Engine::acquireSafeIndexCommit);
                 }
 
                 @Override
                 public GatedCloseable<SegmentInfos> getSegmentInfosSnapshot() {
-                    synchronized (engineMutex) {
-                        if (newEngineReference.get() == null) {
-                            throw new AlreadyClosedException("engine was closed");
-                        }
-                        return applyOnEngine(newEngineReference.get(), Engine::getSegmentInfosSnapshot);
+                    Indexer engine = newEngineReference.get();
+                    if (engine == null) {
+                        throw new AlreadyClosedException("engine was closed");
                     }
+                    return applyOnEngine(engine, Engine::getSegmentInfosSnapshot);
                 }
 
                 @Override
                 public void close() throws IOException {
                     assert Thread.holdsLock(engineMutex);
 
-                    Indexer newEngine = newEngineReference.get();
+                    Indexer newEngine = newEngineReference.getAndSet(null);
                     if (newEngine == currentEngineReference.get()) {
                         // we successfully installed the new engine so do not close it.
                         newEngine = null;
@@ -5453,8 +5456,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             if ((indexSettings.isRemoteTranslogStoreEnabled() || this.isRemoteSeeded()) && shardRouting.primary()) {
                 syncRemoteTranslogAndUpdateGlobalCheckpoint();
             }
-            newEngineReference.set(indexerFactory.createIndexer(newEngineConfig(replicationTracker)));
-            onNewEngine(newEngineReference.get());
+            Indexer newEngine = indexerFactory.createIndexer(newEngineConfig(replicationTracker));
+            newEngineReference.set(newEngine);
+            onNewEngine(newEngine);
         }
         final TranslogRecoveryRunner translogRunner = (snapshot) -> {
             long startTime = System.currentTimeMillis();

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -5441,7 +5441,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 public void close() throws IOException {
                     assert Thread.holdsLock(engineMutex);
 
-                    Indexer newEngine = newEngineReference.getAndSet(null);
+                    Indexer newEngine = newEngineReference.get();
                     if (newEngine == currentEngineReference.get()) {
                         // we successfully installed the new engine so do not close it.
                         newEngine = null;

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -83,6 +83,7 @@ import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.SetOnce;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.annotation.InternalApi;
 import org.opensearch.common.annotation.PublicApi;
@@ -5387,20 +5388,17 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         // flush to make sure the latest commit, which will be opened by the read-only engine, includes all operations.
         flush(new FlushRequest().waitIfOngoing(true));
 
-        AtomicReference<Indexer> newEngineReference = new AtomicReference<>();
+        SetOnce<Indexer> newEngineReference = new SetOnce<>();
         final long globalCheckpoint = getLastKnownGlobalCheckpoint();
         assert globalCheckpoint == getLastSyncedGlobalCheckpoint();
         synchronized (engineMutex) {
             verifyNotClosed();
-            // ReadOnlyEngine delegates forward to the new InternalEngine through an
-            // AtomicReference (null = unavailable, non-null = available). Mutations are
-            // serialized by engineMutex; the atomic provides happens-before visibility to
-            // delegate reads that intentionally do not take the monitor. This avoids
-            // synchronizing delegates on engineMutex, which would deadlock: close holds
-            // engineMutex and needs writeLock, recoverFromTranslog holds readLock and a
-            // refresh listener calls a delegate that would need engineMutex. If a delegate
-            // races with Engine.close(), it either completes before teardown or throws
-            // AlreadyClosedException.
+            // we must create both new read-only engine and new read-write engine under
+            // engineMutex to ensure snapshotStoreMetadata, acquireXXXCommit and close works.
+            // Delegates intentionally do NOT synchronize on engineMutex: doing so would
+            // deadlock because close holds engineMutex and waits for writeLock, while
+            // recoverFromTranslog holds readLock and a refresh listener calls a delegate.
+            // SetOnce is backed by AtomicReference so get() provides happens-before visibility.
             final Engine readOnlyEngine = new ReadOnlyEngine(
                 newEngineConfig(replicationTracker),
                 seqNoStats,
@@ -5411,30 +5409,27 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             ) {
                 @Override
                 public GatedCloseable<IndexCommit> acquireLastIndexCommit(boolean flushFirst) {
-                    Indexer engine = newEngineReference.get();
-                    if (engine == null) {
+                    if (newEngineReference.get() == null) {
                         throw new AlreadyClosedException("engine was closed");
                     }
                     // ignore flushFirst since we flushed above and we do not want to interfere with ongoing translog replay
-                    return applyOnEngine(engine, e -> e.acquireLastIndexCommit(false));
+                    return applyOnEngine(newEngineReference.get(), engine -> engine.acquireLastIndexCommit(false));
                 }
 
                 @Override
                 public GatedCloseable<IndexCommit> acquireSafeIndexCommit() {
-                    Indexer engine = newEngineReference.get();
-                    if (engine == null) {
+                    if (newEngineReference.get() == null) {
                         throw new AlreadyClosedException("engine was closed");
                     }
-                    return applyOnEngine(engine, Engine::acquireSafeIndexCommit);
+                    return applyOnEngine(newEngineReference.get(), Engine::acquireSafeIndexCommit);
                 }
 
                 @Override
                 public GatedCloseable<SegmentInfos> getSegmentInfosSnapshot() {
-                    Indexer engine = newEngineReference.get();
-                    if (engine == null) {
+                    if (newEngineReference.get() == null) {
                         throw new AlreadyClosedException("engine was closed");
                     }
-                    return applyOnEngine(engine, Engine::getSegmentInfosSnapshot);
+                    return applyOnEngine(newEngineReference.get(), Engine::getSegmentInfosSnapshot);
                 }
 
                 @Override
@@ -5456,9 +5451,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             if ((indexSettings.isRemoteTranslogStoreEnabled() || this.isRemoteSeeded()) && shardRouting.primary()) {
                 syncRemoteTranslogAndUpdateGlobalCheckpoint();
             }
-            Indexer newEngine = indexerFactory.createIndexer(newEngineConfig(replicationTracker));
-            newEngineReference.set(newEngine);
-            onNewEngine(newEngine);
+            newEngineReference.set(indexerFactory.createIndexer(newEngineConfig(replicationTracker)));
+            onNewEngine(newEngineReference.get());
         }
         final TranslogRecoveryRunner translogRunner = (snapshot) -> {
             long startTime = System.currentTimeMillis();

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -6177,6 +6177,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return nonClosingReaderWrapperCache;
     }
 
+    // Visible for testing
+    Object getEngineMutex() {
+        return engineMutex;
+    }
+
     // Below methods exists for bwc only. We should never make indexshard aware of DataFormatAwareEngine directy.
     // All interactions should happen via indexer only.
     @Deprecated

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -113,6 +113,7 @@ import org.opensearch.index.engine.NRTReplicationEngineFactory;
 import org.opensearch.index.engine.ReadOnlyEngine;
 import org.opensearch.index.engine.exec.EngineBackedIndexerFactory;
 import org.opensearch.index.engine.exec.Indexer;
+import org.opensearch.index.engine.exec.IndexerFactory;
 import org.opensearch.index.fielddata.FieldDataStats;
 import org.opensearch.index.fielddata.IndexFieldData;
 import org.opensearch.index.fielddata.IndexFieldDataCache;
@@ -4768,6 +4769,92 @@ public class IndexShardTests extends IndexShardTestCase {
         closeShardThread.join();
 
         // close store.
+        closeShard(shard, false);
+    }
+
+    /**
+     * Verifies that {@code getSegmentInfosSnapshot()} on the ReadOnlyEngine created during
+     * {@link IndexShard#resetEngineToGlobalCheckpoint()} does not block on {@code engineMutex}.
+     * <p>
+     * Regression test for
+     * <a href="https://github.com/opensearch-project/OpenSearch/issues/11869">#11869</a>:
+     * the close thread holds {@code engineMutex} and waits for {@code writeLock}, while the
+     * recovery thread holds {@code readLock} (via {@code recoverFromTranslog}) and calls
+     * {@code getSegmentInfosSnapshot()} through the {@code ReplicationCheckpointUpdater} refresh
+     * listener -- if both paths synchronize on {@code engineMutex}, the cycle deadlocks.
+     * <p>
+     * Pauses {@code resetEngineToGlobalCheckpoint} before translog replay, holds
+     * {@code engineMutex} via reflection, and asserts {@code getSegmentInfosSnapshot()}
+     * completes within 5 seconds.
+     */
+    public void testNoDeadlockOnCloseWhileRecoveringTranslog() throws Exception {
+        CountDownLatch recoveryStartedLatch = new CountDownLatch(1);
+        CountDownLatch proceedWithRecoveryLatch = new CountDownLatch(1);
+        AtomicBoolean armed = new AtomicBoolean(false);
+        Settings segRepSettings = Settings.builder().put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build();
+        IndexerFactory customFactory = new EngineBackedIndexerFactory(config -> new InternalEngine(config, new TranslogEventListener() {
+            @Override
+            public void onBeginTranslogRecovery() {
+                if (armed.compareAndSet(true, false)) {
+                    recoveryStartedLatch.countDown();
+                    try {
+                        proceedWithRecoveryLatch.await(30, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                    }
+                }
+            }
+        }));
+        IndexShard shard = newShard(false, segRepSettings, customFactory);
+        IndexShard primary = newStartedShard(true, segRepSettings);
+        recoverReplica(shard, primary, true, (a) -> null);
+        closeShards(primary);
+
+        java.lang.reflect.Field engineMutexField = IndexShard.class.getDeclaredField("engineMutex");
+        engineMutexField.setAccessible(true);
+        Object engineMutex = engineMutexField.get(shard);
+
+        final CountDownLatch engineResetLatch = new CountDownLatch(1);
+
+        shard.acquireAllReplicaOperationsPermits(
+            shard.getOperationPrimaryTerm(),
+            shard.getLastKnownGlobalCheckpoint(),
+            0L,
+            ActionListener.wrap(r -> {
+                try (Releasable dummy = r) {
+                    armed.set(true);
+                    shard.resetEngineToGlobalCheckpoint();
+                } finally {
+                    engineResetLatch.countDown();
+                }
+            }, Assert::assertNotNull),
+            TimeValue.timeValueMinutes(1L)
+        );
+
+        // Wait until the reset has created the ReadOnlyEngine (installed as current engine)
+        // and the new InternalEngine, then paused before translog replay.
+        assertTrue("recovery should start", recoveryStartedLatch.await(30, TimeUnit.SECONDS));
+
+        // Verify getSegmentInfosSnapshot() on the ReadOnlyEngine doesn't block when
+        // engineMutex is held -- this is the code path that deadlocks in production.
+        CountDownLatch snapshotCompletedLatch = new CountDownLatch(1);
+        Thread snapshotThread = new Thread(() -> {
+            try {
+                GatedCloseable<SegmentInfos> snapshot = shard.getSegmentInfosSnapshot();
+                if (snapshot != null) snapshot.close();
+            } catch (IOException | IllegalStateException ignored) {} finally {
+                snapshotCompletedLatch.countDown();
+            }
+        });
+
+        synchronized (engineMutex) {
+            snapshotThread.start();
+            assertTrue("getSegmentInfosSnapshot should not block on engineMutex", snapshotCompletedLatch.await(5, TimeUnit.SECONDS));
+        }
+        snapshotThread.join(5_000);
+
+        proceedWithRecoveryLatch.countDown();
+        assertTrue("engine reset should complete", engineResetLatch.await(30, TimeUnit.SECONDS));
         closeShard(shard, false);
     }
 

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -4810,9 +4810,7 @@ public class IndexShardTests extends IndexShardTestCase {
         recoverReplica(shard, primary, true, (a) -> null);
         closeShards(primary);
 
-        java.lang.reflect.Field engineMutexField = IndexShard.class.getDeclaredField("engineMutex");
-        engineMutexField.setAccessible(true);
-        Object engineMutex = engineMutexField.get(shard);
+        Object engineMutex = shard.getEngineMutex();
 
         final CountDownLatch engineResetLatch = new CountDownLatch(1);
 

--- a/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/IndexShardTests.java
@@ -4857,6 +4857,63 @@ public class IndexShardTests extends IndexShardTestCase {
     }
 
     /**
+     * Verifies that the ReadOnlyEngine delegates throw {@link AlreadyClosedException} when
+     * {@code newEngineReference} is still null -- the window between ReadOnlyEngine installation
+     * and {@code newEngineReference.set(newEngine)} inside {@code resetEngineToGlobalCheckpoint}.
+     * Covers the defensive null-check branches in {@code acquireLastIndexCommit},
+     * {@code acquireSafeIndexCommit}, and {@code getSegmentInfosSnapshot}.
+     */
+    public void testDelegateThrowsAlreadyClosedBeforeNewEngineSet() throws Exception {
+        CountDownLatch creatingEngineLatch = new CountDownLatch(1);
+        CountDownLatch proceedWithCreationLatch = new CountDownLatch(1);
+        AtomicBoolean armed = new AtomicBoolean(false);
+        Settings segRepSettings = Settings.builder().put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT).build();
+        IndexerFactory customFactory = new EngineBackedIndexerFactory(config -> {
+            if (armed.compareAndSet(true, false)) {
+                creatingEngineLatch.countDown();
+                try {
+                    proceedWithCreationLatch.await(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    throw new AssertionError(e);
+                }
+            }
+            return new InternalEngine(config);
+        });
+        IndexShard shard = newShard(false, segRepSettings, customFactory);
+        IndexShard primary = newStartedShard(true, segRepSettings);
+        recoverReplica(shard, primary, true, (a) -> null);
+        closeShards(primary);
+
+        final CountDownLatch engineResetLatch = new CountDownLatch(1);
+
+        shard.acquireAllReplicaOperationsPermits(
+            shard.getOperationPrimaryTerm(),
+            shard.getLastKnownGlobalCheckpoint(),
+            0L,
+            ActionListener.wrap(r -> {
+                try (Releasable dummy = r) {
+                    armed.set(true);
+                    shard.resetEngineToGlobalCheckpoint();
+                } finally {
+                    engineResetLatch.countDown();
+                }
+            }, Assert::assertNotNull),
+            TimeValue.timeValueMinutes(1L)
+        );
+
+        assertTrue("engine creation should start", creatingEngineLatch.await(30, TimeUnit.SECONDS));
+
+        // The ReadOnlyEngine is now the current engine, but newEngineReference is still null.
+        expectThrows(AlreadyClosedException.class, () -> shard.acquireLastIndexCommit(false));
+        expectThrows(AlreadyClosedException.class, shard::acquireSafeIndexCommit);
+        expectThrows(AlreadyClosedException.class, shard::getSegmentInfosSnapshot);
+
+        proceedWithCreationLatch.countDown();
+        assertTrue("engine reset should complete", engineResetLatch.await(30, TimeUnit.SECONDS));
+        closeShard(shard, false);
+    }
+
+    /**
      * This test simulates a scenario seen rarely in ConcurrentSeqNoVersioningIT. While engine is inside
      * resetEngineToGlobalCheckpoint snapshot metadata could fail
      */


### PR DESCRIPTION
During `resetEngineToGlobalCheckpoint` on a segment replication replica, the `ReadOnlyEngine` delegates (`acquireLastIndexCommit`, `acquireSafeIndexCommit`, `getSegmentInfosSnapshot`) synchronized on `engineMutex`.  This creates a deadlock cycle when close runs concurrently: the close thread holds `engineMutex` and waits for `writeLock`, while the recovery thread holds `readLock` (via `recoverFromTranslog`) and a refresh listener calls a delegate that waits for `engineMutex`.

Replace `synchronized(engineMutex)` in the delegates with an `AtomicReference` that provides happens-before visibility to unsynchronized readers. Mutations remain serialized by `engineMutex`; the engine's own `writeLock` in `Engine.close()` ensures in-flight delegate calls complete before teardown.

Fixes: #11869
May fix: #12114

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
