### PR TITLE
Add failure handling for composite multi-format indexing engine

### DIFF
--- a/libs/concurrent-queue/build.gradle
+++ b/libs/concurrent-queue/build.gradle
@@ -8,7 +8,7 @@
 
 /*
  * Shared concurrent queue utilities for the composite indexing engine.
- * No external dependencies — pure Java concurrency primitives.
+ * Only depends on opensearch-common for the Releasable interface.
  */
 
 // ---- JMH benchmark source set ----
@@ -21,9 +21,7 @@ sourceSets {
 }
 
 dependencies {
-  /*******
-   *  !!!! NO RUNTIME DEPENDENCIES !!!!
-   *******/
+  api project(':libs:opensearch-common')
 
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testImplementation "junit:junit:${versions.junit}"

--- a/libs/concurrent-queue/src/main/java/org/opensearch/common/queue/LockablePool.java
+++ b/libs/concurrent-queue/src/main/java/org/opensearch/common/queue/LockablePool.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.common.queue;
 
+import org.opensearch.common.lease.Releasable;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -134,6 +136,23 @@ public final class LockablePool<T extends Lockable> implements Iterable<T>, Clos
      */
     public synchronized boolean isRegistered(T item) {
         return items.contains(item);
+    }
+
+    /**
+     * Removes a single already-locked item from the pool. The returned {@link Releasable}
+     * unlocks the item when closed, intended for use with try-with-resources. The caller
+     * still owns the item itself and is responsible for closing any underlying resources.
+     *
+     * @param item the locked item to remove
+     * @return a releasable whose {@code close()} unlocks the item
+     * @throws IllegalArgumentException if the item is not registered in this pool
+     */
+    public synchronized Releasable checkout(T item) {
+        if (items.remove(item) == false) {
+            throw new IllegalArgumentException("Item is not registered in this pool");
+        }
+        availableItems.remove(item);
+        return item::unlock;
     }
 
     private void ensureOpen() {

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneReaderManager.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneReaderManager.java
@@ -102,16 +102,12 @@ public class LuceneReaderManager implements EngineReaderManager<LuceneReader> {
         }
         DirectoryReader refreshed = readerRefresher.apply(currentReader, LuceneReplicaCommitter.getSegmentInfos(catalogSnapshot));
         if (refreshed != null) {
-            // Guard against refresh/merge-apply races: a prior IT regression surfaced when
-            // overlapping threads produced a refreshed reader whose leaves disagreed with the
-            // catalog snapshot being registered, effectively pairing the snapshot with a stale
-            // reader. This assert catches that drift in test builds before the mismatched pair
-            // is published to readers.
             currentReader = refreshed;
         } else {
-            // If same reader is used, assert that calalog snapshot is same.
             currentReader.incRef();
         }
+        // Catches refresh/merge-apply races where the refreshed reader's leaves disagree
+        // with the catalog snapshot being registered.
         assert readersAreSame(catalogSnapshot, currentReader);
 
         Map<Long, String> generationToSegmentName = buildGenerationToSegmentName(catalogSnapshot, currentReader.leaves());

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneCommitter.java
@@ -216,6 +216,20 @@ public class LuceneCommitter extends SafeBootstrapCommitter {
         return fileName.startsWith(IndexFileNames.SEGMENTS) || fileName.equals(IndexWriter.WRITE_LOCK_NAME);
     }
 
+    @Override
+    public void markStoreCorrupted(IOException cause) {
+        if (store.tryIncRef() == false) {
+            return;
+        }
+        try {
+            store.markStoreCorrupted(cause);
+        } catch (IOException e) {
+            logger.warn("Couldn't mark store corrupted", e);
+        } finally {
+            store.decRef();
+        }
+    }
+
     /**
      * Builds upload-time Lucene {@code SegmentInfos} bytes from the {@link DirectoryReader}
      * registered for this {@code catalogSnapshot} (opened at that snapshot's refresh point).

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDocumentInput.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDocumentInput.java
@@ -39,6 +39,7 @@ public class LuceneDocumentInput implements DocumentInput<Document> {
 
     private final Document document;
     private final LuceneFieldFactoryRegistry fieldFactoryRegistry;
+    private long rowId = -1L;
 
     /**
      * Creates a new LuceneDocumentInput with the default field factory registry.
@@ -110,6 +111,12 @@ public class LuceneDocumentInput implements DocumentInput<Document> {
     @Override
     public void setRowId(String rowIdFieldName, long rowId) {
         document.add(new SortedNumericDocValuesField(rowIdFieldName, rowId));
+        this.rowId = rowId;
+    }
+
+    /** Returns the row ID assigned via {@link #setRowId}, or {@code -1} if none. */
+    public long getRowId() {
+        return rowId;
     }
 
     @Override

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
@@ -168,7 +168,7 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
         assert sharedWriter.isOpen() : "Cannot create writer — shared IndexWriter is closed";
         try {
             long mappingVersion = mapperService.getIndexSettings().getIndexMetadata().getMappingVersion();
-            return new LuceneWriter(
+            return buildLuceneWriter(
                 config.writerGeneration(),
                 mappingVersion,
                 dataFormat,
@@ -180,6 +180,24 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
         } catch (IOException e) {
             throw new RuntimeException("Failed to create LuceneWriter for generation " + config.writerGeneration(), e);
         }
+    }
+
+    /**
+     * Factory hook for tests: builds the per-generation {@link LuceneWriter}. Subclasses
+     * (notably test-only fault-injecting variants) override this to return a custom
+     * {@link LuceneWriter} subclass — e.g., one that wraps the {@code Directory} with a
+     * fault injector to exercise {@code IndexWriter.addDocument} failure paths.
+     */
+    protected LuceneWriter buildLuceneWriter(
+        long writerGeneration,
+        long mappingVersion,
+        LuceneDataFormat dataFormat,
+        Path baseDirectory,
+        Analyzer analyzer,
+        Codec codec,
+        Sort indexSort
+    ) throws IOException {
+        return new LuceneWriter(writerGeneration, mappingVersion, dataFormat, baseDirectory, analyzer, codec, indexSort);
     }
 
     private Sort getChildWriterSortConfiguration() {
@@ -290,7 +308,7 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
                         if (!writerGenerations.contains(writerGen)) {
                             continue;
                         }
-                        long numDocs = segInfo.info.maxDoc();
+                        long numDocs = segReader.maxDoc();
 
                         WriterFileSet.Builder wfsBuilder = WriterFileSet.builder()
                             .directory(sharedDir)
@@ -312,10 +330,22 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
         return new RefreshResult(List.copyOf(resultSegments));
     }
 
-    /** Returns {@code null} — merge scheduling is not yet implemented for the Lucene format. */
     @Override
     public Merger getMerger() {
         return this.luceneMerger;
+    }
+
+    /**
+     * Surfaces the shared {@link org.apache.lucene.index.IndexWriter}'s tragic exception
+     * so DFAE can fail the engine. Wraps non-Exception throwables (e.g., Errors from
+     * background merges) in {@link RuntimeException} since the contract returns Exception.
+     */
+    @Override
+    public Exception getTragicException() {
+        if (sharedWriter == null) return null;
+        Throwable tragic = sharedWriter.getTragicException();
+        if (tragic == null) return null;
+        return tragic instanceof Exception ? (Exception) tragic : new RuntimeException(tragic);
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
@@ -12,7 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
@@ -40,11 +40,13 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.index.engine.dataformat.DeleteInput;
 import org.opensearch.index.engine.dataformat.DeleteResult;
+import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.FlushInput;
 import org.opensearch.index.engine.dataformat.RowIdMapping;
 import org.opensearch.index.engine.dataformat.WriteResult;
 import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterState;
 import org.opensearch.index.engine.exec.WriterFileSet;
 
 import java.io.IOException;
@@ -98,6 +100,8 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
     private final IndexWriter indexWriter;
     private long mappingVersion;
     private volatile long docCount;
+    private volatile boolean flushed;
+    private volatile WriterState state = WriterState.ACTIVE;
 
     /**
      * Creates a new LuceneWriter for the given generation.
@@ -128,8 +132,8 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
         // Create an isolated temp directory for this writer's segment
         this.tempDirectory = baseDirectory.resolve("lucene_gen_" + writerGeneration);
         logger.info("Creating directory for temp lucene writer: " + tempDirectory);
-        Files.createDirectory(tempDirectory);
-        this.directory = new MMapDirectory(tempDirectory);
+        Files.createDirectories(tempDirectory);
+        this.directory = createDirectory(tempDirectory);
 
         IndexWriterConfig iwc = analyzer != null ? new IndexWriterConfig(analyzer) : new IndexWriterConfig();
         iwc.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
@@ -155,6 +159,15 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
     }
 
     /**
+     * Hook for tests to wrap the underlying {@link Directory} (e.g., to inject I/O
+     * faults). Default is a plain {@link MMapDirectory}. Invoked once from the
+     * constructor with the writer's per-generation temp directory.
+     */
+    protected Directory createDirectory(Path tempDirectory) throws IOException {
+        return new MMapDirectory(tempDirectory);
+    }
+
+    /**
      * Hook for tests to override the IndexWriter RAM buffer size. Default is
      * {@link #RAM_BUFFER_SIZE_MB}, large enough that production accumulates all
      * docs into a single in-memory segment before flush.
@@ -167,7 +180,7 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
      * <p>This method is invoked from the constructor, so overrides must be
      * stateless (return a constant) — they cannot depend on any instance fields.
      */
-    double ramBufferSizeMB() {
+    protected double ramBufferSizeMB() {
         return RAM_BUFFER_SIZE_MB;
     }
 
@@ -184,33 +197,69 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
      * <p>This method is invoked from the constructor, so overrides must be
      * stateless (return a constant) — they cannot depend on any instance fields.
      */
-    int maxBufferedDocs() {
+    protected int maxBufferedDocs() {
         return IndexWriterConfig.DISABLE_AUTO_FLUSH;
     }
 
     /**
-     * Adds a document to this writer's isolated IndexWriter.
-     * The document is obtained from the input's {@link LuceneDocumentInput#getFinalInput()}.
-     *
-     * @param input the document input containing the Lucene document to index
-     * @return a success result containing the current doc ID (0-based sequential)
-     * @throws IOException if the underlying IndexWriter fails to add the document
+     * Adds a document to the underlying {@link IndexWriter}. {@link IOException} (low-level
+     * I/O fault) and {@link IllegalArgumentException} (per-doc rejection from
+     * {@code IndexingChain}, e.g. oversized term, missing binary value, duplicate term) are
+     * translated to {@link WriteResult.Failure}, with {@code docCount} advanced to capture
+     * the partial slot and the writer moved to {@link WriterState#PENDING_ROLLBACK}; the caller must
+     * then invoke {@link #rollbackTo(long)}. Anything else (e.g.
+     * {@link org.apache.lucene.store.AlreadyClosedException} after a tragic event) propagates.
      */
     @Override
     public WriteResult addDoc(LuceneDocumentInput input) throws IOException {
-        Document doc = input.getFinalInput();
-        assert doc.getField(LuceneDocumentInput.ROW_ID_FIELD) != null : "Document missing required "
-            + LuceneDocumentInput.ROW_ID_FIELD
-            + " field at doc position "
-            + docCount;
-        assert doc.getField(LuceneDocumentInput.ROW_ID_FIELD).numericValue().longValue() == docCount : "Row ID mismatch: expected "
-            + docCount
-            + " but got "
-            + doc.getField(LuceneDocumentInput.ROW_ID_FIELD).numericValue().longValue();
-        indexWriter.addDocument(doc);
+        if (state != WriterState.ACTIVE) {
+            throw new IllegalStateException("addDoc requires ACTIVE state but was " + state);
+        }
+        // Defense-in-depth: CompositeWriter enforces rowId == docCount at the multiplexer
+        // layer, but we re-check here so a single-format Lucene path is also protected.
+        if (input.getRowId() != docCount) {
+            throw new IllegalStateException("rowId [" + input.getRowId() + "] does not match doc count [" + docCount + "]");
+        }
+        try {
+            indexWriter.addDocument(input.getFinalInput());
+        } catch (IOException | IllegalArgumentException e) {
+            // Lucene's IndexWriter may have consumed a docId before throwing; advance our
+            // counter to match so rollbackTo can tombstone the partial slot, and
+            // retire to preserve the docId == rowId invariant for subsequent writes.
+            docCount++;
+            state = WriterState.PENDING_ROLLBACK;
+            return new WriteResult.Failure(e, -1L, -1L, -1L);
+        }
         long currentDocId = docCount;
         docCount++;
         return new WriteResult.Success(1L, 1L, currentDocId);
+    }
+
+    @Override
+    public void rollbackTo(long rowCount) throws IOException {
+        if (state != WriterState.PENDING_ROLLBACK && state != WriterState.ACTIVE) {
+            throw new IllegalStateException("rollbackTo requires ACTIVE or PENDING_ROLLBACK state but was " + state);
+        }
+        if (rowCount > docCount) {
+            throw new IllegalStateException("Cannot rollback to " + rowCount + ": only " + docCount + " docs admitted");
+        }
+        if (rowCount == docCount) {
+            state = WriterState.RETIRED_FLUSHABLE;
+            return;
+        }
+        if (docCount - rowCount != 1) {
+            throw new IllegalStateException(
+                "rollbackTo supports rolling back exactly 1 doc, but asked to roll back " + (docCount - rowCount)
+            );
+        }
+        indexWriter.deleteDocuments(NumericDocValuesField.newSlowExactQuery(DocumentInput.ROW_ID_FIELD, rowCount));
+        docCount = rowCount;
+        state = WriterState.RETIRED_FLUSHABLE;
+    }
+
+    @Override
+    public WriterState state() {
+        return state;
     }
 
     /**
@@ -271,7 +320,7 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
                         + "]"
                 );
             }
-            configureSortedMerge(mapping);
+            configureSortedMerge(mapping, state == WriterState.RETIRED_FLUSHABLE);
         } else if (indexWriter.getConfig().getIndexSort() != null) {
             // Lucene is primary with IndexSort: Lucene natively reorders docs during
             // forceMerge, but __row_id__ values were assigned at insertion time and will
@@ -310,6 +359,14 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
         assert segmentInfos.size() == 1 : "Expected exactly 1 segment after force merge, got " + segmentInfos.size();
 
         SegmentCommitInfo segmentInfo = segmentInfos.info(0);
+        // After flush the segment must contain exactly docCount live docs. Any tombstones
+        // from rollbackTo are expunged by the reordering forceMerge (secondary path)
+        // or by LogByteSizeMergePolicy's forceMerge (primary-with-indexSort path).
+        // TODO: this assertion will trip if Lucene is configured as the primary format
+        // without an IndexSort and a rollbackTo has run — the no-sort/no-mapping
+        // branch uses NoMergePolicy, so forceMerge is a no-op and the tombstone remains.
+        // Production never wires Lucene as primary without IndexSort, but tests that do
+        // need to either configure index.sort.field or avoid the rollback path.
         assert segmentInfo.info.maxDoc() == docCount : "Expected " + docCount + " docs in segment, got " + segmentInfo.info.maxDoc();
 
         // Invariant: ___row_id__ doc values must be sequential 0..maxDoc-1 after forceMerge.
@@ -344,6 +401,9 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
             }
         }
 
+        directory.close();
+        flushed = true;
+
         long totalFlushDurationMs = TimeValue.nsecToMSec(System.nanoTime() - flushStartNanos);
         logger.info(
             "flush: DONE generation={}, totalRows={}, forceMerge={}ms, commit={}ms, total={}ms",
@@ -362,8 +422,8 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
      * that forces a merge of all segments (with optional doc reordering via the mapping).
      * Row ID rewrite is already enabled on the codec at construction time.
      */
-    private void configureSortedMerge(RowIdMapping mapping) {
-        indexWriter.getConfig().setMergePolicy(new ReorderingMergePolicy(mapping));
+    private void configureSortedMerge(RowIdMapping mapping, boolean hasRolledBack) {
+        indexWriter.getConfig().setMergePolicy(new ReorderingMergePolicy(mapping, hasRolledBack ? mapping.size() : -1));
         Codec currentCodec = indexWriter.getConfig().getCodec();
         if (currentCodec instanceof LuceneWriterCodec lwc) {
             lwc.enableRowIdRewrite();
@@ -507,16 +567,18 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
     static class ReorderingMergePolicy extends MergePolicy {
         private final RowIdMapping mapping; // nullable
         private volatile boolean mergeDone = false;
+        private final int rowIdToPurge;
 
         /**
          * @param mapping the sort permutation to apply during merge, or null for a plain
          *                rewrite merge (used when Lucene's IndexSort already sorted the docs)
          */
-        ReorderingMergePolicy(RowIdMapping mapping) {
+        ReorderingMergePolicy(RowIdMapping mapping, int rowIdToPurge) {
             if (mapping != null && mapping.isNewToOldSupported() == false) {
                 throw new IllegalArgumentException("RowIdMapping must support reverse lookup (newToOld) for sorted flush reordering");
             }
             this.mapping = mapping;
+            this.rowIdToPurge = rowIdToPurge;
         }
 
         @Override
@@ -545,7 +607,7 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
             }
             MergeSpecification spec = new MergeSpecification();
             if (mapping != null) {
-                spec.add(new ReorderingOneMerge(segments, mapping));
+                spec.add(new ReorderingOneMerge(segments, mapping, rowIdToPurge));
             } else {
                 spec.add(new MergePolicy.OneMerge(segments));
             }
@@ -565,10 +627,12 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
      */
     static class ReorderingOneMerge extends MergePolicy.OneMerge {
         private final RowIdMapping mapping;
+        private final int rowIdToPurge;
 
-        ReorderingOneMerge(List<SegmentCommitInfo> segments, RowIdMapping mapping) {
+        ReorderingOneMerge(List<SegmentCommitInfo> segments, RowIdMapping mapping, int rowIdToPurge) {
             super(segments);
             this.mapping = mapping;
+            this.rowIdToPurge = rowIdToPurge;
         }
 
         @Override
@@ -576,17 +640,23 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
             return new Sorter.DocMap() {
                 @Override
                 public int oldToNew(int docID) {
+                    if (docID == rowIdToPurge) {
+                        return rowIdToPurge;
+                    }
                     return (int) mapping.getNewRowId(docID, RowIdMapping.SINGLE_GEN);
                 }
 
                 @Override
                 public int newToOld(int docID) {
+                    if (docID == rowIdToPurge) {
+                        return rowIdToPurge;
+                    }
                     return (int) mapping.getOldRowId(docID);
                 }
 
                 @Override
                 public int size() {
-                    return mapping.size();
+                    return mapping.size() + (rowIdToPurge != -1 ? 1 : 0);
                 }
             };
         }
@@ -655,7 +725,10 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
         } catch (Exception e) {
             logger.warn("Failed to close directory for generation[{}]: {}", writerGeneration, e);
         }
-        IOUtils.rm(tempDirectory);
+        if (flushed == false) {
+            IOUtils.rm(tempDirectory);
+        }
+        state = WriterState.CLOSED;
     }
 
     /**

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterSortedFlushTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterSortedFlushTests.java
@@ -539,12 +539,12 @@ public class LuceneWriterSortedFlushTests extends OpenSearchTestCase {
         final int override = maxBufferedDocsOverride;
         return new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), null) {
             @Override
-            double ramBufferSizeMB() {
+            protected double ramBufferSizeMB() {
                 return 1024.0;
             }
 
             @Override
-            int maxBufferedDocs() {
+            protected int maxBufferedDocs() {
                 return override;
             }
         };

--- a/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/test/java/org/opensearch/be/lucene/index/LuceneWriterTests.java
@@ -19,6 +19,9 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.util.BytesRef;
@@ -355,5 +358,68 @@ public class LuceneWriterTests extends OpenSearchTestCase {
             () -> writer.deleteDocument(new DeleteInput("_id", new BytesRef("1"), 1L))
         );
         assertTrue(e.getMessage().contains("deleteDocument is not supported"));
+    }
+
+    /**
+     * Rollback path with the indexSort branch (LogByteSizeMergePolicy + IndexSort). Here
+     * forceMerge actually rewrites the segment, so the tombstone is physically expunged
+     * and maxDoc equals the live row count.
+     */
+    public void testRollbackInIndexSortBranchExpungesTombstone() throws IOException {
+        Path baseDir = createTempDir();
+        Sort indexSort = new Sort(new SortedNumericSortField(LuceneDocumentInput.ROW_ID_FIELD, SortField.Type.LONG));
+        try (LuceneWriter writer = new LuceneWriter(1L, 0L, dataFormat, baseDir, null, Codec.getDefault(), indexSort)) {
+            MappedFieldType textField = mockTextField("content");
+            for (int i = 0; i < 5; i++) {
+                LuceneDocumentInput input = new LuceneDocumentInput();
+                input.addField(textField, "value " + i);
+                input.setRowId(LuceneDocumentInput.ROW_ID_FIELD, i);
+                writer.addDoc(input);
+            }
+            LuceneDocumentInput rollback = new LuceneDocumentInput();
+            rollback.addField(textField, "to-rollback");
+            rollback.setRowId(LuceneDocumentInput.ROW_ID_FIELD, 5);
+            writer.addDoc(rollback);
+            writer.rollbackTo(5);
+
+            FileInfos fileInfos = writer.flush(FlushInput.EMPTY);
+            WriterFileSet wfs = fileInfos.getWriterFileSet(dataFormat).get();
+            assertThat("WriterFileSet must report live row count only", wfs.numRows(), equalTo(5L));
+
+            try (NIOFSDirectory dir = new NIOFSDirectory(Path.of(wfs.directory())); IndexReader reader = DirectoryReader.open(dir)) {
+                assertThat(
+                    "forceMerge under real merge policy must expunge tombstone",
+                    reader.leaves().get(0).reader().maxDoc(),
+                    equalTo(5)
+                );
+                assertThat(reader.numDocs(), equalTo(5));
+            }
+        }
+    }
+
+    /**
+     * After rollbackLastDoc the writer must transition to RETIRED_FLUSHABLE — further addDoc
+     * calls are rejected. Holds for both no-sort and indexSort branches.
+     */
+    public void testRollbackRetiresWriterInBothBranches() throws IOException {
+        Path baseDir = createTempDir();
+        Sort indexSort = new Sort(new SortedNumericSortField(LuceneDocumentInput.ROW_ID_FIELD, SortField.Type.LONG));
+        for (Sort sort : new Sort[] { null, indexSort }) {
+            try (LuceneWriter writer = new LuceneWriter(1L, 0L, dataFormat, createTempDir(), null, Codec.getDefault(), sort)) {
+                MappedFieldType textField = mockTextField("content");
+                LuceneDocumentInput input = new LuceneDocumentInput();
+                input.addField(textField, "v");
+                input.setRowId(LuceneDocumentInput.ROW_ID_FIELD, 0);
+                writer.addDoc(input);
+                writer.rollbackTo(0);
+
+                assertThat("rollback must retire the writer (sort=" + sort + ")", writer.state().toString(), equalTo("RETIRED_FLUSHABLE"));
+
+                LuceneDocumentInput nextDoc = new LuceneDocumentInput();
+                nextDoc.addField(textField, "should-fail");
+                nextDoc.setRowId(LuceneDocumentInput.ROW_ID_FIELD, 0);
+                expectThrows(IllegalStateException.class, () -> writer.addDoc(nextDoc));
+            }
+        }
     }
 }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeCommitterFailureIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeCommitterFailureIT.java
@@ -1,0 +1,204 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.engine.DataFormatAwareEngine;
+import org.opensearch.index.engine.FlushFailedEngineException;
+import org.opensearch.index.engine.dataformat.stub.FileBackedDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.InMemoryCommitter;
+import org.opensearch.index.engine.exec.commit.CommitterFactory;
+import org.opensearch.index.shard.IndexShardTestCase;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.plugins.EnginePlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * IT for committer failure injection. Uses {@link FailureInjectingCommitterPlugin} which provides
+ * an {@link InMemoryCommitter} with configurable commit failures via static supplier.
+ * <p>
+ * Tests:
+ * <ul>
+ *   <li>{@code testCommitCorruptionFailsEngine} — CorruptIndexException during commit fails the engine</li>
+ *   <li>{@code testCommitIOExceptionEngineStaysOpen} — plain IOException (disk full) during commit,
+ *       engine stays open, retry succeeds</li>
+ *   <li>{@code testCommitFailureThenRecovery} — commit fails, clear failure, new docs indexed and flushed</li>
+ * </ul>
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1)
+public class CompositeCommitterFailureIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX_NAME = "test-committer-failure";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(FileBackedDataFormatPlugin.class, CompositeDataFormatPlugin.class, FailureInjectingCommitterPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .build();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        FailureInjectingCommitterPlugin.clearFailure();
+        FileBackedDataFormatPlugin.clearFailure();
+        FileBackedDataFormatPlugin.setDataDirectory(createTempDir("filebacked"));
+        super.setUp();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        FailureInjectingCommitterPlugin.clearFailure();
+        FileBackedDataFormatPlugin.clearFailure();
+        super.tearDown();
+    }
+
+    /** CorruptIndexException during commit → engine fails. */
+    public void testCommitCorruptionFailsEngine() throws Exception {
+        createCompositeIndex();
+        indexDocs(5);
+
+        FailureInjectingCommitterPlugin.setCommitFailure(
+            () -> new org.apache.lucene.index.CorruptIndexException("simulated corruption", "test")
+        );
+
+        try {
+            flush();
+        } catch (FlushFailedEngineException e) {
+            assertTrue("cause should be CorruptIndexException", e.getCause() instanceof org.apache.lucene.index.CorruptIndexException);
+        }
+
+        FailureInjectingCommitterPlugin.clearFailure();
+
+        // Engine should be failed — subsequent ops throw
+        expectThrows(Exception.class, () -> indexDocs(1));
+    }
+
+    /** Plain IOException during commit → engine stays open, retry succeeds. */
+    public void testCommitIOExceptionEngineStaysOpen() throws Exception {
+        createCompositeIndex();
+        indexDocs(5);
+
+        FailureInjectingCommitterPlugin.setCommitFailure(() -> new IOException("No space left on device"));
+
+        try {
+            flush();
+        } catch (FlushFailedEngineException e) {
+            assertTrue("cause should be IOException", e.getCause() instanceof IOException);
+        }
+
+        // Engine should still be open — verify by indexing
+        FailureInjectingCommitterPlugin.clearFailure();
+        indexDocs(3);
+        // Retry flush should succeed
+        flush();
+        assertEquals(7, getEngine().getSeqNoStats(-1).getMaxSeqNo());
+    }
+
+    /** Commit fails, clear failure, new flush succeeds with all data. */
+    public void testCommitFailureThenRecovery() throws Exception {
+        createCompositeIndex();
+        indexDocs(5);
+        flush();
+
+        indexDocs(5);
+
+        FailureInjectingCommitterPlugin.setCommitFailure(() -> new IOException("disk full"));
+        try {
+            flush();
+        } catch (OpenSearchException e) {
+            assertTrue("should contain IOException", e.getMessage().contains("disk full") || e.getCause() instanceof IOException);
+        }
+
+        FailureInjectingCommitterPlugin.clearFailure();
+        indexDocs(2);
+        flush();
+        // 5 + 5 + 2 = 12 ops
+        assertEquals(11, getEngine().getSeqNoStats(-1).getMaxSeqNo());
+    }
+
+    // --- Helpers ---
+
+    private void createCompositeIndex() {
+        createIndex(
+            INDEX_NAME,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put("index.pluggable.dataformat.enabled", true)
+                .put("index.pluggable.dataformat", "composite")
+                .put("index.composite.primary_data_format", FileBackedDataFormatPlugin.FORMAT_NAME)
+                .putList("index.composite.secondary_data_formats")
+                .build()
+        );
+        ensureGreen(INDEX_NAME);
+    }
+
+    private DataFormatAwareEngine getEngine() {
+        String nodeId = clusterService().state().routingTable().index(INDEX_NAME).shard(0).primaryShard().currentNodeId();
+        String nodeName = clusterService().state().nodes().get(nodeId).getName();
+        IndexService svc = internalCluster().getInstance(IndicesService.class, nodeName).indexServiceSafe(resolveIndex(INDEX_NAME));
+        return (DataFormatAwareEngine) IndexShardTestCase.getIndexer(svc.getShard(0));
+    }
+
+    private void indexDocs(int count) {
+        for (int i = 0; i < count; i++) {
+            assertEquals(RestStatus.CREATED, client().prepareIndex(INDEX_NAME).setSource("field", "v" + i).get().status());
+        }
+    }
+
+    private void flush() {
+        client().admin().indices().prepareFlush(INDEX_NAME).setForce(true).get();
+    }
+
+    // --- FailureInjectingCommitterPlugin ---
+
+    public static class FailureInjectingCommitterPlugin extends Plugin implements EnginePlugin {
+        private static final AtomicReference<Supplier<Exception>> commitFailure = new AtomicReference<>();
+
+        public static void setCommitFailure(Supplier<Exception> failure) {
+            commitFailure.set(failure);
+        }
+
+        public static void clearFailure() {
+            commitFailure.set(null);
+        }
+
+        @Override
+        public Optional<CommitterFactory> getCommitterFactory(org.opensearch.index.IndexSettings indexSettings) {
+            return Optional.of(config -> {
+                InMemoryCommitter committer = new InMemoryCommitter(config.engineConfig().getStore());
+                // Wire the static failure supplier so it's checked on every commit
+                committer.setCommitFailure(() -> {
+                    Supplier<Exception> failure = commitFailure.get();
+                    return failure != null ? failure.get() : null;
+                });
+                return committer;
+            });
+        }
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEngineCreationFailureIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEngineCreationFailureIT.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.engine.dataformat.stub.FileBackedDataFormatPlugin;
+import org.opensearch.index.engine.dataformat.stub.InMemoryCommitter;
+import org.opensearch.index.engine.exec.commit.CommitterFactory;
+import org.opensearch.plugins.EnginePlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Verifies that persistent engine creation failure (e.g., disk full during committer init)
+ * causes the shard to go UNASSIGNED after max allocation retries, not loop endlessly.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1)
+public class CompositeEngineCreationFailureIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX_NAME = "test-creation-failure";
+    private static final AtomicBoolean failOnCreation = new AtomicBoolean(false);
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(FileBackedDataFormatPlugin.class, CompositeDataFormatPlugin.class, FailOnCreationCommitterPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .build();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        failOnCreation.set(false);
+        FileBackedDataFormatPlugin.setDataDirectory(createTempDir("filebacked"));
+        super.setUp();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        failOnCreation.set(false);
+        super.tearDown();
+    }
+
+    public void testEngineCreationFailureShardGoesUnassigned() throws Exception {
+        failOnCreation.set(true);
+
+        createIndex(
+            INDEX_NAME,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put("index.pluggable.dataformat.enabled", true)
+                .put("index.pluggable.dataformat", "composite")
+                .put("index.composite.primary_data_format", FileBackedDataFormatPlugin.FORMAT_NAME)
+                .putList("index.composite.secondary_data_formats")
+                .build()
+        );
+
+        // Shard should go UNASSIGNED after max retries — not loop endlessly
+        assertBusy(() -> {
+            ShardRouting primary = clusterService().state().routingTable().index(INDEX_NAME).shard(0).primaryShard();
+            assertTrue("shard should be unassigned after persistent creation failure", primary.unassigned());
+        }, 2, java.util.concurrent.TimeUnit.MINUTES);
+    }
+
+    public static class FailOnCreationCommitterPlugin extends Plugin implements EnginePlugin {
+        @Override
+        public Optional<CommitterFactory> getCommitterFactory(org.opensearch.index.IndexSettings indexSettings) {
+            return Optional.of(config -> {
+                if (failOnCreation.get()) {
+                    throw new IOException("simulated engine creation failure (disk full)");
+                }
+                return new InMemoryCommitter(config.engineConfig().getStore());
+            });
+        }
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEngineHelper.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEngineHelper.java
@@ -1,0 +1,194 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.opensearch.be.lucene.LuceneReader;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.concurrent.GatedCloseable;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexService;
+import org.opensearch.index.engine.DataFormatAwareEngine;
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DataFormatRegistry;
+import org.opensearch.index.engine.exec.IndexReaderProvider;
+import org.opensearch.index.engine.exec.Segment;
+import org.opensearch.index.engine.exec.WriterFileSet;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.shard.IndexShardTestCase;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.plugins.PluginsService;
+import org.opensearch.test.InternalTestCluster;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Shared utility methods for composite engine integration tests.
+ * Stateless — all methods take explicit parameters so any IT can use them.
+ */
+public final class CompositeEngineHelper {
+
+    private CompositeEngineHelper() {}
+
+    // -- Index creation --
+
+    public static void createCompositeIndex(
+        OpenSearchIntegTestCase testCase,
+        String indexName,
+        String primaryFormat,
+        String... secondaryFormats
+    ) {
+        Settings.Builder sb = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", primaryFormat);
+        sb.putList("index.composite.secondary_data_formats", secondaryFormats);
+        testCase.createIndex(indexName, sb.build());
+        testCase.ensureGreen(indexName);
+    }
+
+    public static void createCompositeIndexWithMapping(
+        OpenSearchIntegTestCase testCase,
+        String indexName,
+        String primaryFormat,
+        Settings extraSettings,
+        String... secondaryFormats
+    ) {
+        Settings.Builder sb = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", primaryFormat)
+            .put(extraSettings);
+        sb.putList("index.composite.secondary_data_formats", secondaryFormats);
+        OpenSearchIntegTestCase.client()
+            .admin()
+            .indices()
+            .prepareCreate(indexName)
+            .setSettings(sb)
+            .setMapping("field_keyword", "type=keyword", "field_number", "type=integer")
+            .get();
+        testCase.ensureGreen(indexName);
+    }
+
+    // -- Engine access --
+
+    public static IndexShard getPrimaryShard(ClusterService clusterService, InternalTestCluster cluster, String indexName) {
+        ClusterState state = clusterService.state();
+        String nodeId = state.routingTable().index(indexName).shard(0).primaryShard().currentNodeId();
+        String nodeName = state.nodes().get(nodeId).getName();
+        IndexService svc = cluster.getInstance(IndicesService.class, nodeName)
+            .indexServiceSafe(state.metadata().index(indexName).getIndex());
+        return svc.getShard(0);
+    }
+
+    public static DataFormatAwareEngine getEngine(ClusterService clusterService, InternalTestCluster cluster, String indexName) {
+        return (DataFormatAwareEngine) IndexShardTestCase.getIndexer(getPrimaryShard(clusterService, cluster, indexName));
+    }
+
+    // -- Row counts --
+
+    /**
+     * Returns the total live-doc count for a format by querying its actual reader.
+     *
+     * <p>For Lucene we use {@link DirectoryReader#numDocs()} which excludes soft-deleted
+     * docs (e.g., docs removed by {@code rollbackLastDoc}). For Parquet — which has no
+     * delete primitive in this codebase yet — we fall back to summing
+     * {@link WriterFileSet#numRows()} from the catalog snapshot, since the file footer's
+     * numRows IS the authoritative source for a Parquet file.
+     */
+    public static long getRowCount(ClusterService clusterService, InternalTestCluster cluster, String indexName, String formatName)
+        throws IOException {
+        DataFormatAwareEngine engine = getEngine(clusterService, cluster, indexName);
+        if ("lucene".equals(formatName)) {
+            String nodeId = clusterService.state().routingTable().index(indexName).shard(0).primaryShard().currentNodeId();
+            String nodeName = clusterService.state().nodes().get(nodeId).getName();
+            DataFormat luceneFormat = new DataFormatRegistry(cluster.getInstance(PluginsService.class, nodeName)).format(formatName);
+            try (GatedCloseable<IndexReaderProvider.Reader> ref = engine.acquireReader()) {
+                Object raw = ref.get().reader(luceneFormat);
+                if (raw == null) {
+                    return 0L;
+                }
+                if (raw instanceof LuceneReader == false) {
+                    throw new IllegalStateException(
+                        "Expected LuceneReader for format [" + formatName + "] but got " + raw.getClass().getName()
+                    );
+                }
+                return ((LuceneReader) raw).directoryReader().numDocs();
+            }
+        }
+        // Parquet path: file-footer numRows is the source of truth (no deletes for parquet today).
+        try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+            return ref.get().getSearchableFiles(formatName).stream().mapToLong(WriterFileSet::numRows).sum();
+        }
+    }
+
+    /**
+     * Engine-only overload — used when the caller already has the engine and only needs the
+     * Parquet/file-metadata path. The Lucene branch routes through
+     * {@link #getRowCount(ClusterService, InternalTestCluster, String, String)} which can
+     * resolve {@link DataFormat} via {@link DataFormatRegistry}.
+     */
+    public static long getRowCount(DataFormatAwareEngine engine, String formatName) throws IOException {
+        try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+            return ref.get().getSearchableFiles(formatName).stream().mapToLong(WriterFileSet::numRows).sum();
+        }
+    }
+
+    // -- Indexing --
+
+    public static void indexDocs(OpenSearchIntegTestCase testCase, String indexName, int count) {
+        for (int i = 0; i < count; i++) {
+            assertEquals(
+                RestStatus.CREATED,
+                OpenSearchIntegTestCase.client()
+                    .prepareIndex(indexName)
+                    .setSource(
+                        "field_keyword",
+                        OpenSearchIntegTestCase.randomAlphaOfLength(10),
+                        "field_number",
+                        OpenSearchIntegTestCase.randomIntBetween(0, 1000)
+                    )
+                    .get()
+                    .status()
+            );
+        }
+    }
+
+    // -- Flush --
+
+    public static void flush(OpenSearchIntegTestCase testCase, String indexName) {
+        OpenSearchIntegTestCase.client().admin().indices().prepareFlush(indexName).setForce(true).setWaitIfOngoing(true).get();
+    }
+
+    // -- Assertions --
+
+    public static void assertPerSegmentRowCountsMatch(DataFormatAwareEngine engine, String format1, String format2) throws IOException {
+        try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+            for (Segment seg : ref.get().getSegments()) {
+                WriterFileSet wfs1 = seg.dfGroupedSearchableFiles().get(format1);
+                WriterFileSet wfs2 = seg.dfGroupedSearchableFiles().get(format2);
+                assertNotNull("segment gen=" + seg.generation() + " missing " + format1, wfs1);
+                assertNotNull("segment gen=" + seg.generation() + " missing " + format2, wfs2);
+                assertEquals("segment gen=" + seg.generation() + " row counts must match", wfs1.numRows(), wfs2.numRows());
+            }
+        }
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEngineLuceneFailureCheckpointIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEngineLuceneFailureCheckpointIT.java
@@ -1,0 +1,161 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
+import org.opensearch.test.InternalSettingsPlugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Verifies seqNo / checkpoint correctness on the composite engine when a Lucene secondary
+ * write hits a {@link org.apache.lucene.store.Directory}-level I/O fault. The IOException
+ * is a tragic event: IndexWriter self-closes, DFAE fails the engine, the cluster fails the
+ * primary, the replica is promoted, and the bulk client retries the failed doc on the new
+ * primary.
+ *
+ * <p>Cluster: 2 data nodes, 1 shard, 1 replica, segment replication, remote-store-backed,
+ * with Lucene wrapped by {@link FailableLuceneDataFormatPlugin}. After flush + explicit GCP
+ * sync, primary {@code maxSeqNo}, processed/persisted LCP, and lastSyncedGCP converge to 2
+ * and the replica's processed LCP catches up.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class CompositeEngineLuceneFailureCheckpointIT extends RemoteStoreBaseIntegTestCase {
+
+    private static final String INDEX_NAME = "composite-lucene-failure-idx";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Stream.concat(
+            super.nodePlugins().stream(),
+            Stream.of(
+                ArrowBasePlugin.class,
+                ParquetDataFormatPlugin.class,
+                CompositeDataFormatPlugin.class,
+                FailableLuceneDataFormatPlugin.class,
+                DataFusionPlugin.class,
+                InternalSettingsPlugin.class
+            )
+        ).collect(Collectors.toList());
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .build();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        FailableLuceneDataFormatPlugin.clearFailure();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        FailableLuceneDataFormatPlugin.clearFailure();
+        super.tearDown();
+    }
+
+    private Settings dfaIndexSettings() {
+        return Settings.builder()
+            .put(remoteStoreIndexSettings(1, 1))
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", List.of("lucene"))
+            // Tighten the periodic GCP sync so the post-failover assertion doesn't race a
+            // 30s default timer waiting for the replica to catch up.
+            .put("index.global_checkpoint_sync.interval", "1s")
+            .build();
+    }
+
+    private String primaryNodeName() {
+        String nodeId = getClusterState().routingTable().index(INDEX_NAME).shard(0).primaryShard().currentNodeId();
+        return getClusterState().nodes().get(nodeId).getName();
+    }
+
+    private String replicaNodeName() {
+        String nodeId = getClusterState().routingTable()
+            .index(INDEX_NAME)
+            .shard(0)
+            .replicaShards()
+            .stream()
+            .filter(s -> s.started())
+            .findFirst()
+            .orElseThrow()
+            .currentNodeId();
+        return getClusterState().nodes().get(nodeId).getName();
+    }
+
+    public void testCheckpointsConvergeAfterLuceneDirectoryFault() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(2);
+        client().admin().indices().prepareCreate(INDEX_NAME).setSettings(dfaIndexSettings()).get();
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        BulkItemResponse doc1 = indexOne("1", "value-1");
+        assertFalse("doc 1 must succeed: " + doc1.getFailureMessage(), doc1.isFailed());
+
+        // Arm a Directory write fault on the next op. Lucene's flush triggered by doc 2's
+        // addDoc hits the fault, IndexWriter goes tragic, engine fails, primary fails over
+        // to the replica, and the bulk client retries doc 2 on the new primary.
+        FailableLuceneDataFormatPlugin.failOnNthWrite(0);
+        BulkItemResponse doc2 = indexOne("2", "value-2");
+        FailableLuceneDataFormatPlugin.clearFailure();
+        assertFalse("doc 2 must ultimately succeed via failover retry: " + doc2.getFailureMessage(), doc2.isFailed());
+        ensureGreen(INDEX_NAME);
+
+        BulkItemResponse doc3 = indexOne("3", "value-3");
+        assertFalse("doc 3 must succeed: " + doc3.getFailureMessage(), doc3.isFailed());
+
+        client().admin().indices().prepareFlush(INDEX_NAME).get();
+        client().admin().indices().prepareRefresh(INDEX_NAME).get();
+        // Force the GCP sync immediately instead of waiting for the periodic timer (default
+        // 30s) — the new primary's lastKnownGCP has advanced past what it propagated to the
+        // replica during failover and we want the replica to catch up before assertions.
+        getIndexShard(primaryNodeName(), INDEX_NAME).maybeSyncGlobalCheckpoint("post-failover-test-sync");
+
+        assertBusy(() -> {
+            IndexShard p = getIndexShard(primaryNodeName(), INDEX_NAME);
+            IndexShard r = getIndexShard(replicaNodeName(), INDEX_NAME);
+            assertEquals("primary maxSeqNo", 2L, p.seqNoStats().getMaxSeqNo());
+            assertEquals("primary processedLCP", 2L, p.getProcessedLocalCheckpoint());
+            assertEquals("primary persistedLCP", 2L, p.getLocalCheckpoint());
+            assertEquals("primary lastSyncedGCP catches up to LCP", p.getLocalCheckpoint(), p.getLastSyncedGlobalCheckpoint());
+            assertEquals("replica lastProcessedLCP matches primary", p.getProcessedLocalCheckpoint(), r.getProcessedLocalCheckpoint());
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    private BulkItemResponse indexOne(String id, String value) {
+        BulkResponse bulk = client().prepareBulk().add(client().prepareIndex(INDEX_NAME).setId(id).setSource("field", value)).get();
+        assertEquals(1, bulk.getItems().length);
+        return bulk.getItems()[0];
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEngineLuceneOversizedTermIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEngineLuceneOversizedTermIT.java
@@ -1,0 +1,259 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.apache.lucene.index.IndexWriter;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.engine.DataFormatAwareEngine;
+import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterState;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
+import org.opensearch.test.InternalSettingsPlugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Exercises the per-doc failure path on a parquet-primary / lucene-secondary composite index
+ * when Lucene's {@link IndexWriter#MAX_TERM_LENGTH} (32766 UTF-8 bytes) rejects a doc with
+ * {@link IllegalArgumentException}. No fault injection — a 33000-char {@code keyword} value
+ * trips the limit naturally.
+ *
+ * <p>Two variants cover both branches of {@code LuceneWriter#flush}: without index sort
+ * (plain force-merge) and with index sort (RowIdMapping-driven reorder merge).
+ *
+ * <p>Asserts: engine stays open, primary maxSeqNo, processed/persisted LCP, and lastSyncedGCP
+ * all converge to 2 (the failed doc's seqNo backfilled by a Translog.NoOp), replica
+ * processedLCP catches up, and parquet/lucene each hold the 2 successful docs.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class CompositeEngineLuceneOversizedTermIT extends RemoteStoreBaseIntegTestCase {
+
+    private static final String INDEX_NAME = "composite-lucene-oversized-term-idx";
+    /** 33000 chars > MAX_TERM_LENGTH (32766 bytes); ASCII so byte-length == char-length. */
+    private static final int OVERSIZED_TERM_CHARS = 33000;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Stream.concat(
+            super.nodePlugins().stream(),
+            Stream.of(
+                ArrowBasePlugin.class,
+                ParquetDataFormatPlugin.class,
+                CompositeDataFormatPlugin.class,
+                LucenePlugin.class,
+                DataFusionPlugin.class,
+                InternalSettingsPlugin.class
+            )
+        ).collect(Collectors.toList());
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .build();
+    }
+
+    private Settings dfaIndexSettings(boolean withIndexSort) {
+        Settings.Builder sb = Settings.builder()
+            .put(remoteStoreIndexSettings(1, 1))
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", List.of("lucene"))
+            // Tighten the periodic GCP sync so the post-failover assertion doesn't race a
+            // 30s default timer waiting for the replica to catch up.
+            .put("index.global_checkpoint_sync.interval", "1s");
+        if (withIndexSort) {
+            // Forces parquet to compute a RowIdMapping on flush, which drives the secondary
+            // Lucene flush down the ReorderingMergePolicy branch.
+            sb.putList("index.sort.field", "sort_key").putList("index.sort.order", "asc");
+        }
+        return sb.build();
+    }
+
+    private void createIndex(boolean withIndexSort) {
+        // keyword field with default ignore_above forwards the entire string as one token,
+        // so an oversized value reaches Lucene's per-term length check verbatim.
+        client().admin()
+            .indices()
+            .prepareCreate(INDEX_NAME)
+            .setSettings(dfaIndexSettings(withIndexSort))
+            .setMapping("field", "type=keyword", "sort_key", "type=long")
+            .get();
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+    }
+
+    private String primaryNodeName() {
+        String nodeId = getClusterState().routingTable().index(INDEX_NAME).shard(0).primaryShard().currentNodeId();
+        return getClusterState().nodes().get(nodeId).getName();
+    }
+
+    private String replicaNodeName() {
+        String nodeId = getClusterState().routingTable()
+            .index(INDEX_NAME)
+            .shard(0)
+            .replicaShards()
+            .stream()
+            .filter(s -> s.started())
+            .findFirst()
+            .orElseThrow()
+            .currentNodeId();
+        return getClusterState().nodes().get(nodeId).getName();
+    }
+
+    public void testOversizedTermProducesNoOpAndEngineStaysHealthy() throws Exception {
+        runOversizedTermScenario(/* withIndexSort= */ false);
+    }
+
+    public void testOversizedTermWithIndexSortProducesNoOpAndEngineStaysHealthy() throws Exception {
+        runOversizedTermScenario(/* withIndexSort= */ true);
+    }
+
+    private void runOversizedTermScenario(boolean withIndexSort) throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(2);
+        createIndex(withIndexSort);
+
+        // Doc 1: succeeds.
+        IndexResponse ok1 = client().prepareIndex(INDEX_NAME).setId("1").setSource("field", "value-1", "sort_key", 10L).get();
+        assertEquals(RestStatus.CREATED, ok1.status());
+
+        // Doc 2: a single oversized keyword token. Lucene's IndexingChain throws
+        // IllegalArgumentException from termsHashPerField.add — no tragic event, IndexWriter
+        // remains open, the bulk item surfaces as a per-doc failure.
+        String oversized = "x".repeat(OVERSIZED_TERM_CHARS);
+        BulkResponse bulk = client().prepareBulk()
+            .add(client().prepareIndex(INDEX_NAME).setId("2").setSource("field", oversized, "sort_key", 5L))
+            .get();
+        assertEquals(1, bulk.getItems().length);
+        BulkItemResponse failed = bulk.getItems()[0];
+        assertTrue("oversized term doc must fail: " + failed.getFailureMessage(), failed.isFailed());
+        assertNotNull("failure message should be present", failed.getFailureMessage());
+        assertTrue(
+            "failure should mention immense term: " + failed.getFailureMessage(),
+            failed.getFailureMessage().contains("immense term") || failed.getFailureMessage().contains("max length")
+        );
+
+        // Engine must still be open: an oversized-term IAE is a per-doc rejection, not a
+        // tragic event. The Lucene secondary writer transitions ACTIVE→PENDING_ROLLBACK, the composite
+        // rolls back the parquet primary, and DFAE retires the writer to RETIRED_FLUSHABLE
+        // (its buffered N-1 docs flushed into pendingSegments). The engine remains usable —
+        // commitStats() throws AlreadyClosedException if the engine has failed/closed.
+        DataFormatAwareEngine engineAfterFailure = CompositeEngineHelper.getEngine(clusterService(), internalCluster(), INDEX_NAME);
+        assertNotNull("engine must still hold a valid commit after per-doc IAE", engineAfterFailure.commitStats());
+
+        // Doc 3: succeeds on the same primary — proves the engine and writer pool recovered.
+        // sort_key=1 is less than doc 1's sort_key=10, so the index-sort variant exercises
+        // a non-trivial RowIdMapping permutation rather than the identity case.
+        IndexResponse ok3 = client().prepareIndex(INDEX_NAME).setId("3").setSource("field", "value-3", "sort_key", 1L).get();
+        assertEquals(RestStatus.CREATED, ok3.status());
+
+        client().admin().indices().prepareFlush(INDEX_NAME).get();
+        client().admin().indices().prepareRefresh(INDEX_NAME).get();
+        // Force the GCP sync immediately instead of waiting for the periodic timer — after
+        // the NoOp + flush there are no further indexing ops to piggyback the new GCP onto a
+        // replication request, and we want to assert state quickly.
+        getIndexShard(primaryNodeName(), INDEX_NAME).maybeSyncGlobalCheckpoint("post-noop-test-sync");
+
+        assertBusy(() -> {
+            IndexShard p = getIndexShard(primaryNodeName(), INDEX_NAME);
+            IndexShard r = getIndexShard(replicaNodeName(), INDEX_NAME);
+            assert p.isActive() : "Primary is not active";
+            assert r.isActive() : "Replica is not active";
+            // Sequence-number bookkeeping: 3 ops attempted (seq 0, 1, 2). The failed doc 2 was
+            // backfilled by a Translog.NoOp at DataFormatAwareEngine.indexIntoEngine, so the
+            // LCP covers the gap and processed/persisted both equal maxSeqNo.
+            assertEquals("primary maxSeqNo", 2L, p.seqNoStats().getMaxSeqNo());
+            assertEquals("primary processedLCP", 2L, p.getProcessedLocalCheckpoint());
+            assertEquals("primary persistedLCP", 2L, p.getLocalCheckpoint());
+            assertEquals("primary lastSyncedGCP catches up to LCP", p.getLocalCheckpoint(), p.getLastSyncedGlobalCheckpoint());
+            assertEquals("replica processedLCP matches primary", p.getProcessedLocalCheckpoint(), r.getProcessedLocalCheckpoint());
+        }, 30, TimeUnit.SECONDS);
+
+        // Cross-format parity on the primary: 2 successful docs in parquet AND in lucene —
+        // the failed doc contributed neither a parquet row nor a lucene live doc.
+        long parquetRows = CompositeEngineHelper.getRowCount(clusterService(), internalCluster(), INDEX_NAME, "parquet");
+        long luceneRows = CompositeEngineHelper.getRowCount(clusterService(), internalCluster(), INDEX_NAME, "lucene");
+        assertEquals("parquet must hold exactly 2 successful docs", 2L, parquetRows);
+        assertEquals("lucene must hold exactly 2 successful docs", 2L, luceneRows);
+    }
+
+    /**
+     * Lucene's docId allocator can't be reversed: after a per-doc IAE the secondary
+     * transitions to RETIRED_FLUSHABLE post-rollback, DFAE retires it (flushes the buffered
+     * N-1 docs, closes the writer, queues the segment in pendingSegments). The pool then
+     * mints a fresh writer for the next doc.
+     *
+     * <p>This test asserts both halves: the writer instance held by the pool after the
+     * failure is <b>different</b> from the one before, and the original writer is
+     * <b>closed</b> (state == CLOSED — its IndexWriter, Directory, and temp dir released).
+     */
+    public void testLuceneFailureReplacesWriterAndClosesOldOne() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(2);
+        createIndex(/* withIndexSort= */ false);
+
+        // Doc 1 mints writer-1 in the pool.
+        assertEquals(
+            RestStatus.CREATED,
+            client().prepareIndex(INDEX_NAME).setId("1").setSource("field", "v1", "sort_key", 10L).get().status()
+        );
+
+        DataFormatAwareEngine engine = CompositeEngineHelper.getEngine(clusterService(), internalCluster(), INDEX_NAME);
+        Writer<?> writerBefore = singleWriter(engine);
+
+        // Doc 2: oversized term → Lucene IAE → RETIRED_FLUSHABLE → DFAE retires + closes.
+        String oversized = "x".repeat(OVERSIZED_TERM_CHARS);
+        BulkResponse bulk = client().prepareBulk()
+            .add(client().prepareIndex(INDEX_NAME).setId("2").setSource("field", oversized, "sort_key", 5L))
+            .get();
+        assertTrue("oversized term doc must fail", bulk.getItems()[0].isFailed());
+
+        // Doc 3 forces the pool to mint a fresh writer (the old one is gone).
+        assertEquals(
+            RestStatus.CREATED,
+            client().prepareIndex(INDEX_NAME).setId("3").setSource("field", "v3", "sort_key", 1L).get().status()
+        );
+
+        Writer<?> writerAfter = singleWriter(engine);
+        assertNotSame("Lucene retirement must replace the writer instance in the pool", writerBefore, writerAfter);
+        assertEquals("the retired writer must be CLOSED — resources released", WriterState.CLOSED, writerBefore.state());
+        assertEquals("the new writer must be ACTIVE", WriterState.ACTIVE, writerAfter.state());
+    }
+
+    private static Writer<?> singleWriter(DataFormatAwareEngine engine) {
+        List<Writer<?>> writers = new ArrayList<>();
+        engine.getWriterPool().forEach(writers::add);
+        assertEquals("expected exactly one writer in pool", 1, writers.size());
+        return writers.get(0);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEngineParquetFailureCheckpointIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEngineParquetFailureCheckpointIT.java
@@ -1,0 +1,235 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.engine.DataFormatAwareEngine;
+import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterState;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
+import org.opensearch.test.InternalSettingsPlugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Exercises the parquet-primary self-rollback path end-to-end. Sequence:
+ * <ol>
+ *   <li>Doc 1 with field {@code f1} succeeds.</li>
+ *   <li>Arm {@link FailableParquetDataFormatPlugin#armSchemaSuppression()} and add a new
+ *       field {@code f2} via put-mapping. The parquet writer's mapping-version update is
+ *       dropped, so its schema stays at v1.</li>
+ *   <li>Doc 2 carries {@code f2}. {@code VSRManager.addDocument} raises
+ *       {@link org.opensearch.parquet.writer.MismatchedInputException} (no {@code f2} vector
+ *       on the active VSR). {@code ParquetWriter.addDoc} catches it (state PENDING_ROLLBACK → returns
+ *       {@code WriteResult.Failure}), the composite drives {@code rollbackLastDoc} which
+ *       no-ops in the VSR (since the doc never landed) and restores ACTIVE.</li>
+ *   <li>Flush — retires the v1 writer, drains pending segments, mints a fresh writer.</li>
+ *   <li>Clear suppression. Doc 3 with {@code f1} succeeds on the new writer (no schema
+ *       mismatch since {@code f1} is in every schema version).</li>
+ * </ol>
+ *
+ * <p>Asserts: engine stays open, primary maxSeqNo, processed/persisted LCP, and lastSyncedGCP
+ * converge to 2 (failed doc backfilled by Translog.NoOp), replica processedLCP catches up,
+ * and parquet/lucene each hold the 2 successful docs.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class CompositeEngineParquetFailureCheckpointIT extends RemoteStoreBaseIntegTestCase {
+
+    private static final String INDEX_NAME = "composite-parquet-failure-idx";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Stream.concat(
+            super.nodePlugins().stream(),
+            Stream.of(
+                ArrowBasePlugin.class,
+                FailableParquetDataFormatPlugin.class,
+                CompositeDataFormatPlugin.class,
+                LucenePlugin.class,
+                DataFusionPlugin.class,
+                InternalSettingsPlugin.class
+            )
+        ).collect(Collectors.toList());
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .build();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        FailableParquetDataFormatPlugin.clearFailure();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        FailableParquetDataFormatPlugin.clearFailure();
+        super.tearDown();
+    }
+
+    private Settings dfaIndexSettings() {
+        return Settings.builder()
+            .put(remoteStoreIndexSettings(1, 1))
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", List.of("lucene"))
+            // Tighten the periodic GCP sync so the post-failure assertion doesn't race a
+            // 30s default timer waiting for the replica to catch up.
+            .put("index.global_checkpoint_sync.interval", "1s")
+            .build();
+    }
+
+    private String primaryNodeName() {
+        String nodeId = getClusterState().routingTable().index(INDEX_NAME).shard(0).primaryShard().currentNodeId();
+        return getClusterState().nodes().get(nodeId).getName();
+    }
+
+    private String replicaNodeName() {
+        String nodeId = getClusterState().routingTable()
+            .index(INDEX_NAME)
+            .shard(0)
+            .replicaShards()
+            .stream()
+            .filter(s -> s.started())
+            .findFirst()
+            .orElseThrow()
+            .currentNodeId();
+        return getClusterState().nodes().get(nodeId).getName();
+    }
+
+    public void testParquetAddDocFailureSelfRollsAndCheckpointsConverge() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(2);
+        client().admin().indices().prepareCreate(INDEX_NAME).setSettings(dfaIndexSettings()).setMapping("f1", "type=keyword").get();
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        // Doc 1 with the original mapping (just f1) — succeeds.
+        IndexResponse ok1 = client().prepareIndex(INDEX_NAME).setId("1").setSource("f1", "value-1").get();
+        assertEquals(RestStatus.CREATED, ok1.status());
+
+        // Suppress the parquet writer's mapping-version updates. Then add a new field f2
+        // to the index mapping — the writer's schema stays at v1, so a doc carrying f2 will
+        // hit VSRManager.addDocument with no ParquetField mapping and the production code
+        // raises MismatchedInputException. ParquetWriter.addDoc catches it, briefly
+        // transitions to PENDING_ROLLBACK, runs rollbackLastDoc (no-op against the VSR since the doc
+        // never landed), restores ACTIVE, and returns WriteResult.Failure.
+        FailableParquetDataFormatPlugin.armSchemaSuppression();
+        client().admin().indices().preparePutMapping(INDEX_NAME).setSource("f2", "type=keyword").get();
+
+        BulkResponse bulk = client().prepareBulk().add(client().prepareIndex(INDEX_NAME).setId("2").setSource("f2", "value-2")).get();
+        assertEquals(1, bulk.getItems().length);
+        BulkItemResponse failed = bulk.getItems()[0];
+        assertTrue("doc 2 must surface as a per-item failure: " + failed.getFailureMessage(), failed.isFailed());
+        assertNotNull("failure message should be present", failed.getFailureMessage());
+
+        // Engine must still be open: MismatchedInputException is per-doc, not tragic.
+        // commitStats() throws AlreadyClosedException if the engine has failed/closed.
+        DataFormatAwareEngine engineAfterFailure = CompositeEngineHelper.getEngine(clusterService(), internalCluster(), INDEX_NAME);
+        assertNotNull("engine must still hold a valid commit after parquet per-doc failure", engineAfterFailure.commitStats());
+
+        // Flush the v1-schema writer out so doc 3 mints a fresh writer that reconciles to
+        // the live mapping cleanly. Then drop suppression so future mapping updates propagate.
+        client().admin().indices().prepareFlush(INDEX_NAME).get();
+        FailableParquetDataFormatPlugin.clearFailure();
+
+        // Doc 3 with f1 (already in every schema version) succeeds on the fresh writer —
+        // proves the engine survives a per-doc parquet failure and continues serving writes.
+        IndexResponse ok3 = client().prepareIndex(INDEX_NAME).setId("3").setSource("f1", "value-3").get();
+        assertEquals(RestStatus.CREATED, ok3.status());
+
+        client().admin().indices().prepareFlush(INDEX_NAME).get();
+        client().admin().indices().prepareRefresh(INDEX_NAME).get();
+        getIndexShard(primaryNodeName(), INDEX_NAME).maybeSyncGlobalCheckpoint("post-failure-test-sync");
+
+        assertBusy(() -> {
+            IndexShard p = getIndexShard(primaryNodeName(), INDEX_NAME);
+            IndexShard r = getIndexShard(replicaNodeName(), INDEX_NAME);
+            assert p.isActive() : "Primary is not active";
+            assert r.isActive() : "Replica is not active";
+            assertEquals("primary maxSeqNo", 2L, p.seqNoStats().getMaxSeqNo());
+            assertEquals("primary processedLCP", 2L, p.getProcessedLocalCheckpoint());
+            assertEquals("primary persistedLCP", 2L, p.getLocalCheckpoint());
+            assertEquals("primary lastSyncedGCP catches up to LCP", p.getLocalCheckpoint(), p.getLastSyncedGlobalCheckpoint());
+            assertEquals("replica processedLCP matches primary", p.getProcessedLocalCheckpoint(), r.getProcessedLocalCheckpoint());
+        }, 30, TimeUnit.SECONDS);
+
+        long parquetRows = CompositeEngineHelper.getRowCount(clusterService(), internalCluster(), INDEX_NAME, "parquet");
+        long luceneRows = CompositeEngineHelper.getRowCount(clusterService(), internalCluster(), INDEX_NAME, "lucene");
+        assertEquals("parquet must hold exactly 2 successful docs", 2L, parquetRows);
+        assertEquals("lucene must hold exactly 2 successful docs", 2L, luceneRows);
+    }
+
+    /**
+     * After a parquet self-rollback (Failure → state PENDING_ROLLBACK → composite drives rollback →
+     * state ACTIVE), the writer should remain in the pool and the next doc must land on the
+     * <b>same writer instance</b>. This validates that ACTIVE post-rollback prevents
+     * unnecessary writer churn for fully-reversible failure modes.
+     */
+    public void testParquetSelfRollbackKeepsSameWriterInPool() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(2);
+        client().admin().indices().prepareCreate(INDEX_NAME).setSettings(dfaIndexSettings()).setMapping("f1", "type=keyword").get();
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        // Doc 1 mints writer-1 in the pool.
+        assertEquals(RestStatus.CREATED, client().prepareIndex(INDEX_NAME).setId("1").setSource("f1", "v1").get().status());
+
+        DataFormatAwareEngine engine = CompositeEngineHelper.getEngine(clusterService(), internalCluster(), INDEX_NAME);
+        Writer<?> writerBefore = singleWriter(engine);
+
+        // Force a parquet self-rollback: suppression + new field → MismatchedInputException
+        // → composite rollback → state restored to ACTIVE (no flush, no retire).
+        FailableParquetDataFormatPlugin.armSchemaSuppression();
+        client().admin().indices().preparePutMapping(INDEX_NAME).setSource("f2", "type=keyword").get();
+        BulkResponse bulk = client().prepareBulk().add(client().prepareIndex(INDEX_NAME).setId("fail").setSource("f2", "x")).get();
+        assertTrue("must surface per-item failure", bulk.getItems()[0].isFailed());
+        FailableParquetDataFormatPlugin.clearFailure();
+
+        // Doc 3 (f1, schema v1-compatible) must land on the same writer instance.
+        assertEquals(RestStatus.CREATED, client().prepareIndex(INDEX_NAME).setId("3").setSource("f1", "v3").get().status());
+        Writer<?> writerAfter = singleWriter(engine);
+
+        assertSame("parquet self-rollback must keep the same writer instance in the pool", writerBefore, writerAfter);
+        assertEquals("writer must still be ACTIVE after self-rollback", WriterState.ACTIVE, writerAfter.state());
+    }
+
+    private static Writer<?> singleWriter(DataFormatAwareEngine engine) {
+        List<Writer<?>> writers = new ArrayList<>();
+        engine.getWriterPool().forEach(writers::add);
+        assertEquals("expected exactly one writer in pool", 1, writers.size());
+        return writers.get(0);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEngineParquetFailureDurabilityIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEngineParquetFailureDurabilityIT.java
@@ -1,0 +1,175 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
+import org.opensearch.test.InternalSettingsPlugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Validates durability of the parquet-primary / lucene-secondary composite engine across a
+ * full cluster restart, when a writer is retired mid-stream because of a per-doc failure.
+ *
+ * <p>Three variants exercise different durability paths:
+ * <ul>
+ *   <li>{@code testRetiredWriterDataSurvivesRestart_translogReplayOnly} — no refresh, no
+ *       flush. Restart relies entirely on translog replay rebuilding the segments.</li>
+ *   <li>{@code testRetiredWriterDataSurvivesRestart_refreshOnly} — refresh (segments
+ *       searchable, but no commit). Restart still has to replay the translog from the last
+ *       persisted commit.</li>
+ *   <li>{@code testRetiredWriterDataSurvivesRestart_refreshAndFlush} — refresh + flush
+ *       (catalog snapshot committed). Restart restores from the committed snapshot;
+ *       translog replay is a no-op past the commit point.</li>
+ * </ul>
+ *
+ * <p>Each variant indexes N docs into writer-1, induces a per-doc parquet failure that
+ * retires writer-1, indexes M more docs into writer-2, then full-restarts. After restart,
+ * both formats must report exactly {@code N + M} live docs.
+ *
+ * <p>Cluster: 1 shard, 0 replicas (durability-only test, no replication assertions).
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class CompositeEngineParquetFailureDurabilityIT extends RemoteStoreBaseIntegTestCase {
+
+    private static final String INDEX_NAME = "composite-parquet-durability-idx";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Stream.concat(
+            super.nodePlugins().stream(),
+            Stream.of(
+                ArrowBasePlugin.class,
+                FailableParquetDataFormatPlugin.class,
+                CompositeDataFormatPlugin.class,
+                LucenePlugin.class,
+                DataFusionPlugin.class,
+                InternalSettingsPlugin.class
+            )
+        ).collect(Collectors.toList());
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .build();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        FailableParquetDataFormatPlugin.clearFailure();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        FailableParquetDataFormatPlugin.clearFailure();
+        super.tearDown();
+    }
+
+    private Settings dfaIndexSettings() {
+        return Settings.builder()
+            .put(remoteStoreIndexSettings(0, 1))
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", List.of("lucene"))
+            .build();
+    }
+
+    /** Restart relies entirely on translog replay — no segments committed pre-restart. */
+    public void testRetiredWriterDataSurvivesRestart_translogReplayOnly() throws Exception {
+        runDurabilityScenario(/* refreshBeforeRestart= */ false, /* flushBeforeRestart= */ false);
+    }
+
+    /** Refresh makes segments searchable but doesn't commit; translog replay still required. */
+    public void testRetiredWriterDataSurvivesRestart_refreshOnly() throws Exception {
+        runDurabilityScenario(/* refreshBeforeRestart= */ true, /* flushBeforeRestart= */ false);
+    }
+
+    /** Refresh + flush commits the catalog snapshot; restart restores from commit. */
+    public void testRetiredWriterDataSurvivesRestart_refreshAndFlush() throws Exception {
+        runDurabilityScenario(/* refreshBeforeRestart= */ true, /* flushBeforeRestart= */ true);
+    }
+
+    private void runDurabilityScenario(boolean refreshBeforeRestart, boolean flushBeforeRestart) throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNode();
+        client().admin().indices().prepareCreate(INDEX_NAME).setSettings(dfaIndexSettings()).setMapping("f1", "type=keyword").get();
+        ensureGreen(INDEX_NAME);
+
+        // Phase 1: index N docs with f1 into writer-1.
+        final int initialDocs = 5;
+        for (int i = 0; i < initialDocs; i++) {
+            IndexResponse r = client().prepareIndex(INDEX_NAME).setId("d" + i).setSource("f1", "v" + i).get();
+            assertEquals(RestStatus.CREATED, r.status());
+        }
+
+        // Phase 2: suppress the writer's mapping-version updates and add f2 to the live
+        // mapping. The writer's schema stays at v1, so a doc carrying f2 trips
+        // MismatchedInputException on the parquet primary. Composite rolls back; DFAE
+        // retires writer-1 and queues its flushed segment in pendingSegments.
+        FailableParquetDataFormatPlugin.armSchemaSuppression();
+        client().admin().indices().preparePutMapping(INDEX_NAME).setSource("f2", "type=keyword").get();
+
+        BulkResponse bulk = client().prepareBulk().add(client().prepareIndex(INDEX_NAME).setId("fail").setSource("f2", "value-fail")).get();
+        assertEquals(1, bulk.getItems().length);
+        BulkItemResponse failed = bulk.getItems()[0];
+        assertTrue("oversized-schema doc must surface as a per-item failure: " + failed.getFailureMessage(), failed.isFailed());
+
+        // Phase 3: drop suppression so a fresh writer reconciles to v2 cleanly. Index M
+        // more docs with f1 — these go into writer-2.
+        FailableParquetDataFormatPlugin.clearFailure();
+        final int postRetirementDocs = 3;
+        for (int i = 0; i < postRetirementDocs; i++) {
+            IndexResponse r = client().prepareIndex(INDEX_NAME).setId("p" + i).setSource("f1", "p" + i).get();
+            assertEquals(RestStatus.CREATED, r.status());
+        }
+
+        // Phase 4: optional refresh / flush before restart, per scenario.
+        if (refreshBeforeRestart) {
+            client().admin().indices().prepareRefresh(INDEX_NAME).get();
+        }
+        if (flushBeforeRestart) {
+            client().admin().indices().prepareFlush(INDEX_NAME).setForce(true).setWaitIfOngoing(true).get();
+        }
+
+        // Phase 5: full cluster restart.
+        internalCluster().fullRestart();
+        ensureGreen(INDEX_NAME);
+
+        // Phase 6: every successful doc must have survived. Both formats must agree —
+        // whether durability came from the committed catalog snapshot, an in-flight
+        // segment recovered via translog replay, or pure translog replay.
+        long expected = initialDocs + postRetirementDocs;
+        long parquetRows = CompositeEngineHelper.getRowCount(clusterService(), internalCluster(), INDEX_NAME, "parquet");
+        long luceneRows = CompositeEngineHelper.getRowCount(clusterService(), internalCluster(), INDEX_NAME, "lucene");
+        assertEquals("parquet must hold exactly " + expected + " live docs after restart", expected, parquetRows);
+        assertEquals("lucene must hold exactly " + expected + " live docs after restart", expected, luceneRows);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEnginePrimaryFailoverCheckpointIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeEnginePrimaryFailoverCheckpointIT.java
@@ -1,0 +1,159 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.routing.allocation.command.CancelAllocationCommand;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
+import org.opensearch.test.InternalSettingsPlugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Control variant of {@link CompositeEngineLuceneFailureCheckpointIT}: unmodified
+ * {@link LucenePlugin}, with failover triggered by {@link CancelAllocationCommand} so both
+ * nodes stay alive and the node-scoped DataFusion runtime survives.
+ *
+ * <p>Cluster: 2 data nodes, 1 shard, 1 replica, segment replication, remote-store-backed.
+ * After cancel-reroute → 3 docs → flush + explicit GCP sync, asserts the same invariants as
+ * the fault-injection variant: primary maxSeqNo, processed/persisted LCP, and lastSyncedGCP
+ * converge to 2 and the replica's processed LCP catches up.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class CompositeEnginePrimaryFailoverCheckpointIT extends RemoteStoreBaseIntegTestCase {
+
+    private static final String INDEX_NAME = "composite-failover-idx";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Stream.concat(
+            super.nodePlugins().stream(),
+            Stream.of(
+                ArrowBasePlugin.class,
+                ParquetDataFormatPlugin.class,
+                CompositeDataFormatPlugin.class,
+                LucenePlugin.class,
+                DataFusionPlugin.class,
+                InternalSettingsPlugin.class
+            )
+        ).collect(Collectors.toList());
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .build();
+    }
+
+    private Settings dfaIndexSettings() {
+        return Settings.builder()
+            .put(remoteStoreIndexSettings(1, 1))
+            .put(IndexMetadata.SETTING_REPLICATION_TYPE, ReplicationType.SEGMENT)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "parquet")
+            .putList("index.composite.secondary_data_formats", List.of("lucene"))
+            // Tighten the periodic GCP sync so the post-failover assertion doesn't race a
+            // 30s default timer waiting for the replica to catch up.
+            .put("index.global_checkpoint_sync.interval", "1s")
+            .build();
+    }
+
+    private String primaryNodeName() {
+        String nodeId = getClusterState().routingTable().index(INDEX_NAME).shard(0).primaryShard().currentNodeId();
+        return getClusterState().nodes().get(nodeId).getName();
+    }
+
+    private String replicaNodeName() {
+        String nodeId = getClusterState().routingTable()
+            .index(INDEX_NAME)
+            .shard(0)
+            .replicaShards()
+            .stream()
+            .filter(s -> s.started())
+            .findFirst()
+            .orElseThrow()
+            .currentNodeId();
+        return getClusterState().nodes().get(nodeId).getName();
+    }
+
+    public void testCheckpointsConvergeAfterPrimaryFailover() throws Exception {
+        internalCluster().startClusterManagerOnlyNode();
+        internalCluster().startDataOnlyNodes(2);
+        client().admin().indices().prepareCreate(INDEX_NAME).setSettings(dfaIndexSettings()).get();
+        ensureYellowAndNoInitializingShards(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        BulkItemResponse doc1 = indexOne("1", "value-1");
+        assertFalse("doc 1 must succeed: " + doc1.getFailureMessage(), doc1.isFailed());
+
+        // Trigger a graceful primary handover: cancel the primary's allocation via cluster
+        // reroute. Both nodes stay alive, the replica is promoted, and we avoid tearing down
+        // the node-scoped DataFusion Tokio runtime manager (which dies on hard node stop).
+        String oldPrimary = primaryNodeName();
+        client().admin().cluster().prepareReroute().add(new CancelAllocationCommand(INDEX_NAME, 0, oldPrimary, true)).execute().actionGet();
+        waitForPrimaryTerm(2L, TimeValue.timeValueSeconds(30));
+        ensureGreen(INDEX_NAME);
+        logger.info("Current Allocation: {}", getClusterState().routingTable().index(INDEX_NAME));
+        BulkItemResponse doc2 = indexOne("2", "value-2");
+        assertFalse("doc 2 must succeed on new primary: " + doc2.getFailureMessage(), doc2.isFailed());
+
+        BulkItemResponse doc3 = indexOne("3", "value-3");
+        assertFalse("doc 3 must succeed: " + doc3.getFailureMessage(), doc3.isFailed());
+
+        client().admin().indices().prepareFlush(INDEX_NAME).get();
+        client().admin().indices().prepareRefresh(INDEX_NAME).get();
+        getIndexShard(primaryNodeName(), INDEX_NAME).maybeSyncGlobalCheckpoint("post-failover-test-sync");
+
+        assertBusy(() -> {
+            IndexShard p = getIndexShard(primaryNodeName(), INDEX_NAME);
+            IndexShard r = getIndexShard(replicaNodeName(), INDEX_NAME);
+            assert p.isActive() : "Primary is not active";
+            assert r.isActive() : "Replica is not active";
+            assertEquals("primary maxSeqNo", 2L, p.seqNoStats().getMaxSeqNo());
+            assertEquals("primary processedLCP", 2L, p.getProcessedLocalCheckpoint());
+            assertEquals("primary persistedLCP", 2L, p.getLocalCheckpoint());
+            assertEquals("primary lastSyncedGCP catches up to LCP", p.getLocalCheckpoint(), p.getLastSyncedGlobalCheckpoint());
+            assertEquals("replica lastProcessedLCP matches primary", p.getProcessedLocalCheckpoint(), r.getProcessedLocalCheckpoint());
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    /** Waits until the primary's operationPrimaryTerm reaches {@code expectedTerm}. */
+    private void waitForPrimaryTerm(long expectedTerm, TimeValue timeout) throws Exception {
+        assertBusy(() -> {
+            IndexShard shard = getIndexShard(primaryNodeName(), INDEX_NAME);
+            assertEquals("primary term did not reach expected value", expectedTerm, shard.getOperationPrimaryTerm());
+        }, timeout.seconds(), TimeUnit.SECONDS);
+    }
+
+    private BulkItemResponse indexOne(String id, String value) {
+        BulkResponse bulk = client().prepareBulk().add(client().prepareIndex(INDEX_NAME).setId(id).setSource("field", value)).get();
+        assertEquals(1, bulk.getItems().length);
+        return bulk.getItems()[0];
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeParquetIndexIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeParquetIndexIT.java
@@ -14,15 +14,21 @@ import org.opensearch.action.admin.indices.refresh.RefreshResponse;
 import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.opensearch.action.admin.indices.stats.ShardStats;
+import org.opensearch.action.bulk.BulkRequestBuilder;
+import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.arrow.allocator.ArrowBasePlugin;
 import org.opensearch.be.datafusion.DataFusionPlugin;
 import org.opensearch.be.lucene.LucenePlugin;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.engine.CommitStats;
+import org.opensearch.index.engine.DataFormatAwareEngine;
+import org.opensearch.index.engine.exec.Segment;
+import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.engine.exec.coord.DataformatAwareCatalogSnapshot;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
@@ -33,6 +39,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 /**
@@ -238,6 +246,493 @@ public class CompositeParquetIndexIT extends OpenSearchIntegTestCase {
         }
 
         ensureGreen(indexName);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Contract tests: InternalEngine equivalents for Parquet+Lucene composite
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Concurrent indexing must not lose docs. Both formats must have identical row counts.
+     * Reference: InternalEngineTests.testAppendConcurrently
+     */
+    public void testConcurrentAppendsCrossFormatConsistency() throws Exception {
+        String indexName = "test-concurrent-appends";
+        createParquetLuceneIndex(indexName);
+
+        int numThreads = 4;
+        int docsPerThread = 25;
+        CyclicBarrier barrier = new CyclicBarrier(numThreads);
+        AtomicInteger successCount = new AtomicInteger();
+
+        Thread[] threads = new Thread[numThreads];
+        for (int t = 0; t < numThreads; t++) {
+            final int threadId = t;
+            threads[t] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    for (int i = 0; i < docsPerThread; i++) {
+                        IndexResponse resp = client().prepareIndex(indexName)
+                            .setSource("field_keyword", "t" + threadId + "_d" + i, "field_number", i)
+                            .get();
+                        if (resp.status() == RestStatus.CREATED) successCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            threads[t].start();
+        }
+        for (Thread t : threads) {
+            t.join();
+        }
+
+        int totalExpected = numThreads * docsPerThread;
+        assertEquals("all must succeed", totalExpected, successCount.get());
+
+        flushIndex(indexName);
+        assertParquetLuceneRowCountsMatch(indexName, totalExpected);
+    }
+
+    /**
+     * Bulk indexing must be per-doc atomic — all docs visible, formats consistent.
+     * Reference: InternalEngineTests.testConcurrentWritesAndCommits
+     */
+    public void testBulkIndexCrossFormatConsistency() throws Exception {
+        String indexName = "test-bulk-index";
+        createParquetLuceneIndex(indexName);
+
+        int batchSize = 50;
+        BulkRequestBuilder bulk = client().prepareBulk();
+        for (int i = 0; i < batchSize; i++) {
+            bulk.add(client().prepareIndex(indexName).setSource("field_keyword", "bulk_" + i, "field_number", i));
+        }
+        BulkResponse resp = bulk.get();
+        assertFalse("no failures in bulk", resp.hasFailures());
+
+        flushIndex(indexName);
+        assertParquetLuceneRowCountsMatch(indexName, batchSize);
+    }
+
+    /**
+     * Multiple flush cycles produce additive, consistent state across formats.
+     * Reference: InternalEngineTests.testShouldPeriodicallyFlush
+     */
+    public void testMultipleFlushCyclesAdditive() throws Exception {
+        String indexName = "test-multi-flush";
+        createParquetLuceneIndex(indexName);
+
+        indexDocsTo(indexName, 5);
+        flushIndex(indexName);
+        assertParquetLuceneRowCountsMatch(indexName, 5);
+
+        indexDocsTo(indexName, 7);
+        flushIndex(indexName);
+        assertParquetLuceneRowCountsMatch(indexName, 12);
+
+        indexDocsTo(indexName, 3);
+        flushIndex(indexName);
+        assertParquetLuceneRowCountsMatch(indexName, 15);
+    }
+
+    /**
+     * Refresh must make all buffered docs visible atomically across both formats.
+     * After a single refresh, both parquet and lucene must show the same new segment
+     * with the same row count — no partial visibility where one format lags.
+     * Reference: InternalEngineTests.testRefreshScopedSearcher
+     */
+    public void testRefreshAtomicityAcrossFormats() throws Exception {
+        String indexName = "test-refresh-atomicity";
+        createParquetLuceneIndex(indexName);
+
+        indexDocsTo(indexName, 10);
+
+        // Single refresh — not flush. Docs should become visible in both formats simultaneously.
+        DataFormatAwareEngine engine = getEngine(indexName);
+        engine.refresh("test");
+
+        try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+            CatalogSnapshot snapshot = ref.get();
+            long parquetRows = snapshot.getSearchableFiles("parquet").stream().mapToLong(WriterFileSet::numRows).sum();
+            long luceneRows = snapshot.getSearchableFiles("lucene").stream().mapToLong(WriterFileSet::numRows).sum();
+            assertEquals("refresh must make same docs visible in both formats", parquetRows, luceneRows);
+            assertEquals("all 10 docs must be visible after refresh", 10, parquetRows);
+        }
+    }
+
+    /**
+     * flushAndClose must commit all buffered data. After reopen, both formats must have
+     * all docs that were indexed before shutdown.
+     * Reference: InternalEngineTests.testFlushAndClose
+     */
+    public void testFlushAndClosePreservesAllData() throws Exception {
+        String indexName = "test-flush-and-close";
+        createParquetLuceneIndex(indexName);
+
+        indexDocsTo(indexName, 10);
+        // Do NOT flush explicitly — flushAndClose should handle it
+
+        // flushAndClose via index close (which triggers flushAndClose on the engine)
+        client().admin().indices().prepareClose(indexName).get();
+        client().admin().indices().prepareOpen(indexName).get();
+        ensureGreen(indexName);
+
+        DataFormatAwareEngine recovered = getEngine(indexName);
+        assertEquals("all 10 ops recovered via translog", 9, recovered.getSeqNoStats(-1).getMaxSeqNo());
+
+        // Flush + refresh to make recovered data visible in catalog
+        flushIndex(indexName);
+        recovered.refresh("verify");
+
+        long parquetRows = getRowCount(indexName, "parquet");
+        long luceneRows = getRowCount(indexName, "lucene");
+        assertEquals("post-close parquet and lucene must match", parquetRows, luceneRows);
+        assertEquals("all 10 docs must survive flushAndClose", 10, parquetRows);
+    }
+
+    /**
+     * Translog replay after clean shutdown (close/reopen) must produce identical state
+     * in both formats. Index docs, flush some, then index more WITHOUT flushing. Close/reopen.
+     * The close triggers flushAndClose which persists uncommitted data via translog.
+     * After reopen, both formats must have all docs.
+     * Reference: InternalEngineTests.testTranslogReplay + testRecoverFromLocalTranslog
+     */
+    public void testTranslogReplayCleanShutdownCrossFormatConsistency() throws Exception {
+        String indexName = "test-translog-replay-clean";
+        createParquetLuceneIndex(indexName);
+
+        // Phase 1: committed data
+        indexDocsTo(indexName, 8);
+        flushIndex(indexName);
+
+        // Phase 2: uncommitted data (in translog only)
+        indexDocsTo(indexName, 5);
+        // NO explicit flush — close will trigger flushAndClose, translog holds these ops
+
+        DataFormatAwareEngine engine = getEngine(indexName);
+        assertEquals("13 ops total", 12, engine.getSeqNoStats(-1).getMaxSeqNo());
+
+        // Close/reopen — close triggers flushAndClose, reopen replays from translog if needed
+        client().admin().indices().prepareClose(indexName).get();
+        client().admin().indices().prepareOpen(indexName).get();
+        ensureGreen(indexName);
+
+        DataFormatAwareEngine recovered = getEngine(indexName);
+        assertEquals("all 13 ops recovered", 12, recovered.getSeqNoStats(-1).getMaxSeqNo());
+
+        flushIndex(indexName);
+        recovered.refresh("verify");
+
+        long parquetRows = getRowCount(indexName, "parquet");
+        long luceneRows = getRowCount(indexName, "lucene");
+        assertEquals("post-replay: formats must match", parquetRows, luceneRows);
+        assertEquals("post-replay: all 13 docs present", 13, parquetRows);
+    }
+
+    /**
+     * Translog replay after unclean shutdown (failEngine) must produce identical state
+     * in both formats. Index docs, flush some, then index more WITHOUT flushing.
+     * Fail engine (simulates crash). After recovery, both formats must have all docs
+     * (committed + replayed from translog).
+     * Reference: InternalEngineTests.testTranslogReplay
+     */
+    public void testTranslogReplayUncleanShutdownCrossFormatConsistency() throws Exception {
+        String indexName = "test-translog-replay-crash";
+        createParquetLuceneIndex(indexName);
+
+        // Phase 1: committed data
+        indexDocsTo(indexName, 8);
+        flushIndex(indexName);
+
+        // Phase 2: uncommitted data (in translog only)
+        indexDocsTo(indexName, 5);
+        // NO flush — these are only in the translog
+
+        DataFormatAwareEngine engine = getEngine(indexName);
+        assertEquals("13 ops total", 12, engine.getSeqNoStats(-1).getMaxSeqNo());
+
+        // Simulate unclean shutdown — engine fails without flushing
+        engine.failEngine("simulated-crash", new java.io.IOException("disk error"));
+
+        // Reopen — triggers translog replay of the 5 uncommitted docs
+        client().admin().indices().prepareClose(indexName).get();
+        client().admin().indices().prepareOpen(indexName).get();
+        ensureGreen(indexName);
+
+        DataFormatAwareEngine recovered = getEngine(indexName);
+        assertEquals("all 13 ops recovered", 12, recovered.getSeqNoStats(-1).getMaxSeqNo());
+
+        flushIndex(indexName);
+        recovered.refresh("verify");
+
+        long parquetRows = getRowCount(indexName, "parquet");
+        long luceneRows = getRowCount(indexName, "lucene");
+        assertEquals("post-replay: formats must match", parquetRows, luceneRows);
+        assertEquals("post-replay: all 13 docs present", 13, parquetRows);
+    }
+
+    /**
+     * Concurrent indexing + refresh must produce consistent cross-format snapshots.
+     * While indexing threads are active, refresh threads take snapshots. Every snapshot
+     * must have matching row counts across both formats.
+     * Reference: InternalEngineTests.testConcurrentAppendUpdateAndRefresh
+     */
+    public void testConcurrentIndexAndRefreshConsistency() throws Exception {
+        String indexName = "test-concurrent-refresh";
+        createParquetLuceneIndex(indexName);
+
+        int numIndexThreads = 3;
+        int docsPerThread = 20;
+        int numRefreshes = 10;
+        CyclicBarrier barrier = new CyclicBarrier(numIndexThreads + 1);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger inconsistencyCount = new AtomicInteger();
+
+        // Indexing threads
+        Thread[] indexThreads = new Thread[numIndexThreads];
+        for (int t = 0; t < numIndexThreads; t++) {
+            final int threadId = t;
+            indexThreads[t] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    for (int i = 0; i < docsPerThread; i++) {
+                        IndexResponse resp = client().prepareIndex(indexName)
+                            .setSource("field_keyword", "t" + threadId + "_d" + i, "field_number", i)
+                            .get();
+                        if (resp.status() == RestStatus.CREATED) successCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            indexThreads[t].start();
+        }
+
+        // Refresh thread — checks cross-format consistency at each refresh point
+        Thread refreshThread = new Thread(() -> {
+            try {
+                barrier.await();
+                DataFormatAwareEngine eng = getEngine(indexName);
+                for (int r = 0; r < numRefreshes; r++) {
+                    eng.refresh("concurrent-check-" + r);
+                    try (GatedCloseable<CatalogSnapshot> ref = eng.acquireSnapshot()) {
+                        CatalogSnapshot snap = ref.get();
+                        long pq = snap.getSearchableFiles("parquet").stream().mapToLong(WriterFileSet::numRows).sum();
+                        long lc = snap.getSearchableFiles("lucene").stream().mapToLong(WriterFileSet::numRows).sum();
+                        if (pq != lc) {
+                            inconsistencyCount.incrementAndGet();
+                        }
+                    }
+                    Thread.sleep(5);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        refreshThread.start();
+
+        for (Thread t : indexThreads) {
+            t.join();
+        }
+        refreshThread.join();
+
+        assertEquals("every intermediate refresh must show consistent cross-format counts", 0, inconsistencyCount.get());
+
+        // Final verification
+        flushIndex(indexName);
+        assertParquetLuceneRowCountsMatch(indexName, numIndexThreads * docsPerThread);
+    }
+
+    /**
+     * After multiple refresh cycles, each segment must have matching numRows in both
+     * its parquet and lucene WriterFileSets. This verifies that row IDs are
+     * correctly assigned within each writer generation across formats.
+     * (No direct InternalEngine analog — unique to multi-format)
+     */
+    public void testSegmentGenerationAlignmentAcrossFormats() throws Exception {
+        String indexName = "test-segment-alignment";
+        createParquetLuceneIndex(indexName);
+
+        // Create 3 segments with different sizes
+        indexDocsTo(indexName, 4);
+        flushIndex(indexName);
+
+        indexDocsTo(indexName, 7);
+        flushIndex(indexName);
+
+        indexDocsTo(indexName, 2);
+        flushIndex(indexName);
+
+        DataFormatAwareEngine engine = getEngine(indexName);
+        engine.refresh("verify");
+
+        try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+            CatalogSnapshot snapshot = ref.get();
+            for (Segment segment : snapshot.getSegments()) {
+                WriterFileSet parquetWfs = segment.dfGroupedSearchableFiles().get("parquet");
+                WriterFileSet luceneWfs = segment.dfGroupedSearchableFiles().get("lucene");
+
+                assertNotNull("segment gen=" + segment.generation() + " must have parquet files", parquetWfs);
+                assertNotNull("segment gen=" + segment.generation() + " must have lucene files", luceneWfs);
+                assertEquals(
+                    "segment gen=" + segment.generation() + " must have same numRows in both formats",
+                    parquetWfs.numRows(),
+                    luceneWfs.numRows()
+                );
+                assertTrue("segment gen=" + segment.generation() + " must have positive numRows", parquetWfs.numRows() > 0);
+            }
+        }
+    }
+
+    /**
+     * Writer generation counter must resume from the committed value after recovery,
+     * not restart from 1. Otherwise new segments collide with committed segments in
+     * the CatalogSnapshot.
+     * Reference: InternalEngineTests.testSequenceNumberAdvancesToMaxSeqOnEngineOpenOnPrimary
+     */
+    public void testWriterGenerationResumesAfterRestart() throws Exception {
+        String indexName = "test-writer-gen-resume";
+        createParquetLuceneIndex(indexName);
+
+        // Create 3 segments — writer generations 1, 2, 3
+        indexDocsTo(indexName, 5);
+        flushIndex(indexName);
+        indexDocsTo(indexName, 5);
+        flushIndex(indexName);
+        indexDocsTo(indexName, 5);
+        flushIndex(indexName);
+
+        // Close and reopen
+        client().admin().indices().prepareClose(indexName).get();
+        client().admin().indices().prepareOpen(indexName).get();
+        ensureGreen(indexName);
+
+        // Index more after reopen — should NOT collide with existing segment generations
+        indexDocsTo(indexName, 5);
+        flushIndex(indexName);
+
+        DataFormatAwareEngine engine = getEngine(indexName);
+        engine.refresh("verify");
+
+        // Verify: 20 total docs, no generation conflicts
+        try (GatedCloseable<CatalogSnapshot> ref = engine.acquireSnapshot()) {
+            CatalogSnapshot snapshot = ref.get();
+            long totalParquet = snapshot.getSearchableFiles("parquet").stream().mapToLong(WriterFileSet::numRows).sum();
+            long totalLucene = snapshot.getSearchableFiles("lucene").stream().mapToLong(WriterFileSet::numRows).sum();
+            assertEquals("all 20 docs must be present in parquet", 20, totalParquet);
+            assertEquals("all 20 docs must be present in lucene", 20, totalLucene);
+
+            // Verify no duplicate generations
+            java.util.List<Long> generations = snapshot.getSegments()
+                .stream()
+                .map(Segment::generation)
+                .collect(java.util.stream.Collectors.toList());
+            assertEquals(
+                "all segment generations must be unique (no collision after restart)",
+                generations.size(),
+                generations.stream().distinct().count()
+            );
+        }
+    }
+
+    /**
+     * Concurrent indexing + flush must not lose documents. All docs that got
+     * CREATED responses must be visible after flush settles.
+     * Reference: InternalEngineTests.testConcurrentWritesAndCommits
+     */
+    public void testConcurrentIndexAndFlushNoDataLoss() throws Exception {
+        String indexName = "test-concurrent-flush";
+        createParquetLuceneIndex(indexName);
+
+        int numIndexThreads = 3;
+        int docsPerThread = 30;
+        CyclicBarrier barrier = new CyclicBarrier(numIndexThreads + 1);
+        AtomicInteger successCount = new AtomicInteger();
+
+        Thread[] indexThreads = new Thread[numIndexThreads];
+        for (int t = 0; t < numIndexThreads; t++) {
+            final int tid = t;
+            indexThreads[t] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    for (int i = 0; i < docsPerThread; i++) {
+                        IndexResponse resp = client().prepareIndex(indexName)
+                            .setSource("field_keyword", "t" + tid + "_d" + i, "field_number", i)
+                            .get();
+                        if (resp.status() == RestStatus.CREATED) successCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            indexThreads[t].start();
+        }
+
+        // Flush thread — flushes while indexing is in progress
+        Thread flushThread = new Thread(() -> {
+            try {
+                barrier.await();
+                for (int i = 0; i < 5; i++) {
+                    Thread.sleep(10);
+                    flushIndex(indexName);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        flushThread.start();
+
+        for (Thread t : indexThreads) {
+            t.join();
+        }
+        flushThread.join();
+
+        // Final flush to commit any remaining buffered data
+        flushIndex(indexName);
+        DataFormatAwareEngine engine = getEngine(indexName);
+        engine.refresh("verify");
+
+        int expected = successCount.get();
+        long parquetRows = getRowCount(indexName, "parquet");
+        long luceneRows = getRowCount(indexName, "lucene");
+        assertEquals("parquet must have all successful docs", expected, parquetRows);
+        assertEquals("lucene must have all successful docs", expected, luceneRows);
+    }
+
+    // ── Helpers for Parquet+Lucene tests ──
+
+    private void createParquetLuceneIndex(String indexName) {
+        CompositeEngineHelper.createCompositeIndexWithMapping(this, indexName, "parquet", Settings.EMPTY, "lucene");
+    }
+
+    private void indexDocsTo(String indexName, int count) {
+        CompositeEngineHelper.indexDocs(this, indexName, count);
+    }
+
+    private void flushIndex(String indexName) {
+        CompositeEngineHelper.flush(this, indexName);
+    }
+
+    private DataFormatAwareEngine getEngine(String indexName) {
+        return CompositeEngineHelper.getEngine(clusterService(), internalCluster(), indexName);
+    }
+
+    private long getRowCount(String indexName, String formatName) throws IOException {
+        return CompositeEngineHelper.getRowCount(clusterService(), internalCluster(), indexName, formatName);
+    }
+
+    private void assertParquetLuceneRowCountsMatch(String indexName, long expected) throws IOException {
+        DataFormatAwareEngine engine = getEngine(indexName);
+        engine.refresh("test");
+        assertEquals("parquet row count", expected, getRowCount(indexName, "parquet"));
+        assertEquals("lucene row count", expected, getRowCount(indexName, "lucene"));
+
+        CompositeEngineHelper.assertPerSegmentRowCountsMatch(engine, "parquet", "lucene");
+
+        // Checkpoint must be consistent with seqNo
+        long maxSeq = engine.getSeqNoStats(-1).getMaxSeqNo();
+        long processedCp = engine.getProcessedLocalCheckpoint();
+        assertEquals("processed checkpoint must equal maxSeqNo", maxSeq, processedCp);
     }
 
     public void testCompositeIndexUsesClusterDefaultFormatsWhenOverridesAbsent() throws IOException {

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeVSRRotationIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeVSRRotationIT.java
@@ -1,0 +1,414 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.action.bulk.BulkRequestBuilder;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.arrow.allocator.ArrowBasePlugin;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.common.concurrent.GatedCloseable;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.engine.DataFormatAwareEngine;
+import org.opensearch.index.engine.exec.WriterFileSet;
+import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Integration tests exercising Parquet VSR (VectorSchemaRoot) rotation under multi-format
+ * composite indexing (Parquet primary + Lucene secondary).
+ *
+ * Uses a low {@code parquet.max_rows_per_vsr} (5 rows) to force frequent VSR rotation
+ * during normal indexing. This validates that:
+ * <ul>
+ *   <li>VSR rotation boundaries don't break cross-format atomicity</li>
+ *   <li>Background native writes complete without data loss</li>
+ *   <li>Concurrent indexing across rotation boundaries maintains format consistency</li>
+ *   <li>High-throughput batches spanning multiple rotations produce correct totals</li>
+ * </ul>
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1)
+public class CompositeVSRRotationIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX_NAME = "test-vsr-rotation";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(
+            ArrowBasePlugin.class,
+            ParquetDataFormatPlugin.class,
+            CompositeDataFormatPlugin.class,
+            LucenePlugin.class,
+            DataFusionPlugin.class
+        );
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .put("parquet.max_rows_per_vsr", 5)
+            .build();
+    }
+
+    /**
+     * Indexing more docs than the VSR threshold in a single writer generation must
+     * trigger rotation and still produce consistent cross-format state.
+     * With max_rows_per_vsr=5, indexing 20 docs triggers 4 rotations.
+     */
+    public void testRotationDuringSequentialIndexingMaintainsConsistency() throws Exception {
+        createParquetLuceneIndex();
+
+        indexDocs(20);
+        flush();
+
+        assertCrossFormatConsistency(20);
+    }
+
+    /**
+     * Multiple flush cycles where each cycle exceeds the VSR threshold.
+     * Each cycle triggers rotations independently; cross-format state must be
+     * additive and consistent after each flush.
+     */
+    public void testMultipleFlushCyclesWithRotation() throws Exception {
+        createParquetLuceneIndex();
+
+        // Cycle 1: 12 docs → 2+ rotations
+        indexDocs(12);
+        flush();
+        assertCrossFormatConsistency(12);
+
+        // Cycle 2: 8 docs → 1+ rotation
+        indexDocs(8);
+        flush();
+        assertCrossFormatConsistency(20);
+
+        // Cycle 3: 15 docs → 3 rotations
+        indexDocs(15);
+        flush();
+        assertCrossFormatConsistency(35);
+    }
+
+    /**
+     * Bulk indexing a batch larger than the VSR threshold must not lose docs
+     * at rotation boundaries. All docs in the bulk must appear in both formats.
+     */
+    public void testBulkIndexSpanningMultipleRotations() throws Exception {
+        createParquetLuceneIndex();
+
+        int batchSize = 30; // 6 rotations at threshold=5
+        BulkRequestBuilder bulk = client().prepareBulk();
+        for (int i = 0; i < batchSize; i++) {
+            bulk.add(client().prepareIndex(INDEX_NAME).setSource("field_keyword", "bulk_" + i, "field_number", i));
+        }
+        BulkResponse resp = bulk.get();
+        assertFalse("no failures in bulk", resp.hasFailures());
+
+        flush();
+        assertCrossFormatConsistency(batchSize);
+    }
+
+    /**
+     * Concurrent indexing from multiple threads where total docs far exceed the
+     * VSR threshold. Rotations happen under contention — must not lose docs or
+     * produce cross-format mismatches.
+     */
+    public void testConcurrentIndexingAcrossRotationBoundaries() throws Exception {
+        createParquetLuceneIndex();
+
+        int numThreads = 4;
+        int docsPerThread = 15; // 60 total → 12 rotations at threshold=5
+        CyclicBarrier barrier = new CyclicBarrier(numThreads);
+        AtomicInteger successCount = new AtomicInteger();
+
+        Thread[] threads = new Thread[numThreads];
+        for (int t = 0; t < numThreads; t++) {
+            final int tid = t;
+            threads[t] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    for (int i = 0; i < docsPerThread; i++) {
+                        IndexResponse resp = client().prepareIndex(INDEX_NAME)
+                            .setSource("field_keyword", "t" + tid + "_d" + i, "field_number", i)
+                            .get();
+                        if (resp.status() == RestStatus.CREATED) successCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            threads[t].start();
+        }
+        for (Thread t : threads) {
+            t.join();
+        }
+
+        int expected = successCount.get();
+        assertEquals("all should succeed", numThreads * docsPerThread, expected);
+
+        flush();
+        assertCrossFormatConsistency(expected);
+    }
+
+    /**
+     * Alternating flush and index cycles where each batch crosses rotation boundaries.
+     * Tests that rotation state resets correctly between writer generations.
+     */
+    public void testRotationStateResetsAcrossWriterGenerations() throws Exception {
+        createParquetLuceneIndex();
+
+        // Each flush retires the current writer; new writer starts fresh VSR state
+        for (int cycle = 0; cycle < 5; cycle++) {
+            indexDocs(7); // crosses threshold once per cycle
+            flush();
+        }
+
+        assertCrossFormatConsistency(35);
+    }
+
+    /**
+     * After VSR rotation, a refresh must capture all docs including those from the
+     * rotated (background-written) batch. No docs lost at rotation seams.
+     */
+    public void testRefreshAfterRotationCapturesAllDocs() throws Exception {
+        createParquetLuceneIndex();
+
+        // Index exactly at threshold boundaries: 5 + 5 + 3 = 13 docs
+        indexDocs(5); // fills first VSR exactly
+        indexDocs(5); // triggers rotation, fills second VSR
+        indexDocs(3); // partial third VSR
+
+        // Refresh without flush — must see all 13
+        DataFormatAwareEngine engine = getEngine();
+        engine.refresh("test");
+
+        long parquetRows = getRowCount("parquet");
+        long luceneRows = getRowCount("lucene");
+        assertEquals("parquet must see all docs after rotation + refresh", 13, parquetRows);
+        assertEquals("lucene must match parquet", parquetRows, luceneRows);
+    }
+
+    /**
+     * Index docs, flush, then index more docs spanning rotation, then close/reopen.
+     * After recovery, both formats must have all committed + replayed docs.
+     */
+    public void testRecoveryAfterRotation() throws Exception {
+        createParquetLuceneIndex();
+
+        // Committed: 12 docs (2+ rotations)
+        indexDocs(12);
+        flush();
+
+        // Uncommitted: 8 more docs (1+ rotation) — only in translog
+        indexDocs(8);
+
+        // Close/reopen — flushAndClose commits everything, reopen recovers
+        client().admin().indices().prepareClose(INDEX_NAME).get();
+        client().admin().indices().prepareOpen(INDEX_NAME).get();
+        ensureGreen(INDEX_NAME);
+
+        flush();
+        getEngine().refresh("verify");
+
+        long parquetRows = getRowCount("parquet");
+        long luceneRows = getRowCount("lucene");
+        assertEquals("both formats must match after recovery", parquetRows, luceneRows);
+        assertEquals("all 20 docs must survive recovery", 20, parquetRows);
+    }
+
+    /**
+     * Concurrent indexing + flush where flushes happen while VSR rotation is in progress.
+     * Tests the interaction between: rotation (freezes VSR, submits background write) and
+     * flush (awaits pending write, then writes remaining). Under low threshold (5), almost
+     * every flush will race with a pending rotation write.
+     */
+    public void testConcurrentFlushDuringVSRRotation() throws Exception {
+        createParquetLuceneIndex();
+
+        int numIndexThreads = 3;
+        int docsPerThread = 20;
+        CyclicBarrier barrier = new CyclicBarrier(numIndexThreads + 1);
+        AtomicInteger successCount = new AtomicInteger();
+
+        Thread[] indexThreads = new Thread[numIndexThreads];
+        for (int t = 0; t < numIndexThreads; t++) {
+            final int tid = t;
+            indexThreads[t] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    for (int i = 0; i < docsPerThread; i++) {
+                        IndexResponse resp = client().prepareIndex(INDEX_NAME)
+                            .setSource("field_keyword", "t" + tid + "_d" + i, "field_number", i)
+                            .get();
+                        if (resp.status() == RestStatus.CREATED) successCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            indexThreads[t].start();
+        }
+
+        // Flush thread — flushes repeatedly while indexing is ongoing
+        Thread flushThread = new Thread(() -> {
+            try {
+                barrier.await();
+                for (int i = 0; i < 8; i++) {
+                    Thread.sleep(5);
+                    flush();
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        flushThread.start();
+
+        for (Thread t : indexThreads) {
+            t.join();
+        }
+        flushThread.join();
+
+        // Final flush to commit any remaining buffered data
+        flush();
+
+        int expected = successCount.get();
+        assertCrossFormatConsistency(expected);
+    }
+
+    /**
+     * Concurrent indexing + refresh where refreshes race with VSR rotation.
+     * Each refresh acquires the writer pool, flushes writers (triggering awaitPendingWrite
+     * inside ParquetWriter.flush → VSRManager.flush), and commits a new CatalogSnapshot.
+     * Tests that concurrent refresh during rotation doesn't lose docs or break atomicity.
+     */
+    public void testConcurrentRefreshDuringVSRRotation() throws Exception {
+        createParquetLuceneIndex();
+
+        int numIndexThreads = 3;
+        int docsPerThread = 15;
+        int numRefreshes = 10;
+        CyclicBarrier barrier = new CyclicBarrier(numIndexThreads + 1);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger inconsistencyCount = new AtomicInteger();
+
+        Thread[] indexThreads = new Thread[numIndexThreads];
+        for (int t = 0; t < numIndexThreads; t++) {
+            final int tid = t;
+            indexThreads[t] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    for (int i = 0; i < docsPerThread; i++) {
+                        IndexResponse resp = client().prepareIndex(INDEX_NAME)
+                            .setSource("field_keyword", "t" + tid + "_d" + i, "field_number", i)
+                            .get();
+                        if (resp.status() == RestStatus.CREATED) successCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            indexThreads[t].start();
+        }
+
+        // Refresh thread — refreshes repeatedly, checking cross-format consistency each time
+        Thread refreshThread = new Thread(() -> {
+            try {
+                barrier.await();
+                DataFormatAwareEngine eng = getEngine();
+                for (int r = 0; r < numRefreshes; r++) {
+                    eng.refresh("concurrent-check-" + r);
+                    try (GatedCloseable<CatalogSnapshot> ref = eng.acquireSnapshot()) {
+                        CatalogSnapshot snap = ref.get();
+                        long pq = snap.getSearchableFiles("parquet").stream().mapToLong(WriterFileSet::numRows).sum();
+                        long lc = snap.getSearchableFiles("lucene").stream().mapToLong(WriterFileSet::numRows).sum();
+                        if (pq != lc) {
+                            inconsistencyCount.incrementAndGet();
+                        }
+                    }
+                    Thread.sleep(3);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        refreshThread.start();
+
+        for (Thread t : indexThreads) {
+            t.join();
+        }
+        refreshThread.join();
+
+        assertEquals("every mid-stream refresh must be cross-format consistent during rotation", 0, inconsistencyCount.get());
+
+        flush();
+        assertCrossFormatConsistency(successCount.get());
+    }
+
+    /**
+     * High-throughput burst that triggers many rapid rotations back-to-back.
+     * With max_rows_per_vsr=5 and 100 docs, this creates 20 rotation cycles.
+     * Tests that the background write pipeline doesn't drop batches under pressure.
+     */
+    public void testHighThroughputBurstWithRapidRotations() throws Exception {
+        createParquetLuceneIndex();
+
+        int totalDocs = 100;
+        BulkRequestBuilder bulk = client().prepareBulk();
+        for (int i = 0; i < totalDocs; i++) {
+            bulk.add(client().prepareIndex(INDEX_NAME).setSource("field_keyword", "burst_" + i, "field_number", i));
+        }
+        BulkResponse resp = bulk.get();
+        assertFalse("no failures in high-throughput burst", resp.hasFailures());
+
+        flush();
+        assertCrossFormatConsistency(totalDocs);
+    }
+
+    // ── Helpers ──
+
+    private void createParquetLuceneIndex() {
+        CompositeEngineHelper.createCompositeIndexWithMapping(this, INDEX_NAME, "parquet", Settings.EMPTY, "lucene");
+    }
+
+    private void indexDocs(int count) {
+        CompositeEngineHelper.indexDocs(this, INDEX_NAME, count);
+    }
+
+    private void flush() {
+        CompositeEngineHelper.flush(this, INDEX_NAME);
+    }
+
+    private DataFormatAwareEngine getEngine() {
+        return CompositeEngineHelper.getEngine(clusterService(), internalCluster(), INDEX_NAME);
+    }
+
+    private long getRowCount(String formatName) throws IOException {
+        return CompositeEngineHelper.getRowCount(clusterService(), internalCluster(), INDEX_NAME, formatName);
+    }
+
+    private void assertCrossFormatConsistency(long expected) throws IOException {
+        DataFormatAwareEngine engine = getEngine();
+        engine.refresh("verify");
+        assertEquals("parquet row count", expected, getRowCount("parquet"));
+        assertEquals("lucene row count", expected, getRowCount("lucene"));
+        CompositeEngineHelper.assertPerSegmentRowCountsMatch(engine, "parquet", "lucene");
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FailableLuceneDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FailableLuceneDataFormatPlugin.java
@@ -1,0 +1,191 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MMapDirectory;
+import org.opensearch.be.lucene.LuceneDataFormat;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.be.lucene.index.LuceneCommitter;
+import org.opensearch.be.lucene.index.LuceneIndexingExecutionEngine;
+import org.opensearch.be.lucene.index.LuceneWriter;
+import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
+import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
+import org.opensearch.index.engine.exec.commit.Committer;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Test-only plugin that wraps {@link LucenePlugin} and injects deterministic I/O failures
+ * inside Lucene's {@link Directory} layer — simulating real-world disk faults that surface
+ * mid-{@code IndexWriter.addDocument}. Mirrors the failure-injection model of the original
+ * stub but for Lucene, so tests can exercise checkpoint/promotion paths where a Lucene
+ * secondary writer fails at the directory level.
+ *
+ * <p>Failure isolation: only writes from this plugin's writers are affected. Each new
+ * Lucene writer creates its own injected directory; failures are not cross-writer.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ *   nodePlugins() -> include FailableLuceneDataFormatPlugin.class instead of LucenePlugin.class
+ *   FailableLuceneDataFormatPlugin.failOnNthWrite(1);  // next write op throws IOException
+ *   ... index docs ...
+ *   FailableLuceneDataFormatPlugin.clearFailure();
+ * }</pre>
+ */
+public class FailableLuceneDataFormatPlugin extends LucenePlugin {
+
+    /**
+     * Counts down on each Directory write op; when it hits zero the next op throws.
+     * "Disabled" means "set to a large enough number that we won't realistically reach zero"
+     * — see {@link #DISABLED}.
+     */
+    private static final int DISABLED = 1000;
+    private static final AtomicInteger countdownToFailure = new AtomicInteger(DISABLED);
+
+    /**
+     * After {@code n} successful Directory write operations across all Lucene writers in
+     * this JVM, the (n+1)th will throw {@code IOException}.
+     */
+    public static void failOnNthWrite(int n) {
+        countdownToFailure.set(n);
+    }
+
+    /** Disables fault injection by setting the countdown to {@link #DISABLED}. */
+    public static void clearFailure() {
+        countdownToFailure.set(DISABLED);
+    }
+
+    @Override
+    public IndexingExecutionEngine<?, ?> indexingEngine(IndexingEngineConfig indexingEngineConfig) {
+        Committer committer = indexingEngineConfig.committer();
+        if (committer instanceof LuceneCommitter luceneCommitter) {
+            return new FaultInjectingLuceneEngine(
+                (LuceneDataFormat) getDataFormat(),
+                luceneCommitter,
+                indexingEngineConfig.mapperService(),
+                indexingEngineConfig.store()
+            );
+        }
+        throw new IllegalStateException(
+            "FailableLuceneDataFormatPlugin requires a LuceneCommitter but got: "
+                + (committer != null ? committer.getClass().getName() : "null")
+        );
+    }
+
+    /**
+     * Subclass of the production engine that swaps in a {@link FaultInjectingLuceneWriter}
+     * for every per-generation writer. Everything else flows through unchanged.
+     */
+    private static final class FaultInjectingLuceneEngine extends LuceneIndexingExecutionEngine {
+
+        FaultInjectingLuceneEngine(
+            LuceneDataFormat dataFormat,
+            LuceneCommitter luceneCommitter,
+            org.opensearch.index.mapper.MapperService mapperService,
+            org.opensearch.index.store.Store store
+        ) {
+            super(dataFormat, luceneCommitter, mapperService, store);
+        }
+
+        @Override
+        protected LuceneWriter buildLuceneWriter(
+            long writerGeneration,
+            long mappingVersion,
+            LuceneDataFormat dataFormat,
+            Path baseDirectory,
+            Analyzer analyzer,
+            Codec codec,
+            Sort indexSort
+        ) throws IOException {
+            return new FaultInjectingLuceneWriter(writerGeneration, mappingVersion, dataFormat, baseDirectory, analyzer, codec, indexSort);
+        }
+    }
+
+    /**
+     * LuceneWriter subclass that wraps the underlying {@link MMapDirectory} with a
+     * {@link FaultInjectingDirectory}. The fault directory triggers an {@code IOException}
+     * inside any in-flight {@code IndexWriter.addDocument} once {@link #countdownToFailure}
+     * reaches zero.
+     */
+    private static final class FaultInjectingLuceneWriter extends LuceneWriter {
+        FaultInjectingLuceneWriter(
+            long writerGeneration,
+            long mappingVersion,
+            LuceneDataFormat dataFormat,
+            Path baseDirectory,
+            Analyzer analyzer,
+            Codec codec,
+            Sort indexSort
+        ) throws IOException {
+            super(writerGeneration, mappingVersion, dataFormat, baseDirectory, analyzer, codec, indexSort);
+        }
+
+        @Override
+        protected Directory createDirectory(Path tempDirectory) throws IOException {
+            return new FaultInjectingDirectory(new MMapDirectory(tempDirectory));
+        }
+
+        /**
+         * Force a flush after every 2nd doc so the {@link FaultInjectingDirectory} sees a
+         * write op at predictable doc boundaries. Mirrors the existing
+         * {@code newWriterWithMaxBufferedDocs} pattern in the codebase: very large RAM buffer
+         * (1024 MB) so doc count is the sole flush trigger, with {@code maxBufferedDocs=2}
+         * (the smallest legal value).
+         */
+        @Override
+        protected double ramBufferSizeMB() {
+            return 1024.0;
+        }
+
+        @Override
+        protected int maxBufferedDocs() {
+            return 2;
+        }
+    }
+
+    /**
+     * {@link FilterDirectory} that throws {@code IOException} from any {@code createOutput}
+     * once the static countdown reaches zero. This is the path Lucene's IndexWriter uses
+     * to write segment files, so failures here propagate up as IOExceptions inside
+     * {@code addDocument} or other IndexWriter operations.
+     */
+    private static final class FaultInjectingDirectory extends FilterDirectory {
+
+        FaultInjectingDirectory(Directory delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public IndexOutput createOutput(String name, IOContext context) throws IOException {
+            maybeFail(name);
+            return super.createOutput(name, context);
+        }
+
+        @Override
+        public IndexOutput createTempOutput(String prefix, String suffix, IOContext context) throws IOException {
+            maybeFail(prefix + "/" + suffix);
+            return super.createTempOutput(prefix, suffix, context);
+        }
+
+        private static void maybeFail(String name) throws IOException {
+            if (countdownToFailure.getAndDecrement() == 0) {
+                throw new IOException("injected lucene directory failure on " + name + " (test-only)");
+            }
+        }
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FailableParquetDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/FailableParquetDataFormatPlugin.java
@@ -1,0 +1,219 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.FileInfos;
+import org.opensearch.index.engine.dataformat.FlushInput;
+import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
+import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
+import org.opensearch.index.engine.dataformat.Merger;
+import org.opensearch.index.engine.dataformat.ReaderManagerConfig;
+import org.opensearch.index.engine.dataformat.RefreshInput;
+import org.opensearch.index.engine.dataformat.RefreshResult;
+import org.opensearch.index.engine.dataformat.WriteResult;
+import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterConfig;
+import org.opensearch.index.engine.dataformat.WriterState;
+import org.opensearch.index.engine.exec.EngineReaderManager;
+import org.opensearch.index.engine.exec.commit.IndexStoreProvider;
+import org.opensearch.index.store.FormatChecksumStrategy;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.parquet.engine.ParquetDataFormat;
+import org.opensearch.parquet.writer.ParquetDocumentInput;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Test-only plugin that exercises {@link org.opensearch.parquet.writer.ParquetWriter}'s
+ * production schema-mismatch failure path end-to-end through the cluster client by
+ * suppressing schema reconciliation. When armed, the wrapped writer's
+ * {@link Writer#updateMappingVersion} is a no-op, so a doc carrying a newly-mapped field
+ * arrives at {@code VSRManager.addDocument} without a corresponding {@code ParquetField}
+ * mapping. The real {@link org.opensearch.parquet.writer.MismatchedInputException} is
+ * thrown by the production code path and the production catch block (state PENDING_ROLLBACK →
+ * inline rollback → state ACTIVE → return Failure) handles it.
+ *
+ * <p>Mirrors {@link FailableLuceneDataFormatPlugin} but exercises the parquet self-rollback
+ * contract instead of Lucene's directory-fault path.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ *   FailableParquetDataFormatPlugin.armSchemaSuppression();   // next addDoc on a new field fails
+ *   ... index doc with a previously-unseen field type ...
+ *   FailableParquetDataFormatPlugin.clearFailure();
+ * }</pre>
+ */
+public class FailableParquetDataFormatPlugin extends ParquetDataFormatPlugin {
+
+    private static final AtomicBoolean suppressMappingUpdates = new AtomicBoolean(false);
+
+    /** While armed, every wrapped writer's {@code updateMappingVersion} is a no-op. */
+    public static void armSchemaSuppression() {
+        suppressMappingUpdates.set(true);
+    }
+
+    /** Re-enables mapping propagation. */
+    public static void clearFailure() {
+        suppressMappingUpdates.set(false);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public IndexingExecutionEngine<?, ?> indexingEngine(IndexingEngineConfig engineConfig) {
+        IndexingExecutionEngine<ParquetDataFormat, ParquetDocumentInput> delegate = (IndexingExecutionEngine<
+            ParquetDataFormat,
+            ParquetDocumentInput>) super.indexingEngine(engineConfig);
+        return new MappingSuppressingEngine(delegate);
+    }
+
+    /** Delegating wrapper that intercepts only {@code createWriter}. */
+    private static final class MappingSuppressingEngine implements IndexingExecutionEngine<ParquetDataFormat, ParquetDocumentInput> {
+
+        private final IndexingExecutionEngine<ParquetDataFormat, ParquetDocumentInput> delegate;
+
+        MappingSuppressingEngine(IndexingExecutionEngine<ParquetDataFormat, ParquetDocumentInput> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Writer<ParquetDocumentInput> createWriter(WriterConfig config) {
+            return new MappingSuppressingWriter(delegate.createWriter(config));
+        }
+
+        @Override
+        public Merger getMerger() {
+            return delegate.getMerger();
+        }
+
+        @Override
+        public RefreshResult refresh(RefreshInput refreshInput) throws IOException {
+            return delegate.refresh(refreshInput);
+        }
+
+        @Override
+        public long getNextWriterGeneration() {
+            return delegate.getNextWriterGeneration();
+        }
+
+        @Override
+        public ParquetDataFormat getDataFormat() {
+            return delegate.getDataFormat();
+        }
+
+        @Override
+        public long getNativeBytesUsed() {
+            return delegate.getNativeBytesUsed();
+        }
+
+        @Override
+        public Map<String, Collection<String>> deleteFiles(Map<String, Collection<String>> filesToDelete) throws IOException {
+            return delegate.deleteFiles(filesToDelete);
+        }
+
+        @Override
+        public ParquetDocumentInput newDocumentInput() {
+            return delegate.newDocumentInput();
+        }
+
+        @Override
+        public IndexStoreProvider getProvider() {
+            return delegate.getProvider();
+        }
+
+        @Override
+        public FormatChecksumStrategy getChecksumStrategy() {
+            return delegate.getChecksumStrategy();
+        }
+
+        @Override
+        public Map<DataFormat, EngineReaderManager<?>> buildReaderManager(ReaderManagerConfig config) throws IOException {
+            return delegate.buildReaderManager(config);
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+
+    /**
+     * Delegating writer that drops {@code updateMappingVersion} calls while the static flag
+     * is armed, so a doc carrying a field added in a later mapping version reaches the
+     * production VSR with an unreconciled schema and triggers
+     * {@link org.opensearch.parquet.writer.MismatchedInputException} naturally.
+     */
+    private static final class MappingSuppressingWriter implements Writer<ParquetDocumentInput> {
+
+        private final Writer<ParquetDocumentInput> delegate;
+
+        MappingSuppressingWriter(Writer<ParquetDocumentInput> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public WriteResult addDoc(ParquetDocumentInput input) throws IOException {
+            return delegate.addDoc(input);
+        }
+
+        @Override
+        public void rollbackTo(long rowCount) throws IOException {
+            delegate.rollbackTo(rowCount);
+        }
+
+        @Override
+        public FileInfos flush(FlushInput flushInput) throws IOException {
+            return delegate.flush(flushInput);
+        }
+
+        @Override
+        public void sync() throws IOException {
+            delegate.sync();
+        }
+
+        @Override
+        public long generation() {
+            return delegate.generation();
+        }
+
+        @Override
+        public boolean isSchemaMutable() {
+            return delegate.isSchemaMutable();
+        }
+
+        @Override
+        public long mappingVersion() {
+            return delegate.mappingVersion();
+        }
+
+        @Override
+        public void updateMappingVersion(long newVersion) {
+            // The whole point: when armed, the writer is left out of sync with the live
+            // mapping so any new field type reaches VSRManager.addDocument unmapped, where
+            // production code raises MismatchedInputException.
+            if (suppressMappingUpdates.get()) {
+                return;
+            }
+            delegate.updateMappingVersion(newVersion);
+        }
+
+        @Override
+        public WriterState state() {
+            return delegate.state();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+}

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDocumentInput.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDocumentInput.java
@@ -33,6 +33,7 @@ public class CompositeDocumentInput implements DocumentInput<List<? extends Docu
     private final DocumentInput<?> primaryDocumentInput;
     private final DataFormat primaryFormat;
     private final Map<DataFormat, DocumentInput<?>> secondaryDocumentInputs;
+    private long rowId = -1L;
 
     /**
      * Constructs a CompositeDocumentInput with a primary format input and secondary format inputs.
@@ -81,6 +82,12 @@ public class CompositeDocumentInput implements DocumentInput<List<? extends Docu
         for (DocumentInput<?> input : secondaryDocumentInputs.values()) {
             input.setRowId(rowIdFieldName, rowId);
         }
+        this.rowId = rowId;
+    }
+
+    /** Returns the row ID assigned via {@link #setRowId}, or {@code -1} if none. */
+    public long getRowId() {
+        return rowId;
     }
 
     public long getFieldCount(String fieldName) {

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeIndexingExecutionEngine.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeIndexingExecutionEngine.java
@@ -37,7 +37,6 @@ import org.opensearch.index.store.FormatChecksumStrategy;
 import org.opensearch.index.store.Store;
 
 import java.io.IOException;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -47,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * A composite {@link IndexingExecutionEngine} that orchestrates indexing across
@@ -194,6 +192,22 @@ public class CompositeIndexingExecutionEngine implements IndexingExecutionEngine
     }
 
     /**
+     * Multiplexes tragic-exception detection across primary and secondary engines.
+     * Returns the first non-null tragic exception found (primary checked first), or
+     * {@code null} if every delegate is healthy.
+     */
+    @Override
+    public Exception getTragicException() {
+        Exception primaryTragic = primaryEngine.getTragicException();
+        if (primaryTragic != null) return primaryTragic;
+        for (IndexingExecutionEngine<?, ?> engine : secondaryEngines) {
+            Exception tragic = engine.getTragicException();
+            if (tragic != null) return tragic;
+        }
+        return null;
+    }
+
+    /**
      * Refreshes all per-format engines and merges their results into a unified list of
      * {@link Segment} instances. Each segment groups its per-format {@link WriterFileSet}
      * entries by writer generation.
@@ -204,16 +218,15 @@ public class CompositeIndexingExecutionEngine implements IndexingExecutionEngine
      */
     @Override
     public RefreshResult refresh(RefreshInput refreshInput) throws IOException {
-        RefreshResult primary = primaryEngine.refresh(refreshInput);
-        List<RefreshResult> secResults = new ArrayList<>();
+        Map<DataFormat, RefreshResult> resultsByFormat = new LinkedHashMap<>();
+        resultsByFormat.put(primaryEngine.getDataFormat(), primaryEngine.refresh(refreshInput));
         for (IndexingExecutionEngine<?, ?> engine : secondaryEngines) {
-            secResults.add(engine.refresh(refreshInput));
+            resultsByFormat.put(engine.getDataFormat(), engine.refresh(refreshInput));
         }
 
         Map<Long, Segment.Builder> mergedByGen = new LinkedHashMap<>();
-        buildSegment(primary, mergedByGen);
-        for (RefreshResult secResult : secResults) {
-            buildSegment(secResult, mergedByGen);
+        for (Map.Entry<DataFormat, RefreshResult> entry : resultsByFormat.entrySet()) {
+            buildSegment(entry.getKey(), entry.getValue(), mergedByGen);
         }
 
         List<Segment> merged = new ArrayList<>(mergedByGen.size());
@@ -221,15 +234,22 @@ public class CompositeIndexingExecutionEngine implements IndexingExecutionEngine
             merged.add(builder.build());
         }
 
+        assert merged.stream().allMatch(s -> s.dfGroupedSearchableFiles().size() >= 1 + secondaryEngines.size())
+            : "refresh result segments must contain all configured formats";
         return new RefreshResult(merged);
     }
 
-    private void buildSegment(RefreshResult primary, Map<Long, Segment.Builder> mergedByGen) {
-        for (Segment seg : primary.refreshedSegments()) {
+    /**
+     * Adds only the {@code ownFormat}'s {@link WriterFileSet} from each segment in
+     * {@code result.refreshedSegments()} into {@code mergedByGen}. Any other formats present
+     * in the per-engine result (e.g. echoed back from {@link RefreshInput#writerFiles()}) are
+     * intentionally ignored so each format's authoritative entry comes solely from its own engine.
+     */
+    private void buildSegment(DataFormat ownFormat, RefreshResult result, Map<Long, Segment.Builder> mergedByGen) {
+        for (Segment seg : result.refreshedSegments()) {
+            WriterFileSet ownFiles = seg.dfGroupedSearchableFiles().get(ownFormat.name());
             Segment.Builder builder = mergedByGen.computeIfAbsent(seg.generation(), Segment::builder);
-            for (Map.Entry<String, WriterFileSet> entry : seg.dfGroupedSearchableFiles().entrySet()) {
-                builder.addSearchableFiles(entry.getKey(), entry.getValue());
-            }
+            builder.addSearchableFiles(ownFormat, ownFiles);
         }
     }
 
@@ -351,17 +371,22 @@ public class CompositeIndexingExecutionEngine implements IndexingExecutionEngine
             {
                 Map<DataFormat, IndexStoreProvider> tempProviders = new HashMap<>();
                 tempProviders.put(primaryEngine.getDataFormat(), primaryEngine.getProvider());
-                tempProviders.putAll(
-                    secondaryEngines.stream()
-                        .map(eng -> new AbstractMap.SimpleEntry<>(eng.getDataFormat(), eng.getProvider()))
-                        .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue))
-                );
+                if (primaryEngine.getProvider() == null) {
+                    logger.debug("IndexStoreProvider is null for primary engine [{}]", primaryEngine.getDataFormat().name());
+                }
+                for (IndexingExecutionEngine<?, ?> eng : secondaryEngines) {
+                    tempProviders.put(eng.getDataFormat(), eng.getProvider());
+                    if (eng.getProvider() == null) {
+                        logger.debug("IndexStoreProvider is null for secondary engine [{}]", eng.getDataFormat().name());
+                    }
+                }
                 providers = tempProviders;
             }
 
             @Override
             public FormatStore getStore(DataFormat dataFormat) {
-                return providers.get(dataFormat).getStore(dataFormat);
+                IndexStoreProvider provider = providers.get(dataFormat);
+                return provider != null ? provider.getStore(dataFormat) : null;
             }
         };
     }

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
@@ -20,14 +20,16 @@ import org.opensearch.index.engine.dataformat.RowIdMapping;
 import org.opensearch.index.engine.dataformat.WriteResult;
 import org.opensearch.index.engine.dataformat.Writer;
 import org.opensearch.index.engine.dataformat.WriterConfig;
+import org.opensearch.index.engine.dataformat.WriterState;
 import org.opensearch.index.engine.exec.WriterFileSet;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A composite {@link Writer} that wraps one {@link Writer} per registered data format
@@ -49,41 +51,23 @@ class CompositeWriter implements Writer<CompositeDocumentInput> {
     private final Writer<DocumentInput<?>> primaryWriter;
     private final Map<DataFormat, Writer<DocumentInput<?>>> secondaryWritersByFormat;
     private final long writerGeneration;
-    private final AtomicReference<WriterState> state;
+    private final FailureHandlerStrategy failureHandler;
+    private volatile boolean closed;
     private long mappingVersion;
-
-    /**
-     * Represents the lifecycle state of a {@link CompositeWriter}.
-     * <p>
-     * State transitions are one-way from {@code ACTIVE}:
-     * <ul>
-     *   <li>{@code ACTIVE} → {@code FLUSH_PENDING} (when refresh marks the writer for flushing)</li>
-     *   <li>{@code ACTIVE} → {@code ABORTED} (when the writer is aborted due to failure)</li>
-     * </ul>
-     */
-    @ExperimentalApi
-    enum WriterState {
-        /** Writer is actively accepting documents. */
-        ACTIVE,
-        /** Writer has been marked for flushing and should not accept new documents. */
-        FLUSH_PENDING,
-        /** Writer has been aborted due to a failure and should not be reused. */
-        ABORTED
-    }
+    /** Successful addDoc count — every incoming rowId must equal this. */
+    private long acceptedRows = 0L;
 
     /**
      * Constructs a CompositeWriter from the given engine and writer generation.
      * <p>
-     * Creates a per-format {@link Writer} for each delegate engine (primary first,
-     * then secondaries). The {@code postWrite} callback releases this writer back
-     * to the engine's writer pool.
+     * Creates a per-format {@link Writer} for each delegate engine (primary first, then
+     * secondaries) and a fresh {@link FailureHandlerStrategy} that lives for the writer's lifetime.
      *
-     * @param engine           the composite indexing execution engine
-     * @param config           the writer configuration
+     * @param engine the composite indexing execution engine
+     * @param config the writer configuration
      */
     @SuppressWarnings("unchecked")
     CompositeWriter(CompositeIndexingExecutionEngine engine, WriterConfig config) {
-        this.state = new AtomicReference<>(WriterState.ACTIVE);
         this.writerGeneration = config.writerGeneration();
 
         IndexingExecutionEngine<?, ?> primaryDelegate = engine.getPrimaryDelegate();
@@ -102,70 +86,69 @@ class CompositeWriter implements Writer<CompositeDocumentInput> {
             secondaries.put(delegate.getDataFormat(), secondary);
         }
         this.secondaryWritersByFormat = Collections.unmodifiableMap(secondaries);
+        this.failureHandler = new FailureHandlerStrategy();
     }
 
     @Override
     public WriteResult addDoc(CompositeDocumentInput doc) throws IOException {
-        if (state.get() != WriterState.ACTIVE) {
-            throw new IllegalStateException("Cannot add document to writer in state " + state.get());
+        WriterState currentState = state();
+        if (currentState != WriterState.ACTIVE) {
+            throw new IllegalStateException("Cannot add document to writer in state " + currentState);
         }
 
-        // Write to primary first
+        if (doc.getRowId() != acceptedRows) {
+            throw new IllegalStateException("rowId [" + doc.getRowId() + "] does not match accepted row count [" + acceptedRows + "]");
+        }
+
+        // Roll back exactly the writers we've called addDoc on, in order.
+        List<Writer<DocumentInput<?>>> touched = new ArrayList<>();
+        touched.add(primaryWriter);
         WriteResult primaryResult = primaryWriter.addDoc(doc.getPrimaryInput());
-        switch (primaryResult) {
-            case WriteResult.Success s -> logger.trace("Successfully added document in primary format [{}]", primaryFormat.name());
-            case WriteResult.Failure f -> {
-                logger.debug("Failed to add document in primary format [{}]", primaryFormat.name());
-                return primaryResult;
-            }
+        if (primaryResult instanceof WriteResult.Failure pf) {
+            logger.warn("Failed to add document in primary format [{}], rolling back", primaryFormat.name());
+            failureHandler.rollback(touched, acceptedRows);
+            return new WriteResult.Failure(pf.cause(), -1, -1, -1);
         }
 
-        // Then write to each secondary — keyed lookup by DataFormat (equals/hashCode based on name)
         Map<DataFormat, DocumentInput<?>> secondaryInputs = doc.getSecondaryInputs();
         for (Map.Entry<DataFormat, DocumentInput<?>> inputEntry : secondaryInputs.entrySet()) {
             DataFormat format = inputEntry.getKey();
             Writer<DocumentInput<?>> writer = secondaryWritersByFormat.get(format);
-            if (writer == null) {
-                logger.warn("No writer found for secondary format [{}], skipping", format.name());
-                continue;
-            }
+            touched.add(writer);
             WriteResult result = writer.addDoc(inputEntry.getValue());
-            switch (result) {
-                case WriteResult.Success s -> logger.trace("Successfully added document in secondary format [{}]", format.name());
-                case WriteResult.Failure f -> {
-                    logger.debug("Failed to add document in secondary format [{}]", format.name());
-                    return result;
-                }
+            if (result instanceof WriteResult.Failure sf) {
+                logger.warn("Failed to add document in secondary format [{}], rolling back", format.name());
+                failureHandler.rollback(touched, acceptedRows);
+                return new WriteResult.Failure(sf.cause(), -1, -1, -1);
             }
         }
 
+        assert touched.size() == 1 + secondaryInputs.size() : "all writers must succeed if we reach here; touched="
+            + touched.size()
+            + " expected="
+            + (1 + secondaryInputs.size());
+        acceptedRows++;
         return primaryResult;
     }
 
     @Override
     public FileInfos flush(FlushInput flushInput) throws IOException {
-        setFlushPending();
         FileInfos.Builder builder = FileInfos.builder();
 
-        // Flush primary (Parquet) first to get the sort permutation
+        // Flush primary first to capture the row ID mapping that secondaries need.
         FileInfos primaryFileInfos = primaryWriter.flush(flushInput);
         Optional<WriterFileSet> primaryWfs = primaryFileInfos.getWriterFileSet(primaryFormat);
         primaryWfs.ifPresent(writerFileSet -> builder.putWriterFileSet(primaryFormat, writerFileSet));
 
-        // Capture the row ID mapping from the primary flush
         RowIdMapping rowIdMapping = primaryFileInfos.rowIdMapping();
         if (rowIdMapping != null) {
             builder.rowIdMapping(rowIdMapping);
         }
-
-        // Build FlushInput for secondaries, carrying the row ID mapping from the primary
         FlushInput secondaryFlushInput = rowIdMapping != null ? new FlushInput(rowIdMapping) : FlushInput.EMPTY;
 
-        // Flush secondaries with the sort permutation context
         for (Map.Entry<DataFormat, Writer<DocumentInput<?>>> entry : secondaryWritersByFormat.entrySet()) {
             FileInfos fileInfos = entry.getValue().flush(secondaryFlushInput);
             for (Map.Entry<DataFormat, WriterFileSet> fileEntry : fileInfos.writerFilesMap().entrySet()) {
-                // Secondary format's WriterFileSet must also match this writer's generation
                 assert fileEntry.getValue().writerGeneration() == writerGeneration : "secondary WriterFileSet generation ["
                     + fileEntry.getValue().writerGeneration()
                     + "] for format ["
@@ -176,7 +159,13 @@ class CompositeWriter implements Writer<CompositeDocumentInput> {
                 builder.putWriterFileSet(fileEntry.getKey(), fileEntry.getValue());
             }
         }
-        return builder.build();
+        FileInfos result = builder.build();
+        assert result.writerFilesMap().isEmpty() || result.writerFilesMap().size() == 1 + secondaryWritersByFormat.size()
+            : "flush must produce files for all formats or none; got "
+                + result.writerFilesMap().size()
+                + " expected 0 or "
+                + (1 + secondaryWritersByFormat.size());
+        return result;
     }
 
     @Override
@@ -219,9 +208,13 @@ class CompositeWriter implements Writer<CompositeDocumentInput> {
 
     @Override
     public void close() throws IOException {
-        primaryWriter.close();
-        for (Writer<DocumentInput<?>> writer : secondaryWritersByFormat.values()) {
-            writer.close();
+        try {
+            primaryWriter.close();
+            for (Writer<DocumentInput<?>> writer : secondaryWritersByFormat.values()) {
+                writer.close();
+            }
+        } finally {
+            closed = true;
         }
     }
 
@@ -248,51 +241,58 @@ class CompositeWriter implements Writer<CompositeDocumentInput> {
     }
 
     /**
-     * Marks this writer as aborted. Only transitions from {@code ACTIVE}.
-     *
-     * @throws IllegalStateException if the writer is not in {@code ACTIVE} state
+     * Returns the lifecycle state aggregated by the composite's {@link FailureHandlerStrategy} —
+     * the worst (most-progressed) state across primary and all secondary writers.
      */
-    void abort() {
-        if (this.state.compareAndSet(WriterState.ACTIVE, WriterState.ABORTED) == false) {
-            throw new IllegalStateException("Cannot abort writer in state " + state.get());
+    @Override
+    public WriterState state() {
+        return failureHandler.aggregateState(closed, primaryWriter, secondaryWritersByFormat.values());
+    }
+
+    /**
+     * Per-composite failure-handling helper. Owns rollback orchestration and aggregates
+     * sub-writer states into the single {@link WriterState} the engine acts on.
+     * {@link #rollback} undoes the in-flight doc on each writer the composite touched;
+     * a rollback that itself throws propagates to DFAE, which fails the engine so
+     * recovery can replay the translog.
+     */
+    private static final class FailureHandlerStrategy {
+
+        /**
+         * Rolls back each writer in {@code touched} to the composite's current
+         * {@code acceptedRows}. Each writer either reaches the target or throws.
+         */
+        void rollback(List<Writer<DocumentInput<?>>> touched, long targetRowCount) throws IOException {
+            for (Writer<DocumentInput<?>> w : touched) {
+                w.rollbackTo(targetRowCount);
+            }
         }
-    }
 
-    /**
-     * Returns whether this writer has been aborted.
-     *
-     * @return {@code true} if aborted
-     */
-    boolean isAborted() {
-        return getState() == WriterState.ABORTED;
-    }
-
-    /**
-     * Marks this writer as having a pending flush. Only transitions from {@code ACTIVE}.
-     *
-     * @throws IllegalStateException if the writer is not in {@code ACTIVE} state
-     */
-    void setFlushPending() {
-        if (this.state.compareAndSet(WriterState.ACTIVE, WriterState.FLUSH_PENDING) == false) {
-            throw new IllegalStateException("Cannot set flush pending on writer in state " + state.get());
+        WriterState aggregateState(
+            boolean closed,
+            Writer<DocumentInput<?>> primary,
+            java.util.Collection<Writer<DocumentInput<?>>> secondaries
+        ) {
+            if (closed) return WriterState.CLOSED;
+            WriterState worst = WriterState.ACTIVE;
+            worst = worse(worst, primary.state());
+            for (Writer<?> w : secondaries) {
+                worst = worse(worst, w.state());
+            }
+            return worst;
         }
-    }
 
-    /**
-     * Returns whether this writer has a pending flush.
-     *
-     * @return {@code true} if a flush is pending
-     */
-    boolean isFlushPending() {
-        return getState() == WriterState.FLUSH_PENDING;
-    }
+        private static WriterState worse(WriterState a, WriterState b) {
+            return rank(a) >= rank(b) ? a : b;
+        }
 
-    /**
-     * Returns the current state of this writer for testing purpose.
-     *
-     * @return the writer state
-     */
-    WriterState getState() {
-        return state.get();
+        private static int rank(WriterState s) {
+            return switch (s) {
+                case ACTIVE -> 0;
+                case RETIRED_FLUSHABLE -> 1;
+                case PENDING_ROLLBACK -> 2;
+                case CLOSED -> 3;
+            };
+        }
     }
 }

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeEngineFailureTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeEngineFailureTests.java
@@ -1,0 +1,647 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.store.Directory;
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.common.lucene.uid.Versions;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.VersionType;
+import org.opensearch.index.engine.DataFormatAwareEngine;
+import org.opensearch.index.engine.Engine;
+import org.opensearch.index.engine.EngineConfig;
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DataFormatRegistry;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.dataformat.WriteResult;
+import org.opensearch.index.engine.dataformat.stub.FileBackedFailableIndexingExecutionEngine;
+import org.opensearch.index.engine.dataformat.stub.FileBackedFailableWriter;
+import org.opensearch.index.engine.dataformat.stub.InMemoryCommitter;
+import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.index.mapper.ParsedDocument;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
+import org.opensearch.index.mapper.SourceFieldMapper;
+import org.opensearch.index.mapper.Uid;
+import org.opensearch.index.seqno.RetentionLeases;
+import org.opensearch.index.seqno.SequenceNumbers;
+import org.opensearch.index.shard.ShardPath;
+import org.opensearch.index.store.FsDirectoryFactory;
+import org.opensearch.index.store.Store;
+import org.opensearch.index.translog.Translog;
+import org.opensearch.index.translog.TranslogConfig;
+import org.opensearch.test.DummyShardLock;
+import org.opensearch.test.IndexSettingsModule;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import static org.opensearch.index.engine.EngineTestCase.tombstoneDocSupplier;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests verifying file-level data consistency through the full stack:
+ * DataFormatAwareEngine → CompositeIndexingExecutionEngine → CompositeWriter → FileBackedFailableWriter.
+ * <p>
+ * Tests:
+ * <ul>
+ *   <li>{@code testSuccessfulIndexProducesConsistentFiles} — both format files have N lines, cross-format match</li>
+ *   <li>{@code testSecondaryFailureFlushesNMinus1AndClosesWriter} — flushed file has N-1 docs after rollback,
+ *       inner writer closed, fresh writer created for next doc</li>
+ *   <li>{@code testPrimaryFailureWriterStaysOpenInPool} — inner writer NOT closed, same writer reused</li>
+ *   <li>{@code testAbortedWriterClosedNoFileOnDisk} — inner writer closed, no file on disk (not flushed)</li>
+ *   <li>{@code testIntermittentFailuresProduceConsistentFiles} — total rows across all files match successes,
+ *       cross-format consistency across multiple writer generations</li>
+ * </ul>
+ */
+public class CompositeEngineFailureTests extends OpenSearchTestCase {
+
+    private ThreadPool threadPool;
+    private Store store;
+    private ShardId shardId;
+    private AtomicLong primaryTerm;
+    private FileBackedFailableIndexingExecutionEngine fbPrimary;
+    private FileBackedFailableIndexingExecutionEngine fbSecondary;
+    private CompositeIndexingExecutionEngine compositeEngine;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        shardId = new ShardId(new Index("test", "_na_"), 0);
+        primaryTerm = new AtomicLong(randomLongBetween(1, Long.MAX_VALUE));
+        threadPool = new TestThreadPool(getClass().getName());
+        store = createStore();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            store.close();
+        } finally {
+            terminate(threadPool);
+        }
+        super.tearDown();
+    }
+
+    // --- Infrastructure ---
+
+    private Store createStore() throws IOException {
+        Directory dir = newDirectory();
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                .build()
+        );
+        Path path = createTempDir().resolve(shardId.getIndex().getUUID()).resolve(String.valueOf(shardId.id()));
+        ShardPath shardPath = new ShardPath(false, path, path, shardId);
+        return new Store(
+            shardId,
+            indexSettings,
+            dir,
+            new DummyShardLock(shardId),
+            Store.OnClose.EMPTY,
+            shardPath,
+            new FsDirectoryFactory()
+        );
+    }
+
+    private void bootstrapStoreWithMetadata(Store s, String translogUUID) throws IOException {
+        try (
+            IndexWriter writer = new IndexWriter(
+                s.directory(),
+                new IndexWriterConfig(Lucene.STANDARD_ANALYZER).setMergePolicy(NoMergePolicy.INSTANCE)
+                    .setOpenMode(IndexWriterConfig.OpenMode.CREATE)
+            )
+        ) {
+            Map<String, String> commitData = new HashMap<>();
+            commitData.put(Translog.TRANSLOG_UUID_KEY, translogUUID);
+            commitData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, Long.toString(SequenceNumbers.NO_OPS_PERFORMED));
+            commitData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(SequenceNumbers.NO_OPS_PERFORMED));
+            commitData.put(Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID, "-1");
+            commitData.put(Engine.HISTORY_UUID_KEY, UUID.randomUUID().toString());
+            writer.setLiveCommitData(commitData.entrySet());
+            writer.commit();
+        }
+    }
+
+    private DataFormatAwareEngine createEngine(Store s, Path translogPath) throws IOException {
+        return createEngine(s, translogPath, () -> SequenceNumbers.NO_OPS_PERFORMED, true);
+    }
+
+    private DataFormatAwareEngine createEngine(Store s, Path translogPath, java.util.function.LongSupplier globalCheckpointSupplier)
+        throws IOException {
+        return createEngine(s, translogPath, globalCheckpointSupplier, true);
+    }
+
+    private DataFormatAwareEngine createEngine(
+        Store s,
+        Path translogPath,
+        java.util.function.LongSupplier globalCheckpointSupplier,
+        boolean bootstrapTranslog
+    ) throws IOException {
+        Path dataDir = createTempDir("file-backed-data");
+        fbPrimary = new FileBackedFailableIndexingExecutionEngine("lucene", dataDir);
+        fbSecondary = new FileBackedFailableIndexingExecutionEngine("parquet", dataDir);
+
+        CompositeTestHelper.FailableCommitter committer = new CompositeTestHelper.FailableCommitter();
+        DataFormatRegistry registry = mock(DataFormatRegistry.class);
+        when(registry.format("lucene")).thenReturn(fbPrimary.getDataFormat());
+        when(registry.format("parquet")).thenReturn(fbSecondary.getDataFormat());
+        when(registry.getIndexingEngine(any(), any())).thenAnswer(inv -> {
+            DataFormat fmt = inv.getArgument(1);
+            if (fmt.name().equals("lucene")) return fbPrimary;
+            if (fmt.name().equals("parquet")) return fbSecondary;
+            return null;
+        });
+
+        Settings.Builder sb = Settings.builder()
+            .put("index.composite.primary_data_format", "lucene")
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1);
+        sb.putList("index.composite.secondary_data_formats", "parquet");
+        IndexMetadata meta = IndexMetadata.builder("test-fb").settings(sb.build()).build();
+        IndexSettings fbSettings = new IndexSettings(meta, Settings.EMPTY);
+        compositeEngine = new CompositeIndexingExecutionEngine(fbSettings, null, committer, registry, null, null);
+
+        DataFormatRegistry dfaRegistry = mock(DataFormatRegistry.class);
+        when(dfaRegistry.format("composite")).thenReturn(compositeEngine.getDataFormat());
+        when(dfaRegistry.getIndexingEngine(any(), any())).thenAnswer(inv -> compositeEngine);
+
+        if (bootstrapTranslog) {
+            String uuid = Translog.createEmptyTranslog(translogPath, SequenceNumbers.NO_OPS_PERFORMED, shardId, primaryTerm.get());
+            bootstrapStoreWithMetadata(s, uuid);
+        }
+
+        IndexSettings engineSettings = IndexSettingsModule.newIndexSettings(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+                .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "composite")
+                .build()
+        );
+        TranslogConfig tc = new TranslogConfig(shardId, translogPath, engineSettings, BigArrays.NON_RECYCLING_INSTANCE, "", false);
+        org.opensearch.index.mapper.MapperService mapperService = mock(org.opensearch.index.mapper.MapperService.class);
+        when(mapperService.getIndexSettings()).thenReturn(engineSettings);
+        EngineConfig config = new EngineConfig.Builder().shardId(shardId)
+            .threadPool(threadPool)
+            .indexSettings(engineSettings)
+            .store(s)
+            .mergePolicy(NoMergePolicy.INSTANCE)
+            .translogConfig(tc)
+            .flushMergesAfter(TimeValue.timeValueMinutes(5))
+            .externalRefreshListener(List.of())
+            .internalRefreshListener(List.of())
+            .globalCheckpointSupplier(globalCheckpointSupplier)
+            .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+            .primaryTermSupplier(primaryTerm::get)
+            .tombstoneDocSupplier(tombstoneDocSupplier())
+            .dataFormatRegistry(dfaRegistry)
+            .committerFactory(c -> new InMemoryCommitter(s))
+            .eventListener(new Engine.EventListener() {
+                @Override
+                public void onFailedEngine(String reason, Exception e) {}
+            })
+            .mapperService(mapperService)
+            .build();
+        return new DataFormatAwareEngine(config);
+    }
+
+    private ParsedDocument doc(String id) {
+        ParseContext.Document document = new ParseContext.Document();
+        Field uidField = new Field("_id", Uid.encodeId(id), IdFieldMapper.Defaults.FIELD_TYPE);
+        Field versionField = new NumericDocValuesField("_version", 0);
+        SeqNoFieldMapper.SequenceIDFields seqID = SeqNoFieldMapper.SequenceIDFields.emptySeqID();
+        document.add(uidField);
+        document.add(versionField);
+        document.add(seqID.seqNo);
+        document.add(seqID.seqNoDocValue);
+        document.add(seqID.primaryTerm);
+        BytesReference source = new BytesArray("{}");
+        org.apache.lucene.util.BytesRef ref = source.toBytesRef();
+        document.add(new StoredField(SourceFieldMapper.NAME, ref.bytes, ref.offset, ref.length));
+        DocumentInput<?> input = compositeEngine.newDocumentInput();
+        return new ParsedDocument(versionField, seqID, id, null, Arrays.asList(document), source, MediaTypeRegistry.JSON, null, input);
+    }
+
+    private Engine.Index indexOp(ParsedDocument d) {
+        return new Engine.Index(
+            new Term(IdFieldMapper.NAME, Uid.encodeId(d.id())),
+            d,
+            SequenceNumbers.UNASSIGNED_SEQ_NO,
+            primaryTerm.get(),
+            Versions.MATCH_ANY,
+            VersionType.INTERNAL,
+            Engine.Operation.Origin.PRIMARY,
+            System.nanoTime(),
+            -1,
+            false,
+            SequenceNumbers.UNASSIGNED_SEQ_NO,
+            0
+        );
+    }
+
+    // --- Tests ---
+
+    public void testSuccessfulIndexProducesConsistentFiles() throws IOException {
+        try (DataFormatAwareEngine engine = createEngine(store, createTempDir())) {
+            for (int i = 0; i < 5; i++) {
+                assertThat(engine.index(indexOp(doc(Integer.toString(i)))).getResultType(), equalTo(Engine.Result.Type.SUCCESS));
+            }
+            engine.refresh("test");
+
+            List<String> primary = FileBackedFailableIndexingExecutionEngine.readFlushedFile(
+                fbPrimary.getLastCreatedWriter().getFilePath()
+            );
+            List<String> secondary = FileBackedFailableIndexingExecutionEngine.readFlushedFile(
+                fbSecondary.getLastCreatedWriter().getFilePath()
+            );
+            assertEquals(5, primary.size());
+            assertEquals(5, secondary.size());
+            assertEquals(primary.size(), secondary.size());
+        }
+    }
+
+    public void testSecondaryFailureFlushesNMinus1AndClosesWriter() throws IOException {
+        try (DataFormatAwareEngine engine = createEngine(store, createTempDir())) {
+            for (int i = 0; i < 5; i++) {
+                engine.index(indexOp(doc(Integer.toString(i))));
+            }
+
+            FileBackedFailableWriter innerWriter = fbPrimary.getLastCreatedWriter();
+
+            fbSecondary.getLastCreatedWriter().writeResultSupplier = () -> new WriteResult.Failure(
+                new IOException("secondary failed"),
+                -1,
+                -1,
+                -1
+            );
+
+            try {
+                engine.index(indexOp(doc("5")));
+            } catch (UnsupportedOperationException e) { /* expected */ }
+
+            // Writer closed and removed from pool
+            assertTrue("inner writer closed", innerWriter.isClosed());
+
+            // Flushed file has N-1 docs, cross-format consistent
+            List<String> primary = FileBackedFailableIndexingExecutionEngine.readFlushedFile(innerWriter.getFilePath());
+            List<String> secondary = FileBackedFailableIndexingExecutionEngine.readFlushedFile(
+                fbSecondary.getLastCreatedWriter().getFilePath()
+            );
+            assertEquals(5, primary.size());
+            assertEquals(5, secondary.size());
+
+            // Fresh writer created for next doc
+            fbSecondary.getLastCreatedWriter().writeResultSupplier = null;
+            fbSecondary.setDefaultWriteResultSupplier(null);
+            assertThat(engine.index(indexOp(doc("6"))).getResultType(), equalTo(Engine.Result.Type.SUCCESS));
+            assertNotSame(innerWriter, fbPrimary.getLastCreatedWriter());
+        }
+    }
+
+    public void testPrimaryFailureWriterStaysOpenInPool() throws IOException {
+        try (DataFormatAwareEngine engine = createEngine(store, createTempDir())) {
+            for (int i = 0; i < 5; i++) {
+                engine.index(indexOp(doc(Integer.toString(i))));
+            }
+
+            FileBackedFailableWriter innerWriter = fbPrimary.getLastCreatedWriter();
+
+            // Model a Parquet-style format: addDoc failure transitions to PENDING_ROLLBACK, then
+            // rollback brings the writer back to ACTIVE (fully reversible — no row consumed
+            // on failure) so subsequent addDoc calls succeed.
+            innerWriter.setStateAfterRollback(org.opensearch.index.engine.dataformat.WriterState.ACTIVE);
+            innerWriter.writeResultSupplier = () -> new WriteResult.Failure(new IOException("primary full"), -1, -1, -1);
+
+            try {
+                engine.index(indexOp(doc("5")));
+            } catch (UnsupportedOperationException e) { /* expected */ }
+
+            // Writer NOT closed, still in pool
+            assertFalse("inner writer still open", innerWriter.isClosed());
+
+            innerWriter.writeResultSupplier = null;
+            assertThat(engine.index(indexOp(doc("6"))).getResultType(), equalTo(Engine.Result.Type.SUCCESS));
+        }
+    }
+
+    /**
+     * RETIRED_DROP path: secondary fails AND primary's rollback fails. Composite reports
+     * RETIRED_DROP. The engine fails so recovery can replay the translog and restore the
+     * acked-but-unflushed docs. Verifies the writer was closed and no file was flushed.
+     */
+    public void testAbortedWriterClosedAndEngineFailed() throws IOException {
+        DataFormatAwareEngine engine = createEngine(store, createTempDir());
+        try {
+            for (int i = 0; i < 5; i++) {
+                engine.index(indexOp(doc(Integer.toString(i))));
+            }
+
+            FileBackedFailableWriter innerWriter = fbPrimary.getLastCreatedWriter();
+
+            fbSecondary.getLastCreatedWriter().writeResultSupplier = () -> new WriteResult.Failure(
+                new IOException("secondary failed"),
+                -1,
+                -1,
+                -1
+            );
+            fbPrimary.getLastCreatedWriter().rollbackFailure = new IOException("rollback failed");
+
+            try {
+                engine.index(indexOp(doc("5")));
+            } catch (Exception expected) { /* RETIRED_DROP fails engine; index call may throw */ }
+
+            assertTrue("inner writer closed", innerWriter.isClosed());
+            assertFalse("no file on disk (not flushed)", java.nio.file.Files.exists(innerWriter.getFilePath()));
+            // Subsequent index ops must throw — engine has been failed.
+            expectThrows(org.apache.lucene.store.AlreadyClosedException.class, () -> engine.index(indexOp(doc("6"))));
+        } finally {
+            engine.close();
+        }
+    }
+
+    public void testIntermittentFailuresProduceConsistentFiles() throws IOException {
+        try (DataFormatAwareEngine engine = createEngine(store, createTempDir())) {
+            engine.index(indexOp(doc("init")));
+            int expected = 1;
+
+            for (int i = 0; i < 9; i++) {
+                boolean fail = (i % 3 == 2);
+                WriteResult failResult = new WriteResult.Failure(new IOException("intermittent"), -1, -1, -1);
+                fbSecondary.setDefaultWriteResultSupplier(fail ? () -> failResult : null);
+                fbSecondary.getLastCreatedWriter().writeResultSupplier = fail ? () -> failResult : null;
+
+                try {
+                    Engine.IndexResult r = engine.index(indexOp(doc(Integer.toString(i))));
+                    if (fail == false) {
+                        assertThat(r.getResultType(), equalTo(Engine.Result.Type.SUCCESS));
+                        expected++;
+                    }
+                } catch (UnsupportedOperationException e) {
+                    assertTrue(fail);
+                }
+            }
+            fbSecondary.setDefaultWriteResultSupplier(null);
+            engine.refresh("verify");
+
+            long primaryRows = 0;
+            for (FileBackedFailableWriter w : fbPrimary.getAllWriters()) {
+                primaryRows += FileBackedFailableIndexingExecutionEngine.readFlushedFile(w.getFilePath()).size();
+            }
+            long secondaryRows = 0;
+            for (FileBackedFailableWriter w : fbSecondary.getAllWriters()) {
+                secondaryRows += FileBackedFailableIndexingExecutionEngine.readFlushedFile(w.getFilePath()).size();
+            }
+            assertEquals(expected, primaryRows);
+            assertEquals(expected, secondaryRows);
+            assertEquals(primaryRows, secondaryRows);
+        }
+    }
+
+    // ============================================================================
+    // SeqNo / checkpoint / recovery invariants under per-doc failure injection.
+    //
+    // For each failure mode we verify, post-indexing-of-10-docs:
+    // 1. localCheckpoint == globalCheckpoint == 9 (seqNos 0..9 consumed, no holes)
+    // 2. Failed seqNos persisted as Translog.NoOp; successful ops as Translog.Index
+    // 3. After close + reopen + translog replay, localCheckpoint == 9 again
+    // ============================================================================
+
+    /** Mode 1: secondary fails (with rollback success) — primary stays consistent. */
+    public void testSeqNoInvariantsSecondaryFailRollbackOk() throws IOException {
+        runSeqNoAndRecoveryScenario(/*failPrimary*/ false, /*rollbackFails*/ false);
+    }
+
+    /**
+     * Mode 2: secondary fails AND primary's rollback fails. Composite reports RETIRED_DROP
+     * → engine MUST fail (acked docs would otherwise be lost until restart). Verify the
+     * engine is in failed state and translog still has the in-flight ops for recovery.
+     */
+    public void testSeqNoInvariantsSecondaryFailRollbackFailsFailsEngine() throws IOException {
+        Path translogPath = createTempDir();
+        java.util.concurrent.atomic.AtomicLong globalCheckpoint = new java.util.concurrent.atomic.AtomicLong(
+            SequenceNumbers.NO_OPS_PERFORMED
+        );
+        DataFormatAwareEngine engine = createEngine(store, translogPath, globalCheckpoint::get);
+        try {
+            engine.translogManager().recoverFromTranslog(s -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+            // Index a couple successful docs.
+            for (int i = 0; i < 2; i++) {
+                Engine.IndexResult r = engine.index(indexOp(doc(Integer.toString(i))));
+                assertThat(r.getResultType(), equalTo(Engine.Result.Type.SUCCESS));
+            }
+            // Wire secondary failure + primary rollback failure.
+            fbSecondary.getLastCreatedWriter().writeResultSupplier = () -> new WriteResult.Failure(
+                new IOException("secondary failed"),
+                -1,
+                -1,
+                -1
+            );
+            fbPrimary.getLastCreatedWriter().rollbackFailure = new IOException("primary rollback fails");
+
+            // The doc that hits both failures triggers RETIRED_DROP → engine fails.
+            try {
+                engine.index(indexOp(doc("2")));
+            } catch (Exception expected) { /* engine failure may surface as throw */ }
+
+            // Subsequent index calls fail — engine is closed. The 2 acked docs (seqNos 0, 1)
+            // remain durably persisted in the translog files on disk; on the next shard
+            // recovery a fresh engine will replay them. We don't assert translog stats here
+            // because reading them via the closed engine throws AlreadyClosedException.
+            expectThrows(org.apache.lucene.store.AlreadyClosedException.class, () -> engine.index(indexOp(doc("3"))));
+        } finally {
+            engine.close();
+        }
+    }
+
+    /** Mode 3: primary fails immediately (no secondary touched, no rollback needed). */
+    public void testSeqNoInvariantsPrimaryFailRollbackOk() throws IOException {
+        runSeqNoAndRecoveryScenario(/*failPrimary*/ true, /*rollbackFails*/ false);
+    }
+
+    /**
+     * Mode 4: primary fails AND its writer's rollback would fail — but since primary failure
+     * does not require rolling back any other writer (no secondary was touched), this mode
+     * still terminates cleanly. We exercise it for symmetry; the result is identical to mode 3.
+     */
+    public void testSeqNoInvariantsPrimaryFailRollbackFails() throws IOException {
+        runSeqNoAndRecoveryScenario(/*failPrimary*/ true, /*rollbackFails*/ true);
+    }
+
+    /**
+     * Drives 10 indexing operations with failures injected at calls 4, 7, 9 on the configured
+     * failing side. Verifies seqNo/checkpoint invariants both pre-restart and post-translog-replay.
+     *
+     * <p>Note: {@code rollbackFails=true && failPrimary=false} (RETIRED_DROP case) is covered
+     * separately by {@link #testSeqNoInvariantsSecondaryFailRollbackFailsFailsEngine}, since
+     * that path now intentionally fails the engine and so the 10-doc loop cannot complete.
+     */
+    private void runSeqNoAndRecoveryScenario(boolean failPrimary, boolean rollbackFails) throws IOException {
+        assert !(rollbackFails && !failPrimary) : "RETIRED_DROP path is exercised by a dedicated test";
+        Path translogPath = createTempDir();
+        java.util.concurrent.atomic.AtomicLong globalCheckpoint = new java.util.concurrent.atomic.AtomicLong(
+            SequenceNumbers.NO_OPS_PERFORMED
+        );
+        java.util.Set<Long> failedSeqNos = new java.util.HashSet<>();
+
+        DataFormatAwareEngine engine = createEngine(store, translogPath, globalCheckpoint::get);
+        try {
+            engine.translogManager().recoverFromTranslog(s -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+            FileBackedFailableIndexingExecutionEngine targetEngine = failPrimary ? fbPrimary : fbSecondary;
+            // Fail on the 4th, 7th, and 9th calls (1-based); succeed otherwise. The supplier is
+            // installed as the default so it survives writer retirement + recreation.
+            java.util.concurrent.atomic.AtomicInteger callIdx = new java.util.concurrent.atomic.AtomicInteger();
+            Supplier<WriteResult> failureSupplier = () -> {
+                int n = callIdx.incrementAndGet();
+                if (n == 4 || n == 7 || n == 9) {
+                    return new WriteResult.Failure(new IOException("injected failure on call " + n), -1, -1, -1);
+                }
+                return null; // null tells FileBackedFailableWriter to take the success path
+            };
+            targetEngine.setDefaultWriteResultSupplier(failureSupplier);
+            if (failPrimary) {
+                // Primary models a Parquet-style writer: addDoc Failure → PENDING_ROLLBACK, then
+                // rollback brings it back to ACTIVE (fully reversible). Apply to all writers
+                // created by this engine, since the composite recreates a writer per refresh.
+                fbPrimary.setDefaultStateAfterRollback(org.opensearch.index.engine.dataformat.WriterState.ACTIVE);
+            }
+            // For "rollback fails" scenarios, the rollback target's writer factory should produce
+            // writers that throw on rollback. We don't have a setter for this on the engine, so
+            // we install it lazily — after each writer is created, set rollbackFailure on it.
+            // Simpler: rely on the fact that on a single-doc test, only the first writer matters.
+            // We'll set rollbackFailure inside the loop after the first index call.
+
+            int succeeded = 0;
+            for (int i = 0; i < 10; i++) {
+                // After the first writer is created, install rollbackFailure on the primary if needed.
+                // (For "rollback fails" with secondary failure mode: the composite calls
+                // primary.rollbackLastDoc when the secondary fails; we want that to throw.)
+                if (i == 0 && rollbackFails && failPrimary == false) {
+                    Engine.IndexResult firstResult = engine.index(indexOp(doc(Integer.toString(i))));
+                    if (firstResult.getResultType() == Engine.Result.Type.SUCCESS) succeeded++;
+                    else failedSeqNos.add(firstResult.getSeqNo());
+                    fbPrimary.getLastCreatedWriter().rollbackFailure = new IOException("primary rollback fails");
+                    continue;
+                }
+                Engine.IndexResult result = engine.index(indexOp(doc(Integer.toString(i))));
+                if (result.getResultType() == Engine.Result.Type.SUCCESS) {
+                    succeeded++;
+                } else {
+                    failedSeqNos.add(result.getSeqNo());
+                }
+            }
+
+            // Pre-restart invariants
+            assertEquals("3 failures injected", 7, succeeded);
+            assertEquals("3 failed seqNos recorded", 3, failedSeqNos.size());
+            assertEquals("max seqNo == last assigned", 9L, engine.getSeqNoStats(globalCheckpoint.get()).getMaxSeqNo());
+            assertEquals("processed checkpoint advanced through all 10", 9L, engine.getProcessedLocalCheckpoint());
+            // Promote global to match local (replication tracker would do this externally)
+            globalCheckpoint.set(engine.getProcessedLocalCheckpoint());
+            assertEquals("global == local after promotion", engine.getProcessedLocalCheckpoint(), globalCheckpoint.get());
+
+            // Translog should contain 10 ops (7 Index + 3 NoOp). We deliberately do NOT flush
+            // so the translog is the only durable record — restart must replay it.
+            assertEquals(10, engine.translogManager().getTranslogStats().estimatedNumberOfOperations());
+        } finally {
+            engine.close();
+        }
+
+        // Reopen with a fresh failable engine (no failure injection) and replay the translog.
+        // Successful Index ops must replay successfully; NoOps replay as no-ops. End state:
+        // localCheckpoint == 9, max == 9, identical to pre-restart.
+        // bootstrapTranslog=false so we don't clobber the existing translog files.
+        DataFormatAwareEngine reopened = createEngine(store, translogPath, globalCheckpoint::get, false);
+        try {
+            org.opensearch.index.engine.exec.Indexer indexer = reopened;
+            int[] replayedCount = new int[1];
+            int recovered = reopened.translogManager().recoverFromTranslog(snapshot -> {
+                Translog.Operation op;
+                while ((op = snapshot.next()) != null) {
+                    Engine.Result result;
+                    if (op instanceof Translog.Index idx) {
+                        Engine.Index e = new Engine.Index(
+                            new Term(IdFieldMapper.NAME, Uid.encodeId(idx.id())),
+                            doc(idx.id()),
+                            idx.seqNo(),
+                            idx.primaryTerm(),
+                            idx.version(),
+                            null,
+                            Engine.Operation.Origin.LOCAL_TRANSLOG_RECOVERY,
+                            System.nanoTime(),
+                            idx.getAutoGeneratedIdTimestamp(),
+                            true,
+                            SequenceNumbers.UNASSIGNED_SEQ_NO,
+                            0
+                        );
+                        result = indexer.index(e);
+                    } else if (op instanceof Translog.NoOp noop) {
+                        Engine.NoOp e = new Engine.NoOp(
+                            noop.seqNo(),
+                            noop.primaryTerm(),
+                            Engine.Operation.Origin.LOCAL_TRANSLOG_RECOVERY,
+                            System.nanoTime(),
+                            noop.reason()
+                        );
+                        result = indexer.noOp(e);
+                    } else {
+                        throw new AssertionError("unexpected op type: " + op.opType());
+                    }
+                    if (result.getResultType() == Engine.Result.Type.FAILURE) {
+                        throw new AssertionError("replay failed for " + op + ": " + result.getFailure());
+                    }
+                    replayedCount[0]++;
+                }
+                return replayedCount[0];
+            }, reopened.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+            assertEquals("replay processed all 10 translog ops", 10, recovered);
+            assertEquals("post-replay max seqNo == 9", 9L, reopened.getSeqNoStats(globalCheckpoint.get()).getMaxSeqNo());
+            assertEquals("post-replay localCheckpoint == 9", 9L, reopened.getProcessedLocalCheckpoint());
+        } finally {
+            reopened.close();
+        }
+    }
+}

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeTestHelper.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeTestHelper.java
@@ -29,17 +29,22 @@ import org.opensearch.index.engine.dataformat.RefreshResult;
 import org.opensearch.index.engine.dataformat.WriteResult;
 import org.opensearch.index.engine.dataformat.Writer;
 import org.opensearch.index.engine.dataformat.WriterConfig;
+import org.opensearch.index.engine.dataformat.stub.MockDocumentInput;
 import org.opensearch.index.engine.exec.commit.Committer;
 import org.opensearch.index.engine.exec.commit.IndexStoreProvider;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -254,7 +259,7 @@ final class CompositeTestHelper {
 
         @Override
         public IndexStoreProvider getProvider() {
-            return null;
+            return df -> null;
         }
 
         @Override
@@ -270,6 +275,8 @@ final class CompositeTestHelper {
         private WriteResult resultToReturn = new WriteResult.Success(1, 1, 1);
         private boolean schemaMutable = true;
         private long mappingVersion = 0;
+        private volatile org.opensearch.index.engine.dataformat.WriterState state =
+            org.opensearch.index.engine.dataformat.WriterState.ACTIVE;
 
         StubWriter(DataFormat format) {
             this.format = format;
@@ -283,8 +290,14 @@ final class CompositeTestHelper {
             this.schemaMutable = mutable;
         }
 
+        /** Test-only setter to inject a state directly. */
+        void setState(org.opensearch.index.engine.dataformat.WriterState s) {
+            this.state = s;
+        }
+
         @Override
         public WriteResult addDoc(DocumentInput<?> d) {
+            assert state == org.opensearch.index.engine.dataformat.WriterState.ACTIVE : "addDoc requires ACTIVE state but was " + state;
             return resultToReturn;
         }
 
@@ -297,7 +310,9 @@ final class CompositeTestHelper {
         public void sync() {}
 
         @Override
-        public void close() {}
+        public void close() {
+            state = org.opensearch.index.engine.dataformat.WriterState.CLOSED;
+        }
 
         @Override
         public long generation() {
@@ -317,6 +332,11 @@ final class CompositeTestHelper {
         @Override
         public void updateMappingVersion(long newVersion) {
             this.mappingVersion = newVersion;
+        }
+
+        @Override
+        public org.opensearch.index.engine.dataformat.WriterState state() {
+            return state;
         }
     }
 
@@ -386,6 +406,240 @@ final class CompositeTestHelper {
         @Override
         public byte[] serializeToCommitFormat(CatalogSnapshot snapshot) {
             throw new UnsupportedOperationException("stub");
+        }
+    }
+
+    // --- Failable stubs for failure injection tests ---
+
+    /** Builds a CompositeIndexingExecutionEngine wired with failable stubs. */
+    static CompositeIndexingExecutionEngine buildFailableEngine(
+        FailableEngine primary,
+        FailableCommitter committer,
+        FailableEngine... secondaries
+    ) {
+        DataFormatRegistry registry = mock(DataFormatRegistry.class);
+        when(registry.format(primary.getDataFormat().name())).thenReturn(primary.getDataFormat());
+        when(registry.getIndexingEngine(any(), any())).thenAnswer(inv -> {
+            DataFormat fmt = inv.getArgument(1);
+            if (fmt.name().equals(primary.getDataFormat().name())) return primary;
+            for (FailableEngine sec : secondaries) {
+                if (fmt.name().equals(sec.getDataFormat().name())) return sec;
+            }
+            return null;
+        });
+        for (FailableEngine sec : secondaries) {
+            when(registry.format(sec.getDataFormat().name())).thenReturn(sec.getDataFormat());
+        }
+        Settings.Builder sb = Settings.builder()
+            .put("index.composite.primary_data_format", primary.getDataFormat().name())
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1);
+        if (secondaries.length > 0) {
+            String[] names = new String[secondaries.length];
+            for (int i = 0; i < secondaries.length; i++)
+                names[i] = secondaries[i].getDataFormat().name();
+            sb.putList("index.composite.secondary_data_formats", names);
+        }
+        IndexMetadata meta = IndexMetadata.builder("test-index").settings(sb.build()).build();
+        return new CompositeIndexingExecutionEngine(new IndexSettings(meta, Settings.EMPTY), null, committer, registry, null, null);
+    }
+
+    /** Writer stub accepting {@code DocumentInput<?>} with configurable failures. */
+    static class FailableWriter implements Writer<DocumentInput<?>> {
+        volatile WriteResult resultToReturn = new WriteResult.Success(1, 1, 1);
+        volatile IOException flushFailure;
+        volatile IOException rollbackFailure;
+        volatile boolean rollbackCalled;
+        final AtomicInteger addDocCallCount = new AtomicInteger();
+        // Models a Lucene-style strategy by default: rollback success → RETIRED_FLUSHABLE.
+        // Tests that want Parquet-style "stay ACTIVE" semantics can flip this flag.
+        volatile boolean retireOnRollbackSuccess = true;
+        private volatile org.opensearch.index.engine.dataformat.WriterState state =
+            org.opensearch.index.engine.dataformat.WriterState.ACTIVE;
+
+        FailableWriter(DataFormat format) {}
+
+        void setResultToReturn(WriteResult result) {
+            this.resultToReturn = result;
+        }
+
+        /** Test-only setter to inject a state directly. */
+        void setState(org.opensearch.index.engine.dataformat.WriterState s) {
+            this.state = s;
+        }
+
+        @Override
+        public WriteResult addDoc(DocumentInput<?> d) {
+            assert state == org.opensearch.index.engine.dataformat.WriterState.ACTIVE : "addDoc requires ACTIVE state but was " + state;
+            addDocCallCount.incrementAndGet();
+            return resultToReturn;
+        }
+
+        @Override
+        public FileInfos flush(org.opensearch.index.engine.dataformat.FlushInput flushInput) throws IOException {
+            if (flushFailure != null) throw flushFailure;
+            return FileInfos.empty();
+        }
+
+        @Override
+        public void rollbackTo(long rowCount) throws IOException {
+            rollbackCalled = true;
+            if (rollbackFailure != null) throw rollbackFailure;
+            if (retireOnRollbackSuccess) {
+                state = org.opensearch.index.engine.dataformat.WriterState.RETIRED_FLUSHABLE;
+            }
+        }
+
+        @Override
+        public org.opensearch.index.engine.dataformat.WriterState state() {
+            return state;
+        }
+
+        @Override
+        public void sync() {}
+
+        @Override
+        public long generation() {
+            return 0;
+        }
+
+        @Override
+        public boolean isSchemaMutable() {
+            return true;
+        }
+
+        @Override
+        public long mappingVersion() {
+            return 0;
+        }
+
+        @Override
+        public void updateMappingVersion(long newVersion) {}
+
+        @Override
+        public void close() {
+            state = org.opensearch.index.engine.dataformat.WriterState.CLOSED;
+        }
+    }
+
+    /** Engine stub producing {@link FailableWriter} instances with optional default failure. */
+    static class FailableEngine implements IndexingExecutionEngine<DataFormat, DocumentInput<?>> {
+        private final DataFormat dataFormat;
+        private final AtomicLong writerGen = new AtomicLong();
+        private final List<FailableWriter> createdWriters = new ArrayList<>();
+        private volatile Supplier<WriteResult> defaultWriteResultSupplier;
+
+        FailableEngine(String name) {
+            this.dataFormat = new DataFormat() {
+                @Override
+                public String name() {
+                    return name;
+                }
+
+                @Override
+                public long priority() {
+                    return 1;
+                }
+
+                @Override
+                public Set<FieldTypeCapabilities> supportedFields() {
+                    return Set.of();
+                }
+            };
+        }
+
+        FailableWriter getLastCreatedWriter() {
+            return createdWriters.get(createdWriters.size() - 1);
+        }
+
+        void setDefaultWriteResultSupplier(Supplier<WriteResult> s) {
+            this.defaultWriteResultSupplier = s;
+        }
+
+        @Override
+        public Writer<DocumentInput<?>> createWriter(WriterConfig config) {
+            FailableWriter w = new FailableWriter(dataFormat);
+            if (defaultWriteResultSupplier != null) w.setResultToReturn(defaultWriteResultSupplier.get());
+            createdWriters.add(w);
+            return w;
+        }
+
+        @Override
+        public Merger getMerger() {
+            return i -> new MergeResult(Map.of());
+        }
+
+        @Override
+        public RefreshResult refresh(RefreshInput input) {
+            return new RefreshResult(Collections.emptyList());
+        }
+
+        @Override
+        public DataFormat getDataFormat() {
+            return dataFormat;
+        }
+
+        @Override
+        public Map<String, Collection<String>> deleteFiles(Map<String, Collection<String>> f) {
+            return Map.of();
+        }
+
+        @Override
+        public long getNextWriterGeneration() {
+            return writerGen.getAndIncrement();
+        }
+
+        @Override
+        public DocumentInput<?> newDocumentInput() {
+            return new MockDocumentInput();
+        }
+
+        @Override
+        public IndexStoreProvider getProvider() {
+            return df -> null;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /** Minimal committer stub for tests that don't exercise commit-side failures. */
+    static class FailableCommitter implements Committer {
+        @Override
+        public Committer.CommitResult commit(Committer.CommitInput data) {
+            return null;
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public Map<String, String> getLastCommittedData() {
+            return Map.of();
+        }
+
+        @Override
+        public CommitStats getCommitStats() {
+            return null;
+        }
+
+        @Override
+        public List<CatalogSnapshot> listCommittedSnapshots() {
+            return List.of();
+        }
+
+        @Override
+        public void deleteCommit(CatalogSnapshot s) {}
+
+        @Override
+        public boolean isCommitManagedFile(String f) {
+            return false;
+        }
+
+        @Override
+        public byte[] serializeToCommitFormat(CatalogSnapshot snapshot) {
+            return new byte[0];
         }
     }
 }

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterFailureTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterFailureTests.java
@@ -1,0 +1,199 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.dataformat.WriteResult;
+import org.opensearch.index.engine.dataformat.WriterConfig;
+import org.opensearch.index.engine.dataformat.WriterState;
+import org.opensearch.index.engine.dataformat.stub.MockDocumentInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link CompositeWriter} failure handling: primary/secondary write failures,
+ * rollback behavior, abort state transitions, and flush failure propagation.
+ */
+public class CompositeWriterFailureTests extends OpenSearchTestCase {
+
+    private CompositeTestHelper.FailableEngine primaryEngine;
+    private CompositeTestHelper.FailableEngine secondaryEngine;
+    private CompositeTestHelper.FailableCommitter committer;
+    private CompositeIndexingExecutionEngine compositeEngine;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        primaryEngine = new CompositeTestHelper.FailableEngine("lucene");
+        secondaryEngine = new CompositeTestHelper.FailableEngine("parquet");
+        committer = new CompositeTestHelper.FailableCommitter();
+        compositeEngine = CompositeTestHelper.buildFailableEngine(primaryEngine, committer, secondaryEngine);
+    }
+
+    public void testPrimaryWriteFailureReturnsFailureImmediately() throws IOException {
+        CompositeWriter writer = new CompositeWriter(compositeEngine, new WriterConfig(0));
+        try {
+            primaryEngine.getLastCreatedWriter()
+                .setResultToReturn(new WriteResult.Failure(new IOException("primary disk full"), -1, -1, -1));
+            WriteResult result = writer.addDoc(createDocumentInput());
+            assertTrue(result instanceof WriteResult.Failure);
+            assertEquals(0, secondaryEngine.getLastCreatedWriter().addDocCallCount.get());
+        } finally {
+            writer.close();
+        }
+    }
+
+    public void testSecondaryWriteFailureRollsBackPrimary() throws IOException {
+        CompositeWriter writer = new CompositeWriter(compositeEngine, new WriterConfig(0));
+        try {
+            IOException secondaryCause = new IOException("secondary write failed");
+            secondaryEngine.getLastCreatedWriter().setResultToReturn(new WriteResult.Failure(secondaryCause, -1, -1, -1));
+            WriteResult result = writer.addDoc(createDocumentInput());
+            assertTrue(result instanceof WriteResult.Failure);
+            // Rollback succeeds, original cause is propagated (no signal exception wrapping).
+            assertSame(secondaryCause, ((WriteResult.Failure) result).cause());
+            assertEquals(1, primaryEngine.getLastCreatedWriter().addDocCallCount.get());
+            assertTrue(primaryEngine.getLastCreatedWriter().rollbackCalled);
+            // FailableWriter mimics Lucene-style strategy: rollback success → RETIRED_FLUSHABLE.
+            // Composite aggregates worst child state.
+            assertEquals(WriterState.RETIRED_FLUSHABLE, writer.state());
+        } finally {
+            writer.close();
+        }
+    }
+
+    public void testPrimaryFlushFailurePropagates() throws IOException {
+        CompositeWriter writer = new CompositeWriter(compositeEngine, new WriterConfig(0));
+        try {
+            primaryEngine.getLastCreatedWriter().flushFailure = new IOException("primary flush failed");
+            IOException e = expectThrows(IOException.class, () -> writer.flush(org.opensearch.index.engine.dataformat.FlushInput.EMPTY));
+            assertEquals("primary flush failed", e.getMessage());
+        } finally {
+            writer.close();
+        }
+    }
+
+    public void testSecondaryFlushFailurePropagates() throws IOException {
+        CompositeWriter writer = new CompositeWriter(compositeEngine, new WriterConfig(0));
+        try {
+            secondaryEngine.getLastCreatedWriter().flushFailure = new IOException("secondary flush failed");
+            IOException e = expectThrows(IOException.class, () -> writer.flush(org.opensearch.index.engine.dataformat.FlushInput.EMPTY));
+            assertEquals("secondary flush failed", e.getMessage());
+        } finally {
+            writer.close();
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // State transitions
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public void testStateActiveAfterSuccessfulAddDoc() throws IOException {
+        CompositeWriter writer = new CompositeWriter(compositeEngine, new WriterConfig(0));
+        try {
+            WriteResult result = writer.addDoc(createDocumentInput());
+            assertTrue("expected success", result instanceof WriteResult.Success);
+            assertEquals(WriterState.ACTIVE, writer.state());
+        } finally {
+            writer.close();
+        }
+    }
+
+    public void testAddDocAfterRetiredFlushableThrows() throws IOException {
+        CompositeWriter writer = new CompositeWriter(compositeEngine, new WriterConfig(0));
+        try {
+            primaryEngine.getLastCreatedWriter().setState(WriterState.RETIRED_FLUSHABLE);
+            expectThrows(IllegalStateException.class, () -> writer.addDoc(createDocumentInput()));
+        } finally {
+            writer.close();
+        }
+    }
+
+    public void testAddDocAfterCloseThrows() throws IOException {
+        CompositeWriter writer = new CompositeWriter(compositeEngine, new WriterConfig(0));
+        writer.close();
+        expectThrows(IllegalStateException.class, () -> writer.addDoc(createDocumentInput()));
+    }
+
+    public void testRollbackToOnCompositeIsUnsupported() throws IOException {
+        // CompositeWriter does not override Writer.rollbackTo — calling it externally
+        // should hit the interface default which throws UnsupportedOperationException.
+        // Cross-format rollback is handled internally during a failed addDoc.
+        CompositeWriter writer = new CompositeWriter(compositeEngine, new WriterConfig(0));
+        try {
+            expectThrows(UnsupportedOperationException.class, () -> writer.rollbackTo(0));
+        } finally {
+            writer.close();
+        }
+    }
+
+    public void testRollbackHappensOncePerFailedAddDoc() throws IOException {
+        CompositeWriter writer = new CompositeWriter(compositeEngine, new WriterConfig(0));
+        try {
+            // Secondary fails on the first addDoc → composite rolls back primary once.
+            secondaryEngine.getLastCreatedWriter()
+                .setResultToReturn(new WriteResult.Failure(new IOException("secondary failed"), -1, -1, -1));
+            WriteResult result = writer.addDoc(createDocumentInput());
+            assertTrue(result instanceof WriteResult.Failure);
+
+            // Primary's rollback was called exactly once for this failed addDoc — not twice.
+            assertTrue("primary rollback should have been called", primaryEngine.getLastCreatedWriter().rollbackCalled);
+            // Composite is now RETIRED_FLUSHABLE (Lucene-style sub-writer); the next addDoc
+            // must throw IllegalStateException because state != ACTIVE. Importantly, this
+            // means there is NO second call into primaryWriter.rollbackLastDoc — once a
+            // rollback has run, the writer is retired and cannot accept another addDoc that
+            // could trigger a second rollback.
+            assertEquals(WriterState.RETIRED_FLUSHABLE, writer.state());
+            expectThrows(IllegalStateException.class, () -> writer.addDoc(createDocumentInput()));
+        } finally {
+            writer.close();
+        }
+    }
+
+    public void testPrimaryFailureLeavesSecondariesUntouched() throws IOException {
+        CompositeWriter writer = new CompositeWriter(compositeEngine, new WriterConfig(0));
+        try {
+            primaryEngine.getLastCreatedWriter().setResultToReturn(new WriteResult.Failure(new IOException("primary failed"), -1, -1, -1));
+            WriteResult result = writer.addDoc(createDocumentInput());
+            assertTrue(result instanceof WriteResult.Failure);
+
+            // No secondary writer should have seen the doc.
+            assertEquals(0, secondaryEngine.getLastCreatedWriter().addDocCallCount.get());
+            // Primary's rollback was invoked by CompositeWriter so the leaf can decide whether
+            // it has anything to undo (idempotent inside the leaf). FailableWriter records the
+            // call regardless of whether work was done.
+            assertTrue("primary rollback should have been called by CompositeWriter", primaryEngine.getLastCreatedWriter().rollbackCalled);
+        } finally {
+            writer.close();
+        }
+    }
+
+    public void testCloseFromRetiredFlushableTransitionsToClosed() throws IOException {
+        CompositeWriter writer = new CompositeWriter(compositeEngine, new WriterConfig(0));
+        primaryEngine.getLastCreatedWriter().setState(WriterState.RETIRED_FLUSHABLE);
+        assertEquals(WriterState.RETIRED_FLUSHABLE, writer.state());
+        writer.close();
+        assertEquals(WriterState.CLOSED, writer.state());
+    }
+
+    private CompositeDocumentInput createDocumentInput() {
+        return createDocumentInput(0L);
+    }
+
+    private CompositeDocumentInput createDocumentInput(long rowId) {
+        DocumentInput<?> primaryInput = new MockDocumentInput();
+        Map<DataFormat, DocumentInput<?>> secondaryInputs = Map.of(secondaryEngine.getDataFormat(), new MockDocumentInput());
+        CompositeDocumentInput composite = new CompositeDocumentInput(primaryEngine.getDataFormat(), primaryInput, secondaryInputs);
+        composite.setRowId(DocumentInput.ROW_ID_FIELD, rowId);
+        return composite;
+    }
+}

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterSortPropagationTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterSortPropagationTests.java
@@ -174,6 +174,11 @@ public class CompositeWriterSortPropagationTests extends OpenSearchTestCase {
         }
 
         @Override
+        public org.opensearch.index.engine.dataformat.WriterState state() {
+            return org.opensearch.index.engine.dataformat.WriterState.ACTIVE;
+        }
+
+        @Override
         public void sync() {}
 
         @Override

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeWriterTests.java
@@ -11,6 +11,7 @@ package org.opensearch.composite;
 import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.FlushInput;
 import org.opensearch.index.engine.dataformat.WriterConfig;
+import org.opensearch.index.engine.dataformat.WriterState;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -35,52 +36,30 @@ public class CompositeWriterTests extends OpenSearchTestCase {
         writer.close();
     }
 
-    public void testAbortedDefaultsToFalse() throws IOException {
+    public void testStateDefaultsToActive() throws IOException {
         CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
-        assertFalse(writer.isAborted());
-        assertEquals(CompositeWriter.WriterState.ACTIVE, writer.getState());
+        assertEquals(WriterState.ACTIVE, writer.state());
         writer.close();
     }
 
-    public void testAbortSetsAbortedFlag() throws IOException {
+    public void testStateAggregatesWorstChild() throws IOException {
         CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
-        writer.abort();
-        assertTrue(writer.isAborted());
-        assertEquals(CompositeWriter.WriterState.ABORTED, writer.getState());
+        // No child has retired → composite is ACTIVE
+        assertEquals(WriterState.ACTIVE, writer.state());
+
+        // Force a child into RETIRED_FLUSHABLE — composite should reflect it (worst state wins)
+        CompositeTestHelper.StubIndexingExecutionEngine primaryEngine = (CompositeTestHelper.StubIndexingExecutionEngine) engine
+            .getPrimaryDelegate();
+        primaryEngine.lastCreatedWriter.setState(WriterState.RETIRED_FLUSHABLE);
+        assertEquals(WriterState.RETIRED_FLUSHABLE, writer.state());
+
         writer.close();
     }
 
-    public void testFlushPendingDefaultsToFalse() throws IOException {
+    public void testCloseTransitionsToClosed() throws IOException {
         CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
-        assertFalse(writer.isFlushPending());
-        assertEquals(CompositeWriter.WriterState.ACTIVE, writer.getState());
         writer.close();
-    }
-
-    public void testSetFlushPendingSetsFlag() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
-        writer.setFlushPending();
-        assertTrue(writer.isFlushPending());
-        assertEquals(CompositeWriter.WriterState.FLUSH_PENDING, writer.getState());
-        writer.close();
-    }
-
-    public void testAbortDoesNotTransitionFromFlushPending() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
-        writer.setFlushPending();
-        expectThrows(IllegalStateException.class, writer::abort);
-        assertTrue(writer.isFlushPending());
-        assertEquals(CompositeWriter.WriterState.FLUSH_PENDING, writer.getState());
-        writer.close();
-    }
-
-    public void testFlushPendingDoesNotTransitionFromAborted() throws IOException {
-        CompositeWriter writer = new CompositeWriter(engine, new WriterConfig(0));
-        writer.abort();
-        expectThrows(IllegalStateException.class, writer::setFlushPending);
-        assertTrue(writer.isAborted());
-        assertEquals(CompositeWriter.WriterState.ABORTED, writer.getState());
-        writer.close();
+        assertEquals(WriterState.CLOSED, writer.state());
     }
 
     public void testFlushReturnsFileInfos() throws IOException {

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/engine/ParquetIndexingEngine.java
@@ -262,6 +262,7 @@ public class ParquetIndexingEngine implements IndexingExecutionEngine<ParquetDat
             mappingVersion,
             dataFormat,
             schema,
+            () -> getOrBuildSchema(mappingVersionSupplier.get()),
             bufferPool,
             indexSettings,
             threadPool,

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/vsr/VSRManager.java
@@ -10,7 +10,6 @@ package org.opensearch.parquet.vsr;
 
 import org.apache.arrow.c.ArrowSchema;
 import org.apache.arrow.vector.BigIntVector;
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.logging.log4j.LogManager;
@@ -28,6 +27,7 @@ import org.opensearch.parquet.fields.ArrowFieldRegistry;
 import org.opensearch.parquet.fields.ParquetField;
 import org.opensearch.parquet.memory.ArrowBufferPool;
 import org.opensearch.parquet.writer.FieldValuePair;
+import org.opensearch.parquet.writer.MismatchedInputException;
 import org.opensearch.parquet.writer.ParquetDocumentInput;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -73,6 +73,7 @@ public class VSRManager implements AutoCloseable {
     private NativeParquetWriter writer;
     private final int ROTATION_TIMEOUT = 120;
     private LongAdder rowCount = new LongAdder();
+    private long acceptedRows = 0L;
 
     /**
      * Creates a new VSRManager with asynchronous background writes (production default).
@@ -130,20 +131,36 @@ public class VSRManager implements AutoCloseable {
      * @param doc the document input containing field-value pairs
      */
     public void addDocument(ParquetDocumentInput doc) throws IOException {
+        if (pendingWrite != null && pendingWrite.isDone() && pendingWrite.exceptionNow() != null) {
+            throw new IllegalStateException(pendingWrite.exceptionNow());
+        }
+        maybeRotateActiveVSR();
+        // Re-check the rowId invariant so a single-format Parquet path is protected too.
+        if (doc.getRowId() != acceptedRows) {
+            throw new IllegalStateException(
+                "rowId [" + doc.getRowId() + "] does not match accepted row count [" + acceptedRows + "] for " + fileName
+            );
+        }
         ManagedVSR activeVSR = managedVSR.get();
         for (FieldValuePair pair : doc.getFinalInput()) {
             MappedFieldType fieldType = pair.getFieldType();
             ParquetField parquetField = ArrowFieldRegistry.getParquetField(fieldType.typeName());
             if (parquetField == null) {
-                continue;
+                // Defense-in-depth: schema reconciliation is supposed to happen in
+                // ParquetWriter.updateMappingVersion before any addDocument with a new
+                // field type. If we still see an unmapped type here, the writer is
+                // out of sync with the mapping — surface as a recoverable failure.
+                // TODO:: we can remove this post the validation on mapping update
+                throw new MismatchedInputException(
+                    "No ParquetField mapping for field [" + fieldType.name() + "] of type [" + fieldType.typeName() + "]"
+                );
             }
-            // Dynamic field vector addition: create vector if not present in VSR
-            FieldVector vector = activeVSR.getVector(fieldType.name());
-            if (vector == null) {
-                Field field = new Field(fieldType.name(), parquetField.getFieldType(), null);
-                activeVSR.addFieldVector(field);
-                // Update pool schema so future VSRs include this field
-                vsrPool.updateSchema(activeVSR.getSchema());
+            if (activeVSR.getVector(fieldType.name()) == null) {
+                throw new MismatchedInputException(
+                    "Active VSR has no vector for field ["
+                        + fieldType.name()
+                        + "] — schema reconciliation must run via updateMappingVersion before addDocument"
+                );
             }
             parquetField.createField(fieldType, activeVSR, pair.getValue());
         }
@@ -153,7 +170,37 @@ public class VSRManager implements AutoCloseable {
             rowIdVector.setSafe(rowIndex, doc.getRowId());
         }
         activeVSR.setRowCount(rowIndex + 1);
-        maybeRotateActiveVSR();
+        acceptedRows++;
+    }
+
+    public long getAcceptedRows() {
+        return acceptedRows;
+    }
+
+    /**
+     * Reconciles the active VSR with the given schema by adding vectors for any fields
+     * present in {@code newSchema} but not yet in the active VSR. Also updates the pool
+     * schema so subsequently rotated VSRs include the new fields.
+     * <p>
+     * Called from {@link org.opensearch.parquet.writer.ParquetWriter#updateMappingVersion}
+     * when the mapping version advances. No-op if every field in {@code newSchema} is
+     * already present in the active VSR.
+     *
+     * @param newSchema the schema to reconcile against
+     */
+    public void reconcileSchema(Schema newSchema) {
+        ManagedVSR activeVSR = managedVSR.get();
+        boolean changed = false;
+        for (Field schemaField : newSchema.getFields()) {
+            if (activeVSR.getVector(schemaField.getName()) == null) {
+                Field field = new Field(schemaField.getName(), schemaField.getFieldType(), null);
+                activeVSR.addFieldVector(field);
+                changed = true;
+            }
+        }
+        if (changed) {
+            vsrPool.updateSchema(activeVSR.getSchema());
+        }
     }
 
     /**
@@ -282,6 +329,29 @@ public class VSRManager implements AutoCloseable {
         } finally {
             pendingWrite = null;
         }
+    }
+
+    /**
+     * Rolls the VSR back to hold exactly {@code rowCount} admitted rows. No-op if already
+     * at the target. Throws if the target is higher than current or if the active VSR
+     * doesn't have enough rows to trim (rollback crossed a rotation boundary).
+     *
+     * @param rowCount the desired row count after this call
+     */
+    public void rollbackTo(long rowCount) {
+        if (rowCount > acceptedRows) {
+            throw new IllegalStateException("Cannot rollback to " + rowCount + ": only " + acceptedRows + " rows in VSR");
+        }
+        if (rowCount == acceptedRows) {
+            return;
+        }
+        ManagedVSR activeVSR = managedVSR.get();
+        long diff = acceptedRows - rowCount;
+        if (diff > activeVSR.getRowCount()) {
+            throw new IllegalStateException("Cannot rollback " + diff + " rows: active VSR only has " + activeVSR.getRowCount() + " rows");
+        }
+        activeVSR.setRowCount(activeVSR.getRowCount() - (int) diff);
+        acceptedRows = rowCount;
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/MismatchedInputException.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/MismatchedInputException.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.writer;
+
+/**
+ * Thrown when a document presents a field whose declared type does not have a
+ * corresponding {@link org.opensearch.parquet.fields.ParquetField} mapping in the
+ * Arrow field registry — i.e., the input schema is incompatible with the writer's
+ * known schema. The failure is per-document and recoverable: callers should surface
+ * it as a {@link org.opensearch.index.engine.dataformat.WriteResult.Failure} so the
+ * writer can be rolled back and remain usable for subsequent docs.
+ */
+public class MismatchedInputException extends IllegalArgumentException {
+
+    public MismatchedInputException(String message) {
+        super(message);
+    }
+
+    public MismatchedInputException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetWriter.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/writer/ParquetWriter.java
@@ -14,6 +14,7 @@ import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.FlushInput;
 import org.opensearch.index.engine.dataformat.WriteResult;
 import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterState;
 import org.opensearch.index.engine.exec.MonoFileWriterSet;
 import org.opensearch.index.store.FileMetadata;
 import org.opensearch.index.store.FormatChecksumStrategy;
@@ -27,6 +28,7 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.function.Supplier;
 
 /**
  * Parquet file writer integrating OpenSearch's {@link Writer} interface with the VSR batching layer.
@@ -48,7 +50,10 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
     private final ParquetDataFormat dataFormat;
     private final VSRManager vsrManager;
     private final FormatChecksumStrategy checksumStrategy;
+    private final Supplier<Schema> schemaSupplier;
     private long mappingVersion;
+    private volatile WriterState state = WriterState.ACTIVE;
+    private long acceptedRows = 0L;
 
     /**
      * Creates a new ParquetWriter.
@@ -57,7 +62,10 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
      * @param writerGeneration generation number for this writer
      * @param mappingVersion the initial mapping version
      * @param dataFormat the Parquet data format instance
-     * @param schema Arrow schema for vector creation
+     * @param schema Arrow schema for vector creation at construction time
+     * @param schemaSupplier supplies the up-to-date schema when the mapping version
+     *                       advances, used by {@link #updateMappingVersion} to add new
+     *                       field vectors before {@code addDoc} encounters them
      * @param bufferPool shared Arrow buffer pool
      * @param indexSettings index settings for writer configuration
      * @param threadPool the thread pool for background native writes
@@ -69,6 +77,7 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
         long mappingVersion,
         ParquetDataFormat dataFormat,
         Schema schema,
+        Supplier<Schema> schemaSupplier,
         ArrowBufferPool bufferPool,
         IndexSettings indexSettings,
         ThreadPool threadPool,
@@ -79,6 +88,7 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
         this.mappingVersion = mappingVersion;
         this.dataFormat = dataFormat;
         this.checksumStrategy = checksumStrategy;
+        this.schemaSupplier = schemaSupplier;
         this.vsrManager = new VSRManager(
             file,
             indexSettings,
@@ -92,8 +102,42 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
 
     @Override
     public WriteResult addDoc(ParquetDocumentInput d) throws IOException {
-        vsrManager.addDocument(d);
+        if (state != WriterState.ACTIVE) {
+            throw new IllegalStateException("Writer is not active, state=" + state);
+        }
+        // Schema mismatch is recoverable: the VSR rejected the doc pre-admission, so the
+        // caller-driven rollback no-ops in the VSR and restores ACTIVE.
+        try {
+            vsrManager.addDocument(d);
+        } catch (MismatchedInputException e) {
+            state = WriterState.PENDING_ROLLBACK;
+            return new WriteResult.Failure(e, -1, -1, -1);
+        }
+        acceptedRows++;
         return new WriteResult.Success(1L, 1L, 1L);
+    }
+
+    @Override
+    public void rollbackTo(long rowCount) throws IOException {
+        if (state != WriterState.ACTIVE && state != WriterState.PENDING_ROLLBACK) {
+            throw new IllegalStateException("rollbackTo requires ACTIVE or PENDING_ROLLBACK state but was " + state);
+        }
+        if (rowCount > acceptedRows) {
+            throw new IllegalStateException("Cannot rollback to " + rowCount + ": only " + acceptedRows + " rows admitted");
+        }
+        if (acceptedRows - rowCount > 1) {
+            throw new IllegalStateException(
+                "rollbackTo supports rolling back exactly 1 doc, but asked to roll back " + (acceptedRows - rowCount)
+            );
+        }
+        vsrManager.rollbackTo(rowCount);
+        acceptedRows = rowCount;
+        state = WriterState.ACTIVE;
+    }
+
+    @Override
+    public WriterState state() {
+        return state;
     }
 
     @Override
@@ -147,12 +191,19 @@ public class ParquetWriter implements Writer<ParquetDocumentInput> {
     public void updateMappingVersion(long newVersion) {
         if (newVersion > this.mappingVersion) {
             this.mappingVersion = newVersion;
+            // Reconcile the active VSR with the new mapping's schema so addDoc never has
+            // to add field vectors itself.
+            vsrManager.reconcileSchema(schemaSupplier.get());
         }
     }
 
     @Override
     public void close() throws IOException {
-        vsrManager.close();
+        try {
+            vsrManager.close();
+        } finally {
+            state = WriterState.CLOSED;
+        }
     }
 
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/engine/ParquetDataFormatAwareEngineTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/engine/ParquetDataFormatAwareEngineTests.java
@@ -243,7 +243,7 @@ public class ParquetDataFormatAwareEngineTests extends AbstractDataFormatAwareEn
 
     private static final String BYTE_FIELD_NAME = "byte_field";
     private static final String SHORT_FIELD_NAME = "short_field";
-    private static final String INT_FIELD_NAME = "int_field";
+    private static final String INT_FIELD_NAME = "integer_field";
     private static final String LONG_FIELD_NAME = "long_field";
     private static final String FLOAT_FIELD_NAME = "float_field";
     private static final String DOUBLE_FIELD_NAME = "double_field";
@@ -274,9 +274,7 @@ public class ParquetDataFormatAwareEngineTests extends AbstractDataFormatAwareEn
         for (Map.Entry<String, ParquetField> dataField : new CoreDataFieldPlugin().getParquetFields().entrySet()) {
             fields.add(new Field(dataField.getKey() + "_field", dataField.getValue().getFieldType(), null));
         }
-        // Metadata fields (long, not nullable)
         fields.addAll(metadataFields());
-        // Row ID field (long) — added by RowIdAwareWriter
         fields.add(new Field(DocumentInput.ROW_ID_FIELD, FieldType.notNullable(new ArrowType.Int(64, true)), null));
         return new Schema(fields);
     }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/engine/ParquetIndexingEngineTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/engine/ParquetIndexingEngineTests.java
@@ -37,7 +37,6 @@ import org.opensearch.index.shard.ShardPath;
 import org.opensearch.parquet.ParquetDataFormatPlugin;
 import org.opensearch.parquet.bridge.RustBridge;
 import org.opensearch.parquet.fields.ArrowFieldRegistry;
-import org.opensearch.parquet.fields.ArrowSchemaBuilder;
 import org.opensearch.parquet.fields.ParquetField;
 import org.opensearch.parquet.writer.ParquetDocumentInput;
 import org.opensearch.test.OpenSearchTestCase;
@@ -131,7 +130,8 @@ public class ParquetIndexingEngineTests extends OpenSearchTestCase {
             doc.addField(idField, (int) gen);
             doc.addField(nameField, "user_" + gen);
             doc.addField(scoreField, gen * 100);
-            doc.setRowId("__row_id__", gen);
+            // Each writer is fresh — rowIds restart at 0 within a writer's lifetime.
+            doc.setRowId("__row_id__", 0L);
 
             writer.addDoc(doc);
             doc.close();
@@ -208,11 +208,14 @@ public class ParquetIndexingEngineTests extends OpenSearchTestCase {
             IndexMetadata indexMetadata = IndexMetadata.builder("test_index").settings(indexSettingsBuilder).build();
             IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
             MapperService mapperService = createMockMapperService(schema, indexSettings);
+            // Use the test's pre-built schema directly. The mock MapperService has no
+            // documentMapper, so going through ArrowSchemaBuilder would yield only metadata
+            // fields and addDocument would reject id/name/score with MismatchedInputException.
             return new ParquetIndexingEngine(
                 Settings.EMPTY,
                 new ParquetDataFormat(),
                 shardPath,
-                () -> ArrowSchemaBuilder.getSchema(mapperService),
+                () -> schema,
                 () -> mapperService.getIndexSettings().getIndexMetadata().getMappingVersion(),
                 indexSettings,
                 threadPool,

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/vsr/VSRManagerTests.java
@@ -40,6 +40,7 @@ public class VSRManagerTests extends OpenSearchTestCase {
 
     private ArrowNativeAllocator nativeAllocator;
     private ArrowBufferPool bufferPool;
+    /** Minimal schema VSRManager is constructed with; addDocument tests reconcile metadata fields in via {@link #reconcileMetadata}. */
     private Schema schema;
     private ThreadPool threadPool;
     private IndexSettings indexSettings;
@@ -307,15 +308,20 @@ public class VSRManagerTests extends OpenSearchTestCase {
         manager.close();
     }
 
-    public void testAddDocumentWithUnknownFieldDynamicallyAddsVector() throws Exception {
+    public void testAddDocumentAfterReconcileSchemaAddsVector() throws Exception {
         String filePath = createTempDir().resolve("unknown-field.parquet").toString();
         VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 1L);
+
+        // Simulate a mapping update: the new schema introduces a tag field. reconcileSchema
+        // adds the missing vector to the active VSR before addDocument runs.
+        Schema updatedSchema = schemaWith("tag", new ArrowType.Utf8());
+        manager.reconcileSchema(updatedSchema);
 
         NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
         KeywordFieldMapper.KeywordFieldType tagField = new KeywordFieldMapper.KeywordFieldType("tag");
         ParquetDocumentInput doc = new ParquetDocumentInput();
         populateMetadataFields(doc);
-        doc.setRowId(DocumentInput.ROW_ID_FIELD, 1);
+        doc.setRowId(DocumentInput.ROW_ID_FIELD, 0);
         doc.addField(valField, 42);
         doc.addField(tagField, "hello");
         manager.addDocument(doc);
@@ -328,13 +334,14 @@ public class VSRManagerTests extends OpenSearchTestCase {
     public void testIsSchemaMutableBeforeAndAfterFlush() throws Exception {
         String filePath = createTempDir().resolve("schema-mutable.parquet").toString();
         VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 1L);
+        reconcileMetadata(manager);
 
         assertTrue(manager.isSchemaMutable());
 
         NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
         ParquetDocumentInput doc = new ParquetDocumentInput();
         populateMetadataFields(doc);
-        doc.setRowId(DocumentInput.ROW_ID_FIELD, 1);
+        doc.setRowId(DocumentInput.ROW_ID_FIELD, 0);
         doc.addField(valField, 1);
         manager.addDocument(doc);
 
@@ -349,16 +356,20 @@ public class VSRManagerTests extends OpenSearchTestCase {
         NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
         KeywordFieldMapper.KeywordFieldType tagField = new KeywordFieldMapper.KeywordFieldType("tag");
 
+        // Reconcile once before any docs — the tag vector must persist across the VSR
+        // rotation triggered by maxRowsPerVSR=1.
+        manager.reconcileSchema(schemaWith("tag", new ArrowType.Utf8()));
+
         ParquetDocumentInput doc1 = new ParquetDocumentInput();
         populateMetadataFields(doc1);
-        doc1.setRowId(DocumentInput.ROW_ID_FIELD, 1L);
+        doc1.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
         doc1.addField(valField, 1);
         doc1.addField(tagField, "a");
         manager.addDocument(doc1);
 
         ParquetDocumentInput doc2 = new ParquetDocumentInput();
         populateMetadataFields(doc2);
-        doc2.setRowId(DocumentInput.ROW_ID_FIELD, 2L);
+        doc2.setRowId(DocumentInput.ROW_ID_FIELD, 1L);
         doc2.addField(valField, 2);
         doc2.addField(tagField, "b");
         manager.addDocument(doc2);
@@ -367,9 +378,18 @@ public class VSRManagerTests extends OpenSearchTestCase {
         assertEquals(2, metadata.numRows());
     }
 
-    public void testAddDocumentWithMultipleUnknownFields() throws Exception {
+    public void testReconcileSchemaAddsMultipleVectorsAtOnce() throws Exception {
         String filePath = createTempDir().resolve("multi-unknown.parquet").toString();
         VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 1L);
+
+        // Single reconcileSchema call adds three vectors plus the metadata fields the next
+        // addDocument needs.
+        List<Field> updatedFields = new ArrayList<>(schema.getFields());
+        updatedFields.addAll(metadataFields());
+        updatedFields.add(new Field("tag1", FieldType.nullable(new ArrowType.Utf8()), null));
+        updatedFields.add(new Field("tag2", FieldType.nullable(new ArrowType.Utf8()), null));
+        updatedFields.add(new Field("tag3", FieldType.nullable(new ArrowType.Utf8()), null));
+        manager.reconcileSchema(new Schema(updatedFields));
 
         NumberFieldMapper.NumberFieldType valField = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
         KeywordFieldMapper.KeywordFieldType tag1Field = new KeywordFieldMapper.KeywordFieldType("tag1");
@@ -378,7 +398,7 @@ public class VSRManagerTests extends OpenSearchTestCase {
 
         ParquetDocumentInput doc = new ParquetDocumentInput();
         populateMetadataFields(doc);
-        doc.setRowId(DocumentInput.ROW_ID_FIELD, 1L);
+        doc.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
         doc.addField(valField, 1);
         doc.addField(tag1Field, "a");
         doc.addField(tag2Field, "b");
@@ -388,5 +408,93 @@ public class VSRManagerTests extends OpenSearchTestCase {
         ParquetFileMetadata metadata = manager.flush();
         assertNotNull(metadata);
         assertEquals(1, metadata.numRows());
+    }
+
+    /**
+     * Verifies that {@link VSRManager#getAcceptedRows} is incremented only after a
+     * successful row admit, and decremented by {@link VSRManager#rollbackTo(long)}.
+     */
+    public void testAcceptedRowsCounterTracksAdmitsAndRollbacks() throws Exception {
+        String filePath = createTempDir().resolve("accepted-counter.parquet").toString();
+        VSRManager manager = new VSRManager(filePath, indexSettings, schema, bufferPool, 50000, threadPool, 0L);
+        reconcileMetadata(manager);
+        try {
+            assertEquals(0L, manager.getAcceptedRows());
+
+            ParquetDocumentInput doc1 = new ParquetDocumentInput();
+            populateMetadataFields(doc1);
+            doc1.setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+            manager.addDocument(doc1);
+            assertEquals(1L, manager.getAcceptedRows());
+
+            ParquetDocumentInput doc2 = new ParquetDocumentInput();
+            populateMetadataFields(doc2);
+            doc2.setRowId(DocumentInput.ROW_ID_FIELD, 1L);
+            manager.addDocument(doc2);
+            assertEquals(2L, manager.getAcceptedRows());
+
+            manager.rollbackTo(1L);
+            assertEquals(1L, manager.getAcceptedRows());
+
+            // Next doc reuses rowId 1 (the slot freed by rollback).
+            ParquetDocumentInput doc3 = new ParquetDocumentInput();
+            populateMetadataFields(doc3);
+            doc3.setRowId(DocumentInput.ROW_ID_FIELD, 1L);
+            manager.addDocument(doc3);
+            assertEquals(2L, manager.getAcceptedRows());
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * Verifies that the rowId column in the active VSR is sorted, contiguous, and
+     * starts at 0 — the per-flush invariant that protects cross-format correlation.
+     * Reads the rowId vector directly so it doesn't depend on the native flush.
+     */
+    public void testRowIdColumnIsSortedAndContiguous() throws Exception {
+        String filePath = createTempDir().resolve("rowid-monotonic.parquet").toString();
+        // Schema must declare __row_id__ for VSRManager to populate the column.
+        List<Field> fields = new ArrayList<>(metadataFields());
+        fields.add(new Field("val", FieldType.nullable(new ArrowType.Int(32, true)), null));
+        fields.add(new Field(DocumentInput.ROW_ID_FIELD, FieldType.nullable(new ArrowType.Int(64, true)), null));
+        Schema schemaWithRowId = new Schema(fields);
+        VSRManager manager = new VSRManager(filePath, indexSettings, schemaWithRowId, bufferPool, 50000, threadPool, 0L);
+        try {
+            for (int i = 0; i < 50; i++) {
+                ParquetDocumentInput doc = new ParquetDocumentInput();
+                populateMetadataFields(doc);
+                doc.setRowId(DocumentInput.ROW_ID_FIELD, (long) i);
+                manager.addDocument(doc);
+            }
+
+            org.apache.arrow.vector.BigIntVector rowIdVector = (org.apache.arrow.vector.BigIntVector) manager.getActiveManagedVSR()
+                .getVector(DocumentInput.ROW_ID_FIELD);
+            assertNotNull(rowIdVector);
+            for (int i = 0; i < 50; i++) {
+                assertEquals("rowId at position " + i + " must equal " + i, (long) i, rowIdVector.get(i));
+            }
+        } finally {
+            manager.close();
+        }
+    }
+
+    /** Returns a copy of the test schema with one extra field appended (alongside metadata fields). */
+    private Schema schemaWith(String name, ArrowType type) {
+        List<Field> fields = new ArrayList<>(schema.getFields());
+        fields.addAll(metadataFields());
+        fields.add(new Field(name, FieldType.nullable(type), null));
+        return new Schema(fields);
+    }
+
+    /**
+     * Simulates the production mapping-update path: reconcile the active VSR with the
+     * production-shaped schema (val + metadata fields) so that subsequent
+     * {@code addDocument} calls find every vector they need.
+     */
+    private void reconcileMetadata(VSRManager manager) {
+        List<Field> fields = new ArrayList<>(schema.getFields());
+        fields.addAll(metadataFields());
+        manager.reconcileSchema(new Schema(fields));
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetWriterTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/writer/ParquetWriterTests.java
@@ -101,6 +101,7 @@ public class ParquetWriterTests extends OpenSearchTestCase {
             1L,
             new ParquetDataFormat(),
             schema,
+            () -> schema,
             bufferPool,
             indexSettings,
             threadPool,
@@ -112,7 +113,7 @@ public class ParquetWriterTests extends OpenSearchTestCase {
         doc.addField(idField, 1);
         doc.addField(nameField, "alice");
         doc.addField(scoreField, 100L);
-        doc.setRowId(DocumentInput.ROW_ID_FIELD, 1);
+        doc.setRowId(DocumentInput.ROW_ID_FIELD, 0);
         WriteResult result = writer.addDoc(doc);
         assertTrue(result instanceof WriteResult.Success);
         doc.close();
@@ -127,6 +128,7 @@ public class ParquetWriterTests extends OpenSearchTestCase {
             1L,
             new ParquetDataFormat(),
             schema,
+            () -> schema,
             bufferPool,
             indexSettings,
             threadPool,
@@ -138,7 +140,7 @@ public class ParquetWriterTests extends OpenSearchTestCase {
         doc.addField(idField, 42);
         doc.addField(nameField, "bob");
         doc.addField(scoreField, 500L);
-        doc.setRowId(DocumentInput.ROW_ID_FIELD, 1);
+        doc.setRowId(DocumentInput.ROW_ID_FIELD, 0);
         writer.addDoc(doc);
         doc.close();
 
@@ -154,6 +156,7 @@ public class ParquetWriterTests extends OpenSearchTestCase {
             1L,
             new ParquetDataFormat(),
             schema,
+            () -> schema,
             bufferPool,
             indexSettings,
             threadPool,
@@ -185,6 +188,7 @@ public class ParquetWriterTests extends OpenSearchTestCase {
             1L,
             new ParquetDataFormat(),
             schema,
+            () -> schema,
             bufferPool,
             indexSettings,
             threadPool,
@@ -201,6 +205,7 @@ public class ParquetWriterTests extends OpenSearchTestCase {
             1L,
             new ParquetDataFormat(),
             schema,
+            () -> schema,
             bufferPool,
             indexSettings,
             threadPool,

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -22,6 +22,7 @@ import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.concurrent.GatedConditionalCloseable;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.queue.DefaultLockableHolder;
 import org.opensearch.common.queue.LockablePool;
 import org.opensearch.common.unit.TimeValue;
@@ -45,6 +46,7 @@ import org.opensearch.index.engine.dataformat.RowIdAwareWriter;
 import org.opensearch.index.engine.dataformat.WriteResult;
 import org.opensearch.index.engine.dataformat.Writer;
 import org.opensearch.index.engine.dataformat.WriterConfig;
+import org.opensearch.index.engine.dataformat.WriterState;
 import org.opensearch.index.engine.dataformat.merge.DataFormatAwareMergePolicy;
 import org.opensearch.index.engine.dataformat.merge.MergeFailedEngineException;
 import org.opensearch.index.engine.dataformat.merge.MergeHandler;
@@ -190,8 +192,8 @@ public class DataFormatAwareEngine implements Indexer {
 
     // TODO Refactor these flush managing activities into FlushManager.
 
-    // Segments flushed inline by indexing threads (via preIndex) that are pending
-    // registration in the catalog. Drained by the next refresh() call.
+    // Segments flushed inline outside refresh — by indexing threads (preIndex cooperative drain)
+    // or by failure-handling retirement (retireWriterIfNeeded). Drained by the next refresh().
     private final ConcurrentLinkedQueue<Segment> pendingSegments = new ConcurrentLinkedQueue<>();
 
     // Writers that have been flushed inline but not yet closed. Their Lucene temp
@@ -226,6 +228,20 @@ public class DataFormatAwareEngine implements Indexer {
      * @param engineConfig the engine configuration
      */
     public DataFormatAwareEngine(EngineConfig engineConfig) {
+        // DataFormatAwareEngine is the writable primary-side engine. Read-only replicas
+        // (segment-rep) and warm-tier shards must use a read-only engine instead — fail
+        // fast so a misconfiguration surfaces before any indexing or recovery.
+        if (engineConfig.isReadOnlyReplica() || engineConfig.getIndexSettings().isWarmIndex()) {
+            throw new IllegalStateException(
+                "DataFormatAwareEngine cannot be used on a read-only shard ["
+                    + engineConfig.getShardId()
+                    + "] (readOnlyReplica="
+                    + engineConfig.isReadOnlyReplica()
+                    + ", warm="
+                    + engineConfig.getIndexSettings().isWarmIndex()
+                    + "); use a segment-consuming or read-only engine"
+            );
+        }
         this.logger = Loggers.getLogger(DataFormatAwareEngine.class, engineConfig.getShardId());
         this.engineConfig = engineConfig;
         this.shardId = engineConfig.getShardId();
@@ -526,6 +542,8 @@ public class DataFormatAwareEngine implements Indexer {
     @Override
     public Engine.IndexResult index(Engine.Index index) throws IOException {
         assert Objects.equals(index.uid().field(), IdFieldMapper.NAME) : index.uid().field();
+        // DataFormatAwareEngine is the primary-side engine in a segment-replication cluster.
+        // Replicas use a separate engine (analogous to NRTReplicationEngine) that consumes segments.
         assert (index.origin() == Engine.Operation.Origin.PRIMARY
             || index.origin() == Engine.Operation.Origin.LOCAL_TRANSLOG_RECOVERY
             || index.origin() == Engine.Operation.Origin.LOCAL_RESET)
@@ -601,17 +619,17 @@ public class DataFormatAwareEngine implements Indexer {
         Engine.IndexResult indexResult;
 
         assert index.seqNo() >= 0 : "ops should have an assigned seq no.; origin: " + index.origin();
-        // Primary term must be positive — it identifies the current primary shard
         assert index.primaryTerm() > 0 : "primary term must be positive but was: " + index.primaryTerm();
-
-        // Convert ParsedDocument to DocumentInput and write via the execution engine's writer
-        Writer currentWriter = null;
+        DefaultLockableHolder<Writer<?>> lockedWriter = null;
+        boolean writerCheckedOut = false;
         long mappingVersion = currentMappingVersion();
-        DefaultLockableHolder<Writer<?>> lockedWriter = writerPool.getAndLock(
-            h -> h.get().isSchemaMutable() || h.get().mappingVersion() >= mappingVersion
-        );
         try {
-            currentWriter = lockedWriter.get();
+            lockedWriter = writerPool.getAndLock(h -> {
+                Writer<?> w = h.get();
+                if (w.state() != WriterState.ACTIVE) return false;
+                return w.isSchemaMutable() || w.mappingVersion() >= mappingVersion;
+            });
+            Writer currentWriter = lockedWriter.get();
             currentWriter.updateMappingVersion(mappingVersion);
             // Writer pool must never return null — it creates on demand via the supplier
             assert index.seqNo() >= 0 : "seqNo must be assigned before writing but was: " + index.seqNo();
@@ -624,7 +642,6 @@ public class DataFormatAwareEngine implements Indexer {
 
             if (result instanceof WriteResult.Success) {
                 indexResult = new Engine.IndexResult(plan.version, index.primaryTerm(), index.seqNo(), true);
-                // The result must carry the same seq no that was assigned to the operation
                 assert indexResult.getSeqNo() == index.seqNo() : "IndexResult seq no ["
                     + indexResult.getSeqNo()
                     + "] must match operation seq no ["
@@ -632,13 +649,32 @@ public class DataFormatAwareEngine implements Indexer {
                     + "]";
             } else {
                 WriteResult.Failure f = (WriteResult.Failure) result;
+                try {
+                    writerCheckedOut = retireWriterIfNeeded(lockedWriter);
+                } catch (IllegalStateException bufferLoss) {
+                    // Acked docs can't reach the catalog (writer in an unreconcilable state, or
+                    // flush-on-retire threw). Fail the engine so recovery replays the translog.
+                    writerCheckedOut = true;
+                    failEngine("writer retirement could not preserve buffered acked docs", bufferLoss);
+                }
                 indexResult = new Engine.IndexResult(f.cause(), plan.version, index.primaryTerm(), index.seqNo());
             }
         } catch (Exception e) {
-            indexResult = new Engine.IndexResult(e, plan.version, index.primaryTerm(), index.seqNo());
+            // A throw from addDoc is unmodeled. Known per-doc rejections must come back as
+            // WriteResult.Failure with the writer's state already reconciled (ACTIVE after a
+            // self-rollback, or PENDING_ROLLBACK awaiting CompositeWriter rollback). Anything thrown
+            // means we don't know the writer's buffer state and cannot safely retire it —
+            // fail the engine and let recovery replay the translog.
+            failEngine("uncaught exception during indexing id[" + index.id() + "] seq#[" + index.seqNo() + "]", e);
+            throw e;
         } finally {
-            if (currentWriter != null) {
-                writerPool.releaseAndUnlock(lockedWriter);
+            if (lockedWriter != null) {
+                // Invariant: writerCheckedOut ⇒ writer no longer registered in the pool.
+                assert writerCheckedOut == false || writerPool.isRegistered(lockedWriter) == false
+                    : "writer claimed checked-out but still registered in pool";
+                if (writerPool.isRegistered(lockedWriter)) {
+                    writerPool.releaseAndUnlock(lockedWriter);
+                }
             }
         }
 
@@ -671,6 +707,7 @@ public class DataFormatAwareEngine implements Indexer {
             : "translog-origin op should not have a translog location";
 
         // Track the sequence number
+        assert indexResult.getSeqNo() >= 0 : "indexResult must have assigned seqNo but was: " + indexResult.getSeqNo();
         localCheckpointTracker.markSeqNoAsProcessed(indexResult.getSeqNo());
         if (indexResult.getTranslogLocation() == null) {
             localCheckpointTracker.markSeqNoAsPersisted(indexResult.getSeqNo());
@@ -692,13 +729,44 @@ public class DataFormatAwareEngine implements Indexer {
     }
 
     /**
-     * Not supported — no-op operations are not implemented for data-format-aware engines.
+     * Records a no-op for the given seqNo. Used for failed indexing attempts (so the failed
+     * seqNo is durably recorded), translog replay, and {@link #fillSeqNoGaps} after a
+     * primary-term bump.
      *
-     * @throws UnsupportedOperationException always
+     * <p>Unlike {@code InternalEngine.noOp}, this implementation does not write a tombstone
+     * document — DataFormatAwareEngine has no soft-delete tracking. The seqNo is marked as
+     * seen and processed so the local checkpoint advances, and a {@link Translog.NoOp} is
+     * appended when the op originated outside the translog itself.
      */
     @Override
     public Engine.NoOpResult noOp(Engine.NoOp noOp) throws IOException {
-        throw new UnsupportedOperationException("no_op operation not supported.");
+        try (ReleasableLock ignored = readLock.acquire()) {
+            ensureOpen();
+            return innerNoOp(noOp);
+        }
+    }
+
+    /**
+     * Lock-free no-op: marks the seqNo as seen + processed and (when not from translog)
+     * appends a Translog.NoOp. No tombstone is written — DataFormatAwareEngine has no
+     * soft-delete tracking. Caller must hold either the readLock or the writeLock.
+     */
+    private Engine.NoOpResult innerNoOp(Engine.NoOp noOp) throws IOException {
+        assert rwl.getReadHoldCount() > 0 || rwl.isWriteLockedByCurrentThread() : "innerNoOp requires a read or write lock";
+        assert noOp.seqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO : "noOp must have an assigned seqNo: " + noOp;
+        markSeqNoAsSeen(noOp.seqNo());
+        Engine.NoOpResult result = new Engine.NoOpResult(noOp.primaryTerm(), noOp.seqNo());
+        if (noOp.origin().isFromTranslog() == false) {
+            Translog.Location location = translogManager.add(new Translog.NoOp(noOp.seqNo(), noOp.primaryTerm(), noOp.reason()));
+            result.setTranslogLocation(location);
+        }
+        localCheckpointTracker.markSeqNoAsProcessed(noOp.seqNo());
+        if (result.getTranslogLocation() == null) {
+            localCheckpointTracker.markSeqNoAsPersisted(noOp.seqNo());
+        }
+        result.setTook(System.nanoTime() - noOp.startTime());
+        result.freeze();
+        return result;
     }
 
     /**
@@ -793,6 +861,7 @@ public class DataFormatAwareEngine implements Indexer {
         List<Closeable> toClose = new ArrayList<>();
         try (ReleasableLock ignored = readLock.acquire()) {
             ensureOpen();
+            ensureNoTragicException();
             refreshLock.lock();
             try (GatedCloseable<CatalogSnapshot> catalogSnapshot = catalogSnapshotManager.acquireSnapshot()) {
                 if (store.tryIncRef()) {
@@ -889,7 +958,6 @@ public class DataFormatAwareEngine implements Indexer {
                         // Every new segment must contain files from at least one data format
                         assert newSegments.stream().allMatch(s -> s.dfGroupedSearchableFiles().isEmpty() == false)
                             : "new segments must have at least one format's files";
-
                         // No two new segments may share the same generation
                         assert newSegments.stream().map(Segment::generation).distinct().count() == newSegments.size()
                             : "new segments must have unique generations";
@@ -989,6 +1057,7 @@ public class DataFormatAwareEngine implements Indexer {
         }
         try (ReleasableLock ignored = readLock.acquire()) {
             ensureOpen();
+            ensureNoTragicException();
             if (flushLock.tryLock() == false) {
                 if (waitIfOngoing == false) {
                     return;
@@ -1063,6 +1132,7 @@ public class DataFormatAwareEngine implements Indexer {
                 failOnTragicEvent(e);
                 throw e;
             } catch (Exception e) {
+                maybeFailEngine("flush", e);
                 throw new FlushFailedEngineException(shardId, e);
             } finally {
                 flushLock.unlock();
@@ -1304,8 +1374,10 @@ public class DataFormatAwareEngine implements Indexer {
 
     @Override
     public int fillSeqNoGaps(long primaryTerm) throws IOException {
-        // No-op: data-format engines do not maintain Lucene-style gaps
-        return 0;
+        try (ReleasableLock ignored = writeLock.acquire()) {
+            ensureOpen();
+            return SeqNoGapFiller.fillGaps(localCheckpointTracker, translogManager, primaryTerm, noOp -> innerNoOp(noOp));
+        }
     }
 
     @Override
@@ -1490,6 +1562,15 @@ public class DataFormatAwareEngine implements Indexer {
                     assert isClosed.get() : "engine must be closed after failEngine";
                 } finally {
                     logger.warn(() -> new ParameterizedMessage("failed engine [{}]", reason), failure);
+                    // Delegate corruption marking to the committer (same as Engine.java's intent)
+                    if (failure != null && Lucene.isCorruptionException(failure)) {
+                        committer.markStoreCorrupted(
+                            new IOException(
+                                "failed engine (reason: [" + reason + "])",
+                                org.opensearch.ExceptionsHelper.unwrapCorruption(failure)
+                            )
+                        );
+                    }
                     engineConfig.getEventListener().onFailedEngine(reason, failure);
                 }
             } catch (Exception inner) {
@@ -1501,6 +1582,80 @@ public class DataFormatAwareEngine implements Indexer {
         } else {
             logger.debug(() -> new ParameterizedMessage("tried to fail engine but could not acquire lock [{}]", reason), failure);
         }
+    }
+
+    /**
+     * Retires the writer if its {@link WriterState} is non-ACTIVE: ACTIVE returns {@code false}
+     * (writer stays in the pool); RETIRED_FLUSHABLE checks the writer out, flushes the buffered
+     * N-1 docs into {@link #pendingSegments}, and closes it; any other state — or a flush failure
+     * — throws {@link IllegalStateException} so the caller can {@link #failEngine} and let
+     * recovery replay the translog. The writer is checked out of the pool before any work that
+     * could throw, so on throw the caller can still safely flag it as checked-out.
+     */
+    private boolean retireWriterIfNeeded(DefaultLockableHolder<Writer<?>> lockedWriter) {
+        Writer<?> writer = lockedWriter.get();
+        WriterState postState = writer.state();
+        if (postState == WriterState.ACTIVE) {
+            return false;
+        }
+        try (Releasable ignored = writerPool.checkout(lockedWriter)) {
+            if (postState != WriterState.RETIRED_FLUSHABLE) {
+                throw new IllegalStateException(
+                    "writer generation [" + writer.generation() + "] retired with inconsistent buffer (state=" + postState + ")"
+                );
+            }
+
+            // RETIRED_FLUSHABLE: flush the buffered N-1 docs. A throw here loses those acked
+            // docs; surface as IllegalStateException so the caller fails the engine for recovery.
+            FileInfos retiredFileInfos;
+            try {
+                retiredFileInfos = writer.flush(FlushInput.EMPTY);
+            } catch (Exception flushEx) {
+                throw new IllegalStateException(
+                    "flush failed retiring writer generation [" + writer.generation() + "]; buffered acked docs lost",
+                    flushEx
+                );
+            }
+            Segment.Builder segBuilder = Segment.builder(writer.generation());
+            boolean hasFiles = false;
+            for (Map.Entry<DataFormat, WriterFileSet> entry : retiredFileInfos.writerFilesMap().entrySet()) {
+                segBuilder.addSearchableFiles(entry.getKey(), entry.getValue());
+                hasFiles = true;
+            }
+            if (hasFiles) {
+                Segment retiredSegment = segBuilder.build();
+                assert retiredSegment.generation() == writer.generation() : "retired segment generation must match writer generation";
+                assert assertRetiredSegmentInvariants(writer, retiredFileInfos);
+                pendingSegments.add(retiredSegment);
+            }
+        } finally {
+            IOUtils.closeWhileHandlingException(writer);
+        }
+        assert writerPool.isRegistered(lockedWriter) == false : "retired writer must not be in pool";
+        return true;
+    }
+
+    /**
+     * Verifies cross-format row-count parity on a retired writer's flushed segment.
+     * Always called inside an {@code assert} so the map walk is stripped when assertions are disabled.
+     */
+    private static boolean assertRetiredSegmentInvariants(Writer<?> writer, FileInfos retiredFileInfos) {
+        Map<DataFormat, WriterFileSet> filesMap = retiredFileInfos.writerFilesMap();
+        long expectedRows = filesMap.values().iterator().next().numRows();
+        for (Map.Entry<DataFormat, WriterFileSet> entry : filesMap.entrySet()) {
+            long rows = entry.getValue().numRows();
+            if (rows != expectedRows) {
+                throw new AssertionError(
+                    "retired segment row counts diverge across formats: format ["
+                        + entry.getKey().name()
+                        + "] has "
+                        + rows
+                        + " rows, expected "
+                        + expectedRows
+                );
+            }
+        }
+        return true;
     }
 
     /**
@@ -1642,6 +1797,13 @@ public class DataFormatAwareEngine implements Indexer {
             assert rwl.isWriteLockedByCurrentThread() || failEngineLock.isHeldByCurrentThread()
                 : "Either the write lock must be held or the engine must be currently failing";
             try {
+                // Discard any pending segments not yet picked up by refresh
+                pendingSegments.clear();
+                // Close any writers queued for deferred close (their files won't reach the catalog)
+                Writer<?> pendingWriter;
+                while ((pendingWriter = pendingWritersToClose.poll()) != null) {
+                    IOUtils.closeWhileHandlingException(pendingWriter);
+                }
                 // Close all writers still in the pool (unflushed writers from the current cycle)
                 for (var holder : writerPool.checkoutAll()) {
                     IOUtils.closeWhileHandlingException(holder.get());
@@ -1747,6 +1909,16 @@ public class DataFormatAwareEngine implements Indexer {
     }
 
     private boolean failOnTragicEvent(AlreadyClosedException ex) {
+        // Safety net for AlreadyClosedException caught mid-refresh / mid-flush — e.g., a
+        // background merge in a format's underlying writer turns tragic between an entry-time
+        // ensureNoTragicException check and the actual addIndexes / commit call. Consult the
+        // indexing engine (multiplexes across formats) and the translog: either can be the
+        // source of an ACE reaching this catch.
+        Exception engineTragic = indexingExecutionEngine.getTragicException();
+        if (engineTragic != null) {
+            failEngine("already closed by tragic event on indexing engine", engineTragic);
+            return true;
+        }
         if (translogManager.getTragicExceptionIfClosed() != null) {
             failEngine("already closed by tragic event on the translog", translogManager.getTragicExceptionIfClosed());
             return true;
@@ -1756,8 +1928,25 @@ public class DataFormatAwareEngine implements Indexer {
         return false;
     }
 
+    /**
+     * If any per-format indexing engine has recorded a tragic exception (e.g., an
+     * unrecoverable IndexWriter failure), fail the engine. Called at refresh and flush entry
+     * points so a tragic event surfaces on the next maintenance op rather than on a doc
+     * write — keeping the indexing hot path free of cross-component state checks.
+     */
+    private void ensureNoTragicException() {
+        Exception engineTragic = indexingExecutionEngine.getTragicException();
+        if (engineTragic != null) {
+            failEngine("tragic event on indexing engine", engineTragic);
+            throw new AlreadyClosedException(shardId + " engine is closed", engineTragic);
+        }
+    }
+
     private boolean maybeFailEngine(String source, Exception e) {
-        if (e instanceof AlreadyClosedException) {
+        if (Lucene.isCorruptionException(e)) {
+            failEngine("corrupt file (source: [" + source + "])", e);
+            return true;
+        } else if (e instanceof AlreadyClosedException) {
             return failOnTragicEvent((AlreadyClosedException) e);
         } else if (e != null && translogManager.getTragicExceptionIfClosed() == e) {
             failEngine(source, e);
@@ -1848,4 +2037,39 @@ public class DataFormatAwareEngine implements Indexer {
         }
     }
 
+    // -- Visible for testing --
+
+    /** Returns the writers in the pool. Visible for testing only. */
+    public Iterable<Writer<?>> getWriterPool() {
+        List<Writer<?>> writers = new ArrayList<>();
+        for (DefaultLockableHolder<Writer<?>> holder : writerPool) {
+            writers.add(holder.get());
+        }
+        return writers;
+    }
+
+    /** Returns whether the writer is registered in the pool. Visible for testing only. */
+    boolean isWriterRegistered(Writer<?> writer) {
+        for (DefaultLockableHolder<Writer<?>> holder : writerPool) {
+            if (holder.get() == writer) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Returns the indexing execution engine. Visible for testing only. */
+    IndexingExecutionEngine<?, ?> getIndexingExecutionEngine() {
+        return indexingExecutionEngine;
+    }
+
+    /** Returns the failed engine exception, or null. Visible for testing only. */
+    Exception getFailedEngine() {
+        return failedEngine.get();
+    }
+
+    /** Returns the store. Visible for testing only. */
+    Store getStore() {
+        return store;
+    }
 }

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -545,28 +545,7 @@ public class InternalEngine extends Engine {
     public int fillSeqNoGaps(long primaryTerm) throws IOException {
         try (ReleasableLock ignored = writeLock.acquire()) {
             ensureOpen();
-            final long localCheckpoint = localCheckpointTracker.getProcessedCheckpoint();
-            final long maxSeqNo = localCheckpointTracker.getMaxSeqNo();
-            int numNoOpsAdded = 0;
-            for (long seqNo = localCheckpoint + 1; seqNo <= maxSeqNo; seqNo = localCheckpointTracker.getProcessedCheckpoint()
-                + 1 /* leap-frog the local checkpoint */) {
-                innerNoOp(new NoOp(seqNo, primaryTerm, Operation.Origin.PRIMARY, System.nanoTime(), "filling gaps"));
-                numNoOpsAdded++;
-                assert seqNo <= localCheckpointTracker.getProcessedCheckpoint() : "local checkpoint did not advance; was ["
-                    + seqNo
-                    + "], now ["
-                    + localCheckpointTracker.getProcessedCheckpoint()
-                    + "]";
-
-            }
-            translogManager.syncTranslog(); // to persist noops associated with the advancement of the local checkpoint
-            assert localCheckpointTracker.getPersistedCheckpoint() == maxSeqNo
-                : "persisted local checkpoint did not advance to max seq no; is ["
-                    + localCheckpointTracker.getPersistedCheckpoint()
-                    + "], max seq no ["
-                    + maxSeqNo
-                    + "]";
-            return numNoOpsAdded;
+            return SeqNoGapFiller.fillGaps(localCheckpointTracker, translogManager, primaryTerm, noOp -> innerNoOp(noOp));
         }
     }
 
@@ -1439,6 +1418,7 @@ public class InternalEngine extends Engine {
                         throw ex;
                     }
                 }
+
                 noOpResult = new NoOpResult(noOp.primaryTerm(), noOp.seqNo());
                 if (noOp.origin().isFromTranslog() == false && noOpResult.getResultType() == Result.Type.SUCCESS) {
                     final Translog.Location location = translogManager.add(

--- a/server/src/main/java/org/opensearch/index/engine/SeqNoGapFiller.java
+++ b/server/src/main/java/org/opensearch/index/engine/SeqNoGapFiller.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import org.opensearch.index.seqno.LocalCheckpointTracker;
+import org.opensearch.index.translog.TranslogManager;
+
+import java.io.IOException;
+
+/**
+ * Shared loop that fills gaps in a {@link LocalCheckpointTracker}'s seqNo space by issuing
+ * NoOp operations until the local checkpoint catches up to the max seq no.
+ *
+ * <p>Used by primary-side engines after a recovery or primary-term bump to plug seqNos that
+ * were assigned but never made it into a durable record (e.g., the previous primary crashed
+ * before persisting). Without this step, the local checkpoint stays stuck below maxSeqNo and
+ * blocks replication progress.
+ *
+ * <p>Each engine supplies its own {@link NoOpHandler} so the leaf operation can vary —
+ * {@link InternalEngine} writes a soft-delete tombstone, {@link DataFormatAwareEngine} does
+ * not (it has no tombstone concept). The loop, leap-frog over the processed checkpoint, and
+ * post-fill translog sync are identical across both.
+ *
+ * <p>Caller must hold the engine's write lock for the duration.
+ */
+final class SeqNoGapFiller {
+
+    private SeqNoGapFiller() {}
+
+    @FunctionalInterface
+    interface NoOpHandler {
+        void apply(Engine.NoOp noOp) throws IOException;
+    }
+
+    /**
+     * Issues NoOps for every seqNo gap below {@code maxSeqNo} via {@code handler}, then
+     * fsyncs the translog.
+     *
+     * @return the number of NoOps written
+     */
+    static int fillGaps(LocalCheckpointTracker tracker, TranslogManager translogManager, long primaryTerm, NoOpHandler handler)
+        throws IOException {
+        final long localCheckpoint = tracker.getProcessedCheckpoint();
+        final long maxSeqNo = tracker.getMaxSeqNo();
+        int numNoOpsAdded = 0;
+        for (long seqNo = localCheckpoint + 1; seqNo <= maxSeqNo; seqNo = tracker.getProcessedCheckpoint()
+            + 1 /* leap-frog the local checkpoint */) {
+            handler.apply(new Engine.NoOp(seqNo, primaryTerm, Engine.Operation.Origin.PRIMARY, System.nanoTime(), "filling gaps"));
+            numNoOpsAdded++;
+            assert seqNo <= tracker.getProcessedCheckpoint() : "local checkpoint did not advance; was ["
+                + seqNo
+                + "], now ["
+                + tracker.getProcessedCheckpoint()
+                + "]";
+        }
+        translogManager.syncTranslog(); // persist noops associated with the advancement of the local checkpoint
+        assert tracker.getPersistedCheckpoint() == maxSeqNo : "persisted local checkpoint did not advance to max seq no; is ["
+            + tracker.getPersistedCheckpoint()
+            + "], max seq no ["
+            + maxSeqNo
+            + "]";
+        return numNoOpsAdded;
+    }
+}

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/IndexingExecutionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/IndexingExecutionEngine.java
@@ -122,4 +122,15 @@ public interface IndexingExecutionEngine<T extends DataFormat, P extends Documen
     default Map<DataFormat, EngineReaderManager<?>> buildReaderManager(ReaderManagerConfig config) throws IOException {
         return config.registry().getReaderManager(config);
     }
+
+    /**
+     * Returns the tragic exception recorded by the underlying writer/store, if any.
+     * Composite engines multiplex this across delegates and surface the first non-null
+     * result so DFAE can fail the engine without consulting the committer.
+     *
+     * @return the tragic exception, or {@code null} if the engine has not turned tragic
+     */
+    default Exception getTragicException() {
+        return null;
+    }
 }

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/RowIdAwareWriter.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/RowIdAwareWriter.java
@@ -62,6 +62,17 @@ public class RowIdAwareWriter<P extends DocumentInput<?>> implements Writer<P> {
     }
 
     /**
+     * Returns the wrapped delegate writer.
+     * <p>
+     * <b>Test-only:</b> exposed solely so tests can reach a {@code MockWriter} held inside this
+     * decorator without relying on reflection (forbidden in test bytecode). Production code must
+     * not depend on this accessor.
+     */
+    public Writer<P> getDelegate() {
+        return delegate;
+    }
+
+    /**
      * Assigns a sequential row ID to the document input, then delegates to the
      * underlying writer. The row ID is set via {@link DocumentInput#setRowId}
      * using the standard {@link DocumentInput#ROW_ID_FIELD} field name.
@@ -72,8 +83,14 @@ public class RowIdAwareWriter<P extends DocumentInput<?>> implements Writer<P> {
      */
     @Override
     public WriteResult addDoc(P d) throws IOException {
+        ensureActive();
         d.setRowId(DocumentInput.ROW_ID_FIELD, rowIdCounter.getAndIncrement());
-        return delegate.addDoc(d);
+        WriteResult result = delegate.addDoc(d);
+        if (result instanceof WriteResult.Failure) {
+            // Move to older state, in case writes come to the writer
+            rowIdCounter.decrementAndGet();
+        }
+        return result;
     }
 
     /** {@inheritDoc} Delegates to the underlying writer. */
@@ -92,6 +109,24 @@ public class RowIdAwareWriter<P extends DocumentInput<?>> implements Writer<P> {
     @Override
     public long generation() {
         return delegate.generation();
+    }
+
+    /** {@inheritDoc} Delegates to the underlying writer. */
+    @Override
+    public WriterState state() {
+        return delegate.state();
+    }
+
+    @Override
+    public void rollbackTo(long rowCount) {
+        throw new UnsupportedOperationException("RowIdAwareWriter.rollbackTo must not be called — composite drives rollback internally");
+    }
+
+    private void ensureActive() {
+        WriterState s = delegate.state();
+        if (s != WriterState.ACTIVE) {
+            throw new IllegalStateException("Writer is not ACTIVE: " + s);
+        }
     }
 
     /** {@inheritDoc} Delegates to the underlying writer. */

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/Writer.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/Writer.java
@@ -26,10 +26,17 @@ public interface Writer<P extends DocumentInput<?>> extends Closeable {
 
     /**
      * Adds a document to the writer.
+     * <p>
+     * Per-document failures (e.g., schema mismatches, partial Lucene IndexWriter advance)
+     * must be returned as a {@link WriteResult.Failure} rather than thrown. The writer
+     * sets its {@link #state()} to {@link WriterState#PENDING_ROLLBACK} to signal the caller that
+     * {@link #rollbackTo(long)} must be invoked before any further writes. Throws are
+     * reserved for unexpected errors (corrupted state, unrecoverable I/O); the engine
+     * treats those as fatal and fails the shard.
      *
      * @param d the document input
-     * @return the write result
-     * @throws IOException if an I/O error occurs
+     * @return {@link WriteResult.Success} on accept, {@link WriteResult.Failure} on per-doc rejection
+     * @throws IOException for unexpected, fatal I/O errors only
      */
     WriteResult addDoc(P d) throws IOException;
 
@@ -54,6 +61,53 @@ public interface Writer<P extends DocumentInput<?>> extends Closeable {
      * @return the generation number
      */
     long generation();
+
+    /**
+     * Rolls the writer back so it holds exactly {@code rowCount} admitted documents.
+     * The caller declares the target; the writer either reaches it or throws.
+     *
+     * <ul>
+     *   <li>If the writer's current accepted count <b>equals</b> {@code rowCount}, this
+     *       is a no-op — nothing was admitted past the target. State is unchanged.</li>
+     *   <li>If the writer's current accepted count is <b>greater</b> than {@code rowCount},
+     *       the surplus docs must be undone. Fully reversible writers (e.g., Parquet's
+     *       row-count decrement) stay in {@link WriterState#ACTIVE}; writers whose internal
+     *       counters cannot be reversed (e.g., Lucene's docId allocator) transition to
+     *       {@link WriterState#RETIRED_FLUSHABLE} — buffered docs remain flushable but no
+     *       more {@code addDoc} calls are allowed.</li>
+     *   <li>If the writer's current accepted count is <b>less</b> than {@code rowCount},
+     *       the writer cannot synthesize the missing rows — throw {@link IllegalStateException}.</li>
+     * </ul>
+     *
+     * <p>A rollback that throws {@link IOException} or {@link IllegalStateException} leaves
+     * the writer in an unknown state; the engine is expected to fail the shard so recovery
+     * replays the translog.
+     *
+     * <p>Implementations must override this method — the default raises
+     * {@link UnsupportedOperationException} because a writer that cannot reach a target
+     * row count cannot participate in {@code CompositeWriter}'s cross-format atomicity
+     * protocol.
+     *
+     * @param rowCount the desired number of admitted documents after this call
+     * @throws IOException if the rollback fails
+     * @throws IllegalStateException if the writer cannot reach {@code rowCount} (e.g.,
+     *         it has accepted fewer than {@code rowCount} docs, or its current state forbids rollback)
+     */
+    default void rollbackTo(long rowCount) throws IOException {
+        throw new UnsupportedOperationException("rollbackTo must be implemented by " + getClass().getName());
+    }
+
+    /**
+     * Returns this writer's current lifecycle state. The engine inspects {@code state()}
+     * after every {@link #addDoc} or {@link #rollbackTo(long)} to decide whether the writer
+     * should be returned to the pool, retired with a flush, or retired without a flush.
+     * <p>
+     * Implementations must track and expose state honestly: returning a stale
+     * {@link WriterState#ACTIVE} after a failure would leave a poisoned writer in the pool.
+     *
+     * @return the current state
+     */
+    WriterState state();
 
     /**
      * Whether this writer's schema can still evolve.

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/WriterState.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/WriterState.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat;
+
+import org.opensearch.common.annotation.ExperimentalApi;
+
+/**
+ * Lifecycle state of a {@link Writer}. Inspected by the engine after every write or
+ * rollback to decide whether the writer can keep accepting docs, must be retired with
+ * a final flush, or must be discarded.
+ *
+ * <p>Allowed transitions (every other transition is a contract violation and must
+ * throw {@code IllegalStateException}):
+ * <pre>
+ *   ACTIVE ──────────addDoc(success)─────────▶ ACTIVE
+ *   ACTIVE ──────────addDoc(Failure)─────────▶ PENDING_ROLLBACK
+ *   ACTIVE ──────────rollbackTo (sibling)────▶ ACTIVE             (fully reversible, e.g. Parquet)
+ *   ACTIVE ──────────rollbackTo (sibling)────▶ RETIRED_FLUSHABLE  (counters can't reverse, e.g. Lucene)
+ *   PENDING_ROLLBACK ─rollbackTo─────────────▶ ACTIVE             (fully reversible)
+ *   PENDING_ROLLBACK ─rollbackTo─────────────▶ RETIRED_FLUSHABLE  (counters can't reverse)
+ *   RETIRED_FLUSHABLE ─flush+close (engine)──▶ CLOSED
+ *   any state ────close (engine teardown)────▶ CLOSED
+ * </pre>
+ *
+ * <p>None of these states fail the shard — the engine only fails on tragic events
+ * (corruption, translog/committer exceptions) via {@code failEngine}, independent of
+ * {@code WriterState}.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public enum WriterState {
+    /**
+     * Writer is accepting new documents.
+     *
+     * <p>Engine action: release back to the pool; subsequent {@code addDoc} calls are allowed.
+     */
+    ACTIVE,
+
+    /**
+     * Writer's last {@code addDoc} returned a {@link org.opensearch.index.engine.dataformat.WriteResult.Failure}
+     * and the caller must invoke {@link Writer#rollbackTo(long)} to reconcile the writer.
+     * Post-rollback the writer transitions to {@link #ACTIVE} (fully reversible, e.g. Parquet)
+     * or {@link #RETIRED_FLUSHABLE} (counters can't reverse, e.g. Lucene).
+     */
+    PENDING_ROLLBACK,
+    /**
+     * Writer can no longer accept documents but holds N-1 consistent docs worth
+     * flushing before close. Reached after a successful {@code rollbackTo} on a
+     * writer whose counters cannot be reversed — e.g., Lucene's soft-delete-based
+     * rollback, where the docId allocator advances even when the doc is undone.
+     *
+     * <p>Engine action: checkout from pool, call {@code flush}, queue the resulting
+     * segment in {@code pendingSegments} for the next refresh, then close the writer.
+     */
+    RETIRED_FLUSHABLE,
+
+    /**
+     * Terminal state set after the engine has closed the writer. No further operations
+     * are valid on the writer.
+     */
+    CLOSED
+}

--- a/server/src/main/java/org/opensearch/index/engine/exec/commit/Committer.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/commit/Committer.java
@@ -97,4 +97,13 @@ public interface Committer extends CommitFileManager, Closeable {
      * @throws IOException if reading commits fails
      */
     List<CatalogSnapshot> listCommittedSnapshots() throws IOException;
+
+    /**
+     * Marks the underlying store as corrupted. Called by the engine on a corruption-class
+     * failure so that the next shard recovery sees the store as unhealthy. Implementations
+     * that do not back a recoverable store may no-op.
+     *
+     * @param cause the corruption cause to record
+     */
+    default void markStoreCorrupted(IOException cause) {}
 }

--- a/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/DataFormatAwareEngineTests.java
@@ -32,14 +32,19 @@ import org.opensearch.index.engine.dataformat.DataFormatPlugin;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
+import org.opensearch.index.engine.dataformat.RowIdAwareWriter;
+import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterState;
 import org.opensearch.index.engine.dataformat.stub.InMemoryCommitter;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormat;
 import org.opensearch.index.engine.dataformat.stub.MockDataFormatPlugin;
 import org.opensearch.index.engine.dataformat.stub.MockDocumentInput;
 import org.opensearch.index.engine.dataformat.stub.MockIndexingExecutionEngine;
 import org.opensearch.index.engine.dataformat.stub.MockSearchBackEndPlugin;
+import org.opensearch.index.engine.dataformat.stub.MockWriter;
 import org.opensearch.index.engine.exec.IndexReaderProvider;
 import org.opensearch.index.engine.exec.WriterFileSet;
+import org.opensearch.index.engine.exec.commit.Committer;
 import org.opensearch.index.engine.exec.commit.CommitterFactory;
 import org.opensearch.index.engine.exec.coord.CatalogSnapshot;
 import org.opensearch.index.mapper.IdFieldMapper;
@@ -76,7 +81,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.opensearch.index.engine.EngineTestCase.createParsedDoc;
 import static org.opensearch.index.engine.EngineTestCase.tombstoneDocSupplier;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -228,6 +232,10 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
             .tombstoneDocSupplier(tombstoneDocSupplier())
             .dataFormatRegistry(registry)
             .committerFactory(committerFactory)
+            .eventListener(new Engine.EventListener() {
+                @Override
+                public void onFailedEngine(String reason, Exception e) {}
+            })
             .mapperService(mapperService)
             .build();
     }
@@ -259,11 +267,15 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
     }
 
     /**
-     * Creates a ParsedDocument with a MockDocumentInput attached, which is required
-     * by DataFormatAwareEngine.indexIntoEngine for updateField calls.
+     * Wraps {@link EngineTestCase#createParsedDoc(String, String)} to attach a
+     * {@link MockDocumentInput}. {@link DataFormatAwareEngine#indexIntoEngine} requires a
+     * non-null {@code DocumentInput} on every doc (it calls {@code addField} for version,
+     * seqNo, primaryTerm), but the base helper leaves that field null because production
+     * code (e.g., {@code IndexShard.applyIndexOperation}) populates it via
+     * {@code DocumentMapperForType.parse}.
      */
-    private ParsedDocument createParsedDocWithInput(String id, String routing) {
-        ParsedDocument base = createParsedDoc(id, routing);
+    private ParsedDocument createParsedDoc(String id, String routing) {
+        ParsedDocument base = EngineTestCase.createParsedDoc(id, routing);
         return new ParsedDocument(
             base.version(),
             SeqNoFieldMapper.SequenceIDFields.emptySeqID(),
@@ -275,6 +287,11 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
             null,
             new MockDocumentInput()
         );
+    }
+
+    /** Backwards-compatible alias for tests that explicitly call {@code createParsedDocWithInput}. */
+    private ParsedDocument createParsedDocWithInput(String id, String routing) {
+        return createParsedDoc(id, routing);
     }
 
     public void testSequenceNumbersAssignedOnPrimary() throws IOException {
@@ -2032,9 +2049,20 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
         }
     }
 
-    // ═══════════════════════════════════════════════════════════════
-    // Helpers for writer-flush-failure tests
-    // ═══════════════════════════════════════════════════════════════
+    /**
+     * Helper: creates a DFA engine with a committer that can inject failures.
+     */
+    private record FailingEngineResult(DataFormatAwareEngine engine, FailureInjectingCommitter committer) {
+    }
+
+    private FailingEngineResult createDFAEngineWithFailingCommitter(Store store, Path translogPath) throws IOException {
+        String uuid = Translog.createEmptyTranslog(translogPath, SequenceNumbers.NO_OPS_PERFORMED, shardId, primaryTerm.get());
+        bootstrapStoreWithMetadata(store, uuid);
+        // Create committer AFTER bootstrap so InMemoryCommitter can read segments info
+        FailureInjectingCommitter committer = new FailureInjectingCommitter(store);
+        EngineConfig config = buildDFAEngineConfigWithCommitterFactory(store, translogPath, c -> committer);
+        return new FailingEngineResult(new DataFormatAwareEngine(config), committer);
+    }
 
     /**
      * Builds an engine config wired to a custom data format plugin (whose writer can be
@@ -2045,7 +2073,62 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
         Path translogPath = createTempDir();
         String uuid = Translog.createEmptyTranslog(translogPath, SequenceNumbers.NO_OPS_PERFORMED, shardId, primaryTerm.get());
         bootstrapStoreWithMetadata(store, uuid);
+        return buildEngineConfigForPluginAndListener(translogPath, plugin, listener);
+    }
 
+    private EngineConfig buildDFAEngineConfigWithCommitterFactory(Store store, Path translogPath, CommitterFactory committerFactory) {
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+                .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), mockDataFormat.name())
+                .build()
+        );
+        TranslogConfig translogConfig = new TranslogConfig(
+            shardId,
+            translogPath,
+            indexSettings,
+            BigArrays.NON_RECYCLING_INSTANCE,
+            "",
+            false
+        );
+        DataFormatRegistry registry = createMockRegistry();
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+        return new EngineConfig.Builder().shardId(shardId)
+            .threadPool(threadPool)
+            .indexSettings(indexSettings)
+            .store(store)
+            .mergePolicy(NoMergePolicy.INSTANCE)
+            .translogConfig(translogConfig)
+            .flushMergesAfter(TimeValue.timeValueMinutes(5))
+            .externalRefreshListener(List.of())
+            .internalRefreshListener(List.of())
+            .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
+            .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+            .primaryTermSupplier(primaryTerm::get)
+            .tombstoneDocSupplier(tombstoneDocSupplier())
+            .dataFormatRegistry(registry)
+            .committerFactory(committerFactory)
+            .eventListener(new Engine.EventListener() {
+                @Override
+                public void onFailedEngine(String reason, Exception e) {}
+            })
+            .mapperService(mapperService)
+            .build();
+    }
+
+    /**
+     * Builds an EngineConfig using a real DataFormatRegistry built from the given plugin,
+     * with the supplied event listener — used by upstream's writer-flush-failure tests.
+     */
+    private EngineConfig buildEngineConfigForPluginAndListener(
+        Path translogPath,
+        MockDataFormatPlugin plugin,
+        Engine.EventListener listener
+    ) {
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
             "test",
             Settings.builder()
@@ -2087,10 +2170,783 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
             .primaryTermSupplier(primaryTerm::get)
             .tombstoneDocSupplier(tombstoneDocSupplier())
             .dataFormatRegistry(registry)
-            .committerFactory(c -> new InMemoryCommitter(store))
-            .mapperService(mapperService)
+            .committerFactory(c -> {
+                try {
+                    return new InMemoryCommitter(store);
+                } catch (IOException ex) {
+                    throw new RuntimeException(ex);
+                }
+            })
             .eventListener(listener)
+            .mapperService(mapperService)
             .build();
+    }
+
+    /**
+     * A committer wrapper that can inject failures on commit. Tragic exceptions are now
+     * surfaced via {@link MockIndexingExecutionEngine#setTragicException} instead.
+     */
+    static class FailureInjectingCommitter implements Committer {
+        private final InMemoryCommitter delegate;
+        private volatile IOException commitFailure;
+
+        FailureInjectingCommitter(Store store) throws IOException {
+            this.delegate = new InMemoryCommitter(store);
+        }
+
+        void setCommitFailure(IOException failure) {
+            this.commitFailure = failure;
+        }
+
+        @Override
+        public Committer.CommitResult commit(Committer.CommitInput commitInput) throws IOException {
+            if (commitFailure != null) throw commitFailure;
+            return delegate.commit(commitInput);
+        }
+
+        @Override
+        public Map<String, String> getLastCommittedData() throws IOException {
+            return delegate.getLastCommittedData();
+        }
+
+        @Override
+        public CommitStats getCommitStats() {
+            return delegate.getCommitStats();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public java.util.List<org.opensearch.index.engine.exec.coord.CatalogSnapshot> listCommittedSnapshots() {
+            return delegate.listCommittedSnapshots();
+        }
+
+        @Override
+        public void deleteCommit(org.opensearch.index.engine.exec.coord.CatalogSnapshot snapshot) {
+            delegate.deleteCommit(snapshot);
+        }
+
+        @Override
+        public boolean isCommitManagedFile(String fileName) {
+            return delegate.isCommitManagedFile(fileName);
+        }
+
+        @Override
+        public byte[] serializeToCommitFormat(org.opensearch.index.engine.exec.coord.CatalogSnapshot snapshot) throws IOException {
+            return delegate.serializeToCommitFormat(snapshot);
+        }
+
+        @Override
+        public void markStoreCorrupted(IOException cause) {
+            delegate.markStoreCorrupted(cause);
+        }
+    }
+
+    // --- Test: failEngine marks store as corrupted for CorruptIndexException ---
+
+    public void testFailEngineWithCorruptionMarksStoreCorrupted() throws IOException {
+        DataFormatAwareEngine engine = createDFAEngine(store, createTempDir());
+        engine.index(indexOp(createParsedDoc("1", null)));
+
+        // Fail with a corruption exception
+        org.apache.lucene.index.CorruptIndexException corruption = new org.apache.lucene.index.CorruptIndexException(
+            "test corruption",
+            "test"
+        );
+        engine.failEngine("corruption test", corruption);
+
+        // Engine should be closed
+        expectThrows(AlreadyClosedException.class, () -> engine.index(indexOp(createParsedDoc("2", null))));
+        // Store should be marked as corrupted
+        assertTrue("store should be marked corrupted", store.isMarkedCorrupted());
+    }
+
+    // --- Test: failEngine does NOT mark store corrupted for non-corruption exceptions ---
+
+    public void testFailEngineWithNonCorruptionDoesNotMarkStoreCorrupted() throws IOException {
+        DataFormatAwareEngine engine = createDFAEngine(store, createTempDir());
+        engine.index(indexOp(createParsedDoc("1", null)));
+
+        engine.failEngine("non-corruption test", new RuntimeException("simulated"));
+
+        expectThrows(AlreadyClosedException.class, () -> engine.index(indexOp(createParsedDoc("2", null))));
+        assertFalse("store should NOT be marked corrupted for non-corruption failures", store.isMarkedCorrupted());
+    }
+
+    // --- Test: index → refresh → failEngine → verify no data loss for committed data ---
+
+    public void testFailEngineAfterFlushPreservesCommittedData() throws IOException {
+        Path translogPath = createTempDir();
+        FailingEngineResult fer = createDFAEngineWithFailingCommitter(store, translogPath);
+        DataFormatAwareEngine engine = fer.engine();
+        FailureInjectingCommitter committer = fer.committer();
+        engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+        // Index and flush to commit data
+        int numDocs = randomIntBetween(3, 10);
+        for (int i = 0; i < numDocs; i++) {
+            engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+        }
+        engine.flush(false, true);
+
+        // Verify commit data was persisted
+        Map<String, String> committedData = committer.getLastCommittedData();
+        assertThat(committedData, notNullValue());
+        assertTrue("committed data should contain translog UUID", committedData.containsKey(Translog.TRANSLOG_UUID_KEY));
+
+        // Now fail the engine
+        engine.failEngine("test", new RuntimeException("simulated"));
+
+        // Committed data should still be accessible from the committer
+        Map<String, String> dataAfterFail = committer.getLastCommittedData();
+        assertThat(dataAfterFail, equalTo(committedData));
+    }
+    // --- Test: failEngine with null failure ---
+
+    public void testFailEngineWithNullFailure() throws IOException {
+        DataFormatAwareEngine engine = createDFAEngine(store, createTempDir());
+        engine.index(indexOp(createParsedDoc("1", null)));
+
+        // failEngine with null failure should still close the engine
+        engine.failEngine("null failure test", null);
+
+        expectThrows(AlreadyClosedException.class, () -> engine.index(indexOp(createParsedDoc("2", null))));
+        // Store should NOT be marked corrupted (null failure)
+        assertFalse("store should not be corrupted for null failure", store.isMarkedCorrupted());
+    }
+
+    /**
+     * Returns the first MockWriter currently in the engine's writer pool via reflection.
+     * The engine must have indexed at least one doc so a writer exists in the pool.
+     */
+
+    private MockWriter getPooledMockWriter(DataFormatAwareEngine engine) {
+        for (Writer<?> w : engine.getWriterPool()) {
+            if (w instanceof MockWriter mw) return mw;
+            if (w instanceof RowIdAwareWriter<?> riw && riw.getDelegate() instanceof MockWriter mw) return mw;
+        }
+        throw new AssertionError("No MockWriter found in writer pool");
+    }
+
+    public void testCorruptionExceptionDuringIndexFailsEngineAndMarksStore() throws IOException {
+        DataFormatAwareEngine engine = createDFAEngine(store, createTempDir());
+        try {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+            // Index 5 docs, refresh, flush to establish baseline
+            for (int i = 0; i < 5; i++) {
+                Engine.IndexResult result = engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+                assertThat(result.getResultType(), equalTo(Engine.Result.Type.SUCCESS));
+            }
+            engine.refresh("baseline");
+            engine.flush(false, true);
+
+            // Index one more doc to ensure a writer exists in the pool after flush
+            Engine.IndexResult extraResult = engine.index(indexOp(createParsedDoc("extra", null)));
+            assertThat(extraResult.getResultType(), equalTo(Engine.Result.Type.SUCCESS));
+
+            // Configure MockWriter to throw CorruptIndexException as the addDoc cause.
+            // On primary, maybeFailEngine sees Lucene.isCorruptionException and calls failEngine,
+            // which marks the store corrupted before notifying listeners.
+            MockWriter writer = getPooledMockWriter(engine);
+            org.apache.lucene.index.CorruptIndexException corruption = new org.apache.lucene.index.CorruptIndexException(
+                "simulated corruption during index",
+                "test"
+            );
+            writer.setWriteResultSupplier(() -> { throw new java.io.UncheckedIOException(new java.io.IOException(corruption)); });
+
+            // Index doc on primary → corruption escalates via maybeFailEngine → failEngine.
+            expectThrows(Exception.class, () -> engine.index(indexOp(createParsedDoc("6", null))));
+
+            // Engine should be failed
+            assertNotNull(
+                "engine should have failed on primary with CorruptIndexException",
+                new FailableDataFormatAwareEngine(engine).getFailedEngine()
+            );
+
+            // Store should be marked corrupted
+            assertTrue("store should be marked corrupted", store.isMarkedCorrupted());
+
+            // Verify corruption marker file exists on disk
+            boolean foundCorruptionMarker = false;
+            for (String file : store.directory().listAll()) {
+                if (file.startsWith(Store.CORRUPTED_MARKER_NAME_PREFIX)) {
+                    foundCorruptionMarker = true;
+                    break;
+                }
+            }
+            assertTrue("corruption marker file should exist on disk", foundCorruptionMarker);
+
+            // No further operations possible
+            expectThrows(AlreadyClosedException.class, () -> engine.index(indexOp(createParsedDoc("6", null))));
+        } finally {
+            engine.close();
+        }
+    }
+
+    private MockIndexingExecutionEngine getMockExecutionEngine(DataFormatAwareEngine engine) {
+        return (MockIndexingExecutionEngine) engine.getIndexingExecutionEngine();
+    }
+
+    public void testRefreshAlreadyClosedWithTragicSourceFailsEngine() throws IOException {
+        Path translogPath = createTempDir();
+        FailingEngineResult fer = createDFAEngineWithFailingCommitter(store, translogPath);
+        DataFormatAwareEngine engine = fer.engine();
+        try {
+            for (int i = 0; i < 5; i++) {
+                Engine.IndexResult result = engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+                assertThat(result.getResultType(), equalTo(Engine.Result.Type.SUCCESS));
+            }
+
+            // Configure refresh to throw AlreadyClosedException, with a tragic exception
+            // recorded on the indexing engine (the new tragic-source channel).
+            MockIndexingExecutionEngine mockExecEngine = getMockExecutionEngine(engine);
+            IOException tragicCause = new IOException("engine tragic");
+            mockExecEngine.setTragicException(tragicCause);
+            mockExecEngine.setRefreshFailure(() -> new AlreadyClosedException("engine closed"));
+
+            // Refresh catches ACE → failOnTragicEvent → detect engine tragic → failEngine
+            expectThrows(AlreadyClosedException.class, () -> engine.refresh("test"));
+
+            Exception failedEngine = new FailableDataFormatAwareEngine(engine).getFailedEngine();
+            assertNotNull("engine should have failed via failOnTragicEvent", failedEngine);
+            assertSame("failed engine cause should be the indexing engine's tragic exception", tragicCause, failedEngine);
+
+            expectThrows(AlreadyClosedException.class, () -> engine.index(indexOp(createParsedDoc("5", null))));
+        } finally {
+            engine.close();
+        }
+    }
+
+    public void testRefreshFailureAfterIndexingFailsEngine() throws Exception {
+        DataFormatAwareEngine engine = createDFAEngine(store, createTempDir());
+        try {
+            MockIndexingExecutionEngine mockExecEngine = getMockExecutionEngine(engine);
+
+            // Index some docs and refresh to establish baseline
+            for (int i = 0; i < 10; i++) {
+                engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+            }
+            engine.refresh("setup");
+
+            // Index more docs so next refresh has unflushed segments to process
+            for (int i = 10; i < 15; i++) {
+                engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+            }
+
+            // Now inject refresh failure — next refresh will fail the engine
+            mockExecEngine.setRefreshFailure(() -> new IOException("injected refresh failure"));
+
+            // Trigger the failure — refresh will flush writers, find new segments, call
+            // indexingExecutionEngine.refresh() which throws, then failEngine is called
+            try {
+                engine.refresh("trigger-failure");
+            } catch (Exception e) {
+                // expected
+            }
+
+            // Verify engine failed
+            FailableDataFormatAwareEngine failable = new FailableDataFormatAwareEngine(engine);
+            assertNotNull("engine should have failed from refresh IOException", failable.getFailedEngine());
+
+            // Verify subsequent ops throw AlreadyClosedException
+            expectThrows(AlreadyClosedException.class, () -> engine.index(indexOp(createParsedDoc("post-fail", null))));
+            expectThrows(AlreadyClosedException.class, () -> engine.refresh("post-fail"));
+        } finally {
+            engine.close();
+        }
+    }
+
+    public void testFlushCorruptionExceptionFailsEngineViaMaybeFailEngine() throws IOException {
+        Path translogPath = createTempDir();
+        FailingEngineResult fer = createDFAEngineWithFailingCommitter(store, translogPath);
+        DataFormatAwareEngine engine = fer.engine();
+        FailureInjectingCommitter failingCommitter = fer.committer();
+        try {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+            // Index 20 docs
+            for (int i = 0; i < 20; i++) {
+                Engine.IndexResult result = engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+                assertThat(result.getResultType(), equalTo(Engine.Result.Type.SUCCESS));
+            }
+
+            // Refresh to make docs visible
+            engine.refresh("test");
+
+            // Configure committer to throw CorruptIndexException on commit
+            org.apache.lucene.index.CorruptIndexException corruption = new org.apache.lucene.index.CorruptIndexException(
+                "simulated corruption via maybeFailEngine",
+                "test"
+            );
+            failingCommitter.setCommitFailure(corruption);
+
+            // Flush — maybeFailEngine detects corruption and fails the engine
+            FlushFailedEngineException thrown = expectThrows(FlushFailedEngineException.class, () -> engine.flush(false, true));
+
+            // Verify the cause chain contains the original corruption exception
+            assertTrue("cause should be CorruptIndexException", thrown.getCause() instanceof org.apache.lucene.index.CorruptIndexException);
+            assertTrue(
+                "cause message should reference simulated corruption",
+                thrown.getCause().getMessage().contains("simulated corruption via maybeFailEngine")
+            );
+
+            // Engine should be failed
+            assertNotNull("engine should have failed", new FailableDataFormatAwareEngine(engine).getFailedEngine());
+
+            // Store should be marked corrupted (maybeFailEngine → Lucene.isCorruptionException → failEngine → markStoreCorrupted)
+            assertTrue("store should be marked corrupted", store.isMarkedCorrupted());
+
+            // No further operations possible
+            expectThrows(AlreadyClosedException.class, () -> engine.index(indexOp(createParsedDoc("20", null))));
+            expectThrows(AlreadyClosedException.class, () -> engine.refresh("test"));
+            expectThrows(AlreadyClosedException.class, () -> engine.flush(false, true));
+        } finally {
+            engine.close();
+        }
+    }
+
+    public void testFlushNonCorruptionExceptionWrapsInFlushFailedEngineException() throws IOException {
+        Path translogPath = createTempDir();
+        FailingEngineResult fer = createDFAEngineWithFailingCommitter(store, translogPath);
+        DataFormatAwareEngine engine = fer.engine();
+        FailureInjectingCommitter failingCommitter = fer.committer();
+        try {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+            // Index 10 docs
+            for (int i = 0; i < 10; i++) {
+                Engine.IndexResult result = engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+                assertThat(result.getResultType(), equalTo(Engine.Result.Type.SUCCESS));
+            }
+
+            // Configure committer to throw non-corruption IOException on commit
+            failingCommitter.setCommitFailure(new IOException("disk error"));
+
+            // Flush should throw FlushFailedEngineException
+            expectThrows(FlushFailedEngineException.class, () -> engine.flush(false, true));
+
+            // Engine should still be open (non-corruption doesn't fail the engine)
+            assertNull("engine should still be open", new FailableDataFormatAwareEngine(engine).getFailedEngine());
+
+            // Disable failure
+            failingCommitter.setCommitFailure(null);
+
+            // Flush again — should succeed now
+            engine.flush(false, true);
+
+            // Verify all 10 docs committed via checkpoint
+            assertThat("all 10 docs should be committed", engine.getProcessedLocalCheckpoint(), equalTo(9L));
+        } finally {
+            engine.close();
+        }
+    }
+
+    public void testFlushWithCommitCorruptionFailsEngineAndMarksStore() throws Exception {
+        Path translogPath = createTempDir();
+        FailingEngineResult fer = createDFAEngineWithFailingCommitter(store, translogPath);
+        DataFormatAwareEngine engine = fer.engine();
+        FailureInjectingCommitter failingCommitter = fer.committer();
+        try {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+            // Index docs and flush successfully first
+            for (int i = 0; i < 20; i++) {
+                engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+            }
+            engine.refresh("setup");
+            engine.flush(false, true);
+
+            // Index more docs
+            for (int i = 20; i < 30; i++) {
+                engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+            }
+
+            // Inject CorruptIndexException on commit
+            failingCommitter.setCommitFailure(new org.apache.lucene.index.CorruptIndexException("injected corruption", "test"));
+
+            // Flush should fail the engine via maybeFailEngine
+            try {
+                engine.flush(false, true);
+            } catch (FlushFailedEngineException | AlreadyClosedException e) {
+                // expected
+            }
+
+            // Verify engine failed
+            FailableDataFormatAwareEngine failable = new FailableDataFormatAwareEngine(engine);
+            assertNotNull("engine should have failed from commit corruption", failable.getFailedEngine());
+
+            // Verify store marked corrupted
+            assertTrue("store should be marked corrupted", store.isMarkedCorrupted());
+        } finally {
+            engine.close();
+        }
+    }
+
+    // --- Test: concurrent failEngine from multiple sources is idempotent ---
+
+    public void testConcurrentFailEngineFromMultipleSourcesIsIdempotent() throws Exception {
+        // Build engine with a counting event listener to verify onFailedEngine called exactly once
+        AtomicInteger onFailedCount = new AtomicInteger(0);
+        Engine.EventListener countingListener = new Engine.EventListener() {
+            @Override
+            public void onFailedEngine(String reason, Exception e) {
+                onFailedCount.incrementAndGet();
+            }
+        };
+
+        Path translogPath = createTempDir();
+        String uuid = Translog.createEmptyTranslog(translogPath, SequenceNumbers.NO_OPS_PERFORMED, shardId, primaryTerm.get());
+        bootstrapStoreWithMetadata(store, uuid);
+
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(
+            "test",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+                .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), mockDataFormat.name())
+                .build()
+        );
+        TranslogConfig translogConfig = new TranslogConfig(
+            shardId,
+            translogPath,
+            indexSettings,
+            BigArrays.NON_RECYCLING_INSTANCE,
+            "",
+            false
+        );
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+        EngineConfig config = new EngineConfig.Builder().shardId(shardId)
+            .threadPool(threadPool)
+            .indexSettings(indexSettings)
+            .store(store)
+            .mergePolicy(NoMergePolicy.INSTANCE)
+            .translogConfig(translogConfig)
+            .flushMergesAfter(TimeValue.timeValueMinutes(5))
+            .externalRefreshListener(List.of())
+            .internalRefreshListener(List.of())
+            .globalCheckpointSupplier(() -> SequenceNumbers.NO_OPS_PERFORMED)
+            .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+            .primaryTermSupplier(primaryTerm::get)
+            .tombstoneDocSupplier(tombstoneDocSupplier())
+            .dataFormatRegistry(createMockRegistry())
+            .committerFactory(c -> new InMemoryCommitter(store))
+            .eventListener(countingListener)
+            .mapperService(mapperService)
+            .build();
+
+        DataFormatAwareEngine engine = new DataFormatAwareEngine(config);
+        try {
+            // Index 10 docs
+            for (int i = 0; i < 10; i++) {
+                engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+            }
+
+            // Spawn 5 threads each calling failEngine with different reasons
+            int numThreads = 5;
+            CyclicBarrier barrier = new CyclicBarrier(numThreads);
+            AtomicInteger threadErrors = new AtomicInteger(0);
+
+            Thread[] threads = new Thread[numThreads];
+            for (int t = 0; t < numThreads; t++) {
+                final int id = t;
+                threads[t] = new Thread(() -> {
+                    try {
+                        barrier.await();
+                        engine.failEngine("reason-" + id, new RuntimeException("exception-" + id));
+                    } catch (Exception e) {
+                        threadErrors.incrementAndGet();
+                    }
+                });
+                threads[t].start();
+            }
+            for (Thread t : threads) {
+                t.join(10_000);
+                assertFalse("thread should have completed", t.isAlive());
+            }
+
+            // No thread should have thrown
+            assertThat("no thread should have thrown", threadErrors.get(), equalTo(0));
+
+            // Verify engine failed exactly once (first caller wins)
+            FailableDataFormatAwareEngine failable = new FailableDataFormatAwareEngine(engine);
+            assertNotNull("engine should have failed", failable.getFailedEngine());
+
+            // Verify onFailedEngine called exactly once
+            assertThat("onFailedEngine should be called exactly once", onFailedCount.get(), equalTo(1));
+
+            // Verify all subsequent ops throw AlreadyClosedException
+            expectThrows(AlreadyClosedException.class, () -> engine.index(indexOp(createParsedDoc("post-fail", null))));
+            expectThrows(AlreadyClosedException.class, () -> engine.refresh("post-fail"));
+            expectThrows(AlreadyClosedException.class, () -> engine.flush(false, true));
+        } finally {
+            engine.close();
+        }
+    }
+
+    // --- Test: refresh failure with buffered unflushed segments ---
+
+    public void testRefreshFailureWithBufferedSegmentsFailsEngine() throws Exception {
+        DataFormatAwareEngine engine = createDFAEngine(store, createTempDir());
+        try {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+            // Index docs, refresh, flush — establish baseline
+            for (int i = 0; i < 20; i++) {
+                engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+            }
+            engine.refresh("setup");
+            engine.flush(false, true);
+
+            // Index more docs so next refresh has unflushed segments
+            for (int i = 20; i < 40; i++) {
+                engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+            }
+
+            // Inject refresh failure via MockIndexingExecutionEngine
+            MockIndexingExecutionEngine mockExecEngine = getMockExecutionEngine(engine);
+            mockExecEngine.setRefreshFailure(() -> new IOException("injected writer failure"));
+
+            // Trigger failure via refresh
+            try {
+                engine.refresh("trigger-failure");
+            } catch (Exception e) {
+                // expected
+            }
+
+            // Verify consistent terminal state
+            FailableDataFormatAwareEngine failable = new FailableDataFormatAwareEngine(engine);
+            Exception failedEngine = failable.getFailedEngine();
+            if (failedEngine != null) {
+                expectThrows(AlreadyClosedException.class, () -> engine.index(indexOp(createParsedDoc("post-fail", null))));
+            }
+        } finally {
+            engine.close();
+        }
+    }
+
+    // --- Test: operations after failEngine throw AlreadyClosedException with original cause ---
+
+    public void testIndexAfterFailEngineThrowsAlreadyClosedWithOriginalCause() throws Exception {
+        DataFormatAwareEngine engine = createDFAEngine(store, createTempDir());
+        try {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+            // Index 5 docs successfully
+            for (int i = 0; i < 5; i++) {
+                engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+            }
+
+            // Fail engine with a known cause
+            IOException originalCause = new IOException("original cause");
+            engine.failEngine("test failure", originalCause);
+
+            // Index → AlreadyClosedException with original cause
+            AlreadyClosedException indexEx = expectThrows(
+                AlreadyClosedException.class,
+                () -> engine.index(indexOp(createParsedDoc("post-fail", null)))
+            );
+            assertSame("index ACE cause should be the original failure", originalCause, indexEx.getCause());
+
+            // Refresh → AlreadyClosedException with original cause
+            AlreadyClosedException refreshEx = expectThrows(AlreadyClosedException.class, () -> engine.refresh("post-fail"));
+            assertSame("refresh ACE cause should be the original failure", originalCause, refreshEx.getCause());
+
+            // Flush → AlreadyClosedException with original cause
+            AlreadyClosedException flushEx = expectThrows(AlreadyClosedException.class, () -> engine.flush(false, true));
+            assertSame("flush ACE cause should be the original failure", originalCause, flushEx.getCause());
+        } finally {
+            engine.close();
+        }
+    }
+
+    public void testEngineRecoveryAfterFailurePreservesCommittedData() throws Exception {
+        Path translogPath = createTempDir();
+        DataFormatAwareEngine engine = createDFAEngine(store, translogPath);
+        try {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+            // Index 20 docs, refresh, flush (commit point)
+            for (int i = 0; i < 20; i++) {
+                Engine.IndexResult result = engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+                assertThat(result.getResultType(), equalTo(Engine.Result.Type.SUCCESS));
+            }
+            engine.refresh("test");
+            engine.flush(false, true);
+            assertThat(engine.getProcessedLocalCheckpoint(), equalTo(19L));
+
+            // Index 10 more (unflushed — in translog only)
+            for (int i = 20; i < 30; i++) {
+                Engine.IndexResult result = engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+                assertThat(result.getResultType(), equalTo(Engine.Result.Type.SUCCESS));
+            }
+            assertThat(engine.getProcessedLocalCheckpoint(), equalTo(29L));
+        } finally {
+            engine.close();
+        }
+
+        // Reopen engine from same store/translog — verifies committed data survives restart
+        // (InMemoryCommitter doesn't persist commit data to store, so checkpoint reflects
+        // bootstrap state; we verify the engine is operational after recovery)
+        try (DataFormatAwareEngine engine2 = new DataFormatAwareEngine(buildDFAEngineConfig(store, translogPath))) {
+            engine2.translogManager().recoverFromTranslog(ignore -> 0, engine2.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+            // Refresh and verify engine is operational
+            engine2.refresh("recovery-verify");
+
+            // Verify engine is fully operational — can index new docs
+            Engine.IndexResult newResult = engine2.index(indexOp(createParsedDoc("new-after-recovery", null)));
+            assertThat("new doc after recovery should succeed", newResult.getResultType(), equalTo(Engine.Result.Type.SUCCESS));
+
+            // Refresh and flush work
+            engine2.refresh("post-recovery");
+            engine2.flush(false, true);
+        }
+    }
+
+    public void testIOExceptionDuringRefreshFailsEngine() throws IOException {
+        DataFormatAwareEngine engine = createDFAEngine(store, createTempDir());
+        try {
+            for (int i = 0; i < 10; i++) {
+                engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+            }
+
+            // Inject IOException on refresh
+            MockIndexingExecutionEngine mockExecEngine = getMockExecutionEngine(engine);
+            mockExecEngine.setRefreshFailure(() -> new IOException("disk full during refresh"));
+
+            // Refresh should fail the engine
+            try {
+                engine.refresh("test");
+            } catch (Exception e) {
+                // expected
+            }
+
+            // Engine should be failed
+            assertNotNull(
+                "engine should have failed from refresh IOException",
+                new FailableDataFormatAwareEngine(engine).getFailedEngine()
+            );
+            expectThrows(AlreadyClosedException.class, () -> engine.index(indexOp(createParsedDoc("post-fail", null))));
+        } finally {
+            engine.close();
+        }
+    }
+
+    public void testIOExceptionDuringCommitFailsEngineOnCorruption() throws IOException {
+        Path translogPath = createTempDir();
+        FailingEngineResult fer = createDFAEngineWithFailingCommitter(store, translogPath);
+        DataFormatAwareEngine engine = fer.engine();
+        FailureInjectingCommitter failingCommitter = fer.committer();
+        try {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+            for (int i = 0; i < 5; i++) {
+                engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+            }
+
+            // Simulate disk full as CorruptIndexException during commit
+            failingCommitter.setCommitFailure(new org.apache.lucene.index.CorruptIndexException("No space left on device", "test"));
+
+            // Flush triggers commit which fails
+            expectThrows(FlushFailedEngineException.class, () -> engine.flush(false, true));
+
+            // Engine should be failed and store marked corrupted
+            assertNotNull("engine should have failed", new FailableDataFormatAwareEngine(engine).getFailedEngine());
+            assertTrue("store should be marked corrupted", store.isMarkedCorrupted());
+        } finally {
+            engine.close();
+        }
+    }
+
+    public void testIOExceptionDuringCommitEngineStaysOpenForNonCorruption() throws IOException {
+        Path translogPath = createTempDir();
+        FailingEngineResult fer = createDFAEngineWithFailingCommitter(store, translogPath);
+        DataFormatAwareEngine engine = fer.engine();
+        FailureInjectingCommitter failingCommitter = fer.committer();
+        try {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+            for (int i = 0; i < 5; i++) {
+                engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+            }
+
+            // Simulate disk full as plain IOException (not corruption)
+            failingCommitter.setCommitFailure(new IOException("No space left on device"));
+
+            // Flush fails but engine stays open (non-corruption)
+            expectThrows(FlushFailedEngineException.class, () -> engine.flush(false, true));
+
+            // Engine should still be open
+            assertNull(
+                "engine should not have failed for non-corruption IO error",
+                new FailableDataFormatAwareEngine(engine).getFailedEngine()
+            );
+            assertFalse("store should NOT be corrupted", store.isMarkedCorrupted());
+
+            // Clear failure and flush again — should succeed
+            failingCommitter.setCommitFailure(null);
+            engine.flush(false, true);
+        } finally {
+            engine.close();
+        }
+    }
+
+    public void testOutOfMemoryErrorDuringFlushViaCommitter() throws IOException {
+        Path translogPath = createTempDir();
+        FailingEngineResult fer = createDFAEngineWithFailingCommitter(store, translogPath);
+        DataFormatAwareEngine engine = fer.engine();
+        FailureInjectingCommitter failingCommitter = fer.committer();
+        try {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+            for (int i = 0; i < 5; i++) {
+                engine.index(indexOp(createParsedDoc(Integer.toString(i), null)));
+            }
+
+            failingCommitter.setCommitFailure(new IOException(new OutOfMemoryError("fake OOM during commit")));
+
+            FlushFailedEngineException ex = expectThrows(FlushFailedEngineException.class, () -> engine.flush(false, true));
+            assertTrue("root cause should be OOM", ex.getCause().getCause() instanceof OutOfMemoryError);
+        } finally {
+            engine.close();
+        }
+    }
+
+    /**
+     * Test helper that wraps a {@link DataFormatAwareEngine} to expose its private failure
+     * handling methods ({@code failOnTragicEvent}, {@code maybeFailEngine}) and internal
+     * state ({@code failedEngine}, {@code store}) for direct testing via reflection.
+     */
+    static class FailableDataFormatAwareEngine implements java.io.Closeable {
+        private final DataFormatAwareEngine engine;
+
+        FailableDataFormatAwareEngine(DataFormatAwareEngine engine) {
+            this.engine = engine;
+        }
+
+        void failEngine(String reason, Exception failure) {
+            engine.failEngine(reason, failure);
+        }
+
+        Exception getFailedEngine() {
+            return engine.getFailedEngine();
+        }
+
+        Store getStore() {
+            return engine.getStore();
+        }
+
+        DataFormatAwareEngine getEngine() {
+            return engine;
+        }
+
+        @Override
+        public void close() throws IOException {
+            engine.close();
+        }
     }
 
     /**
@@ -2141,6 +2997,7 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
     private static final class FailingFlushWriter implements org.opensearch.index.engine.dataformat.Writer<MockDocumentInput> {
         private final long writerGeneration;
         private final org.opensearch.index.engine.dataformat.DataFormat dataFormat;
+        private volatile WriterState state = WriterState.ACTIVE;
 
         FailingFlushWriter(long writerGeneration, org.opensearch.index.engine.dataformat.DataFormat dataFormat) {
             this.writerGeneration = writerGeneration;
@@ -2167,6 +3024,11 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
         }
 
         @Override
+        public WriterState state() {
+            return state;
+        }
+
+        @Override
         public boolean isSchemaMutable() {
             return true;
         }
@@ -2180,7 +3042,9 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
         public void updateMappingVersion(long newVersion) {}
 
         @Override
-        public void close() {}
+        public void close() {
+            state = WriterState.CLOSED;
+        }
     }
 
     /**
@@ -2190,6 +3054,7 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
     private static final class SuccessFlushWriter implements org.opensearch.index.engine.dataformat.Writer<MockDocumentInput> {
         private final long writerGeneration;
         private final org.opensearch.index.engine.dataformat.DataFormat dataFormat;
+        private volatile WriterState state = WriterState.ACTIVE;
 
         SuccessFlushWriter(long writerGeneration, org.opensearch.index.engine.dataformat.DataFormat dataFormat) {
             this.writerGeneration = writerGeneration;
@@ -2215,6 +3080,11 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
         }
 
         @Override
+        public WriterState state() {
+            return state;
+        }
+
+        @Override
         public boolean isSchemaMutable() {
             return true;
         }
@@ -2228,6 +3098,111 @@ public class DataFormatAwareEngineTests extends OpenSearchTestCase {
         public void updateMappingVersion(long newVersion) {}
 
         @Override
-        public void close() {}
+        public void close() {
+            state = WriterState.CLOSED;
+        }
+    }
+
+    /** With no gap (lcp == max), fillSeqNoGaps writes 0 NoOps and returns 0. */
+    public void testFillSeqNoGapsNoGap() throws IOException {
+        try (DataFormatAwareEngine engine = createDFAEngine(store, createTempDir())) {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+            for (int i = 0; i < 5; i++) {
+                engine.index(indexOp(createParsedDocWithInput(Integer.toString(i), null)));
+            }
+            // localCheckpoint == maxSeqNo == 4 — no gap to fill.
+            assertEquals(4L, engine.getProcessedLocalCheckpoint());
+            assertEquals(4L, engine.getSeqNoStats(SequenceNumbers.NO_OPS_PERFORMED).getMaxSeqNo());
+
+            int filled = engine.fillSeqNoGaps(primaryTerm.get() + 1);
+            assertEquals("no gaps to fill", 0, filled);
+            assertEquals(4L, engine.getProcessedLocalCheckpoint());
+        }
+    }
+
+    /**
+     * Simulates a real failover gap: index N docs as PRIMARY, then replay a recovery-origin
+     * op at a higher seqNo. The recovery op processes its own seqNo but leaves a gap below
+     * it — fillSeqNoGaps must close the gap so localCheckpoint catches up to max.
+     */
+    public void testFillSeqNoGapsClosesGapAndWritesTranslogNoOps() throws IOException {
+        try (DataFormatAwareEngine engine = createDFAEngine(store, createTempDir())) {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+            // 3 successful PRIMARY ops → seqNos 0, 1, 2 / lcp = 2 / max = 2
+            for (int i = 0; i < 3; i++) {
+                engine.index(indexOp(createParsedDocWithInput(Integer.toString(i), null)));
+            }
+            assertEquals(2L, engine.getProcessedLocalCheckpoint());
+
+            // Replay a recovery-origin op at seqNo=7. That marks 7 as seen+processed, but
+            // localCheckpoint stays at 2 (the largest contiguous prefix). Gap: seqNos 3..6.
+            ParsedDocument far = createParsedDocWithInput("7", null);
+            Engine.Index recoveryOp = new Engine.Index(
+                new Term(IdFieldMapper.NAME, Uid.encodeId(far.id())),
+                far,
+                7L,
+                primaryTerm.get(),
+                1L,
+                null,
+                Engine.Operation.Origin.LOCAL_TRANSLOG_RECOVERY,
+                System.nanoTime(),
+                -1,
+                false,
+                SequenceNumbers.UNASSIGNED_SEQ_NO,
+                0
+            );
+            engine.index(recoveryOp);
+            assertEquals("max advanced via recovery op", 7L, engine.getSeqNoStats(SequenceNumbers.NO_OPS_PERFORMED).getMaxSeqNo());
+            assertEquals("lcp blocked by gap at 3..6", 2L, engine.getProcessedLocalCheckpoint());
+
+            int translogOpsBefore = engine.translogManager().getTranslogStats().estimatedNumberOfOperations();
+            int filled = engine.fillSeqNoGaps(primaryTerm.get());
+
+            assertEquals("4 NoOps written for gap 3..6", 4, filled);
+            assertEquals("lcp now equals max", 7L, engine.getProcessedLocalCheckpoint());
+            assertEquals(
+                "translog grew by 4 NoOps",
+                translogOpsBefore + 4,
+                engine.translogManager().getTranslogStats().estimatedNumberOfOperations()
+            );
+        }
+    }
+
+    /** fillSeqNoGaps is idempotent — second call after the first finds nothing to do. */
+    public void testFillSeqNoGapsIdempotent() throws IOException {
+        try (DataFormatAwareEngine engine = createDFAEngine(store, createTempDir())) {
+            engine.translogManager().recoverFromTranslog(ignore -> 0, engine.getProcessedLocalCheckpoint(), Long.MAX_VALUE);
+
+            // Index 1 doc, then create a gap via a recovery op at seqNo=5.
+            engine.index(indexOp(createParsedDocWithInput("0", null)));
+            ParsedDocument far = createParsedDocWithInput("5", null);
+            engine.index(
+                new Engine.Index(
+                    new Term(IdFieldMapper.NAME, Uid.encodeId(far.id())),
+                    far,
+                    5L,
+                    primaryTerm.get(),
+                    1L,
+                    null,
+                    Engine.Operation.Origin.LOCAL_TRANSLOG_RECOVERY,
+                    System.nanoTime(),
+                    -1,
+                    false,
+                    SequenceNumbers.UNASSIGNED_SEQ_NO,
+                    0
+                )
+            );
+            assertEquals(0L, engine.getProcessedLocalCheckpoint());
+            assertEquals(5L, engine.getSeqNoStats(SequenceNumbers.NO_OPS_PERFORMED).getMaxSeqNo());
+
+            int firstFill = engine.fillSeqNoGaps(primaryTerm.get());
+            assertEquals("4 NoOps written for gap 1..4", 4, firstFill);
+            assertEquals(5L, engine.getProcessedLocalCheckpoint());
+
+            int secondFill = engine.fillSeqNoGaps(primaryTerm.get());
+            assertEquals("no further NoOps on second call", 0, secondFill);
+            assertEquals(5L, engine.getProcessedLocalCheckpoint());
+        }
     }
 }

--- a/server/src/test/java/org/opensearch/index/engine/dataformat/RowIdAwareWriterTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/dataformat/RowIdAwareWriterTests.java
@@ -22,15 +22,21 @@ import static org.mockito.Mockito.when;
 public class RowIdAwareWriterTests extends OpenSearchTestCase {
 
     @SuppressWarnings("unchecked")
-    public void testDocCountStartsAtZero() {
+    private static Writer<DocumentInput<?>> activeDelegate() {
         Writer<DocumentInput<?>> delegate = mock(Writer.class);
+        when(delegate.state()).thenReturn(WriterState.ACTIVE);
+        return delegate;
+    }
+
+    public void testDocCountStartsAtZero() {
+        Writer<DocumentInput<?>> delegate = activeDelegate();
         RowIdAwareWriter<DocumentInput<?>> writer = new RowIdAwareWriter<>(delegate);
         assertEquals(0L, writer.docCount());
     }
 
     @SuppressWarnings("unchecked")
     public void testDocCountIncrementsOnAddDoc() throws IOException {
-        Writer<DocumentInput<?>> delegate = mock(Writer.class);
+        Writer<DocumentInput<?>> delegate = activeDelegate();
         DocumentInput<?> input = mock(DocumentInput.class);
         when(delegate.addDoc(input)).thenReturn(new WriteResult.Success(1L, 1L, 0L));
 
@@ -44,20 +50,24 @@ public class RowIdAwareWriterTests extends OpenSearchTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    public void testAddDocSetsRowId() throws IOException {
-        Writer<DocumentInput<?>> delegate = mock(Writer.class);
+    public void testAddDocSetsRowIdInOrder() throws IOException {
+        Writer<DocumentInput<?>> delegate = activeDelegate();
         DocumentInput<?> input = mock(DocumentInput.class);
         when(delegate.addDoc(input)).thenReturn(new WriteResult.Success(1L, 1L, 0L));
 
         RowIdAwareWriter<DocumentInput<?>> writer = new RowIdAwareWriter<>(delegate);
         writer.addDoc(input);
+        writer.addDoc(input);
+        writer.addDoc(input);
 
         verify(input).setRowId(DocumentInput.ROW_ID_FIELD, 0L);
+        verify(input).setRowId(DocumentInput.ROW_ID_FIELD, 1L);
+        verify(input).setRowId(DocumentInput.ROW_ID_FIELD, 2L);
     }
 
     @SuppressWarnings("unchecked")
     public void testFlushDelegatesToUnderlying() throws IOException {
-        Writer<DocumentInput<?>> delegate = mock(Writer.class);
+        Writer<DocumentInput<?>> delegate = activeDelegate();
         FileInfos expected = FileInfos.empty();
         when(delegate.flush(FlushInput.EMPTY)).thenReturn(expected);
 
@@ -70,7 +80,7 @@ public class RowIdAwareWriterTests extends OpenSearchTestCase {
 
     @SuppressWarnings("unchecked")
     public void testFlushWithRowIdMapping() throws IOException {
-        Writer<DocumentInput<?>> delegate = mock(Writer.class);
+        Writer<DocumentInput<?>> delegate = activeDelegate();
         RowIdMapping mapping = new PackedRowIdMapping(new long[] { 1, 0 }, true);
         FlushInput flushInput = new FlushInput(mapping);
         FileInfos expected = FileInfos.empty();
@@ -106,5 +116,63 @@ public class RowIdAwareWriterTests extends OpenSearchTestCase {
         RowIdAwareWriter<DocumentInput<?>> writer = new RowIdAwareWriter<>(delegate);
         writer.close();
         verify(delegate).close();
+    }
+
+    // ==============================================================================
+    // Failure handling: rowId counter behavior under different leaf failure modes
+    // ==============================================================================
+
+    /**
+     * Parquet-style: leaf throws but recovers (rolls back internally) and stays ACTIVE.
+     * The consumed rowId must be returned so the next addDoc reuses it — otherwise we
+     * leave a permanent gap in the rowId sequence.
+     */
+    /**
+     * Cross-doc rowId monotonicity: across many addDoc calls (all successful), the
+     * sequence of rowIds set on inputs must be 0, 1, 2, ... contiguous and ordered.
+     */
+    @SuppressWarnings("unchecked")
+    public void testRowIdMonotonicityAcrossManyDocs() throws IOException {
+        Writer<DocumentInput<?>> delegate = activeDelegate();
+        when(delegate.addDoc(org.mockito.ArgumentMatchers.any())).thenReturn(new WriteResult.Success(1L, 1L, 0L));
+
+        RowIdAwareWriter<DocumentInput<?>> writer = new RowIdAwareWriter<>(delegate);
+        long[] observed = new long[100];
+        for (int i = 0; i < 100; i++) {
+            DocumentInput<?> input = mock(DocumentInput.class);
+            final int idx = i;
+            org.mockito.Mockito.doAnswer(inv -> {
+                observed[idx] = inv.getArgument(1);
+                return null;
+            }).when(input).setRowId(org.mockito.ArgumentMatchers.eq(DocumentInput.ROW_ID_FIELD), org.mockito.ArgumentMatchers.anyLong());
+            writer.addDoc(input);
+        }
+
+        for (int i = 0; i < 100; i++) {
+            assertEquals("rowId at position " + i + " must equal " + i, (long) i, observed[i]);
+        }
+    }
+
+    /**
+     * Direct invariant: ensureActive() throws on a non-ACTIVE delegate (was an assert,
+     * now a runtime check per review feedback).
+     */
+    @SuppressWarnings("unchecked")
+    public void testAddDocOnRetiredWriterThrowsRuntime() {
+        Writer<DocumentInput<?>> delegate = mock(Writer.class);
+        when(delegate.state()).thenReturn(WriterState.RETIRED_FLUSHABLE);
+        DocumentInput<?> input = mock(DocumentInput.class);
+
+        RowIdAwareWriter<DocumentInput<?>> writer = new RowIdAwareWriter<>(delegate);
+        expectThrows(IllegalStateException.class, () -> writer.addDoc(input));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testRollbackOnRetiredWriterThrowsRuntime() {
+        Writer<DocumentInput<?>> delegate = mock(Writer.class);
+        when(delegate.state()).thenReturn(WriterState.RETIRED_FLUSHABLE);
+
+        RowIdAwareWriter<DocumentInput<?>> writer = new RowIdAwareWriter<>(delegate);
+        expectThrows(UnsupportedOperationException.class, () -> writer.rollbackTo(0));
     }
 }

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/FileBackedDataFormatPlugin.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/FileBackedDataFormatPlugin.java
@@ -1,0 +1,405 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat.stub;
+
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DataFormatDescriptor;
+import org.opensearch.index.engine.dataformat.DataFormatPlugin;
+import org.opensearch.index.engine.dataformat.DataFormatRegistry;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
+import org.opensearch.index.engine.dataformat.FileInfos;
+import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
+import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
+import org.opensearch.index.engine.dataformat.MergeResult;
+import org.opensearch.index.engine.dataformat.Merger;
+import org.opensearch.index.engine.dataformat.ReaderManagerConfig;
+import org.opensearch.index.engine.dataformat.RefreshInput;
+import org.opensearch.index.engine.dataformat.RefreshResult;
+import org.opensearch.index.engine.dataformat.WriteResult;
+import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterConfig;
+import org.opensearch.index.engine.dataformat.WriterState;
+import org.opensearch.index.engine.exec.EngineReaderManager;
+import org.opensearch.index.engine.exec.Segment;
+import org.opensearch.index.engine.exec.WriterFileSet;
+import org.opensearch.index.engine.exec.commit.IndexStoreProvider;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.store.PrecomputedChecksumStrategy;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.SearchBackEndPlugin;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A file-backed data format plugin for integration tests. Format name: "filebacked".
+ * Writers persist doc IDs as lines in text files. Supports failure injection via static methods.
+ */
+public class FileBackedDataFormatPlugin extends Plugin implements DataFormatPlugin, SearchBackEndPlugin<Object> {
+
+    public static final String FORMAT_NAME = "filebacked";
+
+    private static final DataFormat DATA_FORMAT = new DataFormat() {
+        @Override
+        public String name() {
+            return FORMAT_NAME;
+        }
+
+        @Override
+        public long priority() {
+            return 0;
+        }
+
+        @Override
+        public Set<FieldTypeCapabilities> supportedFields() {
+            return Set.of();
+        }
+    };
+
+    private static final AtomicInteger failOnNextNDocs = new AtomicInteger(0);
+    private static final AtomicInteger failEveryNthDoc = new AtomicInteger(0);
+    private static final AtomicInteger docCounter = new AtomicInteger(0);
+    private static volatile boolean failOnNextRollback;
+    private static volatile boolean throwOnNextDoc;
+    private static volatile Path dataDirectory;
+
+    public static void setDataDirectory(Path dir) {
+        dataDirectory = dir;
+    }
+
+    public static void setFailOnNextNDocs(int n) {
+        failOnNextNDocs.set(n);
+    }
+
+    public static void setFailEveryNthDoc(int n) {
+        failEveryNthDoc.set(n);
+        docCounter.set(0);
+    }
+
+    public static void setFailOnNextRollback(boolean fail) {
+        failOnNextRollback = fail;
+    }
+
+    public static void setThrowOnNextDoc(boolean throwException) {
+        throwOnNextDoc = throwException;
+    }
+
+    public static void clearFailure() {
+        failOnNextNDocs.set(0);
+        failEveryNthDoc.set(0);
+        docCounter.set(0);
+        failOnNextRollback = false;
+        throwOnNextDoc = false;
+    }
+
+    public static Path getDataDirectory() {
+        return dataDirectory;
+    }
+
+    /** Reads all entries from flushed filebacked data files. Each entry is "gen=N,rowId=M,fields={...}". */
+    public static List<String> readAllEntries() throws IOException {
+        Path dir = dataDirectory;
+        if (dir == null || Files.exists(dir) == false) return List.of();
+        List<String> entries = new ArrayList<>();
+        try (var stream = Files.list(dir)) {
+            for (Path file : stream.filter(p -> p.getFileName().toString().endsWith(".txt")).toList()) {
+                entries.addAll(Files.readAllLines(file));
+            }
+        }
+        return entries;
+    }
+
+    /** Parses entries into a map of "gen:rowId" → "fields" for cross-format comparison. */
+    public static java.util.Map<String, String> parseEntryMap() throws IOException {
+        java.util.Map<String, String> map = new java.util.LinkedHashMap<>();
+        for (String entry : readAllEntries()) {
+            // entry format: gen=N,rowId=M,fields={...}
+            String[] parts = entry.split(",", 3);
+            String key = parts[0] + "," + parts[1]; // "gen=N,rowId=M"
+            String fields = parts.length > 2 ? parts[2] : "";
+            map.put(key, fields);
+        }
+        return map;
+    }
+
+    static WriteResult checkFailure() {
+        int remaining;
+        do {
+            remaining = failOnNextNDocs.get();
+            if (remaining <= 0) break;
+        } while (failOnNextNDocs.compareAndSet(remaining, remaining - 1) == false);
+        if (remaining > 0) {
+            return new WriteResult.Failure(new IOException("filebacked injected failure"), -1, -1, -1);
+        }
+        int count = docCounter.incrementAndGet();
+        int every = failEveryNthDoc.get();
+        if (every > 0 && count % every == 0) {
+            return new WriteResult.Failure(new IOException("filebacked injected failure"), -1, -1, -1);
+        }
+        return null;
+    }
+
+    @Override
+    public DataFormat getDataFormat() {
+        return DATA_FORMAT;
+    }
+
+    @Override
+    public IndexingExecutionEngine<?, ?> indexingEngine(IndexingEngineConfig settings) {
+        return new FBEngine(settings);
+    }
+
+    @Override
+    public Map<String, java.util.function.Supplier<DataFormatDescriptor>> getFormatDescriptors(IndexSettings s, DataFormatRegistry r) {
+        return Map.of(FORMAT_NAME, () -> new DataFormatDescriptor(FORMAT_NAME, new PrecomputedChecksumStrategy()));
+    }
+
+    @Override
+    public String name() {
+        return "filebacked-backend";
+    }
+
+    @Override
+    public List<String> getSupportedFormats() {
+        return List.of(FORMAT_NAME);
+    }
+
+    @Override
+    public EngineReaderManager<?> createReaderManager(ReaderManagerConfig config) {
+        return new MockReaderManager(FORMAT_NAME);
+    }
+
+    static class FBEngine implements IndexingExecutionEngine<DataFormat, DocumentInput<?>> {
+        private final AtomicLong writerGen = new AtomicLong();
+        private volatile Path directory;
+        private final IndexingEngineConfig config;
+
+        FBEngine() {
+            this.config = null;
+        }
+
+        FBEngine(IndexingEngineConfig config) {
+            this.config = config;
+        }
+
+        private Path ensureDirectory() {
+            if (directory == null) {
+                if (dataDirectory == null) {
+                    throw new IllegalStateException("FileBackedDataFormatPlugin.setDataDirectory() must be called before use");
+                }
+                directory = dataDirectory;
+            }
+            return directory;
+        }
+
+        private long currentMappingVersion() {
+            if (config == null || config.mapperService() == null) return 0L;
+            return config.mapperService().getIndexSettings().getIndexMetadata().getMappingVersion();
+        }
+
+        @Override
+        public Writer<DocumentInput<?>> createWriter(WriterConfig config) {
+            return new FBWriter(config.writerGeneration(), ensureDirectory(), currentMappingVersion());
+        }
+
+        @Override
+        public DataFormat getDataFormat() {
+            return DATA_FORMAT;
+        }
+
+        @Override
+        public Merger getMerger() {
+            return i -> new MergeResult(Map.of());
+        }
+
+        @Override
+        public RefreshResult refresh(RefreshInput input) {
+            List<Segment> segments = new ArrayList<>(input.existingSegments());
+            segments.addAll(input.writerFiles());
+            return new RefreshResult(segments);
+        }
+
+        @Override
+        public Map<String, Collection<String>> deleteFiles(Map<String, Collection<String>> f) {
+            return Map.of();
+        }
+
+        @Override
+        public long getNextWriterGeneration() {
+            return writerGen.getAndIncrement();
+        }
+
+        @Override
+        public DocumentInput<?> newDocumentInput() {
+            return new FBDocInput();
+        }
+
+        @Override
+        public IndexStoreProvider getProvider() {
+            return df -> null;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    static class FBWriter implements Writer<DocumentInput<?>> {
+        private final long generation;
+        private final Path directory;
+        private final String fileName;
+        private final List<String> docs = new ArrayList<>();
+        private final AtomicInteger localCount = new AtomicInteger();
+        private volatile WriterState state = WriterState.ACTIVE;
+        private volatile long mappingVersion;
+
+        FBWriter(long generation, Path directory) {
+            this(generation, directory, 0L);
+        }
+
+        FBWriter(long generation, Path directory, long mappingVersion) {
+            this.generation = generation;
+            this.directory = directory;
+            this.fileName = "data_gen" + generation + ".txt";
+            this.mappingVersion = mappingVersion;
+        }
+
+        @Override
+        public WriteResult addDoc(DocumentInput<?> d) throws IOException {
+            assert state == WriterState.ACTIVE : "addDoc requires ACTIVE state but was " + state;
+            // Lucene-style: any addDoc failure retires the writer.
+            if (throwOnNextDoc) {
+                throwOnNextDoc = false;
+                throw new IOException("filebacked injected IOException (throw mode)");
+            }
+            WriteResult failure = checkFailure();
+            if (failure != null) {
+                // Lucene-style contract: signal PENDING_ROLLBACK so the composite can drive
+                // rollbackLastDoc, which moves us to RETIRED_FLUSHABLE.
+                if (state == WriterState.ACTIVE) state = WriterState.PENDING_ROLLBACK;
+                return failure;
+            }
+            long rowId = (d instanceof FBDocInput) ? ((FBDocInput) d).rowId : -1;
+            String fields = (d instanceof FBDocInput) ? ((FBDocInput) d).fields.toString() : "{}";
+            docs.add("gen=" + generation + ",rowId=" + rowId + ",fields=" + fields);
+            int n = localCount.incrementAndGet();
+            return new WriteResult.Success(1L, 1L, n);
+        }
+
+        @Override
+        public FileInfos flush(org.opensearch.index.engine.dataformat.FlushInput flushInput) throws IOException {
+            // No docs in this writer's buffer (e.g. only doc was rolled back) → no file. This
+            // mirrors LuceneWriter.flush(docCount == 0 → empty) and is required for the
+            // composite multi-format atomicity assertion: every format must agree on empty
+            // vs non-empty.
+            if (docs.isEmpty()) {
+                return FileInfos.empty();
+            }
+            Path file = directory.resolve(fileName);
+            Files.write(file, docs, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            WriterFileSet wfs = WriterFileSet.builder()
+                .directory(directory)
+                .writerGeneration(generation)
+                .addFile(fileName)
+                .addNumRows(docs.size())
+                .build();
+            return FileInfos.builder().putWriterFileSet(DATA_FORMAT, wfs).build();
+        }
+
+        @Override
+        public void rollbackTo(long rowCount) throws IOException {
+            if (failOnNextRollback) {
+                failOnNextRollback = false;
+                throw new IOException("filebacked rollback injected failure");
+            }
+            if (rowCount > docs.size()) {
+                throw new IllegalStateException("Cannot rollback to " + rowCount + ": only " + docs.size() + " docs");
+            }
+            while (docs.size() > rowCount) {
+                docs.remove(docs.size() - 1);
+            }
+            state = WriterState.RETIRED_FLUSHABLE;
+        }
+
+        @Override
+        public WriterState state() {
+            return state;
+        }
+
+        @Override
+        public void sync() {}
+
+        @Override
+        public long generation() {
+            return generation;
+        }
+
+        @Override
+        public boolean isSchemaMutable() {
+            return true;
+        }
+
+        @Override
+        public long mappingVersion() {
+            return mappingVersion;
+        }
+
+        @Override
+        public void updateMappingVersion(long newVersion) {
+            if (newVersion > mappingVersion) {
+                mappingVersion = newVersion;
+            }
+        }
+
+        @Override
+        public void close() {
+            state = WriterState.CLOSED;
+        }
+    }
+
+    static class FBDocInput implements DocumentInput<Object> {
+        long rowId = -1;
+        final java.util.Map<String, String> fields = new java.util.LinkedHashMap<>();
+
+        @Override
+        public Object getFinalInput() {
+            return null;
+        }
+
+        @Override
+        public void addField(MappedFieldType fieldType, Object value) {
+            if (fieldType != null && value != null) {
+                fields.put(fieldType.name(), value.toString());
+            }
+        }
+
+        @Override
+        public void setRowId(String rowIdFieldName, long rowId) {
+            this.rowId = rowId;
+        }
+
+        @Override
+        public long getFieldCount(String fieldName) {
+            return fields.containsKey(fieldName) ? 1 : 0;
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/FileBackedFailableIndexingExecutionEngine.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/FileBackedFailableIndexingExecutionEngine.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat.stub;
+
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.dataformat.FieldTypeCapabilities;
+import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
+import org.opensearch.index.engine.dataformat.MergeResult;
+import org.opensearch.index.engine.dataformat.Merger;
+import org.opensearch.index.engine.dataformat.RefreshInput;
+import org.opensearch.index.engine.dataformat.RefreshResult;
+import org.opensearch.index.engine.dataformat.WriteResult;
+import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterConfig;
+import org.opensearch.index.engine.exec.Segment;
+import org.opensearch.index.engine.exec.commit.IndexStoreProvider;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/**
+ * An {@link IndexingExecutionEngine} that creates {@link FileBackedFailableWriter}
+ * instances writing real files to disk. Supports failure injection at the engine
+ * and writer level, and returns proper {@link RefreshResult} with {@link Segment}
+ * objects referencing the flushed files.
+ */
+/**
+ * An {@link IndexingExecutionEngine} that creates {@link FileBackedFailableWriter} instances
+ * writing real files to disk. Supports engine-level failure injection and returns proper
+ * {@link RefreshResult} carrying forward segments from {@link RefreshInput}.
+ */
+public class FileBackedFailableIndexingExecutionEngine implements IndexingExecutionEngine<DataFormat, DocumentInput<?>> {
+
+    private final DataFormat dataFormat;
+    private final Path directory;
+    private final AtomicLong writerGen = new AtomicLong();
+    private final List<FileBackedFailableWriter> createdWriters = new ArrayList<>();
+    private volatile Supplier<WriteResult> defaultWriteResultSupplier;
+    private volatile org.opensearch.index.engine.dataformat.WriterState defaultStateAfterRollback;
+
+    public FileBackedFailableIndexingExecutionEngine(String name, Path baseDir) throws IOException {
+        this.directory = baseDir.resolve(name);
+        Files.createDirectories(this.directory);
+        this.dataFormat = new DataFormat() {
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public long priority() {
+                return 1;
+            }
+
+            @Override
+            public Set<FieldTypeCapabilities> supportedFields() {
+                return Set.of();
+            }
+
+            @Override
+            public String toString() {
+                return "FileBackedFormat{" + name + "}";
+            }
+        };
+    }
+
+    public FileBackedFailableWriter getLastCreatedWriter() {
+        return createdWriters.get(createdWriters.size() - 1);
+    }
+
+    public List<FileBackedFailableWriter> getAllWriters() {
+        return List.copyOf(createdWriters);
+    }
+
+    public void setDefaultWriteResultSupplier(Supplier<WriteResult> supplier) {
+        this.defaultWriteResultSupplier = supplier;
+    }
+
+    /** Apply a Parquet-style "stay ACTIVE after rollback" semantic to every freshly created writer. */
+    public void setDefaultStateAfterRollback(org.opensearch.index.engine.dataformat.WriterState state) {
+        this.defaultStateAfterRollback = state;
+    }
+
+    public Path getDirectory() {
+        return directory;
+    }
+
+    @Override
+    public Writer<DocumentInput<?>> createWriter(WriterConfig config) {
+        FileBackedFailableWriter w = new FileBackedFailableWriter(dataFormat, config.writerGeneration(), directory);
+        if (defaultWriteResultSupplier != null) {
+            w.writeResultSupplier = defaultWriteResultSupplier;
+        }
+        if (defaultStateAfterRollback != null) {
+            w.setStateAfterRollback(defaultStateAfterRollback);
+        }
+        createdWriters.add(w);
+        return w;
+    }
+
+    @Override
+    public RefreshResult refresh(RefreshInput input) {
+        // Carry forward existing segments + new writer segments
+        List<Segment> segments = new ArrayList<>(input.existingSegments());
+        segments.addAll(input.writerFiles());
+        return new RefreshResult(segments);
+    }
+
+    @Override
+    public Merger getMerger() {
+        return i -> new MergeResult(Map.of());
+    }
+
+    @Override
+    public DataFormat getDataFormat() {
+        return dataFormat;
+    }
+
+    @Override
+    public Map<String, Collection<String>> deleteFiles(Map<String, Collection<String>> f) {
+        return Map.of();
+    }
+
+    @Override
+    public long getNextWriterGeneration() {
+        return writerGen.getAndIncrement();
+    }
+
+    @Override
+    public DocumentInput<?> newDocumentInput() {
+        return new MockDocumentInput();
+    }
+
+    @Override
+    public IndexStoreProvider getProvider() {
+        return df -> null;
+    }
+
+    @Override
+    public void close() {}
+
+    public static List<String> readFlushedFile(Path filePath) throws IOException {
+        if (Files.exists(filePath) == false) return Collections.emptyList();
+        return Files.readAllLines(filePath);
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/FileBackedFailableWriter.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/FileBackedFailableWriter.java
@@ -1,0 +1,171 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat.stub;
+
+import org.opensearch.index.engine.dataformat.DataFormat;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.dataformat.FileInfos;
+import org.opensearch.index.engine.dataformat.WriteResult;
+import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterState;
+import org.opensearch.index.engine.exec.WriterFileSet;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+/**
+ * A writer that persists doc IDs as lines in a text file for file-level consistency
+ * verification in tests. Supports failure injection, rollback, and produces real
+ * {@link WriterFileSet} on flush. Tracks close state for writer pool lifecycle assertions.
+ */
+public class FileBackedFailableWriter implements Writer<DocumentInput<?>> {
+
+    private final DataFormat format;
+    private final long writerGeneration;
+    private final Path directory;
+    private final String fileName;
+    private final List<String> docs = new ArrayList<>();
+    final AtomicInteger addDocCallCount = new AtomicInteger();
+    public volatile Supplier<WriteResult> writeResultSupplier;
+    volatile IOException flushFailure;
+    public volatile IOException rollbackFailure;
+    volatile boolean rollbackCalled;
+    private volatile WriterState state = WriterState.ACTIVE;
+    /**
+     * State to transition into when {@link #rollbackTo(long)} succeeds. Defaults to
+     * {@link WriterState#RETIRED_FLUSHABLE} — Lucene-style. Parquet-style writers that can
+     * cleanly undo the last row return to {@link WriterState#ACTIVE}; tests can flip via
+     * {@link #setStateAfterRollback}.
+     */
+    private volatile WriterState stateAfterRollback = WriterState.RETIRED_FLUSHABLE;
+
+    public FileBackedFailableWriter(DataFormat format, long writerGeneration, Path directory) {
+        this.format = format;
+        this.writerGeneration = writerGeneration;
+        this.directory = directory;
+        this.fileName = "data_gen" + writerGeneration + "_" + format.name() + ".txt";
+    }
+
+    @Override
+    public WriteResult addDoc(DocumentInput<?> d) {
+        assert state == WriterState.ACTIVE : "addDoc requires ACTIVE state but was " + state;
+        int callNum = addDocCallCount.incrementAndGet();
+        if (writeResultSupplier != null) {
+            WriteResult result = writeResultSupplier.get();
+            // Null result means "fall through to default success behavior" — useful for
+            // selective per-call failure injection where most calls should succeed normally.
+            if (result != null) {
+                if (result instanceof WriteResult.Failure && state == WriterState.ACTIVE) {
+                    state = WriterState.PENDING_ROLLBACK;
+                }
+                return result;
+            }
+        }
+        docs.add("doc_" + callNum);
+        return new WriteResult.Success(1L, 1L, callNum);
+    }
+
+    @Override
+    public FileInfos flush(org.opensearch.index.engine.dataformat.FlushInput flushInput) throws IOException {
+        if (flushFailure != null) throw flushFailure;
+        Path file = directory.resolve(fileName);
+        Files.write(file, docs, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        WriterFileSet fileSet = WriterFileSet.builder()
+            .directory(directory)
+            .writerGeneration(writerGeneration)
+            .addFile(fileName)
+            .addNumRows(docs.size())
+            .build();
+        return FileInfos.builder().putWriterFileSet(format, fileSet).build();
+    }
+
+    @Override
+    public void rollbackTo(long rowCount) throws IOException {
+        rollbackCalled = true;
+        if (rollbackFailure != null) {
+            throw rollbackFailure;
+        }
+        if (rowCount > docs.size()) {
+            throw new IllegalStateException("Cannot rollback to " + rowCount + ": only " + docs.size() + " docs");
+        }
+        while (docs.size() > rowCount) {
+            docs.remove(docs.size() - 1);
+        }
+        state = stateAfterRollback;
+    }
+
+    @Override
+    public WriterState state() {
+        return state;
+    }
+
+    /**
+     * Test-only: override the post-rollback state (default {@link WriterState#RETIRED_FLUSHABLE}).
+     * Pass {@link WriterState#ACTIVE} for Parquet-style "stay ACTIVE after a clean rollback".
+     */
+    public void setStateAfterRollback(WriterState state) {
+        this.stateAfterRollback = state;
+    }
+
+    /** Returns the doc IDs currently held in memory (before flush). */
+    List<String> getDocs() {
+        return List.copyOf(docs);
+    }
+
+    int numRows() {
+        return docs.size();
+    }
+
+    String getFileName() {
+        return fileName;
+    }
+
+    public Path getFilePath() {
+        return directory.resolve(fileName);
+    }
+
+    @Override
+    public void sync() {}
+
+    @Override
+    public long generation() {
+        return writerGeneration;
+    }
+
+    @Override
+    public boolean isSchemaMutable() {
+        return true;
+    }
+
+    @Override
+    public long mappingVersion() {
+        return 0;
+    }
+
+    @Override
+    public void updateMappingVersion(long newVersion) {}
+
+    private volatile boolean closed;
+
+    public boolean isClosed() {
+        return closed;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        state = WriterState.CLOSED;
+    }
+}

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/InMemoryCommitter.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/InMemoryCommitter.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -29,6 +30,8 @@ import java.util.stream.StreamSupport;
  */
 public class InMemoryCommitter implements Committer {
     private volatile Map<String, String> committedData;
+    private volatile Supplier<Exception> commitFailure;
+    private volatile boolean markCorruptedCalled;
     private final long initialCommitGeneration;
     private final Store store;
 
@@ -39,17 +42,30 @@ public class InMemoryCommitter implements Committer {
         this.store = store;
     }
 
+    public void setCommitFailure(Supplier<Exception> supplier) {
+        this.commitFailure = supplier;
+    }
+
+    public boolean isMarkCorruptedCalled() {
+        return markCorruptedCalled;
+    }
+
+    public void setMarkCorruptedCalled(boolean v) {
+        this.markCorruptedCalled = v;
+    }
+
     @Override
-    public CommitResult commit(CommitInput commitData) {
+    public CommitResult commit(CommitInput commitData) throws IOException {
+        Supplier<Exception> supplier = commitFailure;
+        if (supplier != null) {
+            Exception failure = supplier.get();
+            if (failure != null) {
+                if (failure instanceof IOException) throw (IOException) failure;
+                throw new IOException(failure);
+            }
+        }
         this.committedData = StreamSupport.stream(commitData.userData().spliterator(), false)
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    Map.Entry::getValue,
-                    (existing, replacement) -> replacement, // Merge function for duplicate keys
-                    HashMap::new
-                )
-            );
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (existing, replacement) -> replacement, HashMap::new));
         return null;
     }
 
@@ -97,5 +113,20 @@ public class InMemoryCommitter implements Committer {
     public byte[] serializeToCommitFormat(CatalogSnapshot snapshot) {
         // Test stub does not upload to remote store.
         throw new UnsupportedOperationException("InMemoryCommitter does not serialize commits");
+    }
+
+    @Override
+    public void markStoreCorrupted(IOException cause) {
+        markCorruptedCalled = true;
+        if (store.tryIncRef() == false) {
+            return;
+        }
+        try {
+            store.markStoreCorrupted(cause);
+        } catch (IOException ignored) {
+            // test stub: best-effort
+        } finally {
+            store.decRef();
+        }
     }
 }

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockIndexingExecutionEngine.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockIndexingExecutionEngine.java
@@ -26,7 +26,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 import static org.apache.lucene.tests.util.LuceneTestCase.createTempDir;
 
@@ -38,6 +40,9 @@ public class MockIndexingExecutionEngine implements IndexingExecutionEngine<Data
     private final Path directory;
     private final AtomicLong seqNo = new AtomicLong(0);
     private final AtomicLong writerGeneration = new AtomicLong(0);
+    private volatile Supplier<Exception> refreshFailure;
+    private volatile Exception tragicException;
+    private final AtomicInteger refreshCallCount = new AtomicInteger(0);
 
     public MockIndexingExecutionEngine(MockDataFormat dataFormat) {
         this.dataFormat = dataFormat;
@@ -54,8 +59,32 @@ public class MockIndexingExecutionEngine implements IndexingExecutionEngine<Data
         return new MockMerger(dataFormat, directory);
     }
 
+    public void setRefreshFailure(Supplier<Exception> supplier) {
+        refreshFailure = supplier;
+    }
+
+    public int getRefreshCallCount() {
+        return refreshCallCount.get();
+    }
+
+    public void setTragicException(Exception e) {
+        this.tragicException = e;
+    }
+
     @Override
-    public RefreshResult refresh(RefreshInput refreshInput) {
+    public Exception getTragicException() {
+        return tragicException;
+    }
+
+    @Override
+    public RefreshResult refresh(RefreshInput refreshInput) throws IOException {
+        refreshCallCount.incrementAndGet();
+        if (refreshFailure != null) {
+            Exception e = refreshFailure.get();
+            if (e instanceof IOException) throw (IOException) e;
+            if (e instanceof RuntimeException) throw (RuntimeException) e;
+            throw new IOException(e);
+        }
         List<Segment> segments = new ArrayList<>(refreshInput.existingSegments());
         segments.addAll(refreshInput.writerFiles());
         return new RefreshResult(segments);
@@ -83,7 +112,7 @@ public class MockIndexingExecutionEngine implements IndexingExecutionEngine<Data
 
     @Override
     public IndexStoreProvider getProvider() {
-        return null;
+        return df -> null;
     }
 
     @Override

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockWriter.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockWriter.java
@@ -13,12 +13,15 @@ import org.opensearch.index.engine.dataformat.FileInfos;
 import org.opensearch.index.engine.dataformat.FlushInput;
 import org.opensearch.index.engine.dataformat.WriteResult;
 import org.opensearch.index.engine.dataformat.Writer;
+import org.opensearch.index.engine.dataformat.WriterState;
 import org.opensearch.index.engine.exec.WriterFileSet;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 /**
  * A mock {@link Writer} for testing purposes.
@@ -29,6 +32,40 @@ public class MockWriter implements Writer<MockDocumentInput> {
     private final Path directory;
     private final List<MockDocumentInput> docs = new ArrayList<>();
     private final AtomicLong seqNo;
+    private Supplier<WriteResult> writeResultSupplier;
+    /**
+     * If set, addDoc admits the doc (counter++) and then throws this exception. Models a
+     * Parquet-style writer where a row is committed before a downstream operation fails.
+     */
+    private volatile Supplier<RuntimeException> throwAfterAdmit;
+    private volatile WriterState state = WriterState.ACTIVE;
+    private final AtomicInteger addDocCallCount = new AtomicInteger();
+
+    public void setWriteResultSupplier(Supplier<WriteResult> supplier) {
+        this.writeResultSupplier = supplier;
+    }
+
+    /**
+     * Configure addDoc to admit the doc (counter advances) and then throw. Used to model
+     * the Parquet rotation-after-admit failure mode.
+     */
+    public void setThrowAfterAdmit(Supplier<RuntimeException> throwSupplier) {
+        this.throwAfterAdmit = throwSupplier;
+    }
+
+    /** Test-only: directly inject a state to simulate post-failure conditions. */
+    public void setState(WriterState state) {
+        this.state = state;
+    }
+
+    @Override
+    public WriterState state() {
+        return state;
+    }
+
+    public int getAddDocCallCount() {
+        return addDocCallCount.get();
+    }
 
     public MockWriter(long writerGeneration, DataFormat dataFormat, Path directory, AtomicLong seqNo) {
         this.writerGeneration = writerGeneration;
@@ -39,9 +76,48 @@ public class MockWriter implements Writer<MockDocumentInput> {
 
     @Override
     public WriteResult addDoc(MockDocumentInput d) {
+        assert state == WriterState.ACTIVE : "addDoc requires ACTIVE state but was " + state;
+        addDocCallCount.incrementAndGet();
+        if (writeResultSupplier != null) {
+            WriteResult result = writeResultSupplier.get();
+            if (result instanceof WriteResult.Failure && state == WriterState.ACTIVE) {
+                state = WriterState.PENDING_ROLLBACK;
+            }
+            return result;
+        }
+        if (throwAfterAdmit != null) {
+            // Admit the doc (mirroring Parquet's setRowCount + acceptedRows++), then throw.
+            // State remains ACTIVE so the caller can call rollbackLastDoc to undo, just as
+            // ParquetWriter.addDoc does on top of VSRManager.
+            docs.add(d);
+            seqNo.getAndIncrement();
+            throw throwAfterAdmit.get();
+        }
         docs.add(d);
         long seq = seqNo.getAndIncrement();
         return new WriteResult.Success(1L, 1L, seq);
+    }
+
+    /**
+     * If true, rollbackTo keeps the writer ACTIVE (Parquet-style). Default false
+     * means rollback always retires (Lucene-style).
+     */
+    private volatile boolean rollbackKeepsActive = false;
+
+    /** Test-only: switch rollback behavior to "stay ACTIVE" (Parquet-style). */
+    public void setRollbackKeepsActive(boolean keepActive) {
+        this.rollbackKeepsActive = keepActive;
+    }
+
+    @Override
+    public void rollbackTo(long rowCount) {
+        if (rowCount > docs.size()) {
+            throw new IllegalStateException("Cannot rollback to " + rowCount + ": only " + docs.size() + " docs");
+        }
+        while (docs.size() > rowCount) {
+            docs.remove(docs.size() - 1);
+        }
+        state = rollbackKeepsActive ? WriterState.ACTIVE : WriterState.RETIRED_FLUSHABLE;
     }
 
     @Override
@@ -77,5 +153,7 @@ public class MockWriter implements Writer<MockDocumentInput> {
     public void updateMappingVersion(long newVersion) {}
 
     @Override
-    public void close() {}
+    public void close() {
+        state = WriterState.CLOSED;
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

Adds failure handling to DataFormatAwareEngine and CompositeWriter to maintain cross-format data consistency when document write failures occur in the composite indexing engine.

 #### Testing
  
  - DataFormatAwareEngineTests — single-format failure handling (write failures, corruption, tragic events, flush failures, concurrent failures, recovery)
  - CompositeWriterFailureTests — CompositeWriter isolation (rollback, abort, flush failures)
  - CompositeEngineFailureTests — file-backed e2e with data integrity verification and writer pool lifecycle assertions
  - CompositeEngineFailureIT — cluster-level with single-format and multi-format configurations, cross-format consistency verification (CatalogSnapshot row counts, Lucene DirectoryReader numDocs, docId == rowId invariant, rowId set matching across formats)

### Related Issues
Resolves #21455
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
