### PR TITLE
Fix stream transport example plugin

### DIFF
--- a/gradle/run.gradle
+++ b/gradle/run.gradle
@@ -63,6 +63,8 @@ testClusters {
           plugin(':plugins:' + p)
         } else if (project.findProject(':sandbox:plugins:' + p) != null) {
           plugin(':sandbox:plugins:' + p)
+        } else if (project.findProject(':example-plugins:' + p) != null) {
+          plugin(':example-plugins:' + p)
         } else {
           // attempt to fetch it from maven
           project.repositories.mavenLocal()

--- a/plugins/examples/stream-transport-example/build.gradle
+++ b/plugins/examples/stream-transport-example/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.internal-cluster-test'
+apply plugin: 'opensearch.yaml-rest-test'
 
 opensearchplugin {
   name = 'stream-transport-example'
@@ -13,6 +14,18 @@ dependencies {
   compileOnly project(':plugins:arrow-flight-rpc')
 }
 testingConventions.enabled = false
+
+testClusters {
+  yamlRestTest {
+    plugin ':plugins:arrow-flight-rpc'
+    systemProperty 'opensearch.experimental.feature.transport.stream.enabled', 'true'
+    systemProperty 'io.netty.allocator.numDirectArenas', '1'
+    systemProperty 'io.netty.noUnsafe', 'false'
+    systemProperty 'io.netty.tryUnsafe', 'true'
+    systemProperty 'io.netty.tryReflectionSetAccessible', 'true'
+  }
+}
+
 internalClusterTest {
   systemProperty 'io.netty.allocator.numDirectArenas', '1'
   systemProperty 'io.netty.noUnsafe', 'false'

--- a/plugins/examples/stream-transport-example/build.gradle
+++ b/plugins/examples/stream-transport-example/build.gradle
@@ -5,11 +5,12 @@ opensearchplugin {
   name = 'stream-transport-example'
   description = 'Example plugin demonstrating stream-based transport actions'
   classname = 'org.opensearch.example.stream.StreamTransportExamplePlugin'
+  extendedPlugins = ['arrow-flight-rpc']
   licenseFile = rootProject.file('licenses/APACHE-LICENSE-2.0.txt')
   noticeFile = rootProject.file('NOTICE.txt')
 }
 dependencies {
-  api project(':plugins:arrow-flight-rpc')
+  compileOnly project(':plugins:arrow-flight-rpc')
 }
 testingConventions.enabled = false
 internalClusterTest {

--- a/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/RestNativeArrowStreamAction.java
+++ b/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/RestNativeArrowStreamAction.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.example.stream;
+
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.StreamTransportResponseHandler;
+import org.opensearch.transport.StreamTransportService;
+import org.opensearch.transport.TransportException;
+import org.opensearch.transport.TransportRequestOptions;
+import org.opensearch.transport.client.node.NodeClient;
+import org.opensearch.transport.stream.StreamTransportResponse;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+public class RestNativeArrowStreamAction extends BaseRestHandler {
+
+    private final Supplier<DiscoveryNodes> nodesLookup;
+    private final Supplier<StreamTransportService> stsSupplier;
+
+    public RestNativeArrowStreamAction(Supplier<DiscoveryNodes> nodesLookup, Supplier<StreamTransportService> stsSupplier) {
+        this.nodesLookup = nodesLookup;
+        this.stsSupplier = stsSupplier;
+    }
+
+    @Override
+    public String getName() {
+        return "native_arrow_stream_test";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(RestRequest.Method.GET, "/_native_arrow_test"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        int batches = request.paramAsInt("batches", 2);
+        int rows = request.paramAsInt("rows", 3);
+
+        return channel -> {
+            StreamTransportService sts = stsSupplier.get();
+            DiscoveryNode localNode = nodesLookup.get().getLocalNode();
+            CountDownLatch latch = new CountDownLatch(1);
+            AtomicReference<String> result = new AtomicReference<>();
+            AtomicReference<Exception> failure = new AtomicReference<>();
+
+            sts.sendRequest(
+                localNode,
+                NativeArrowStreamDataAction.NAME,
+                new NativeArrowStreamDataRequest(batches, rows),
+                TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build(),
+                new StreamTransportResponseHandler<NativeArrowStreamDataResponse>() {
+                    @Override
+                    public void handleStreamResponse(StreamTransportResponse<NativeArrowStreamDataResponse> response) {
+                        try {
+                            int batchCount = 0;
+                            int totalRows = 0;
+                            NativeArrowStreamDataResponse r;
+                            while ((r = response.nextResponse()) != null) {
+                                batchCount++;
+                                totalRows += r.getRoot().getRowCount();
+                            }
+                            response.close();
+                            result.set("{\"batches\":" + batchCount + ",\"total_rows\":" + totalRows + "}");
+                            latch.countDown();
+                        } catch (Exception e) {
+                            failure.set(e);
+                            response.cancel("error", e);
+                            latch.countDown();
+                        }
+                    }
+
+                    @Override
+                    public void handleException(TransportException exp) {
+                        failure.set(exp);
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public String executor() {
+                        return ThreadPool.Names.GENERIC;
+                    }
+
+                    @Override
+                    public NativeArrowStreamDataResponse read(StreamInput in) throws IOException {
+                        return new NativeArrowStreamDataResponse(in);
+                    }
+                }
+            );
+
+            latch.await(10, TimeUnit.SECONDS);
+            if (failure.get() != null) {
+                channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, "text/plain", failure.get().toString()));
+            } else if (result.get() != null) {
+                channel.sendResponse(new BytesRestResponse(RestStatus.OK, "application/json", result.get()));
+            } else {
+                channel.sendResponse(new BytesRestResponse(RestStatus.REQUEST_TIMEOUT, "text/plain", "timeout"));
+            }
+        };
+    }
+}

--- a/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/StreamTransportExamplePlugin.java
+++ b/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/StreamTransportExamplePlugin.java
@@ -11,6 +11,8 @@ package org.opensearch.example.stream;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.common.inject.AbstractModule;
+import org.opensearch.common.inject.Module;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Settings;
@@ -22,15 +24,26 @@ import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.transport.StreamTransportService;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 public class StreamTransportExamplePlugin extends Plugin implements ActionPlugin {
 
-    static final AtomicReference<StreamTransportService> STS_REF = new AtomicReference<>();
+    private final AtomicReference<StreamTransportService> stsRef = new AtomicReference<>();
 
     public StreamTransportExamplePlugin() {}
+
+    @Override
+    public Collection<Module> createGuiceModules() {
+        return List.of(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(StreamTransportServiceHolder.class).toInstance(new StreamTransportServiceHolder(stsRef));
+            }
+        });
+    }
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
@@ -50,6 +63,6 @@ public class StreamTransportExamplePlugin extends Plugin implements ActionPlugin
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesLookup
     ) {
-        return List.of(new RestNativeArrowStreamAction(nodesLookup, STS_REF::get));
+        return List.of(new RestNativeArrowStreamAction(nodesLookup, stsRef::get));
     }
 }

--- a/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/StreamTransportExamplePlugin.java
+++ b/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/StreamTransportExamplePlugin.java
@@ -9,13 +9,26 @@
 package org.opensearch.example.stream;
 
 import org.opensearch.action.ActionRequest;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.rest.RestController;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.transport.StreamTransportService;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 public class StreamTransportExamplePlugin extends Plugin implements ActionPlugin {
+
+    static final AtomicReference<StreamTransportService> STS_REF = new AtomicReference<>();
 
     public StreamTransportExamplePlugin() {}
 
@@ -25,5 +38,18 @@ public class StreamTransportExamplePlugin extends Plugin implements ActionPlugin
             new ActionHandler<>(StreamDataAction.INSTANCE, TransportStreamDataAction.class),
             new ActionHandler<>(NativeArrowStreamDataAction.INSTANCE, TransportNativeArrowStreamDataAction.class)
         );
+    }
+
+    @Override
+    public List<RestHandler> getRestHandlers(
+        Settings settings,
+        RestController restController,
+        ClusterSettings clusterSettings,
+        IndexScopedSettings indexScopedSettings,
+        SettingsFilter settingsFilter,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<DiscoveryNodes> nodesLookup
+    ) {
+        return List.of(new RestNativeArrowStreamAction(nodesLookup, STS_REF::get));
     }
 }

--- a/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/StreamTransportServiceHolder.java
+++ b/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/StreamTransportServiceHolder.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.example.stream;
+
+import org.opensearch.transport.StreamTransportService;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Guice-injectable holder that bridges StreamTransportService from transport actions to REST handlers.
+ *
+ * StreamTransportService is bound in Guice after plugin components are created, so REST handlers
+ * (instantiated by the plugin) can't receive it directly. Transport actions set it here via Guice
+ * injection; the plugin passes a supplier from this holder to REST handlers.
+ */
+public class StreamTransportServiceHolder {
+    private final AtomicReference<StreamTransportService> ref;
+
+    public StreamTransportServiceHolder(AtomicReference<StreamTransportService> ref) {
+        this.ref = ref;
+    }
+
+    public void set(StreamTransportService service) {
+        ref.set(service);
+    }
+}

--- a/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/TransportNativeArrowStreamDataAction.java
+++ b/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/TransportNativeArrowStreamDataAction.java
@@ -55,6 +55,7 @@ public class TransportNativeArrowStreamDataAction extends TransportAction<Native
     @Inject
     public TransportNativeArrowStreamDataAction(StreamTransportService streamTransportService, ActionFilters actionFilters) {
         super(NativeArrowStreamDataAction.NAME, actionFilters, streamTransportService.getTaskManager());
+        StreamTransportExamplePlugin.STS_REF.set(streamTransportService);
         streamTransportService.registerRequestHandler(
             NativeArrowStreamDataAction.NAME,
             ThreadPool.Names.GENERIC,

--- a/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/TransportNativeArrowStreamDataAction.java
+++ b/plugins/examples/stream-transport-example/src/main/java/org/opensearch/example/stream/TransportNativeArrowStreamDataAction.java
@@ -53,9 +53,13 @@ public class TransportNativeArrowStreamDataAction extends TransportAction<Native
     private static final String[] NAMES = { "Alice", "Bob", "Carol", "Dave", "Eve" };
 
     @Inject
-    public TransportNativeArrowStreamDataAction(StreamTransportService streamTransportService, ActionFilters actionFilters) {
+    public TransportNativeArrowStreamDataAction(
+        StreamTransportService streamTransportService,
+        ActionFilters actionFilters,
+        StreamTransportServiceHolder holder
+    ) {
         super(NativeArrowStreamDataAction.NAME, actionFilters, streamTransportService.getTaskManager());
-        StreamTransportExamplePlugin.STS_REF.set(streamTransportService);
+        holder.set(streamTransportService);
         streamTransportService.registerRequestHandler(
             NativeArrowStreamDataAction.NAME,
             ThreadPool.Names.GENERIC,

--- a/plugins/examples/stream-transport-example/src/yamlRestTest/java/org/opensearch/example/stream/StreamTransportClientYamlTestSuiteIT.java
+++ b/plugins/examples/stream-transport-example/src/yamlRestTest/java/org/opensearch/example/stream/StreamTransportClientYamlTestSuiteIT.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.example.stream;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
+import org.opensearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.opensearch.test.rest.yaml.OpenSearchClientYamlSuiteTestCase;
+
+@AwaitsFix(bugUrl = "https://github.com/opensearch-project/OpenSearch/pull/21426")
+public class StreamTransportClientYamlTestSuiteIT extends OpenSearchClientYamlSuiteTestCase {
+
+    public StreamTransportClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return OpenSearchClientYamlSuiteTestCase.createParameters();
+    }
+}

--- a/plugins/examples/stream-transport-example/src/yamlRestTest/resources/rest-api-spec/api/native_arrow_test.json
+++ b/plugins/examples/stream-transport-example/src/yamlRestTest/resources/rest-api-spec/api/native_arrow_test.json
@@ -1,0 +1,29 @@
+{
+  "native_arrow_test": {
+    "documentation": {
+      "description": "Tests native Arrow stream transport"
+    },
+    "stability": "experimental",
+    "url": {
+      "paths": [
+        {
+          "path": "/_native_arrow_test",
+          "methods": ["GET"]
+        }
+      ]
+    },
+    "params": {
+      "batches": {
+        "type": "int",
+        "description": "Number of batches to stream",
+        "default": 2
+      },
+      "rows": {
+        "type": "int",
+        "description": "Number of rows per batch",
+        "default": 3
+      }
+    },
+    "body": null
+  }
+}

--- a/plugins/examples/stream-transport-example/src/yamlRestTest/resources/rest-api-spec/test/stream_transport/10_native_arrow.yml
+++ b/plugins/examples/stream-transport-example/src/yamlRestTest/resources/rest-api-spec/test/stream_transport/10_native_arrow.yml
@@ -1,0 +1,8 @@
+"Test native Arrow stream transport with classloader isolation":
+  - do:
+      native_arrow_test:
+        batches: 3
+        rows: 5
+
+  - match: { batches: 3 }
+  - match: { total_rows: 15 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The example plugin used `api project(':plugins:arrow-flight-rpc')` which bundles flight's jars into the example plugin's zip. In a real cluster, each plugin gets its own classloader, so ArrowBatchResponse and ArrowFlightChannel loaded by the example plugin are different classes from those loaded by arrow-flight-rpc. This causes instanceof checks to fail at runtime.

https://github.com/opensearch-project/OpenSearch/blob/dec02f901209d6b4b90bb4aeda76ad34f4ec13ba/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowFlightChannel.java#L47

https://github.com/opensearch-project/OpenSearch/blob/dec02f901209d6b4b90bb4aeda76ad34f4ec13ba/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightOutboundHandler.java#L156

```
java.lang.IllegalArgumentException: Channel is not backed by an ArrowFlightChannel: org.opensearch.transport.TaskTransportChannel
  at ArrowFlightChannel.from(ArrowFlightChannel.java:62)
  at TransportNativeArrowStreamDataAction.handleStreamRequest(TransportNativeArrowStreamDataAction.java:79)
```

Fix: use `extendedPlugins = ['arrow-flight-rpc']` with `compileOnly` so the example plugin delegates to flight's classloader. Both plugins see the same Arrow and flight classes.

Also adds:
- REST endpoint (/_native_arrow_test) to trigger the native Arrow streaming path from curl for manual verification
- run.gradle support for example-plugins so they can be installed via the standard -PinstalledPlugins mechanism

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
