### PR TITLE
Update logic in FIPS bootstrap check

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -31,7 +31,7 @@
 import groovy.xml.XmlParser
 
 plugins {
-  id('com.google.protobuf') version '0.9.6'
+  id('com.google.protobuf') version '0.10.0'
   id('opensearch.build')
   id('opensearch.publish')
   id('opensearch.internal-cluster-test')

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -31,7 +31,7 @@
 import groovy.xml.XmlParser
 
 plugins {
-  id('com.google.protobuf') version '0.10.0'
+  id('com.google.protobuf') version '0.9.6'
   id('opensearch.build')
   id('opensearch.publish')
   id('opensearch.internal-cluster-test')

--- a/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/opensearch/bootstrap/Bootstrap.java
@@ -197,7 +197,9 @@ final class Bootstrap {
         );
 
         var cryptoStandard = System.getenv("OPENSEARCH_CRYPTO_STANDARD");
-        if ("FIPS-140-3".equals(cryptoStandard) || "true".equalsIgnoreCase(System.getProperty("org.bouncycastle.fips.approved_only"))) {
+        var fipsMode = System.getenv("OPENSEARCH_FIPS_MODE");
+
+        if ("FIPS-140-3".equals(cryptoStandard) || "true".equalsIgnoreCase(fipsMode)) {
             LogManager.getLogger(Bootstrap.class).info("running in FIPS-140-3 mode");
             SecurityProviderManager.removeNonCompliantFipsProviders();
             FipsTrustStoreValidator.validate();


### PR DESCRIPTION
### Description
Currently, Bootstrap.java looks for the system prop (org.bouncycastle.fips.approved_only) to determine if FIPS is enforced at runtime. This system prop is specific to the bouncycastle library and implicitly set [here in opensearch-env](https://github.com/opensearch-project/OpenSearch/blob/main/distribution/src/bin/opensearch-env#L115-L128). This PR makes configuring FIPS more intentional by the cluster operator by looking for an OpenSearch env var instead of the bouncycastle system prop to determine if FIPS should be enforced at runtime.

Accompanies https://github.com/opensearch-project/OpenSearch/pull/21366

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/19702
<!-- List any other related issues here -->
Related to:
https://github.com/opensearch-project/OpenSearch/pull/21366
https://github.com/opensearch-project/OpenSearch/issues/20738

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
