### PR TITLE
Add module wiring and integration tests for WritableWarm tiered storage

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/storage/WarmIndexBasicIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/storage/WarmIndexBasicIT.java
@@ -1,0 +1,327 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.opensearch.action.admin.indices.close.CloseIndexRequest;
+import org.opensearch.action.admin.indices.close.CloseIndexResponse;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.admin.indices.get.GetIndexRequest;
+import org.opensearch.action.admin.indices.get.GetIndexResponse;
+import org.opensearch.action.admin.indices.open.OpenIndexRequest;
+import org.opensearch.action.admin.indices.open.OpenIndexResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.common.unit.ByteSizeUnit;
+import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.index.IndexModule;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.shard.IndexShard;
+import org.opensearch.index.store.CompositeDirectory;
+import org.opensearch.index.store.remote.file.CleanerDaemonThreadLeakFilter;
+import org.opensearch.index.store.remote.filecache.FileCache;
+import org.opensearch.index.store.remote.utils.FileTypeUtils;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.node.Node;
+import org.opensearch.remotestore.RemoteStoreBaseIntegTestCase;
+import org.opensearch.storage.directory.TieredDirectory;
+import org.opensearch.test.InternalTestCluster;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertHitCount;
+
+/**
+ * Integration tests for basic warm index operations.
+ *
+ * @opensearch.experimental
+ */
+@ThreadLeakFilters(filters = CleanerDaemonThreadLeakFilter.class)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0, supportsDedicatedMasters = false)
+public class WarmIndexBasicIT extends RemoteStoreBaseIntegTestCase {
+
+    protected static final String INDEX_NAME = "test-idx-1";
+    protected static final int NUM_DOCS_IN_BULK = 1000;
+
+    @Override
+    protected boolean addMockIndexStorePlugin() {
+        return false;
+    }
+
+    @Override
+    protected boolean ignoreExternalCluster() {
+        return true;
+    }
+
+    @Override
+    protected Settings featureFlagSettings() {
+        Settings.Builder featureSettings = Settings.builder();
+        featureSettings.put(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG, true);
+        return featureSettings.build();
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        ByteSizeValue cacheSize = new ByteSizeValue(1, ByteSizeUnit.GB);
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(Node.NODE_SEARCH_CACHE_SIZE_SETTING.getKey(), cacheSize.toString())
+            .build();
+    }
+
+    public void testWritableWarm() throws Exception {
+        InternalTestCluster internalTestCluster = internalCluster();
+        internalTestCluster.startClusterManagerOnlyNode();
+        internalTestCluster.startDataAndWarmNodes(1);
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), true)
+            .put(IndexModule.INDEX_COMPOSITE_STORE_TYPE_SETTING.getKey(), "tiered-storage")
+            .build();
+        // create a tiered-storage warm index with 1p0r configuration
+        assertAcked(client().admin().indices().prepareCreate(INDEX_NAME).setSettings(settings).get());
+
+        // Verify from the cluster settings that the warm setting is true
+        GetIndexResponse getIndexResponse = client().admin()
+            .indices()
+            .getIndex(new GetIndexRequest().indices(INDEX_NAME).includeDefaults(true))
+            .get();
+        Settings indexSettings = getIndexResponse.settings().get(INDEX_NAME);
+        assertTrue(indexSettings.getAsBoolean(IndexModule.IS_WARM_INDEX_SETTING.getKey(), false));
+
+        FileCache fileCache = internalTestCluster.getDataNodeInstance(Node.class).fileCache();
+        IndexShard shard = internalTestCluster.getDataNodeInstance(IndicesService.class)
+            .indexService(resolveIndex(INDEX_NAME))
+            .getShardOrNull(0);
+        Directory directory = unwrapToCompositeDirectory(shard.store().directory());
+
+        // Ingesting some docs
+        indexBulk(INDEX_NAME, NUM_DOCS_IN_BULK);
+        flushAndRefresh(INDEX_NAME);
+
+        // ensuring cluster is green after performing force-merge
+        ensureGreen();
+
+        SearchResponse searchResponse = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchAllQuery()).get();
+        // Asserting that search returns same number of docs as ingested
+        assertHitCount(searchResponse, NUM_DOCS_IN_BULK);
+
+        // Ingesting docs again before force merge
+        indexBulk(INDEX_NAME, NUM_DOCS_IN_BULK);
+        flushAndRefresh(INDEX_NAME);
+
+        // Force merging the index
+        Set<String> filesBeforeMerge = new HashSet<>(Arrays.asList(directory.listAll()));
+        client().admin().indices().prepareForceMerge(INDEX_NAME).setMaxNumSegments(1).get();
+        flushAndRefresh(INDEX_NAME);
+        Set<String> filesAfterMerge = new HashSet<>(Arrays.asList(directory.listAll()));
+
+        Set<String> filesFromPreviousGenStillPresent = filesBeforeMerge.stream()
+            .filter(filesAfterMerge::contains)
+            .filter(file -> !FileTypeUtils.isLockFile(file))
+            .filter(file -> !FileTypeUtils.isSegmentsFile(file))
+            .collect(Collectors.toUnmodifiableSet());
+
+        // Asserting that after merge all the files from previous gen are no more part of the directory
+        assertTrue(filesFromPreviousGenStillPresent.isEmpty());
+
+        // Asserting that files from previous gen are not present in File Cache as well
+        CompositeDirectory compositeDir = (CompositeDirectory) directory;
+        filesBeforeMerge.stream()
+            .filter(file -> !FileTypeUtils.isLockFile(file))
+            .filter(file -> !FileTypeUtils.isSegmentsFile(file))
+            .forEach(file -> assertNull(fileCache.get(compositeDir.getFilePath(file))));
+
+        // Deleting the index to avoid any file leaks
+        assertAcked(client().admin().indices().delete(new DeleteIndexRequest(INDEX_NAME)).get());
+    }
+
+    public void testLocalDirectoryFilesAfterRefresh() throws Exception {
+        InternalTestCluster internalTestCluster = internalCluster();
+        internalTestCluster.startClusterManagerOnlyNode();
+        internalTestCluster.startDataAndWarmNodes(1);
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), true)
+            .put(IndexModule.INDEX_COMPOSITE_STORE_TYPE_SETTING.getKey(), "tiered-storage")
+            .build();
+        assertAcked(client().admin().indices().prepareCreate(INDEX_NAME).setSettings(settings).get());
+
+        IndexShard shard = internalTestCluster.getDataNodeInstance(IndicesService.class)
+            .indexService(resolveIndex(INDEX_NAME))
+            .getShardOrNull(0);
+
+        TieredDirectory tieredDirectory = unwrapToTieredDirectory(shard.store().directory());
+
+        indexBulk(INDEX_NAME, NUM_DOCS_IN_BULK);
+        refresh(INDEX_NAME);
+
+        waitUntil(() -> {
+            try {
+                return Arrays.stream(tieredDirectory.listLocalFiles()).anyMatch(file -> file.contains("block"));
+            } catch (IOException ignored) {
+                return false;
+            }
+        }, 30, TimeUnit.SECONDS);
+        assertTrue(
+            Arrays.stream(tieredDirectory.listLocalFiles())
+                .filter(file -> !file.contains("block"))
+                .filter(file -> !file.contains("write.lock"))
+                .findAny()
+                .isEmpty()
+        );
+
+        // Deleting the index to avoid any file leaks
+        assertAcked(client().admin().indices().delete(new DeleteIndexRequest(INDEX_NAME)).get());
+    }
+
+    /**
+     * Unwraps the directory chain (walking through FilterDirectory wrappers including
+     * BucketedCompositeDirectory) to find the underlying CompositeDirectory.
+     */
+    private static Directory unwrapToCompositeDirectory(Directory directory) {
+        Directory current = directory;
+        while (current instanceof FilterDirectory) {
+            if (current instanceof CompositeDirectory) {
+                return current;
+            }
+            current = ((FilterDirectory) current).getDelegate();
+        }
+        if (current instanceof CompositeDirectory) {
+            return current;
+        }
+        throw new IllegalArgumentException("Expected CompositeDirectory but got: " + directory.getClass().getName());
+    }
+
+    /**
+     * Unwraps the directory chain (walking through FilterDirectory wrappers including
+     * BucketedCompositeDirectory) to find the underlying TieredDirectory.
+     */
+    private static TieredDirectory unwrapToTieredDirectory(Directory directory) {
+        Directory current = directory;
+        while (current instanceof FilterDirectory) {
+            if (current instanceof TieredDirectory) {
+                return (TieredDirectory) current;
+            }
+            current = ((FilterDirectory) current).getDelegate();
+        }
+        if (current instanceof TieredDirectory) {
+            return (TieredDirectory) current;
+        }
+        throw new IllegalArgumentException("Expected TieredDirectory but got: " + directory.getClass().getName());
+    }
+
+    protected long getDocCount(String indexName) {
+        refresh(indexName);
+        SearchResponse response = client().prepareSearch(indexName).setQuery(QueryBuilders.matchAllQuery()).setSize(0).get();
+        return response.getHits().getTotalHits().value();
+    }
+
+    public void testCloseIndex() throws ExecutionException, InterruptedException {
+        InternalTestCluster internalTestCluster = internalCluster();
+        internalTestCluster.startClusterManagerOnlyNode();
+        internalTestCluster.startDataAndWarmNodes(2);
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), true)
+            .put(IndexModule.INDEX_COMPOSITE_STORE_TYPE_SETTING.getKey(), "tiered-storage")
+            .build();
+        // create a warm index with 1p0r configuration
+        assertAcked(client().admin().indices().prepareCreate(INDEX_NAME).setSettings(settings).get());
+
+        // Verify from the cluster settings if the warm index setting is true
+        GetIndexResponse getIndexResponse = client().admin()
+            .indices()
+            .getIndex(new GetIndexRequest().indices(INDEX_NAME).includeDefaults(true))
+            .get();
+        Settings indexSettings = getIndexResponse.settings().get(INDEX_NAME);
+        assertTrue(indexSettings.getAsBoolean(IndexModule.IS_WARM_INDEX_SETTING.getKey(), false));
+        // Ingesting some docs
+        indexBulk(INDEX_NAME, NUM_DOCS_IN_BULK);
+        flushAndRefresh(INDEX_NAME);
+
+        // ensuring cluster is green after performing force-merge
+        ensureGreen();
+
+        long docCount = getDocCount(INDEX_NAME);
+        CloseIndexResponse closeIndexResponse = client().admin().indices().close(new CloseIndexRequest(INDEX_NAME)).get();
+        assertTrue(closeIndexResponse.isShardsAcknowledged());
+
+        OpenIndexResponse openIndexResponse = client().admin().indices().open(new OpenIndexRequest(INDEX_NAME)).get();
+        assertTrue(openIndexResponse.isShardsAcknowledged());
+
+        long docCountUpdated = getDocCount(INDEX_NAME);
+        assertEquals(docCountUpdated, docCount);
+    }
+
+    public void testWritableWarmPrimaryReplicaBoth() throws Exception {
+        InternalTestCluster internalTestCluster = internalCluster();
+        internalTestCluster.startClusterManagerOnlyNode();
+        internalTestCluster.startDataAndWarmNodes(2);
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+            .put(IndexModule.IS_WARM_INDEX_SETTING.getKey(), true)
+            .put(IndexModule.INDEX_COMPOSITE_STORE_TYPE_SETTING.getKey(), "tiered-storage")
+            .build();
+        // create a tiered-storage warm index with 1p1r configuration
+        assertAcked(client().admin().indices().prepareCreate(INDEX_NAME).setSettings(settings).get());
+
+        // Verify from the cluster settings if the warm index setting is true
+        GetIndexResponse getIndexResponse = client().admin()
+            .indices()
+            .getIndex(new GetIndexRequest().indices(INDEX_NAME).includeDefaults(true))
+            .get();
+        Settings indexSettings = getIndexResponse.settings().get(INDEX_NAME);
+        assertTrue(indexSettings.getAsBoolean(IndexModule.IS_WARM_INDEX_SETTING.getKey(), false));
+
+        // Ingesting some docs
+        indexBulk(INDEX_NAME, NUM_DOCS_IN_BULK);
+        flushAndRefresh(INDEX_NAME);
+
+        // ensuring cluster is green after performing force-merge
+        ensureGreen();
+
+        SearchResponse searchResponse = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchAllQuery()).get();
+        // Asserting that search returns same number of docs as ingested
+        assertHitCount(searchResponse, NUM_DOCS_IN_BULK);
+
+        // Ingesting docs again before force merge
+        indexBulk(INDEX_NAME, NUM_DOCS_IN_BULK);
+        flushAndRefresh(INDEX_NAME);
+
+        // Force merging the index
+        client().admin().indices().prepareForceMerge(INDEX_NAME).setMaxNumSegments(1).get();
+        flushAndRefresh(INDEX_NAME);
+
+        ensureGreen();
+        searchResponse = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchAllQuery()).get();
+        // verify again after force merge search response return same no of docs as ingested
+        assertHitCount(searchResponse, 2 * NUM_DOCS_IN_BULK);
+
+        // Deleting the index to avoid any file leaks
+        assertAcked(client().admin().indices().delete(new DeleteIndexRequest(INDEX_NAME)).get());
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -78,6 +78,7 @@ import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.BigArrays;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.concurrent.AbstractRefCounted;
 import org.opensearch.common.util.concurrent.AbstractRunnable;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
@@ -181,6 +182,9 @@ import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.query.QueryPhase;
 import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.storage.prefetch.StoredFieldsPrefetch;
+import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
+import org.opensearch.storage.slowlogs.TieredStorageSearchSlowLog;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -385,6 +389,7 @@ public class IndicesService extends AbstractLifecycleComponent
     private final BigArrays bigArrays;
     private final ScriptService scriptService;
     private final ClusterService clusterService;
+    private final Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier;
     private final Client client;
     private volatile Map<String, IndexService> indices = emptyMap();
     private final Map<Index, List<PendingDelete>> pendingDeletes = new HashMap<>();
@@ -508,6 +513,12 @@ public class IndicesService extends AbstractLifecycleComponent
         this.bigArrays = bigArrays;
         this.scriptService = scriptService;
         this.clusterService = clusterService;
+        if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)) {
+            final TieredStoragePrefetchSettings prefetchSettings = new TieredStoragePrefetchSettings(clusterService.getClusterSettings());
+            this.tieredStoragePrefetchSettingsSupplier = () -> prefetchSettings;
+        } else {
+            this.tieredStoragePrefetchSettingsSupplier = () -> null;
+        }
         this.client = client;
         this.idFieldDataEnabled = INDICES_ID_FIELD_DATA_ENABLED_SETTING.get(clusterService.getSettings());
         clusterService.getClusterSettings().addSettingsUpdateConsumer(INDICES_ID_FIELD_DATA_ENABLED_SETTING, this::setIdFieldDataEnabled);
@@ -1124,6 +1135,11 @@ public class IndicesService extends AbstractLifecycleComponent
             indexModule.addIndexOperationListener(operationListener);
         }
         pluginsService.onIndexModule(indexModule);
+        // Add tiered storage search listeners
+        if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)) {
+            indexModule.addSearchOperationListener(new TieredStorageSearchSlowLog(idxSettings));
+            indexModule.addSearchOperationListener(new StoredFieldsPrefetch(tieredStoragePrefetchSettingsSupplier));
+        }
         for (IndexEventListener listener : builtInListeners) {
             indexModule.addIndexEventListener(listener);
         }

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -270,6 +270,10 @@ import org.opensearch.snapshots.RestoreService;
 import org.opensearch.snapshots.SnapshotShardsService;
 import org.opensearch.snapshots.SnapshotsInfoService;
 import org.opensearch.snapshots.SnapshotsService;
+import org.opensearch.storage.common.tiering.TieringUtils;
+import org.opensearch.storage.directory.TieredDirectoryFactory;
+import org.opensearch.storage.metrics.TierActionMetrics;
+import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
 import org.opensearch.storage.tiering.HotToWarmTieringService;
 import org.opensearch.storage.tiering.WarmToHotTieringService;
 import org.opensearch.task.commons.clients.TaskManagerClient;
@@ -900,6 +904,17 @@ public class Node implements Closeable {
             pluginsService.filterPlugins(IngestionConsumerPlugin.class)
                 .forEach(plugin -> ingestionConsumerFactories.putAll(plugin.getIngestionConsumerFactories()));
 
+            // Initialize tiered storage prefetch settings
+            final TieredStoragePrefetchSettings tieredStoragePrefetchSettings;
+            final Supplier<TieredStoragePrefetchSettings> tieredStoragePrefetchSettingsSupplier;
+            if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)) {
+                tieredStoragePrefetchSettings = new TieredStoragePrefetchSettings(clusterService.getClusterSettings());
+                tieredStoragePrefetchSettingsSupplier = () -> tieredStoragePrefetchSettings;
+            } else {
+                tieredStoragePrefetchSettings = null;
+                tieredStoragePrefetchSettingsSupplier = () -> null;
+            }
+
             final Map<String, IndexStorePlugin.DirectoryFactory> builtInDirectoryFactories = IndexModule.createBuiltInDirectoryFactories(
                 repositoriesServiceReference::get,
                 threadPool,
@@ -936,6 +951,14 @@ public class Node implements Closeable {
                     compositeDirectoryFactories.put(k, v);
                 });
             compositeDirectoryFactories.put("default", new DefaultCompositeDirectoryFactory());
+
+            // Register tiered storage directory factories
+            if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)) {
+                compositeDirectoryFactories.put(
+                    TieringUtils.TIERED_COMPOSITE_INDEX_TYPE,
+                    new TieredDirectoryFactory(tieredStoragePrefetchSettingsSupplier)
+                );
+            }
             final Map<String, org.opensearch.index.store.DataFormatAwareStoreDirectoryFactory> dataFormatAwareStoreDirectoryFactories =
                 new HashMap<>();
 
@@ -1730,6 +1753,7 @@ public class Node implements Closeable {
                 if (FeatureFlags.isEnabled(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG)) {
                     b.bind(HotToWarmTieringService.class).asEagerSingleton();
                     b.bind(WarmToHotTieringService.class).asEagerSingleton();
+                    b.bind(TierActionMetrics.class).toInstance(new TierActionMetrics(metricsRegistry));
                 }
             });
             injector = modules.createInjector();

--- a/server/src/main/java/org/opensearch/storage/directory/TieredDirectory.java
+++ b/server/src/main/java/org/opensearch/storage/directory/TieredDirectory.java
@@ -12,9 +12,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.store.CompositeDirectory;
 import org.opensearch.index.store.RemoteSegmentStoreDirectory;
 import org.opensearch.index.store.remote.filecache.CachedIndexInput;
@@ -24,6 +24,7 @@ import org.opensearch.storage.indexinput.CachedSwitchableIndexInput;
 import org.opensearch.storage.indexinput.SwitchableIndexInput;
 import org.opensearch.storage.indexinput.SwitchableIndexInputWrapper;
 import org.opensearch.storage.prefetch.TieredStoragePrefetchSettings;
+import org.opensearch.storage.utils.DirectoryUtils;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -40,7 +41,10 @@ import static org.apache.lucene.index.IndexFileNames.SEGMENTS;
 
 /**
  * Extension of Composite directory to support writable warm and other related features
+ *
+ * @opensearch.experimental
  */
+@ExperimentalApi
 public class TieredDirectory extends CompositeDirectory {
 
     private static final Logger logger = LogManager.getLogger(TieredDirectory.class);
@@ -229,7 +233,7 @@ public class TieredDirectory extends CompositeDirectory {
             new CachedSwitchableIndexInput(
                 fileCache,
                 fileName,
-                (FSDirectory) localDirectory,
+                DirectoryUtils.unwrapFSDirectory(localDirectory),
                 remoteDirectory,
                 transferManager,
                 cacheFromRemote,

--- a/server/src/main/java/org/opensearch/storage/directory/TieredDirectoryFactory.java
+++ b/server/src/main/java/org/opensearch/storage/directory/TieredDirectoryFactory.java
@@ -10,6 +10,7 @@ package org.opensearch.storage.directory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.Directory;
+import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.shard.ShardPath;
 import org.opensearch.index.store.remote.filecache.FileCache;
@@ -22,7 +23,10 @@ import java.util.function.Supplier;
 
 /**
  * Factory for creating {@link TieredDirectory} instances that combine local and remote storage.
+ *
+ * @opensearch.experimental
  */
+@ExperimentalApi
 public class TieredDirectoryFactory implements IndexStorePlugin.CompositeDirectoryFactory {
 
     private static final Logger logger = LogManager.getLogger(TieredDirectoryFactory.class);

--- a/server/src/main/java/org/opensearch/storage/utils/DirectoryUtils.java
+++ b/server/src/main/java/org/opensearch/storage/utils/DirectoryUtils.java
@@ -10,21 +10,58 @@ package org.opensearch.storage.utils;
 
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FilterDirectory;
+import org.opensearch.common.annotation.ExperimentalApi;
 
 import java.nio.file.Path;
 
 /**
  * Utility methods for directory path resolution in tiered storage.
+ *
+ * @opensearch.experimental
  */
+@ExperimentalApi
 public class DirectoryUtils {
 
+    /** Suffix for switchable file paths. */
     public static final String SWITCHABLE_PREFIX = "_switchable";
 
+    /**
+     * Resolves the file path for a given file name in the directory.
+     * @param localDirectory the directory
+     * @param fileName the file name
+     * @return the resolved path
+     */
     public static Path getFilePath(Directory localDirectory, String fileName) {
-        return ((FSDirectory) localDirectory).getDirectory().resolve(fileName);
+        return unwrapFSDirectory(localDirectory).getDirectory().resolve(fileName);
     }
 
+    /**
+     * Resolves the switchable file path for a given file name in the directory.
+     * @param localDirectory the directory
+     * @param fileName the file name
+     * @return the resolved switchable path
+     */
     public static Path getFilePathSwitchable(Directory localDirectory, String fileName) {
-        return ((FSDirectory) localDirectory).getDirectory().resolve(fileName + SWITCHABLE_PREFIX);
+        return unwrapFSDirectory(localDirectory).getDirectory().resolve(fileName + SWITCHABLE_PREFIX);
+    }
+
+    /**
+     * Unwraps a directory chain to find the underlying FSDirectory.
+     * Handles cases where the directory is wrapped in FilterDirectory layers
+     * such as BucketedCompositeDirectory.
+     * @param directory the directory to unwrap
+     * @return the underlying FSDirectory
+     * @throws IllegalArgumentException if no FSDirectory is found in the chain
+     */
+    public static FSDirectory unwrapFSDirectory(Directory directory) {
+        Directory current = directory;
+        while (current instanceof FilterDirectory) {
+            current = ((FilterDirectory) current).getDelegate();
+        }
+        if (current instanceof FSDirectory) {
+            return (FSDirectory) current;
+        }
+        throw new IllegalArgumentException("Expected FSDirectory but got: " + directory.getClass().getName());
     }
 }

--- a/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/opensearch/threadpool/ThreadPool.java
@@ -125,6 +125,8 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         public static final String REMOTE_PURGE = "remote_purge";
         public static final String REMOTE_REFRESH_RETRY = "remote_refresh_retry";
         public static final String REMOTE_RECOVERY = "remote_recovery";
+        /** Thread pool name for remote downloads in tiered storage. */
+        public static final String REMOTE_DOWNLOAD = "remote_download";
         public static final String REMOTE_STATE_READ = "remote_state_read";
         public static final String INDEX_SEARCHER = "index_searcher";
         public static final String REMOTE_STATE_CHECKSUM = "remote_state_checksum";
@@ -206,6 +208,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         map.put(Names.REMOTE_PURGE, ThreadPoolType.SCALING);
         map.put(Names.REMOTE_REFRESH_RETRY, ThreadPoolType.SCALING);
         map.put(Names.REMOTE_RECOVERY, ThreadPoolType.SCALING);
+        map.put(Names.REMOTE_DOWNLOAD, ThreadPoolType.SCALING);
         map.put(Names.REMOTE_STATE_READ, ThreadPoolType.FIXED);
         map.put(Names.INDEX_SEARCHER, ThreadPoolType.RESIZABLE);
         map.put(Names.REMOTE_STATE_CHECKSUM, ThreadPoolType.FIXED);
@@ -323,6 +326,15 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
             Names.REMOTE_RECOVERY,
             new ScalingExecutorBuilder(
                 Names.REMOTE_RECOVERY,
+                1,
+                twiceAllocatedProcessors(allocatedProcessors),
+                TimeValue.timeValueMinutes(5)
+            )
+        );
+        builders.put(
+            Names.REMOTE_DOWNLOAD,
+            new ScalingExecutorBuilder(
+                Names.REMOTE_DOWNLOAD,
                 1,
                 twiceAllocatedProcessors(allocatedProcessors),
                 TimeValue.timeValueMinutes(5)

--- a/server/src/test/java/org/opensearch/node/NodeTests.java
+++ b/server/src/test/java/org/opensearch/node/NodeTests.java
@@ -42,6 +42,7 @@ import org.opensearch.common.SetOnce;
 import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsException;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.common.transport.BoundTransportAddress;
@@ -64,6 +65,7 @@ import org.opensearch.plugins.TelemetryAwarePlugin;
 import org.opensearch.plugins.TelemetryPlugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
+import org.opensearch.storage.metrics.TierActionMetrics;
 import org.opensearch.telemetry.Telemetry;
 import org.opensearch.telemetry.TelemetrySettings;
 import org.opensearch.telemetry.metrics.MetricsRegistry;
@@ -419,6 +421,24 @@ public class NodeTests extends OpenSearchTestCase {
             FsInfo fsInfo = fsProbe.stats(null);
             FsInfo.Path cachePathInfo = fsInfo.iterator().next();
             assertEquals(cachePathInfo.getFileCacheReserved().getBytes(), fileCacheNodePath.fileCacheReservedSize.getBytes());
+        }
+    }
+
+    public void testTieredStorageWiringWithFeatureFlag() throws Exception {
+        Settings warmRoleSettings = addRoles(
+            baseSettings().put(FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG, true)
+                .put(Node.NODE_SEARCH_CACHE_SIZE_SETTING.getKey(), "1gb")
+                .build(),
+            Set.of(DiscoveryNodeRole.WARM_ROLE)
+        );
+        List<Class<? extends Plugin>> plugins = basePlugins();
+        try (MockNode mockNode = new MockNode(warmRoleSettings, plugins)) {
+            assertNotNull(mockNode);
+            // Verify TierActionMetrics was bound in Guice
+            assertNotNull(mockNode.injector().getInstance(TierActionMetrics.class));
+            // Verify remote_download thread pool exists
+            ThreadPool threadPool = mockNode.injector().getInstance(ThreadPool.class);
+            assertNotNull(threadPool.executor(ThreadPool.Names.REMOTE_DOWNLOAD));
         }
     }
 

--- a/server/src/test/java/org/opensearch/storage/utils/DirectoryUtilsTests.java
+++ b/server/src/test/java/org/opensearch/storage/utils/DirectoryUtilsTests.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.storage.utils;
+
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FilterDirectory;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.nio.file.Path;
+
+/**
+ * Tests for {@link DirectoryUtils}.
+ *
+ * @opensearch.experimental
+ */
+public class DirectoryUtilsTests extends OpenSearchTestCase {
+
+    private Path tempDir;
+    private FSDirectory fsDirectory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        tempDir = createTempDir();
+        fsDirectory = FSDirectory.open(tempDir);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        fsDirectory.close();
+        super.tearDown();
+    }
+
+    public void testUnwrapFSDirectoryDirect() {
+        FSDirectory result = DirectoryUtils.unwrapFSDirectory(fsDirectory);
+        assertSame(fsDirectory, result);
+    }
+
+    public void testUnwrapFSDirectorySingleWrapper() {
+        FilterDirectory wrapped = new FilterDirectory(fsDirectory) {
+        };
+        FSDirectory result = DirectoryUtils.unwrapFSDirectory(wrapped);
+        assertSame(fsDirectory, result);
+    }
+
+    public void testUnwrapFSDirectoryMultipleWrappers() {
+        FilterDirectory inner = new FilterDirectory(fsDirectory) {
+        };
+        FilterDirectory outer = new FilterDirectory(inner) {
+        };
+        FSDirectory result = DirectoryUtils.unwrapFSDirectory(outer);
+        assertSame(fsDirectory, result);
+    }
+
+    public void testUnwrapFSDirectoryThrowsWhenNoFSDirectory() {
+        Directory nonFsDir = new ByteBuffersDirectory();
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> DirectoryUtils.unwrapFSDirectory(nonFsDir));
+        assertTrue(ex.getMessage().contains("Expected FSDirectory but got"));
+    }
+
+    public void testUnwrapFSDirectoryThrowsWhenWrappedNonFSDirectory() {
+        Directory nonFsDir = new ByteBuffersDirectory();
+        FilterDirectory wrapped = new FilterDirectory(nonFsDir) {
+        };
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> DirectoryUtils.unwrapFSDirectory(wrapped));
+        assertTrue(ex.getMessage().contains("Expected FSDirectory but got"));
+    }
+
+    public void testGetFilePath() {
+        Path result = DirectoryUtils.getFilePath(fsDirectory, "test_file.si");
+        assertEquals(tempDir.resolve("test_file.si"), result);
+    }
+
+    public void testGetFilePathWithWrappedDirectory() {
+        FilterDirectory wrapped = new FilterDirectory(fsDirectory) {
+        };
+        Path result = DirectoryUtils.getFilePath(wrapped, "test_file.si");
+        assertEquals(tempDir.resolve("test_file.si"), result);
+    }
+
+    public void testGetFilePathSwitchable() {
+        Path result = DirectoryUtils.getFilePathSwitchable(fsDirectory, "test_file.si");
+        assertEquals(tempDir.resolve("test_file.si" + DirectoryUtils.SWITCHABLE_PREFIX), result);
+    }
+
+    public void testGetFilePathSwitchableWithWrappedDirectory() {
+        FilterDirectory wrapped = new FilterDirectory(fsDirectory) {
+        };
+        Path result = DirectoryUtils.getFilePathSwitchable(wrapped, "test_file.si");
+        assertEquals(tempDir.resolve("test_file.si" + DirectoryUtils.SWITCHABLE_PREFIX), result);
+    }
+}

--- a/server/src/test/java/org/opensearch/threadpool/ScalingThreadPoolTests.java
+++ b/server/src/test/java/org/opensearch/threadpool/ScalingThreadPoolTests.java
@@ -156,6 +156,7 @@ public class ScalingThreadPoolTests extends OpenSearchThreadPoolTestCase {
         sizes.put(ThreadPool.Names.REMOTE_PURGE, ThreadPool::halfAllocatedProcessors);
         sizes.put(ThreadPool.Names.REMOTE_REFRESH_RETRY, ThreadPool::halfAllocatedProcessors);
         sizes.put(ThreadPool.Names.REMOTE_RECOVERY, ThreadPool::twiceAllocatedProcessors);
+        sizes.put(ThreadPool.Names.REMOTE_DOWNLOAD, ThreadPool::twiceAllocatedProcessors);
         sizes.put(ThreadPool.Names.MERGE, n -> n);
         return sizes.get(threadPoolName).apply(numberOfProcessors);
     }


### PR DESCRIPTION
### Description

Wires the remaining tiered storage components into the server and adds integration tests for warm index operations.

**Module wiring:**
- `Node.java`: Registered `TieredDirectoryFactory` as a composite directory factory, initialized `TieredStoragePrefetchSettings` from cluster settings, and bound `TierActionMetrics` in Guice for migration metrics tracking
- `IndicesService.java`: Added `TieredStorageSearchSlowLog` and `StoredFieldsPrefetch` as search operation listeners for each index, with prefetch settings supplier initialized from cluster settings
- `ThreadPool.java`: Added `remote_download` scaling thread pool executor used by `BlockTransferManager` for async block downloads from remote storage

All wiring is gated behind `FeatureFlags.WRITABLE_WARM_INDEX_EXPERIMENTAL_FLAG`.

**Integration tests (WarmIndexBasicIT):**
- `testWritableWarm`: Creates a warm index, ingests docs, searches, force merges, and verifies file cleanup from directory and file cache
- `testLocalDirectoryFilesAfterRefresh`: Verifies that local directory only contains block files after refresh (no full files)
- `testCloseIndex`: Verifies data is preserved after close and reopen of a warm index
- `testWritableWarmPrimaryReplicaBoth`: Verifies warm index operations with primary and replica shards

Depends on #21332

### Related Issues
Resolves #21101

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

