### PR TITLE
Add cluster-scope defaults for pluggable dataformat settings

### DIFF
--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeParquetIndexIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeParquetIndexIT.java
@@ -230,4 +230,168 @@ public class CompositeParquetIndexIT extends OpenSearchIntegTestCase {
 
         ensureGreen(indexName);
     }
+
+    public void testCompositeIndexUsesClusterDefaultFormatsWhenOverridesAbsent() throws IOException {
+        String indexName = "test-composite-cluster-default";
+
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(
+                Settings.builder()
+                    .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+                    .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "lucene")
+            )
+            .get();
+
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .build();
+
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(indexName)
+            .setSettings(indexSettings)
+            .setMapping("field_text", "type=text", "field_keyword", "type=keyword", "field_number", "type=integer")
+            .get();
+        assertTrue("Index creation should be acknowledged", response.isAcknowledged());
+
+        ensureGreen(indexName);
+
+        GetSettingsResponse settingsResponse = client().admin().indices().prepareGetSettings(indexName).get();
+        Settings actual = settingsResponse.getIndexToSettings().get(indexName);
+        assertEquals("parquet", actual.get(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey()));
+        assertEquals("lucene", actual.getAsList(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.getKey()).get(0));
+
+        for (int i = 0; i < 10; i++) {
+            IndexResponse indexResponse = client().prepareIndex()
+                .setIndex(indexName)
+                .setSource("field_text", randomAlphaOfLength(10), "field_keyword", randomAlphaOfLength(10), "field_number", randomInt(100))
+                .get();
+            assertEquals(RestStatus.CREATED, indexResponse.status());
+        }
+
+        assertEquals(RestStatus.OK, client().admin().indices().prepareRefresh(indexName).get().getStatus());
+        assertEquals(RestStatus.OK, client().admin().indices().prepareFlush(indexName).get().getStatus());
+
+        IndicesStatsResponse statsResponse = client().admin()
+            .indices()
+            .prepareStats(indexName)
+            .clear()
+            .setIndexing(true)
+            .setRefresh(true)
+            .setDocs(true)
+            .setStore(true)
+            .get();
+        ShardStats shardStats = statsResponse.getIndex(indexName).getShards()[0];
+        assertEquals(10, shardStats.getStats().indexing.getTotal().getIndexCount());
+
+        CommitStats commitStats = shardStats.getCommitStats();
+        assertNotNull(commitStats);
+        assertTrue(commitStats.getUserData().containsKey(DataformatAwareCatalogSnapshot.CATALOG_SNAPSHOT_KEY));
+
+        DataformatAwareCatalogSnapshot snapshot = DataformatAwareCatalogSnapshot.deserializeFromString(
+            commitStats.getUserData().get(DataformatAwareCatalogSnapshot.CATALOG_SNAPSHOT_KEY),
+            Function.identity()
+        );
+        assertEquals(Set.of("parquet", "lucene"), snapshot.getDataFormats());
+
+        ensureGreen(indexName);
+
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(
+                Settings.builder()
+                    .putNull(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey())
+                    .putNull(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey())
+            )
+            .get();
+    }
+
+    public void testCompositeIndexRequestOverrideBeatsClusterDefault() throws IOException {
+        String indexName = "test-composite-request-override";
+
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(
+                Settings.builder()
+                    .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+                    .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "lucene")
+            )
+            .get();
+
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.pluggable.dataformat.enabled", true)
+            .put("index.pluggable.dataformat", "composite")
+            .put("index.composite.primary_data_format", "lucene")
+            .putList("index.composite.secondary_data_formats")
+            .build();
+
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(indexName)
+            .setSettings(indexSettings)
+            .setMapping("field_text", "type=text", "field_keyword", "type=keyword", "field_number", "type=integer")
+            .get();
+        assertTrue("Index creation should be acknowledged", response.isAcknowledged());
+
+        ensureGreen(indexName);
+
+        GetSettingsResponse settingsResponse = client().admin().indices().prepareGetSettings(indexName).get();
+        Settings actual = settingsResponse.getIndexToSettings().get(indexName);
+        assertEquals("lucene", actual.get(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey()));
+        assertTrue(actual.getAsList(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.getKey()).isEmpty());
+
+        for (int i = 0; i < 10; i++) {
+            IndexResponse indexResponse = client().prepareIndex()
+                .setIndex(indexName)
+                .setSource("field_text", randomAlphaOfLength(10), "field_keyword", randomAlphaOfLength(10), "field_number", randomInt(100))
+                .get();
+            assertEquals(RestStatus.CREATED, indexResponse.status());
+        }
+
+        assertEquals(RestStatus.OK, client().admin().indices().prepareRefresh(indexName).get().getStatus());
+        assertEquals(RestStatus.OK, client().admin().indices().prepareFlush(indexName).get().getStatus());
+
+        IndicesStatsResponse statsResponse = client().admin()
+            .indices()
+            .prepareStats(indexName)
+            .clear()
+            .setIndexing(true)
+            .setRefresh(true)
+            .setDocs(true)
+            .setStore(true)
+            .get();
+        ShardStats shardStats = statsResponse.getIndex(indexName).getShards()[0];
+        assertEquals(10, shardStats.getStats().indexing.getTotal().getIndexCount());
+
+        CommitStats commitStats = shardStats.getCommitStats();
+        assertNotNull(commitStats);
+        assertTrue(commitStats.getUserData().containsKey(DataformatAwareCatalogSnapshot.CATALOG_SNAPSHOT_KEY));
+
+        DataformatAwareCatalogSnapshot snapshot = DataformatAwareCatalogSnapshot.deserializeFromString(
+            commitStats.getUserData().get(DataformatAwareCatalogSnapshot.CATALOG_SNAPSHOT_KEY),
+            Function.identity()
+        );
+        assertEquals(Set.of("lucene"), snapshot.getDataFormats());
+
+        ensureGreen(indexName);
+
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(
+                Settings.builder()
+                    .putNull(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey())
+                    .putNull(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey())
+            )
+            .get();
+    }
 }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeParquetIndexIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/CompositeParquetIndexIT.java
@@ -239,8 +239,8 @@ public class CompositeParquetIndexIT extends OpenSearchIntegTestCase {
             .prepareUpdateSettings()
             .setTransientSettings(
                 Settings.builder()
-                    .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
-                    .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "lucene")
+                    .put(CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+                    .putList(CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS.getKey(), "lucene")
             )
             .get();
 
@@ -306,8 +306,8 @@ public class CompositeParquetIndexIT extends OpenSearchIntegTestCase {
             .prepareUpdateSettings()
             .setTransientSettings(
                 Settings.builder()
-                    .putNull(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey())
-                    .putNull(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey())
+                    .putNull(CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.getKey())
+                    .putNull(CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS.getKey())
             )
             .get();
     }
@@ -320,8 +320,8 @@ public class CompositeParquetIndexIT extends OpenSearchIntegTestCase {
             .prepareUpdateSettings()
             .setTransientSettings(
                 Settings.builder()
-                    .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
-                    .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "lucene")
+                    .put(CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+                    .putList(CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS.getKey(), "lucene")
             )
             .get();
 
@@ -389,8 +389,8 @@ public class CompositeParquetIndexIT extends OpenSearchIntegTestCase {
             .prepareUpdateSettings()
             .setTransientSettings(
                 Settings.builder()
-                    .putNull(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey())
-                    .putNull(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey())
+                    .putNull(CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.getKey())
+                    .putNull(CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS.getKey())
             )
             .get();
     }

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/RestrictCompositeDataFormatOverrideIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/RestrictCompositeDataFormatOverrideIT.java
@@ -1,0 +1,169 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite;
+
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.be.datafusion.DataFusionPlugin;
+import org.opensearch.be.lucene.LucenePlugin;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.parquet.ParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.opensearch.composite.CompositeDataFormatPlugin.CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING;
+
+/**
+ * Integration tests for {@link CompositeDataFormatPlugin#CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING}
+ * enforcement. The setting is {@code Property.Final}, so each test starts nodes with its own
+ * settings bag.
+ */
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class RestrictCompositeDataFormatOverrideIT extends OpenSearchIntegTestCase {
+
+    private static final String INDEX_NAME = "test-composite-restrict";
+    private static final String CLUSTER_DEFAULT_PRIMARY = "lucene";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(ParquetDataFormatPlugin.class, CompositeDataFormatPlugin.class, LucenePlugin.class, DataFusionPlugin.class);
+    }
+
+    private Settings nodeSettings(boolean restrict) {
+        return Settings.builder()
+            .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
+            .put(CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey(), restrict)
+            .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), CLUSTER_DEFAULT_PRIMARY)
+            .build();
+    }
+
+    public void testRejectsPrimaryOverrideWhenRestrictIsTrue() {
+        internalCluster().startClusterManagerOnlyNode(nodeSettings(true));
+        internalCluster().startDataOnlyNode(nodeSettings(true));
+
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey(), "parquet")
+            .build();
+
+        IllegalArgumentException thrown = expectThrows(
+            IllegalArgumentException.class,
+            () -> client().admin().indices().prepareCreate(INDEX_NAME).setSettings(indexSettings).get()
+        );
+        String message = thrown.getMessage();
+        assertTrue(
+            "expected validation error to mention ["
+                + CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey()
+                + "] but was ["
+                + message
+                + "]",
+            message.contains(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey())
+        );
+        assertTrue(
+            "expected validation error to mention restrict setting but was [" + message + "]",
+            message.contains(CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey())
+        );
+    }
+
+    public void testRejectsSecondaryOverrideWhenRestrictIsTrue() {
+        internalCluster().startClusterManagerOnlyNode(nodeSettings(true));
+        internalCluster().startDataOnlyNode(nodeSettings(true));
+
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .putList(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.getKey(), "parquet")
+            .build();
+
+        IllegalArgumentException thrown = expectThrows(
+            IllegalArgumentException.class,
+            () -> client().admin().indices().prepareCreate(INDEX_NAME).setSettings(indexSettings).get()
+        );
+        String message = thrown.getMessage();
+        assertTrue(
+            "expected validation error to mention ["
+                + CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.getKey()
+                + "] but was ["
+                + message
+                + "]",
+            message.contains(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.getKey())
+        );
+    }
+
+    public void testAcceptsMatchingOverrideWhenRestrictIsTrue() {
+        internalCluster().startClusterManagerOnlyNode(nodeSettings(true));
+        internalCluster().startDataOnlyNode(nodeSettings(true));
+
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey(), CLUSTER_DEFAULT_PRIMARY)
+            .build();
+
+        CreateIndexResponse response = client().admin().indices().prepareCreate(INDEX_NAME).setSettings(indexSettings).get();
+        assertTrue(response.isAcknowledged());
+        ensureGreen(INDEX_NAME);
+    }
+
+    public void testAllowsOverrideWhenRestrictIsFalse() {
+        internalCluster().startClusterManagerOnlyNode(nodeSettings(false));
+        internalCluster().startDataOnlyNode(nodeSettings(false));
+
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey(), "parquet")
+            .build();
+
+        CreateIndexResponse response = client().admin().indices().prepareCreate(INDEX_NAME).setSettings(indexSettings).get();
+        assertTrue(response.isAcknowledged());
+        ensureGreen(INDEX_NAME);
+    }
+
+    public void testRejectsTemplateOverrideWhenRestrictIsTrue() {
+        internalCluster().startClusterManagerOnlyNode(nodeSettings(true));
+        internalCluster().startDataOnlyNode(nodeSettings(true));
+
+        AcknowledgedResponse putTemplate = client().admin()
+            .indices()
+            .preparePutTemplate("restrict-composite-template")
+            .setPatterns(Collections.singletonList(INDEX_NAME + "*"))
+            .setSettings(Settings.builder().put(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey(), "parquet"))
+            .setOrder(0)
+            .get();
+        assertTrue(putTemplate.isAcknowledged());
+
+        IllegalArgumentException thrown = expectThrows(IllegalArgumentException.class, () -> createIndex(INDEX_NAME));
+        assertTrue(thrown.getMessage().contains(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey()));
+    }
+
+    public void testAllowsTemplateOverrideWhenRestrictIsFalse() {
+        internalCluster().startClusterManagerOnlyNode(nodeSettings(false));
+        internalCluster().startDataOnlyNode(nodeSettings(false));
+
+        AcknowledgedResponse putTemplate = client().admin()
+            .indices()
+            .preparePutTemplate("permissive-composite-template")
+            .setPatterns(Collections.singletonList(INDEX_NAME + "*"))
+            .setSettings(Settings.builder().put(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey(), "parquet"))
+            .setOrder(0)
+            .get();
+        assertTrue(putTemplate.isAcknowledged());
+
+        createIndex(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/RestrictCompositeDataFormatOverrideIT.java
+++ b/sandbox/plugins/composite-engine/src/internalClusterTest/java/org/opensearch/composite/RestrictCompositeDataFormatOverrideIT.java
@@ -23,10 +23,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
-import static org.opensearch.composite.CompositeDataFormatPlugin.CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING;
+import static org.opensearch.composite.CompositeDataFormatPlugin.CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING;
 
 /**
- * Integration tests for {@link CompositeDataFormatPlugin#CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING}
+ * Integration tests for {@link CompositeDataFormatPlugin#CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING}
  * enforcement. The setting is {@code Property.Final}, so each test starts nodes with its own
  * settings bag.
  */
@@ -44,8 +44,8 @@ public class RestrictCompositeDataFormatOverrideIT extends OpenSearchIntegTestCa
     private Settings nodeSettings(boolean restrict) {
         return Settings.builder()
             .put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true)
-            .put(CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey(), restrict)
-            .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), CLUSTER_DEFAULT_PRIMARY)
+            .put(CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey(), restrict)
+            .put(CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.getKey(), CLUSTER_DEFAULT_PRIMARY)
             .build();
     }
 
@@ -74,7 +74,7 @@ public class RestrictCompositeDataFormatOverrideIT extends OpenSearchIntegTestCa
         );
         assertTrue(
             "expected validation error to mention restrict setting but was [" + message + "]",
-            message.contains(CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey())
+            message.contains(CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey())
         );
     }
 

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -192,6 +192,9 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
         return Collections.singletonList(new IndexSettingProvider() {
             @Override
             public Settings getAdditionalIndexSettings(String indexName, boolean isDataStreamIndex, Settings templateAndRequestSettings) {
+                if (clusterService == null) {
+                    return Settings.EMPTY;
+                }
                 ClusterSettings clusterSettings = clusterService.getClusterSettings();
                 boolean restrict = clusterSettings.get(CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING);
                 String clusterPrimary = clusterSettings.get(CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT);

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -152,6 +152,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
+
     public CompositeDataFormatPlugin() {}
 
     @Override

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -61,6 +61,14 @@ import java.util.function.Supplier;
  *       formats (default empty)</li>
  * </ul>
  *
+ * <p>And three cluster settings:
+ * <ul>
+ *   <li>{@code cluster.composite.primary_data_format} — cluster-level default for the primary format</li>
+ *   <li>{@code cluster.composite.secondary_data_formats} — cluster-level default for secondary formats</li>
+ *   <li>{@code cluster.restrict.composite.dataformat} — when true, rejects index-level overrides that
+ *       differ from the cluster defaults</li>
+ * </ul>
+ *
  * <p>Format plugins (e.g., Parquet) extend this plugin by declaring
  * {@code extendedPlugins = ['composite-engine']} in their {@code build.gradle}
  * and implementing {@link DataFormatPlugin}.
@@ -134,7 +142,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
      * {@link #PRIMARY_DATA_FORMAT} and {@link #SECONDARY_DATA_FORMATS} settings.
      *
      * <p>This is scoped to the composite plugin so restriction can be toggled independently of the server-level
-     * {@code cluster.index.restrict.pluggable.dataformat} flag that governs the core
+     * {@code cluster.restrict.pluggable.dataformat} flag that governs the core
      * {@code index.pluggable.dataformat.*} settings.
      */
     public static final Setting<Boolean> CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING = Setting.boolSetting(
@@ -181,7 +189,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
      *
      * <p>Because both index settings are {@link Setting.Property#Final}, the effective value is
      * resolved once at index-creation time from the live {@link ClusterSettings} registry and
-     * frozen into the index metadata. Later updates to the {@code cluster.default.*} settings
+     * frozen into the index metadata. Later updates to the {@code cluster.composite.*} settings
      * affect only indices created after the update.
      *
      * <p>If {@link #createComponents} has not run yet (e.g. during early bootstrap), the provider

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -206,8 +206,8 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
                 }
                 ClusterSettings clusterSettings = clusterService.getClusterSettings();
 
-                List<String> skiplist = clusterSettings.get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST);
-                if (skiplist.stream().anyMatch(indexName::startsWith)) {
+                List<String> allowlist = clusterSettings.get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_ALLOWLIST);
+                if (allowlist.stream().anyMatch(indexName::startsWith)) {
                     return Settings.EMPTY;
                 }
 

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -31,6 +31,7 @@ import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
 import org.opensearch.index.engine.dataformat.StoreStrategy;
 import org.opensearch.index.shard.IndexSettingProvider;
 import org.opensearch.indices.IndexCreationException;
+import org.opensearch.indices.IndicesService;
 import org.opensearch.plugins.ExtensiblePlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
@@ -204,6 +205,12 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
                     return Settings.EMPTY;
                 }
                 ClusterSettings clusterSettings = clusterService.getClusterSettings();
+
+                List<String> skiplist = clusterSettings.get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST);
+                if (skiplist.stream().anyMatch(indexName::startsWith)) {
+                    return Settings.EMPTY;
+                }
+
                 boolean restrict = clusterSettings.get(CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING);
                 String clusterPrimary = clusterSettings.get(CLUSTER_PRIMARY_DATA_FORMAT);
                 List<String> clusterSecondary = clusterSettings.get(CLUSTER_SECONDARY_DATA_FORMATS);
@@ -215,7 +222,9 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
                         errors.add(
                             "index setting ["
                                 + PRIMARY_DATA_FORMAT.getKey()
-                                + "] is not allowed to be set as ["
+                                + "] cannot differ from cluster default ["
+                                + clusterPrimary
+                                + "] when ["
                                 + CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey()
                                 + "=true]"
                         );
@@ -225,7 +234,9 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
                         errors.add(
                             "index setting ["
                                 + SECONDARY_DATA_FORMATS.getKey()
-                                + "] is not allowed to be set as ["
+                                + "] cannot differ from cluster default "
+                                + clusterSecondary
+                                + " when ["
                                 + CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey()
                                 + "=true]"
                         );

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -10,9 +10,16 @@ package org.opensearch.composite;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.env.Environment;
+import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatDescriptor;
@@ -21,9 +28,16 @@ import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
 import org.opensearch.index.engine.dataformat.StoreStrategy;
+import org.opensearch.index.shard.IndexSettingProvider;
 import org.opensearch.plugins.ExtensiblePlugin;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.script.ScriptService;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+import org.opensearch.watcher.ResourceWatcherService;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -56,6 +70,13 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
     private static final Logger logger = LogManager.getLogger(CompositeDataFormatPlugin.class);
 
     /**
+     * Populated during {@link #createComponents} so the {@link IndexSettingProvider} registered by
+     * {@link #getAdditionalIndexSettingProviders()} can read live cluster-scope default settings
+     * at index-creation time.
+     */
+    private ClusterService clusterService;
+
+    /**
      * Index setting that designates the primary data format for an index.
      * The primary format is the authoritative format used for merge operations.
      */
@@ -79,11 +100,87 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
         Setting.Property.Final
     );
 
+    /**
+     * Cluster-level default for {@code index.composite.primary_data_format}.
+     * When the index setting is not explicitly provided, this cluster setting is used as the fallback.
+     */
+    public static final Setting<String> CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT = Setting.simpleString(
+        "cluster.default.index.composite.primary_data_format",
+        "lucene",
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Cluster-level default for {@code index.composite.secondary_data_formats}.
+     * When the index setting is not explicitly provided, this cluster setting is used as the fallback.
+     */
+    public static final Setting<List<String>> CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS = Setting.listSetting(
+        "cluster.default.index.composite.secondary_data_formats",
+        Collections.emptyList(),
+        s -> s,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
     public CompositeDataFormatPlugin() {}
 
     @Override
     public List<Setting<?>> getSettings() {
-        return List.of(PRIMARY_DATA_FORMAT, SECONDARY_DATA_FORMATS);
+        return List.of(
+            PRIMARY_DATA_FORMAT,
+            SECONDARY_DATA_FORMATS,
+            CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT,
+            CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS
+        );
+    }
+
+    @Override
+    public Collection<Object> createComponents(
+        Client client,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ResourceWatcherService resourceWatcherService,
+        ScriptService scriptService,
+        NamedXContentRegistry xContentRegistry,
+        Environment environment,
+        NodeEnvironment nodeEnvironment,
+        NamedWriteableRegistry namedWriteableRegistry,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<RepositoriesService> repositoriesServiceSupplier
+    ) {
+        this.clusterService = clusterService;
+        return Collections.emptyList();
+    }
+
+    /**
+     * Stamps the cluster-scope defaults for {@link #PRIMARY_DATA_FORMAT} and
+     * {@link #SECONDARY_DATA_FORMATS} into newly created indices when those index-level settings
+     * are not supplied by the request or a matching template.
+     *
+     * <p>Because both index settings are {@link Setting.Property#Final}, the effective value is
+     * resolved once at index-creation time from the live {@link ClusterSettings} registry and
+     * frozen into the index metadata. Later updates to the {@code cluster.default.*} settings
+     * affect only indices created after the update.
+     *
+     * <p>If {@link #createComponents} has not run yet (e.g. during early bootstrap), the provider
+     * contributes no settings so that index creation falls back to the per-setting defaults.
+     */
+    @Override
+    public Collection<IndexSettingProvider> getAdditionalIndexSettingProviders() {
+        return Collections.singletonList(new IndexSettingProvider() {
+            @Override
+            public Settings getAdditionalIndexSettings(String indexName, boolean isDataStreamIndex, Settings templateAndRequestSettings) {
+                ClusterSettings clusterSettings = clusterService.getClusterSettings();
+                Settings.Builder out = Settings.builder();
+                if (PRIMARY_DATA_FORMAT.exists(templateAndRequestSettings) == false) {
+                    out.put(PRIMARY_DATA_FORMAT.getKey(), clusterSettings.get(CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT));
+                }
+                if (SECONDARY_DATA_FORMATS.exists(templateAndRequestSettings) == false) {
+                    out.putList(SECONDARY_DATA_FORMATS.getKey(), clusterSettings.get(CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS));
+                }
+                return out.build();
+            }
+        });
     }
 
     @Override

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -94,7 +94,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
      */
     public static final Setting<String> PRIMARY_DATA_FORMAT = Setting.simpleString(
         "index.composite.primary_data_format",
-        "lucene",
+        "parquet",
         Setting.Property.IndexScope,
         Setting.Property.Final
     );
@@ -118,7 +118,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
      */
     public static final Setting<String> CLUSTER_PRIMARY_DATA_FORMAT = Setting.simpleString(
         "cluster.composite.primary_data_format",
-        "lucene",
+        "parquet",
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -108,7 +108,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
      * When the index setting is not explicitly provided, this cluster setting is used as the fallback.
      */
     public static final Setting<String> CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT = Setting.simpleString(
-        "cluster.default.index.composite.primary_data_format",
+        "cluster.composite.primary_data_format",
         "lucene",
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
@@ -119,7 +119,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
      * When the index setting is not explicitly provided, this cluster setting is used as the fallback.
      */
     public static final Setting<List<String>> CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS = Setting.listSetting(
-        "cluster.default.index.composite.secondary_data_formats",
+        "cluster.composite.secondary_data_formats",
         Collections.emptyList(),
         s -> s,
         Setting.Property.NodeScope,
@@ -138,7 +138,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
      * {@code index.pluggable.dataformat.*} settings.
      */
     public static final Setting<Boolean> CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING = Setting.boolSetting(
-        "cluster.index.restrict.composite.dataformat",
+        "cluster.restrict.composite.dataformat",
         false,
         Setting.Property.NodeScope,
         Setting.Property.Final

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -107,7 +107,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
      * Cluster-level default for {@code index.composite.primary_data_format}.
      * When the index setting is not explicitly provided, this cluster setting is used as the fallback.
      */
-    public static final Setting<String> CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT = Setting.simpleString(
+    public static final Setting<String> CLUSTER_PRIMARY_DATA_FORMAT = Setting.simpleString(
         "cluster.composite.primary_data_format",
         "lucene",
         Setting.Property.NodeScope,
@@ -118,7 +118,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
      * Cluster-level default for {@code index.composite.secondary_data_formats}.
      * When the index setting is not explicitly provided, this cluster setting is used as the fallback.
      */
-    public static final Setting<List<String>> CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS = Setting.listSetting(
+    public static final Setting<List<String>> CLUSTER_SECONDARY_DATA_FORMATS = Setting.listSetting(
         "cluster.composite.secondary_data_formats",
         Collections.emptyList(),
         s -> s,
@@ -128,8 +128,8 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
 
     /**
      * If enabled, this cluster setting enforces that indexes will be created with composite data-format settings
-     * matching the cluster-level defaults defined in {@link #CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT} and
-     * {@link #CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS} by rejecting any request that specifies an index-level value
+     * matching the cluster-level defaults defined in {@link #CLUSTER_PRIMARY_DATA_FORMAT} and
+     * {@link #CLUSTER_SECONDARY_DATA_FORMATS} by rejecting any request that specifies an index-level value
      * that does not match. If disabled, users may choose the composite data-format on a per-index basis using the
      * {@link #PRIMARY_DATA_FORMAT} and {@link #SECONDARY_DATA_FORMATS} settings.
      *
@@ -137,7 +137,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
      * {@code cluster.index.restrict.pluggable.dataformat} flag that governs the core
      * {@code index.pluggable.dataformat.*} settings.
      */
-    public static final Setting<Boolean> CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING = Setting.boolSetting(
+    public static final Setting<Boolean> CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING = Setting.boolSetting(
         "cluster.restrict.composite.dataformat",
         false,
         Setting.Property.NodeScope,
@@ -150,9 +150,9 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
         return List.of(
             PRIMARY_DATA_FORMAT,
             SECONDARY_DATA_FORMATS,
-            CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT,
-            CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS,
-            CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING
+            CLUSTER_PRIMARY_DATA_FORMAT,
+            CLUSTER_SECONDARY_DATA_FORMATS,
+            CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING
         );
     }
 
@@ -196,9 +196,9 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
                     return Settings.EMPTY;
                 }
                 ClusterSettings clusterSettings = clusterService.getClusterSettings();
-                boolean restrict = clusterSettings.get(CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING);
-                String clusterPrimary = clusterSettings.get(CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT);
-                List<String> clusterSecondary = clusterSettings.get(CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS);
+                boolean restrict = clusterSettings.get(CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING);
+                String clusterPrimary = clusterSettings.get(CLUSTER_PRIMARY_DATA_FORMAT);
+                List<String> clusterSecondary = clusterSettings.get(CLUSTER_SECONDARY_DATA_FORMATS);
 
                 if (restrict) {
                     List<String> errors = new ArrayList<>();
@@ -208,7 +208,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
                             "index setting ["
                                 + PRIMARY_DATA_FORMAT.getKey()
                                 + "] is not allowed to be set as ["
-                                + CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey()
+                                + CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey()
                                 + "=true]"
                         );
                     }
@@ -218,7 +218,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
                             "index setting ["
                                 + SECONDARY_DATA_FORMATS.getKey()
                                 + "] is not allowed to be set as ["
-                                + CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey()
+                                + CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey()
                                 + "=true]"
                         );
                     }

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -150,7 +150,7 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
         "cluster.restrict.composite.dataformat",
         false,
         Setting.Property.NodeScope,
-        Setting.Property.Final
+        Setting.Property.Dynamic
     );
     public CompositeDataFormatPlugin() {}
 

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeDataFormatPlugin.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.ValidationException;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
@@ -29,6 +30,7 @@ import org.opensearch.index.engine.dataformat.IndexingEngineConfig;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
 import org.opensearch.index.engine.dataformat.StoreStrategy;
 import org.opensearch.index.shard.IndexSettingProvider;
+import org.opensearch.indices.IndexCreationException;
 import org.opensearch.plugins.ExtensiblePlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
@@ -37,6 +39,7 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 import org.opensearch.watcher.ResourceWatcherService;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -122,6 +125,24 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
+
+    /**
+     * If enabled, this cluster setting enforces that indexes will be created with composite data-format settings
+     * matching the cluster-level defaults defined in {@link #CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT} and
+     * {@link #CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS} by rejecting any request that specifies an index-level value
+     * that does not match. If disabled, users may choose the composite data-format on a per-index basis using the
+     * {@link #PRIMARY_DATA_FORMAT} and {@link #SECONDARY_DATA_FORMATS} settings.
+     *
+     * <p>This is scoped to the composite plugin so restriction can be toggled independently of the server-level
+     * {@code cluster.index.restrict.pluggable.dataformat} flag that governs the core
+     * {@code index.pluggable.dataformat.*} settings.
+     */
+    public static final Setting<Boolean> CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING = Setting.boolSetting(
+        "cluster.index.restrict.composite.dataformat",
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Final
+    );
     public CompositeDataFormatPlugin() {}
 
     @Override
@@ -130,7 +151,8 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
             PRIMARY_DATA_FORMAT,
             SECONDARY_DATA_FORMATS,
             CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT,
-            CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS
+            CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS,
+            CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING
         );
     }
 
@@ -171,12 +193,45 @@ public class CompositeDataFormatPlugin extends Plugin implements DataFormatPlugi
             @Override
             public Settings getAdditionalIndexSettings(String indexName, boolean isDataStreamIndex, Settings templateAndRequestSettings) {
                 ClusterSettings clusterSettings = clusterService.getClusterSettings();
+                boolean restrict = clusterSettings.get(CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING);
+                String clusterPrimary = clusterSettings.get(CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT);
+                List<String> clusterSecondary = clusterSettings.get(CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS);
+
+                if (restrict) {
+                    List<String> errors = new ArrayList<>();
+                    if (PRIMARY_DATA_FORMAT.exists(templateAndRequestSettings)
+                        && PRIMARY_DATA_FORMAT.get(templateAndRequestSettings).equals(clusterPrimary) == false) {
+                        errors.add(
+                            "index setting ["
+                                + PRIMARY_DATA_FORMAT.getKey()
+                                + "] is not allowed to be set as ["
+                                + CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey()
+                                + "=true]"
+                        );
+                    }
+                    if (SECONDARY_DATA_FORMATS.exists(templateAndRequestSettings)
+                        && SECONDARY_DATA_FORMATS.get(templateAndRequestSettings).equals(clusterSecondary) == false) {
+                        errors.add(
+                            "index setting ["
+                                + SECONDARY_DATA_FORMATS.getKey()
+                                + "] is not allowed to be set as ["
+                                + CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING.getKey()
+                                + "=true]"
+                        );
+                    }
+                    if (errors.isEmpty() == false) {
+                        ValidationException validationException = new ValidationException();
+                        validationException.addValidationErrors(errors);
+                        throw new IndexCreationException(indexName, validationException);
+                    }
+                }
+
                 Settings.Builder out = Settings.builder();
                 if (PRIMARY_DATA_FORMAT.exists(templateAndRequestSettings) == false) {
-                    out.put(PRIMARY_DATA_FORMAT.getKey(), clusterSettings.get(CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT));
+                    out.put(PRIMARY_DATA_FORMAT.getKey(), clusterPrimary);
                 }
                 if (SECONDARY_DATA_FORMATS.exists(templateAndRequestSettings) == false) {
-                    out.putList(SECONDARY_DATA_FORMATS.getKey(), clusterSettings.get(CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS));
+                    out.putList(SECONDARY_DATA_FORMATS.getKey(), clusterSecondary);
                 }
                 return out.build();
             }

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
@@ -184,7 +184,8 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
             Settings.EMPTY,
             Set.of(
                 CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT,
-                CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS
+                CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS,
+                CompositeDataFormatPlugin.CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING
             )
         );
         ClusterService clusterService = mock(ClusterService.class);
@@ -343,7 +344,8 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
             clusterBag,
             Set.of(
                 CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT,
-                CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS
+                CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS,
+                CompositeDataFormatPlugin.CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING
             )
         );
         ClusterService clusterService = mock(ClusterService.class);

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
@@ -185,7 +185,7 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
                 CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT,
                 CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS,
                 CompositeDataFormatPlugin.CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING,
-                IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST
+                IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_ALLOWLIST
             )
         );
         ClusterService clusterService = mock(ClusterService.class);
@@ -346,7 +346,7 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
                 CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT,
                 CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS,
                 CompositeDataFormatPlugin.CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING,
-                IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST
+                IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_ALLOWLIST
             )
         );
         ClusterService clusterService = mock(ClusterService.class);

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
@@ -44,9 +44,9 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
         assertEquals(5, settings.size());
         assertTrue(settings.contains(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT));
         assertTrue(settings.contains(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS));
-        assertTrue(settings.contains(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT));
-        assertTrue(settings.contains(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS));
-        assertTrue(settings.contains(CompositeDataFormatPlugin.CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING));
+        assertTrue(settings.contains(CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT));
+        assertTrue(settings.contains(CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS));
+        assertTrue(settings.contains(CompositeDataFormatPlugin.CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING));
     }
 
     // ---- Setting defaults and value parsing ----
@@ -72,25 +72,23 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
     }
 
     public void testClusterDefaultPrimaryDataFormatDefaultsToLucene() {
-        assertEquals("lucene", CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.get(Settings.EMPTY));
+        assertEquals("lucene", CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.get(Settings.EMPTY));
     }
 
     public void testClusterDefaultPrimaryDataFormatReadsExplicitValue() {
-        Settings settings = Settings.builder()
-            .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
-            .build();
-        assertEquals("parquet", CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.get(settings));
+        Settings settings = Settings.builder().put(CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.getKey(), "parquet").build();
+        assertEquals("parquet", CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.get(settings));
     }
 
     public void testClusterDefaultSecondaryDataFormatsDefaultsToEmpty() {
-        assertTrue(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.get(Settings.EMPTY).isEmpty());
+        assertTrue(CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS.get(Settings.EMPTY).isEmpty());
     }
 
     public void testClusterDefaultSecondaryDataFormatsReadsExplicitList() {
         Settings settings = Settings.builder()
-            .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "parquet", "arrow")
+            .putList(CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS.getKey(), "parquet", "arrow")
             .build();
-        assertEquals(List.of("parquet", "arrow"), CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.get(settings));
+        assertEquals(List.of("parquet", "arrow"), CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS.get(settings));
     }
 
     // ---- IndexSettingProvider behavior ----
@@ -107,8 +105,8 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
     public void testIndexSettingProviderStampsBothClusterDefaultsWhenIndexLevelAbsent() {
         CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
         Settings clusterBag = Settings.builder()
-            .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
-            .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "arrow")
+            .put(CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+            .putList(CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS.getKey(), "arrow")
             .build();
         injectClusterService(plugin, clusterBag);
 
@@ -122,8 +120,8 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
     public void testIndexSettingProviderSkipsPrimaryWhenAlreadySet() {
         CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
         Settings clusterBag = Settings.builder()
-            .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
-            .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "arrow")
+            .put(CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+            .putList(CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS.getKey(), "arrow")
             .build();
         injectClusterService(plugin, clusterBag);
 
@@ -139,8 +137,8 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
     public void testIndexSettingProviderSkipsSecondaryWhenAlreadySet() {
         CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
         Settings clusterBag = Settings.builder()
-            .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
-            .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "arrow")
+            .put(CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+            .putList(CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS.getKey(), "arrow")
             .build();
         injectClusterService(plugin, clusterBag);
 
@@ -158,8 +156,8 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
     public void testIndexSettingProviderSkipsBothWhenBothAlreadySet() {
         CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
         Settings clusterBag = Settings.builder()
-            .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
-            .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "arrow")
+            .put(CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+            .putList(CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS.getKey(), "arrow")
             .build();
         injectClusterService(plugin, clusterBag);
 
@@ -183,9 +181,9 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
         ClusterSettings clusterSettings = new ClusterSettings(
             Settings.EMPTY,
             Set.of(
-                CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT,
-                CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS,
-                CompositeDataFormatPlugin.CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING
+                CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT,
+                CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS,
+                CompositeDataFormatPlugin.CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING
             )
         );
         ClusterService clusterService = mock(ClusterService.class);
@@ -201,8 +199,8 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
         // Simulate a PUT /_cluster/settings updating the dynamic cluster defaults.
         clusterSettings.applySettings(
             Settings.builder()
-                .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
-                .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "arrow")
+                .put(CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+                .putList(CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS.getKey(), "arrow")
                 .build()
         );
 
@@ -343,9 +341,9 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
         ClusterSettings clusterSettings = new ClusterSettings(
             clusterBag,
             Set.of(
-                CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT,
-                CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS,
-                CompositeDataFormatPlugin.CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING
+                CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT,
+                CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS,
+                CompositeDataFormatPlugin.CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING
             )
         );
         ClusterService clusterService = mock(ClusterService.class);

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
@@ -26,8 +26,8 @@ import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
@@ -22,7 +22,6 @@ import org.opensearch.index.engine.dataformat.StoreStrategy;
 import org.opensearch.index.shard.IndexSettingProvider;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -352,12 +351,6 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
     }
 
     private static void setClusterServiceField(CompositeDataFormatPlugin plugin, ClusterService clusterService) {
-        try {
-            Field f = CompositeDataFormatPlugin.class.getDeclaredField("clusterService");
-            f.setAccessible(true);
-            f.set(plugin, clusterService);
-        } catch (ReflectiveOperationException e) {
-            throw new AssertionError("failed to inject clusterService into CompositeDataFormatPlugin", e);
-        }
+        plugin.createComponents(null, clusterService, null, null, null, null, null, null, null, null, null);
     }
 }

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
@@ -20,6 +20,7 @@ import org.opensearch.index.engine.dataformat.DataFormatDescriptor;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.engine.dataformat.StoreStrategy;
 import org.opensearch.index.shard.IndexSettingProvider;
+import org.opensearch.indices.IndicesService;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.Collection;
@@ -183,7 +184,8 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
             Set.of(
                 CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT,
                 CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS,
-                CompositeDataFormatPlugin.CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING
+                CompositeDataFormatPlugin.CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING,
+                IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST
             )
         );
         ClusterService clusterService = mock(ClusterService.class);
@@ -343,7 +345,8 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
             Set.of(
                 CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT,
                 CompositeDataFormatPlugin.CLUSTER_SECONDARY_DATA_FORMATS,
-                CompositeDataFormatPlugin.CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING
+                CompositeDataFormatPlugin.CLUSTER_RESTRICT_COMPOSITE_DATAFORMAT_SETTING,
+                IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST
             )
         );
         ClusterService clusterService = mock(ClusterService.class);

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
@@ -41,11 +41,12 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsAllFourSettings() {
         CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
         List<Setting<?>> settings = plugin.getSettings();
-        assertEquals(4, settings.size());
+        assertEquals(5, settings.size());
         assertTrue(settings.contains(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT));
         assertTrue(settings.contains(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS));
         assertTrue(settings.contains(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT));
         assertTrue(settings.contains(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS));
+        assertTrue(settings.contains(CompositeDataFormatPlugin.CLUSTER_INDEX_RESTRICT_COMPOSITE_DATAFORMAT_SETTING));
     }
 
     // ---- Setting defaults and value parsing ----

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
@@ -52,8 +52,8 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
 
     // ---- Setting defaults and value parsing ----
 
-    public void testPrimaryDataFormatDefaultsToLucene() {
-        assertEquals("lucene", CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.get(Settings.EMPTY));
+    public void testPrimaryDataFormatDefaultsToParquet() {
+        assertEquals("parquet", CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.get(Settings.EMPTY));
     }
 
     public void testPrimaryDataFormatReadsExplicitValue() {
@@ -72,8 +72,8 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
         assertEquals(List.of("parquet", "arrow"), CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.get(settings));
     }
 
-    public void testClusterDefaultPrimaryDataFormatDefaultsToLucene() {
-        assertEquals("lucene", CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.get(Settings.EMPTY));
+    public void testClusterDefaultPrimaryDataFormatDefaultsToParquet() {
+        assertEquals("parquet", CompositeDataFormatPlugin.CLUSTER_PRIMARY_DATA_FORMAT.get(Settings.EMPTY));
     }
 
     public void testClusterDefaultPrimaryDataFormatReadsExplicitValue() {
@@ -195,7 +195,7 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
         IndexSettingProvider provider = singleProvider(plugin);
 
         Settings first = provider.getAdditionalIndexSettings("idx-1", false, Settings.EMPTY);
-        assertEquals("lucene", CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.get(first));
+        assertEquals("parquet", CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.get(first));
         assertTrue(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.get(first).isEmpty());
 
         // Simulate a PUT /_cluster/settings updating the dynamic cluster defaults.

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
@@ -127,9 +127,7 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
             .build();
         injectClusterService(plugin, clusterBag);
 
-        Settings requestOrTemplate = Settings.builder()
-            .put(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey(), "lucene")
-            .build();
+        Settings requestOrTemplate = Settings.builder().put(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey(), "lucene").build();
 
         IndexSettingProvider provider = singleProvider(plugin);
         Settings out = provider.getAdditionalIndexSettings("some-index", false, requestOrTemplate);

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/CompositeDataFormatPluginTests.java
@@ -10,6 +10,8 @@ package org.opensearch.composite;
 
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.IndexSettings;
@@ -17,11 +19,15 @@ import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatDescriptor;
 import org.opensearch.index.engine.dataformat.DataFormatRegistry;
 import org.opensearch.index.engine.dataformat.StoreStrategy;
+import org.opensearch.index.shard.IndexSettingProvider;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.lang.reflect.Field;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.Set;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -31,23 +37,182 @@ import static org.mockito.Mockito.when;
  */
 public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
 
-    public void testGetSettingsReturnsBothSettings() {
+    // ---- Setting registration ----
+
+    public void testGetSettingsReturnsAllFourSettings() {
         CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
         List<Setting<?>> settings = plugin.getSettings();
-        assertEquals(2, settings.size());
+        assertEquals(4, settings.size());
         assertTrue(settings.contains(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT));
         assertTrue(settings.contains(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS));
+        assertTrue(settings.contains(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT));
+        assertTrue(settings.contains(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS));
     }
 
+    // ---- Setting defaults and value parsing ----
+
     public void testPrimaryDataFormatDefaultsToLucene() {
-        Settings settings = Settings.builder().build();
-        assertEquals("lucene", CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.get(settings));
+        assertEquals("lucene", CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.get(Settings.EMPTY));
+    }
+
+    public void testPrimaryDataFormatReadsExplicitValue() {
+        Settings settings = Settings.builder().put(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey(), "parquet").build();
+        assertEquals("parquet", CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.get(settings));
     }
 
     public void testSecondaryDataFormatsDefaultsToEmpty() {
-        Settings settings = Settings.builder().build();
-        assertTrue(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.get(settings).isEmpty());
+        assertTrue(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.get(Settings.EMPTY).isEmpty());
     }
+
+    public void testSecondaryDataFormatsReadsExplicitList() {
+        Settings settings = Settings.builder()
+            .putList(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.getKey(), "parquet", "arrow")
+            .build();
+        assertEquals(List.of("parquet", "arrow"), CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.get(settings));
+    }
+
+    public void testClusterDefaultPrimaryDataFormatDefaultsToLucene() {
+        assertEquals("lucene", CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.get(Settings.EMPTY));
+    }
+
+    public void testClusterDefaultPrimaryDataFormatReadsExplicitValue() {
+        Settings settings = Settings.builder()
+            .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+            .build();
+        assertEquals("parquet", CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.get(settings));
+    }
+
+    public void testClusterDefaultSecondaryDataFormatsDefaultsToEmpty() {
+        assertTrue(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.get(Settings.EMPTY).isEmpty());
+    }
+
+    public void testClusterDefaultSecondaryDataFormatsReadsExplicitList() {
+        Settings settings = Settings.builder()
+            .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "parquet", "arrow")
+            .build();
+        assertEquals(List.of("parquet", "arrow"), CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.get(settings));
+    }
+
+    // ---- IndexSettingProvider behavior ----
+
+    public void testIndexSettingProviderReturnsEmptyBeforeCreateComponents() {
+        CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
+        IndexSettingProvider provider = singleProvider(plugin);
+        // createComponents has not run, so clusterService is null and the provider must
+        // contribute nothing rather than NPE — allowing fallback to per-setting defaults.
+        Settings out = provider.getAdditionalIndexSettings("some-index", false, Settings.EMPTY);
+        assertEquals(Settings.EMPTY, out);
+    }
+
+    public void testIndexSettingProviderStampsBothClusterDefaultsWhenIndexLevelAbsent() {
+        CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
+        Settings clusterBag = Settings.builder()
+            .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+            .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "arrow")
+            .build();
+        injectClusterService(plugin, clusterBag);
+
+        IndexSettingProvider provider = singleProvider(plugin);
+        Settings out = provider.getAdditionalIndexSettings("some-index", false, Settings.EMPTY);
+
+        assertEquals("parquet", CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.get(out));
+        assertEquals(List.of("arrow"), CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.get(out));
+    }
+
+    public void testIndexSettingProviderSkipsPrimaryWhenAlreadySet() {
+        CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
+        Settings clusterBag = Settings.builder()
+            .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+            .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "arrow")
+            .build();
+        injectClusterService(plugin, clusterBag);
+
+        Settings requestOrTemplate = Settings.builder()
+            .put(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey(), "lucene")
+            .build();
+
+        IndexSettingProvider provider = singleProvider(plugin);
+        Settings out = provider.getAdditionalIndexSettings("some-index", false, requestOrTemplate);
+
+        assertFalse(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.exists(out));
+        assertEquals(List.of("arrow"), CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.get(out));
+    }
+
+    public void testIndexSettingProviderSkipsSecondaryWhenAlreadySet() {
+        CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
+        Settings clusterBag = Settings.builder()
+            .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+            .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "arrow")
+            .build();
+        injectClusterService(plugin, clusterBag);
+
+        Settings requestOrTemplate = Settings.builder()
+            .putList(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.getKey(), "parquet")
+            .build();
+
+        IndexSettingProvider provider = singleProvider(plugin);
+        Settings out = provider.getAdditionalIndexSettings("some-index", false, requestOrTemplate);
+
+        assertEquals("parquet", CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.get(out));
+        assertFalse(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.exists(out));
+    }
+
+    public void testIndexSettingProviderSkipsBothWhenBothAlreadySet() {
+        CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
+        Settings clusterBag = Settings.builder()
+            .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+            .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "arrow")
+            .build();
+        injectClusterService(plugin, clusterBag);
+
+        Settings requestOrTemplate = Settings.builder()
+            .put(CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.getKey(), "lucene")
+            .putList(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.getKey(), "parquet")
+            .build();
+
+        IndexSettingProvider provider = singleProvider(plugin);
+        Settings out = provider.getAdditionalIndexSettings("some-index", false, requestOrTemplate);
+
+        // Provider contributes nothing when both settings are already explicit.
+        assertEquals(Settings.EMPTY, out);
+    }
+
+    public void testIndexSettingProviderReadsLiveClusterSettingsOnEachCall() {
+        CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
+
+        // Seed cluster settings with empty defaults, then flip them and verify the provider
+        // picks up the new values on the next call without any re-init of the plugin.
+        ClusterSettings clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            Set.of(
+                CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT,
+                CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS
+            )
+        );
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        setClusterServiceField(plugin, clusterService);
+
+        IndexSettingProvider provider = singleProvider(plugin);
+
+        Settings first = provider.getAdditionalIndexSettings("idx-1", false, Settings.EMPTY);
+        assertEquals("lucene", CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.get(first));
+        assertTrue(CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.get(first).isEmpty());
+
+        // Simulate a PUT /_cluster/settings updating the dynamic cluster defaults.
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put(CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT.getKey(), "parquet")
+                .putList(CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS.getKey(), "arrow")
+                .build()
+        );
+
+        Settings second = provider.getAdditionalIndexSettings("idx-2", false, Settings.EMPTY);
+        assertEquals("parquet", CompositeDataFormatPlugin.PRIMARY_DATA_FORMAT.get(second));
+        assertEquals(List.of("arrow"), CompositeDataFormatPlugin.SECONDARY_DATA_FORMATS.get(second));
+    }
+
+    // ---- Existing getFormatDescriptors coverage ----
 
     public void testGetFormatDescriptorsDelegatestoPlugins() {
         CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
@@ -94,7 +259,6 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
         DataFormatRegistry registry = mock(DataFormatRegistry.class);
 
         IndexSettings indexSettings = buildIndexSettings(Settings.builder().put("index.composite.primary_data_format", "parquet").build());
-        // Registry resolves the format but the composite pipeline finds no plugin → empty map.
         DataFormat parquetFormat = CompositeTestHelper.stubFormat("parquet", 2, java.util.Set.of());
         when(registry.format("parquet")).thenReturn(parquetFormat);
         when(registry.getStoreStrategies(indexSettings, parquetFormat)).thenReturn(Map.of());
@@ -148,7 +312,7 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
         CompositeDataFormatPlugin plugin = new CompositeDataFormatPlugin();
         DataFormatRegistry registry = mock(DataFormatRegistry.class);
 
-        IndexSettings indexSettings = buildIndexSettings(Settings.EMPTY); // defaults: primary=lucene, secondary=[]
+        IndexSettings indexSettings = buildIndexSettings(Settings.EMPTY);
         DataFormat luceneFormat = CompositeTestHelper.stubFormat("lucene", 1, java.util.Set.of());
         when(registry.format("lucene")).thenReturn(luceneFormat);
         when(registry.getStoreStrategies(indexSettings, luceneFormat)).thenReturn(Map.of());
@@ -156,6 +320,8 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
         Map<DataFormat, StoreStrategy> result = plugin.getStoreStrategies(indexSettings, registry);
         assertTrue("Should return empty when lucene sub-plugin not found", result.isEmpty());
     }
+
+    // ---- Helpers ----
 
     private static IndexSettings buildIndexSettings(Settings extra) {
         Settings settings = Settings.builder()
@@ -166,5 +332,34 @@ public class CompositeDataFormatPluginTests extends OpenSearchTestCase {
             .build();
         IndexMetadata indexMetadata = IndexMetadata.builder("test-index").settings(settings).build();
         return new IndexSettings(indexMetadata, Settings.EMPTY);
+    }
+
+    private static IndexSettingProvider singleProvider(CompositeDataFormatPlugin plugin) {
+        Collection<IndexSettingProvider> providers = plugin.getAdditionalIndexSettingProviders();
+        assertEquals(1, providers.size());
+        return providers.iterator().next();
+    }
+
+    private static void injectClusterService(CompositeDataFormatPlugin plugin, Settings clusterBag) {
+        ClusterSettings clusterSettings = new ClusterSettings(
+            clusterBag,
+            Set.of(
+                CompositeDataFormatPlugin.CLUSTER_DEFAULT_PRIMARY_DATA_FORMAT,
+                CompositeDataFormatPlugin.CLUSTER_DEFAULT_SECONDARY_DATA_FORMATS
+            )
+        );
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        setClusterServiceField(plugin, clusterService);
+    }
+
+    private static void setClusterServiceField(CompositeDataFormatPlugin plugin, ClusterService clusterService) {
+        try {
+            Field f = CompositeDataFormatPlugin.class.getDeclaredField("clusterService");
+            f.setAccessible(true);
+            f.set(plugin, clusterService);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("failed to inject clusterService into CompositeDataFormatPlugin", e);
+        }
     }
 }

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterDefaultPluggableDataFormatIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterDefaultPluggableDataFormatIT.java
@@ -14,13 +14,24 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
+import org.opensearch.index.engine.dataformat.stub.MockParquetDataFormatPlugin;
+import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.Collection;
+import java.util.List;
 
 import static org.opensearch.indices.IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING;
 import static org.opensearch.indices.IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1)
 public class ClusterDefaultPluggableDataFormatIT extends OpenSearchIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(MockCommitterEnginePlugin.class, MockParquetDataFormatPlugin.class);
+    }
 
     @Override
     protected Settings featureFlagSettings() {

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterDefaultPluggableDataFormatIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterDefaultPluggableDataFormatIT.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.metadata;
+
+import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.opensearch.common.settings.FeatureFlagSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import static org.opensearch.indices.IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING;
+import static org.opensearch.indices.IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING;
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1)
+public class ClusterDefaultPluggableDataFormatIT extends OpenSearchIntegTestCase {
+
+    @Override
+    protected Settings featureFlagSettings() {
+        Settings.Builder builder = Settings.builder();
+        for (Setting<?> builtInFlag : FeatureFlagSettings.BUILT_IN_FEATURE_FLAGS) {
+            builder.put(builtInFlag.getKey(), builtInFlag.getDefaultRaw(Settings.EMPTY));
+        }
+        builder.put(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG, true);
+        return builder.build();
+    }
+
+    public void testClusterDefaultStampedIntoNewIndexWhenNoOverride() {
+        String indexName = "test-pluggable-cluster-default";
+
+        setClusterDefaults(true, "parquet");
+        createIndex(indexName);
+        ensureGreen(indexName);
+
+        Settings effective = getIndexSettings(indexName);
+        assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(effective));
+        assertEquals("parquet", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(effective));
+    }
+
+    public void testExplicitIndexSettingOverridesClusterDefault() {
+        String indexName = "test-pluggable-request-override";
+
+        setClusterDefaults(true, "parquet");
+        createIndex(
+            indexName,
+            Settings.builder()
+                .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false)
+                .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "lucene")
+                .build()
+        );
+        ensureGreen(indexName);
+
+        Settings effective = getIndexSettings(indexName);
+        assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(effective));
+        assertEquals("lucene", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(effective));
+    }
+
+    public void testClusterDefaultUpdateAppliesToNewIndicesOnly() {
+        String indexBefore = "test-pluggable-before-update";
+        String indexAfter = "test-pluggable-after-update";
+
+        setClusterDefaults(true, "parquet");
+        createIndex(indexBefore);
+        ensureGreen(indexBefore);
+
+        Settings before = getIndexSettings(indexBefore);
+        assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(before));
+        assertEquals("parquet", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(before));
+
+        setClusterDefaults(false, "arrow");
+        createIndex(indexAfter);
+        ensureGreen(indexAfter);
+
+        Settings after = getIndexSettings(indexAfter);
+        assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(after));
+        assertEquals("arrow", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(after));
+
+        Settings beforeReread = getIndexSettings(indexBefore);
+        assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(beforeReread));
+        assertEquals("parquet", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(beforeReread));
+    }
+
+    private void setClusterDefaults(boolean enabled, String value) {
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(
+                Settings.builder()
+                    .put(CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), enabled)
+                    .put(CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), value)
+            )
+            .get();
+    }
+
+    private Settings getIndexSettings(String indexName) {
+        GetSettingsResponse resp = client().admin().indices().prepareGetSettings(indexName).get();
+        Settings s = resp.getIndexToSettings().get(indexName);
+        assertNotNull(s);
+        return s;
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterDefaultPluggableDataFormatIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterDefaultPluggableDataFormatIT.java
@@ -16,6 +16,7 @@ import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.stub.MockCommitterEnginePlugin;
 import org.opensearch.index.engine.dataformat.stub.MockParquetDataFormatPlugin;
+import org.opensearch.indices.IndicesService;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
@@ -96,6 +97,38 @@ public class ClusterDefaultPluggableDataFormatIT extends OpenSearchIntegTestCase
         Settings beforeReread = getIndexSettings(indexBefore);
         assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(beforeReread));
         assertEquals("parquet", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(beforeReread));
+    }
+
+    public void testSkiplistBypassesClusterDefaultStamping() {
+        String skippedIndex = ".kibana-01";
+        String normalIndex = "test-pluggable-normal";
+
+        setClusterDefaults(true, "parquet");
+
+        // Add .kibana prefix to skiplist
+        client().admin()
+            .cluster()
+            .prepareUpdateSettings()
+            .setTransientSettings(
+                Settings.builder().putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST.getKey(), ".kibana")
+            )
+            .get();
+
+        createIndex(skippedIndex);
+        ensureGreen(skippedIndex);
+
+        createIndex(normalIndex);
+        ensureGreen(normalIndex);
+
+        // Skipped index should NOT have cluster defaults stamped
+        Settings skippedSettings = getIndexSettings(skippedIndex);
+        assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(skippedSettings));
+        assertEquals("", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(skippedSettings));
+
+        // Normal index should have cluster defaults stamped
+        Settings normalSettings = getIndexSettings(normalIndex);
+        assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(normalSettings));
+        assertEquals("parquet", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(normalSettings));
     }
 
     private void setClusterDefaults(boolean enabled, String value) {

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterDefaultPluggableDataFormatIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterDefaultPluggableDataFormatIT.java
@@ -35,6 +35,14 @@ public class ClusterDefaultPluggableDataFormatIT extends OpenSearchIntegTestCase
     }
 
     @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_ALLOWLIST.getKey(), ".kibana")
+            .build();
+    }
+
+    @Override
     protected Settings featureFlagSettings() {
         Settings.Builder builder = Settings.builder();
         for (Setting<?> builtInFlag : FeatureFlagSettings.BUILT_IN_FEATURE_FLAGS) {
@@ -99,20 +107,11 @@ public class ClusterDefaultPluggableDataFormatIT extends OpenSearchIntegTestCase
         assertEquals("parquet", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(beforeReread));
     }
 
-    public void testSkiplistBypassesClusterDefaultStamping() {
+    public void testAllowlistBypassesClusterDefaultStamping() {
         String skippedIndex = ".kibana-01";
         String normalIndex = "test-pluggable-normal";
 
         setClusterDefaults(true, "parquet");
-
-        // Add .kibana prefix to skiplist
-        client().admin()
-            .cluster()
-            .prepareUpdateSettings()
-            .setTransientSettings(
-                Settings.builder().putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST.getKey(), ".kibana")
-            )
-            .get();
 
         createIndex(skippedIndex);
         ensureGreen(skippedIndex);

--- a/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterDefaultPluggableDataFormatIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/cluster/metadata/ClusterDefaultPluggableDataFormatIT.java
@@ -22,8 +22,8 @@ import org.opensearch.test.OpenSearchIntegTestCase;
 import java.util.Collection;
 import java.util.List;
 
-import static org.opensearch.indices.IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING;
-import static org.opensearch.indices.IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING;
+import static org.opensearch.indices.IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING;
+import static org.opensearch.indices.IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING;
 
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 1)
 public class ClusterDefaultPluggableDataFormatIT extends OpenSearchIntegTestCase {
@@ -104,8 +104,8 @@ public class ClusterDefaultPluggableDataFormatIT extends OpenSearchIntegTestCase
             .prepareUpdateSettings()
             .setTransientSettings(
                 Settings.builder()
-                    .put(CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), enabled)
-                    .put(CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), value)
+                    .put(CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), enabled)
+                    .put(CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), value)
             )
             .get();
     }

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1436,14 +1436,14 @@ public class MetadataCreateIndexService {
         if (IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.exists(current) == false) {
             settingsBuilder.put(
                 IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(),
-                clusterSettings.get(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
+                clusterSettings.get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
             );
         }
 
         if (IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.exists(current) == false) {
             settingsBuilder.put(
                 IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(),
-                clusterSettings.get(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING)
+                clusterSettings.get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING)
             );
         }
     }
@@ -1848,7 +1848,7 @@ public class MetadataCreateIndexService {
 
         if (requestSettings.hasValue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey())
             && IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(requestSettings)
-                .equals(clusterSettings.get(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)) == false) {
+                .equals(clusterSettings.get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)) == false) {
             return Optional.of(
                 "index setting ["
                     + IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey()
@@ -1860,7 +1860,7 @@ public class MetadataCreateIndexService {
 
         if (requestSettings.hasValue(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey())
             && IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(requestSettings)
-                .equals(clusterSettings.get(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING)) == false) {
+                .equals(clusterSettings.get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING)) == false) {
             return Optional.of(
                 "index setting ["
                     + IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey()

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1426,7 +1426,7 @@ public class MetadataCreateIndexService {
     /**
      * Stamps the cluster-scope defaults for the pluggable data-format index settings into the
      * index metadata at creation time when no explicit override is supplied. No-op when the
-     * pluggable data-format feature flag is disabled or the index matches the skiplist.
+     * pluggable data-format feature flag is disabled or the index matches the allowlist.
      */
     public static void updatePluggableDataFormatSettings(
         Settings.Builder settingsBuilder,
@@ -1437,7 +1437,7 @@ public class MetadataCreateIndexService {
             return;
         }
 
-        if (isSkippedForPluggableDataFormat(indexName, clusterSettings)) {
+        if (isAllowedForPluggableDataFormat(indexName, clusterSettings)) {
             return;
         }
 
@@ -1860,7 +1860,7 @@ public class MetadataCreateIndexService {
         if (clusterSettings.get(IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING) == false) {
             return Optional.empty();
         }
-        if (isSkippedForPluggableDataFormat(indexName, clusterSettings)) {
+        if (isAllowedForPluggableDataFormat(indexName, clusterSettings)) {
             return Optional.empty();
         }
 
@@ -1896,12 +1896,12 @@ public class MetadataCreateIndexService {
 
     /**
      * Returns {@code true} if the given index name matches any prefix in the
-     * {@code cluster.pluggable.dataformat.restrict.skiplist} setting, meaning it should bypass
+     * {@code cluster.pluggable.dataformat.restrict.allowlist} setting, meaning it should bypass
      * pluggable data-format default-stamping and restrict validation.
      */
-    private static boolean isSkippedForPluggableDataFormat(String indexName, ClusterSettings clusterSettings) {
-        List<String> skiplist = clusterSettings.get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST);
-        return skiplist.stream().anyMatch(indexName::startsWith);
+    private static boolean isAllowedForPluggableDataFormat(String indexName, ClusterSettings clusterSettings) {
+        List<String> allowlist = clusterSettings.get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_ALLOWLIST);
+        return allowlist.stream().anyMatch(indexName::startsWith);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1218,7 +1218,7 @@ public class MetadataCreateIndexService {
 
         updateReplicationStrategy(indexSettingsBuilder, request.settings(), settings, combinedTemplateSettings, clusterSettings);
         updateRemoteStoreSettings(indexSettingsBuilder, currentState, clusterSettings, settings, request.index());
-        updatePluggableDataFormatSettings(indexSettingsBuilder, clusterSettings);
+        updatePluggableDataFormatSettings(indexSettingsBuilder, clusterSettings, request.index());
 
         if (sourceMetadata != null) {
             assert request.resizeType() != null;
@@ -1235,7 +1235,9 @@ public class MetadataCreateIndexService {
 
         List<String> validationErrors = new ArrayList<>();
         validateIndexReplicationTypeSettings(indexSettingsBuilder.build(), clusterSettings).ifPresent(validationErrors::add);
-        validatePluggableDataFormatSettings(indexSettingsBuilder.build(), clusterSettings).ifPresent(validationErrors::add);
+        validatePluggableDataFormatSettings(indexSettingsBuilder.build(), clusterSettings, request.index()).ifPresent(
+            validationErrors::add
+        );
         validateErrors(request.index(), validationErrors);
 
         Settings indexSettings = indexSettingsBuilder.build();
@@ -1424,10 +1426,18 @@ public class MetadataCreateIndexService {
     /**
      * Stamps the cluster-scope defaults for the pluggable data-format index settings into the
      * index metadata at creation time when no explicit override is supplied. No-op when the
-     * pluggable data-format feature flag is disabled.
+     * pluggable data-format feature flag is disabled or the index matches the skiplist.
      */
-    public static void updatePluggableDataFormatSettings(Settings.Builder settingsBuilder, ClusterSettings clusterSettings) {
+    public static void updatePluggableDataFormatSettings(
+        Settings.Builder settingsBuilder,
+        ClusterSettings clusterSettings,
+        String indexName
+    ) {
         if (FeatureFlags.isEnabled(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG) == false) {
+            return;
+        }
+
+        if (isSkippedForPluggableDataFormat(indexName, clusterSettings)) {
             return;
         }
 
@@ -1723,7 +1733,7 @@ public class MetadataCreateIndexService {
         throws IndexCreationException {
         List<String> validationErrors = getIndexSettingsValidationErrors(settings, forbidPrivateIndexSettings, indexName);
         validateIndexReplicationTypeSettings(settings, clusterService.getClusterSettings()).ifPresent(validationErrors::add);
-        validatePluggableDataFormatSettings(settings, clusterService.getClusterSettings()).ifPresent(validationErrors::add);
+        validatePluggableDataFormatSettings(settings, clusterService.getClusterSettings(), indexName).ifPresent(validationErrors::add);
         validateErrors(indexName, validationErrors);
     }
 
@@ -1831,18 +1841,26 @@ public class MetadataCreateIndexService {
 
     /**
      * Validates that {@code index.pluggable.dataformat.enabled} and {@code index.pluggable.dataformat} match the
-     * cluster-level defaults {@code cluster.default.index.pluggable.dataformat.enabled} and
-     * {@code cluster.default.index.pluggable.dataformat} when
-     * {@code cluster.index.restrict.pluggable.dataformat} is set to true.
+     * cluster-level defaults {@code cluster.pluggable.dataformat.enabled} and
+     * {@code cluster.pluggable.dataformat} when
+     * {@code cluster.restrict.pluggable.dataformat} is set to true.
      *
      * @param requestSettings settings resulting from merging request, templates, and cluster-level defaults
      * @param clusterSettings cluster setting
+     * @param indexName name of the index being created
      */
-    private static Optional<String> validatePluggableDataFormatSettings(Settings requestSettings, ClusterSettings clusterSettings) {
+    private static Optional<String> validatePluggableDataFormatSettings(
+        Settings requestSettings,
+        ClusterSettings clusterSettings,
+        String indexName
+    ) {
         if (FeatureFlags.isEnabled(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG) == false) {
             return Optional.empty();
         }
-        if (clusterSettings.get(IndicesService.CLUSTER_INDEX_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING) == false) {
+        if (clusterSettings.get(IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING) == false) {
+            return Optional.empty();
+        }
+        if (isSkippedForPluggableDataFormat(indexName, clusterSettings)) {
             return Optional.empty();
         }
 
@@ -1852,8 +1870,10 @@ public class MetadataCreateIndexService {
             return Optional.of(
                 "index setting ["
                     + IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey()
-                    + "] is not allowed to be set as ["
-                    + IndicesService.CLUSTER_INDEX_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey()
+                    + "] cannot differ from cluster default ["
+                    + clusterSettings.get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
+                    + "] when ["
+                    + IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey()
                     + "=true]"
             );
         }
@@ -1864,12 +1884,24 @@ public class MetadataCreateIndexService {
             return Optional.of(
                 "index setting ["
                     + IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey()
-                    + "] is not allowed to be set as ["
-                    + IndicesService.CLUSTER_INDEX_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey()
+                    + "] cannot differ from cluster default ["
+                    + clusterSettings.get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING)
+                    + "] when ["
+                    + IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey()
                     + "=true]"
             );
         }
         return Optional.empty();
+    }
+
+    /**
+     * Returns {@code true} if the given index name matches any prefix in the
+     * {@code cluster.pluggable.dataformat.restrict.skiplist} setting, meaning it should bypass
+     * pluggable data-format default-stamping and restrict validation.
+     */
+    private static boolean isSkippedForPluggableDataFormat(String indexName, ClusterSettings clusterSettings) {
+        List<String> skiplist = clusterSettings.get(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST);
+        return skiplist.stream().anyMatch(indexName::startsWith);
     }
 
     /**

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1218,6 +1218,7 @@ public class MetadataCreateIndexService {
 
         updateReplicationStrategy(indexSettingsBuilder, request.settings(), settings, combinedTemplateSettings, clusterSettings);
         updateRemoteStoreSettings(indexSettingsBuilder, currentState, clusterSettings, settings, request.index());
+        updatePluggableDataFormatSettings(indexSettingsBuilder, clusterSettings);
 
         if (sourceMetadata != null) {
             assert request.resizeType() != null;
@@ -1416,6 +1417,33 @@ public class MetadataCreateIndexService {
                     throw new IndexCreationException(indexName, validationException);
                 }
             }
+        }
+    }
+
+    /**
+     * Stamps the cluster-scope defaults for the pluggable data-format index settings into the
+     * index metadata at creation time when no explicit override is supplied. No-op when the
+     * pluggable data-format feature flag is disabled.
+     */
+    public static void updatePluggableDataFormatSettings(Settings.Builder settingsBuilder, ClusterSettings clusterSettings) {
+        if (FeatureFlags.isEnabled(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG) == false) {
+            return;
+        }
+
+        final Settings current = settingsBuilder.build();
+
+        if (IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.exists(current) == false) {
+            settingsBuilder.put(
+                IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(),
+                clusterSettings.get(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)
+            );
+        }
+
+        if (IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.exists(current) == false) {
+            settingsBuilder.put(
+                IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(),
+                clusterSettings.get(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING)
+            );
         }
     }
 

--- a/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1235,6 +1235,7 @@ public class MetadataCreateIndexService {
 
         List<String> validationErrors = new ArrayList<>();
         validateIndexReplicationTypeSettings(indexSettingsBuilder.build(), clusterSettings).ifPresent(validationErrors::add);
+        validatePluggableDataFormatSettings(indexSettingsBuilder.build(), clusterSettings).ifPresent(validationErrors::add);
         validateErrors(request.index(), validationErrors);
 
         Settings indexSettings = indexSettingsBuilder.build();
@@ -1722,6 +1723,7 @@ public class MetadataCreateIndexService {
         throws IndexCreationException {
         List<String> validationErrors = getIndexSettingsValidationErrors(settings, forbidPrivateIndexSettings, indexName);
         validateIndexReplicationTypeSettings(settings, clusterService.getClusterSettings()).ifPresent(validationErrors::add);
+        validatePluggableDataFormatSettings(settings, clusterService.getClusterSettings()).ifPresent(validationErrors::add);
         validateErrors(indexName, validationErrors);
     }
 
@@ -1821,6 +1823,49 @@ public class MetadataCreateIndexService {
             return Optional.of(
                 "index setting [index.replication.type] is not allowed to be set as ["
                     + IndicesService.CLUSTER_INDEX_RESTRICT_REPLICATION_TYPE_SETTING.getKey()
+                    + "=true]"
+            );
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Validates that {@code index.pluggable.dataformat.enabled} and {@code index.pluggable.dataformat} match the
+     * cluster-level defaults {@code cluster.default.index.pluggable.dataformat.enabled} and
+     * {@code cluster.default.index.pluggable.dataformat} when
+     * {@code cluster.index.restrict.pluggable.dataformat} is set to true.
+     *
+     * @param requestSettings settings resulting from merging request, templates, and cluster-level defaults
+     * @param clusterSettings cluster setting
+     */
+    private static Optional<String> validatePluggableDataFormatSettings(Settings requestSettings, ClusterSettings clusterSettings) {
+        if (FeatureFlags.isEnabled(FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG) == false) {
+            return Optional.empty();
+        }
+        if (clusterSettings.get(IndicesService.CLUSTER_INDEX_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING) == false) {
+            return Optional.empty();
+        }
+
+        if (requestSettings.hasValue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey())
+            && IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(requestSettings)
+                .equals(clusterSettings.get(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING)) == false) {
+            return Optional.of(
+                "index setting ["
+                    + IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey()
+                    + "] is not allowed to be set as ["
+                    + IndicesService.CLUSTER_INDEX_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey()
+                    + "=true]"
+            );
+        }
+
+        if (requestSettings.hasValue(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey())
+            && IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(requestSettings)
+                .equals(clusterSettings.get(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING)) == false) {
+            return Optional.of(
+                "index setting ["
+                    + IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey()
+                    + "] is not allowed to be set as ["
+                    + IndicesService.CLUSTER_INDEX_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey()
                     + "=true]"
             );
         }

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -864,6 +864,10 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 CompositeIndexSettings.STAR_TREE_INDEX_ENABLED_SETTING,
                 CompositeIndexSettings.COMPOSITE_INDEX_MAX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING,
 
+                // Pluggable dataformat cluster defaults
+                IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING,
+                IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING,
+
                 SystemTemplatesService.SETTING_APPLICATION_BASED_CONFIGURATION_TEMPLATES_ENABLED,
 
                 // WorkloadManagement settings

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -868,7 +868,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING,
                 IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING,
                 IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING,
-                IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST,
+                IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_ALLOWLIST,
 
                 SystemTemplatesService.SETTING_APPLICATION_BASED_CONFIGURATION_TEMPLATES_ENABLED,
 

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -865,8 +865,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 CompositeIndexSettings.COMPOSITE_INDEX_MAX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING,
 
                 // Pluggable dataformat cluster defaults
-                IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING,
-                IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING,
+                IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING,
+                IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING,
                 IndicesService.CLUSTER_INDEX_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING,
 
                 SystemTemplatesService.SETTING_APPLICATION_BASED_CONFIGURATION_TEMPLATES_ENABLED,

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -867,7 +867,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 // Pluggable dataformat cluster defaults
                 IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING,
                 IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING,
-                IndicesService.CLUSTER_INDEX_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING,
+                IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING,
+                IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST,
 
                 SystemTemplatesService.SETTING_APPLICATION_BASED_CONFIGURATION_TEMPLATES_ENABLED,
 

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -867,6 +867,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 // Pluggable dataformat cluster defaults
                 IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING,
                 IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING,
+                IndicesService.CLUSTER_INDEX_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING,
 
                 SystemTemplatesService.SETTING_APPLICATION_BASED_CONFIGURATION_TEMPLATES_ENABLED,
 

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -394,16 +394,29 @@ public class IndicesService extends AbstractLifecycleComponent
 
     /**
      * If enabled, this setting enforces that indexes will be created with pluggable data-format settings matching the
-     * cluster-level defaults defined in {@code cluster.default.index.pluggable.dataformat.enabled} and
-     * {@code cluster.default.index.pluggable.dataformat} by rejecting any request that specifies an index-level value
+     * cluster-level defaults defined in {@code cluster.pluggable.dataformat.enabled} and
+     * {@code cluster.pluggable.dataformat} by rejecting any request that specifies an index-level value
      * that does not match. If disabled, users may choose the pluggable data-format on a per-index basis using the
      * {@code index.pluggable.dataformat.enabled} and {@code index.pluggable.dataformat} settings.
      */
-    public static final Setting<Boolean> CLUSTER_INDEX_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING = Setting.boolSetting(
+    public static final Setting<Boolean> CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING = Setting.boolSetting(
         "cluster.restrict.pluggable.dataformat",
         false,
         Property.NodeScope,
-        Property.Final
+        Property.Dynamic
+    );
+
+    /**
+     * A list of index name prefixes that bypass the pluggable data-format restrict validation and
+     * cluster-default stamping. Indices whose name starts with any of these prefixes will not have
+     * cluster defaults applied and will not be rejected by the restrict setting.
+     */
+    public static final Setting<List<String>> CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST = Setting.listSetting(
+        "cluster.pluggable.dataformat.restrict.skiplist",
+        Collections.emptyList(),
+        s -> s,
+        Property.NodeScope,
+        Property.Dynamic
     );
 
     /**

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -411,12 +411,11 @@ public class IndicesService extends AbstractLifecycleComponent
      * cluster-default stamping. Indices whose name starts with any of these prefixes will not have
      * cluster defaults applied and will not be rejected by the restrict setting.
      */
-    public static final Setting<List<String>> CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST = Setting.listSetting(
-        "cluster.pluggable.dataformat.restrict.skiplist",
+    public static final Setting<List<String>> CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_ALLOWLIST = Setting.listSetting(
+        "cluster.pluggable.dataformat.restrict.allowlist",
         Collections.emptyList(),
         s -> s,
-        Property.NodeScope,
-        Property.Dynamic
+        Property.NodeScope
     );
 
     /**

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -309,6 +309,28 @@ public class IndicesService extends AbstractLifecycleComponent
     );
 
     /**
+     * Cluster-level default for {@code index.pluggable.dataformat.enabled}.
+     * Applied at index creation time when the index setting is not explicitly provided.
+     */
+    public static final Setting<Boolean> CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING = Setting.boolSetting(
+        "cluster.default.index.pluggable.dataformat.enabled",
+        false,
+        Property.NodeScope,
+        Property.Dynamic
+    );
+
+    /**
+     * Cluster-level default for {@code index.pluggable.dataformat}.
+     * Applied at index creation time when the index setting is not explicitly provided.
+     */
+    public static final Setting<String> CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING = Setting.simpleString(
+        "cluster.default.index.pluggable.dataformat",
+        "",
+        Property.NodeScope,
+        Property.Dynamic
+    );
+
+    /**
      * This setting is used to set the minimum refresh interval applicable for all indexes in a cluster. The
      * {@code cluster.default.index.refresh_interval} setting value needs to be higher than this setting's value. Index
      * creation will fail if the index setting {@code index.refresh_interval} is supplied with a value lower than the

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -400,7 +400,7 @@ public class IndicesService extends AbstractLifecycleComponent
      * {@code index.pluggable.dataformat.enabled} and {@code index.pluggable.dataformat} settings.
      */
     public static final Setting<Boolean> CLUSTER_INDEX_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING = Setting.boolSetting(
-        "cluster.index.restrict.pluggable.dataformat",
+        "cluster.restrict.pluggable.dataformat",
         false,
         Property.NodeScope,
         Property.Final

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -393,6 +393,20 @@ public class IndicesService extends AbstractLifecycleComponent
     );
 
     /**
+     * If enabled, this setting enforces that indexes will be created with pluggable data-format settings matching the
+     * cluster-level defaults defined in {@code cluster.default.index.pluggable.dataformat.enabled} and
+     * {@code cluster.default.index.pluggable.dataformat} by rejecting any request that specifies an index-level value
+     * that does not match. If disabled, users may choose the pluggable data-format on a per-index basis using the
+     * {@code index.pluggable.dataformat.enabled} and {@code index.pluggable.dataformat} settings.
+     */
+    public static final Setting<Boolean> CLUSTER_INDEX_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING = Setting.boolSetting(
+        "cluster.index.restrict.pluggable.dataformat",
+        false,
+        Property.NodeScope,
+        Property.Final
+    );
+
+    /**
      * The node's settings.
      */
     private final Settings settings;

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -312,8 +312,8 @@ public class IndicesService extends AbstractLifecycleComponent
      * Cluster-level default for {@code index.pluggable.dataformat.enabled}.
      * Applied at index creation time when the index setting is not explicitly provided.
      */
-    public static final Setting<Boolean> CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING = Setting.boolSetting(
-        "cluster.default.index.pluggable.dataformat.enabled",
+    public static final Setting<Boolean> CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING = Setting.boolSetting(
+        "cluster.pluggable.dataformat.enabled",
         false,
         Property.NodeScope,
         Property.Dynamic
@@ -323,8 +323,8 @@ public class IndicesService extends AbstractLifecycleComponent
      * Cluster-level default for {@code index.pluggable.dataformat}.
      * Applied at index creation time when the index setting is not explicitly provided.
      */
-    public static final Setting<String> CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING = Setting.simpleString(
-        "cluster.default.index.pluggable.dataformat",
+    public static final Setting<String> CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING = Setting.simpleString(
+        "cluster.pluggable.dataformat",
         "",
         Property.NodeScope,
         Property.Dynamic

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -81,6 +81,7 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.remote.RemoteStoreEnums.PathHashAlgorithm;
 import org.opensearch.index.remote.RemoteStoreEnums.PathType;
+import org.opensearch.index.shard.IndexSettingProvider;
 import org.opensearch.index.translog.Translog;
 import org.opensearch.indices.DefaultRemoteStoreSettings;
 import org.opensearch.indices.IndexCreationException;
@@ -2312,6 +2313,47 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
 
         assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(aggregated));
         assertEquals("parquet", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(aggregated));
+    }
+
+    public void testAggregateIndexSettingsPropagatesIndexCreationExceptionFromProvider() {
+        // Simulates a plugin-supplied IndexSettingProvider (like CompositeDataFormatPlugin) rejecting
+        // a forbidden index-level override by throwing IndexCreationException wrapping a
+        // ValidationException. The exception must propagate out of aggregateIndexSettings unchanged so
+        // the REST layer reports it the same way as the built-in validateErrors path does.
+        final String expectedError = "index setting [index.example] is not allowed to be set as [cluster.test.restrict=true]";
+        IndexSettingProvider throwingProvider = new IndexSettingProvider() {
+            @Override
+            public Settings getAdditionalIndexSettings(String indexName, boolean isDataStreamIndex, Settings templateAndRequestSettings) {
+                ValidationException ve = new ValidationException();
+                ve.addValidationError(expectedError);
+                throw new IndexCreationException(indexName, ve);
+            }
+        };
+
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        request.settings(Settings.EMPTY);
+
+        IndexCreationException thrown = expectThrows(
+            IndexCreationException.class,
+            () -> aggregateIndexSettings(
+                ClusterState.EMPTY_STATE,
+                request,
+                Settings.EMPTY,
+                null,
+                Settings.EMPTY,
+                IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+                randomShardLimitService(),
+                Collections.singleton(throwingProvider),
+                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+            )
+        );
+
+        assertEquals("test", thrown.getIndex().getName());
+        assertTrue(thrown.getCause() instanceof ValidationException);
+        assertTrue(
+            "expected validation error to contain [" + expectedError + "] but was [" + thrown.getCause().getMessage() + "]",
+            thrown.getCause().getMessage().contains(expectedError)
+        );
     }
 
     public void testAnyTranslogDurabilityWhenRestrictSettingFalse() {

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -2229,8 +2229,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
         // Primary override is preserved; value still stamped from the cluster default.
-        Settings.Builder indexSettingsBuilder = Settings.builder()
-            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false);
+        Settings.Builder indexSettingsBuilder = Settings.builder().put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false);
         MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
 
         Settings out = indexSettingsBuilder.build();
@@ -2246,8 +2245,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             .build();
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
-        Settings.Builder indexSettingsBuilder = Settings.builder()
-            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "lucene");
+        Settings.Builder indexSettingsBuilder = Settings.builder().put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "lucene");
         MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
 
         Settings out = indexSettingsBuilder.build();

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -159,6 +159,7 @@ import static org.opensearch.cluster.metadata.MetadataCreateIndexService.parseV1
 import static org.opensearch.cluster.metadata.MetadataCreateIndexService.resolveAndValidateAliases;
 import static org.opensearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider.INDEX_TOTAL_PRIMARY_SHARDS_PER_NODE_SETTING;
 import static org.opensearch.common.util.FeatureFlags.APPLICATION_BASED_CONFIGURATION_TEMPLATES;
+import static org.opensearch.common.util.FeatureFlags.PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG;
 import static org.opensearch.common.util.FeatureFlags.REMOTE_STORE_MIGRATION_EXPERIMENTAL;
 import static org.opensearch.index.IndexModule.INDEX_STORE_TYPE_SETTING;
 import static org.opensearch.index.IndexSettings.INDEX_MERGE_POLICY;
@@ -2182,6 +2183,137 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
                 + "]: cannot be smaller than cluster.minimum.index.refresh_interval [10s]",
             exception.getMessage()
         );
+    }
+
+    // ---- updatePluggableDataFormatSettings ----
+
+    public void testUpdatePluggableDataFormatSettingsNoopWhenFeatureFlagDisabled() {
+        // Feature flag is off by default in tests; the helper must not contribute either setting,
+        // even when a cluster-scope default is present.
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        Settings.Builder indexSettingsBuilder = Settings.builder();
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
+
+        Settings out = indexSettingsBuilder.build();
+        assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.exists(out));
+        assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.exists(out));
+    }
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testUpdatePluggableDataFormatSettingsStampsClusterDefaultsWhenIndexLevelAbsent() {
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        Settings.Builder indexSettingsBuilder = Settings.builder();
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
+
+        Settings out = indexSettingsBuilder.build();
+        assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(out));
+        assertEquals("parquet", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(out));
+    }
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testUpdatePluggableDataFormatSettingsSkipsEnabledWhenAlreadySet() {
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        // Primary override is preserved; value still stamped from the cluster default.
+        Settings.Builder indexSettingsBuilder = Settings.builder()
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false);
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
+
+        Settings out = indexSettingsBuilder.build();
+        assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(out));
+        assertEquals("parquet", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(out));
+    }
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testUpdatePluggableDataFormatSettingsSkipsValueWhenAlreadySet() {
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        Settings.Builder indexSettingsBuilder = Settings.builder()
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "lucene");
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
+
+        Settings out = indexSettingsBuilder.build();
+        assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(out));
+        assertEquals("lucene", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(out));
+    }
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testUpdatePluggableDataFormatSettingsSkipsBothWhenAlreadySet() {
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        Settings.Builder indexSettingsBuilder = Settings.builder()
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "lucene");
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
+
+        Settings out = indexSettingsBuilder.build();
+        assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(out));
+        assertEquals("lucene", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(out));
+    }
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testUpdatePluggableDataFormatSettingsStampsBuiltInDefaultsWhenClusterBagEmpty() {
+        ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        Settings.Builder indexSettingsBuilder = Settings.builder();
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
+
+        Settings out = indexSettingsBuilder.build();
+        assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.exists(out));
+        assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(out));
+        assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.exists(out));
+        assertEquals("", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(out));
+    }
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testAggregateIndexSettingsStampsPluggableDataFormatClusterDefaults() {
+        // End-to-end sanity: confirm updatePluggableDataFormatSettings is wired into the create-index
+        // pipeline, so the effective values land in the settings returned by aggregateIndexSettings.
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        request.settings(Settings.EMPTY);
+
+        Settings aggregated = aggregateIndexSettings(
+            ClusterState.EMPTY_STATE,
+            request,
+            Settings.EMPTY,
+            null,
+            Settings.EMPTY,
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            randomShardLimitService(),
+            Collections.emptySet(),
+            cs
+        );
+
+        assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(aggregated));
+        assertEquals("parquet", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(aggregated));
     }
 
     public void testAnyTranslogDurabilityWhenRestrictSettingFalse() {

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -2198,7 +2198,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
         Settings.Builder indexSettingsBuilder = Settings.builder();
-        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs, "test-index");
 
         Settings out = indexSettingsBuilder.build();
         assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.exists(out));
@@ -2214,7 +2214,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
         Settings.Builder indexSettingsBuilder = Settings.builder();
-        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs, "test-index");
 
         Settings out = indexSettingsBuilder.build();
         assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(out));
@@ -2231,7 +2231,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
 
         // Primary override is preserved; value still stamped from the cluster default.
         Settings.Builder indexSettingsBuilder = Settings.builder().put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false);
-        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs, "test-index");
 
         Settings out = indexSettingsBuilder.build();
         assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(out));
@@ -2247,7 +2247,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
         Settings.Builder indexSettingsBuilder = Settings.builder().put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "lucene");
-        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs, "test-index");
 
         Settings out = indexSettingsBuilder.build();
         assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(out));
@@ -2265,7 +2265,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         Settings.Builder indexSettingsBuilder = Settings.builder()
             .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false)
             .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "lucene");
-        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs, "test-index");
 
         Settings out = indexSettingsBuilder.build();
         assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(out));
@@ -2277,7 +2277,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         ClusterSettings cs = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
         Settings.Builder indexSettingsBuilder = Settings.builder();
-        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs);
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs, "test-index");
 
         Settings out = indexSettingsBuilder.build();
         assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.exists(out));
@@ -2354,6 +2354,67 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
             "expected validation error to contain [" + expectedError + "] but was [" + thrown.getCause().getMessage() + "]",
             thrown.getCause().getMessage().contains(expectedError)
         );
+    }
+
+    // ---- skiplist tests ----
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testUpdatePluggableDataFormatSettingsSkipsWhenIndexMatchesSkiplist() {
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST.getKey(), ".system", ".kibana")
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        Settings.Builder indexSettingsBuilder = Settings.builder();
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs, ".system-index-1");
+
+        Settings out = indexSettingsBuilder.build();
+        assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.exists(out));
+        assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.exists(out));
+    }
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testUpdatePluggableDataFormatSettingsStampsWhenIndexDoesNotMatchSkiplist() {
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST.getKey(), ".system", ".kibana")
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        Settings.Builder indexSettingsBuilder = Settings.builder();
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs, "user-index");
+
+        Settings out = indexSettingsBuilder.build();
+        assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(out));
+        assertEquals("parquet", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(out));
+    }
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testValidatePluggableDataFormatSettingsSkipsWhenIndexMatchesSkiplist() {
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST.getKey(), ".system")
+            .put(IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey(), true)
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        // Index explicitly sets a different value — normally rejected, but skiplist bypasses it.
+        Settings indexSettings = Settings.builder()
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "lucene")
+            .build();
+
+        Settings.Builder indexSettingsBuilder = Settings.builder().put(indexSettings);
+        MetadataCreateIndexService.updatePluggableDataFormatSettings(indexSettingsBuilder, cs, ".system-test");
+
+        // No exception, no stamping — the index is left alone.
+        Settings out = indexSettingsBuilder.build();
+        assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(out));
+        assertEquals("lucene", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(out));
     }
 
     public void testAnyTranslogDurabilityWhenRestrictSettingFalse() {

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -2356,14 +2356,14 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         );
     }
 
-    // ---- skiplist tests ----
+    // ---- allowlist tests ----
 
     @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
-    public void testUpdatePluggableDataFormatSettingsSkipsWhenIndexMatchesSkiplist() {
+    public void testUpdatePluggableDataFormatSettingsSkipsWhenIndexMatchesAllowlist() {
         Settings clusterBag = Settings.builder()
             .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
             .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
-            .putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST.getKey(), ".system", ".kibana")
+            .putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_ALLOWLIST.getKey(), ".system", ".kibana")
             .build();
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
@@ -2376,11 +2376,11 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
     }
 
     @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
-    public void testUpdatePluggableDataFormatSettingsStampsWhenIndexDoesNotMatchSkiplist() {
+    public void testUpdatePluggableDataFormatSettingsStampsWhenIndexDoesNotMatchAllowlist() {
         Settings clusterBag = Settings.builder()
             .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
             .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
-            .putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST.getKey(), ".system", ".kibana")
+            .putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_ALLOWLIST.getKey(), ".system", ".kibana")
             .build();
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
@@ -2393,16 +2393,16 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
     }
 
     @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
-    public void testValidatePluggableDataFormatSettingsSkipsWhenIndexMatchesSkiplist() {
+    public void testValidatePluggableDataFormatSettingsSkipsWhenIndexMatchesAllowlist() {
         Settings clusterBag = Settings.builder()
             .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
             .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
-            .putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST.getKey(), ".system")
+            .putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_ALLOWLIST.getKey(), ".system")
             .put(IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey(), true)
             .build();
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
-        // Index explicitly sets a different value — normally rejected, but skiplist bypasses it.
+        // Index explicitly sets a different value — normally rejected, but allowlist bypasses it.
         Settings indexSettings = Settings.builder()
             .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false)
             .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "lucene")
@@ -2580,12 +2580,12 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
     }
 
     @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
-    public void testValidatePluggableDataFormatSkiplistBypassesRestrict() {
+    public void testValidatePluggableDataFormatAllowlistBypassesRestrict() {
         Settings clusterBag = Settings.builder()
             .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
             .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
             .put(IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey(), true)
-            .putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST.getKey(), ".system")
+            .putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_ALLOWLIST.getKey(), ".system")
             .build();
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
@@ -2597,7 +2597,7 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         request = new CreateIndexClusterStateUpdateRequest("create index", ".system-index", ".system-index");
         request.settings(mismatch);
 
-        // Should NOT throw — index matches skiplist
+        // Should NOT throw — index matches allowlist
         Settings aggregated = aggregateIndexSettings(
             ClusterState.EMPTY_STATE,
             request,

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -2417,6 +2417,202 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         assertEquals("lucene", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(out));
     }
 
+    // ---- validatePluggableDataFormatSettings tests ----
+
+    public void testValidatePluggableDataFormatNoopWhenFeatureFlagDisabled() {
+        // Feature flag off — no validation even with restrict=true and mismatching values.
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .put(IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey(), true)
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        Settings mismatch = Settings.builder()
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "lucene")
+            .build();
+
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        request.settings(mismatch);
+
+        // Should NOT throw — feature flag is off by default in tests without @LockFeatureFlag
+        Settings aggregated = aggregateIndexSettings(
+            ClusterState.EMPTY_STATE,
+            request,
+            Settings.EMPTY,
+            null,
+            Settings.EMPTY,
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            randomShardLimitService(),
+            Collections.emptySet(),
+            cs
+        );
+        assertNotNull(aggregated);
+    }
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testValidatePluggableDataFormatNoopWhenRestrictDisabled() {
+        // restrict=false — mismatching values are allowed.
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        Settings mismatch = Settings.builder()
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "lucene")
+            .build();
+
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        request.settings(mismatch);
+
+        Settings aggregated = aggregateIndexSettings(
+            ClusterState.EMPTY_STATE,
+            request,
+            Settings.EMPTY,
+            null,
+            Settings.EMPTY,
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            randomShardLimitService(),
+            Collections.emptySet(),
+            cs
+        );
+        assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(aggregated));
+        assertEquals("lucene", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(aggregated));
+    }
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testValidatePluggableDataFormatRejectsEnabledMismatch() {
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .put(IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey(), true)
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        Settings mismatch = Settings.builder().put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false).build();
+
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        request.settings(mismatch);
+
+        IndexCreationException exception = expectThrows(
+            IndexCreationException.class,
+            () -> aggregateIndexSettings(
+                ClusterState.EMPTY_STATE,
+                request,
+                Settings.EMPTY,
+                null,
+                Settings.EMPTY,
+                IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+                randomShardLimitService(),
+                Collections.emptySet(),
+                cs
+            )
+        );
+        assertTrue(exception.getCause().getMessage().contains(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey()));
+        assertTrue(exception.getCause().getMessage().contains("cannot differ from cluster default"));
+    }
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testValidatePluggableDataFormatRejectsValueMismatch() {
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .put(IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey(), true)
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        Settings mismatch = Settings.builder().put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "lucene").build();
+
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        request.settings(mismatch);
+
+        IndexCreationException exception = expectThrows(
+            IndexCreationException.class,
+            () -> aggregateIndexSettings(
+                ClusterState.EMPTY_STATE,
+                request,
+                Settings.EMPTY,
+                null,
+                Settings.EMPTY,
+                IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+                randomShardLimitService(),
+                Collections.emptySet(),
+                cs
+            )
+        );
+        assertTrue(exception.getCause().getMessage().contains(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey()));
+        assertTrue(exception.getCause().getMessage().contains("cannot differ from cluster default"));
+    }
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testValidatePluggableDataFormatAllowsMatchingValues() {
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .put(IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey(), true)
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        Settings matching = Settings.builder()
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .build();
+
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        request.settings(matching);
+
+        Settings aggregated = aggregateIndexSettings(
+            ClusterState.EMPTY_STATE,
+            request,
+            Settings.EMPTY,
+            null,
+            Settings.EMPTY,
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            randomShardLimitService(),
+            Collections.emptySet(),
+            cs
+        );
+        assertTrue(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(aggregated));
+        assertEquals("parquet", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(aggregated));
+    }
+
+    @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
+    public void testValidatePluggableDataFormatSkiplistBypassesRestrict() {
+        Settings clusterBag = Settings.builder()
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .put(IndicesService.CLUSTER_RESTRICT_PLUGGABLE_DATAFORMAT_SETTING.getKey(), true)
+            .putList(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_RESTRICT_SKIPLIST.getKey(), ".system")
+            .build();
+        ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+
+        Settings mismatch = Settings.builder()
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), false)
+            .put(IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "lucene")
+            .build();
+
+        request = new CreateIndexClusterStateUpdateRequest("create index", ".system-index", ".system-index");
+        request.settings(mismatch);
+
+        // Should NOT throw — index matches skiplist
+        Settings aggregated = aggregateIndexSettings(
+            ClusterState.EMPTY_STATE,
+            request,
+            Settings.EMPTY,
+            null,
+            Settings.EMPTY,
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            randomShardLimitService(),
+            Collections.emptySet(),
+            cs
+        );
+        assertFalse(IndexSettings.PLUGGABLE_DATAFORMAT_ENABLED_SETTING.get(aggregated));
+        assertEquals("lucene", IndexSettings.PLUGGABLE_DATAFORMAT_VALUE_SETTING.get(aggregated));
+    }
+
     public void testAnyTranslogDurabilityWhenRestrictSettingFalse() {
         // This checks that aggregateIndexSettings works for the case when the cluster setting
         // cluster.remote_store.index.restrict.async-durability is false or not set, it allows all types of durability modes

--- a/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -2192,8 +2192,8 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         // Feature flag is off by default in tests; the helper must not contribute either setting,
         // even when a cluster-scope default is present.
         Settings clusterBag = Settings.builder()
-            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
-            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
             .build();
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
@@ -2208,8 +2208,8 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
     @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testUpdatePluggableDataFormatSettingsStampsClusterDefaultsWhenIndexLevelAbsent() {
         Settings clusterBag = Settings.builder()
-            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
-            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
             .build();
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
@@ -2224,8 +2224,8 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
     @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testUpdatePluggableDataFormatSettingsSkipsEnabledWhenAlreadySet() {
         Settings clusterBag = Settings.builder()
-            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
-            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
             .build();
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
@@ -2241,8 +2241,8 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
     @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testUpdatePluggableDataFormatSettingsSkipsValueWhenAlreadySet() {
         Settings clusterBag = Settings.builder()
-            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
-            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
             .build();
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
@@ -2257,8 +2257,8 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
     @LockFeatureFlag(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_FLAG)
     public void testUpdatePluggableDataFormatSettingsSkipsBothWhenAlreadySet() {
         Settings clusterBag = Settings.builder()
-            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
-            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
             .build();
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
@@ -2291,8 +2291,8 @@ public class MetadataCreateIndexServiceTests extends OpenSearchTestCase {
         // End-to-end sanity: confirm updatePluggableDataFormatSettings is wired into the create-index
         // pipeline, so the effective values land in the settings returned by aggregateIndexSettings.
         Settings clusterBag = Settings.builder()
-            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
-            .put(IndicesService.CLUSTER_DEFAULT_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_ENABLED_SETTING.getKey(), true)
+            .put(IndicesService.CLUSTER_PLUGGABLE_DATAFORMAT_VALUE_SETTING.getKey(), "parquet")
             .build();
         ClusterSettings cs = new ClusterSettings(clusterBag, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 

--- a/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockParquetDataFormatPlugin.java
+++ b/test/framework/src/main/java/org/opensearch/index/engine/dataformat/stub/MockParquetDataFormatPlugin.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.dataformat.stub;
+
+import java.util.Set;
+
+/**
+ * A mock {@link MockDataFormatPlugin} that registers "parquet" as a data format for testing.
+ */
+public class MockParquetDataFormatPlugin extends MockDataFormatPlugin {
+
+    public MockParquetDataFormatPlugin() {
+        super(new MockDataFormat("parquet", 100L, Set.of()));
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
The PR introduces cluster level settings for data format aware engine. For more details check the issue: #21439 

### Related Issues
Resolves #21439 
Part of meta: #20876 

<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
