### PR TITLE
update DefaultPlanExecutor to be async.

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/exec/QueryPlanExecutor.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/exec/QueryPlanExecutor.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.analytics.exec;
 
+import org.opensearch.core.action.ActionListener;
+
 /**
  * Executes a logical query plan fragment against the underlying data store.
  *
@@ -17,11 +19,12 @@ package org.opensearch.analytics.exec;
 public interface QueryPlanExecutor<LogicalPlan, Stream> {
 
     /**
-     * Executes the given logical fragment and returns result rows.
+     * Executes the given logical fragment and delivers the result stream (or a failure)
+     * to {@code listener}.
      *
-     * @param plan    the logical subtree to execute
-     * @param context execution context (opaque Object to avoid server dependency)
-     * @return rows produced by the engine
+     * @param plan     the logical subtree to execute
+     * @param context  execution context (opaque Object to avoid server dependency)
+     * @param listener receives the produced stream on success, or the failure cause on error
      */
-    Stream execute(LogicalPlan plan, Object context);
+    void execute(LogicalPlan plan, Object context, ActionListener<Stream> listener);
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -141,22 +141,12 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
         // walker has already cascaded cancellations by the time we see the failure.
         // Scheduler yields batches; we materialize rows at the API edge for callers
         // that still consume Iterable<Object[]>.
-        ActionListener<Iterable<VectorSchemaRoot>> batchesListener = ActionListener.wrap(batches -> {
-            Iterable<Object[]> rows;
-            try {
-                rows = batchesToRows(batches);
-            } finally {
-                config.closeBufferAllocator();
-                taskManager.unregister(queryTask);
-            }
-            listener.onResponse(rows);
-        }, e -> {
+        ActionListener<Iterable<VectorSchemaRoot>> batchesListener = buildBatchesListener(listener, () -> {
             try {
                 config.closeBufferAllocator();
             } finally {
                 taskManager.unregister(queryTask);
             }
-            listener.onFailure(e);
         });
 
         TimeValue taskTimeout = queryTask.getCancelAfterTimeInterval();
@@ -210,6 +200,24 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
         public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
             return new AnalyticsQueryTask(id, type, action, queryId, parentTaskId, headers, cancelAfterTimeInterval);
         }
+    }
+
+    /**
+     * Builds the batches→rows {@link ActionListener} used by {@link #executeInternal}. {@code cleanup}
+     * runs exactly once before {@code downstream} is notified — on either response or failure paths.
+     * A cleanup failure on the response path is routed to {@code downstream.onFailure}; on the failure
+     * path it is attached as a suppressed exception. This eliminates the double-cleanup that the prior
+     * try/finally pattern produced when an exception in the success path was caught by
+     * {@link ActionListener#wrap} and re-routed to the failure callback.
+     *
+     * <p>Package-private for unit testing.
+     */
+    static ActionListener<Iterable<VectorSchemaRoot>> buildBatchesListener(
+        ActionListener<Iterable<Object[]>> downstream,
+        Runnable cleanup
+    ) {
+        ActionListener<Iterable<Object[]>> wrapped = ActionListener.runBefore(downstream, cleanup::run);
+        return ActionListener.wrap(batches -> wrapped.onResponse(batchesToRows(batches)), wrapped::onFailure);
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/DefaultPlanExecutor.java
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
-import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.support.TimeoutTaskCancellationUtility;
 import org.opensearch.analytics.EngineContext;
 import org.opensearch.analytics.exec.action.AnalyticsQueryAction;
@@ -54,9 +53,10 @@ import static org.opensearch.action.search.TransportSearchAction.SEARCH_CANCEL_A
  * so that Guice injects all dependencies ({@link TransportService},
  * {@link ClusterService}, {@link ThreadPool}, etc.) automatically.
  *
- * <p>The SQL plugin resolves this class from the Node's Guice injector and invokes
- * {@link #execute(RelNode, Object)} directly. The transport path ({@code doExecute})
- * is reserved for future remote query invocation.
+ * <p>Front-end plugins resolve this class from the Node's Guice injector and invoke
+ * {@link #execute(RelNode, Object, ActionListener)} directly. Execution is asynchronous —
+ * the listener is fired by the scheduler once the query completes (or fails). The transport
+ * path ({@code doExecute}) is reserved for future remote query invocation.
  *
  * @opensearch.internal
  */
@@ -99,7 +99,27 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
     // that takes the logical fragment and returns a fully-built DAG ready for scheduling.
     // Also add per-step timing (plan, fork, convert, schedule, execute) for observability.
     @Override
-    public Iterable<Object[]> execute(RelNode logicalFragment, Object context) {
+    public void execute(RelNode logicalFragment, Object context, ActionListener<Iterable<Object[]>> listener) {
+        // Fork the entire query lifecycle (planning, scheduling, cleanup) onto the SEARCH
+        // executor so the calling thread — which may be a transport thread — is freed
+        // immediately. The scheduler then drives execution asynchronously and fires
+        // {@code listener} once the query terminates; nothing on this path blocks.
+        searchExecutor.execute(() -> {
+            try {
+                executeInternal(logicalFragment, listener);
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    /**
+     * Plans, registers the query task, and dispatches to the {@link Scheduler}. Runs on
+     * the SEARCH thread pool — never on a transport thread. The result (or failure) is
+     * delivered to {@code listener} by the scheduler; this method returns as soon as the
+     * scheduler has accepted the query.
+     */
+    private void executeInternal(RelNode logicalFragment, ActionListener<Iterable<Object[]>> listener) {
         RelNode plan = PlannerImpl.createPlan(logicalFragment, new PlannerContext(capabilityRegistry, clusterService.state()));
         QueryDAG dag = DAGBuilder.build(plan, capabilityRegistry, clusterService);
         PlanForker.forkAll(dag, capabilityRegistry);
@@ -108,49 +128,57 @@ public class DefaultPlanExecutor extends HandledTransportAction<ActionRequest, A
 
         // Register coordinator-level query task with TaskManager (like SearchTask).
         // This gives us a proper unique ID, visibility in _tasks API, and cancellation support.
-        // TODO: accept a request type from FrontEnd including cancelAfterTimeInterval - its set from cluster settings below, null in req.
+        // TODO: accept a request type from FrontEnd including cancelAfterTimeInterval — set from cluster settings below, null in req.
         final AnalyticsQueryTask queryTask = (AnalyticsQueryTask) taskManager.register(
             "transport",
             "analytics_query",
             new AnalyticsQueryTaskRequest(dag.queryId(), null)
         );
-
-        // Create per-query context
-        QueryContext config = new QueryContext(dag, searchExecutor, queryTask);
-
-        PlainActionFuture<Iterable<Object[]>> future = new PlainActionFuture<>();
+        final QueryContext config = new QueryContext(dag, searchExecutor, queryTask);
 
         // Per-query cleanup on terminal. Stage-execution cancellation on external
         // task-cancel/timeout is wired inside the Scheduler — on this path the
         // walker has already cascaded cancellations by the time we see the failure.
         // Scheduler yields batches; we materialize rows at the API edge for callers
         // that still consume Iterable<Object[]>.
-        ActionListener<Iterable<VectorSchemaRoot>> listener = ActionListener.wrap(batches -> {
-            Iterable<Object[]> rows = batchesToRows(batches);
-            config.closeBufferAllocator();
-            taskManager.unregister(queryTask);
-            future.onResponse(rows);
+        ActionListener<Iterable<VectorSchemaRoot>> batchesListener = ActionListener.wrap(batches -> {
+            Iterable<Object[]> rows;
+            try {
+                rows = batchesToRows(batches);
+            } finally {
+                config.closeBufferAllocator();
+                taskManager.unregister(queryTask);
+            }
+            listener.onResponse(rows);
         }, e -> {
-            config.closeBufferAllocator();
-            taskManager.unregister(queryTask);
-            future.onFailure(e);
+            try {
+                config.closeBufferAllocator();
+            } finally {
+                taskManager.unregister(queryTask);
+            }
+            listener.onFailure(e);
         });
 
         TimeValue taskTimeout = queryTask.getCancelAfterTimeInterval();
         TimeValue clusterTimeout = clusterService.getClusterSettings().get(SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING);
         if (taskTimeout != null || SearchService.NO_TIMEOUT.equals(clusterTimeout) == false) {
-            listener = TimeoutTaskCancellationUtility.wrapWithCancellationListener(client, queryTask, clusterTimeout, listener, e -> {});
+            batchesListener = TimeoutTaskCancellationUtility.wrapWithCancellationListener(
+                client,
+                queryTask,
+                clusterTimeout,
+                batchesListener,
+                e -> {}
+            );
         }
 
-        scheduler.execute(config, listener);
-        return future.actionGet();  // TODO: single blocking point — Should be async with Front-End passing listener.
+        scheduler.execute(config, batchesListener);
     }
 
     @Override
     protected void doExecute(Task task, ActionRequest request, ActionListener<ActionResponse> listener) {
         // Transport path — reserved for future remote query invocation.
-        // Currently, the SQL plugin invokes execute(RelNode, Object) directly.
-        listener.onFailure(new UnsupportedOperationException("Direct invocation only — use execute(RelNode, Object)"));
+        // Currently, front-ends invoke execute(RelNode, Object, ActionListener) directly.
+        listener.onFailure(new UnsupportedOperationException("Direct invocation only — use execute(RelNode, Object, ActionListener)"));
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryAction.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/exec/action/AnalyticsQueryAction.java
@@ -19,8 +19,8 @@ import org.opensearch.core.action.ActionResponse;
  * <p>Currently used as a Guice injection vehicle for {@link DefaultPlanExecutor}
  * — the transport action registration lets Guice construct the executor with all
  * its dependencies ({@code TransportService}, {@code ClusterService}, etc.).
- * The SQL plugin invokes the executor directly via
- * {@link QueryPlanExecutor#execute(Object, Object)}, not through transport.
+ * Front-end plugins invoke the executor directly via
+ * {@link QueryPlanExecutor#execute}, not through transport.
  *
  * <p>Future: the transport path ({@code doExecute}) will accept query strings
  * for remote invocation.

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/DefaultPlanExecutorTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/analytics/exec/DefaultPlanExecutorTests.java
@@ -18,12 +18,15 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Tests for {@link DefaultPlanExecutor}'s row-materialization boundary.
@@ -136,6 +139,86 @@ public class DefaultPlanExecutorTests extends OpenSearchTestCase {
         assertEquals("hello", rows.get(0)[0]);
         assertEquals("world", rows.get(1)[0]);
         assertTrue(rows.get(0)[0] instanceof String);
+    }
+
+    public void testBuildBatchesListenerSuccessRunsCleanupOnce() {
+        AtomicInteger cleanupCount = new AtomicInteger(0);
+        AtomicReference<Iterable<Object[]>> result = new AtomicReference<>();
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        ActionListener<Iterable<Object[]>> downstream = ActionListener.wrap(result::set, failure::set);
+
+        ActionListener<Iterable<VectorSchemaRoot>> batchesListener = DefaultPlanExecutor.buildBatchesListener(
+            downstream,
+            cleanupCount::incrementAndGet
+        );
+
+        VectorSchemaRoot batch = makeIntBatch("x", 1, 2);
+        batchesListener.onResponse(List.of(batch));
+
+        assertEquals(1, cleanupCount.get());
+        assertNotNull(result.get());
+        assertEquals(2, toList(result.get()).size());
+        assertNull(failure.get());
+    }
+
+    public void testBuildBatchesListenerFailureRunsCleanupOnce() {
+        AtomicInteger cleanupCount = new AtomicInteger(0);
+        AtomicReference<Iterable<Object[]>> result = new AtomicReference<>();
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        ActionListener<Iterable<Object[]>> downstream = ActionListener.wrap(result::set, failure::set);
+
+        ActionListener<Iterable<VectorSchemaRoot>> batchesListener = DefaultPlanExecutor.buildBatchesListener(
+            downstream,
+            cleanupCount::incrementAndGet
+        );
+
+        Exception cause = new RuntimeException("upstream failure");
+        batchesListener.onFailure(cause);
+
+        assertEquals(1, cleanupCount.get());
+        assertNull(result.get());
+        assertSame(cause, failure.get());
+    }
+
+    public void testBuildBatchesListenerConversionFailureRoutesToFailureWithSingleCleanup() {
+        AtomicInteger cleanupCount = new AtomicInteger(0);
+        AtomicReference<Iterable<Object[]>> result = new AtomicReference<>();
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        ActionListener<Iterable<Object[]>> downstream = ActionListener.wrap(result::set, failure::set);
+
+        ActionListener<Iterable<VectorSchemaRoot>> batchesListener = DefaultPlanExecutor.buildBatchesListener(
+            downstream,
+            cleanupCount::incrementAndGet
+        );
+
+        Iterable<VectorSchemaRoot> badBatches = () -> { throw new RuntimeException("conversion failed"); };
+        batchesListener.onResponse(badBatches);
+
+        assertEquals("cleanup must run exactly once when conversion throws", 1, cleanupCount.get());
+        assertNull(result.get());
+        assertNotNull(failure.get());
+        assertEquals("conversion failed", failure.get().getMessage());
+    }
+
+    public void testBuildBatchesListenerCleanupFailureOnSuccessRoutesToFailure() {
+        AtomicInteger cleanupCount = new AtomicInteger(0);
+        AtomicReference<Iterable<Object[]>> result = new AtomicReference<>();
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        ActionListener<Iterable<Object[]>> downstream = ActionListener.wrap(result::set, failure::set);
+
+        Runnable cleanup = () -> {
+            cleanupCount.incrementAndGet();
+            throw new RuntimeException("cleanup failed");
+        };
+        ActionListener<Iterable<VectorSchemaRoot>> batchesListener = DefaultPlanExecutor.buildBatchesListener(downstream, cleanup);
+
+        VectorSchemaRoot batch = makeIntBatch("x", 1, 2);
+        batchesListener.onResponse(List.of(batch));
+
+        assertEquals("cleanup runs exactly once even when it throws", 1, cleanupCount.get());
+        assertNull("downstream onResponse must not fire when cleanup throws on success path", result.get());
+        assertNotNull(failure.get());
+        assertEquals("cleanup failed", failure.get().getMessage());
     }
 
     public void testBatchesToRowsClosesBatches() {

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/ppl/planner/PushDownPlannerTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/ppl/planner/PushDownPlannerTests.java
@@ -84,7 +84,7 @@ public class PushDownPlannerTests extends OpenSearchTestCase {
         table = catalogReader.getTable(List.of("test_table"));
         assertNotNull("Table should be found in catalog", table);
 
-        planExecutor = (fragment, ctx) -> Collections.emptyList();
+        planExecutor = (fragment, ctx, l) -> l.onResponse(Collections.emptyList());
     }
 
     /**

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/ppl/planner/rel/OpenSearchBoundaryTableScan.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/ppl/planner/rel/OpenSearchBoundaryTableScan.java
@@ -113,7 +113,12 @@ public class OpenSearchBoundaryTableScan extends TableScan implements Enumerable
     @SuppressWarnings("unchecked")
     public Enumerable<Object[]> bind(DataContext dataContext) {
         try {
-            Iterable<Object[]> result = (Iterable<Object[]>) planExecutor.execute(logicalFragment, dataContext);
+            // Calcite's bind() is synchronous (driven by the EnumerableInterpreter), so we
+            // block here on the async planExecutor until the engine completes.
+            org.opensearch.action.support.PlainActionFuture<Iterable<Object[]>> future =
+                new org.opensearch.action.support.PlainActionFuture<>();
+            planExecutor.execute(logicalFragment, dataContext, future);
+            Iterable<Object[]> result = future.actionGet();
             return Linq4j.asEnumerable(result);
         } catch (Exception e) {
             throw new RuntimeException(

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/ppl/planner/rel/OpenSearchBoundaryTableScanTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/ppl/planner/rel/OpenSearchBoundaryTableScanTests.java
@@ -84,7 +84,7 @@ public class OpenSearchBoundaryTableScanTests extends OpenSearchTestCase {
     public void testExtendsTableScanNotLogicalTableScan() {
         LogicalTableScan scan = LogicalTableScan.create(cluster, table, List.of());
         RelTraitSet traitSet = cluster.traitSetOf(EnumerableConvention.INSTANCE);
-        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx) -> Linq4j.emptyEnumerable();
+        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx, l) -> l.onResponse(Linq4j.emptyEnumerable());
 
         OpenSearchBoundaryTableScan boundary = new OpenSearchBoundaryTableScan(cluster, traitSet, table, scan, executor);
 
@@ -95,7 +95,7 @@ public class OpenSearchBoundaryTableScanTests extends OpenSearchTestCase {
     public void testImplementsEnumerableRel() {
         LogicalTableScan scan = LogicalTableScan.create(cluster, table, List.of());
         RelTraitSet traitSet = cluster.traitSetOf(EnumerableConvention.INSTANCE);
-        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx) -> Linq4j.emptyEnumerable();
+        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx, l) -> l.onResponse(Linq4j.emptyEnumerable());
 
         OpenSearchBoundaryTableScan boundary = new OpenSearchBoundaryTableScan(cluster, traitSet, table, scan, executor);
 
@@ -112,10 +112,10 @@ public class OpenSearchBoundaryTableScanTests extends OpenSearchTestCase {
         final RelNode[] capturedFragment = new RelNode[1];
         final Object[] capturedContext = new Object[1];
         Object[][] rows = { new Object[] { 1, "a", 1.0 } };
-        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx) -> {
+        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx, l) -> {
             capturedFragment[0] = fragment;
             capturedContext[0] = ctx;
-            return Linq4j.asEnumerable(rows);
+            l.onResponse(Linq4j.asEnumerable(rows));
         };
 
         OpenSearchBoundaryTableScan boundary = new OpenSearchBoundaryTableScan(cluster, traitSet, table, scan, executor);
@@ -134,9 +134,9 @@ public class OpenSearchBoundaryTableScanTests extends OpenSearchTestCase {
         RelTraitSet traitSet = cluster.traitSetOf(EnumerableConvention.INSTANCE);
 
         final RelNode[] capturedFragment = new RelNode[1];
-        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx) -> {
+        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx, l) -> {
             capturedFragment[0] = fragment;
-            return Linq4j.emptyEnumerable();
+            l.onResponse(Linq4j.emptyEnumerable());
         };
 
         OpenSearchBoundaryTableScan boundary = new OpenSearchBoundaryTableScan(cluster, traitSet, table, filter, executor);
@@ -151,7 +151,7 @@ public class OpenSearchBoundaryTableScanTests extends OpenSearchTestCase {
     public void testCopyPreservesLogicalFragment() {
         LogicalTableScan scan = LogicalTableScan.create(cluster, table, List.of());
         RelTraitSet traitSet = cluster.traitSetOf(EnumerableConvention.INSTANCE);
-        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx) -> Linq4j.emptyEnumerable();
+        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx, l) -> l.onResponse(Linq4j.emptyEnumerable());
 
         OpenSearchBoundaryTableScan boundary = new OpenSearchBoundaryTableScan(cluster, traitSet, table, scan, executor);
 
@@ -165,7 +165,7 @@ public class OpenSearchBoundaryTableScanTests extends OpenSearchTestCase {
     public void testCopyPreservesTable() {
         LogicalTableScan scan = LogicalTableScan.create(cluster, table, List.of());
         RelTraitSet traitSet = cluster.traitSetOf(EnumerableConvention.INSTANCE);
-        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx) -> Linq4j.emptyEnumerable();
+        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx, l) -> l.onResponse(Linq4j.emptyEnumerable());
 
         OpenSearchBoundaryTableScan boundary = new OpenSearchBoundaryTableScan(cluster, traitSet, table, scan, executor);
 
@@ -180,7 +180,7 @@ public class OpenSearchBoundaryTableScanTests extends OpenSearchTestCase {
     public void testGetLogicalFragmentReturnsScanSubtree() {
         LogicalTableScan scan = LogicalTableScan.create(cluster, table, List.of());
         RelTraitSet traitSet = cluster.traitSetOf(EnumerableConvention.INSTANCE);
-        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx) -> Linq4j.emptyEnumerable();
+        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx, l) -> l.onResponse(Linq4j.emptyEnumerable());
 
         OpenSearchBoundaryTableScan boundary = new OpenSearchBoundaryTableScan(cluster, traitSet, table, scan, executor);
 
@@ -192,7 +192,7 @@ public class OpenSearchBoundaryTableScanTests extends OpenSearchTestCase {
         RexNode condition = rexBuilder.makeLiteral(true);
         LogicalFilter filter = LogicalFilter.create(scan, condition);
         RelTraitSet traitSet = cluster.traitSetOf(EnumerableConvention.INSTANCE);
-        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx) -> Linq4j.emptyEnumerable();
+        QueryPlanExecutor<RelNode, Enumerable<Object[]>> executor = (fragment, ctx, l) -> l.onResponse(Linq4j.emptyEnumerable());
 
         OpenSearchBoundaryTableScan boundary = new OpenSearchBoundaryTableScan(cluster, traitSet, table, filter, executor);
 

--- a/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/ppl/planner/rules/PushDownRulesTests.java
+++ b/sandbox/plugins/analytics-engine/src/test/java/org/opensearch/ppl/planner/rules/PushDownRulesTests.java
@@ -86,7 +86,7 @@ public class PushDownRulesTests extends OpenSearchTestCase {
         table = catalogReader.getTable(List.of("test_table"));
         assertNotNull("Table should be found in catalog", table);
 
-        planExecutor = (fragment, ctx) -> Linq4j.emptyEnumerable();
+        planExecutor = (fragment, ctx, l) -> l.onResponse(Linq4j.emptyEnumerable());
     }
 
     // --- BoundaryTableScanRule tests (ConverterRule, uses VolcanoPlanner) ---

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -92,7 +92,14 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
                 return;
             }
             planExecutor.execute(plans, ActionListener.wrap(results -> {
-                SearchResponse response = SearchResponseBuilder.build(results, convertTime);
+                final SearchResponse response;
+                try {
+                    response = SearchResponseBuilder.build(results, convertTime);
+                } catch (Exception buildEx) {
+                    logger.error("DSL response building failed", buildEx);
+                    listener.onFailure(buildEx);
+                    return;
+                }
                 listener.onResponse(response);
             }, e -> {
                 logger.error("DSL execution failed", e);

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/TransportDslExecuteAction.java
@@ -25,13 +25,10 @@ import org.opensearch.core.index.Index;
 import org.opensearch.dsl.converter.SearchSourceConverter;
 import org.opensearch.dsl.executor.DslQueryPlanExecutor;
 import org.opensearch.dsl.executor.QueryPlans;
-import org.opensearch.dsl.result.ExecutionResult;
 import org.opensearch.dsl.result.SearchResponseBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
-
-import java.util.List;
 
 /**
  * Coordinates DSL query execution: converts SearchSourceBuilder to Calcite RelNode plans,
@@ -81,20 +78,26 @@ public class TransportDslExecuteAction extends HandledTransportAction<SearchRequ
     @Override
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
         threadPool.executor(ThreadPool.Names.SEARCH).execute(() -> {
+            final QueryPlans plans;
+            final long convertTime;
             try {
                 String indexName = resolveToSingleIndex(request);
-
                 long convertStart = System.nanoTime();
                 SearchSourceConverter converter = new SearchSourceConverter(engineContext.getSchema());
-                QueryPlans plans = converter.convert(request.source(), indexName);
-                long convertTime = System.nanoTime() - convertStart;
-                List<ExecutionResult> results = planExecutor.execute(plans);
+                plans = converter.convert(request.source(), indexName);
+                convertTime = System.nanoTime() - convertStart;
+            } catch (Exception e) {
+                logger.error("DSL conversion failed", e);
+                listener.onFailure(e);
+                return;
+            }
+            planExecutor.execute(plans, ActionListener.wrap(results -> {
                 SearchResponse response = SearchResponseBuilder.build(results, convertTime);
                 listener.onResponse(response);
-            } catch (Exception e) {
+            }, e -> {
                 logger.error("DSL execution failed", e);
                 listener.onFailure(e);
-            }
+            }));
         });
     }
 

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/DslQueryPlanExecutor.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/executor/DslQueryPlanExecutor.java
@@ -12,6 +12,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.dsl.result.ExecutionResult;
 
 import java.util.ArrayList;
@@ -40,25 +41,40 @@ public class DslQueryPlanExecutor {
     // TODO: add per-plan error handling so a failure in one plan
     // doesn't prevent returning partial results from other plans (e.g. HITS)
     /**
-     * Executes all plans and returns results in plan order.
+     * Executes all plans sequentially and delivers results, in plan order, to the listener.
      *
-     * @param plans the query plans to execute
-     * @return execution results, one per plan
+     * <p>Plans run one-at-a-time: plan {@code N+1} is dispatched only after plan {@code N}
+     * completes successfully. The first failure aborts the chain — the listener fires
+     * {@code onFailure} with that error and remaining plans do not run.
+     *
+     * @param plans    the query plans to execute
+     * @param listener receives the ordered list of results on success, or the first failure
      */
-    public List<ExecutionResult> execute(QueryPlans plans) {
+    public void execute(QueryPlans plans, ActionListener<List<ExecutionResult>> listener) {
         List<QueryPlans.QueryPlan> queryPlans = plans.getAll();
         List<ExecutionResult> results = new ArrayList<>(queryPlans.size());
+        executeNext(queryPlans, 0, results, listener);
+    }
 
-        for (QueryPlans.QueryPlan plan : queryPlans) {
-            RelNode relNode = plan.relNode();
-            logPlan(relNode);
-            // TODO: context param is null, may carry execution hints
-            Iterable<Object[]> rows = executor.execute(relNode, null);
+    private void executeNext(
+        List<QueryPlans.QueryPlan> queryPlans,
+        int index,
+        List<ExecutionResult> results,
+        ActionListener<List<ExecutionResult>> outer
+    ) {
+        if (index >= queryPlans.size()) {
+            outer.onResponse(results);
+            return;
+        }
+        QueryPlans.QueryPlan plan = queryPlans.get(index);
+        RelNode relNode = plan.relNode();
+        logPlan(relNode);
+        // TODO: context param is null, may carry execution hints
+        executor.execute(relNode, null, ActionListener.wrap(rows -> {
             logRows(rows);
             results.add(new ExecutionResult(plan, rows));
-        }
-
-        return results;
+            executeNext(queryPlans, index + 1, results, outer);
+        }, outer::onFailure));
     }
 
     private static void logRows(Iterable<Object[]> rows) {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/TransportDslExecuteActionTests.java
@@ -86,7 +86,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
             mock(TransportService.class),
             new ActionFilters(Collections.emptySet()),
             buildEngineContext(),
-            (plan, ctx) -> Collections.emptyList(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
             clusterService,
             resolver,
             mockThreadPool()
@@ -119,7 +119,7 @@ public class TransportDslExecuteActionTests extends OpenSearchTestCase {
             mock(TransportService.class),
             new ActionFilters(Collections.emptySet()),
             buildEngineContext(),
-            (plan, ctx) -> Collections.emptyList(),
+            (plan, ctx, l) -> l.onResponse(Collections.emptyList()),
             clusterService,
             resolver,
             mockThreadPool()

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/DslQueryPlanExecutorTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/executor/DslQueryPlanExecutorTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.dsl.executor;
 
 import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.dsl.TestUtils;
 import org.opensearch.dsl.result.ExecutionResult;
 import org.opensearch.test.OpenSearchTestCase;
@@ -28,10 +29,12 @@ public class DslQueryPlanExecutorTests extends OpenSearchTestCase {
     public void testExecuteDelegatesEachPlanToExecutor() {
         List<Object[]> expectedRows = List.<Object[]>of(new Object[] { "laptop", 1200 });
 
-        DslQueryPlanExecutor executor = new DslQueryPlanExecutor((plan, ctx) -> expectedRows);
+        DslQueryPlanExecutor executor = new DslQueryPlanExecutor((plan, ctx, listener) -> listener.onResponse(expectedRows));
         QueryPlans plans = new QueryPlans.Builder().add(new QueryPlans.QueryPlan(QueryPlans.Type.HITS, scan)).build();
 
-        List<ExecutionResult> results = executor.execute(plans);
+        PlainActionFuture<List<ExecutionResult>> future = new PlainActionFuture<>();
+        executor.execute(plans, future);
+        List<ExecutionResult> results = future.actionGet();
 
         assertEquals(1, results.size());
         ExecutionResult result = results.get(0);


### PR DESCRIPTION

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
This change updates DefaultPlanExecutor to accept an actionlistener from front-end plugins.

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/21402

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
