### PR TITLE
Transfer Flight batch to a response-owned root before returning

### DIFF
--- a/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeArrowTransportIT.java
+++ b/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeArrowTransportIT.java
@@ -124,6 +124,93 @@ public class NativeArrowTransportIT extends OpenSearchIntegTestCase {
         }
     }
 
+    /**
+     * Regression test: prior to the FlightTransportResponse.nextResponse() fix, the returned response
+     * held a reference to FlightStream's internal shared root. Subsequent next()/close() calls would
+     * clear those vectors, so a consumer that deferred reading the data (e.g. to dispatch work to an
+     * async listener) would see valueCount=0 / null data.
+     *
+     * This test retains references to all batch roots and only validates them AFTER the stream has
+     * been fully drained and closed — reproducing the condition the fix protects against.
+     */
+    @LockFeatureFlag(STREAM_TRANSPORT)
+    public void testBatchesSurviveStreamAdvanceAndClose() throws Exception {
+        DiscoveryNode node = getClusterState().nodes().iterator().next();
+        StreamTransportService sts = internalCluster().getInstance(StreamTransportService.class);
+        List<TestArrowResponse> retained = new ArrayList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> failure = new AtomicReference<>();
+
+        int batchCount = 3;
+        int rowsPerBatch = 4;
+        sts.sendRequest(
+            node,
+            TestArrowAction.NAME,
+            new TestArrowRequest(batchCount, rowsPerBatch, 1),
+            TransportRequestOptions.builder().withType(TransportRequestOptions.Type.STREAM).build(),
+            new StreamTransportResponseHandler<TestArrowResponse>() {
+                @Override
+                public void handleStreamResponse(StreamTransportResponse<TestArrowResponse> streamResponse) {
+                    try {
+                        TestArrowResponse response;
+                        // Collect references WITHOUT reading vector data — defer that until after close.
+                        while ((response = streamResponse.nextResponse()) != null) {
+                            retained.add(response);
+                        }
+                        streamResponse.close();
+                    } catch (Exception e) {
+                        failure.set(e);
+                        streamResponse.cancel("Test error", e);
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+
+                @Override
+                public void handleException(TransportException exp) {
+                    failure.set(exp);
+                    latch.countDown();
+                }
+
+                @Override
+                public String executor() {
+                    return ThreadPool.Names.GENERIC;
+                }
+
+                @Override
+                public TestArrowResponse read(StreamInput in) throws IOException {
+                    return new TestArrowResponse(in);
+                }
+            }
+        );
+
+        assertTrue("Stream should complete within 30s", latch.await(30, TimeUnit.SECONDS));
+        assertNull("No exception expected: " + failure.get(), failure.get());
+        assertEquals(batchCount, retained.size());
+
+        try {
+            // Every retained batch must still have its data intact even though the stream has
+            // advanced and closed. Without the fix, these roots would be empty/cleared.
+            for (int batchIdx = 0; batchIdx < retained.size(); batchIdx++) {
+                VectorSchemaRoot root = retained.get(batchIdx).getRoot();
+                assertEquals("row count must survive stream close", rowsPerBatch, root.getRowCount());
+                IntVector batchIdVec = (IntVector) root.getVector("batch_id");
+                VarCharVector nameVec = (VarCharVector) root.getVector("name");
+                IntVector valueVec = (IntVector) root.getVector("value");
+                assertEquals("valueCount must survive stream close", rowsPerBatch, batchIdVec.getValueCount());
+                for (int row = 0; row < rowsPerBatch; row++) {
+                    assertEquals("batch_id survives", batchIdx, batchIdVec.get(row));
+                    assertEquals("name survives", "row-" + batchIdx + "-" + row, new String(nameVec.get(row), StandardCharsets.UTF_8));
+                    assertEquals("value survives", batchIdx * 1000 + row, valueVec.get(row));
+                }
+            }
+        } finally {
+            for (TestArrowResponse r : retained) {
+                r.getRoot().close();
+            }
+        }
+    }
+
     @LockFeatureFlag(STREAM_TRANSPORT)
     public void testParallelBatchProduction() throws Exception {
         // 100 batches, 10 rows each, produced by 5 parallel threads.

--- a/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeArrowTransportIT.java
+++ b/plugins/arrow-flight-rpc/src/internalClusterTest/java/org/opensearch/arrow/flight/NativeArrowTransportIT.java
@@ -125,13 +125,9 @@ public class NativeArrowTransportIT extends OpenSearchIntegTestCase {
     }
 
     /**
-     * Regression test: prior to the FlightTransportResponse.nextResponse() fix, the returned response
-     * held a reference to FlightStream's internal shared root. Subsequent next()/close() calls would
-     * clear those vectors, so a consumer that deferred reading the data (e.g. to dispatch work to an
-     * async listener) would see valueCount=0 / null data.
-     *
-     * This test retains references to all batch roots and only validates them AFTER the stream has
-     * been fully drained and closed — reproducing the condition the fix protects against.
+     * Collects every batch without reading vector data, fully drains and closes the stream, then
+     * verifies each retained batch still holds its data. Mirrors an async consumer that defers
+     * reading until after the stream has advanced or been closed.
      */
     @LockFeatureFlag(STREAM_TRANSPORT)
     public void testBatchesSurviveStreamAdvanceAndClose() throws Exception {
@@ -190,7 +186,7 @@ public class NativeArrowTransportIT extends OpenSearchIntegTestCase {
 
         try {
             // Every retained batch must still have its data intact even though the stream has
-            // advanced and closed. Without the fix, these roots would be empty/cleared.
+            // advanced and closed.
             for (int batchIdx = 0; batchIdx < retained.size(); batchIdx++) {
                 VectorSchemaRoot root = retained.get(batchIdx).getRoot();
                 assertEquals("row count must survive stream close", rowsPerBatch, root.getRowCount());

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/ArrowBatchResponse.java
@@ -8,16 +8,13 @@
 
 package org.opensearch.arrow.flight.transport;
 
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.util.TransferPair;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
  * Base class for transport responses carrying native Arrow data.
@@ -96,13 +93,7 @@ public abstract class ArrowBatchResponse extends ActionResponse {
      * @param target the channel's shared root (bound to the Flight stream via start())
      */
     void transferTo(VectorSchemaRoot target) {
-        List<FieldVector> sourceVectors = producerRoot.getFieldVectors();
-        List<FieldVector> targetVectors = target.getFieldVectors();
-        for (int i = 0; i < sourceVectors.size(); i++) {
-            TransferPair transfer = sourceVectors.get(i).makeTransferPair(targetVectors.get(i));
-            transfer.transfer();
-        }
-        target.setRowCount(producerRoot.getRowCount());
+        FlightUtils.transferRoot(producerRoot, target);
     }
 
     @Override

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java
@@ -121,9 +121,10 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
             boolean hasNext = firstBatchConsumed ? flightStream.next() : (firstBatchConsumed = true);
             if (!hasNext) return null;
 
-            VectorSchemaRoot root = flightStream.getRoot();
-            currentBatchSize = FlightUtils.calculateVectorSchemaRootSize(root);
-            try (VectorStreamInput input = new VectorStreamInput(root, namedWriteableRegistry)) {
+            VectorSchemaRoot sharedRoot = flightStream.getRoot();
+            currentBatchSize = FlightUtils.calculateVectorSchemaRootSize(sharedRoot);
+            VectorSchemaRoot ownedRoot = transferToOwnedRoot(sharedRoot);
+            try (VectorStreamInput input = new VectorStreamInput(ownedRoot, namedWriteableRegistry)) {
                 input.setVersion(initialHeader.getVersion());
                 return handler.read(input);
             }
@@ -142,6 +143,21 @@ class FlightTransportResponse<T extends TransportResponse> implements StreamTran
 
     long getCurrentBatchSize() {
         return currentBatchSize;
+    }
+
+    /**
+     * Transfers the shared root's vectors into a response-owned root so the returned response
+     * is independent of FlightStream's lifecycle. The next call to {@code flightStream.next()}
+     * clears the shared root, and {@code stream.close()} releases its vectors — both would wipe
+     * the data out from under an async listener if we handed back a reference to the shared root.
+     */
+    private static VectorSchemaRoot transferToOwnedRoot(VectorSchemaRoot sharedRoot) {
+        VectorSchemaRoot ownedRoot = VectorSchemaRoot.create(
+            sharedRoot.getSchema(),
+            sharedRoot.getFieldVectors().getFirst().getAllocator()
+        );
+        FlightUtils.transferRoot(sharedRoot, ownedRoot);
+        return ownedRoot;
     }
 
     @Override

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightUtils.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightUtils.java
@@ -8,7 +8,11 @@
 
 package org.opensearch.arrow.flight.transport;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.util.TransferPair;
+
+import java.util.List;
 
 class FlightUtils {
 
@@ -26,5 +30,20 @@ class FlightUtils {
             }
         }
         return totalSize;
+    }
+
+    /**
+     * Zero-copy transfers every vector from {@code source} into {@code target} and copies
+     * the row count. After this call, the source vectors are empty and the target owns
+     * the buffers.
+     */
+    static void transferRoot(VectorSchemaRoot source, VectorSchemaRoot target) {
+        List<FieldVector> sources = source.getFieldVectors();
+        List<FieldVector> targets = target.getFieldVectors();
+        for (int i = 0; i < sources.size(); i++) {
+            TransferPair tp = sources.get(i).makeTransferPair(targets.get(i));
+            tp.transfer();
+        }
+        target.setRowCount(source.getRowCount());
     }
 }

--- a/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightUtils.java
+++ b/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightUtils.java
@@ -33,9 +33,8 @@ class FlightUtils {
     }
 
     /**
-     * Zero-copy transfers every vector from {@code source} into {@code target} and copies
-     * the row count. After this call, the source vectors are empty and the target owns
-     * the buffers.
+     * Zero-copy transfers every vector from {@code source} into {@code target}. After this call,
+     * the target owns the buffers and holds the row count; the source is empty with row count 0.
      */
     static void transferRoot(VectorSchemaRoot source, VectorSchemaRoot target) {
         List<FieldVector> sources = source.getFieldVectors();
@@ -45,5 +44,6 @@ class FlightUtils {
             tp.transfer();
         }
         target.setRowCount(source.getRowCount());
+        source.setRowCount(0);
     }
 }

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseTests.java
@@ -99,6 +99,35 @@ public class ArrowBatchResponseTests extends OpenSearchTestCase {
         dst.close();
     }
 
+    /**
+     * After transfer, closing the source must not affect the destination — the destination owns
+     * its buffers. This is the invariant FlightTransportResponse relies on to decouple the
+     * returned response from FlightStream's shared, reused root.
+     */
+    public void testDestinationSurvivesSourceClose() {
+        VectorSchemaRoot src = VectorSchemaRoot.create(schema, allocator);
+        IntVector srcVec = (IntVector) src.getVector("val");
+        srcVec.allocateNew();
+        srcVec.setSafe(0, 7);
+        srcVec.setSafe(1, 13);
+        srcVec.setValueCount(2);
+        src.setRowCount(2);
+
+        VectorSchemaRoot dst = VectorSchemaRoot.create(schema, allocator);
+        new TestResponse(src).transferTo(dst);
+
+        // Close the source — simulates FlightStream clearing/closing its shared root.
+        src.close();
+
+        assertEquals(2, dst.getRowCount());
+        IntVector dstVec = (IntVector) dst.getVector("val");
+        assertEquals(2, dstVec.getValueCount());
+        assertEquals(7, dstVec.get(0));
+        assertEquals(13, dstVec.get(1));
+
+        dst.close();
+    }
+
     public void testTransferToWithMultipleVectors() {
         Schema multiSchema = new Schema(
             List.of(

--- a/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseTests.java
+++ b/plugins/arrow-flight-rpc/src/test/java/org/opensearch/arrow/flight/transport/ArrowBatchResponseTests.java
@@ -92,8 +92,9 @@ public class ArrowBatchResponseTests extends OpenSearchTestCase {
         assertEquals(42, dstVec.get(0));
         assertEquals(99, dstVec.get(1));
 
-        // Source should be empty after transfer
+        // Source should be empty after transfer — both at vector and root level
         assertEquals(0, srcVec.getValueCount());
+        assertEquals(0, src.getRowCount());
 
         src.close();
         dst.close();


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description

FlightTransportResponse.nextResponse() returned a reference to the shared root held by Arrow's FlightStream. 
FlightStream reuses one root across batches — the next call to next() clears it and re-loads (FlightStream.java:273), and stream.close() releases its vectors. 

The streaming handler could dispatch onStreamResponse asynchronously to the search executor, so by the time the listener reads the VSR, the shared root has already been wiped. The coordinator saw valueCount=0 on every column despite a correct rowCount and schema.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
