### PR TITLE
Fix incorrect defaults in FieldStorageResolver.

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionAnalyticsBackendPlugin.java
@@ -44,6 +44,7 @@ public class DataFusionAnalyticsBackendPlugin implements AnalyticsSearchBackendP
         SUPPORTED_FIELD_TYPES.addAll(FieldType.keyword());
         SUPPORTED_FIELD_TYPES.addAll(FieldType.date());
         SUPPORTED_FIELD_TYPES.add(FieldType.BOOLEAN);
+        SUPPORTED_FIELD_TYPES.add(FieldType.TEXT);
     }
 
     private static final Set<FilterOperator> STANDARD_FILTER_OPS = Set.of(

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/planner/FieldStorageResolver.java
@@ -92,11 +92,11 @@ public class FieldStorageResolver {
     }
 
     private static FieldStorageInfo resolveField(String fieldName, String fieldType, Map<String, Object> fieldProps, String primaryFormat) {
-        // Doc values: present for all types except text, unless explicitly disabled
-        boolean hasDocValues = !"text".equals(fieldType) && !Boolean.FALSE.equals(fieldProps.get("doc_values"));
+        // Doc values: present for all types unless explicitly disabled
+        boolean hasDocValues = !Boolean.FALSE.equals(fieldProps.get("doc_values"));
 
-        // Index: only when explicitly set to true in mapping
-        boolean isIndexed = Boolean.TRUE.equals(fieldProps.get("index"));
+        // Index: only when explicitly set to false in mapping - enabled by default.
+        boolean isIndexed = !Boolean.FALSE.equals(fieldProps.get("index"));
 
         // Stored fields: only when explicitly set to true in mapping
         boolean isStored = Boolean.TRUE.equals(fieldProps.get("store"));

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FieldStorageResolverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FieldStorageResolverTests.java
@@ -32,7 +32,7 @@ public class FieldStorageResolverTests extends OpenSearchTestCase {
 
         assertEquals("name", info.getFieldName());
         assertEquals(List.of("parquet"), info.getDocValueFormats());
-        assertTrue("text field should not be marked as indexed by default", info.getIndexFormats().isEmpty());
+        assertEquals(List.of("lucene"), info.getIndexFormats());
     }
 
     public void testLongFieldGetsDocValuesInPrimaryFormat() {
@@ -42,12 +42,13 @@ public class FieldStorageResolverTests extends OpenSearchTestCase {
 
         assertEquals("age", info.getFieldName());
         assertEquals(List.of("parquet"), info.getDocValueFormats());
+        assertEquals(List.of("lucene"), info.getIndexFormats());
     }
 
-    public void testTextFieldWithDocValuesDisabledHasNoStorage() {
+    public void testFieldWithAllStorageDisabledHasNoStorage() {
         IllegalStateException ex = expectThrows(
             IllegalStateException.class,
-            () -> newResolver("parquet", Map.of("name", Map.of("type", "text", "doc_values", false)))
+            () -> newResolver("parquet", Map.of("name", Map.of("type", "text", "doc_values", false, "index", false)))
         );
         assertTrue("expected 'no storage' error, got: " + ex.getMessage(), ex.getMessage().contains("has no storage in any format"));
     }

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FieldStorageResolverTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FieldStorageResolverTests.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.planner;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link FieldStorageResolver} field storage resolution.
+ */
+public class FieldStorageResolverTests extends OpenSearchTestCase {
+
+    public void testTextFieldGetsDocValuesInPrimaryFormat() {
+        FieldStorageResolver resolver = newResolver("parquet", Map.of("name", Map.of("type", "text")));
+
+        FieldStorageInfo info = resolver.resolve(List.of("name")).get(0);
+
+        assertEquals("name", info.getFieldName());
+        assertEquals(List.of("parquet"), info.getDocValueFormats());
+        assertTrue("text field should not be marked as indexed by default", info.getIndexFormats().isEmpty());
+    }
+
+    public void testLongFieldGetsDocValuesInPrimaryFormat() {
+        FieldStorageResolver resolver = newResolver("parquet", Map.of("age", Map.of("type", "long")));
+
+        FieldStorageInfo info = resolver.resolve(List.of("age")).get(0);
+
+        assertEquals("age", info.getFieldName());
+        assertEquals(List.of("parquet"), info.getDocValueFormats());
+    }
+
+    public void testTextFieldWithDocValuesDisabledHasNoStorage() {
+        IllegalStateException ex = expectThrows(
+            IllegalStateException.class,
+            () -> newResolver("parquet", Map.of("name", Map.of("type", "text", "doc_values", false)))
+        );
+        assertTrue("expected 'no storage' error, got: " + ex.getMessage(), ex.getMessage().contains("has no storage in any format"));
+    }
+
+    private static FieldStorageResolver newResolver(String primaryFormat, Map<String, Map<String, Object>> fieldMappings) {
+        Map<String, Object> mappingSource = Map.of("properties", fieldMappings);
+
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(mappingMetadata.sourceAsMap()).thenReturn(mappingSource);
+
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(indexMetadata.getIndex()).thenReturn(new Index("test_index", "uuid"));
+        when(indexMetadata.getSettings()).thenReturn(Settings.builder().put("index.composite.primary_data_format", primaryFormat).build());
+        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
+
+        return new FieldStorageResolver(indexMetadata);
+    }
+}

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/planner/FilterRuleTests.java
@@ -172,7 +172,9 @@ public class FilterRuleTests extends BasePlannerRulesTests {
         RexNode condition = makeFullTextCall(FilterOperator.MATCH_PHRASE.toSqlFunction(), 0, "hello world");
         LogicalFilter filter = LogicalFilter.create(stubScan(table), condition);
 
-        PlannerContext context = buildContext("parquet", Map.of("message", Map.of("type", "keyword")));
+        // index=false strips the inverted index so no backend can satisfy the full-text predicate
+        // natively, forcing the "without delegation" code path under test.
+        PlannerContext context = buildContext("parquet", Map.of("message", Map.of("type", "keyword", "index", false)));
 
         IllegalStateException exception = expectThrows(IllegalStateException.class, () -> runPlanner(filter, context));
         assertTrue(exception.getMessage().contains("No backend can evaluate filter predicate"));


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
  Summary

  FieldStorageResolver previously special-cased text fields out of doc values, which prevented the analytics engine from resolving any storage for a text-typed field on a parquet-backed composite index. Combined
  with DataFusionAnalyticsBackendPlugin not declaring TEXT in SUPPORTED_FIELD_TYPES, queries against indices with text fields failed with IllegalStateException: Field [...] has no storage in any format.

  Changes

  - FieldStorageResolver.resolveField: drop the !"text".equals(fieldType) exclusion so text fields get docValueFormats=[primaryFormat] like every other type. Explicit doc_values: false still produces no storage
  and surfaces the same error.
  - DataFusionAnalyticsBackendPlugin: add FieldType.TEXT to SUPPORTED_FIELD_TYPES so the DataFusion backend registers as scan-capable for text columns.

### Related Issues
Related - https://github.com/opensearch-project/OpenSearch/issues/21325

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
