### PR TITLE
Deleter impl

### DIFF
--- a/modules/parent-join/src/test/java/org/opensearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/opensearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -42,6 +42,7 @@ import org.opensearch.index.IndexService;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockDeleteDataFormatPlugin;
 import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperException;
@@ -63,7 +64,12 @@ import static org.hamcrest.Matchers.containsString;
 public class ParentJoinFieldMapperTests extends OpenSearchSingleNodeTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
-        return List.of(ParentJoinModulePlugin.class, MockDataFormatPlugin.class, MockCommitterEnginePlugin.class);
+        return List.of(
+            ParentJoinModulePlugin.class,
+            MockDataFormatPlugin.class,
+            MockCommitterEnginePlugin.class,
+            MockDeleteDataFormatPlugin.class
+        );
     }
 
     public void testSingleLevel() throws Exception {

--- a/plugins/mapper-size/src/internalClusterTest/java/org/opensearch/index/mapper/size/SizeMappingTests.java
+++ b/plugins/mapper-size/src/internalClusterTest/java/org/opensearch/index/mapper/size/SizeMappingTests.java
@@ -43,6 +43,7 @@ import org.opensearch.index.IndexService;
 import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockDeleteDataFormatPlugin;
 import org.opensearch.index.mapper.DocumentMapper;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
@@ -68,7 +69,8 @@ public class SizeMappingTests extends OpenSearchSingleNodeTestCase {
             MapperSizePlugin.class,
             InternalSettingsPlugin.class,
             MockDataFormatPlugin.class,
-            MockCommitterEnginePlugin.class
+            MockCommitterEnginePlugin.class,
+            MockDeleteDataFormatPlugin.class
         );
     }
 

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
@@ -17,6 +17,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MMapDirectory;
 import org.opensearch.be.lucene.LuceneDataFormat;
@@ -31,6 +32,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -236,5 +238,25 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
             logger.warn("Failed to close directory for generation[{}]: {}", writerGeneration, e);
         }
         IOUtils.rm(tempDirectory);
+    }
+
+    /**
+     * {@inheritDoc}
+     * Returns this writer if the format name matches this writer's data format.
+     */
+    @Override
+    public Optional<Writer<?>> findWriterByFormat(String formatName) {
+        return dataFormat.name().equals(formatName) ? Optional.of(this) : Optional.empty();
+    }
+
+    /**
+     * Deletes all documents containing the given term from this writer's {@link IndexWriter}.
+     *
+     * @param term the {@code _id} term identifying the document(s) to delete
+     * @throws IOException if a low-level I/O error occurs
+     */
+    @Override
+    public void deleteDocument(Term term) throws IOException {
+        indexWriter.deleteDocuments(term);
     }
 }

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
@@ -259,6 +259,59 @@ public class LuceneWriterTests extends OpenSearchTestCase {
         }
     }
 
+    public void testDeleteDocumentRemovesDocFromSegment() throws IOException {
+        Path baseDir = createTempDir();
+        MappedFieldType keywordField = mockKeywordField("_id");
+        MappedFieldType textField = mockTextField("content");
+
+        try (LuceneWriter writer = new LuceneWriter(1L, dataFormat, baseDir, null, Codec.getDefault())) {
+            for (int i = 0; i < 3; i++) {
+                LuceneDocumentInput input = new LuceneDocumentInput();
+                input.addField(keywordField, "doc" + i);
+                input.addField(textField, "content " + i);
+                input.setRowId(LuceneDocumentInput.ROW_ID_FIELD, i);
+                writer.addDoc(input);
+            }
+
+            // Delete the middle document
+            writer.deleteDocument(new Term("_id", "doc1"));
+
+            FileInfos fileInfos = writer.flush();
+            WriterFileSet wfs = fileInfos.getWriterFileSet(dataFormat).get();
+
+            try (NIOFSDirectory dir = new NIOFSDirectory(Path.of(wfs.directory())); IndexReader reader = DirectoryReader.open(dir)) {
+                // 3 docs written, 1 deleted = 2 live docs
+                assertThat(reader.numDocs(), equalTo(2));
+                IndexSearcher searcher = new IndexSearcher(reader);
+                assertThat(searcher.count(new TermQuery(new Term("_id", "doc0"))), equalTo(1));
+                assertThat(searcher.count(new TermQuery(new Term("_id", "doc1"))), equalTo(0));
+                assertThat(searcher.count(new TermQuery(new Term("_id", "doc2"))), equalTo(1));
+            }
+        }
+    }
+
+    public void testDeleteNonExistentDocIsNoOp() throws IOException {
+        Path baseDir = createTempDir();
+        MappedFieldType textField = mockTextField("content");
+
+        try (LuceneWriter writer = new LuceneWriter(1L, dataFormat, baseDir, null, Codec.getDefault())) {
+            LuceneDocumentInput input = new LuceneDocumentInput();
+            input.addField(textField, "hello");
+            input.setRowId(LuceneDocumentInput.ROW_ID_FIELD, 0);
+            writer.addDoc(input);
+
+            // Delete a term that doesn't exist — should not throw
+            writer.deleteDocument(new Term("_id", "nonexistent"));
+
+            FileInfos fileInfos = writer.flush();
+            WriterFileSet wfs = fileInfos.getWriterFileSet(dataFormat).get();
+
+            try (NIOFSDirectory dir = new NIOFSDirectory(Path.of(wfs.directory())); IndexReader reader = DirectoryReader.open(dir)) {
+                assertThat(reader.numDocs(), equalTo(1));
+            }
+        }
+    }
+
     public void testMultipleWriterGenerationsProduceIsolatedSegments() throws IOException {
         Path baseDir = createTempDir();
         MappedFieldType textField = mockTextField("content");

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
@@ -40,7 +40,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @opensearch.experimental
  */
 @ExperimentalApi
-class CompositeWriter implements Writer<CompositeDocumentInput>, Lockable {
+public class CompositeWriter implements Writer<CompositeDocumentInput>, Lockable {
 
     private static final Logger logger = LogManager.getLogger(CompositeWriter.class);
 
@@ -194,6 +194,20 @@ class CompositeWriter implements Writer<CompositeDocumentInput>, Lockable {
         for (Writer<DocumentInput<?>> writer : secondaryWritersByFormat.values()) {
             writer.close();
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     * Searches primary and secondary formats by {@link DataFormat#name()}.
+     */
+    @Override
+    public Optional<Writer<?>> findWriterByFormat(String formatName) {
+        if (primaryFormat.name().equals(formatName)) return Optional.of(primaryWriter);
+        return secondaryWritersByFormat.entrySet()
+            .stream()
+            .filter(e -> e.getKey().name().equals(formatName))
+            .<Writer<?>>map(Map.Entry::getValue)
+            .findFirst();
     }
 
     /**

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeTestHelper.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeTestHelper.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -87,6 +88,47 @@ final class CompositeTestHelper {
         Settings settings = settingsBuilder.build();
         IndexMetadata indexMetadata = IndexMetadata.builder("test-index").settings(settings).build();
         IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
+
+        return new CompositeIndexingExecutionEngine(indexSettings, null, new StubCommitter(), registry, null, null);
+    }
+
+    /**
+     * Creates a CompositeIndexingExecutionEngine with real DataFormat instances for format-class-based lookups.
+     */
+    static CompositeIndexingExecutionEngine createStubEngineWithFormats(DataFormat primary, DataFormat... secondaries) {
+        Map<String, DataFormat> formats = new HashMap<>();
+        formats.put(primary.name(), primary);
+        for (DataFormat s : secondaries) {
+            formats.put(s.name(), s);
+        }
+
+        DataFormatRegistry registry = mock(DataFormatRegistry.class);
+        for (Map.Entry<String, DataFormat> entry : formats.entrySet()) {
+            when(registry.format(entry.getKey())).thenReturn(entry.getValue());
+        }
+        Settings.Builder settingsBuilder = Settings.builder()
+            .put("index.composite.primary_data_format", primary.name())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1);
+
+        if (secondaries.length > 0) {
+            String[] names = new String[secondaries.length];
+            for (int i = 0; i < secondaries.length; i++) {
+                names[i] = secondaries[i].name();
+            }
+            settingsBuilder.putList("index.composite.secondary_data_formats", names);
+        }
+
+        Settings settings = settingsBuilder.build();
+        IndexMetadata indexMetadata = IndexMetadata.builder("test-index").settings(settings).build();
+        IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
+
+        // Use any() for config since constructor creates real IndexingEngineConfig, eq(format) ensures correct format routing
+        when(registry.getIndexingEngine(any(), eq(primary))).thenAnswer(invocation -> new StubIndexingExecutionEngine(primary));
+        for (DataFormat s : secondaries) {
+            when(registry.getIndexingEngine(any(), eq(s))).thenAnswer(invocation -> new StubIndexingExecutionEngine(s));
+        }
 
         return new CompositeIndexingExecutionEngine(indexSettings, null, new StubCommitter(), registry, null, null);
     }

--- a/sandbox/plugins/delete-data-format/build.gradle
+++ b/sandbox/plugins/delete-data-format/build.gradle
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+opensearchplugin {
+  description = 'Default delete data format plugin for OpenSearch.'
+  classname = 'org.opensearch.delete.DeleteDataFormatDefaultPlugin'
+}
+
+java { sourceCompatibility = JavaVersion.toVersion(25); targetCompatibility = JavaVersion.toVersion(25) }
+
+dependencies {
+  implementation project(':sandbox:plugins:parquet-data-format')
+  implementation project(':sandbox:plugins:analytics-backend-lucene')
+  implementation project(':sandbox:plugins:composite-engine')
+  testImplementation project(':test:framework')
+}

--- a/sandbox/plugins/delete-data-format/src/main/java/org/opensearch/delete/DeleteDataFormatDefaultPlugin.java
+++ b/sandbox/plugins/delete-data-format/src/main/java/org/opensearch/delete/DeleteDataFormatDefaultPlugin.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.delete;
+
+import org.opensearch.delete.engine.DeleteExecutionEngineImpl;
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DeleteDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.DeleteExecutionEngine;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
+import org.opensearch.plugins.Plugin;
+
+import java.util.Set;
+
+/**
+ * Default delete data format plugin that provides {@link DeleteExecutionEngineImpl}
+ * for formats that do not handle deletes natively.
+ *
+ * @opensearch.experimental
+ */
+public class DeleteDataFormatDefaultPlugin extends Plugin implements DeleteDataFormatPlugin {
+
+    private static final DataFormat DELETE_FORMAT = new DataFormat() {
+        @Override
+        public String name() {
+            return "delete";
+        }
+
+        @Override
+        public long priority() {
+            return 0;
+        }
+
+        @Override
+        public Set<FieldTypeCapabilities> supportedFields() {
+            return Set.of();
+        }
+    };
+
+    @Override
+    public DataFormat getDataFormat() {
+        return DELETE_FORMAT;
+    }
+
+    @Override
+    public DeleteExecutionEngine<?> deleteEngine() {
+        return new DeleteExecutionEngineImpl(DELETE_FORMAT);
+    }
+}

--- a/sandbox/plugins/delete-data-format/src/main/java/org/opensearch/delete/deleter/DeleterImpl.java
+++ b/sandbox/plugins/delete-data-format/src/main/java/org/opensearch/delete/deleter/DeleterImpl.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.delete.deleter;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.Term;
+import org.opensearch.index.engine.dataformat.DeleteResult;
+import org.opensearch.index.engine.dataformat.Deleter;
+import org.opensearch.index.engine.dataformat.Writer;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Default {@link Deleter} implementation that routes delete operations based on the
+ * underlying {@link Writer}'s capabilities, using only interface methods to avoid
+ * cross-plugin classloader issues.
+ * <p>
+ * At construction, resolves a Lucene-capable writer via {@link Writer#findWriterByFormat(String)}.
+ * If found, deletes delegate to {@link Writer#deleteDocument(Term)}; otherwise,
+ * deletes fall back to row-ID tracking for formats like Parquet.
+ *
+ * @opensearch.experimental
+ */
+public class DeleterImpl implements Deleter {
+    private static final Logger logger = LogManager.getLogger(DeleterImpl.class);
+    private final Set<Long> deletedRowIds = new HashSet<>();
+    private final Writer<?> luceneWriter;
+    private final long deleterGeneration;
+
+    /**
+     * Creates a deleter paired with the given writer. Resolves a Lucene-capable writer
+     * at construction time via {@link Writer#findWriterByFormat(String)}, avoiding
+     * {@code instanceof} checks against plugin classes.
+     *
+     * @param writer the writer this deleter is associated with
+     */
+    public DeleterImpl(Writer<?> writer) {
+        this.luceneWriter = writer.findWriterByFormat("lucene").orElse(null);
+        this.deleterGeneration = writer.generation();
+    }
+
+    @Override
+    public long generation() {
+        return this.deleterGeneration;
+    }
+
+    /**
+     * Returns the set of row IDs that have been deleted by this deleter.
+     *
+     * @return the deleted row IDs
+     */
+    public Set<Long> getDeletedRowIds() {
+        return deletedRowIds;
+    }
+
+    @Override
+    public DeleteResult deleteDoc(Term uid, Long rowId) throws IOException {
+        if (luceneWriter != null) {
+            luceneWriter.deleteDocument(uid);
+        } else {
+            deletedRowIds.add(rowId);
+        }
+        return new DeleteResult.Success(1L, 1L, 1L);
+    }
+
+    @Override
+    public void close() throws IOException {}
+
+    @Override
+    public void lock() {}
+
+    @Override
+    public boolean tryLock() {
+        return false;
+    }
+
+    @Override
+    public void unlock() {}
+}

--- a/sandbox/plugins/delete-data-format/src/main/java/org/opensearch/delete/deleter/package-info.java
+++ b/sandbox/plugins/delete-data-format/src/main/java/org/opensearch/delete/deleter/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Deleter implementation for the DataFormat framework.
+ */
+package org.opensearch.delete.deleter;

--- a/sandbox/plugins/delete-data-format/src/main/java/org/opensearch/delete/engine/DeleteExecutionEngineImpl.java
+++ b/sandbox/plugins/delete-data-format/src/main/java/org/opensearch/delete/engine/DeleteExecutionEngineImpl.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.delete.engine;
+
+import org.opensearch.delete.deleter.DeleterImpl;
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DeleteExecutionEngine;
+import org.opensearch.index.engine.dataformat.Deleter;
+import org.opensearch.index.engine.dataformat.RefreshInput;
+import org.opensearch.index.engine.dataformat.RefreshResult;
+import org.opensearch.index.engine.dataformat.Writer;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Default implementation of {@link DeleteExecutionEngine} for formats that do not
+ * handle deletes natively (e.g. Parquet). Maintains a writer-to-deleter mapping
+ * so the engine layer can retrieve the correct deleter for a given writer.
+ *
+ * @opensearch.experimental
+ */
+public class DeleteExecutionEngineImpl implements DeleteExecutionEngine<DataFormat> {
+
+    private final DataFormat dataFormat;
+    private final Map<Writer<?>, Deleter> writerToDeleter = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a delete execution engine for the given data format.
+     *
+     * @param dataFormat the data format this engine handles deletes for
+     */
+    public DeleteExecutionEngineImpl(DataFormat dataFormat) {
+        this.dataFormat = dataFormat;
+    }
+
+    @Override
+    public Deleter createDeleter(Writer<?> writer) {
+        Deleter deleter = new DeleterImpl(writer);
+        writerToDeleter.put(writer, deleter);
+        return deleter;
+    }
+
+    @Override
+    public Deleter getDeleter(Writer<?> writer) {
+        return writerToDeleter.get(writer);
+    }
+
+    @Override
+    public RefreshResult refresh(RefreshInput refreshInput) throws IOException {
+        return null;
+    }
+
+    @Override
+    public DataFormat getDataFormat() {
+        return dataFormat;
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (Deleter deleter : writerToDeleter.values()) {
+            deleter.close();
+        }
+        writerToDeleter.clear();
+    }
+}

--- a/sandbox/plugins/delete-data-format/src/main/java/org/opensearch/delete/engine/package-info.java
+++ b/sandbox/plugins/delete-data-format/src/main/java/org/opensearch/delete/engine/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Delete execution engine implementation for the DataFormat framework.
+ */
+package org.opensearch.delete.engine;

--- a/sandbox/plugins/delete-data-format/src/main/java/org/opensearch/delete/package-info.java
+++ b/sandbox/plugins/delete-data-format/src/main/java/org/opensearch/delete/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Delete support plugin for the DataFormat framework.
+ */
+package org.opensearch.delete;

--- a/sandbox/plugins/delete-data-format/src/test/java/org/opensearch/delete/deleter/DeleterImplTests.java
+++ b/sandbox/plugins/delete-data-format/src/test/java/org/opensearch/delete/deleter/DeleterImplTests.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.delete.deleter;
+
+import org.apache.lucene.index.Term;
+import org.opensearch.be.lucene.index.LuceneWriter;
+import org.opensearch.composite.CompositeWriter;
+import org.opensearch.index.engine.dataformat.DeleteResult;
+import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.stub.MockDataFormat;
+import org.opensearch.index.engine.dataformat.stub.MockDocumentInput;
+import org.opensearch.index.engine.dataformat.stub.MockIndexingExecutionEngine;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DeleterImplTests extends OpenSearchTestCase {
+
+    public void testDeleteWithLuceneWriterDelegatesToLucene() throws IOException {
+        LuceneWriter luceneWriter = mock(LuceneWriter.class);
+        when(luceneWriter.generation()).thenReturn(5L);
+
+        DeleterImpl deleter = new DeleterImpl(luceneWriter);
+        Term uid = new Term("_id", "doc1");
+        DeleteResult result = deleter.deleteDoc(uid, null);
+
+        verify(luceneWriter).deleteDocument(uid);
+        assertTrue(result instanceof DeleteResult.Success);
+        assertTrue(deleter.getDeletedRowIds().isEmpty());
+    }
+
+    public void testDeleteWithCompositeWriterDelegatesToLucene() throws IOException {
+        LuceneWriter luceneWriter = mock(LuceneWriter.class);
+        CompositeWriter compositeWriter = mock(CompositeWriter.class);
+        when(compositeWriter.generation()).thenReturn(3L);
+        when(compositeWriter.findWriterByFormat("lucene")).thenAnswer(inv -> Optional.of(luceneWriter));
+
+        DeleterImpl deleter = new DeleterImpl(compositeWriter);
+        Term uid = new Term("_id", "doc2");
+        deleter.deleteDoc(uid, null);
+
+        verify(luceneWriter).deleteDocument(uid);
+        assertTrue(deleter.getDeletedRowIds().isEmpty());
+    }
+
+    public void testDeleteWithNonLuceneWriterTracksRowId() throws IOException {
+        MockIndexingExecutionEngine indexEngine = new MockIndexingExecutionEngine(new MockDataFormat());
+        Writer<MockDocumentInput> writer = indexEngine.createWriter(1L);
+
+        DeleterImpl deleter = new DeleterImpl(writer);
+        Term uid = new Term("_id", "doc1");
+        DeleteResult result = deleter.deleteDoc(uid, 42L);
+
+        assertTrue(result instanceof DeleteResult.Success);
+        assertEquals(1, deleter.getDeletedRowIds().size());
+        assertTrue(deleter.getDeletedRowIds().contains(42L));
+    }
+
+    public void testMultipleDeletesAccumulateRowIds() throws IOException {
+        MockIndexingExecutionEngine indexEngine = new MockIndexingExecutionEngine(new MockDataFormat());
+        Writer<MockDocumentInput> writer = indexEngine.createWriter(1L);
+
+        DeleterImpl deleter = new DeleterImpl(writer);
+        deleter.deleteDoc(new Term("_id", "a"), 1L);
+        deleter.deleteDoc(new Term("_id", "b"), 2L);
+        deleter.deleteDoc(new Term("_id", "c"), 3L);
+
+        assertEquals(3, deleter.getDeletedRowIds().size());
+    }
+
+    public void testGenerationMatchesWriter() {
+        LuceneWriter luceneWriter = mock(LuceneWriter.class);
+        when(luceneWriter.generation()).thenReturn(7L);
+
+        DeleterImpl deleter = new DeleterImpl(luceneWriter);
+        assertEquals(7L, deleter.generation());
+    }
+
+    public void testCompositeWriterWithoutLuceneFallsBackToRowId() throws IOException {
+        CompositeWriter compositeWriter = mock(CompositeWriter.class);
+        when(compositeWriter.generation()).thenReturn(2L);
+        when(compositeWriter.findWriterByFormat("lucene")).thenAnswer(inv -> Optional.empty());
+
+        DeleterImpl deleter = new DeleterImpl(compositeWriter);
+        deleter.deleteDoc(new Term("_id", "doc1"), 10L);
+
+        assertEquals(1, deleter.getDeletedRowIds().size());
+        assertTrue(deleter.getDeletedRowIds().contains(10L));
+    }
+}

--- a/sandbox/plugins/delete-data-format/src/test/java/org/opensearch/delete/engine/DeleteExecutionEngineImplTests.java
+++ b/sandbox/plugins/delete-data-format/src/test/java/org/opensearch/delete/engine/DeleteExecutionEngineImplTests.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.delete.engine;
+
+import org.opensearch.index.engine.dataformat.Deleter;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.stub.MockDataFormat;
+import org.opensearch.index.engine.dataformat.stub.MockIndexingExecutionEngine;
+import org.opensearch.test.OpenSearchTestCase;
+
+@SuppressWarnings("unchecked")
+public class DeleteExecutionEngineImplTests extends OpenSearchTestCase {
+
+    private MockDataFormat dataFormat;
+    private DeleteExecutionEngineImpl engine;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        dataFormat = new MockDataFormat();
+        engine = new DeleteExecutionEngineImpl(dataFormat);
+    }
+
+    public void testGetDataFormat() {
+        assertEquals(dataFormat, engine.getDataFormat());
+    }
+
+    public void testCreateDeleterAndGetDeleter() {
+        MockIndexingExecutionEngine indexEngine = new MockIndexingExecutionEngine(dataFormat);
+        Writer<DocumentInput<?>> writer = (Writer<DocumentInput<?>>) (Writer<?>) indexEngine.createWriter(1L);
+
+        Deleter deleter = engine.createDeleter(writer);
+        assertNotNull(deleter);
+
+        Deleter retrieved = engine.getDeleter(writer);
+        assertSame(deleter, retrieved);
+    }
+
+    public void testGetDeleterReturnsNullForUnknownWriter() {
+        MockIndexingExecutionEngine indexEngine = new MockIndexingExecutionEngine(dataFormat);
+        Writer<DocumentInput<?>> writer = (Writer<DocumentInput<?>>) (Writer<?>) indexEngine.createWriter(1L);
+
+        assertNull(engine.getDeleter(writer));
+    }
+
+    public void testMultipleWritersGetDistinctDeleters() {
+        MockIndexingExecutionEngine indexEngine = new MockIndexingExecutionEngine(dataFormat);
+        Writer<DocumentInput<?>> writer1 = (Writer<DocumentInput<?>>) (Writer<?>) indexEngine.createWriter(1L);
+        Writer<DocumentInput<?>> writer2 = (Writer<DocumentInput<?>>) (Writer<?>) indexEngine.createWriter(2L);
+
+        Deleter deleter1 = engine.createDeleter(writer1);
+        Deleter deleter2 = engine.createDeleter(writer2);
+
+        assertNotSame(deleter1, deleter2);
+        assertSame(deleter1, engine.getDeleter(writer1));
+        assertSame(deleter2, engine.getDeleter(writer2));
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -31,6 +31,7 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
+import org.opensearch.index.engine.dataformat.DeleteExecutionEngine;
 import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
@@ -130,6 +131,7 @@ public class DataFormatAwareEngine implements Indexer {
     private final Store store;
 
     private final IndexingExecutionEngine indexingExecutionEngine;
+    private final DeleteExecutionEngine deleteExecutionEngine;
     private final IndexingStrategyPlanner indexingStrategyPlanner;
     private final LockablePool<Writer<?>> writerPool;
     private final AtomicLong writerGenerationCounter;
@@ -243,9 +245,16 @@ public class DataFormatAwareEngine implements Indexer {
                 ),
                 registry.format(config().getIndexSettings().pluggableDataFormat())
             );
-            this.writerGenerationCounter = new AtomicLong(1L);
+
+            this.deleteExecutionEngine = registry.getDeleteEngine();
+            this.writerGenerationCounter = new AtomicLong(1L);// committer.getCommitStats().getGeneration());
             this.writerPool = new LockablePool<>(
-                () -> indexingExecutionEngine.createWriter(writerGenerationCounter.getAndIncrement()),
+                () -> {
+                    long gen = writerGenerationCounter.getAndIncrement();
+                    Writer<?> writer = indexingExecutionEngine.createWriter(gen);
+                    deleteExecutionEngine.createDeleter(writer, gen);
+                    return writer;
+                },
                 LinkedList::new,
                 Runtime.getRuntime().availableProcessors()
             );

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -131,7 +131,7 @@ public class DataFormatAwareEngine implements Indexer {
     private final Store store;
 
     private final IndexingExecutionEngine indexingExecutionEngine;
-    private final DeleteExecutionEngine deleteExecutionEngine;
+    private final DeleteExecutionEngine<?> deleteExecutionEngine;
     private final IndexingStrategyPlanner indexingStrategyPlanner;
     private final LockablePool<Writer<?>> writerPool;
     private final AtomicLong writerGenerationCounter;
@@ -248,16 +248,12 @@ public class DataFormatAwareEngine implements Indexer {
 
             this.deleteExecutionEngine = registry.getDeleteEngine();
             this.writerGenerationCounter = new AtomicLong(1L);// committer.getCommitStats().getGeneration());
-            this.writerPool = new LockablePool<>(
-                () -> {
-                    long gen = writerGenerationCounter.getAndIncrement();
-                    Writer<?> writer = indexingExecutionEngine.createWriter(gen);
-                    deleteExecutionEngine.createDeleter(writer, gen);
-                    return writer;
-                },
-                LinkedList::new,
-                Runtime.getRuntime().availableProcessors()
-            );
+            this.writerPool = new LockablePool<>(() -> {
+                long gen = writerGenerationCounter.getAndIncrement();
+                Writer<?> writer = indexingExecutionEngine.createWriter(gen);
+                deleteExecutionEngine.createDeleter(writer);
+                return writer;
+            }, LinkedList::new, Runtime.getRuntime().availableProcessors());
             // Create Reader managers
             // We will pass IndexStoreProvider to this, which would contain store
             // and any index specific attributes useful for reads.

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatPlugin.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatPlugin.java
@@ -54,4 +54,14 @@ public interface DataFormatPlugin {
     ) {
         return Map.of();
     }
+
+    /**
+     * Returns the delete execution engine for this plugin, or {@code null} if not supported.
+     * Only {@link DeleteDataFormatPlugin} implementations override this.
+     *
+     * @return the delete execution engine, or null
+     */
+    default DeleteExecutionEngine<?> deleteEngine() {
+        return null;
+    }
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatRegistry.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatRegistry.java
@@ -121,7 +121,7 @@ public class DataFormatRegistry {
      *
      * @return the delete execution engine
      */
-    public DeleteExecutionEngine<?, ?> getDeleteEngine(){
+    public DeleteExecutionEngine<?> getDeleteEngine() {
         return this.deleteDataFormatPlugin.deleteEngine();
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatRegistry.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DataFormatRegistry.java
@@ -40,6 +40,8 @@ public class DataFormatRegistry {
     /** Map from data format to the plugin that provides its indexing engine. */
     private final Map<DataFormat, DataFormatPlugin> dataFormatPluginRegistry;
 
+    private final DeleteDataFormatPlugin deleteDataFormatPlugin;
+
     /** Map from data format to a factory that creates an {@link EngineReaderManager} for the given settings. */
     private final Map<DataFormat, CheckedFunction<ReaderManagerConfig, EngineReaderManager<?>, IOException>> readerManagerBuilders;
 
@@ -48,8 +50,9 @@ public class DataFormatRegistry {
     private static final Logger logger = LogManager.getLogger(DataFormatRegistry.class);
 
     /**
-     * Creates a registry by discovering all {@link DataFormatPlugin} and {@link SearchBackEndPlugin} implementations
-     * from the given {@link PluginsService}. Registers each data format with its indexing plugin and reader manager factory.
+     * Creates a registry by discovering all {@link DataFormatPlugin}, {@link DeleteDataFormatPlugin},
+     * and {@link SearchBackEndPlugin} implementations from the given {@link PluginsService}.
+     * Registers each data format with its indexing plugin, delete plugin, and reader manager factory.
      *
      * @param pluginsService the plugins service used to discover data format plugins and search back-end plugins
      * @throws IllegalArgumentException if a data format is registered by more than one plugin
@@ -61,6 +64,7 @@ public class DataFormatRegistry {
         Map<String, DataFormat> dataFormats = new HashMap<>();
 
         for (DataFormatPlugin plugin : pluginsService.filterPlugins(DataFormatPlugin.class)) {
+            if (plugin instanceof DeleteDataFormatPlugin) continue; // skip delete-only plugins
             DataFormat format = plugin.getDataFormat();
             DataFormatPlugin existing = dataFormatPlugiRegistry.putIfAbsent(format, plugin);
             if (existing != null) {
@@ -77,6 +81,11 @@ public class DataFormatRegistry {
                 }
             }
         }
+        List<DeleteDataFormatPlugin> deletePlugins = pluginsService.filterPlugins(DeleteDataFormatPlugin.class);
+        if (deletePlugins.size() > 1) {
+            throw new IllegalArgumentException("Only one DeleteDataFormatPlugin allowed, found " + deletePlugins.size());
+        }
+        this.deleteDataFormatPlugin = deletePlugins.isEmpty() ? null : deletePlugins.getFirst();
 
         this.dataFormatPluginRegistry = Map.copyOf(dataFormatPlugiRegistry);
         this.dataFormats = Map.copyOf(dataFormats);
@@ -105,6 +114,15 @@ public class DataFormatRegistry {
             throw new IllegalArgumentException("No data format registered with name [" + name + "]");
         }
         return format;
+    }
+
+    /**
+     * Returns the delete execution engine, same for all data formats.
+     *
+     * @return the delete execution engine
+     */
+    public DeleteExecutionEngine<?, ?> getDeleteEngine(){
+        return this.deleteDataFormatPlugin.deleteEngine();
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteDataFormatPlugin.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteDataFormatPlugin.java
@@ -9,7 +9,6 @@
 package org.opensearch.index.engine.dataformat;
 
 import org.opensearch.common.annotation.ExperimentalApi;
-import org.opensearch.index.store.FormatChecksumStrategy;
 
 /**
  * Plugin interface for providing custom delete data format implementations.
@@ -19,14 +18,14 @@ import org.opensearch.index.store.FormatChecksumStrategy;
  * @opensearch.experimental
  */
 @ExperimentalApi
-public interface DeleteDataFormatPlugin extends DataFormatPlugin{
+public interface DeleteDataFormatPlugin extends DataFormatPlugin {
 
     /**
      * Creates the delete execution engine for the data format. This should be instantiated per shard.
      *
      * @return the delete execution engine instance
      */
-    DeleteExecutionEngine<?, ?> deleteEngine();
+    DeleteExecutionEngine<?> deleteEngine();
 
     /**
      * Not applicable for delete-only plugins. Always throws {@link UnsupportedOperationException}.
@@ -34,7 +33,7 @@ public interface DeleteDataFormatPlugin extends DataFormatPlugin{
      * @throws UnsupportedOperationException always
      */
     @Override
-    default IndexingExecutionEngine<?, ?> indexingEngine(IndexingEngineConfig s, FormatChecksumStrategy c) {
+    default IndexingExecutionEngine<?, ?> indexingEngine(IndexingEngineConfig settings) {
         throw new UnsupportedOperationException("Delete plugins do not provide an indexing engine");
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteDataFormatPlugin.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteDataFormatPlugin.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.index.store.FormatChecksumStrategy;
+
+/**
+ * Plugin interface for providing custom delete data format implementations.
+ * Plugins implement this to register their delete data format
+ * with the {@link DataFormatRegistry} during node bootstrap.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public interface DeleteDataFormatPlugin extends DataFormatPlugin{
+
+    /**
+     * Creates the delete execution engine for the data format. This should be instantiated per shard.
+     *
+     * @return the delete execution engine instance
+     */
+    DeleteExecutionEngine<?, ?> deleteEngine();
+
+    /**
+     * Not applicable for delete-only plugins. Always throws {@link UnsupportedOperationException}.
+     *
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    default IndexingExecutionEngine<?, ?> indexingEngine(IndexingEngineConfig s, FormatChecksumStrategy c) {
+        throw new UnsupportedOperationException("Delete plugins do not provide an indexing engine");
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteExecutionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteExecutionEngine.java
@@ -19,21 +19,19 @@ import java.io.IOException;
  * format-specific delete tracking (e.g., live-doc bitsets for parquet files).
  *
  * @param <T> the data format type
- * @param <P> the document input type
  * @opensearch.experimental
  */
 @ExperimentalApi
-public interface DeleteExecutionEngine<T extends DataFormat, P extends DocumentInput<?>> extends Closeable {
+public interface DeleteExecutionEngine<T extends DataFormat> extends Closeable {
 
     /**
      * Creates a new deleter paired with the given writer.
      * The deleter tracks deletes for documents managed by this writer.
      *
      * @param writer the writer this deleter is paired with
-     * @param writerGeneration the generation number shared with the writer
      * @return a new deleter instance
      */
-    Deleter<P> createDeleter(Writer<P> writer, long writerGeneration);
+    Deleter createDeleter(Writer<?> writer);
 
     /**
      * Refreshes delete state, making buffered deletes visible to readers.
@@ -50,4 +48,12 @@ public interface DeleteExecutionEngine<T extends DataFormat, P extends DocumentI
      * @return the data format
      */
     T getDataFormat();
+
+    /**
+     * Returns the deleter paired with the given writer.
+     *
+     * @param writer the writer whose deleter to retrieve
+     * @return the deleter for the given writer, or {@code null} if no deleter exists
+     */
+    Deleter getDeleter(Writer<?> writer);
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteExecutionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteExecutionEngine.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Engine for executing delete operations for a specific data format.
+ * Each deleter is paired with a writer and shares its generation, enabling
+ * format-specific delete tracking (e.g., live-doc bitsets for parquet files).
+ *
+ * @param <T> the data format type
+ * @param <P> the document input type
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public interface DeleteExecutionEngine<T extends DataFormat, P extends DocumentInput<?>> extends Closeable {
+
+    /**
+     * Creates a new deleter paired with the given writer.
+     * The deleter tracks deletes for documents managed by this writer.
+     *
+     * @param writer the writer this deleter is paired with
+     * @param writerGeneration the generation number shared with the writer
+     * @return a new deleter instance
+     */
+    Deleter<P> createDeleter(Writer<P> writer, long writerGeneration);
+
+    /**
+     * Refreshes delete state, making buffered deletes visible to readers.
+     *
+     * @param refreshInput the refresh configuration
+     * @return the result of the refresh operation
+     * @throws IOException if an I/O error occurs during refresh
+     */
+    RefreshResult refresh(RefreshInput refreshInput) throws IOException;
+
+    /**
+     * Returns the data format this engine handles deletes for.
+     *
+     * @return the data format
+     */
+    T getDataFormat();
+}

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteResult.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteResult.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+/**
+ * Result of a document delete operation. Sealed to ensure exhaustive handling
+ * of success and failure cases.
+ */
+public sealed interface DeleteResult {
+
+    /**
+     * Indicates a successful delete.
+     *
+     * @param version the document version after deletion
+     * @param term the primary term of the shard
+     * @param seqNo the sequence number assigned to this delete operation
+     */
+    record Success(long version, long term, long seqNo) implements DeleteResult {
+    }
+
+    /**
+     * Indicates a failed delete.
+     *
+     * @param cause the exception that caused the failure
+     * @param version the document version at the time of failure
+     * @param term the primary term of the shard
+     * @param seqNo the sequence number assigned to this delete operation
+     */
+    record Failure(Exception cause, long version, long term, long seqNo) implements DeleteResult {
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteResult.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DeleteResult.java
@@ -8,10 +8,13 @@
 
 package org.opensearch.index.engine.dataformat;
 
+import org.opensearch.common.annotation.ExperimentalApi;
+
 /**
  * Result of a document delete operation. Sealed to ensure exhaustive handling
  * of success and failure cases.
  */
+@ExperimentalApi
 public sealed interface DeleteResult {
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/Deleter.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/Deleter.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.index.engine.dataformat;
 
+import org.apache.lucene.index.Term;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.queue.Lockable;
 
@@ -19,11 +20,10 @@ import java.io.IOException;
  * {@link Writer} and shares its generation. Implements {@link Lockable} for thread-safe
  * pooling via {@link org.opensearch.common.queue.LockablePool}.
  *
- * @param <P> the document input type
  * @opensearch.experimental
  */
 @ExperimentalApi
-public interface Deleter<P extends DocumentInput<?>> extends Closeable, Lockable {
+public interface Deleter extends Closeable, Lockable {
     /**
      * Returns the generation number of this deleter, matching its paired writer.
      *
@@ -34,9 +34,10 @@ public interface Deleter<P extends DocumentInput<?>> extends Closeable, Lockable
     /**
      * Deletes a document from the underlying format-specific storage.
      *
-     * @param d the document input identifying the document to delete
+     * @param uid the term identifying the document in lucene
+     * @param rowId the row ID of the document for parquet
      * @return the result of the delete operation
      * @throws IOException if an I/O error occurs
      */
-    DeleteResult deleteDoc(P d) throws IOException;
+    DeleteResult deleteDoc(Term uid, Long rowId) throws IOException;
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/Deleter.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/Deleter.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.queue.Lockable;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Handles document deletion for a specific data format. Each deleter is paired with a
+ * {@link Writer} and shares its generation. Implements {@link Lockable} for thread-safe
+ * pooling via {@link org.opensearch.common.queue.LockablePool}.
+ *
+ * @param <P> the document input type
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public interface Deleter<P extends DocumentInput<?>> extends Closeable, Lockable {
+    /**
+     * Returns the generation number of this deleter, matching its paired writer.
+     *
+     * @return the generation number
+     */
+    long generation();
+
+    /**
+     * Deletes a document from the underlying format-specific storage.
+     *
+     * @param d the document input identifying the document to delete
+     * @return the result of the delete operation
+     * @throws IOException if an I/O error occurs
+     */
+    DeleteResult deleteDoc(P d) throws IOException;
+}

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/Writer.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/Writer.java
@@ -8,11 +8,13 @@
 
 package org.opensearch.index.engine.dataformat;
 
+import org.apache.lucene.index.Term;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.queue.Lockable;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Interface for writing documents to a data format.
@@ -53,4 +55,26 @@ public interface Writer<P extends DocumentInput<?>> extends Closeable, Lockable 
      * @return the generation number
      */
     long generation();
+
+    /**
+     * Finds a child writer whose data format matches the given format name.
+     * Composite writers override this to search their delegates.
+     *
+     * @param formatName the data format name to match (e.g. "lucene")
+     * @return the matching writer, or empty if not found or not composite
+     */
+    default Optional<Writer<?>> findWriterByFormat(String formatName) {
+        return Optional.empty();
+    }
+
+    /**
+     * Deletes all documents matching the given term from this writer.
+     * Lucene-backed writers override this to delegate to {@code IndexWriter.deleteDocuments}.
+     *
+     * @param uid the term identifying the document(s) to delete
+     * @throws IOException if a low-level I/O error occurs
+     */
+    default void deleteDocument(Term uid) throws IOException {
+        throw new UnsupportedOperationException("deleteDocument not supported by " + getClass().getName());
+    }
 }

--- a/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
@@ -28,9 +28,11 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.engine.dataformat.DataFormatPlugin;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
+import org.opensearch.index.engine.dataformat.DeleteDataFormatPlugin;
 import org.opensearch.index.engine.dataformat.stub.InMemoryCommitter;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormat;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockDeleteDataFormatPlugin;
 import org.opensearch.index.engine.dataformat.stub.MockSearchBackEndPlugin;
 import org.opensearch.index.engine.exec.IndexReaderProvider;
 import org.opensearch.index.engine.exec.WriterFileSet;
@@ -92,6 +94,7 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
     private AtomicLong primaryTerm;
     private MockDataFormat mockDataFormat;
     private MockDataFormatPlugin mockPlugin;
+    private MockDeleteDataFormatPlugin mockDeletePlugin;
 
     @Override
     public void setUp() throws Exception {
@@ -100,6 +103,7 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
         primaryTerm = new AtomicLong(randomLongBetween(1, Long.MAX_VALUE));
         mockDataFormat = new MockDataFormat("composite", 100L, Set.of());
         mockPlugin = MockDataFormatPlugin.of(mockDataFormat);
+        mockDeletePlugin = new MockDeleteDataFormatPlugin();
         threadPool = new TestThreadPool(getClass().getName());
         store = createStore();
     }
@@ -214,6 +218,7 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
         when(pluginsService.filterPlugins(SearchBackEndPlugin.class)).thenReturn(
             List.of(new MockSearchBackEndPlugin(List.of(mockDataFormat.name())))
         );
+        when(pluginsService.filterPlugins(DeleteDataFormatPlugin.class)).thenReturn(List.of(mockDeletePlugin));
         return new DataFormatRegistry(pluginsService);
     }
 

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatRegistryTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/DataFormatRegistryTests.java
@@ -15,6 +15,7 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormat;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockDeleteDataFormatPlugin;
 import org.opensearch.index.engine.dataformat.stub.MockSearchBackEndPlugin;
 import org.opensearch.index.engine.exec.EngineReaderManager;
 import org.opensearch.index.mapper.MapperService;
@@ -314,5 +315,31 @@ public class DataFormatRegistryTests extends OpenSearchTestCase {
 
         Map<String, Supplier<DataFormatDescriptor>> descriptors = registry.getFormatDescriptors(indexSettings, unregistered);
         assertTrue(descriptors.isEmpty());
+    }
+
+    public void testDeletePluginRegistration() {
+        MockDeleteDataFormatPlugin deletePlugin = new MockDeleteDataFormatPlugin();
+
+        when(pluginsService.filterPlugins(DataFormatPlugin.class)).thenReturn(List.of(deletePlugin));
+        when(pluginsService.filterPlugins(DeleteDataFormatPlugin.class)).thenReturn(List.of(deletePlugin));
+        when(pluginsService.filterPlugins(SearchBackEndPlugin.class)).thenReturn(List.of());
+
+        DataFormatRegistry registry = new DataFormatRegistry(pluginsService);
+
+        // getDeleteEngine should return a non-null engine
+        DeleteExecutionEngine<?> deleteEngine = registry.getDeleteEngine();
+        assertNotNull(deleteEngine);
+    }
+
+    public void testDuplicateDeletePluginsThrows() {
+        MockDeleteDataFormatPlugin deletePlugin1 = new MockDeleteDataFormatPlugin();
+        MockDeleteDataFormatPlugin deletePlugin2 = new MockDeleteDataFormatPlugin();
+
+        when(pluginsService.filterPlugins(DataFormatPlugin.class)).thenReturn(List.of(deletePlugin1, deletePlugin2));
+        when(pluginsService.filterPlugins(DeleteDataFormatPlugin.class)).thenReturn(List.of(deletePlugin1, deletePlugin2));
+        when(pluginsService.filterPlugins(SearchBackEndPlugin.class)).thenReturn(List.of());
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new DataFormatRegistry(pluginsService));
+        assertTrue(e.getMessage().contains("Only one DeleteDataFormatPlugin allowed"));
     }
 }

--- a/server/src/test/java/org/opensearch/index/mapper/ConstantKeywordFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/ConstantKeywordFieldMapperTests.java
@@ -28,6 +28,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockDeleteDataFormatPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.InternalSettingsPlugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
@@ -47,7 +48,12 @@ public class ConstantKeywordFieldMapperTests extends OpenSearchSingleNodeTestCas
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
-        return pluginList(InternalSettingsPlugin.class, MockDataFormatPlugin.class, MockCommitterEnginePlugin.class);
+        return pluginList(
+            InternalSettingsPlugin.class,
+            MockDataFormatPlugin.class,
+            MockCommitterEnginePlugin.class,
+            MockDeleteDataFormatPlugin.class
+        );
     }
 
     @Before

--- a/server/src/test/java/org/opensearch/index/mapper/RoutingFieldMapperTests.java
+++ b/server/src/test/java/org/opensearch/index/mapper/RoutingFieldMapperTests.java
@@ -39,6 +39,7 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockDeleteDataFormatPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 
@@ -52,7 +53,7 @@ public class RoutingFieldMapperTests extends OpenSearchSingleNodeTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
-        return List.of(MockDataFormatPlugin.class, MockCommitterEnginePlugin.class);
+        return List.of(MockDataFormatPlugin.class, MockCommitterEnginePlugin.class, MockDeleteDataFormatPlugin.class);
     }
 
     public void testRoutingMapper() throws Exception {

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDeleteDataFormatPlugin.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDeleteDataFormatPlugin.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat.stub;
+
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DeleteDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.DeleteExecutionEngine;
+import org.opensearch.plugins.Plugin;
+
+/**
+ * A mock {@link DeleteDataFormatPlugin} for testing purposes.
+ */
+public class MockDeleteDataFormatPlugin extends Plugin implements DeleteDataFormatPlugin {
+
+    @Override
+    public DataFormat getDataFormat() {
+        return new MockDataFormat("mock-delete", 0L, java.util.Set.of());
+    }
+
+    @Override
+    public DeleteExecutionEngine<?> deleteEngine() {
+        return new MockDeleteExecutionEngine();
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDeleteExecutionEngine.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDeleteExecutionEngine.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat.stub;
+
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DeleteExecutionEngine;
+import org.opensearch.index.engine.dataformat.Deleter;
+import org.opensearch.index.engine.dataformat.RefreshInput;
+import org.opensearch.index.engine.dataformat.RefreshResult;
+import org.opensearch.index.engine.dataformat.Writer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A no-op {@link DeleteExecutionEngine} for testing purposes.
+ */
+public class MockDeleteExecutionEngine implements DeleteExecutionEngine<DataFormat> {
+
+    private final Map<Writer<?>, Deleter> deleters = new ConcurrentHashMap<>();
+
+    @Override
+    public Deleter createDeleter(Writer<?> writer) {
+        MockDeleter deleter = new MockDeleter();
+        deleters.put(writer, deleter);
+        return deleter;
+    }
+
+    @Override
+    public RefreshResult refresh(RefreshInput refreshInput) {
+        return new RefreshResult(List.of());
+    }
+
+    @Override
+    public DataFormat getDataFormat() {
+        return new MockDataFormat("mock-delete", 0L, java.util.Set.of());
+    }
+
+    public Deleter getDeleter(Writer<?> writer) {
+        return deleters.get(writer);
+    }
+
+    @Override
+    public void close() {}
+}

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDeleter.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockDeleter.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat.stub;
+
+import org.apache.lucene.index.Term;
+import org.opensearch.index.engine.dataformat.DeleteResult;
+import org.opensearch.index.engine.dataformat.Deleter;
+
+/**
+ * A no-op {@link Deleter} for testing purposes.
+ */
+public class MockDeleter implements Deleter {
+
+    @Override
+    public long generation() {
+        return 0;
+    }
+
+    @Override
+    public DeleteResult deleteDoc(Term uid, Long rowId) {
+        return new DeleteResult.Success(1, 1, 1);
+    }
+
+    @Override
+    public void lock() {}
+
+    @Override
+    public boolean tryLock() {
+        return true;
+    }
+
+    @Override
+    public void unlock() {}
+
+    @Override
+    public void close() {}
+}


### PR DESCRIPTION
### Description

Implements delete support for `DataFormatAwareEngine` — version map, delete strategy, versionMap lifecycle management, and the concrete delete execution layer for data formats that don't handle deletes natively (e.g., Parquet).

**Version Resolution & Strategy Planning:**
- `resolveDocVersion()`: versionMap lookup for document version resolution. 
- Wired `resolveDocVersion` into both `IndexingStrategyPlanner` and new `DeletionStrategyPlanner` (version conflict detection for deletes).
 - `delete()`: Uses `DeletionStrategyPlanner` to resolve versions and detect conflicts, routes to format-specific deleters, records tombstones in the version map, and writes to translog. Handles both primary and non-primary origins, following the same pattern as InternalEngine.delete()


**VersionMap Lifecycle:**
- `versionMap.beforeRefresh()` / `afterRefresh()` called during `refresh()` to rotate and clear stale version entries, preventing unbounded heap growth.
- `pruneTombstones()` evicts expired delete tombstones after refresh.

**Delete Execution Layer:**
- `DeleterImpl`: Resolves `LuceneWriter` once in constructor (direct or via `CompositeWriter.findWriterByFormat`). Routes deletes to Lucene when available, falls back to rowId tracking for non-Lucene formats.
- `DeleteExecutionEngineImpl`: Maintains `ConcurrentHashMap<Writer, Deleter>` mapping. Creates `DeleterImpl` per writer via `createDeleter()`, retrieves via `getDeleter()`.
- `DeleteDataFormatDefaultPlugin`: Plugin entry point for the `delete-data-format` sandbox module.
- `LuceneWriter.deleteDocument(Term)`: Delegates to `IndexWriter.deleteDocuments()`.
- `DataFormatVersionValue`: Extends `IndexVersionValue` with `rowId` and `Writer` reference for format-specific delete routing.

### Related Issues

<!-- Part of the DataFusion delete support initiative, builds on #21299 -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).