### PR TITLE
Update the Kafka metadata timeout value to be configurable

### DIFF
--- a/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
+++ b/plugins/ingestion-kafka/src/internalClusterTest/java/org/opensearch/plugin/kafka/IngestFromKafkaIT.java
@@ -135,6 +135,7 @@ public class IngestFromKafkaIT extends KafkaIngestionBaseIT {
                 .put("ingestion_source.param.topic", "test")
                 .put("ingestion_source.param.bootstrap_servers", kafka.getBootstrapServers())
                 .put("ingestion_source.param.auto.offset.reset", "latest")
+                .put("ingestion_source.param.topic_metadata_fetch_timeout_ms", 5000)
                 .put("ingestion_source.all_active", true)
                 .build(),
             "{\"properties\":{\"name\":{\"type\": \"text\"},\"age\":{\"type\": \"integer\"}}}}"

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
@@ -45,8 +45,6 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
      * The Kafka consumer
      */
     protected final Consumer<byte[], byte[]> consumer;
-    // TODO: make this configurable
-    private final int timeoutMillis = 1000;
 
     private long lastFetchedOffset = -1;
     final String clientId;
@@ -76,7 +74,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
         this.config = config;
         String topic = config.getTopic();
         List<PartitionInfo> partitionInfos = AccessController.doPrivileged(
-            (PrivilegedAction<List<PartitionInfo>>) () -> consumer.partitionsFor(topic, Duration.ofMillis(timeoutMillis))
+            (PrivilegedAction<List<PartitionInfo>>) () -> consumer.partitionsFor(topic, Duration.ofMillis(config.getTopicMetadataFetchTimeoutMs()))
         );
         if (partitionInfos == null) {
             throw new IllegalArgumentException("Topic " + topic + " does not exist");

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
@@ -74,7 +74,10 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
         this.config = config;
         String topic = config.getTopic();
         List<PartitionInfo> partitionInfos = AccessController.doPrivileged(
-            (PrivilegedAction<List<PartitionInfo>>) () -> consumer.partitionsFor(topic, Duration.ofMillis(config.getTopicMetadataFetchTimeoutMs()))
+            (PrivilegedAction<List<PartitionInfo>>) () -> consumer.partitionsFor(
+                topic,
+                Duration.ofMillis(config.getTopicMetadataFetchTimeoutMs())
+            )
         );
         if (partitionInfos == null) {
             throw new IllegalArgumentException("Topic " + topic + " does not exist");
@@ -84,7 +87,12 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
         }
         topicPartition = new TopicPartition(topic, partitionId);
         consumer.assign(Collections.singletonList(topicPartition));
-        logger.info("Kafka consumer created for topic {} partition {} with topic metadata fetch timeout {}ms", topic, partitionId, config.getTopicMetadataFetchTimeoutMs());
+        logger.info(
+            "Kafka consumer created for topic {} partition {} with topic metadata fetch timeout {}ms",
+            topic,
+            partitionId,
+            config.getTopicMetadataFetchTimeoutMs()
+        );
     }
 
     /**

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaPartitionConsumer.java
@@ -84,7 +84,7 @@ public class KafkaPartitionConsumer implements IngestionShardConsumer<KafkaOffse
         }
         topicPartition = new TopicPartition(topic, partitionId);
         consumer.assign(Collections.singletonList(topicPartition));
-        logger.info("Kafka consumer created for topic {} partition {}", topic, partitionId);
+        logger.info("Kafka consumer created for topic {} partition {} with topic metadata fetch timeout {}ms", topic, partitionId, config.getTopicMetadataFetchTimeoutMs());
     }
 
     /**

--- a/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaSourceConfig.java
+++ b/plugins/ingestion-kafka/src/main/java/org/opensearch/plugin/kafka/KafkaSourceConfig.java
@@ -20,11 +20,14 @@ import java.util.Map;
 public class KafkaSourceConfig {
     private final String PROP_TOPIC = "topic";
     private final String PROP_BOOTSTRAP_SERVERS = "bootstrap_servers";
+    private static final String PROP_TOPIC_METADATA_FETCH_TIMEOUT_MS = "topic_metadata_fetch_timeout_ms";
+    private static final int DEFAULT_TOPIC_METADATA_FETCH_TIMEOUT_MS = 1000;
 
     private final String topic;
     private final String bootstrapServers;
     private final String autoOffsetResetConfig;
     private final int maxPollRecords;
+    private final int topicMetadataFetchTimeoutMs;
 
     private final Map<String, Object> consumerConfigsMap;
 
@@ -46,9 +49,21 @@ public class KafkaSourceConfig {
         // maxPollSize will be used instead.
         this.maxPollRecords = ConfigurationUtils.readIntProperty(params, ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollSize);
 
+        this.topicMetadataFetchTimeoutMs = ConfigurationUtils.readIntProperty(
+            params,
+            PROP_TOPIC_METADATA_FETCH_TIMEOUT_MS,
+            DEFAULT_TOPIC_METADATA_FETCH_TIMEOUT_MS
+        );
+        if (this.topicMetadataFetchTimeoutMs <= 0) {
+            throw new IllegalArgumentException(
+                "topic_metadata_fetch_timeout_ms must be positive, got: " + this.topicMetadataFetchTimeoutMs
+            );
+        }
+
         // remove metadata configurations
         consumerConfigsMap.remove(PROP_TOPIC);
         consumerConfigsMap.remove(PROP_BOOTSTRAP_SERVERS);
+        consumerConfigsMap.remove(PROP_TOPIC_METADATA_FETCH_TIMEOUT_MS);
 
         // add or overwrite required configurations with defaults if not present
         consumerConfigsMap.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetResetConfig);
@@ -83,5 +98,13 @@ public class KafkaSourceConfig {
 
     public Map<String, Object> getConsumerConfigurations() {
         return consumerConfigsMap;
+    }
+
+    /**
+     * Get the topic metadata fetch timeout in milliseconds
+     * @return the topic metadata fetch timeout in milliseconds
+     */
+    public int getTopicMetadataFetchTimeoutMs() {
+        return topicMetadataFetchTimeoutMs;
     }
 }

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionConsumerTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaPartitionConsumerTests.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class KafkaPartitionConsumerTests extends OpenSearchTestCase {
@@ -212,5 +213,20 @@ public class KafkaPartitionConsumerTests extends OpenSearchTestCase {
 
         // Should return -1 on exception
         assertEquals(-1, lag);
+    }
+
+    public void testTopicMetadataFetchTimeoutUsedFromConfig() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("topic", "test-topic");
+        params.put("bootstrap_servers", "localhost:9092");
+        params.put("topic_metadata_fetch_timeout_ms", 5000);
+
+        KafkaSourceConfig customConfig = new KafkaSourceConfig(1000, params);
+        PartitionInfo partitionInfo = new PartitionInfo("test-topic", 0, null, null, null);
+        when(mockConsumer.partitionsFor(eq("test-topic"), any(Duration.class))).thenReturn(Collections.singletonList(partitionInfo));
+
+        new KafkaPartitionConsumer("client1", customConfig, 0, mockConsumer);
+
+        verify(mockConsumer).partitionsFor(eq("test-topic"), eq(Duration.ofMillis(5000)));
     }
 }

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSourceConfigTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSourceConfigTests.java
@@ -40,4 +40,47 @@ public class KafkaSourceConfigTests extends OpenSearchTestCase {
         );
         Assert.assertEquals("Incorrect max.poll.records", 100, config.getConsumerConfigurations().get("max.poll.records"));
     }
+
+    public void testTopicMetadataFetchTimeoutMsDefault() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("topic", "topic");
+        params.put("bootstrap_servers", "bootstrap");
+
+        KafkaSourceConfig config = new KafkaSourceConfig(100, params);
+
+        Assert.assertEquals("Default topic metadata fetch timeout should be 1000ms", 1000, config.getTopicMetadataFetchTimeoutMs());
+        Assert.assertFalse(
+            "topic_metadata_fetch_timeout_ms should not be in consumer configurations",
+            config.getConsumerConfigurations().containsKey("topic_metadata_fetch_timeout_ms")
+        );
+    }
+
+    public void testTopicMetadataFetchTimeoutMsCustom() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("topic", "topic");
+        params.put("bootstrap_servers", "bootstrap");
+        params.put("topic_metadata_fetch_timeout_ms", 5000);
+
+        KafkaSourceConfig config = new KafkaSourceConfig(100, params);
+
+        Assert.assertEquals("Custom topic metadata fetch timeout should be respected", 5000, config.getTopicMetadataFetchTimeoutMs());
+        Assert.assertFalse(
+            "topic_metadata_fetch_timeout_ms should not be in consumer configurations",
+            config.getConsumerConfigurations().containsKey("topic_metadata_fetch_timeout_ms")
+        );
+    }
+
+    public void testTopicMetadataFetchTimeoutMsInvalid() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("topic", "topic");
+        params.put("bootstrap_servers", "bootstrap");
+        params.put("topic_metadata_fetch_timeout_ms", 0);
+
+        try {
+            new KafkaSourceConfig(100, params);
+            fail("Expected IllegalArgumentException for non-positive timeout");
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("topic_metadata_fetch_timeout_ms must be positive, got: 0", e.getMessage());
+        }
+    }
 }

--- a/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSourceConfigTests.java
+++ b/plugins/ingestion-kafka/src/test/java/org/opensearch/plugin/kafka/KafkaSourceConfigTests.java
@@ -82,5 +82,13 @@ public class KafkaSourceConfigTests extends OpenSearchTestCase {
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("topic_metadata_fetch_timeout_ms must be positive, got: 0", e.getMessage());
         }
+
+        params.put("topic_metadata_fetch_timeout_ms", -1);
+        try {
+            new KafkaSourceConfig(100, params);
+            fail("Expected IllegalArgumentException for non-positive timeout");
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("topic_metadata_fetch_timeout_ms must be positive, got: -1", e.getMessage());
+        }
     }
 }

--- a/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
+++ b/server/src/main/java/org/opensearch/indices/pollingingest/DefaultStreamPoller.java
@@ -696,6 +696,10 @@ public class DefaultStreamPoller implements StreamPoller {
         blockingQueueContainer.clearAllQueues();
         initializeConsumer();
 
+        if (this.consumer == null) {
+            return;
+        }
+
         // Handle consumer offset reset the first time an index is created. The reset offset takes precedence if available.
         IngestionShardPointer resetShardPointer = getResetShardPointer();
         if (resetShardPointer != null) {


### PR DESCRIPTION
### Description
Make the Kafka metadata timeout value configurable by introducing a new kafka specific param 'topic_metadata_fetch_timeout_ms'.
Also return early in case of consumer initialization failure to avoid wasteful work of resetting pointers.

Example Create Index request with custom metadata timeout:

```
PUT /my-index                                                                                                                                                   
  {                                                                                                                                                               
    "settings": {                                                                                                                                                 
      "index": {                                                                                                                                                  
        "number_of_shards": 1,                              
        "number_of_replicas": 0,
        "ingestion_source": {
          "type": "kafka",
          "pointer": {                                                                                                                                            
            "init": {
              "reset": "earliest"                                                                                                                                 
            }                                                                                                                                                     
          },
          "param": {                                                                                                                                              
            "topic": "my-topic",                            
            "bootstrap_servers": "localhost:9092",                                                                                                                
            "topic_metadata_fetch_timeout_ms": 5000                                                                                                               
          }                                                                                                                                                       
        }                                                                                                                                                         
      }                                                     
    },
    "mappings": {
      "properties": {                                                                                                                                             
        "name": { "type": "text" },                                                                                                                               
        "age":  { "type": "integer" }                                                                                                                             
      }                                                                                                                                                           
    }                                                                                                                                                             
  }   
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
